### PR TITLE
stop timer on resuming the app after ans

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -177,7 +177,10 @@ open class Reviewer :
     }
 
     override fun onResume() {
-        if (!stopTimerOnAnswer) answerTimer.resume()
+        when {
+            stopTimerOnAnswer && isDisplayingAnswer -> {}
+            else -> answerTimer.resume()
+        }
         super.onResume()
         if (answerField != null) {
             answerField!!.focusWithKeyboard()
@@ -1062,7 +1065,6 @@ open class Reviewer :
     override fun displayCardQuestion() {
         // show timer, if activated in the deck's preferences
         answerTimer.setupForCard(currentCard!!)
-        stopTimerOnAnswer = false
         delayedHide(100)
         super.displayCardQuestion()
     }
@@ -1070,7 +1072,6 @@ open class Reviewer :
     @VisibleForTesting
     override fun displayCardAnswer() {
         delayedHide(100)
-        stopTimerOnAnswer = true
         if (stopTimerOnAnswer) {
             answerTimer.pause()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -177,7 +177,7 @@ open class Reviewer :
     }
 
     override fun onResume() {
-        answerTimer.resume()
+        if (!stopTimerOnAnswer) answerTimer.resume()
         super.onResume()
         if (answerField != null) {
             answerField!!.focusWithKeyboard()
@@ -1062,6 +1062,7 @@ open class Reviewer :
     override fun displayCardQuestion() {
         // show timer, if activated in the deck's preferences
         answerTimer.setupForCard(currentCard!!)
+        stopTimerOnAnswer = false
         delayedHide(100)
         super.displayCardQuestion()
     }
@@ -1069,6 +1070,7 @@ open class Reviewer :
     @VisibleForTesting
     override fun displayCardAnswer() {
         delayedHide(100)
+        stopTimerOnAnswer = true
         if (stopTimerOnAnswer) {
             answerTimer.pause()
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Timer still counts when when app resume after user have seen the answer , and timer didn't start when answer was not shown after resuming app

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/14874

## How Has This Been Tested?
https://github.com/ankidroid/Anki-Android/assets/101629190/9406a3f3-c665-4d22-af97-54995d75d12b

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
