### PR TITLE
fix: API crashes with UnsatisfiedLinkError

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -150,6 +150,7 @@ class CardContentProvider : ContentProvider() {
     override fun onCreate(): Boolean {
         // Initialize content provider on startup.
         Timber.d("CardContentProvider: onCreate")
+        AnkiDroidApp.makeBackendUsable(context!!)
         return true
     }
 


### PR DESCRIPTION
## Purpose / Description

We needed a call to `System.loadLibrary("rsdroid")`

## Fixes

* Fixes #14621
* Fixes #14829

### Exception Fixed

```
java.lang.UnsatisfiedLinkError: No implementation found for byte[][] net.ankiweb.rsdroid.NativeMethods.openBackend(byte[]) (tried Java_net_ankiweb_rsdroid_NativeMethods_openBackend and Java_net_ankiweb_rsdroid_NativeMethods_openBackend___3B) - is the library loaded, e.g. System.loadLibrary?
    at net.ankiweb.rsdroid.NativeMethods.openBackend(Native Method)
```


## Approach
* Uninstall AnkiDroid 'stable' from my 'stable' slot
* Install AnkiDroid 'alpha'
* Figure out getting the API tested
* Verify it was just not loading `rsdroid`

## How Has This Been Tested?
Apply the following and comment/uncomment the line in the ContentProvider

```patch
Subject: [PATCH] fix: API crashes with UnsatisfiedLinkError

Enables testing API
---
Index: AnkiDroid/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/build.gradle b/AnkiDroid/build.gradle
--- a/AnkiDroid/build.gradle	(revision 5f2cc3b10c0ea0852560e119b443f2a46ff60432)
+++ b/AnkiDroid/build.gradle	(date 1701217101164)
@@ -93,9 +93,9 @@
     }
     buildTypes {
         debug {
-            versionNameSuffix "-debug"
+//            versionNameSuffix "-debug"
+//            applicationIdSuffix ".debug"
             debuggable true
-            applicationIdSuffix ".debug"
             splits.abi.universalApk = true // Build universal APK for debug always
             // Check Crash Reports page on developer wiki for info on ACRA testing
             // buildConfigField "String", "ACRA_URL", '"https://918f7f55-f238-436c-b34f-c8b5f1331fe5-bluemix.cloudant.com/acra-ankidroid/_design/acra-storage/_update/report"'
Index: api/build.gradle.kts
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/api/build.gradle.kts b/api/build.gradle.kts
--- a/api/build.gradle.kts	(revision 5f2cc3b10c0ea0852560e119b443f2a46ff60432)
+++ b/api/build.gradle.kts	(date 1701217101165)
@@ -32,9 +32,9 @@
             buildConfigField(
                 "String",
                 "READ_WRITE_PERMISSION",
-                "\"com.ichi2.anki.debug.permission.READ_WRITE_DATABASE\""
+                "\"com.ichi2.anki.permission.READ_WRITE_DATABASE\""
             )
-            buildConfigField("String", "AUTHORITY", "\"com.ichi2.anki.debug.flashcards\"")
+            buildConfigField("String", "AUTHORITY", "\"com.ichi2.anki.flashcards\"")
         }
         release {
             isMinifyEnabled = false
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
