### PR TITLE
refactor: extract SortType

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -20,9 +20,9 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
-import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.model.SortType
 
 class CardBrowserOrderDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -30,7 +30,7 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
         val items = resources.getStringArray(R.array.card_browser_order_labels)
         // Set sort order arrow
         for (i in items.indices) {
-            if (i != CardBrowser.CARD_ORDER_NONE && i == requireArguments().getInt("order")) {
+            if (i != CARD_ORDER_NONE && i == requireArguments().getInt("order")) {
                 if (requireArguments().getBoolean("isOrderAsc")) {
                     items[i] = items[i].toString() + " (\u25b2)"
                 } else {
@@ -48,14 +48,17 @@ class CardBrowserOrderDialog : AnalyticsDialogFragment() {
     companion object {
         private var orderSingleChoiceDialogListener: DialogInterface.OnClickListener? = null
 
+        // SortType.NO_SORTING.cardBrowserLabelIndex
+        private const val CARD_ORDER_NONE = 0
+
         fun newInstance(
-            order: Int,
+            order: SortType,
             isOrderAsc: Boolean,
             orderSingleChoiceDialogListener: DialogInterface.OnClickListener
         ): CardBrowserOrderDialog {
             val f = CardBrowserOrderDialog()
             val args = Bundle()
-            args.putInt("order", order)
+            args.putInt("order", order.cardBrowserLabelIndex)
             args.putBoolean("isOrderAsc", isOrderAsc)
             this.orderSingleChoiceDialogListener = orderSingleChoiceDialogListener
             f.arguments = args

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.R
+import com.ichi2.libanki.Config
+import com.ichi2.libanki.SortOrder
+
+/**
+ * How to sort the rows in the [CardBrowser]
+ *
+ * This is an adapter from our [SharedPreferences] based handling of sorting
+ * to Anki's [Config]
+ *
+ * We can likely remove the SharedPreferences and rely entirely on Anki
+ *
+ * @param ankiSortType The value to be passed into Anki's "sortType" config
+ * @param cardBrowserLabelIndex The index into [R.array.card_browser_order_labels]
+ */
+@Suppress("unused") // 'unused' entries are iterated over by .entries
+enum class SortType(val ankiSortType: String?, val cardBrowserLabelIndex: Int) {
+    NO_SORTING(null, 0),
+    SORT_FIELD("noteFld", 1),
+    CREATED_TIME("noteCrt", 2),
+    NOTE_MODIFICATION_TIME("noteMod", 3),
+    CARD_MODIFICATION_TIME("cardMod", 4),
+    DUE_TIME("cardDue", 5),
+    INTERVAL("cardIvl", 6),
+    EASE("cardEase", 7),
+    REVIEWS("cardReps", 8),
+    LAPSES("cardLapses", 9);
+
+    fun save(config: Config, preferences: SharedPreferences) {
+        // in the case of 'no sorting', we still need a sort type.
+        // The inverse is handled in `fromCol`
+        config.set("sortType", this.ankiSortType ?: SORT_FIELD.ankiSortType)
+        preferences.edit {
+            putBoolean("cardBrowserNoSorting", this@SortType == NO_SORTING)
+        }
+    }
+
+    /** Converts the [SortType] to a [SortOrder] */
+    fun toSortOrder(): SortOrder =
+        if (this == NO_SORTING) SortOrder.NoOrdering() else SortOrder.UseCollectionOrdering()
+
+    companion object {
+        fun fromCol(config: Config, preferences: SharedPreferences): SortType {
+            val colOrder = config.get<String>("sortType")
+            val type = entries.firstOrNull { it.ankiSortType == colOrder } ?: NO_SORTING
+            if (type == SORT_FIELD && preferences.getBoolean("cardBrowserNoSorting", false)) {
+                return NO_SORTING
+            }
+            return type
+        }
+
+        fun fromCardBrowserLabelIndex(index: Int): SortType {
+            return entries.firstOrNull { it.cardBrowserLabelIndex == index } ?: NO_SORTING
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -25,6 +25,7 @@ import androidx.core.app.ActivityCompat
 import androidx.fragment.app.Fragment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CardBrowser.CardCache
+import com.ichi2.anki.model.SortType
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
@@ -426,7 +427,7 @@ class CardBrowserTest : RobolectricTest() {
         )
 
         // reverse
-        b.changeCardOrder(1)
+        b.changeCardOrder(SortType.SORT_FIELD)
 
         assertThat(b.getPropertiesForCardId(cid1).position, equalTo(1))
         assertThat(b.getPropertiesForCardId(cid2).position, equalTo(0))
@@ -682,7 +683,7 @@ class CardBrowserTest : RobolectricTest() {
         )
 
         // Change the display order of the card browser
-        cardBrowserController.get().changeCardOrder(7) // order no. 7 corresponds to "cardEase"
+        cardBrowserController.get().changeCardOrder(SortType.EASE)
 
         // Kill and restart the activity and ensure that display order is preserved
         val outBundle = Bundle()


### PR DESCRIPTION
## Purpose / Description
I'm about to perform a large refactoring on CardBrowse, this large change will be squash merged

This change reduces the impact of this squash, allows a more thorough review and reduces the number of files changed

## Approach
* Extracting methods to a class, then looking through the logic and seeing what can be simplified

## How Has This Been Tested?
Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
