### PR TITLE
refactor: CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -26,6 +26,7 @@ import android.webkit.JavascriptInterface
 import com.github.zafarkhaja.semver.Version
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.snackbar.setMaxLines
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Card
@@ -462,7 +463,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     fun ankiSearchCardWithCallback(query: String) {
         val cards = try {
             runBlocking {
-                searchForCards(query, SortOrder.UseCollectionOrdering(), true)
+                searchForCards(query, SortOrder.UseCollectionOrdering(), CardsOrNotes.CARDS)
             }
         } catch (exc: Exception) {
             activity.webView!!.evaluateJavascript(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1779,7 +1779,7 @@ open class CardBrowser :
             getString(R.string.card_browser_unknown_deck_name)
         }
 
-    private fun onPostExecuteRenderBrowserQA(result: Pair<CardCollection<CardCache>, List<Long>>) {
+    private fun onPostExecuteRenderBrowserQA(result: Pair<List<CardCache>, List<Long>>) {
         val cardsIdsToHide = result.second
         try {
             if (cardsIdsToHide.isNotEmpty()) {
@@ -1842,7 +1842,7 @@ open class CardBrowser :
                 if (currentTime - mLastRenderStart > 300 || lastVisibleItem + 1 >= totalItemCount) {
                     mLastRenderStart = currentTime
                     renderBrowserQAJob?.cancel()
-                    launchCatchingTask { renderBrowserQAParams(firstVisibleItem, visibleItemCount, cards) }
+                    launchCatchingTask { renderBrowserQAParams(firstVisibleItem, visibleItemCount, cards.toList()) }
                 }
             }
         }
@@ -1856,13 +1856,13 @@ open class CardBrowser :
             if (scrollState == AbsListView.OnScrollListener.SCROLL_STATE_IDLE) {
                 val startIdx = listView.firstVisiblePosition
                 val numVisible = listView.lastVisiblePosition - startIdx
-                launchCatchingTask { renderBrowserQAParams(startIdx - 5, 2 * numVisible + 5, mCards) }
+                launchCatchingTask { renderBrowserQAParams(startIdx - 5, 2 * numVisible + 5, mCards.toList()) }
             }
         }
     }
 
     // TODO: Improve progress bar handling in places where this function is used
-    protected suspend fun renderBrowserQAParams(firstVisibleItem: Int, visibleItemCount: Int, cards: CardCollection<CardCache>) {
+    protected suspend fun renderBrowserQAParams(firstVisibleItem: Int, visibleItemCount: Int, cards: List<CardCache>) {
         Timber.d("Starting Q&A background rendering")
         val result = renderBrowserQA(
             cards,
@@ -2359,7 +2359,7 @@ open class CardBrowser :
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     suspend fun rerenderAllCards() {
-        renderBrowserQAParams(0, mCards.size() - 1, mCards)
+        renderBrowserQAParams(0, mCards.size() - 1, mCards.toList())
     }
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -28,17 +28,16 @@ import androidx.appcompat.app.AppCompatDialogFragment
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
+import com.ichi2.anki.model.CardsOrNotes
 
-class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTruncated: Boolean) : AppCompatDialogFragment() {
+class BrowserOptionsDialog(private val cardsOrNotes: CardsOrNotes, private val isTruncated: Boolean) : AppCompatDialogFragment() {
     private lateinit var dialogView: View
 
     private val positiveButtonClick = { _: DialogInterface, _: Int ->
-        val newCardsMode: Boolean
-
         @IdRes val selectedButtonId = dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
-        newCardsMode = selectedButtonId == R.id.select_cards_mode
-        if (inCardsMode != newCardsMode) {
-            (activity as CardBrowser).switchCardOrNote(newCardsMode)
+        val newCardsOrNotes = if (selectedButtonId == R.id.select_cards_mode) CardsOrNotes.CARDS else CardsOrNotes.NOTES
+        if (cardsOrNotes != newCardsOrNotes) {
+            (activity as CardBrowser).switchCardOrNote(newCardsOrNotes)
         }
         val newTruncate = dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked
 
@@ -51,7 +50,7 @@ class BrowserOptionsDialog(private val inCardsMode: Boolean, private val isTrunc
         val layoutInflater = requireActivity().layoutInflater
         dialogView = layoutInflater.inflate(R.layout.browser_options_dialog, null)
 
-        if (inCardsMode) {
+        if (cardsOrNotes == CardsOrNotes.CARDS) {
             dialogView.findViewById<RadioButton>(R.id.select_cards_mode).isChecked = true
         } else {
             dialogView.findViewById<RadioButton>(R.id.select_notes_mode).isChecked = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/CardsOrNotes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/CardsOrNotes.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import anki.config.ConfigKey
+import com.ichi2.libanki.Collection
+
+/**
+ * Config: Whether the `CardBrowser` is in "Cards" or "Notes" mode
+ *
+ * @see ConfigKey.Bool.BROWSER_TABLE_SHOW_NOTES_MODE
+ */
+enum class CardsOrNotes {
+    CARDS,
+    NOTES;
+
+    fun saveToCollection(collection: Collection) {
+        collection.config.setBool(ConfigKey.Bool.BROWSER_TABLE_SHOW_NOTES_MODE, this == NOTES)
+    }
+
+    companion object {
+        fun fromCollection(col: Collection): CardsOrNotes =
+            when (col.config.getBool(ConfigKey.Bool.BROWSER_TABLE_SHOW_NOTES_MODE)) {
+                true -> NOTES
+                false -> CARDS
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -92,6 +92,7 @@ object PreferenceUpgradeService {
                 yield(RemoveScrollingButtons())
                 yield(RemoveAnswerRecommended())
                 yield(RemoveBackupMax())
+                yield(RemoveInCardsMode())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -441,6 +442,15 @@ object PreferenceUpgradeService {
                     putInt("daily_backups_to_keep", legacyValue)
                     putInt("weekly_backups_to_keep", legacyValue)
                     putInt("monthly_backups_to_keep", legacyValue)
+                }
+            }
+        }
+
+        /** We should have used [anki.config.ConfigKey.Bool.BROWSER_TABLE_SHOW_NOTES_MODE] */
+        internal class RemoveInCardsMode : PreferenceUpgrade(14) {
+            override fun upgrade(preferences: SharedPreferences) {
+                preferences.edit {
+                    remove("inCardsMode")
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -72,13 +72,13 @@ fun updateValuesFromDeck(
 }
 
 suspend fun renderBrowserQA(
-    cards: CardBrowser.CardCollection<CardBrowser.CardCache>,
+    cards: List<CardBrowser.CardCache>,
     startPos: Int,
     n: Int,
     column1Index: Int,
     column2Index: Int,
     onProgressUpdate: (Int) -> Unit
-): Pair<CardBrowser.CardCollection<CardBrowser.CardCache>, MutableList<Long>> = withContext(Dispatchers.IO) {
+): Pair<List<CardBrowser.CardCache>, MutableList<Long>> = withContext(Dispatchers.IO) {
     Timber.d("doInBackgroundRenderBrowserQA")
     val invalidCardIds: MutableList<Long> = ArrayList()
     // for each specified card in the browser list
@@ -86,7 +86,7 @@ suspend fun renderBrowserQA(
         // Stop if cancelled, throw cancellationException
         ensureActive()
 
-        if (i < 0 || i >= cards.size()) {
+        if (i < 0 || i >= cards.size) {
             continue
         }
         val card: CardBrowser.CardCache = try {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -25,6 +25,7 @@ import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CardBrowser.CardCache
+import com.ichi2.anki.model.CardsOrNotes.*
 import com.ichi2.anki.model.SortType
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts
@@ -745,7 +746,7 @@ class CardBrowserTest : RobolectricTest() {
         browserWithNoNewCards.apply {
             searchAllDecks()
             assertThat("Result should contain 4 cards", cardCount, equalTo(4))
-            switchCardOrNote(newCardsMode = false)
+            switchCardOrNote(newCardsMode = NOTES)
             assertThat("Result should contain 2 cards (one per note)", cardCount, equalTo(2))
         }
     }
@@ -909,16 +910,14 @@ class CardBrowserTest : RobolectricTest() {
     fun checkCardsNotesMode() = runTest {
         val cardBrowser = getBrowserWithNotes(3, true)
 
-        // set browser to be in cards mode
-        cardBrowser.inCardsMode = true
+        cardBrowser.cardsOrNotes = CARDS
         cardBrowser.searchCards()
 
         advanceRobolectricUiLooper()
         // check if we get both cards of each note
         assertThat(cardBrowser.mCards.size(), equalTo(6))
 
-        // set browser to be in notes mode
-        cardBrowser.inCardsMode = false
+        cardBrowser.cardsOrNotes = NOTES
         cardBrowser.searchCards()
 
         // check if we get one card per note


### PR DESCRIPTION
## Purpose / Description
I have a pending large refactoring of `CardBrowser` which will be squashed, this extracts a few changes to preserve the history of functional changes, primarily the classes outside `CardBrowser`

## Approach
* Commit 1: Change a `CardCollection` to a `List` - primarily for #11889 to churn less code
* Commit 2:
  * Move from Preference to Config Variable so cards/notes will sync (note: the Config is reversed)
  * Convert to an enum for better documentation
  * Remove from `restoreInstanceState`, as it's defined by the collection config.

## How Has This Been Tested?
CI only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)