### PR TITLE
fix(ReviewerServer): return scheduling states with customData

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -393,6 +393,7 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
         exclude module: "protobuf-lite"
     }
+    androidTestImplementation "androidx.test.espresso:espresso-web:$espresso_version"
     androidTestImplementation "androidx.test:core:$androidx_test_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_test_junit_version"
     androidTestImplementation "androidx.test:rules:$androidx_test_version"

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -1,0 +1,143 @@
+/*
+ *  Copyright (c) 2023
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers.hasDescendant
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.espresso.web.assertion.WebViewAssertions.webContent
+import androidx.test.espresso.web.matcher.DomMatchers.containingTextInBody
+import androidx.test.espresso.web.sugar.Web.onWebView
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
+import com.ichi2.anki.testutil.grantPermissions
+import com.ichi2.anki.testutil.notificationPermission
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ReviewerTest : InstrumentedTest() {
+
+    // Launch IntroductionActivity instead of DeckPicker activity because in CI
+    // builds, it seems to create IntroductionActivity after the DeckPicker,
+    // causing the DeckPicker activity to be destroyed. As a consequence, this
+    // will throw RootViewWithoutFocusException when Espresso tries to interact
+    // with an already destroyed activity. By launching IntroductionActivity, we
+    // ensure that IntroductionActivity is launched first and navigate to the
+    // DeckPicker -> Reviewer activities
+    @get:Rule
+    val activityScenarioRule = ActivityScenarioRule(IntroductionActivity::class.java)
+
+    @get:Rule
+    val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
+
+    @Test
+    fun testCustomSchedulerWithCustomData() {
+        col.config.set(
+            "cardStateCustomizer",
+            """
+            states.good.normal.review.easeFactor = 3.0;
+            states.good.normal.review.scheduledDays = 123;
+            customData.good.c += 1;
+            """
+        )
+        val note = addNoteUsingBasicModel("foo", "bar")
+        val card = note.firstCard()
+        val deck = col.decks.get(note.notetype.did)!!
+        card.moveToReviewQueue()
+        col.backend.updateCards(
+            listOf(
+                card.toBackendCard().toBuilder().setCustomData("""{"c":1}""").build()
+            ),
+            true
+        )
+
+        closeGetStartedScreenIfExists()
+        closeBackupCollectionDialogIfExists()
+        reviewDeckWithName(deck.name)
+
+        var cardFromDb = col.getCard(card.id).toBackendCard()
+        assertThat(cardFromDb.easeFactor, equalTo(card.factor))
+        assertThat(cardFromDb.interval, equalTo(card.ivl))
+        assertThat(cardFromDb.customData, equalTo("""{"c":1}"""))
+
+        waitForCardToLoadWithText(note.fields.first())
+        clickShowAnswerAndAnswerGood()
+
+        cardFromDb = col.getCard(card.id).toBackendCard()
+        assertThat(cardFromDb.easeFactor, equalTo(3000))
+        assertThat(cardFromDb.interval, equalTo(123))
+        assertThat(cardFromDb.customData, equalTo("""{"c":2}"""))
+    }
+
+    private fun closeGetStartedScreenIfExists() {
+        onView(withId(R.id.get_started)).withFailureHandler { _, _ -> }.perform(click())
+    }
+
+    private fun closeBackupCollectionDialogIfExists() {
+        onView(withText(R.string.button_backup_later))
+            .withFailureHandler { _, _ -> }
+            .perform(click())
+    }
+
+    private fun clickOnDeckWithName(deckName: String) {
+        onView(withId(R.id.files)).perform(
+            RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
+                hasDescendant(withText(deckName)),
+                click()
+            )
+        )
+    }
+
+    private fun clickOnStudyButtonIfExists() {
+        onView(withId(R.id.studyoptions_start)).withFailureHandler { _, _ -> }.perform(click())
+            .withFailureHandler { _, _ -> }
+            .perform(click())
+    }
+
+    private fun reviewDeckWithName(deckName: String) {
+        clickOnDeckWithName(deckName)
+        // Adding cards directly to the database while in the Deck Picker screen
+        // will not update the page with correct card counts. Hence, clicking
+        // on the deck will bring us to the study options page where we need to
+        // click on the Study button. If we have added cards to the database
+        // before the Deck Picker screen has fully loaded, then we skip clicking
+        // the Study button
+        clickOnStudyButtonIfExists()
+    }
+
+    private fun clickShowAnswerAndAnswerGood() {
+        onView(withId(R.id.flashcard_layout_flip)).perform(click())
+        onView(withId(R.id.flashcard_layout_ease3)).perform(click())
+    }
+
+    private fun waitForCardToLoadWithText(text: String) {
+        // We need to wait for the card to fully load to allow enough time for
+        // the messages to be passed in and out of the WebView when evaluating
+        // the custom JS scheduler code. The card on the review screen takes
+        // some time to load, especially on an emulator
+        onWebView().check(webContent(containingTextInBody(text)))
+    }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -22,7 +22,11 @@ import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.utils.EnsureAllFilesAccessRule
+import com.ichi2.annotations.DuplicatedCode
+import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
+import com.ichi2.libanki.Consts
+import com.ichi2.libanki.Note
 import org.junit.Rule
 import java.io.File
 import java.io.IOException
@@ -74,5 +78,32 @@ abstract class InstrumentedTest {
                     Build.PRODUCT.contains("simulator")
                 )
         }
+    }
+
+    @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
+    protected fun Card.moveToReviewQueue() {
+        this.queue = Consts.QUEUE_TYPE_REV
+        this.type = Consts.CARD_TYPE_REV
+        this.due = 0
+        this.col.updateCard(this, true)
+    }
+
+    @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
+    protected fun addNoteUsingBasicModel(front: String, back: String): Note {
+        return addNoteUsingModelName("Basic", front, back)
+    }
+
+    @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
+    private fun addNoteUsingModelName(name: String, vararg fields: String): Note {
+        val model = col.notetypes.byName(name)
+            ?: throw IllegalArgumentException("Could not find model '$name'")
+        // PERF: if we modify newNote(), we can return the card and return a Pair<Note, Card> here.
+        // Saves a database trip afterwards.
+        val n = col.newNote(model)
+        for ((i, field) in fields.withIndex()) {
+            n.setField(i, field)
+        }
+        check(col.addNote(n) != 0) { "Could not add note: {${fields.joinToString(separator = ", ")}}" }
+        return n
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -94,7 +94,15 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
 
     private fun getSchedulingStatesWithContext(): ByteArray {
         val state = reviewer().queueState ?: return ByteArray(0)
-        return state.schedulingStatesWithContext().toByteArray()
+        return state.schedulingStatesWithContext().toBuilder()
+            .mergeStates(
+                state.states.toBuilder().mergeCurrent(
+                    state.states.current.toBuilder()
+                        .setCustomData(state.topCard.toBackendCard().customData).build()
+                ).build()
+            )
+            .build()
+            .toByteArray()
     }
 
     private fun setSchedulingStates(bytes: ByteArray): ByteArray {

--- a/AnkiDroid/src/main/java/com/ichi2/annotations/DuplicatedCode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/annotations/DuplicatedCode.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2023
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.annotations
+
+/**
+ * Use when code is duplicated and will be refactored at a later date
+ *
+ * @param value the explanation for why the code is duplicated.
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY
+)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class DuplicatedCode(val value: String)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -130,20 +130,7 @@ open class Card : Cloneable {
         renderOutput = null
         note = null
         id = card.id
-        nid = card.noteId
-        did = card.deckId
-        ord = card.templateIdx
-        due = card.due.toLong()
-        this.type = card.ctype
-        queue = card.queue
-        ivl = card.interval
-        factor = card.easeFactor
-        reps = card.reps
-        lapses = card.lapses
-        left = card.remainingSteps
-        oDue = card.originalDue.toLong()
-        oDid = card.originalDeckId
-        flags = card.flags
+        loadFromBackendCard(card)
     }
 
     constructor(col: Collection, id: Long?) {


### PR DESCRIPTION
## Purpose / Description

Currently, the `customData` that gets passed into the custom scheduler when [runStateMutationHook](https://github.com/ankidroid/Anki-Android/blob/v2.17alpha8/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt#L1087) is called is always empty.

According to the [SchedulingState](https://github.com/ankitects/anki/blob/23.10.1/proto/anki/scheduler.proto#L115-L118) protobuf message in Anki 23.10.1, it says
```protobuf
message SchedulingState {
  // ...
  oneof kind {
    Normal normal = 1;
    Filtered filtered = 2;
  }
  // The backend does not populate this field in GetQueuedCards; the front-end
  // is expected to populate it based on the provided Card. If it's not set when
  // answering a card, the existing custom data will not be updated.
  optional string custom_data = 3;
}
```

Hence, we need to populate this in the frontend

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/14865

## Approach

When [getSchedulingStatesWithContext](https://github.com/ankidroid/Anki-Android/blob/v2.17alpha8/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt#L95) gets called in `ReviewerServer.kt`, we populate the `SchedulingStatesWithContext` protobuf message with the missing custom data. This `getSchedulingStatesWithContext()` method gets called before our custom JS scheduler gets executed when we call [mutateNextCardStates](https://github.com/ankitects/anki/blob/23.10.1/ts/reviewer/answering.ts#L45-L52)

Looking at Anki Desktop 23.10.1, they also populate the `states.current.customData` with `top_card.card.custom_data` in [reviewer.py](https://github.com/ankitects/anki/blob/23.10.1/qt/aqt/reviewer.py#L93-L99)

## How Has This Been Tested?

`./gradlew jacocoUnitTestReport` and `./gradlew jacocoAndroidTestReport` has passed on my machine with the emulator `Pixel_3a_API_34_extension_level_7_x86_64`

## Learning (optional, can help others)
Got [help](https://github.com/ankidroid/Anki-Android/issues/14865#issuecomment-1837692322) from @dae and avoided an unnecessary database call when retrieving the card's `customData`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
