### PR TITLE
fix(api): render [sound:] tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -30,6 +30,8 @@ import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts.BUTTON_TYPE
 import com.ichi2.libanki.Notetypes
+import com.ichi2.libanki.TemplateManager.*
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.*
 import com.ichi2.libanki.backend.exception.DeckRenameException
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.exception.EmptyMediaException
@@ -1041,8 +1043,8 @@ class CardContentProvider : ContentProvider() {
         } catch (je: JSONException) {
             throw IllegalArgumentException("Card is using an invalid template", je)
         }
-        val question = currentCard.question()
-        val answer = currentCard.answer()
+        val question = currentCard.renderOutput().questionWithFixedSoundTags()
+        val answer = currentCard.renderOutput().answerWithFixedSoundTags()
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
@@ -1235,3 +1237,11 @@ class CardContentProvider : ContentProvider() {
     private fun knownRogueClient(): Boolean =
         !context!!.arePermissionsDefinedInManifest(callingPackage!!, FlashCardsContract.READ_WRITE_PERMISSION)
 }
+
+/** replaces [anki:play...] with [sound:] */
+private fun TemplateRenderOutput.questionWithFixedSoundTags() =
+    replaceWithSoundTags(questionText, this)
+
+/** replaces [anki:play...] with [sound:] */
+private fun TemplateRenderOutput.answerWithFixedSoundTags() =
+    replaceWithSoundTags(answerText, this)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -25,6 +25,7 @@
 package com.ichi2.libanki
 
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.utils.KotlinCleanup
 
 @KotlinCleanup("combine file with Sound.kt if done in libAnki")
@@ -70,6 +71,28 @@ fun addPlayIcons(content: String): String {
                     <svg viewBox="0 0 64 64"><circle cx="32" cy="32" r="29" fill = "lightgrey"/>
                     <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" fill=black />Replay</svg>
                     </span></a>"""
+    }
+}
+
+/**
+ * Replaces [anki:play:q:0] with [sound:...]
+ */
+fun replaceWithSoundTags(content: String, renderOutput: TemplateRenderOutput): String {
+    return AV_REF_RE.replace(content) { match ->
+        val groups = match.groupValues
+
+        val index = groups[3].toIntOrNull() ?: return@replace match.value
+
+        val tag = when (groups[2]) {
+            "q" -> renderOutput.questionAvTags.getOrNull(index)
+            "a" -> renderOutput.answerAvTags.getOrNull(index)
+            else -> null
+        }
+        if (tag !is SoundOrVideoTag) {
+            return@replace match.value
+        } else {
+            return@replace "[sound:${tag.filename}]"
+        }
     }
 }
 


### PR DESCRIPTION

## Fixes
* Fixes #14866

## Approach
The new backend returned `[anki:play:q:0]`

We added a new method as  `browser = true` wasn't appropriate as this either strips the tags, or removes `[sound:]`


## How Has This Been Tested?
Added a unit test

## Learning (optional, can help others)
safe calls: `toIntOrNull()`, `getOrNull(index)`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
