### PR TITLE
build(api): pin JDK in jitpack, fix publish tasks

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17 now, force it everywhere
+          java-version: "17" # newer libraries require 17, also change jitpack.yml
 
       - name: Verify JDK17
         # Default JDK varies depending on different runner flavors, make sure we are on 17

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,4 @@
 import com.android.build.gradle.internal.tasks.factory.dependsOn
-import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     id("maven-publish")
@@ -21,7 +20,6 @@ android {
 
     defaultConfig {
         minSdk = 16
-        targetSdk = 33
         buildConfigField(
             "String",
             "READ_WRITE_PERMISSION",
@@ -53,6 +51,13 @@ android {
         freeCompilerArgs += "-Xexplicit-api=strict"
         jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
+
+    publishing {
+        singleVariant("release") {
+            withJavadocJar()
+            withSourcesJar()
+        }
+    }
 }
 
 apply(from = "../lint.gradle")
@@ -69,86 +74,65 @@ dependencies {
     lintChecks(project(":lint-rules"))
 }
 
-val androidSourcesJar = tasks.register("androidSourcesJar", Jar::class) {
-    archiveClassifier.set("sources")
-    // For Android libraries
-    from(android.sourceSets["main"].java.srcDirs)
-}
+afterEvaluate {
+    publishing {
+        publications {
+            register<MavenPublication>("release") {
+                version = version
+                groupId = group.toString()
+                artifactId = "api"
 
-val dokkaJavadocJar = tasks.register("dokkaJavadocJar", Jar::class) {
-    val dokkaJavadocProvider: TaskProvider<DokkaTask> = tasks.named<DokkaTask>("dokkaJavadoc")
-    dependsOn(dokkaJavadocProvider)
-    from(dokkaJavadocProvider)
-    archiveClassifier.set("javadoc")
-    doLast {
-        println("API javadocs output directory: ${dokkaJavadocProvider.get().outputDirectory.get()}")
-        println("API javadocs jar output directory: ${destinationDirectory.get()}")
-    }
-}
-
-publishing {
-    publications {
-        create("mavenJava", MavenPublication::class) {
-            artifactId = "api"
-
-            artifact("$buildDir/outputs/aar/${project.getName()}-release.aar")
-            artifact(androidSourcesJar)
-            artifact(dokkaJavadocJar)
-
-            versionMapping {
-                usage("java-api") {
-                    fromResolutionOf("runtimeClasspath")
-                }
-                usage("java-runtime") {
-                    fromResolutionResult()
-                }
-            }
-            pom {
-                name = "AnkiDroid API"
-                description = "A programmatic API exported by AnkiDroid"
-                url = "https://github.com/ankidroid/Anki-Android/tree/main/api"
-                licenses {
-                    license {
-                        name = "GNU LESSER GENERAL PUBLIC LICENSE, v3"
-                        url =
-                            "https://github.com/ankidroid/Anki-Android/blob/main/api/COPYING.LESSER"
+                pom {
+                    name = "AnkiDroid API"
+                    description = "A programmatic API exported by AnkiDroid"
+                    url = "https://github.com/ankidroid/Anki-Android/tree/main/api"
+                    licenses {
+                        license {
+                            name = "GNU LESSER GENERAL PUBLIC LICENSE, v3"
+                            url =
+                                "https://github.com/ankidroid/Anki-Android/blob/main/api/COPYING.LESSER"
+                        }
+                    }
+                    scm {
+                        connection = "scm:git:git://github.com/ankidroid/Anki-Android.git"
+                        url = "https://github.com/ankidroid/Anki-Android"
                     }
                 }
-                scm {
-                    connection = "scm:git:git://github.com/ankidroid/Anki-Android.git"
-                    url = "https://github.com/ankidroid/Anki-Android"
+
+                afterEvaluate {
+                    from(components["release"])
                 }
             }
         }
-    }
-    repositories {
-        maven {
-            // change URLs to point to your repos, e.g. http://my.org/repo
-            val releasesRepoUrl = layout.buildDirectory.dir("repos/releases")
-            val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
-            url = uri(
-                if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
-            )
+        repositories {
+            maven {
+                // change URLs to point to your repos, e.g. http://my.org/repo
+                val releasesRepoUrl = layout.buildDirectory.dir("repos/releases")
+                val snapshotsRepoUrl = layout.buildDirectory.dir("repos/snapshots")
+                url = uri(
+                    if (version.toString().endsWith("SNAPSHOT")) snapshotsRepoUrl else releasesRepoUrl
+                )
+            }
         }
     }
 }
 
 val zipReleaseProvider = tasks.register("zipRelease", Zip::class) {
     from(layout.buildDirectory.dir("repos/releases"))
-    destinationDirectory = buildDir
-    archiveFileName = "$buildDir/release-${archiveVersion.get()}.zip"
+    destinationDirectory = layout.buildDirectory
+    archiveFileName = "${layout.buildDirectory.get()}/release-${archiveVersion.get()}.zip"
 }
 
 // Use this task to make a release you can send to someone
 // You may like `./gradlew :api:publishToMavenLocal for development
 val generateRelease: TaskProvider<Task> = tasks.register("generateRelease") {
     doLast {
-        println("Release $version can be found at $buildDir/repos/releases/")
-        println("Release $version zipped can be found $buildDir/release-$version.zip")
+        println("Release $version can be found at ${layout.buildDirectory.get()}/repos/releases/")
+        println("Release $version zipped can be found ${layout.buildDirectory.get()}/release-$version.zip")
     }
 }
 
-tasks.named("publishMavenJavaPublicationToMavenRepository").dependsOn(tasks.named("assemble"))
-tasks.named("publish").dependsOn(tasks.named("assemble"))
+// tasks.named("publishMavenJavaPublicationToMavenRepository").dependsOn(tasks.named("assemble"))
+// tasks.named("publish").dependsOn(tasks.named("assemble"))
 generateRelease.dependsOn(tasks.named("publish"))
 generateRelease.dependsOn(zipReleaseProvider)

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,6 +1,10 @@
 # We want control over the SDK used to build since we need newer JDKs
 before_install:
     - sdk update
-    - sdk list
+    - sdk list java
     - sdk install java 17.0.9-tem
     - sdk use java 17.0.9-tem
+
+# We can do the absolute minimum to build the API module, no need to build AnkiDroid module
+install:
+    - ./gradlew :api:publishToMavenLocal

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,6 @@
+# We want control over the SDK used to build since we need newer JDKs
+before_install:
+    - sdk update
+    - sdk list
+    - sdk install java 17.0.9-tem
+    - sdk use java 17.0.9-tem


### PR DESCRIPTION

## Purpose / Description

jitpack uses it's own JDK version to build things, and they lag behind sometimes

Since we started checking JDK versions and requiring newer JDKs to build in jitpack, our builds have been unreliable there

This uses jitpack's ability to configure a build via jitpack.yml and jitpack's config powers of sdkman to install and use a JDK we can build with

## Fixes
* Related #14787 - I don't think it fixes the whole issue but hopefully it builds

## Approach

create a config file sort of like: https://docs.jitpack.io/building/#java-version

...however it is not always guaranteed that jitpack will have what we want as a named version. So the approach I take is more like: https://github.com/19MisterX98/SeedcrackerX/blob/master/jitpack.yml

Instead of relying on a named version I use [sdkman ](https://sdkman.io/usage) (which is apparently available in jitpack build hosts) to make sure all SDKs are available, then install and use a fairly modern one

## How Has This Been Tested?

There is not an easy way to test it manually, so now that this commit exists, I'm going to ask jitpack.io to build with it

https://jitpack.io/com/github/mikehardy/Anki-Android/pin-jitpack-build-jdk-v2.5.4-gcd17835-10087/build.log

And it worked! ✅ 


## Learning (optional, can help others)

Well, our API artifact generation, documentation, and usage example are all frighteningly stale, that's for sure.

And jitpack has pretty powerful build environment config capabilities if you know how to use them.

Here's the new way to specify android library artifact contents: https://developer.android.com/build/publish-library/configure-pub-variants#single-pub-var

Here's the new way to specify how to publish them: https://developer.android.com/build/publish-library/upload-library

This stackoverflow was useful to put it all together https://stackoverflow.com/questions/75951117/gradle-8publishmavenpublicationtomavenrepository-uses-this-output-of-task