### PR TITLE
chore: add SharedPreferencesProvider

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.StorageAccessException
+import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.services.BootService
 import com.ichi2.anki.services.NotificationService
@@ -64,7 +65,7 @@ import java.util.regex.Pattern
  */
 @KotlinCleanup("lots to do")
 @KotlinCleanup("IDE Lint")
-open class AnkiDroidApp : Application() {
+open class AnkiDroidApp : Application(), SharedPreferencesProvider {
     /** An exception if the WebView subsystem fails to load  */
     private var mWebViewError: Throwable? = null
     private val mNotifications = MutableLiveData<Void?>()
@@ -554,4 +555,6 @@ open class AnkiDroidApp : Application() {
             Timber.i("${activity::class.simpleName}::${f::class.simpleName}::onDetach")
         }
     }
+
+    override fun sharedPrefs(): SharedPreferences = (this as Context).sharedPrefs()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SharedPreferencesProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SharedPreferencesProvider.kt
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.preferences
+
+import android.content.SharedPreferences
+
+/** Provides a reference to [SharedPreferences] without a required Android dependency */
+// SharedPreferences is an interface, so this remains Android-free
+fun interface SharedPreferencesProvider {
+    fun sharedPrefs(): SharedPreferences
+}


### PR DESCRIPTION
For use in ViewModels to abstract out `AnkiDroidApp.instance`

Suggested in:

* https://github.com/ankidroid/Anki-Android/pull/14843#discussion_r1412322760
