### PR TITLE
Browser: refactor selected rows

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -875,7 +875,7 @@ open class CardBrowser :
         if (mActionBarMenu == null || mActionBarMenu!!.findItem(R.id.action_suspend_card) == null) {
             return
         }
-        if (viewModel.hasSelectedCards()) {
+        if (viewModel.hasSelectedAnyRows()) {
             mActionBarMenu!!.findItem(R.id.action_suspend_card).apply {
                 title = TR.browsingToggleSuspend()
                 setIcon(R.drawable.ic_pause_circle_outline)
@@ -887,26 +887,37 @@ open class CardBrowser :
         }
         mActionBarMenu!!.findItem(R.id.action_export_selected).apply {
             this.title = if (viewModel.cardsOrNotes == CARDS) {
-                resources.getQuantityString(R.plurals.card_browser_export_cards, viewModel.selectedRowCount())
+                resources.getQuantityString(
+                    R.plurals.card_browser_export_cards,
+                    viewModel.selectedRowCount()
+                )
             } else {
-                resources.getQuantityString(R.plurals.card_browser_export_notes, viewModel.selectedRowCount())
+                resources.getQuantityString(
+                    R.plurals.card_browser_export_notes,
+                    viewModel.selectedRowCount()
+                )
             }
         }
         mActionBarMenu!!.findItem(R.id.action_delete_card).apply {
             this.title = if (viewModel.cardsOrNotes == CARDS) {
-                resources.getQuantityString(R.plurals.card_browser_delete_cards, viewModel.selectedRowCount())
+                resources.getQuantityString(
+                    R.plurals.card_browser_delete_cards,
+                    viewModel.selectedRowCount()
+                )
             } else {
-                resources.getQuantityString(R.plurals.card_browser_delete_notes, viewModel.selectedRowCount())
+                resources.getQuantityString(
+                    R.plurals.card_browser_delete_notes,
+                    viewModel.selectedRowCount()
+                )
             }
         }
         mActionBarMenu!!.findItem(R.id.action_select_all).isVisible = !hasSelectedAllCards()
         // Note: Theoretically should not happen, as this should kick us back to the menu
-        mActionBarMenu!!.findItem(R.id.action_select_none).isVisible = hasSelectedCards()
+        mActionBarMenu!!.findItem(R.id.action_select_none).isVisible =
+            viewModel.hasSelectedAnyRows()
         mActionBarMenu!!.findItem(R.id.action_edit_note).isVisible = canPerformMultiSelectEditNote()
         mActionBarMenu!!.findItem(R.id.action_view_card_info).isVisible = canPerformCardInfo()
     }
-
-    private fun hasSelectedCards(): Boolean = viewModel.hasSelectedCards()
 
     private fun hasSelectedAllCards(): Boolean {
         return viewModel.selectedRowCount() >= cardCount // must handle 0.
@@ -1249,7 +1260,7 @@ open class CardBrowser :
     }
 
     private fun rescheduleSelectedCards() {
-        if (!hasSelectedCards()) {
+        if (!viewModel.hasSelectedAnyRows()) {
             Timber.i("Attempted reschedule - no cards selected")
             return
         }
@@ -1287,7 +1298,7 @@ open class CardBrowser :
     }
 
     private fun showChangeDeckDialog() {
-        if (!hasSelectedCards()) {
+        if (!viewModel.hasSelectedAnyRows()) {
             Timber.i("Not showing Change Deck - No Cards")
             return
         }
@@ -1900,10 +1911,10 @@ open class CardBrowser :
     fun onSelectionChanged() {
         Timber.d("onSelectionChanged()")
         try {
-            if (!isInMultiSelectMode && viewModel.hasSelectedCards()) {
+            if (!isInMultiSelectMode && viewModel.hasSelectedAnyRows()) {
                 // If we have selected cards, load multiselect
                 loadMultiSelectMode()
-            } else if (isInMultiSelectMode && !viewModel.hasSelectedCards()) {
+            } else if (isInMultiSelectMode && !viewModel.hasSelectedAnyRows()) {
                 // If we don't have cards, unload multiselect
                 endMultiSelectMode()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -354,12 +354,12 @@ open class CardBrowser :
         get() = viewModel.selectedCardIds
 
     private fun canPerformCardInfo(): Boolean {
-        return checkedCardCount() == 1
+        return viewModel.selectedRowCount() == 1
     }
 
     private fun canPerformMultiSelectEditNote(): Boolean {
         // The noteId is not currently available. Only allow if a single card is selected for now.
-        return checkedCardCount() == 1
+        return viewModel.selectedRowCount() == 1
     }
 
     /**
@@ -888,16 +888,16 @@ open class CardBrowser :
         }
         mActionBarMenu!!.findItem(R.id.action_export_selected).apply {
             this.title = if (viewModel.cardsOrNotes == CARDS) {
-                resources.getQuantityString(R.plurals.card_browser_export_cards, checkedCardCount())
+                resources.getQuantityString(R.plurals.card_browser_export_cards, viewModel.selectedRowCount())
             } else {
-                resources.getQuantityString(R.plurals.card_browser_export_notes, checkedCardCount())
+                resources.getQuantityString(R.plurals.card_browser_export_notes, viewModel.selectedRowCount())
             }
         }
         mActionBarMenu!!.findItem(R.id.action_delete_card).apply {
             this.title = if (viewModel.cardsOrNotes == CARDS) {
-                resources.getQuantityString(R.plurals.card_browser_delete_cards, checkedCardCount())
+                resources.getQuantityString(R.plurals.card_browser_delete_cards, viewModel.selectedRowCount())
             } else {
-                resources.getQuantityString(R.plurals.card_browser_delete_notes, checkedCardCount())
+                resources.getQuantityString(R.plurals.card_browser_delete_notes, viewModel.selectedRowCount())
             }
         }
         mActionBarMenu!!.findItem(R.id.action_select_all).isVisible = !hasSelectedAllCards()
@@ -910,7 +910,7 @@ open class CardBrowser :
     private fun hasSelectedCards(): Boolean = viewModel.hasSelectedCards()
 
     private fun hasSelectedAllCards(): Boolean {
-        return checkedCardCount() >= cardCount // must handle 0.
+        return viewModel.selectedRowCount() >= cardCount // must handle 0.
     }
 
     private fun updateFlagForSelectedRows(flag: Int) {
@@ -1236,7 +1236,7 @@ open class CardBrowser :
     // Multiple cards have been explicitly selected, so preview only those cards
     @get:VisibleForTesting
     val previewIntent: Intent
-        get() = if (isInMultiSelectMode && checkedCardCount() > 1) {
+        get() = if (isInMultiSelectMode && viewModel.selectedRowCount() > 1) {
             // Multiple cards have been explicitly selected, so preview only those cards
             getPreviewIntent(0, selectedCardIds.toLongArray())
         } else {
@@ -1917,7 +1917,7 @@ open class CardBrowser :
                 return
             }
             updateMultiselectMenu()
-            mActionBarTitle.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", checkedCardCount())
+            mActionBarTitle.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", viewModel.selectedRowCount())
         } finally {
             if (colIsOpenUnsafe()) {
                 cardsAdapter.notifyDataSetChanged()
@@ -2212,7 +2212,7 @@ open class CardBrowser :
         isInMultiSelectMode = true
         // show title and hide spinner
         mActionBarTitle.visibility = View.VISIBLE
-        mActionBarTitle.text = checkedCardCount().toString()
+        mActionBarTitle.text = viewModel.selectedRowCount().toString()
         deckSpinnerSelection!!.setSpinnerVisibility(View.GONE)
         // reload the actionbar using the multi-select mode actionbar
         invalidateOptionsMenu()
@@ -2234,11 +2234,6 @@ open class CardBrowser :
         invalidateOptionsMenu()
         deckSpinnerSelection!!.setSpinnerVisibility(View.VISIBLE)
         mActionBarTitle.visibility = View.GONE
-    }
-
-    @VisibleForTesting
-    fun checkedCardCount(): Int {
-        return mCheckedCards.size
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1920,13 +1920,13 @@ open class CardBrowser :
 
     @VisibleForTesting
     fun onSelectAll() {
-        mCheckedCards.addAll(mCards.wrapped)
+        viewModel.selectAll()
         onSelectionChanged()
     }
 
     @VisibleForTesting
     fun onSelectNone() {
-        mCheckedCards.clear()
+        viewModel.selectNone()
         onSelectionChanged()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1897,7 +1897,7 @@ open class CardBrowser :
         }
     }
 
-    private fun onSelectionChanged() {
+    fun onSelectionChanged() {
         Timber.d("onSelectionChanged()")
         try {
             if (!isInMultiSelectMode && viewModel.hasSelectedCards()) {
@@ -2270,17 +2270,6 @@ open class CardBrowser :
         }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun checkCardsAtPositions(vararg positions: Int) {
-        positions.forEach { pos ->
-            check(pos < mCards.size()) {
-                "Attempted to check card at index $pos. ${mCards.size()} cards available"
-            }
-            viewModel.selectRowAtPosition(pos)
-        }
-        onSelectionChanged()
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun getPropertiesForCardId(cardId: CardId): CardCache {
         return mCards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))
     }
@@ -2296,12 +2285,6 @@ open class CardBrowser :
     fun filterByFlag(flag: Int) {
         mCurrentFlag = flag
         filterByFlag()
-    }
-
-    @VisibleForTesting
-    fun replaceSelectionWith(positions: IntArray) {
-        viewModel.selectNone()
-        checkCardsAtPositions(*positions)
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -876,7 +876,7 @@ open class CardBrowser :
         if (mActionBarMenu == null || mActionBarMenu!!.findItem(R.id.action_suspend_card) == null) {
             return
         }
-        if (mCheckedCards.isNotEmpty()) {
+        if (viewModel.hasSelectedCards()) {
             mActionBarMenu!!.findItem(R.id.action_suspend_card).apply {
                 title = TR.browsingToggleSuspend()
                 setIcon(R.drawable.ic_pause_circle_outline)
@@ -1241,7 +1241,7 @@ open class CardBrowser :
             getPreviewIntent(0, selectedCardIds.toLongArray())
         } else {
             // Preview all cards, starting from the one that is currently selected
-            val startIndex = if (mCheckedCards.isEmpty()) 0 else mCheckedCards.iterator().next().position
+            val startIndex = viewModel.selectedCards.firstOrNull()?.position ?: 0
             getPreviewIntent(startIndex, allCardIds)
         }
 
@@ -1901,10 +1901,10 @@ open class CardBrowser :
     private fun onSelectionChanged() {
         Timber.d("onSelectionChanged()")
         try {
-            if (!isInMultiSelectMode && mCheckedCards.isNotEmpty()) {
+            if (!isInMultiSelectMode && viewModel.hasSelectedCards()) {
                 // If we have selected cards, load multiselect
                 loadMultiSelectMode()
-            } else if (isInMultiSelectMode && mCheckedCards.isEmpty()) {
+            } else if (isInMultiSelectMode && !viewModel.hasSelectedCards()) {
                 // If we don't have cards, unload multiselect
                 endMultiSelectMode()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -94,8 +94,6 @@ import java.util.*
 import java.util.function.Consumer
 import kotlin.math.abs
 import kotlin.math.ceil
-import kotlin.math.max
-import kotlin.math.min
 
 @Suppress("LeakingThis")
 // The class is only 'open' due to testing
@@ -554,17 +552,7 @@ open class CardBrowser :
         @KotlinCleanup("helper function for min/max range")
         cardsListView.setOnItemLongClickListener { _: AdapterView<*>?, view: View?, position: Int, _: Long ->
             if (isInMultiSelectMode) {
-                var hasChanged = false
-                for (i in min(mLastSelectedPosition, position)..max(
-                    mLastSelectedPosition,
-                    position
-                )) {
-                    val card = cardsListView.getItemAtPosition(i) as CardCache
-
-                    // Add to the set of checked cards
-                    hasChanged = hasChanged or mCheckedCards.add(card)
-                }
-                if (hasChanged) {
+                if (viewModel.selectRowsBetweenPositions(mLastSelectedPosition, position)) {
                     onSelectionChanged()
                 }
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -240,7 +240,7 @@ open class CardBrowser :
         get() = viewModel.isInMultiSelectMode
         private set(value) { viewModel.isInMultiSelectMode = value }
 
-    private val mCheckedCards: Set<CardCache> get() = viewModel.checkedCards
+    private val mCheckedCards: Set<CardCache> get() = viewModel.selectedCards
     private var mLastSelectedPosition
         get() = viewModel.lastSelectedPosition
         set(value) { viewModel.lastSelectedPosition = value }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -240,7 +240,6 @@ open class CardBrowser :
         get() = viewModel.isInMultiSelectMode
         private set(value) { viewModel.isInMultiSelectMode = value }
 
-    private val mCheckedCards: Set<CardCache> get() = viewModel.selectedCards
     private var mLastSelectedPosition
         get() = viewModel.lastSelectedPosition
         set(value) { viewModel.lastSelectedPosition = value }
@@ -1830,7 +1829,7 @@ open class CardBrowser :
             // if in multi-select mode, be sure to show the checkboxes
             if (isInMultiSelectMode) {
                 checkBox.visibility = View.VISIBLE
-                checkBox.isChecked = mCheckedCards.contains(card)
+                checkBox.isChecked = viewModel.selectedCards.contains(card)
                 // this prevents checkboxes from showing an animation from selected -> unselected when
                 // checkbox was selected, then selection mode was ended and now restarted
                 checkBox.jumpDrawablesToCurrentState()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -240,7 +240,7 @@ open class CardBrowser :
         get() = viewModel.isInMultiSelectMode
         private set(value) { viewModel.isInMultiSelectMode = value }
 
-    private val mCheckedCards get() = viewModel.checkedCards
+    private val mCheckedCards: Set<CardCache> get() = viewModel.checkedCards
     private var mLastSelectedPosition
         get() = viewModel.lastSelectedPosition
         set(value) { viewModel.lastSelectedPosition = value }
@@ -1389,7 +1389,7 @@ open class CardBrowser :
     private fun invalidate() {
         renderBrowserQAJob?.cancel()
         mCards.clear()
-        mCheckedCards.clear()
+        viewModel.selectNone()
     }
 
     /** Currently unused - to be used in #7676  */
@@ -2237,7 +2237,7 @@ open class CardBrowser :
      */
     private fun endMultiSelectMode() {
         Timber.d("endMultiSelectMode()")
-        mCheckedCards.clear()
+        viewModel.selectNone()
         isInMultiSelectMode = false
         // If view which was originally selected when entering multi-select is visible then maintain its position
         val view = cardsListView.getChildAt(mLastSelectedPosition - cardsListView.firstVisiblePosition)
@@ -2295,7 +2295,7 @@ open class CardBrowser :
             check(pos < mCards.size()) {
                 "Attempted to check card at index $pos. ${mCards.size()} cards available"
             }
-            mCheckedCards.add(mCards[pos])
+            viewModel.selectRowAtPosition(pos)
         }
         onSelectionChanged()
     }
@@ -2329,7 +2329,7 @@ open class CardBrowser :
 
     @VisibleForTesting
     fun replaceSelectionWith(positions: IntArray) {
-        mCheckedCards.clear()
+        viewModel.selectNone()
         checkCardsAtPositions(*positions)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -543,7 +543,7 @@ open class CardBrowser :
                 // click on whole cell triggers select
                 val cb = view!!.findViewById<CheckBox>(R.id.card_checkbox)
                 cb.toggle()
-                onCheck(position, view)
+                onCheck(position)
             } else {
                 // load up the card selected on the list
                 val clickedCardId = mCards[position].id
@@ -575,7 +575,7 @@ open class CardBrowser :
                 // click on whole cell triggers select
                 val cb = view!!.findViewById<CheckBox>(R.id.card_checkbox)
                 cb.toggle()
-                onCheck(position, view)
+                onCheck(position)
                 recenterListView(view)
                 cardsAdapter.notifyDataSetChanged()
             }
@@ -1848,7 +1848,7 @@ open class CardBrowser :
                 checkBox.visibility = View.GONE
             }
             // change bg color on check changed
-            checkBox.setOnClickListener { onCheck(position, v) }
+            checkBox.setOnClickListener { onCheck(position) }
             val column1 = v.findViewById<FixedTextView>(R.id.card_sfld)
             val column2 = v.findViewById<FixedTextView>(R.id.card_column2)
 
@@ -1907,14 +1907,8 @@ open class CardBrowser :
         }
     }
 
-    private fun onCheck(position: Int, cell: View) {
-        val checkBox = cell.findViewById<CheckBox>(R.id.card_checkbox)
-        val card = mCards[position]
-        if (checkBox.isChecked) {
-            mCheckedCards.add(card)
-        } else {
-            mCheckedCards.remove(card)
-        }
+    private fun onCheck(position: Int) {
+        viewModel.toggleRowSelectionAtPosition(position)
         onSelectionChanged()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1251,7 +1251,7 @@ open class CardBrowser :
             getPreviewIntent(0, selectedCardIds.toLongArray())
         } else {
             // Preview all cards, starting from the one that is currently selected
-            val startIndex = viewModel.selectedCards.firstOrNull()?.position ?: 0
+            val startIndex = viewModel.selectedRows.firstOrNull()?.position ?: 0
             getPreviewIntent(startIndex, allCardIds)
         }
 
@@ -1840,7 +1840,7 @@ open class CardBrowser :
             // if in multi-select mode, be sure to show the checkboxes
             if (isInMultiSelectMode) {
                 checkBox.visibility = View.VISIBLE
-                checkBox.isChecked = viewModel.selectedCards.contains(card)
+                checkBox.isChecked = viewModel.selectedRows.contains(card)
                 // this prevents checkboxes from showing an animation from selected -> unselected when
                 // checkbox was selected, then selection mode was ended and now restarted
                 checkBox.jumpDrawablesToCurrentState()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2282,15 +2282,6 @@ open class CardBrowser :
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun hasCheckedCardAtPosition(i: Int): Boolean {
-        return mCheckedCards.contains(mCards[i])
-    }
-
-    @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    val checkedCardIds: List<Long>
-        get() = mCheckedCards.map { c -> c.id }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun getPropertiesForCardId(cardId: CardId): CardCache {
         return mCards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -212,6 +212,8 @@ class CardBrowserViewModel(
         refreshSelectedRowsFlow.emit(Unit)
     }
 
+    fun selectedRowCount(): Int = selectedCards.size
+
     fun setColumn1Index(value: Int) = column1IndexFlow.update { value }
 
     fun setColumn2Index(value: Int) = column2IndexFlow.update { value }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -158,6 +158,10 @@ class CardBrowserViewModel(
         }
     }
 
+    fun selectAll() = checkedCards.addAll(cards.wrapped)
+
+    fun selectNone() = checkedCards.clear()
+
     fun setColumn1Index(value: Int) = column1IndexFlow.update { value }
 
     fun setColumn2Index(value: Int) = column2IndexFlow.update { value }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -118,7 +118,8 @@ class CardBrowserViewModel(
         }
     }
 
-    fun hasSelectedCards(): Boolean = selectedCards.isNotEmpty()
+    /** Whether any rows are selected */
+    fun hasSelectedAnyRows(): Boolean = selectedCards.isNotEmpty()
 
     /**
      * All the notes of the selected cards will be marked
@@ -126,7 +127,7 @@ class CardBrowserViewModel(
      * otherwise, they will be unmarked
      */
     suspend fun toggleMark(cardIds: List<CardId>) {
-        if (!hasSelectedCards()) {
+        if (!hasSelectedAnyRows()) {
             Timber.i("Not marking cards - nothing selected")
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -87,14 +87,14 @@ class CardBrowserViewModel(
 
     private val selectedRowsPrivateFlow: MutableStateFlow<MutableSet<CardBrowser.CardCache>> =
         MutableStateFlow(Collections.synchronizedSet(LinkedHashSet()))
-    val checkedCards: MutableSet<CardBrowser.CardCache> get() = selectedRowsPrivateFlow.value
+    val selectedCards: MutableSet<CardBrowser.CardCache> get() = selectedRowsPrivateFlow.value
 
     private val refreshSelectedRowsFlow = MutableSharedFlow<Unit>()
     val selectedRowsFlow: Flow<MutableSet<CardBrowser.CardCache>> =
         selectedRowsPrivateFlow.combine(refreshSelectedRowsFlow) { row, _ -> row }
 
     val selectedCardIds: List<Long>
-        get() = checkedCards.map { c -> c.id }
+        get() = selectedCards.map { c -> c.id }
     var lastSelectedPosition = 0
 
     val cardInfoDestination: CardInfoDestination?
@@ -118,7 +118,7 @@ class CardBrowserViewModel(
         }
     }
 
-    fun hasSelectedCards(): Boolean = checkedCards.isNotEmpty()
+    fun hasSelectedCards(): Boolean = selectedCards.isNotEmpty()
 
     /**
      * All the notes of the selected cards will be marked
@@ -170,29 +170,29 @@ class CardBrowserViewModel(
     }
 
     fun selectAll() {
-        if (checkedCards.addAll(cards.wrapped)) {
+        if (selectedCards.addAll(cards.wrapped)) {
             refreshSelectedRowsFlow()
         }
     }
 
     fun selectNone() {
-        if (checkedCards.isEmpty()) return
-        checkedCards.clear()
+        if (selectedCards.isEmpty()) return
+        selectedCards.clear()
         refreshSelectedRowsFlow()
     }
 
     fun toggleRowSelectionAtPosition(position: Int) {
         val card = cards[position]
-        if (checkedCards.contains(card)) {
-            checkedCards.remove(card)
+        if (selectedCards.contains(card)) {
+            selectedCards.remove(card)
         } else {
-            checkedCards.add(card)
+            selectedCards.add(card)
         }
         refreshSelectedRowsFlow()
     }
 
     fun selectRowAtPosition(pos: Int) {
-        if (checkedCards.add(cards[pos])) {
+        if (selectedCards.add(cards[pos])) {
             refreshSelectedRowsFlow()
         }
     }
@@ -202,7 +202,7 @@ class CardBrowserViewModel(
      */
     fun selectRowsBetweenPositions(startPos: Int, endPos: Int) {
         val cards = (min(startPos, endPos)..max(startPos, endPos)).map { cards[it] }
-        if (checkedCards.addAll(cards)) {
+        if (selectedCards.addAll(cards)) {
             refreshSelectedRowsFlow()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -162,6 +162,15 @@ class CardBrowserViewModel(
 
     fun selectNone() = checkedCards.clear()
 
+    fun toggleRowSelectionAtPosition(position: Int) {
+        val card = cards[position]
+        if (checkedCards.contains(card)) {
+            checkedCards.remove(card)
+        } else {
+            checkedCards.add(card)
+        }
+    }
+
     fun setColumn1Index(value: Int) = column1IndexFlow.update { value }
 
     fun setColumn2Index(value: Int) = column2IndexFlow.update { value }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -87,14 +87,14 @@ class CardBrowserViewModel(
 
     private val selectedRowsPrivateFlow: MutableStateFlow<MutableSet<CardBrowser.CardCache>> =
         MutableStateFlow(Collections.synchronizedSet(LinkedHashSet()))
-    val selectedCards: MutableSet<CardBrowser.CardCache> get() = selectedRowsPrivateFlow.value
+    val selectedRows: MutableSet<CardBrowser.CardCache> get() = selectedRowsPrivateFlow.value
 
     private val refreshSelectedRowsFlow = MutableSharedFlow<Unit>()
     val selectedRowsFlow: Flow<MutableSet<CardBrowser.CardCache>> =
         selectedRowsPrivateFlow.combine(refreshSelectedRowsFlow) { row, _ -> row }
 
     val selectedCardIds: List<Long>
-        get() = selectedCards.map { c -> c.id }
+        get() = selectedRows.map { c -> c.id }
     var lastSelectedPosition = 0
 
     val cardInfoDestination: CardInfoDestination?
@@ -119,7 +119,7 @@ class CardBrowserViewModel(
     }
 
     /** Whether any rows are selected */
-    fun hasSelectedAnyRows(): Boolean = selectedCards.isNotEmpty()
+    fun hasSelectedAnyRows(): Boolean = selectedRows.isNotEmpty()
 
     /**
      * All the notes of the selected cards will be marked
@@ -171,29 +171,29 @@ class CardBrowserViewModel(
     }
 
     fun selectAll() {
-        if (selectedCards.addAll(cards.wrapped)) {
+        if (selectedRows.addAll(cards.wrapped)) {
             refreshSelectedRowsFlow()
         }
     }
 
     fun selectNone() {
-        if (selectedCards.isEmpty()) return
-        selectedCards.clear()
+        if (selectedRows.isEmpty()) return
+        selectedRows.clear()
         refreshSelectedRowsFlow()
     }
 
     fun toggleRowSelectionAtPosition(position: Int) {
         val card = cards[position]
-        if (selectedCards.contains(card)) {
-            selectedCards.remove(card)
+        if (selectedRows.contains(card)) {
+            selectedRows.remove(card)
         } else {
-            selectedCards.add(card)
+            selectedRows.add(card)
         }
         refreshSelectedRowsFlow()
     }
 
     fun selectRowAtPosition(pos: Int) {
-        if (selectedCards.add(cards[pos])) {
+        if (selectedRows.add(cards[pos])) {
             refreshSelectedRowsFlow()
         }
     }
@@ -203,7 +203,7 @@ class CardBrowserViewModel(
      */
     fun selectRowsBetweenPositions(startPos: Int, endPos: Int) {
         val cards = (min(startPos, endPos)..max(startPos, endPos)).map { cards[it] }
-        if (selectedCards.addAll(cards)) {
+        if (selectedRows.addAll(cards)) {
             refreshSelectedRowsFlow()
         }
     }
@@ -213,7 +213,7 @@ class CardBrowserViewModel(
         refreshSelectedRowsFlow.emit(Unit)
     }
 
-    fun selectedRowCount(): Int = selectedCards.size
+    fun selectedRowCount(): Int = selectedRows.size
 
     fun setColumn1Index(value: Int) = column1IndexFlow.update { value }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -45,6 +45,8 @@ import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.Collections
 import java.util.LinkedHashSet
+import kotlin.math.max
+import kotlin.math.min
 
 class CardBrowserViewModel(
     preferences: SharedPreferencesProvider
@@ -169,6 +171,15 @@ class CardBrowserViewModel(
         } else {
             checkedCards.add(card)
         }
+    }
+
+    /**
+     * Selects the cards between [startPos] and [endPos]
+     * @return whether the selection has changed
+     */
+    fun selectRowsBetweenPositions(startPos: Int, endPos: Int): Boolean {
+        val cards = (min(startPos, endPos)..max(startPos, endPos)).map { cards[it] }
+        return checkedCards.addAll(cards)
     }
 
     fun setColumn1Index(value: Int) = column1IndexFlow.update { value }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -165,7 +165,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(browser.cardCount(), equalTo(6L))
         assertThat(
             "A checked card should have been removed",
-            browser.checkedCardCount(),
+            browser.viewModel.selectedRowCount(),
             equalTo(3)
         )
         assertThat(
@@ -718,7 +718,7 @@ class CardBrowserTest : RobolectricTest() {
         val browser = getBrowserWithNotes(25)
         selectOneOfManyCards(browser, 7) // HACK: Fix a bug in tests by choosing a value < 8
         selectOneOfManyCards(browser, 24)
-        assertThat(browser.checkedCardCount(), equalTo(18))
+        assertThat(browser.viewModel.selectedRowCount(), equalTo(18))
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -155,7 +155,7 @@ class CardBrowserTest : RobolectricTest() {
     @Ignore("Not yet implemented, feature has performance implications in large collections, instead we remove selections")
     fun selectionsAreCorrectWhenNonExistingCardIsRemoved() = runTest {
         val browser = getBrowserWithNotes(7)
-        browser.checkCardsAtPositions(1, 3, 5, 6)
+        browser.selectCardsAtPositions(1, 3, 5, 6)
         deleteCardAtPosition(browser, 2) // delete non-selected
         deleteCardAtPosition(browser, 3) // delete selected, ensure it's not still selected
 
@@ -170,17 +170,17 @@ class CardBrowserTest : RobolectricTest() {
         )
         assertThat(
             "Checked card before should not have changed",
-            browser.hasCheckedCardAtPosition(1),
+            browser.hasSelectedCardAtPosition(1),
             equalTo(true)
         )
         assertThat(
             "Checked card after should have changed by 2 places",
-            browser.hasCheckedCardAtPosition(3),
+            browser.hasSelectedCardAtPosition(3),
             equalTo(true)
         )
         assertThat(
             "Checked card after should have changed by 2 places",
-            browser.hasCheckedCardAtPosition(4),
+            browser.hasSelectedCardAtPosition(4),
             equalTo(true)
         )
     }
@@ -237,7 +237,7 @@ class CardBrowserTest : RobolectricTest() {
         addDeck("ZZ")
         selectDefaultDeck()
         val b = getBrowserWithNotes(5)
-        b.checkCardsAtPositions(0, 2)
+        b.selectCardsAtPositions(0, 2)
 
         val cardIds = b.viewModel.selectedCardIds
 
@@ -263,7 +263,7 @@ class CardBrowserTest : RobolectricTest() {
         val dynId = addDynamicDeck("World")
         selectDefaultDeck()
         val b = getBrowserWithNotes(5)
-        b.checkCardsAtPositions(0, 2)
+        b.selectCardsAtPositions(0, 2)
 
         val cardIds = b.viewModel.selectedCardIds
 
@@ -296,10 +296,10 @@ class CardBrowserTest : RobolectricTest() {
         val random = Random(1)
         val cardPosition = random.nextInt(numberOfNotes)
         assumeThat("card position to select is 60", cardPosition, equalTo(60))
-        cardBrowser.checkCardsAtPositions(cardPosition)
+        cardBrowser.selectCardsAtPositions(cardPosition)
         assumeTrue(
             "card at position 60 is selected",
-            cardBrowser.hasCheckedCardAtPosition(cardPosition)
+            cardBrowser.hasSelectedCardAtPosition(cardPosition)
         )
 
         // flag the selected card with flag = 1
@@ -424,7 +424,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(b.getPropertiesForCardId(cid1).position, equalTo(0))
         assertThat(b.getPropertiesForCardId(cid2).position, equalTo(1))
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
         val previewIntent = b.previewIntent
         assertThat("before: index", previewIntent.getIntExtra("index", -100), equalTo(0))
         assertThat(
@@ -509,7 +509,7 @@ class CardBrowserTest : RobolectricTest() {
     fun repositionDataTest() = runTest {
         val b = getBrowserWithNotes(1)
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -542,7 +542,7 @@ class CardBrowserTest : RobolectricTest() {
 
         val b = browserWithNoNewCards
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -569,7 +569,7 @@ class CardBrowserTest : RobolectricTest() {
         TimeManager.reset()
         val b = getBrowserWithNotes(1)
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -591,7 +591,7 @@ class CardBrowserTest : RobolectricTest() {
     fun dataUpdatesAfterUndoReposition() {
         val b = getBrowserWithNotes(1)
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -625,7 +625,7 @@ class CardBrowserTest : RobolectricTest() {
 
         assertUndoDoesNotContain(b, R.string.deck_conf_cram_reschedule)
 
-        b.checkCardsAtPositions(0)
+        b.selectCardsAtPositions(0)
 
         b.rescheduleWithoutValidation(listOf(getCheckedCard(b).id), 2)
 
@@ -998,15 +998,15 @@ class CardBrowserTest : RobolectricTest() {
     }
 }
 
-fun CardBrowser.hasCheckedCardAtPosition(i: Int): Boolean =
+fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =
     viewModel.selectedCards.contains(mCards[i])
 
 fun CardBrowser.replaceSelectionWith(positions: IntArray) {
     viewModel.selectNone()
-    checkCardsAtPositions(*positions)
+    selectCardsAtPositions(*positions)
 }
 
-fun CardBrowser.checkCardsAtPositions(vararg positions: Int) {
+fun CardBrowser.selectCardsAtPositions(vararg positions: Int) {
     // PREF: inefficient as the card flow is updated each iteration
     positions.forEach { pos ->
         check(pos < mCards.size()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -323,8 +323,8 @@ class CardBrowserTest : RobolectricTest() {
         )
 
         // deselect and select all cards
-        cardBrowser.onSelectNone()
-        cardBrowser.onSelectAll()
+        cardBrowser.viewModel.selectNone()
+        cardBrowser.viewModel.selectAll()
         // flag all the cards with flag = 3
         val flagForAll = 3
         cardBrowser.updateSelectedCardsFlag(flagForAll)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -155,7 +155,7 @@ class CardBrowserTest : RobolectricTest() {
     @Ignore("Not yet implemented, feature has performance implications in large collections, instead we remove selections")
     fun selectionsAreCorrectWhenNonExistingCardIsRemoved() = runTest {
         val browser = getBrowserWithNotes(7)
-        browser.selectCardsAtPositions(1, 3, 5, 6)
+        browser.selectRowsWithPositions(1, 3, 5, 6)
         deleteCardAtPosition(browser, 2) // delete non-selected
         deleteCardAtPosition(browser, 3) // delete selected, ensure it's not still selected
 
@@ -237,7 +237,7 @@ class CardBrowserTest : RobolectricTest() {
         addDeck("ZZ")
         selectDefaultDeck()
         val b = getBrowserWithNotes(5)
-        b.selectCardsAtPositions(0, 2)
+        b.selectRowsWithPositions(0, 2)
 
         val cardIds = b.viewModel.selectedCardIds
 
@@ -263,7 +263,7 @@ class CardBrowserTest : RobolectricTest() {
         val dynId = addDynamicDeck("World")
         selectDefaultDeck()
         val b = getBrowserWithNotes(5)
-        b.selectCardsAtPositions(0, 2)
+        b.selectRowsWithPositions(0, 2)
 
         val cardIds = b.viewModel.selectedCardIds
 
@@ -296,7 +296,7 @@ class CardBrowserTest : RobolectricTest() {
         val random = Random(1)
         val cardPosition = random.nextInt(numberOfNotes)
         assumeThat("card position to select is 60", cardPosition, equalTo(60))
-        cardBrowser.selectCardsAtPositions(cardPosition)
+        cardBrowser.selectRowsWithPositions(cardPosition)
         assumeTrue(
             "card at position 60 is selected",
             cardBrowser.hasSelectedCardAtPosition(cardPosition)
@@ -424,7 +424,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(b.getPropertiesForCardId(cid1).position, equalTo(0))
         assertThat(b.getPropertiesForCardId(cid2).position, equalTo(1))
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
         val previewIntent = b.previewIntent
         assertThat("before: index", previewIntent.getIntExtra("index", -100), equalTo(0))
         assertThat(
@@ -509,7 +509,7 @@ class CardBrowserTest : RobolectricTest() {
     fun repositionDataTest() = runTest {
         val b = getBrowserWithNotes(1)
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -542,7 +542,7 @@ class CardBrowserTest : RobolectricTest() {
 
         val b = browserWithNoNewCards
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -569,7 +569,7 @@ class CardBrowserTest : RobolectricTest() {
         TimeManager.reset()
         val b = getBrowserWithNotes(1)
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -591,7 +591,7 @@ class CardBrowserTest : RobolectricTest() {
     fun dataUpdatesAfterUndoReposition() {
         val b = getBrowserWithNotes(1)
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
 
         val card = getCheckedCard(b)
 
@@ -625,7 +625,7 @@ class CardBrowserTest : RobolectricTest() {
 
         assertUndoDoesNotContain(b, R.string.deck_conf_cram_reschedule)
 
-        b.selectCardsAtPositions(0)
+        b.selectRowsWithPositions(0)
 
         b.rescheduleWithoutValidation(listOf(getCheckedCard(b).id), 2)
 
@@ -1003,10 +1003,10 @@ fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =
 
 fun CardBrowser.replaceSelectionWith(positions: IntArray) {
     viewModel.selectNone()
-    selectCardsAtPositions(*positions)
+    selectRowsWithPositions(*positions)
 }
 
-fun CardBrowser.selectCardsAtPositions(vararg positions: Int) {
+fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     // PREF: inefficient as the card flow is updated each iteration
     positions.forEach { pos ->
         check(pos < mCards.size()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -239,7 +239,7 @@ class CardBrowserTest : RobolectricTest() {
         val b = getBrowserWithNotes(5)
         b.checkCardsAtPositions(0, 2)
 
-        val cardIds = b.checkedCardIds
+        val cardIds = b.viewModel.selectedCardIds
 
         for (cardId in cardIds) {
             assertThat(
@@ -265,7 +265,7 @@ class CardBrowserTest : RobolectricTest() {
         val b = getBrowserWithNotes(5)
         b.checkCardsAtPositions(0, 2)
 
-        val cardIds = b.checkedCardIds
+        val cardIds = b.viewModel.selectedCardIds
 
         b.moveSelectedCardsToDeck(dynId).join()
 
@@ -798,7 +798,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     private fun getCheckedCard(b: CardBrowser): CardCache {
-        val ids = b.checkedCardIds
+        val ids = b.viewModel.selectedCardIds
         assertThat("only one card expected to be checked", ids, hasSize(1))
         return b.getPropertiesForCardId(ids[0])
     }
@@ -997,3 +997,6 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(column2SpinnerPosition, equalTo(index2))
     }
 }
+
+fun CardBrowser.hasCheckedCardAtPosition(i: Int): Boolean =
+    viewModel.selectedCards.contains(mCards[i])

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1000,3 +1000,18 @@ class CardBrowserTest : RobolectricTest() {
 
 fun CardBrowser.hasCheckedCardAtPosition(i: Int): Boolean =
     viewModel.selectedCards.contains(mCards[i])
+
+fun CardBrowser.replaceSelectionWith(positions: IntArray) {
+    viewModel.selectNone()
+    checkCardsAtPositions(*positions)
+}
+
+fun CardBrowser.checkCardsAtPositions(vararg positions: Int) {
+    // PREF: inefficient as the card flow is updated each iteration
+    positions.forEach { pos ->
+        check(pos < mCards.size()) {
+            "Attempted to check card at index $pos. ${mCards.size()} cards available"
+        }
+        viewModel.selectRowAtPosition(pos)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -999,7 +999,7 @@ class CardBrowserTest : RobolectricTest() {
 }
 
 fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =
-    viewModel.selectedCards.contains(mCards[i])
+    viewModel.selectedRows.contains(mCards[i])
 
 fun CardBrowser.replaceSelectionWith(positions: IntArray) {
     viewModel.selectNone()


### PR DESCRIPTION
## Purpose / Description
* split out from https://github.com/ankidroid/Anki-Android/pull/14843
* rename 'check' -> 'select'
* rename card -> rows: although we currently use cards, we're not going to in the new world

## How Has This Been Tested?
Unit tests, briefly tested selection on API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
