### PR TITLE
Refactor ImportFileSelectionFragment as a standalone DialogFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -79,7 +79,7 @@ fun DeckPicker.showImportDialog(options: ImportOptions) {
         )
         return
     }
-    showDialogFragment(ImportFileSelectionFragment.createInstance(this, options))
+    showDialogFragment(ImportFileSelectionFragment.newInstance(options))
 }
 
 class DatabaseRestorationListener(val deckPicker: DeckPicker, val newAnkiDroidDirectory: String) : ImportColpkgListener {


### PR DESCRIPTION
## Purpose / Description

Refactors and simplifies the dialog used for choosing the type of import, the previous implementation was using RecursivePictureMenu which is too complex for this dialog.

The goal is to remove RecursivePictureMenu(will also remove its tests that extend RobolectricTest).

See the images below, before and after. Note that I removed the icons, I think they are pretty useless especially as one is duplicated. Will add them back if requested.


<img src="https://github.com/ankidroid/Anki-Android/assets/52494258/4394193b-6846-4e28-a4ce-508d23386aa4" width="300px" height="720px"/><img src="https://github.com/ankidroid/Anki-Android/assets/52494258/4b700f27-bfe4-4739-8642-0d48675d4b3f" width="300px" height="720px"/>

## How Has This Been Tested?

Verified the dialog, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
