### PR TITLE
fix: Syncing handles notetype style changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -152,6 +152,7 @@ fun DeckPicker.handleNewSync(
             updateLogin(baseContext, "", "")
             throw exc
         }
+        withCol { notetypes._clear_cache() }
         refreshState()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -39,6 +39,7 @@ import anki.notetypes.NotetypeNameIdUseCount
 import anki.notetypes.StockNotetype
 import com.google.protobuf.ByteString
 import com.ichi2.anki.CrashReportService
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
@@ -114,6 +115,9 @@ class Notetypes(val col: Collection) {
     private fun _get_cached(ntid: int): NotetypeJson? {
         return _cache.get(ntid)
     }
+
+    @NeedsTest("14827: styles are updated after syncing style changes")
+    fun _clear_cache() = _cache.clear()
 
     /*
     # Listing note types


### PR DESCRIPTION
## Purpose / Description
After a sync, styling is not updated if the card was viewed beforehand

* #14827
## Fixes
* Fixes #14827

## Approach
The notetype cache needed to be cleared after a sync

## How Has This Been Tested?
API 33 emulator & Anki Desktop

## Learning (optional, can help others)
https://github.com/ankidroid/Anki-Android/issues/14827#issuecomment-1828979515

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
