### PR TITLE
fix: Changing Note Type is now an `undoableOp`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -509,7 +509,10 @@ class Notetypes(val col: Collection) {
     # - newModel should be same as m if model is not changing
      */
 
-    /** A compatibility wrapper that converts legacy-style arguments and
+    /**
+     * Modifies the backend schema. Ask the user to confirm schema changes before calling
+     *
+     * A compatibility wrapper that converts legacy-style arguments and
      * feeds them into a backend request, so that AnkiDroid's editor-bound
      * notetype changing can be used. Changing the notetype via the editor is
      * not ideal: it doesn't let users re-order fields in a 2 element note,
@@ -529,7 +532,7 @@ class Notetypes(val col: Collection) {
         newModel: NotetypeJson,
         fmap: Map<Int, Int?>,
         cmap: Map<Int, Int?>
-    ) {
+    ): OpChanges {
         val fieldMap = convertLegacyMap(fmap, newModel.fieldsNames.size)
         val templateMap =
             if (cmap.isEmpty() || m.type == MODEL_CLOZE || newModel.type == MODEL_CLOZE) {
@@ -538,7 +541,7 @@ class Notetypes(val col: Collection) {
                 convertLegacyMap(cmap, newModel.templatesNames.size)
             }
         val isCloze = newModel.isCloze || m.isCloze
-        col.backend.changeNotetype(
+        return col.backend.changeNotetype(
             noteIds = listOf(nid),
             newFields = fieldMap,
             newTemplates = templateMap,


### PR DESCRIPTION
## Purpose / Description
* #14885
## Fixes
* Fixes #14885
* Unblocks #14656

## Approach
* Extract `withErrorHandling`
* Allow it to handle `suspend` calls
* expose `OpChanges`
* apply with `undoableOp`
* A few refactorings of nullable parameters

## How Has This Been Tested?
Briefly on an API 33 emulator, the AbstractFlashcardViewer now picks up on the changes, AND undo works.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
