### PR TITLE
Issue 8602, BasicImageFieldController startActivityForResult Migration

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldControllerTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.multimediacard.fields
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Intent
+import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultRegistry
 import androidx.activity.result.contract.ActivityResultContract
 import androidx.annotation.CheckResult
@@ -35,7 +36,6 @@ import org.mockito.kotlin.whenever
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowToast
 import java.io.File
-import kotlin.test.fail
 
 @RunWith(RobolectricTestRunner::class)
 open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase() {
@@ -110,7 +110,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
                 input: I,
                 options: ActivityOptionsCompat?
             ) {
-                fail("Unexpected access to the activity result registry!")
+                dispatchResult(requestCode, ActivityResult(Activity.RESULT_OK, Intent()))
             }
         }
         val activity = setupActivityMock(controller, controller.getActivity())
@@ -122,7 +122,7 @@ open class BasicImageFieldControllerTest : MultimediaEditFieldActivityTestBase()
     }
 
     private fun performImageResult(controller: BasicImageFieldController, intent: Intent) {
-        controller.onActivityResult(BasicImageFieldController.ACTIVITY_SELECT_IMAGE, Activity.RESULT_OK, intent)
+        controller.selectImageLauncher.launch(intent)
     }
 
     @get:CheckResult


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`startActivityForResult` is deprecated. We want to replace these calls using the new `registerForActivityResult` APIs.

- In `BasicImageFieldController`:
  - Created common `BasicImageFieldControllerResultCallback` inner class to pass to `registerForActivityResult` function. This will capture the common result code check behavior that was being done in `onActivityResult` and apply it to every `ActivityResultLauncher` when using the new `registerForActivityResult` API.
  - Replaced `startActivityForResult` for request codes `ACTIVITY_TAKE_PICTURE`, `ACTIVITY_SELECT_IMAGE`, and `ACTIVITY_DRAWING` with `registerForActivityResult` API implementation.

- In `BasicImageFieldControllerTest`
  -  updated unit test to accommodate new use of registerForActivityResult API for the `ACTIVITY_SELECT_IMAGE` request code.

## Fixes
 - Related: #8602 

## How Has This Been Tested?

I ran unit tests and I manually tested the functionality on an emulator.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
