### PR TITLE
fix: issues with sound playing unexpectedly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -45,6 +45,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toFile
 import androidx.core.view.children
 import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
 import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
 import com.drakeet.drawer.FullDraggableContainer
@@ -1429,7 +1430,13 @@ abstract class AbstractFlashcardViewer :
      * @param doAudioReplay indicates an anki desktop-like replay call is desired, whose behavior is identical to
      * pressing the keyboard shortcut R on the desktop
      */
+    @NeedsTest("audio is not played if opExecuted occurs when viewer is in the background")
     protected open fun playSounds(doAudioReplay: Boolean) {
+        // this can occur due to OpChanges when the viewer is on another screen
+        if (!this.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            Timber.w("sounds are not played as the activity is inactive")
+            return
+        }
         val replayQuestion = mCardSoundConfig!!.replayQuestion
         if (mCardSoundConfig!!.autoplay || doAudioReplay) {
             // Use TTS if TTS preference enabled and no other sound source

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -45,7 +45,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toFile
 import androidx.core.view.children
 import androidx.core.view.isVisible
-import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.Lifecycle.State.RESUMED
 import androidx.webkit.WebViewAssetLoader
 import anki.collection.OpChanges
 import com.drakeet.drawer.FullDraggableContainer
@@ -273,6 +273,13 @@ abstract class AbstractFlashcardViewer :
 
     private val migrationService by migrationServiceWhileStartedOrNull()
 
+    /**
+     * Changes which were received when the viewer was in the background
+     * which should be executed once the viewer is visible again
+     * @see opExecuted
+     * @see refreshIfRequired
+     */
+    private var refreshRequired: ViewerRefresh? = null
     init {
         ChangeManager.subscribe(this)
     }
@@ -445,6 +452,8 @@ abstract class AbstractFlashcardViewer :
     }
 
     internal suspend fun updateCardAndRedraw() {
+        refreshRequired = null // this method is called on refresh
+
         updateCurrentCard()
 
         if (currentCard == null) {
@@ -580,6 +589,30 @@ abstract class AbstractFlashcardViewer :
         // Reset the activity title
         updateActionBar()
         selectNavigationItem(-1)
+        refreshIfRequired(isResuming = true)
+    }
+
+    /**
+     * If the activity is [RESUMED], or is called from [onResume] then execute the pending
+     * operations in [refreshRequired].
+     *
+     * If the activity is NOT [RESUMED], wait until [onResume]
+     */
+    @NeedsTest("if opExecuted is called while activity is in the background, audio plays onResume")
+    private fun refreshIfRequired(isResuming: Boolean = false) {
+        // Defer the execution of `opExecuted` until the user is looking at the screen.
+        // This ensures that audio/timers are not accidentally started
+        if (isResuming || lifecycle.currentState.isAtLeast(RESUMED)) {
+            refreshRequired?.let {
+                Timber.d("refreshIfRequired: redraw")
+                // if changing code, re-evaluate `refreshRequired = null` in `updateCardAndRedraw`
+                launchCatchingTask { updateCardAndRedraw() }
+                refreshRequired = null
+            }
+        } else if (refreshRequired != null) {
+            // onResume() will execute this method
+            Timber.d("deferred refresh as activity was not STARTED")
+        }
     }
 
     override fun onDestroy() {
@@ -1433,7 +1466,7 @@ abstract class AbstractFlashcardViewer :
     @NeedsTest("audio is not played if opExecuted occurs when viewer is in the background")
     protected open fun playSounds(doAudioReplay: Boolean) {
         // this can occur due to OpChanges when the viewer is on another screen
-        if (!this.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+        if (!this.lifecycle.currentState.isAtLeast(RESUMED)) {
             Timber.w("sounds are not played as the activity is inactive")
             return
         }
@@ -2526,10 +2559,9 @@ abstract class AbstractFlashcardViewer :
     }
 
     override fun opExecuted(changes: OpChanges, handler: Any?) {
-        if ((changes.studyQueues || changes.noteText || changes.card) && handler !== this) {
-            Timber.d("opExecuted: redraw")
-            launchCatchingTask { updateCardAndRedraw() }
-        }
+        if (handler === this) return
+        refreshRequired = ViewerRefresh.updateState(refreshRequired, changes)
+        refreshIfRequired()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerRefresh.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerRefresh.kt
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer
+
+import anki.collection.OpChanges
+
+/** Data for a deferred refresh of the CardViewer */
+data class ViewerRefresh(val queues: Boolean, val note: Boolean, val card: Boolean) {
+    companion object {
+        /** updates the current state of the ViewerRefresh with additional data */
+        fun updateState(currentState: ViewerRefresh?, changes: OpChanges): ViewerRefresh? {
+            if (!changes.studyQueues && !changes.noteText && !changes.card) return currentState
+            return ViewerRefresh(
+                queues = changes.studyQueues || currentState?.queues == true,
+                note = changes.noteText || currentState?.note == true,
+                card = changes.card || currentState?.card == true
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -42,7 +42,7 @@ private typealias SoundPath = String
  * Parses, loads and plays sound & video files
  * Called `Sound` Anki uses `[sound:]` for both audio and video
  */
-class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) : SoundPlayer() {
+class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) {
     /**
      * @param soundDir base path to the media files
      */
@@ -109,12 +109,20 @@ class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) 
         soundPathCollection.addAll(paths)
     }
 
+    fun playSound(
+        replacedUrl: String,
+        onCompletionListener: OnCompletionListener?,
+        soundErrorListener: OnErrorListener
+    ) {
+        soundPlayer.playSound(replacedUrl, onCompletionListener, soundErrorListener)
+    }
+
     /** Plays all the sounds for the indicated side(s)  */
     fun playSounds(side: SoundSide, errorListener: OnErrorListener?) {
         // If there are sounds to play for the current card, start with the first one
         val soundPaths = getSounds(side) ?: return
         Timber.d("playSounds: playing $side")
-        this.playSound(
+        this.soundPlayer.playSound(
             soundPaths[0],
             PlayAllCompletionListener(side, errorListener),
             errorListener
@@ -156,7 +164,7 @@ class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) 
             // If there are still more sounds to play for the current card, play the next one
             if (nextIndexToPlay < paths.size) {
                 Timber.i("Play all: Playing next sound")
-                playSound(paths[nextIndexToPlay++], this, errorListener)
+                soundPlayer.playSound(paths[nextIndexToPlay++], this, errorListener)
             } else {
                 Timber.i("Play all: Completed - releasing sound")
                 soundPlayer.stopSounds()
@@ -164,7 +172,8 @@ class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) 
         }
     }
 
-    override fun stopSounds() {
+    fun stopSounds() {
+        Timber.d("stopping sounds")
         soundPlayer.stopSounds()
         ReadText.stopTts() // TODO: Reconsider design
     }


### PR DESCRIPTION
## Fixes
* Fixes #14414
* Fixes #14616
* Fixes #14496
* Fixes #14788
* Probably Fixes #14480

## Approach
* code to stop sounds from playing if the activity is in the wrong state
  * I suspect this occurs after a WebView OOM in the background 
* defer `opChanges` handling to after `onResume()`
* fix `Sounds.kt` breakage

## How Has This Been Tested?
* Add audio to a note
* Change to the answer
* Audio now stops playing

----

* switch to card browser
* switch back

No audio is played

----

* switch to card browser
* mark a note
* audio is played after returning to card viewer

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
