### PR TITLE
fix: show card answer after custom scheduler completes

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -394,7 +394,6 @@ dependencies {
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {
         exclude module: "protobuf-lite"
     }
-    androidTestImplementation "androidx.test.espresso:espresso-web:$espresso_version"
     androidTestImplementation "androidx.test:core:$androidx_test_version"
     androidTestImplementation "androidx.test.ext:junit:$androidx_test_junit_version"
     androidTestImplementation "androidx.test:rules:$androidx_test_version"

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -19,6 +19,8 @@ package com.ichi2.anki.tests
 
 import android.content.Context
 import android.os.Build
+import androidx.test.espresso.ViewAssertion
+import androidx.test.espresso.ViewInteraction
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
@@ -29,10 +31,13 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
+import com.ichi2.libanki.utils.TimeManager
 import org.junit.Before
 import org.junit.Rule
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlin.test.fail
 
 abstract class InstrumentedTest {
     protected val col: Collection
@@ -127,5 +132,24 @@ abstract class InstrumentedTest {
         }
         check(col.addNote(n) != 0) { "Could not add note: {${fields.joinToString(separator = ", ")}}" }
         return n
+    }
+
+    protected fun ViewInteraction.checkWithTimeout(
+        viewAssertion: ViewAssertion,
+        retryWaitTimeInMilliseconds: Long = 100,
+        maxWaitTimeInMilliseconds: Long = TimeUnit.SECONDS.toMillis(10)
+    ) {
+        val startTime = TimeManager.time.intTimeMS()
+
+        while (TimeManager.time.intTimeMS() - startTime < maxWaitTimeInMilliseconds) {
+            try {
+                check(viewAssertion)
+                return
+            } catch (e: Throwable) {
+                Thread.sleep(retryWaitTimeInMilliseconds)
+            }
+        }
+
+        fail("View assertion was not true within $maxWaitTimeInMilliseconds milliseconds")
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -121,11 +121,16 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
 
     private fun setSchedulingStates(bytes: ByteArray): ByteArray {
         val reviewer = reviewer()
-        val state = reviewer.queueState ?: return ByteArray(0)
+        val state = reviewer.queueState
+        if (state == null) {
+            reviewer.statesMutated = true
+            return ByteArray(0)
+        }
         val req = SetSchedulingStatesRequest.parseFrom(bytes)
         if (req.key == reviewer.customSchedulingKey) {
             state.states = req.states
         }
+        reviewer.statesMutated = true
         return ByteArray(0)
     }
 }


### PR DESCRIPTION
## Purpose / Description
Previously, we did not wait for the `webView.evaluateJavascript()` call to complete and allow enough time for the messages to be passed in and out of the webview before showing the ease buttons

Now, we show the ease buttons only after the custom scheduler has completed its execution. If the custom scheduler is not set, then it will behave as before and show the ease buttons immediately

## Fixes
N/A

## Approach

Hide the ease buttons until the custom scheduler has completed its execution. I have used Anki Desktop 23.10.1 as a reference https://github.com/ankitects/anki/blob/23.10.1/qt/aqt/reviewer.py#L707

## How Has This Been Tested?

`./gradlew jacocoUnitTestReport` and `./gradlew jacocoAndroidTestReport` has passed on my machine with the emulator `Pixel_3a_API_34_extension_level_7_x86_64`

## Learning (optional, can help others)
N/A

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
