### PR TITLE
refactor: Extract 'CardStateFilter'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.cardviewer.TypeAnswer.Companion.createInstance
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.reviewer.*
@@ -2503,7 +2504,7 @@ abstract class AbstractFlashcardViewer :
         showDialogFragment(dialog)
     }
 
-    override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int) {
+    override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter) {
         if (currentCard!!.note().tags != selectedTags) {
             val tagString = selectedTags.joinToString(" ")
             val note = currentCard!!.note()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -59,6 +59,7 @@ import com.ichi2.anki.dialogs.IntegerDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivityExtra
@@ -1094,7 +1095,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     override fun onSelectedTags(
         selectedTags: List<String>,
         indeterminateTags: List<String>,
-        option: Int
+        stateFilter: CardStateFilter
     ) {
         if (mSelectedTags != selectedTags) {
             isTagsEdited = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -43,6 +43,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuConfigura
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.*
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
@@ -318,12 +319,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
      * Generates the search screen for the custom study deck.
      */
     @NeedsTest("14537: limit to particular tags")
-    override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int) {
-        val sb = StringBuilder()
-        when (option) {
-            1 -> sb.append("is:new ")
-            2 -> sb.append("is:due ")
-        }
+    override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter) {
+        val sb = StringBuilder(stateFilter.toSearch)
         val arr: MutableList<String?> = ArrayList(selectedTags.size)
         if (selectedTags.isNotEmpty()) {
             for (tag in selectedTags) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki.dialogs.tags
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.ichi2.anki.model.CardStateFilter
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.KotlinCleanup
 import java.util.ArrayList
 
@@ -31,9 +33,9 @@ interface TagsDialogListener {
      * determining if tags in this list is checked or not is done by looking at the list of
      * previous tags. if the tag is found in both previous and indeterminate, it should be kept
      * otherwise it should be removed @see [com.ichi2.utils.TagsUtil.getUpdatedTags]
-     * @param option selection radio option, should be ignored if not expected
+     * @param stateFilter selection radio option, should be ignored if not expected
      */
-    fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int)
+    fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter)
     fun <F> F.registerFragmentResultReceiver() where F : Fragment, F : TagsDialogListener {
         parentFragmentManager.setFragmentResultListener(
             ON_SELECTED_TAGS_KEY,
@@ -43,18 +45,18 @@ interface TagsDialogListener {
                 bundle.getStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS)!!
             val indeterminateTags: List<String> =
                 bundle.getStringArrayList(ON_SELECTED_TAGS__INDETERMINATE_TAGS)!!
-            val option = bundle.getInt(ON_SELECTED_TAGS__OPTION)
+            val option = bundle.getSerializableCompat<CardStateFilter>(ON_SELECTED_TAGS__OPTION)!!
             onSelectedTags(selectedTags, indeterminateTags, option)
         }
     }
 
     companion object {
         fun createFragmentResultSender(fragmentManager: FragmentManager) = object : TagsDialogListener {
-            override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, option: Int) {
+            override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter) {
                 val bundle = Bundle().apply {
                     putStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS, ArrayList(selectedTags))
                     putStringArrayList(ON_SELECTED_TAGS__INDETERMINATE_TAGS, ArrayList(indeterminateTags))
-                    putInt(ON_SELECTED_TAGS__OPTION, option)
+                    putSerializable(ON_SELECTED_TAGS__OPTION, stateFilter)
                 }
                 fragmentManager.setFragmentResult(ON_SELECTED_TAGS_KEY, bundle)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/CardStateFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/CardStateFilter.kt
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.model
+
+/**
+ * Allows filtering a search by the state of cards
+ *
+ * @see [anki.search.SearchNode.CardState]
+ */
+enum class CardStateFilter {
+    ALL_CARDS,
+    NEW,
+    DUE
+    ;
+
+    val toSearch: String
+        get() = when (this) {
+            ALL_CARDS -> ""
+            NEW -> "is:new "
+            DUE -> "is:due "
+        }
+}

--- a/AnkiDroid/src/main/res/layout/tags_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog.xml
@@ -21,7 +21,7 @@
         android:layout_centerHorizontal="true"
         android:layout_alignParentBottom="true"
         android:orientation="horizontal">
-
+        <!-- editing this requires a to map to CardStateFilter inside TagsDialog -->
         <RadioButton
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -30,6 +30,8 @@ import com.afollestad.materialdialogs.WhichButton
 import com.afollestad.materialdialogs.actions.getActionButton
 import com.afollestad.materialdialogs.customview.getCustomView
 import com.ichi2.anki.R
+import com.ichi2.anki.model.CardStateFilter
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.RecyclerViewUtils
 import com.ichi2.ui.CheckBoxTriStates
@@ -42,7 +44,6 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
 import java.util.*
-import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
@@ -64,8 +65,8 @@ class TagsDialogTest {
             val body = dialog!!.getCustomView()
             val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
             Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
-            val expectedOption = 1
-            optionsGroup.getChildAt(expectedOption).performClick()
+            val expectedOption = CardStateFilter.NEW
+            optionsGroup.getChildAt(1).performClick()
             dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
             Mockito.verify(mockListener, Mockito.times(1)).onSelectedTags(ArrayList(), ArrayList(), expectedOption)
         }
@@ -84,23 +85,23 @@ class TagsDialogTest {
             val dialog = f.dialog as MaterialDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
             val returnedList = AtomicReference<List<String>?>()
-            val returnedOption = AtomicInteger()
+            val returnedOption = AtomicReference<CardStateFilter>()
             f.parentFragmentManager.setFragmentResultListener(
                 TagsDialogListener.ON_SELECTED_TAGS_KEY,
                 mockLifecycleOwner(),
                 { _: String?, bundle: Bundle ->
                     returnedList.set(bundle.getStringArrayList(TagsDialogListener.ON_SELECTED_TAGS__SELECTED_TAGS))
-                    returnedOption.set(bundle.getInt(TagsDialogListener.ON_SELECTED_TAGS__OPTION))
+                    returnedOption.set(bundle.getSerializableCompat<CardStateFilter>(TagsDialogListener.ON_SELECTED_TAGS__OPTION))
                 }
             )
             val body = dialog!!.getCustomView()
             val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
             Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
-            val expectedOption = 2
-            optionsGroup.getChildAt(expectedOption).performClick()
+            val expectedOption = CardStateFilter.DUE
+            optionsGroup.getChildAt(2).performClick()
             dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
             ListUtil.assertListEquals(ArrayList(), returnedList.get())
-            Assert.assertEquals(expectedOption.toLong(), returnedOption.get().toLong())
+            Assert.assertEquals(expectedOption, returnedOption.get())
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

TagsDialog contains a confusing 'option' parameter

This maps to `[All Cards, New, Due]`: The card state 

Anki has moved to a much larger collection of states so there is also expected extension here

<img width="338" alt="Screenshot 2023-11-26 at 14 59 26" src="https://github.com/ankidroid/Anki-Android/assets/62114487/bcf1e51b-daf4-4c4c-90cd-9e356c9623e8">


Now, this probably doesn't belong in TagsDialog:

* Not used in Note Editor/CardViewer

but for now, refactor to explain 'option':

This is part of a larger CardBrowser refactoring 

After CardBrowser is completed, there will likely be opportunity to fix this use case of TagsDialog as it will be used in one place

## Approach
* Introduce `CardStateFilter` class
* Fix too many API breakages

## How Has This Been Tested?
Unit test + briefly on an API33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
