### PR TITLE
regression tests: corrupt 'curDeck' value (Issue 14096)

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -25,6 +25,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.editorCard
 import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
 import com.ichi2.anki.NoteEditorTest.FromScreen.REVIEWER
+import com.ichi2.anki.api.AddContentApi.Companion.DEFAULT_DECK_ID
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
@@ -347,6 +348,14 @@ class NoteEditorTest : RobolectricTest() {
         assertEquals("012345text", field.fieldText)
         assertEquals(10, field.selectionStart)
         assertEquals(10, field.selectionEnd)
+    }
+
+    @Test
+    fun `can open with corrupt current deck - Issue 14096`() {
+        col.config.set(CURRENT_DECK, '"' + "1688546411954" + '"')
+        getNoteEditorAddingNote(DECK_LIST, NoteEditor::class.java).apply {
+            assertThat("current deck is default after corruption", deckId, equalTo(DEFAULT_DECK_ID))
+        }
     }
 
     private fun getCopyNoteIntent(editor: NoteEditor): Intent {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ConfigTest.kt
@@ -71,6 +71,17 @@ class ConfigTest : JvmTest() {
             col.config.set("map2", map2)
         }
     }
+
+    @Test
+    fun `A string value is handled as a long - Issue 14096`() {
+        col.config.set("test", '"' + "1688546411954" + '"')
+        col.config.set("test1", "1688546411954")
+        col.config.set("test2", 1688546411954)
+
+        assertThat(col.config.get<Long>("test"), equalTo(null))
+        assertThat(col.config.get<Long>("test1"), equalTo(1688546411954L))
+        assertThat(col.config.get<Long>("test2"), equalTo(1688546411954L))
+    }
 }
 
 @Serializable


### PR DESCRIPTION
## Purpose / Description
Proving that #14096 is fixed

## Fixes
* Fixes #14096

## Approach
Already fixed in

* #14171
* 7a65160e0e23e20080091a30abdd4c05fc610e06
* unsquashed: (a6dce65ab5ac2c43783bfc0b96ee7ec00393121e)

This adds regression cover for Issue 14096

## How Has This Been Tested?
Test-only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
