### PR TITLE
@NeedsTest("ensure mColumn[1/2]Index are used as default columns")

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -381,7 +381,6 @@ open class CardBrowser :
         }
     }
 
-    @NeedsTest("ensure mColumn[1/2]Index are used as default columns")
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -406,9 +405,9 @@ open class CardBrowser :
         mActionBarTitle = findViewById(R.id.toolbar_title)
         cardsListView = findViewById(R.id.card_browser_list)
         val preferences = baseContext.sharedPrefs()
-        mColumn1Index = preferences.getInt("cardBrowserColumn1", 0)
+        mColumn1Index = preferences.getInt(DISPLAY_COLUMN_1_KEY, 0)
         // Load default value for column2 selection
-        mColumn2Index = preferences.getInt("cardBrowserColumn2", 0)
+        mColumn2Index = preferences.getInt(DISPLAY_COLUMN_2_KEY, 0)
         // get the font and font size from the preferences
         val sflRelativeFontSize =
             preferences.getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO)
@@ -485,7 +484,7 @@ open class CardBrowser :
                 if (pos != mColumn1Index) {
                     mColumn1Index = pos
                     AnkiDroidApp.instance.baseContext.sharedPrefs().edit {
-                        putInt("cardBrowserColumn1", mColumn1Index)
+                        putInt(DISPLAY_COLUMN_1_KEY, mColumn1Index)
                     }
                     val fromMap = cardsAdapter.fromMapping
                     fromMap[0] = COLUMN1_KEYS[mColumn1Index]
@@ -514,7 +513,7 @@ open class CardBrowser :
                 if (pos != mColumn2Index) {
                     mColumn2Index = pos
                     AnkiDroidApp.instance.baseContext.sharedPrefs().edit {
-                        putInt("cardBrowserColumn2", mColumn2Index)
+                        putInt(DISPLAY_COLUMN_2_KEY, mColumn2Index)
                     }
                     val fromMap = cardsAdapter.fromMapping
                     fromMap[1] = COLUMN2_KEYS[mColumn2Index]
@@ -2454,6 +2453,8 @@ open class CardBrowser :
         private const val PERSISTENT_STATE_FILE = "DeckPickerState"
         private const val LAST_DECK_ID_KEY = "lastDeckId"
         const val CARD_NOT_AVAILABLE = -1
+        const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
+        const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"
 
         fun clearLastDeckId() {
             val context: Context = AnkiDroidApp.instance


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In CardBrowswer,

`@NeedsTest("ensure mColumn[1/2]Index are used as default columns")`

From looking at what the code is doing, I think the spirit of what this test should be is to make sure that the display column spinner positions are being set based off what's stored in shared preferences, and defaulted to 0 if there are no shared preferences entries for the keys.

- replaced hard coded "cardBrowserColumn1" and "cardBrowserColumn2" strings that were being used in multiple places with const variables in the companion object.
- added 2 tests"
  1. `column spinner positions are set to 0 if no preferences exist`
  2. `column spinner positions are initially set from existing preferences`


## Fixes
Related: #13283 

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Ran the individual unit tests I added.
Ran the whole test suite they are in
Ran the jacocoUnitTestReport

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
