### PR TITLE
fix: 'mark' should not flip card to question

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -216,7 +216,7 @@ open class Reviewer :
             return
         }
         launchCatchingTask {
-            toggleMark(card.note())
+            toggleMark(card.note(), handler = this@Reviewer)
             refreshActionBar()
             onMarkChanged()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -138,7 +138,8 @@ open class Reviewer :
     private var mPrefShowETA = false
 
     /** Handle Mark/Flag state of cards  */
-    private var mCardMarker: CardMarker? = null
+    @VisibleForTesting
+    internal var mCardMarker: CardMarker? = null
 
     // Preferences from the collection
     private var mShowRemainingCardCount = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardMarker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/CardMarker.kt
@@ -38,6 +38,10 @@ class CardMarker(private val markView: ImageView, private val flagView: ImageVie
         }
     }
 
+    /** Whether the mark icon is visible on the toolbar */
+    val isDisplayingMark: Boolean
+        get() = markView.visibility == View.VISIBLE
+
     /** Sets the flag icon on the card  */
     fun displayFlag(@FlagDef flagStatus: Int) {
         when (flagStatus) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -181,14 +181,14 @@ object NoteService {
         }
     }
 
-    suspend fun toggleMark(note: Note) {
+    suspend fun toggleMark(note: Note, handler: Any? = null) {
         if (isMarked(note)) {
             note.delTag("marked")
         } else {
             note.addTag("marked")
         }
 
-        undoableOp {
+        undoableOp(handler) {
             updateNote(note)
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -22,6 +22,8 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_DEFAULT
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.cardviewer.ViewerCommand.FLIP_OR_ANSWER_EASE1
+import com.ichi2.anki.cardviewer.ViewerCommand.MARK
 import com.ichi2.anki.preferences.PreferenceTestUtils
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ActionButtonStatus
@@ -269,6 +271,16 @@ class ReviewerTest : RobolectricTest() {
         )
     }
 
+    @Test
+    fun `A card is not flipped after 'mark' Issue 14656`() = runTest {
+        startReviewer(withCards = 1).apply {
+            executeCommand(FLIP_OR_ANSWER_EASE1)
+            assertThat("card is showing answer", isDisplayingAnswer)
+            executeCommand(MARK)
+            assertThat("card is showing answer after mark", isDisplayingAnswer)
+        }
+    }
+
     private fun toggleWhiteboard(reviewer: ReviewerForMenuItems) {
         reviewer.toggleWhiteboard()
 
@@ -369,7 +381,10 @@ class ReviewerTest : RobolectricTest() {
         notetypes.addTemplate(m, newTemplate)
     }
 
-    private fun startReviewer(): Reviewer {
+    private fun startReviewer(withCards: Int = 0): Reviewer {
+        for (i in 0 until withCards) {
+            addNoteUsingBasicModel()
+        }
         return startReviewer(this)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -281,6 +281,17 @@ class ReviewerTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `Marking a card is undone by marking again`() = runTest {
+        startReviewer(withCards = 1).apply {
+            assertThat("card is not marked before action", !isDisplayingMark)
+            executeCommand(MARK)
+            assertThat("card is marked after action", isDisplayingMark)
+            executeCommand(MARK)
+            assertThat("marking a card twice disables the mark", !isDisplayingMark)
+        }
+    }
+
     private fun toggleWhiteboard(reviewer: ReviewerForMenuItems) {
         reviewer.toggleWhiteboard()
 
@@ -441,3 +452,5 @@ class ReviewerTest : RobolectricTest() {
         }
     }
 }
+
+val Reviewer.isDisplayingMark: Boolean get() = this.mCardMarker!!.isDisplayingMark

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -376,7 +376,7 @@ open class RobolectricTest : AndroidTest {
         return startActivityNormallyOpenCollectionWithIntent(T::class.java, i)
     }
 
-    protected fun addNoteUsingBasicModel(front: String, back: String): Note {
+    protected fun addNoteUsingBasicModel(front: String = "Front", back: String = "Back"): Note {
         return addNoteUsingModelName("Basic", front, back)
     }
 


### PR DESCRIPTION
## Purpose / Description
* #14656

## Fixes
* Partially #14656

## Approach
`AbstractFlashCardViewer::opExecuted` performs `updateCardAndRedraw` unless `handler === this`

`updateCardAndRedraw` flips the card to the question

Since we handle the state change: `onMark` -> `onMarkChanged` we don't need the call to `updateCardAndRedraw`

## How Has This Been Tested?
Added a couple unit tests, tested briefly on device

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
