### PR TITLE
Issue 8602, Reviewer startActivityForResult Migration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -298,7 +298,9 @@ abstract class AbstractFlashcardViewer :
             }
         }
     )
-    protected inner class FlashCardViewerResultCallback(private val callback: (result: ActivityResult, reloadRequired: Boolean) -> Unit = { _, _ -> }) : ActivityResultCallback<ActivityResult> {
+    protected inner class FlashCardViewerResultCallback(
+        private val callback: (result: ActivityResult, reloadRequired: Boolean) -> Unit = { _, _ -> }
+    ) : ActivityResultCallback<ActivityResult> {
         override fun onActivityResult(result: ActivityResult) {
             if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
                 closeReviewer(DeckPicker.RESULT_DB_ERROR)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1644,7 +1644,6 @@ open class Reviewer :
     }
 
     companion object {
-        private const val ADD_NOTE = 12
         private const val REQUEST_AUDIO_PERMISSION = 0
         private const val ANIMATION_DURATION = 200
         private const val TRANSPARENCY = 0.90f

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -34,6 +34,7 @@ import android.text.style.UnderlineSpan
 import android.view.*
 import android.webkit.JavascriptInterface
 import android.widget.*
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
@@ -150,6 +151,11 @@ open class Reviewer :
     @VisibleForTesting
     protected val mProcessor = PeripheralKeymap(this, this)
     private val mOnboarding = Onboarding.Reviewer(this)
+
+    private val addNoteLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult(),
+        FlashCardViewerResultCallback()
+    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -657,7 +663,7 @@ open class Reviewer :
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_ADD)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
-        startActivityForResultWithAnimation(intent, ADD_NOTE, animation)
+        launchActivityForResultWithAnimation(intent, addNoteLauncher, animation)
     }
 
     @NeedsTest("Starting animation from swipe is inverse to the finishing one")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

`startActivityForResult` is deprecated. We want to replace these calls using the new `registerForActivityResult` APIs.

- In `AbstractFlashcardViewer`, 
  - Created common `FlashCardViewerResultCallback` inner class to pass to `registerForActivityResult` function. This will capture the common result code check behavior that was being done in `onActivityResult` and apply it to every `ActivityResultLauncher` when using the new `registerForActivityResult` API. There was only one request code being processed, but the pattern is consistent with the other classes that were updated. 
  - In `FlashCardViewerResultCallback`, gave the lambda a default do-nothing implementation. The ADD_NOTE request code used in Reviewer doesn't specifically do anything with a result, but the common checks that `FlashCardViewerResultCallback` does still needs to be done for every activity result. 
  - Replaced `startActivityForResult` for `EDIT_CURRENT_CARD` with `registerForActivityResult` API implementation. 
  - Removed the now unused `onActivityResult` function override

- In Reviewer, 
  - Replaced `startActivityForResult` for `ADD_NOTE` with `registerForActivityResult` API implementation.

## Fixes
Related: #8602 

## How Has This Been Tested?

I ran unit tests and I manually tested the functionality on an emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
