### PR TITLE
ci: record screen for emulator tests

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -176,6 +176,7 @@ jobs:
           script: |
             touch adb-log.txt
             $ANDROID_HOME/platform-tools/adb logcat '*:D' >> adb-log.txt &
+            adb emu screenrecord start --time-limit 1800 video.webm
             sleep 5
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
@@ -190,6 +191,13 @@ jobs:
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_logs
           path: adb-log.txt.gz
+
+      - name: Upload Emulator Screen Record
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_video
+          path: video.webm
 
       - uses: codecov/codecov-action@v3
         with:

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -398,6 +398,7 @@ dependencies {
     androidTestImplementation "androidx.test:core:$androidx_test_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_test_junit_version"
     androidTestImplementation "androidx.test:rules:$androidx_test_version"
+    androidTestImplementation "androidx.test.uiautomator:uiautomator:$uiautomator_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     androidTestImplementation "org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version"
     androidTestImplementation("androidx.fragment:fragment-testing:$fragments_version")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -30,12 +30,11 @@ import com.ichi2.anki.TestUtils.activityInstance
 import com.ichi2.anki.TestUtils.clickChildViewWithId
 import com.ichi2.anki.TestUtils.isScreenSw600dp
 import com.ichi2.anki.TestUtils.wasBuiltOnCI
-import com.ichi2.anki.tests.InstrumentedTest.Companion.isEmulator
+import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.ThreadUtils.sleep
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
-import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import org.hamcrest.Matchers.instanceOf
 import org.junit.Assume.assumeFalse
 import org.junit.Assume.assumeTrue
@@ -44,15 +43,12 @@ import org.junit.Rule
 import org.junit.Test
 
 @SuppressLint("DirectSystemCurrentTimeMillisUsage")
-class DeckPickerTest {
+class DeckPickerTest : InstrumentedTest() {
     @get:Rule
     val mActivityRule = ActivityScenarioRule(DeckPicker::class.java)
 
     @get:Rule
     val mRuntimePermissionRule = grantPermissions(storagePermission, notificationPermission)
-
-    @get:Rule
-    val ensureAllFilesAccessRule = EnsureAllFilesAccessRule()
 
     @Ignore("This test appears to be flaky everywhere")
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/ModelEditorContextMenuTest.kt
@@ -25,12 +25,13 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.ModelEditorContextMenu.ModelEditorContextMenuAction
+import com.ichi2.anki.tests.InstrumentedTest
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class ModelEditorContextMenuTest {
+class ModelEditorContextMenuTest : InstrumentedTest() {
     private val testDialogTitle = "test editor title"
 
     @Test

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -19,6 +19,7 @@ import android.view.KeyEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.MockReviewerUi
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -26,7 +27,7 @@ import org.hamcrest.Matchers.hasSize
 import org.junit.Test
 import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
-class PeripheralKeymapTest {
+class PeripheralKeymapTest : InstrumentedTest() {
     @Test
     fun testNumpadAction() {
         // #7736 Ensures that a numpad key is passed through (mostly testing num lock)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -20,6 +20,8 @@ package com.ichi2.anki.tests
 import android.content.Context
 import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.uiautomator.UiDevice
+import androidx.test.uiautomator.UiSelector
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import com.ichi2.annotations.DuplicatedCode
@@ -27,6 +29,7 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
+import org.junit.Before
 import org.junit.Rule
 import java.io.File
 import java.io.IOException
@@ -77,6 +80,25 @@ abstract class InstrumentedTest {
                     Build.PRODUCT.contains("emulator") ||
                     Build.PRODUCT.contains("simulator")
                 )
+        }
+    }
+
+    @Before
+    fun runBeforeEachTest() {
+        closeAndroidNotRespondingDialog()
+    }
+
+    // Instrumented tests can fail if there's a "App not responding"
+    // System dialog blocking our test from proceeding
+    //
+    // See: https://stackoverflow.com/questions/39457305/android-testing-waited-for-the-root-of-the-view-hierarchy-to-have-window-focus/54203607#54203607
+    private fun closeAndroidNotRespondingDialog() {
+        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
+        var waitButton = device.findObject(UiSelector().textContains("Wait"))
+        // There may be multiple dialogs
+        while (waitButton.exists()) {
+            waitButton.click()
+            waitButton = device.findObject(UiSelector().textContains("Wait"))
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
     ext.robolectric_version = '4.11.1'
     ext.android_gradle_plugin = "8.1.4"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
+    ext.uiautomator_version = "2.3.0-alpha05"
 
     configurations.configureEach {
         resolutionStrategy.eachDependency { details ->


### PR DESCRIPTION
## Purpose / Description
Record the screen for emulator tests to help debug flaky tests in CI

## Fixes
N/A

## Approach
According to the Emulator screen record [docs](https://developer.android.com/studio/run/emulator-record-screen), we can run `adb emu screenrecord start --time-limit 10 [path to save video]/sample_video.webm`

## How Has This Been Tested?
N/A

## Learning (optional, can help others)
N/A

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
