### PR TITLE
Fix app bar color in tags dialog

### DIFF
--- a/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
@@ -7,6 +7,6 @@
     android:minHeight="?attr/actionBarSize"
     android:layout_alignParentTop="true"
     android:theme="@style/ActionBarStyle"
-    android:background="?attr/colorPrimary"
+    android:background="?attr/appBarColor"
     app:popupTheme="@style/ActionBar.Popup">
 </androidx.appcompat.widget.Toolbar>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -57,7 +57,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -79,7 +79,7 @@ class TagsDialogTest {
         val args = TagsDialog(ParametersUtils.whatever())
             .withArguments(type, ArrayList(), allTags)
             .arguments
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -117,7 +117,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -152,7 +152,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -190,7 +190,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -245,7 +245,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -292,7 +292,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -346,7 +346,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -394,7 +394,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -435,7 +435,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -482,7 +482,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?
@@ -601,7 +601,7 @@ class TagsDialogTest {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
             val dialog = f.dialog as MaterialDialog?


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The tags dialog has a blue bar in Black theme, which looks ugly.

Similar to https://github.com/ankidroid/Anki-Android/issues/14642

## Fixes
* Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

Similar to https://github.com/ankidroid/Anki-Android/pull/14644

## How Has This Been Tested?

Untested

Well, I am not a dev. But, I still made this PR because it took almost the same effort as creating an issue.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)