### PR TITLE
Enable merge queue trigger / remove CI-avoidance optimization event filters

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,30 +8,7 @@ on:
         required: false
         type: string
   pull_request:
-    branches:
-      - '**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
   push:
-    branches:
-      - main
-      - i18n_sync
-      - dependency-updates
-      - 'release**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
         type: string
   pull_request:
   push:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -8,30 +8,7 @@ on:
         required: false
         type: string
   pull_request:
-    branches:
-      - '**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
   push:
-    branches:
-      - main
-      - i18n_sync
-      - dependency-updates
-      - 'release**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -9,6 +9,7 @@ on:
         type: string
   pull_request:
   push:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -8,30 +8,7 @@ on:
         required: false
         type: string
   pull_request:
-    branches:
-      - '**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
   push:
-    branches:
-      - main
-      - i18n_sync
-      - dependency-updates
-      - 'release**'
-    paths:
-      - '.github/workflows/**'
-      - 'AnkiDroid/**'
-      - 'api/**'
-      - 'lint-rules/**'
-      - 'annotations/**'
-      - '**/*.gradle'
-      - 'gradle/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -9,6 +9,7 @@ on:
         type: string
   pull_request:
   push:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Purpose / Description

Merge queues are available to everyone now and may fit us well as a workflow change as we semi-frequently have non-rebased PRs go into main that break main after some intermediate PR made an incompatible change

## Fixes

- ref #14895 
- ref [`@MikeHardy time to try out Merge Queues?`](https://discord.com/channels/368267295601983490/701922522836369498/1182345774772785202)

## Approach

- simplify our CI  - maybe controversial - but it really bothers me that i18n_sync changes require a manual close/reopen. That's just ridiculous. I don't think our "CI avoidance" optimization is worth it
- add the [new `merge_group` event](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue) as a workflow trigger

## How Has This Been Tested?

It is CI so testing is always fraught. We merge it and see if it works, then we fix things up.

## Learning (optional, can help others)

This is step 1 in setting up merge queues.

Once this is in, move to step 2: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#managing-a-merge-queue - this should be here in settings https://github.com/ankidroid/Anki-Android/settings/branch_protection_rules/17281133
