### PR TITLE
feat: add backend version to debug info & cleanup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -31,6 +31,8 @@ object DebugInfoService {
         return """
                AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
                
+               Backend Version = ${BuildConfig.BACKEND_VERSION}
+              
                Android Version = ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})
                
                ProductFlavor = ${BuildConfig.FLAVOR}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -26,7 +26,6 @@ import org.acra.util.Installation
 
 object DebugInfoService {
     fun getDebugInfo(info: Context): String {
-        val dbV2Enabled = true
         val webviewUserAgent = getWebviewUserAgent(info)
         return """
                AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
@@ -48,9 +47,6 @@ object DebugInfoService {
                ACRA UUID = ${Installation.id(info)}
                
                Crash Reports Enabled = ${isSendingCrashReports(info)}
-               
-               DatabaseV2 Enabled = $dbV2Enabled
-               
         """.trimIndent()
     }
 


### PR DESCRIPTION
## Fixes
* Improves #14909 - pending discussion

## Approach
* Expose Build Config we already have
* remove a constant value from the output

## How Has This Been Tested?
New result:

```
AnkiDroid Version = 2.17alpha8-debug (792f444c0529495d07dbc4b055b20e3188010e36)

Backend Version = 0.1.30-anki23.10.1

Android Version = 13 (SDK 33)

ProductFlavor = amazon

Manufacturer = Google

Model = sdk_gphone64_arm64

Hardware = ranchu

Webview User Agent = Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64 Build/TE1A.220922.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/103.0.5060.71 Mobile Safari/537.36

ACRA UUID = 3c6c2b16-05dd-48a7-81e2-7667f5a7eeaa

Crash Reports Enabled = false
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
