### PR TITLE
use `SaveInstanceState` to avoid crash in export file when Activity is recreated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -449,6 +449,7 @@ open class CardBrowser :
             }
             searchCards()
         }
+        mExportingDelegate.onRestoreInstanceState(savedInstanceState)
 
         // Selected cards aren't restored on activity recreation,
         // so it is necessary to dismiss the change deck dialog
@@ -1374,6 +1375,7 @@ open class CardBrowser :
         savedInstanceState.putBoolean("mPostAutoScroll", mPostAutoScroll)
         savedInstanceState.putInt("mLastSelectedPosition", mLastSelectedPosition)
         savedInstanceState.putBoolean("mInMultiSelectMode", isInMultiSelectMode)
+        mExportingDelegate.onSaveInstanceState(savedInstanceState)
         super.onSaveInstanceState(savedInstanceState)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -431,6 +431,7 @@ open class DeckPicker :
             Timber.w(e, "Failed to apply background")
             showThemedToast(this, getString(R.string.failed_to_apply_background_image, e.localizedMessage), false)
         }
+        mExportingDelegate.onRestoreInstanceState(savedInstanceState)
 
         // create and set an adapter for the RecyclerView
         mDeckListAdapter = DeckAdapter(layoutInflater, this).apply {
@@ -1037,6 +1038,7 @@ open class DeckPicker :
                 savedInstanceState.getString("dbRestorationPath", it.newAnkiDroidDirectory)
             }
         }
+        mExportingDelegate.onSaveInstanceState(savedInstanceState)
         savedInstanceState.putSerializable("mediaUsnOnConflict", mediaUsnOnConflict)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -217,7 +217,9 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(EXPORT_FILE_NAME_KEY, fileExportPath)
+        if (::fileExportPath.isInitialized) {
+            outState.putString(EXPORT_FILE_NAME_KEY, fileExportPath)
+        }
     }
 
     fun onRestoreInstanceState(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -19,6 +19,7 @@ import android.app.Activity
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
+import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -60,7 +61,7 @@ import java.util.function.Supplier
 class ActivityExportingDelegate(private val activity: AnkiActivity, private val collectionSupplier: Supplier<Collection>) : ExportDialogListener, ExportReadyDialogListener {
     val mDialogsFactory: ExportDialogsFactory
     private val mSaveFileLauncher: ActivityResultLauncher<Intent>
-    private lateinit var mExportFileName: String
+    private lateinit var fileExportPath: String
 
     fun showExportDialog(params: ExportDialogParams) {
         if (ScopedStorageService.mediaMigrationIsInProgress(activity)) {
@@ -201,8 +202,9 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             return
         }
 
+        fileExportPath = exportPath
+
         // Send the user to the standard Android file picker via Intent
-        mExportFileName = exportPath
         val saveIntent = Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
             addCategory(Intent.CATEGORY_OPENABLE)
             type = "application/apkg"
@@ -212,6 +214,15 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             putExtra("android.content.extra.SHOW_FILESIZE", true)
         }
         mSaveFileLauncher.launch(saveIntent)
+    }
+
+    fun onSaveInstanceState(outState: Bundle) {
+        outState.putString(EXPORT_FILE_NAME_KEY, fileExportPath)
+    }
+
+    fun onRestoreInstanceState(savedInstanceState: Bundle?) {
+        val restoredValue = savedInstanceState?.getString(EXPORT_FILE_NAME_KEY) ?: return
+        fileExportPath = restoredValue
     }
 
     private fun saveFileCallback(result: ActivityResult) {
@@ -231,12 +242,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             return false
         }
         val uri = intent.data
-        Timber.d("Exporting from file to ContentProvider URI: %s/%s", mExportFileName, uri.toString())
+        Timber.d("Exporting from file to ContentProvider URI: %s/%s", fileExportPath, uri.toString())
         try {
             activity.contentResolver.openFileDescriptor(uri!!, "w").use { pfd ->
                 if (pfd != null) {
                     FileOutputStream(pfd.fileDescriptor).use { fileOutputStream ->
-                        CompatHelper.compat.copyFile(mExportFileName, fileOutputStream)
+                        CompatHelper.compat.copyFile(fileExportPath, fileOutputStream)
                     }
                 } else {
                     Timber.w(
@@ -246,11 +257,11 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
                     return false
                 }
             }
-            if (deleteAfterExport && !File(mExportFileName).delete()) {
-                Timber.w("Failed to delete temporary export file %s", mExportFileName)
+            if (deleteAfterExport && !File(fileExportPath).delete()) {
+                Timber.w("Failed to delete temporary export file %s", fileExportPath)
             }
         } catch (e: Exception) {
-            Timber.e(e, "Unable to export file to Uri: %s/%s", mExportFileName, uri.toString())
+            Timber.e(e, "Unable to export file to Uri: %s/%s", fileExportPath, uri.toString())
             return false
         }
         return true
@@ -272,12 +283,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 
     /**
-     * If we exported a collection (hence [mExportFileName] ends with ".colpkg"), save in the preferences
+     * If we exported a collection (hence [fileExportPath] ends with ".colpkg"), save in the preferences
      * the mod of the collection and the time at which it occurred.
      * This will allow to check whether a recent export was made, hence scoped storage migration is safe.
      */
     private fun saveSuccessfulCollectionExportIfRelevant() {
-        if (::mExportFileName.isInitialized && !mExportFileName.endsWith(".colpkg")) return
+        if (!fileExportPath.endsWith(".colpkg")) return
         activity.sharedPrefs().edit {
             putLong(
                 LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY,
@@ -294,5 +305,6 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
     }
 }
 
+private const val EXPORT_FILE_NAME_KEY = "export_file_name_key"
 const val LAST_SUCCESSFUL_EXPORT_AT_MOD_KEY = "last_successful_export_mod"
 const val LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY = "last_successful_export_second"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Remove the lateinit var and use shared pref and nullable string to avoid crash in case the developer's option is turned on

## Fixes
Fixes #14795 

## How Has This Been Tested?
google emulator
[Screen_recording_20231124_152918.webm](https://github.com/ankidroid/Anki-Android/assets/48384865/1aa91e06-7686-425b-b674-044d768accb0)

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
