### PR TITLE
chore(lint): cleanup CI output on failure

### DIFF
--- a/lint.gradle
+++ b/lint.gradle
@@ -11,5 +11,10 @@ android {
         // To output the lint report to stdout set textReport=true, and leave textOutput unset.
         textReport true
         warningsAsErrors true
+
+        if (System.getenv("CI") == "true") {
+            // 14853: we want this to appear in the IDE, but it adds noise to CI
+            disable += "WrongThread"
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

'WrongThread' output 100+ lines of 'Information' which obscured the error

## Fixes
* Fixes #14853

## Approach
Remove these in CI

## How Has This Been Tested?


<details><summary>Before</summary>

```
davidallison@Davids-MBP Anki-Android % ./gradlew lint

> Task :AnkiDroid:lintReportAmazonDebug
Wrote HTML report to file:///Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/build/reports/lint-results-amazonDebug.html

> Task :AnkiDroid:lintAmazonDebug FAILED
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt:2541: Information: Method all must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val tags = ArrayList(getColUnsafe.tags.all())
                             ~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt:705: Information: Method getCard must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        cardBrowserCard = getColUnsafe.getCard(mCurrentCardId)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt:1393: Information: Method all must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val allTags = getColUnsafe.tags.all()
                      ~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt:1427: Information: Method all must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            getColUnsafe.tags.all()
            ~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt:307: Information: Method canonify must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            val tagsSet = currentNote.col.tags.canonify(tagsList)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt:337: Information: Method newNote must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                val note = col.newNote(mEditedNotetype!!).apply {
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt:343: Information: Method clozeNumbersInNote must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                col.clozeNumbersInNote(note).indexOf(clozeNumber)
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt:369: Information: Method newNote must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val n = getColUnsafe.newNote(notetype)
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt:970: Information: Method totalCount must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            if (getColUnsafe.sched.totalCount() == 0) {
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt:1160: Information: Method modSchema must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                getColUnsafe.modSchema()
                ~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt:215: Information: Method modSchema must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            collection.modSchema()
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt:217: Information: Method modSchemaNoCheck must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            collection.modSchemaNoCheck()
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt:246: Information: Method modSchema must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                collection.modSchema()
                ~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt:420: Information: Method modSchema must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            collection.modSchema()
            ~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt:758: Information: Method setDeck must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                getColUnsafe.setDeck(listOf(mCurrentEditedCard!!.id), deckId)
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt:1088: Information: Method all must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val tags = ArrayList(getColUnsafe.tags.all())
                             ~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt:1192: Information: Method getCard must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                    mCurrentEditedCard = getColUnsafe.getCard(mCurrentEditedCard!!.id)
                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt:1850: Information: Method canonify must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            getColUnsafe.tags.join(getColUnsafe.tags.canonify(mSelectedTags!!)).trim { it <= ' ' }.replace(" ", ", ")
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt:1850: Information: Method join must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            getColUnsafe.tags.join(getColUnsafe.tags.canonify(mSelectedTags!!)).trim { it <= ' ' }.replace(" ", ", ")
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt:121: Information: Method getCard must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        currentCard = col.getCard(mCardList[mIndex])
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt:214: Information: Method filterToValidCards must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val newCardList = getColUnsafe.filterToValidCards(mCardList)
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt:221: Information: Method getCard must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        currentCard = getColUnsafe.getCard(mCardList[mIndex])
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt:234: Information: Method getCard must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        currentCard = getColUnsafe.getCard(mCardList[mIndex])
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:293: Information: Method getWhiteboardState must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        prefWhiteboard = MetaDB.getWhiteboardState(this, parentDid)
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:296: Information: Method getWhiteboardVisibility must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            val whiteboardVisibility = MetaDB.getWhiteboardVisibility(this, parentDid)
                                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:299: Information: Method getWhiteboardStylusState must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            toggleStylus = MetaDB.getWhiteboardStylusState(this, parentDid)
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:418: Information: Method storeWhiteboardStylusState must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                MetaDB.storeWhiteboardStylusState(this, parentDid, toggleStylus)
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:718: Information: Method undoAvailable must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            undoEnabled = colIsOpenUnsafe() && getColUnsafe.undoAvailable()
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:728: Information: Method undoAvailable must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            } else if (getColUnsafe.undoAvailable()) {
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:729: Information: Method undoLabel must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
                undoIcon.title = getColUnsafe.undoLabel()
                                 ~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1256: Information: Method storeWhiteboardState must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        MetaDB.storeWhiteboardState(this, parentDid, state)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1332: Information: Method getWhiteboardPenColor must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        val whiteboardPenColor = MetaDB.getWhiteboardPenColor(this, parentDid).fromPreferences()
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1362: Information: Method storeWhiteboardVisibility must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
        MetaDB.storeWhiteboardVisibility(this, parentDid, state)
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1403: Information: Method queryScalar must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            getColUnsafe.db.queryScalar(
            ^
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1417: Information: Method queryScalar must be called from the worker thread, currently inferred thread is UI thread [WrongThread]
            getColUnsafe.db.queryScalar(
            ^
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/res/values-v31/styles.xml:10: Error: The resource R.style.Theme_Dark_Launcher_NoTitleBar appears to be unused [UnusedResources]
    <style name="Theme_Dark.Launcher.NoTitleBar">
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt:462: Information: Calling this method indicates use of dynamic shortcuts, but there are no calls to methods that track shortcut usage, such as pushDynamicShortcut or reportShortcutUsed. Calling these methods is recommended, as they track shortcut usage and allow launchers to adjust which shortcuts appear based on activation history. Please see https://developer.android.com/develop/ui/views/launch/shortcuts/managing-shortcuts#track-usage [ReportShortcutUsage]
            ShortcutManagerCompat.addDynamicShortcuts(
            ^
1 errors, 0 warnings



FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':AnkiDroid:lintAmazonDebug'.
> Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or create a baseline to see only new errors.
  To create a baseline, run `gradlew updateLintBaseline` after adding the following to the module's build.gradle file:

  android {
      lint {
          baseline = file("lint-baseline.xml")
      }
  }

  For more details, see https://developer.android.com/studio/write/lint#snapshot
  
  Lint found 1 errors, 0 warnings. First failure:
  
  /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/res/values-v31/styles.xml:10: Error: The resource R.style.Theme_Dark_Launcher_NoTitleBar appears to be unused [UnusedResources]
      <style name="Theme_Dark.Launcher.NoTitleBar">
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  
  The full lint text report is located at:
    /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/build/intermediates/lint_intermediate_text_report/amazonDebug/lint-results-amazonDebug.txt

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 24s
65 actionable tasks: 12 executed, 1 from cache, 52 up-to-date
```

</details>

<details><summary>After</summary>

```
davidallison@Davids-MBP Anki-Android % ./gradlew lint

> Task :AnkiDroid:lintReportAmazonDebug
Wrote HTML report to file:///Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/build/reports/lint-results-amazonDebug.html

> Task :AnkiDroid:lintAmazonDebug FAILED
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/res/values-v31/styles.xml:10: Error: The resource R.style.Theme_Dark_Launcher_NoTitleBar appears to be unused [UnusedResources]
    <style name="Theme_Dark.Launcher.NoTitleBar">
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt:462: Information: Calling this method indicates use of dynamic shortcuts, but there are no calls to methods that track shortcut usage, such as pushDynamicShortcut or reportShortcutUsed. Calling these methods is recommended, as they track shortcut usage and allow launchers to adjust which shortcuts appear based on activation history. Please see https://developer.android.com/develop/ui/views/launch/shortcuts/managing-shortcuts#track-usage [ReportShortcutUsage]
            ShortcutManagerCompat.addDynamicShortcuts(
            ^
1 errors, 0 warnings


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':AnkiDroid:lintAmazonDebug'.
> Lint found errors in the project; aborting build.
  
  Fix the issues identified by lint, or create a baseline to see only new errors.
  To create a baseline, run `gradlew updateLintBaseline` after adding the following to the module's build.gradle file:
  android {
      lint {
          baseline = file("lint-baseline.xml")
      }
  }
  For more details, see https://developer.android.com/studio/write/lint#snapshot
  
  /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/res/values-v31/styles.xml:10: Error: The resource R.style.Theme_Dark_Launcher_NoTitleBar appears to be unused [UnusedResources]
      <style name="Theme_Dark.Launcher.NoTitleBar">
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt:462: Information: Calling this method indicates use of dynamic shortcuts, but there are no calls to methods that track shortcut usage, such as pushDynamicShortcut or reportShortcutUsed. Calling these methods is recommended, as they track shortcut usage and allow launchers to adjust which shortcuts appear based on activation history. Please see https://developer.android.com/develop/ui/views/launch/shortcuts/managing-shortcuts#track-usage [ReportShortcutUsage]
              ShortcutManagerCompat.addDynamicShortcuts(
              ^
  1 errors, 0 warnings

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 31s
65 actionable tasks: 16 executed, 49 up-to-date
```

</details>


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
