### PR TITLE
use backgroundTint to apply color

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -20,7 +20,6 @@ package com.ichi2.anki
 
 import android.annotation.SuppressLint
 import android.graphics.*
-import android.graphics.drawable.VectorDrawable
 import android.net.Uri
 import android.view.MotionEvent
 import android.view.View
@@ -585,11 +584,9 @@ class Whiteboard(activity: AnkiActivity, handleMultiTouch: Boolean, inverted: Bo
         activity.findViewById<View>(R.id.pen_color_yellow).setOnClickListener { view: View -> onClick(view) }
         activity.findViewById<View>(R.id.pen_color_custom).apply {
             setOnClickListener { view: View -> onClick(view) }
-            (background as? VectorDrawable)?.setTint(foregroundColor)
         }
         activity.findViewById<View>(R.id.stroke_width).apply {
             setOnClickListener { view: View -> onClick(view) }
-            (background as? VectorDrawable)?.setTint(foregroundColor)
         }
     }
 }

--- a/AnkiDroid/src/main/res/layout/reviewer_whiteboard_editor.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_whiteboard_editor.xml
@@ -8,32 +8,32 @@
 
     <Button
         android:id="@+id/pen_color_white"
-        android:background="@color/white"
+        android:backgroundTint="@color/white"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
         android:id="@+id/pen_color_black"
-        android:background="@color/black"
+        android:backgroundTint="@color/black"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
         android:id="@+id/pen_color_red"
-        android:background="@color/material_red_500"
+        android:backgroundTint="@color/material_red_500"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
         android:id="@+id/pen_color_green"
-        android:background="@color/material_green_500"
+        android:backgroundTint="@color/material_green_500"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
         android:id="@+id/pen_color_blue"
-        android:background="@color/material_blue_500"
+        android:backgroundTint="@color/material_blue_500"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button
         android:id="@+id/pen_color_yellow"
-        android:background="@color/material_yellow_500"
+        android:backgroundTint="@color/material_yellow_500"
         style="@style/reviewer_whiteboard_editor_button_style"/>
 
     <Button


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Using Background Tint to apply color to the background in the whiteboard this issue/bug was introduced after Brayan switched to material3, anyways `backgroundTint` applies the color.
The background attribute directly changes what's displayed in the background, while backgroundTint applies a color modification on top of the background drawable.

## Fixes
* Fixes #14802

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Google emulator 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/1cad6a6f-c2c9-42aa-b032-0fdc511cc29f)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
