### PR TITLE
Kotlin Cleanup: KDocs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -21,6 +21,7 @@ import android.annotation.TargetApi
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.Intent
 import android.content.res.Resources
 import android.os.Build
 import androidx.annotation.StringRes
@@ -38,7 +39,7 @@ object NotificationChannels {
      * Note that once a channel is created, only the name may be changed as long as the application
      * is installed on the user device. All other settings are fully under user control.
 
-     * TODO should be called in response to {@link android.content.Intent#ACTION_LOCALE_CHANGED}
+     * TODO should be called in response to [Intent.ACTION_LOCALE_CHANGED]
      * @param context the context for access to localized strings for channel names
      */
     @TargetApi(26)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsParser.kt
@@ -16,9 +16,9 @@ object TtsParser {
      * using the Android text-to-speech engine, together with the languages they are in.
      *
      *
-     * Each returned LocalisedText object contains the text extracted from a &lt;tts&gt; element
+     * Each returned LocalisedText object contains the text extracted from a `<tts>` element
      * whose 'service' attribute is set to 'android', and the localeCode taken from the 'voice'
-     * attribute of that element. This holds unless the HTML fragment contains no such &lt;tts&gt;
+     * attribute of that element. This holds unless the HTML fragment contains no such `<tts>`
      * elements; in that case the function returns a single LocalisedText object containing the
      * text extracted from the whole HTML fragment, with the localeCode set to an empty string.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -32,7 +32,9 @@ import org.acra.dialog.CrashReportDialogHelper
 
 /**
  * This file will appear to have static type errors because BaseCrashReportDialog extends android.support.XXX
- * instead of androidx.XXX . Details at {@see https://github.com/ankidroid/Anki-Android/wiki/Crash-Reports}
+ * instead of androidx.XXX.
+ *
+ * See [AnkiDroid Wiki: Crash-Reports](https://github.com/ankidroid/Anki-Android/wiki/Crash-Reports)
  */
 @SuppressLint("Registered") // we are sufficiently registered in this special case
 class AnkiDroidCrashReportDialog : CrashReportDialog(), DialogInterface.OnClickListener, DialogInterface.OnDismissListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -94,7 +94,7 @@ class TTS {
      * Request that TextToSpeech is stopped and shutdown after it it no longer being used
      * by the context that initialized it.
      * No-op if the current instance of TextToSpeech was initialized by another Context
-     * @param context The context used during {@link #initializeTts(Context, ReadTextListener)}
+     * @param context The context used during [ReadText.initializeTts]
      */
     fun releaseTts(context: Context) {
         if (!enabled) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -33,7 +33,7 @@ import java.util.Stack
 import java.util.TreeSet
 
 /**
- * @param tags A reference to the {@link TagsList} passed.
+ * @param tags A reference to the [TagsList]
  */
 class TagsArrayAdapter(private val tags: TagsList, private val resources: Resources) : RecyclerView.Adapter<TagsArrayAdapter.ViewHolder>(), Filterable {
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -77,7 +77,7 @@ class TagsList constructor(
      * @param index index of the tag to check
      * @return whether the tag is checked or not
      * @throws IndexOutOfBoundsException if the index is out of range
-     * (<tt>index &lt; 0 || index &gt;= size()</tt>)
+     * (`index < 0 || index >= size()`)
      */
     fun isChecked(index: Int): Boolean {
         return isChecked(mAllTags[index])
@@ -99,7 +99,7 @@ class TagsList constructor(
      * @param index index of the tag to check
      * @return whether the tag is indeterminate or not
      * @throws IndexOutOfBoundsException if the index is out of range
-     * (<tt>index &lt; 0 || index &gt;= size()</tt>)
+     * (`index < 0 || index >= size()`)
      */
     fun isIndeterminate(index: Int): Boolean {
         return isIndeterminate(mAllTags[index])
@@ -208,7 +208,7 @@ class TagsList constructor(
      * @param index index of the tag to return
      * @return the tag at the specified position in this list
      * @throws IndexOutOfBoundsException if the index is out of range
-     * (<tt>index &lt; 0 || index &gt;= size()</tt>)
+     * (`index < 0 || index >= size()`)
      */
     operator fun get(index: Int): String {
         return mAllTags[index]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -51,10 +51,10 @@ import java.util.function.Supplier
 /**
  * A delegate class used in any [AnkiActivity] where the exporting feature is required.
  *
- * Must be constructed before calling {@link AnkiActivity#onCreate(Bundle, PersistableBundle)}, this is to fragment
- * factory {@link #mDialogsFactory} is set correctly.
+ * Must be constructed before calling [AnkiActivity.onCreate(Bundle, PersistableBundle)][AnkiActivity.onCreate],
+ * to ensure the fragment factory ([mDialogsFactory]) is set correctly.
  *
- * @param activity the calling activity (must implement {@link ExportReadyDialogListener})
+ * @param activity the calling activity (must implement [ExportReadyDialogListener])
  * @param collectionSupplier a predicate that supplies a collection instance
 */
 class ActivityExportingDelegate(private val activity: AnkiActivity, private val collectionSupplier: Supplier<Collection>) : ExportDialogListener, ExportReadyDialogListener {

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -93,7 +93,7 @@ interface Compat {
      * Returns the value associated with the given key, or `null` if:
      * * No mapping of the desired type exists for the given key.
      * * A `null` value is explicitly associated with the key.
-     * * The object is not of type {@code clazz}.
+     * * The object is not of type `clazz`.
      *
      * @param key a String, or `null`
      * @param clazz The expected class of the returned type

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -17,6 +17,7 @@ package com.ichi2.compat
 
 import android.content.Context
 import android.content.Intent
+import android.content.Intent.CATEGORY_DEFAULT
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
@@ -112,7 +113,7 @@ class CompatHelper private constructor() {
          * @param intent An intent containing all of the desired specification
          *            (action, data, type, category, and/or component).
          * @param flags Additional option flags to modify the data returned.
-         * @return Returns a ResolveInfo object containing the final service intent
+         * @return Returns a [ResolveInfo] object containing the final service intent
          *         that was determined to be the best action. Returns null if no
          *         matching service was found.
          */
@@ -123,17 +124,14 @@ class CompatHelper private constructor() {
         /**
          * Retrieve all activities that can be performed for the given intent.
          *
-         * @param intent The desired intent as per resolveActivity().
-         * @param flags Additional option flags to modify the data returned. The
-         *            most important is [MATCH_DEFAULT_ONLY], to limit the
-         *            resolution to only those activities that support the
-         *            [CATEGORY_DEFAULT]. Or, set
-         *            [MATCH_ALL] to prevent any filtering of the results.
+         * @param intent The desired intent as per [resolveActivityCompat].
+         * @param flags Additional option flags to modify the data returned. The most important is
+         *  [MATCH_DEFAULT_ONLY], to limit the resolution to only those activities that support the
+         *  [CATEGORY_DEFAULT]. Or, set [MATCH_ALL] to prevent any filtering of the results.
          * @return Returns a List of ResolveInfo objects containing one entry for
-         *         each matching activity, ordered from best to worst. In other
-         *         words, the first item is what would be returned by
-         *         {@link #resolveActivity}. If there are no matching activities, an
-         *         empty list is returned.
+         *  each matching activity, ordered from best to worst. In other words, the first item
+         *  is what would be returned by [resolveActivityCompat].
+         *  If there are no matching activities, an empty list is returned.
          */
         fun PackageManager.queryIntentActivitiesCompat(intent: Intent, flags: ResolveInfoFlagsCompat): List<ResolveInfo> {
             return compat.queryIntentActivities(this, intent, flags)
@@ -144,25 +142,23 @@ class CompatHelper private constructor() {
          * resolveActivity finds an activity if a class has not been
          * explicitly specified.
          *
-         * Note: if using an implicit Intent (without an explicit
+         * Note: if using an implicit [Intent] (without an explicit
          * ComponentName specified), be sure to consider whether to set the
-         * MATCH_DEFAULT_ONLY only flag. You need to do so to resolve the
+         * [MATCH_DEFAULT_ONLY] only flag. You need to do so to resolve the
          * activity in the same way that
-         * android.content.Context#startActivity(Intent) and
-         * android.content.Intent#resolveActivity(PackageManager)
-         * Intent.resolveActivity(PackageManager) do.
+         * [Context.startActivity] and [Intent.resolveActivity] do.
          *
          * @param intent An intent containing all of the desired specification
-         *            (action, data, type, category, and/or component).
+         *  (action, data, type, category, and/or component).
          * @param flags Additional option flags to modify the data returned. The
-         *            most important is MATCH_DEFAULT_ONLY, to limit the
-         *            resolution to only those activities that support the
-         *            android.content.Intent#CATEGORY_DEFAULT.
+         *  most important is [MATCH_DEFAULT_ONLY], to limit the
+         *  resolution to only those activities that support the
+         *  [CATEGORY_DEFAULT].
          * @return Returns a ResolveInfo object containing the final activity intent
-         *         that was determined to be the best action. Returns null if no
-         *         matching activity was found. If multiple matching activities are
-         *         found and there is no default set, returns a ResolveInfo object
-         *         containing something else, such as the activity resolver.
+         *  that was determined to be the best action. Returns `null` if no
+         *  matching activity was found. If multiple matching activities are
+         *  found and there is no default set, returns a [ResolveInfo] object
+         *  containing something else, such as the activity resolver.
          */
         fun PackageManager.resolveActivityCompat(intent: Intent, flags: ResolveInfoFlagsCompat): ResolveInfo? {
             return compat.resolveActivity(this, intent, flags)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
@@ -85,7 +85,7 @@ class CustomTabActivityHelper : ServiceConnectionCallback {
     }
 
     /**
-     * @see {@link CustomTabsSession#mayLaunchUrl(Uri, Bundle, List)}.
+     * @see CustomTabsSession.mayLaunchUrl
      * @return true if call to mayLaunchUrl was accepted.
      */
     fun mayLaunchUrl(uri: Uri?, extras: Bundle?, otherLikelyBundles: List<Bundle?>?): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/exception/DeckRenameException.kt
@@ -18,7 +18,7 @@ class DeckRenameException(val errorCode: Int) : Exception() {
         const val ALREADY_EXISTS = 0
         const val FILTERED_NOSUBDECKS = 1
 
-        /** Generates a {@link com.ichi2.libanki.backend.exception.DeckRenameException} with additional information in the message */
+        /** Generates a [DeckRenameException] with additional information in the message */
         fun filteredAncestor(
             deckName: String?,
             filteredAncestorName: String?

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.kt
@@ -35,7 +35,7 @@ import com.ichi2.ui.ButtonItemAdapter.ButtonVH
 
 /**
  * RecyclerView.Adapter class copied almost completely from the Material Dialogs library example
- * {@see [](https://github.com/afollestad/material-dialogs/blob/0.9.6.0/sample/src/main/java/com/afollestad/materialdialogssample/ButtonItemAdapter.java>ButtonItemAdapter.java</a>
+ * see [ButtonItemAdapter.java](https://github.com/afollestad/material-dialogs/blob/0.9.6.0/sample/src/main/java/com/afollestad/materialdialogssample/ButtonItemAdapter.java)
  ) */
 class ButtonItemAdapter(
     private val items: ArrayList<String>,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -22,6 +22,7 @@ import com.afollestad.materialdialogs.MaterialDialog
 import com.afollestad.materialdialogs.WhichButton
 import com.afollestad.materialdialogs.actions.getActionButton
 import com.ichi2.libanki.NotetypeJson
+import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -120,10 +121,10 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
     }
 
     /**
-     * Finds the model with specified name in {@link Models#getModels()} and returns its key
+     * Finds the model with specified name in [Notetypes.getModels] and returns its key
      *
      * @param modelName Name of the model
-     * @return Key in {@link Models#getModels()} HashMap for the model
+     * @return Key in [Notetypes.getModels] HashMap for the model
      */
     @Suppress("SameParameterValue")
     private fun findModelIdByName(modelName: String): Long {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -475,16 +475,16 @@ open class RobolectricTest : AndroidTest {
      * Call to assume that <code>actual</code> satisfies the condition specified by <code>matcher</code>.
      * If not, the test halts and is ignored.
      * Example:
-     * <pre>:
-     *   assumeThat(1, is(1)); // passes
-     *   foo(); // will execute
-     *   assumeThat(0, is(1)); // assumption failure! test halts
-     *   int x = 1 / 0; // will never execute
-     * </pre>
+     * ```kotlin
+     *   assumeThat(1, is(1));  // passes
+     *   foo();                 // will execute
+     *   assumeThat(0, is(1));  // assumption failure! test halts
+     *   int x = 1 / 0;         // will never execute
+     * ```
      *
-     * @param <T> the static type accepted by the matcher (this can flag obvious compile-time problems such as {@code assumeThat(1, is("a"))}
+     * @param <T> the static type accepted by the matcher (this can flag obvious compile-time problems such as `assumeThat(1, equalTo("a"))`)
      * @param actual the computed value being compared
-     * @param matcher an expression, built of {@link Matcher}s, specifying allowed values
+     * @param matcher an expression, built from [Matchers][Matcher], specifying allowed values
      * @see org.hamcrest.CoreMatchers
      * @see org.junit.matchers.JUnitMatchers
      */
@@ -494,19 +494,19 @@ open class RobolectricTest : AndroidTest {
     }
 
     /**
-     * Call to assume that <code>actual</code> satisfies the condition specified by <code>matcher</code>.
+     * Call to assume that `actual` satisfies the condition specified by <code>matcher</code>.
      * If not, the test halts and is ignored.
      * Example:
-     * <pre>:
-     *   assumeThat("alwaysPasses", 1, is(1)); // passes
-     *   foo(); // will execute
-     *   assumeThat("alwaysFails", 0, is(1)); // assumption failure! test halts
-     *   int x = 1 / 0; // will never execute
-     * </pre>
+     * ```kotlin
+     *   assumeThat("alwaysPasses", 1, equalTo(1)); // passes
+     *   foo();                                     // will execute
+     *   assumeThat("alwaysFails", 0, equalTo(1));  // assumption failure! test halts
+     *   int x = 1 / 0;                             // will never execute
+     * ```
      *
-     * @param <T> the static type accepted by the matcher (this can flag obvious compile-time problems such as {@code assumeThat(1, is("a"))}
+     * @param <T> the static type accepted by the matcher (this can flag obvious compile-time problems such as `assumeThat(1, equalTo("a"))`
      * @param actual the computed value being compared
-     * @param matcher an expression, built of {@link Matcher}s, specifying allowed values
+     * @param matcher an expression, built from [Matchers][Matcher], specifying allowed values
      * @see org.hamcrest.CoreMatchers
      * @see org.junit.matchers.JUnitMatchers
      */
@@ -516,11 +516,11 @@ open class RobolectricTest : AndroidTest {
     }
 
     /**
-     * If called with an expression evaluating to {@code false}, the test will halt and be ignored.
+     * If called with an expression evaluating to `false`, the test will halt and be ignored.
      *
-     * @param b If <code>false</code>, the method will attempt to stop the test and ignore it by
-     * throwing {@link AssumptionViolatedException}.
-     * @param message A message to pass to {@link AssumptionViolatedException}.
+     * @param b If `false`, the method will attempt to stop the test and ignore it by
+     * throwing [AssumptionViolatedException]
+     * @param message A message to pass to [AssumptionViolatedException]
      */
     fun assumeTrue(message: String?, b: Boolean) {
         advanceRobolectricLooperWithSleep()

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -223,7 +223,7 @@ public object FlashCardsContract {
         /**
          * This is the ID of the note. It is the same as the note ID in Anki. This ID can be
          * used for accessing the data of a note using the URI
-         * "content://com.ichi2.anki.flashcards/notes/&lt;ID&gt;/data
+         * "content://com.ichi2.anki.flashcards/notes/<ID>/data
          */
         @Suppress("ObjectPropertyName")
         public const val _ID: String = "_id"
@@ -358,7 +358,7 @@ public object FlashCardsContract {
         /**
          * This is the ID of the model. It is the same as the note ID in Anki. This ID can be
          * used for accessing the data of the model using the URI
-         * "content://com.ichi2.anki.flashcards/models/&lt;ID&gt;
+         * `content://com.ichi2.anki.flashcards/models/<ID>`
          */
         @Suppress("ObjectPropertyName")
         public const val _ID: String = "_id"
@@ -407,8 +407,8 @@ public object FlashCardsContract {
     /**
      * Card template for a model. A template defines how to render the fields of a note into the actual HTML that
      * makes up a flashcard. A model can define multiple card templates, for example a Forward and Reverse Card could
-     * be defined with the forward card allowing to review a word from Japanese-&gt;English (e.g. 犬 -&gt; dog), and the
-     * reverse card allowing review in the "reverse" direction (e.g dog -&gt; 犬). When a Note is inserted, a Card will
+     * be defined with the forward card allowing to review a word from Japanese -> English (e.g. 犬 -> dog), and the
+     * reverse card allowing review in the "reverse" direction (e.g dog -> 犬). When a Note is inserted, a Card will
      * be generated for each active CardTemplate which is defined.
      */
     public object CardTemplate {

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -100,7 +100,7 @@ public class AddContentApi(context: Context) {
      * @param deckId id for the deck the cards should be stored in (use #DEFAULT_DECK_ID for default deck)
      * @param fieldsList List of fields arrays (one per note). Array lengths should be same as number of fields in model
      * @param tagsList List of tags (one per note) (may be null)
-     * @return The number of notes added (&lt;0 means there was a problem)
+     * @return The number of notes added (< 0 means there was a problem)
      */
     public fun addNotes(
         modelId: Long,
@@ -319,7 +319,7 @@ public class AddContentApi(context: Context) {
 
     /**
      * Insert a new basic front/back model with two fields and TWO cards
-     * The first card goes from front-&gt;back, and the second goes from back-&gt;front
+     * The first card goes from front->back, and the second goes from back->front
      * @param name name of the model
      * @return the mid of the model which was created, or null if it could not be created
      */
@@ -389,7 +389,7 @@ public class AddContentApi(context: Context) {
 
     /**
      * Get the ID for the note type / model which is currently in use
-     * @return id for current model, or &lt;0 if there was a problem
+     * @return id for current model, or < 0 if there was a problem
      */
     public val currentModelId: Long
         get() {

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/CopyrightHeaderExists.kt
@@ -42,7 +42,7 @@ class CopyrightHeaderExists : Detector(), SourceCodeScanner {
 
         /**
          * &#64;SuppressWarnings doesn't work as it's the first statement, so allow suppression via:
-         * <pre>//noinspection MissingCopyrightHeader &lt;reason&gt;</pre>
+         * `//noinspection MissingCopyrightHeader <reason>`
          */
         private val IGNORE_CHECK_PATTERN = Pattern.compile("MissingCopyrightHeader")
 


### PR DESCRIPTION
## Purpose / Description
I saw one instance of this and it was distracting. Fixed all to stop future distractions 

## Approach
* Search for:
  * `{@`
  * `<pre>`
  * `&lt;` and `&gt;` 
* Change to KDoc equivalents
* Fixup issues found
  * 4 spaces before a line removes KDoc links: `[ClassName]` 
  * Added a few missing links

## Learning (optional, can help others)
* 4 spaces before a line removes KDoc links: `[ClassName]` 
* KDoc doesn't support liking a specific overload

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
