### PR TITLE
Kotlin Cleanup: libAnki & androidTest

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -23,7 +23,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
 import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.utils.KotlinCleanup
-import org.hamcrest.Matchers
+import org.hamcrest.Matchers.*
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
@@ -53,8 +53,8 @@ abstract class NoteEditorTest protected constructor() {
             Assume.assumeThat(
                 "Test fails on Travis API $invalid",
                 Build.VERSION.SDK_INT,
-                Matchers.not(
-                    Matchers.`is`(invalid)
+                not(
+                    equalTo(invalid)
                 )
             )
         }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -24,30 +24,10 @@ import androidx.test.espresso.ViewAction
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage
-import com.ichi2.utils.KotlinCleanup
-import org.hamcrest.Description
 import org.hamcrest.Matcher
-import org.hamcrest.TypeSafeMatcher
+import kotlin.math.min
 
-@KotlinCleanup("IDE Lint")
 object TestUtils {
-    /**
-     * Get view at a particular index when there are multiple views with the same ID
-     */
-    fun withIndex(matcher: Matcher<View?>, index: Int): Matcher<View> {
-        return object : TypeSafeMatcher<View>() {
-            var currentIndex = 0
-            override fun describeTo(description: Description) {
-                description.appendText("with index: ")
-                description.appendValue(index)
-                matcher.describeTo(description)
-            }
-
-            public override fun matchesSafely(view: View?): Boolean {
-                return matcher.matches(view) && currentIndex++ == index
-            }
-        }
-    }
 
     /**
      * Get instance of current activity
@@ -78,7 +58,7 @@ object TestUtils {
             activityInstance!!.windowManager.defaultDisplay.getMetrics(displayMetrics)
             val widthDp = displayMetrics.widthPixels / displayMetrics.density
             val heightDp = displayMetrics.heightPixels / displayMetrics.density
-            val screenSw = Math.min(widthDp, heightDp)
+            val screenSw = min(widthDp, heightDp)
             return screenSw >= 600
         }
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -53,7 +53,6 @@ import kotlin.test.junit.JUnitAsserter.assertNotNull
  *
  * These tests should cover all supported operations for each URI.
  */
-@KotlinCleanup("is -> equalTo")
 class ContentProviderTest : InstrumentedTest() {
     @get:Rule
     var runtimePermissionRule = grantPermissions(storagePermission, FlashCardsContract.READ_WRITE_PERMISSION)
@@ -184,8 +183,8 @@ class ContentProviderTest : InstrumentedTest() {
         // Note: We duplicated the code as it did not appear to be accessible via reflection
         val initialPosition = cursor.position
         cursorFillWindow(cursor, 0, window)
-        assertThat("position should not change", cursor.position, `is`(initialPosition))
-        assertThat("Count should be copied", window.numRows, `is`(cursor.count))
+        assertThat("position should not change", cursor.position, equalTo(initialPosition))
+        assertThat("Count should be copied", window.numRows, equalTo(cursor.count))
     }
 
     /**
@@ -567,7 +566,7 @@ class ContentProviderTest : InstrumentedTest() {
             cv.put(FlashCardsContract.Model.CSS, TEST_MODEL_CSS)
             assertThat(
                 cr.update(modelUri, cv, null, null),
-                `is`(greaterThan(0))
+                greaterThan(0)
             )
             col = reopenCol()
             model = col.notetypes.get(mid)
@@ -589,9 +588,7 @@ class ContentProviderTest : InstrumentedTest() {
                 assertThat(
                     "Update rows",
                     cr.update(tmplUri, cv, null, null),
-                    `is`(
-                        greaterThan(0)
-                    )
+                    greaterThan(0)
                 )
                 col = reopenCol()
                 model = col.notetypes.get(mid)
@@ -633,7 +630,7 @@ class ContentProviderTest : InstrumentedTest() {
             assertThat(
                 "Check that there is at least one result",
                 allModels.count,
-                `is`(greaterThan(0))
+                greaterThan(0)
             )
             while (allModels.moveToNext()) {
                 val modelId =
@@ -665,18 +662,14 @@ class ContentProviderTest : InstrumentedTest() {
                     assertThat(
                         "Check that valid number of fields",
                         Utils.splitFields(flds).size,
-                        `is`(
-                            greaterThanOrEqualTo(1)
-                        )
+                        greaterThanOrEqualTo(1)
                     )
                     val numCards =
                         allModels.getInt(allModels.getColumnIndex(FlashCardsContract.Model.NUM_CARDS))
                     assertThat(
                         "Check that valid number of cards",
                         numCards,
-                        `is`(
-                            greaterThanOrEqualTo(1)
-                        )
+                        greaterThanOrEqualTo(1)
                     )
                 }
             }
@@ -716,9 +709,7 @@ class ContentProviderTest : InstrumentedTest() {
                     assertThat(
                         "Check that there is at least one result for cards",
                         cardsCursor!!.count,
-                        `is`(
-                            greaterThan(0)
-                        )
+                        greaterThan(0)
                     )
                     while (cardsCursor.moveToNext()) {
                         val targetDid = mTestDeckIds[0]
@@ -1295,9 +1286,7 @@ class ContentProviderTest : InstrumentedTest() {
             assertThat(
                 "At least one card added for note",
                 col.addNote(newNote),
-                `is`(
-                    greaterThanOrEqualTo(1)
-                )
+                greaterThanOrEqualTo(1)
             )
             for (c in newNote.cards()) {
                 c.did = did

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -732,9 +732,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // SAVE NOTE METHODS
     // ----------------------------------------------------------------------------
 
-    /**
-     * @param noOfAddedCards
-     */
     @KotlinCleanup("return early and simplify if possible")
     private fun onNoteAdded() {
         var closeEditorAfterSave = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1305,7 +1305,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private fun setMMButtonListener(mediaButton: ImageButton, index: Int) {
         mediaButton.setOnClickListener { v: View ->
             Timber.i("NoteEditor:: Multimedia button pressed for field %d", index)
-            if (mEditorNote!!.items()[index][1]!!.isNotEmpty()) {
+            if (mEditorNote!!.items()[index][1].isNotEmpty()) {
                 val col = CollectionHelper.instance.getColUnsafe(this@NoteEditor)!!
                 // If the field already exists then we start the field editor, which figures out the type
                 // automatically
@@ -1897,9 +1897,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         return mEditorNote!!.items().size > 2
     }
 
-    @KotlinCleanup("remove 'requireNoNulls")
     val fieldsFromSelectedNote: Array<Array<String>>
-        get() = mEditorNote!!.items().map { it.requireNoNulls() }.toTypedArray()
+        get() = mEditorNote!!.items()
 
     // ----------------------------------------------------------------------------
     // INNER CLASSES

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -86,9 +86,9 @@ class CreateDeckDialog(
             negativeButton(R.string.dialog_cancel)
             input(prefill = mInitialDeckName, waitForPositiveButton = false) { dialog, text ->
                 // we need the fully-qualified name for subdecks
-                val fullyQualifiedDeckName = fullyQualifyDeckName(dialogText = text)
+                val maybeDeckName = fullyQualifyDeckName(dialogText = text)
                 // if the name is empty, it seems distracting to show an error
-                if (!Decks.isValidDeckName(fullyQualifiedDeckName)) {
+                if (maybeDeckName == null || !Decks.isValidDeckName(maybeDeckName)) {
                     dialog.setActionButtonEnabled(WhichButton.POSITIVE, false)
                     return@input
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -355,10 +355,14 @@ open class Collection(
         return backend.buildSearchString(node)
     }
 
+    /**
+     * Return a list of card ids
+     * @throws InvalidSearchException
+     */
     fun findCards(
         search: String,
-        order: SortOrder
-    ): List<Long> {
+        order: SortOrder = SortOrder.NoOrdering()
+    ): List<CardId> {
         val adjustedOrder = if (order is SortOrder.UseCollectionOrdering) {
             SortOrder.BuiltinSortKind(
                 config.get("sortType") ?: "noteFld",
@@ -367,12 +371,11 @@ open class Collection(
         } else {
             order
         }
-        val cardIdsList = try {
+        return try {
             backend.searchCards(search, adjustedOrder.toProtoBuf())
         } catch (e: BackendInvalidInputException) {
             throw InvalidSearchException(e)
         }
-        return cardIdsList
     }
 
     fun findNotes(
@@ -393,12 +396,6 @@ open class Collection(
             throw InvalidSearchException(e)
         }
         return noteIDsList
-    }
-
-    /** Return a list of card ids  */
-    @KotlinCleanup("set reasonable defaults")
-    fun findCards(search: String): List<Long> {
-        return findCards(search, SortOrder.NoOrdering())
     }
 
     data class CardIdToNoteId(val id: Long, val nid: Long)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -37,9 +37,9 @@ import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.exception.InvalidSearchException
 import com.ichi2.libanki.sched.DummyScheduler
 import com.ichi2.libanki.sched.Scheduler
-import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.*
+import com.ichi2.utils.KotlinCleanup
+import com.ichi2.utils.VersionUtils
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
@@ -56,7 +56,7 @@ import java.util.*
 @WorkerThread
 open class Collection(
     /**
-     *  @param Path The path to the collection.anki2 database. Must be unicode and openable with [File].
+     *  The path to the collection.anki2 database. Must be unicode and openable with [File].
      */
     val path: String,
     private var debugLog: Boolean, // Not in libAnki.
@@ -316,7 +316,7 @@ open class Collection(
 
     // NOT IN LIBANKI //
     fun cardCount(vararg dids: Long): Int {
-        return db.queryScalar("SELECT count() FROM cards WHERE did IN " + Utils.ids2str(dids))
+        return db.queryScalar("SELECT count() FROM cards WHERE did IN " + ids2str(dids))
     }
 
     fun isEmptyDeck(vararg dids: Long): Boolean {
@@ -351,6 +351,7 @@ open class Collection(
             val text = col.buildSearchString(node)
         }
     */
+    @Suppress("unused")
     fun buildSearchString(node: SearchNode): String {
         return backend.buildSearchString(node)
     }
@@ -415,7 +416,7 @@ open class Collection(
     FROM (
       SELECT nid, MIN(ord) AS ord
       FROM cards
-      WHERE nid IN ${Utils.ids2str(noteIds)} 
+      WHERE nid IN ${ids2str(noteIds)} 
       GROUP BY nid
     ) AS card_with_min_ord
     JOIN cards AS c ON card_with_min_ord.nid = c.nid AND card_with_min_ord.ord = c.ord
@@ -546,7 +547,7 @@ open class Collection(
         }
         val badNotes = db.queryScalar(
             "select 1 from notes where id not in (select distinct nid from cards) " +
-                "or mid not in " + Utils.ids2str(notetypes.ids()) + " limit 1"
+                "or mid not in " + ids2str(notetypes.ids()) + " limit 1"
         ) > 0
         // notes without cards or models
         if (badNotes) {
@@ -635,7 +636,7 @@ open class Collection(
     fun setUserFlag(flag: Int, cids: List<Long>) {
         assert(flag in (0..7))
         db.execute(
-            "update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + Utils.ids2str(
+            "update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + ids2str(
                 cids
             ),
             7,
@@ -650,14 +651,10 @@ open class Collection(
 
     //endregion
 
-    fun crtGregorianCalendar(): GregorianCalendar {
-        return Time.gregorianCalendar((crt * 1000))
-    }
-
     /** Not in libAnki  */
     @CheckResult
     fun filterToValidCards(cards: LongArray?): List<Long> {
-        return db.queryLongList("select id from cards where id in " + Utils.ids2str(cards))
+        return db.queryLongList("select id from cards where id in " + ids2str(cards))
     }
 
     fun setDeck(cids: Iterable<CardId>, did: DeckId): OpChangesWithCount {
@@ -693,6 +690,7 @@ open class Collection(
         return backend.getEmptyCards()
     }
 
+    @Suppress("unused")
     fun syncStatus(auth: SyncAuth): SyncStatusResponse {
         return backend.syncStatus(input = auth)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -52,9 +52,7 @@ import java.util.*
 // tracked, so unused tags can only be removed from the list with a DB check.
 //
 // This module manages the tag cache and tags for notes.
-@KotlinCleanup("TextUtils -> Kotlin isNotEmpty()")
 @KotlinCleanup("inline function in init { } so we don't need to init `crt` etc... at the definition")
-@KotlinCleanup("ids.size != 0")
 @WorkerThread
 open class Collection(
     /**
@@ -104,10 +102,6 @@ open class Collection(
 
     val tags: Tags
 
-    @KotlinCleanup(
-        "move accessor methods here, maybe reconsider return type." +
-            "See variable: conf"
-    )
     lateinit var config: Config
 
     @KotlinCleanup("see if we can inline a function inside init {} and make this `val`")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -300,10 +300,7 @@ class Decks(private val col: Collection) {
     * The methods below are not in LibAnki.
     * ***********************************************************
     */
-        @KotlinCleanup("nullability")
-        fun isValidDeckName(deckName: String?): Boolean {
-            return deckName != null && deckName.trim { it <= ' ' }.isNotEmpty()
-        }
+        fun isValidDeckName(deckName: String): Boolean = deckName.trim { it <= ' ' }.isNotEmpty()
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -20,16 +20,13 @@ package com.ichi2.libanki
 import androidx.annotation.WorkerThread
 import com.google.protobuf.kotlin.toByteString
 import com.ichi2.libanki.exception.EmptyMediaException
-import com.ichi2.utils.*
 import timber.log.Timber
 import java.io.*
-import java.util.*
 
 /**
  * Media manager - handles the addition and removal of media files from the media directory (collection.media) and
  * maintains the media database, which is used to determine the state of files for syncing.
  */
-@KotlinCleanup("IDE Lint")
 @WorkerThread
 open class Media(private val col: Collection) {
     val dir = getCollectionMediaPath(col.path)
@@ -55,16 +52,16 @@ open class Media(private val col: Collection) {
         return col.backend.addMediaFile(oFile.name, oFile.readBytes().toByteString())
     }
 
+    /*
+     * String manipulation
+     * ***********************************************************
+     */
+
     /**
      * Extract media filenames from an HTML string.
      *
      * @param string The string to scan for media filenames ([sound:...] or <img...>).
-     * @param includeRemote If true will also include external http/https/ftp urls.
      * @return A list containing all the sound and image filenames found in the input string.
-     */
-    /**
-     * String manipulation
-     * ***********************************************************
      */
     fun filesInStr(string: String): List<String> {
         return col.backend.extractAvTags(string, true).avTagsList.filter {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -20,6 +20,7 @@ package com.ichi2.libanki
 import androidx.annotation.VisibleForTesting
 import com.ichi2.libanki.exception.WrongId
 import com.ichi2.utils.KotlinCleanup
+import com.ichi2.utils.emptyStringArray
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 import timber.log.Timber
@@ -152,13 +153,12 @@ class Note : Cloneable {
         return fields
     }
 
-    @KotlinCleanup("make non-null")
-    fun items(): Array<Array<String?>> {
+    fun items(): Array<Array<String>> {
         // TODO: Revisit this method. The field order returned differs from Anki.
         // The items here are only used in the note editor, so it's a low priority.
         val result = Array(
             mFMap!!.size
-        ) { arrayOfNulls<String>(2) }
+        ) { emptyStringArray(2) }
         for (fname in mFMap!!.keys) {
             val i = mFMap!![fname]!!.first
             result[i][0] = fname

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -20,6 +20,7 @@ import androidx.annotation.CheckResult
 import com.ichi2.utils.*
 import org.json.JSONArray
 import org.json.JSONObject
+import java.util.HashSet
 
 /**
  * Represents a note type, a.k.a. Model.
@@ -80,19 +81,13 @@ class NotetypeJson : JSONObject {
 
     /**
      * @param sfld Fields of a note of this note type
-     * @return The set of name of non-empty fields.
+     * @return The names of non-empty fields
      */
-    @KotlinCleanup("filter")
-    fun nonEmptyFields(sfld: Array<String>): Set<String> {
-        val fieldNames = fieldsNames
-        val nonemptyFields: MutableSet<String> = HashUtil.hashSetInit(sfld.size)
-        for (i in sfld.indices) {
-            if (sfld[i].trim { it <= ' ' }.isNotEmpty()) {
-                nonemptyFields.add(fieldNames[i])
-            }
-        }
-        return nonemptyFields
-    }
+    fun nonEmptyFields(sfld: Array<String>): Set<String> =
+        sfld.zip(fieldsNames)
+            // filter to the fields which are non-empty
+            .filter { (sfld, _) -> sfld.trim { it <= ' ' }.isNotEmpty() }
+            .mapTo(HashSet()) { (_, fieldName) -> fieldName }
 
     /** Python method
      * https://docs.python.org/3/library/stdtypes.html?highlight=dict#dict.update

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -44,7 +44,6 @@ class NotetypeJson : JSONObject {
      *
      * @see NotetypeJson.from
      */
-    @KotlinCleanup("non-null")
     constructor(json: JSONObject) : super() {
         json.deepClonedInto(this)
     }
@@ -52,8 +51,7 @@ class NotetypeJson : JSONObject {
     /**
      * Creates a model object form json string
      */
-    @KotlinCleanup("non-null")
-    constructor(json: String?) : super(json!!)
+    constructor(json: String) : super(json)
 
     @CheckResult
     fun deepClone(): NotetypeJson {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -48,7 +48,6 @@ import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.*
 import com.ichi2.utils.Assert
 import com.ichi2.utils.HashUtil
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.jsonObjectIterable
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
@@ -637,11 +636,8 @@ class Notetypes(val col: Collection) {
     companion object {
         const val NOT_FOUND_NOTE_TYPE = -1L
 
-        @KotlinCleanup("direct return and use scope function")
-        fun newTemplate(name: String?): JSONObject {
-            val t = JSONObject(defaultTemplate)
-            t.put("name", name)
-            return t
+        fun newTemplate(name: String): JSONObject = JSONObject(defaultTemplate).also {
+            it.put("name", name)
         }
 
         private const val defaultTemplate =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -327,7 +327,7 @@ open class Scheduler(val col: Collection) {
     /**
      * @param ids Ids of cards to put at the end of the new queue.
      */
-    open fun forgetCards(ids: List<Long>): OpChanges {
+    open fun forgetCards(ids: List<CardId>): OpChanges {
         val request = scheduleCardsAsNewRequest {
             cardIds.addAll(ids)
             log = true
@@ -344,7 +344,7 @@ open class Scheduler(val col: Collection) {
      * @param imin the minimum interval (inclusive)
      * @param imax The maximum interval (inclusive)
      */
-    open fun reschedCards(ids: List<Long>, imin: Int, imax: Int): OpChanges {
+    open fun reschedCards(ids: List<CardId>, imin: Int, imax: Int): OpChanges {
         return col.backend.setDueDate(ids, "$imin-$imax!", OptionalStringConfigKey.getDefaultInstance())
     }
 
@@ -356,7 +356,7 @@ open class Scheduler(val col: Collection) {
      * @param shift Whether the cards already new should be shifted to make room for cards of cids
      */
     open fun sortCards(
-        cids: List<Long>,
+        cids: List<CardId>,
         start: Int,
         step: Int = 1,
         shuffle: Boolean = false,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/StringUtil.kt
@@ -41,3 +41,5 @@ fun String.lastIndexOfOrNull(c: Char): Int? =
         -1 -> null
         else -> index
     }
+
+fun emptyStringArray(size: Int): Array<String> = Array(size) { "" }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -299,7 +299,7 @@ class DeckPickerTest : RobolectricTest() {
             assertThat(
                 "Options menu displayed when collection is accessible",
                 d.optionsMenuState,
-                `is`(notNullValue())
+                notNullValue()
             )
         } finally {
             revokeWritePermissions()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -274,7 +274,7 @@ class ReviewerTest : RobolectricTest() {
         assertThat(
             "Counts after an undo should be the same as before an undo",
             countsAfterUndo,
-            `is`(countsBeforeUndo)
+            equalTo(countsBeforeUndo)
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
@@ -29,7 +29,6 @@ import kotlin.test.assertNotNull
 
 // Note: These tests can't be run individually but can from the class-level
 // gradlew AnkiDroid:testDebug --tests "com.ichi2.libanki.AbstractSchedTest.*"
-@KotlinCleanup("is -> equalTo")
 @KotlinCleanup("reduce newlines in asserts")
 @KotlinCleanup("improve increaseAndAssertNewCountsIs")
 @RunWith(AndroidJUnit4::class)
@@ -47,15 +46,15 @@ class AbstractSchedTest : JvmTest() {
             note.setField(0, "a")
             col.addNote(note)
         }
-        assertThat(col.cardCount(), `is`(20))
-        assertThat(sched.newCount(), `is`(10))
+        assertThat(col.cardCount(), equalTo(20))
+        assertThat(sched.newCount(), equalTo(10))
         val card = sched.card
-        assertThat(sched.newCount(), `is`(10))
-        assertThat(sched.counts().new, `is`(10))
+        assertThat(sched.newCount(), equalTo(10))
+        assertThat(sched.counts().new, equalTo(10))
         sched.answerCard(card!!, 3)
         sched.card
         col.undo()
-        assertThat(sched.newCount(), `is`(10))
+        assertThat(sched.newCount(), equalTo(10))
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
13 less usages of `@KotlinCleanup` (202 -> 189)

~~## Blocked On~~
* I don't want this to affect users by adding conflicts 
    * ~~https://github.com/ankidroid/Anki-Android/pull/14881~~ This now has a conflict, ignoring

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
