### PR TITLE
8602 - NoteEditor startActivityForResult Migration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -84,6 +84,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
@@ -178,7 +179,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
     )
 
-    @Suppress("DEPRECATION")
     private val requestMultiMediaEditLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult(),
         @NeedsTest("test to guard against changes in the REQUEST_MULTIMEDIA_EDIT clause preventing text fields to be updated")
@@ -187,7 +187,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 val col = getColUnsafe
                 val extras = result.data!!.extras ?: return@NoteEditorActivityResultCallback
                 val index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX)
-                val field = extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return@NoteEditorActivityResultCallback
+                val field = extras.getSerializableCompat<IField>(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD) ?: return@NoteEditorActivityResultCallback
                 if (field.type != EFieldType.TEXT && (field.imagePath == null && field.audioPath == null)) {
                     Timber.i("field imagePath and audioPath are both null")
                     return@NoteEditorActivityResultCallback

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -35,6 +35,9 @@ import android.view.ViewGroup.MarginLayoutParams
 import android.widget.*
 import android.widget.AdapterView.OnItemSelectedListener
 import androidx.activity.addCallback
+import androidx.activity.result.ActivityResult
+import androidx.activity.result.ActivityResultCallback
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
@@ -165,6 +168,87 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // save field index as key and text as value when toggle sticky clicked in Field Edit Text
     private var mToggleStickyText: HashMap<Int, String?> = HashMap()
     private val mOnboarding = Onboarding.NoteEditor(this)
+
+    private val requestAddLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+        NoteEditorActivityResultCallback {
+            if (it.resultCode != RESULT_CANCELED) {
+                changed = true
+            }
+        }
+    )
+
+    @Suppress("DEPRECATION")
+    private val requestMultiMediaEditLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+        @NeedsTest("test to guard against changes in the REQUEST_MULTIMEDIA_EDIT clause preventing text fields to be updated")
+        NoteEditorActivityResultCallback { result ->
+            if (result.resultCode != RESULT_CANCELED) {
+                val col = getColUnsafe
+                val extras = result.data!!.extras ?: return@NoteEditorActivityResultCallback
+                val index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX)
+                val field = extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return@NoteEditorActivityResultCallback
+                if (field.type != EFieldType.TEXT && (field.imagePath == null && field.audioPath == null)) {
+                    Timber.i("field imagePath and audioPath are both null")
+                    return@NoteEditorActivityResultCallback
+                }
+                val note = getCurrentMultimediaEditableNote(col)
+                note.setField(index, field)
+                val fieldEditText = mEditFields!![index]
+                // Import field media
+                // This goes before setting formattedValue to update
+                // media paths with the checksum when they have the same name
+                NoteService.importMediaToDirectory(col, field)
+                // Completely replace text for text fields (because current text was passed in)
+                val formattedValue = field.formattedValue
+                if (field.type === EFieldType.TEXT) {
+                    fieldEditText!!.setText(formattedValue)
+                } else if (fieldEditText!!.text != null) {
+                    insertStringInField(fieldEditText, formattedValue)
+                }
+                changed = true
+            }
+        }
+    )
+
+    private val requestTemplateEditLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+        NoteEditorActivityResultCallback {
+            // Model can change regardless of exit type - update ourselves and CardBrowser
+            mReloadRequired = true
+            mEditorNote!!.reloadModel()
+            if (mCurrentEditedCard == null || !mEditorNote!!.cids()
+                .contains(mCurrentEditedCard!!.id)
+            ) {
+                if (!addNote) {
+                /* This can occur, for example, if the
+                     * card type was deleted or if the note
+                     * type was changed without moving this
+                     * card to another type. */
+                    Timber.d("onActivityResult() template edit return - current card is gone, close note editor")
+                    showSnackbar(getString(R.string.template_for_current_card_deleted))
+                    closeNoteEditor()
+                } else {
+                    Timber.d("onActivityResult() template edit return, in add mode, just re-display")
+                }
+            } else {
+                Timber.d("onActivityResult() template edit return - current card exists")
+                // reload current card - the template ordinals are possibly different post-edit
+                mCurrentEditedCard = getColUnsafe.getCard(mCurrentEditedCard!!.id)
+                updateCards(mEditorNote!!.notetype)
+            }
+        }
+    )
+
+    private inner class NoteEditorActivityResultCallback(private val callback: (result: ActivityResult) -> Unit) : ActivityResultCallback<ActivityResult> {
+        override fun onActivityResult(result: ActivityResult) {
+            Timber.d("onActivityResult() with result: %s", result.resultCode)
+            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
+                closeNoteEditor(DeckPicker.RESULT_DB_ERROR, null)
+            }
+            callback(result)
+        }
+    }
 
     override fun onDeckSelected(deck: SelectableDeck?) {
         if (deck == null) {
@@ -972,11 +1056,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         intent.putExtra(EXTRA_DID, deckId)
         // mutate event with additional properties
         intentEnricher.accept(intent)
-        startActivityForResultWithAnimation(
-            intent,
-            REQUEST_ADD,
-            START
-        )
+        launchActivityForResultWithAnimation(intent, requestAddLauncher, START)
     }
 
     // ----------------------------------------------------------------------------
@@ -1119,81 +1199,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             intent.putExtra("ordId", mCurrentEditedCard!!.ord)
             Timber.d("showCardTemplateEditor() with ord %s", mCurrentEditedCard!!.ord)
         }
-        startActivityForResultWithAnimation(
-            intent,
-            REQUEST_TEMPLATE_EDIT,
-            START
-        )
-    }
-
-    @Suppress("deprecation") // onActivityResult
-    @Deprecated("Use Activity Result API")
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        Timber.d("onActivityResult() with request/result: %s/%s", requestCode, resultCode)
-        super.onActivityResult(requestCode, resultCode, data)
-        if (resultCode == DeckPicker.RESULT_DB_ERROR) {
-            closeNoteEditor(DeckPicker.RESULT_DB_ERROR, null)
-        }
-        when (requestCode) {
-            REQUEST_ADD -> {
-                if (resultCode != RESULT_CANCELED) {
-                    changed = true
-                }
-            }
-            @NeedsTest("test to guard against changes in the REQUEST_MULTIMEDIA_EDIT clause preventing text fields to be updated")
-            REQUEST_MULTIMEDIA_EDIT -> {
-                if (resultCode != RESULT_CANCELED) {
-                    val col = getColUnsafe
-                    val extras = data!!.extras ?: return
-                    val index = extras.getInt(MultimediaEditFieldActivity.EXTRA_RESULT_FIELD_INDEX)
-                    val field = extras[MultimediaEditFieldActivity.EXTRA_RESULT_FIELD] as IField? ?: return
-                    if (field.type != EFieldType.TEXT && (field.imagePath == null && field.audioPath == null)) {
-                        Timber.i("field imagePath and audioPath are both null")
-                        return
-                    }
-                    val note = getCurrentMultimediaEditableNote(col)
-                    note.setField(index, field)
-                    val fieldEditText = mEditFields!![index]
-                    // Import field media
-                    // This goes before setting formattedValue to update
-                    // media paths with the checksum when they have the same name
-                    NoteService.importMediaToDirectory(col, field)
-                    // Completely replace text for text fields (because current text was passed in)
-                    val formattedValue = field.formattedValue
-                    if (field.type === EFieldType.TEXT) {
-                        fieldEditText!!.setText(formattedValue)
-                    } else if (fieldEditText!!.text != null) {
-                        insertStringInField(fieldEditText, formattedValue)
-                    }
-                    changed = true
-                }
-            }
-            REQUEST_TEMPLATE_EDIT -> {
-                // Model can change regardless of exit type - update ourselves and CardBrowser
-                mReloadRequired = true
-                mEditorNote!!.reloadModel()
-                if (mCurrentEditedCard == null || !mEditorNote!!.cids()
-                    .contains(mCurrentEditedCard!!.id)
-                ) {
-                    if (!addNote) {
-                        /* This can occur, for example, if the
-                             * card type was deleted or if the note
-                             * type was changed without moving this
-                             * card to another type. */
-                        Timber.d("onActivityResult() template edit return - current card is gone, close note editor")
-                        showSnackbar(getString(R.string.template_for_current_card_deleted))
-                        closeNoteEditor()
-                    } else {
-                        Timber.d("onActivityResult() template edit return, in add mode, just re-display")
-                    }
-                } else {
-                    Timber.d("onActivityResult() template edit return - current card exists")
-                    // reload current card - the template ordinals are possibly different post-edit
-                    mCurrentEditedCard = getColUnsafe.getCard(mCurrentEditedCard!!.id)
-                    updateCards(mEditorNote!!.notetype)
-                }
-            }
-        }
+        launchActivityForResultWithAnimation(intent, requestTemplateEditLauncher, START)
     }
 
     /** Appends a string at the selection point, or appends to the end if not in focus  */
@@ -1485,7 +1491,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         val field = note!!.getField(index)!!
         val editCard = Intent(this@NoteEditor, MultimediaEditFieldActivity::class.java)
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY, MultimediaEditFieldActivityExtra(index, field, note))
-        startActivityForResultWithoutAnimation(editCard, REQUEST_MULTIMEDIA_EDIT)
+        launchActivityForResultWithAnimation(editCard, requestMultiMediaEditLauncher, NONE)
     }
 
     private fun initFieldEditText(editText: FieldEditText?, index: Int, enabled: Boolean) {
@@ -2185,9 +2191,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         const val CALLER_CARDBROWSER_ADD = 7
         const val CALLER_NOTEEDITOR = 8
         const val CALLER_NOTEEDITOR_INTENT_ADD = 10
-        const val REQUEST_ADD = 0
-        const val REQUEST_MULTIMEDIA_EDIT = 2
-        const val REQUEST_TEMPLATE_EDIT = 3
 
         // preferences keys
         const val PREF_NOTE_EDITOR_SCROLL_TOOLBAR = "noteEditorScrollToolbar"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`startActivityForResult` is deprecated. We want to replace these calls using the new `registerForActivityResult` APIs.

- Created common NoteEditorActivityResultCallback inner class to pass to registerForActivityResult function. This will capture the common result code check behavior that was being done in onActivityResult and apply it to every ActivityResultLauncher when using the new registerForActivityResult API.
- Replaced startActivityForResult for REQUEST_ADD with registerForActivityResult API implementation.
- Replaced startActivityForResult for REQUEST_MULTIMEDIA_EDIT request code with registerForActivityResult API implementation.
- Replaced startActivityForResult for REQUEST_TEMPLATE_EDIT request code with registerForActivityResult API implementation.
- Removed onActivityResult, since all request codes are covered by the registerForActivityResult API approach.

## Fixes
* Related: #8602 

## How Has This Been Tested?

I ran unit tests and I manually tested the functionality on an emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
