### PR TITLE
Browser: refactor `mCards` partially

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -713,10 +713,7 @@ open class CardBrowser :
     }
 
     override fun onDestroy() {
-        // TODO: Most of this should be handled in viewModel.onCleared
-        if (this::viewModel.isInitialized) {
-            invalidate()
-        }
+        invalidate()
         super.onDestroy()
         if (mUnmountReceiver != null) {
             unregisterReceiver(mUnmountReceiver)
@@ -1397,7 +1394,6 @@ open class CardBrowser :
 
     private fun invalidate() {
         renderBrowserQAJob?.cancel()
-        viewModel.invalidate()
     }
 
     /** Currently unused - to be used in #7676  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1248,7 +1248,7 @@ open class CardBrowser :
         } else {
             // Preview all cards, starting from the one that is currently selected
             val startIndex = viewModel.selectedRows.firstOrNull()?.position ?: 0
-            getPreviewIntent(startIndex, allCardIds)
+            getPreviewIntent(startIndex, viewModel.allCardIds)
         }
 
     private fun getPreviewIntent(index: Int, selectedCardIds: LongArray): Intent {
@@ -1943,8 +1943,6 @@ open class CardBrowser :
         defaultViewModelCreationExtras
     )[CardBrowserViewModel::class.java]
 
-    private val allCardIds: LongArray
-        get() = mCards.map { c -> c.id }.toLongArray()
     // This could be better: use a wrapper class PositionAware<T> to store the position so it's
     // no longer a responsibility of CardCache and we can guarantee it's consistent just by using this collection
     /** A position-aware collection to ensure consistency between the position of items and the collection  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -863,12 +863,8 @@ open class CardBrowser :
     }
 
     private fun updatePreviewMenuItem() {
-        mPreviewItem?.isVisible = cardCount > 0
+        mPreviewItem?.isVisible = viewModel.rowCount > 0
     }
-
-    /** Returns the number of cards that are visible on the screen  */
-    val cardCount: Int
-        get() = mCards.size()
 
     private fun updateMultiselectMenu() {
         Timber.d("updateMultiselectMenu()")
@@ -920,7 +916,7 @@ open class CardBrowser :
     }
 
     private fun hasSelectedAllCards(): Boolean {
-        return viewModel.selectedRowCount() >= cardCount // must handle 0.
+        return viewModel.selectedRowCount() >= viewModel.rowCount // must handle 0.
     }
 
     private fun updateFlagForSelectedRows(flag: Int) {
@@ -1454,7 +1450,7 @@ open class CardBrowser :
             showSnackbar(subtitleText, Snackbar.LENGTH_SHORT)
         } else {
             // If we haven't selected all decks, allow the user the option to search all decks.
-            val message = if (cardCount == 0) {
+            val message = if (viewModel.rowCount == 0) {
                 getString(R.string.card_browser_no_cards_in_deck, selectedDeckNameForUi)
             } else {
                 subtitleText
@@ -1508,7 +1504,7 @@ open class CardBrowser :
      */
     override val subtitleText: String
         get() {
-            val count = cardCount
+            val count = viewModel.rowCount
 
             @androidx.annotation.StringRes val subtitleId = if (viewModel.cardsOrNotes == CARDS) {
                 R.plurals.card_browser_subtitle
@@ -1594,7 +1590,7 @@ open class CardBrowser :
         val idToPos = getPositionMap(mCards)
         cards
             .mapNotNull { c -> idToPos[c.id] }
-            .filterNot { pos -> pos >= cardCount }
+            .filterNot { pos -> pos >= viewModel.rowCount }
             .forEach { pos -> mCards[pos].load(true, viewModel.column1Index, viewModel.column2Index) }
         updateList()
     }
@@ -1726,7 +1722,7 @@ open class CardBrowser :
             val lastVisibleItem = firstVisibleItem + visibleItemCount - 1
             val cards = mCards
             // List is never cleared, only reset to a new list. So it's safe here.
-            val size = cardCount
+            val size = viewModel.rowCount
             if (size > 0 && visibleItemCount <= 0) {
                 // According to Mike, there used to be 5 to 10 report by hour on the beta version. All with
                 // > com.ichi2.anki.exception.ManuallyReportedException: Useless onScroll call, with size 0 firstVisibleItem 0,
@@ -1892,7 +1888,7 @@ open class CardBrowser :
         }
 
         override fun getCount(): Int {
-            return cardCount
+            return viewModel.rowCount
         }
 
         override fun getItem(position: Int): CardCache {
@@ -1922,7 +1918,7 @@ open class CardBrowser :
             // If we're not in mutliselect, we can select cards if there are cards to select
             if (!isInMultiSelectMode) {
                 mActionBarMenu?.findItem(R.id.action_select_all)?.apply {
-                    isVisible = cardCount() != 0
+                    isVisible = viewModel.rowCount != 0
                 }
                 return
             }
@@ -2246,11 +2242,6 @@ open class CardBrowser :
         mActionBarTitle.visibility = View.GONE
     }
 
-    @VisibleForTesting
-    fun cardCount(): Int {
-        return cardCount
-    }
-
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
     val isShowingSelectAll: Boolean
         get() = mActionBarMenu?.findItem(R.id.action_select_all)?.isVisible == true
@@ -2266,7 +2257,7 @@ open class CardBrowser :
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     suspend fun rerenderAllCards() {
-        renderBrowserQAParams(0, cardCount - 1, mCards.toList())
+        renderBrowserQAParams(0, viewModel.rowCount - 1, mCards.toList())
     }
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1467,11 +1467,9 @@ open class CardBrowser :
             return
         }
         mShouldRestoreScroll = false
-        val newPosition = newPositionOfSelectedCard
-        if (newPosition != CARD_NOT_AVAILABLE) {
-            Timber.d("Restoring scroll position after search")
-            autoScrollTo(newPosition)
-        }
+        val card = viewModel.findCardById(mOldCardId) ?: return
+        Timber.d("Restoring scroll position after search")
+        autoScrollTo(card.position)
     }
 
     @VisibleForTesting
@@ -1658,10 +1656,6 @@ open class CardBrowser :
         val v = cardsListView.getChildAt(cardPosition - firstVisiblePosition)
         return v?.top ?: 0
     }
-
-    private val newPositionOfSelectedCard: Int
-        get() = viewModel.findCardById(mOldCardId)?.position
-            ?: CARD_NOT_AVAILABLE
 
     fun hasSelectedAllDecks(): Boolean = lastDeckId == ALL_DECKS_ID
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -125,8 +125,7 @@ open class CardBrowser :
 
     /** List of cards in the browser.
      * When the list is changed, the position member of its elements should get changed. */
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    val mCards get() = viewModel.cards
+    private val mCards get() = viewModel.cards
     var deckSpinnerSelection: DeckSpinnerSelection? = null
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2258,11 +2258,6 @@ open class CardBrowser :
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun getPropertiesForCardId(cardId: CardId): CardCache {
-        return mCards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun filterByTag(vararg tags: String) {
         mTagsDialogListenerAction = TagsDialogListenerAction.FILTER
         onSelectedTags(tags.toList(), emptyList(), CardStateFilter.ALL_CARDS)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1726,7 +1726,7 @@ open class CardBrowser :
             val lastVisibleItem = firstVisibleItem + visibleItemCount - 1
             val cards = mCards
             // List is never cleared, only reset to a new list. So it's safe here.
-            val size = cards.size()
+            val size = cardCount
             if (size > 0 && visibleItemCount <= 0) {
                 // According to Mike, there used to be 5 to 10 report by hour on the beta version. All with
                 // > com.ichi2.anki.exception.ManuallyReportedException: Useless onScroll call, with size 0 firstVisibleItem 0,
@@ -1922,7 +1922,7 @@ open class CardBrowser :
             // If we're not in mutliselect, we can select cards if there are cards to select
             if (!isInMultiSelectMode) {
                 mActionBarMenu?.findItem(R.id.action_select_all)?.apply {
-                    isVisible = cardCount() != 0L
+                    isVisible = cardCount() != 0
                 }
                 return
             }
@@ -2247,8 +2247,8 @@ open class CardBrowser :
     }
 
     @VisibleForTesting
-    fun cardCount(): Long {
-        return mCards.size().toLong()
+    fun cardCount(): Int {
+        return cardCount
     }
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -2266,7 +2266,7 @@ open class CardBrowser :
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     suspend fun rerenderAllCards() {
-        renderBrowserQAParams(0, mCards.size() - 1, mCards.toList())
+        renderBrowserQAParams(0, cardCount - 1, mCards.toList())
     }
 
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1822,7 +1822,7 @@ open class CardBrowser :
         @KotlinCleanup("Unchecked cast")
         private fun bindView(position: Int, v: View) {
             // Draw the content in the columns
-            val card = mCards[position]
+            val card = getItem(position)
             (v.tag as Array<*>)
                 .forEachIndexed { i, col ->
                     setFont(col as TextView) // set font for column

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1660,7 +1660,7 @@ open class CardBrowser :
     }
 
     private val newPositionOfSelectedCard: Int
-        get() = mCards.find { c -> c.id == mOldCardId }?.position
+        get() = viewModel.findCardById(mOldCardId)?.position
             ?: CARD_NOT_AVAILABLE
 
     fun hasSelectedAllDecks(): Boolean = lastDeckId == ALL_DECKS_ID

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -548,7 +548,7 @@ open class CardBrowser :
                 viewModel.selectRowAtPosition(position)
             } else {
                 // load up the card selected on the list
-                val clickedCardId = mCards[position].id
+                val clickedCardId = viewModel.getCardIdAtPosition(position)
                 saveScrollingState(position)
                 openNoteEditorForCard(clickedCardId)
             }
@@ -1652,7 +1652,7 @@ open class CardBrowser :
         invalidateOptionsMenu() // maybe the availability of undo changed
     }
     private fun saveScrollingState(position: Int) {
-        mOldCardId = mCards[position].id
+        mOldCardId = viewModel.getCardIdAtPosition(position)
         mOldCardTopOffset = calculateTopOffset(position)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1581,7 +1581,7 @@ open class CardBrowser :
      * @param cards Cards that were changed
      */
     private fun updateCardsInList(cards: List<Card>) {
-        val idToPos = getPositionMap(mCards)
+        val idToPos = viewModel.cardIdToPositionMap
         // TODO: Inefficient
         cards
             .mapNotNull { c -> idToPos[c.id] }
@@ -1607,7 +1607,7 @@ open class CardBrowser :
      * @param reorderCards Whether to rearrange the positions of checked items (DEFECT: Currently deselects all)
      */
     private fun removeNotesView(cardsIds: Collection<Long>, reorderCards: Boolean) {
-        val idToPos = getPositionMap(mCards)
+        val idToPos = viewModel.cardIdToPositionMap
         val idToRemove = cardsIds.filter { cId -> idToPos.containsKey(cId) }
         mReloadRequired = mReloadRequired || cardsIds.contains(reviewerCardId)
         val newMCards: MutableList<CardCache> = mCards
@@ -2313,10 +2313,6 @@ open class CardBrowser :
             context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
                 remove(LAST_DECK_ID_KEY)
             }
-        }
-
-        private fun getPositionMap(cards: CardCollection<CardCache>): Map<Long, Int> {
-            return cards.mapIndexed { i, c -> c.id to i }.toMap()
         }
 
         @CheckResult

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1397,8 +1397,7 @@ open class CardBrowser :
 
     private fun invalidate() {
         renderBrowserQAJob?.cancel()
-        mCards.clear()
-        viewModel.selectNone()
+        viewModel.invalidate()
     }
 
     /** Currently unused - to be used in #7676  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2257,17 +2257,6 @@ open class CardBrowser :
         renderBrowserQAParams(0, viewModel.rowCount - 1, mCards.toList())
     }
 
-    @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    val cardIds: LongArray
-        get() {
-            val cardsCopy = mCards.wrapped.toTypedArray()
-            val ret = LongArray(cardsCopy.size)
-            for (i in cardsCopy.indices) {
-                ret[i] = cardsCopy[i].id
-            }
-            return ret
-        }
-
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun getPropertiesForCardId(cardId: CardId): CardCache {
         return mCards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -276,6 +276,8 @@ class CardBrowserViewModel(
         sched.sortCards(selectedCardIds, position, 1, shuffle = false, shift = true)
     }.count
 
+    fun getCardIdAtPosition(position: Int): CardId = cards[position].id
+
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
         const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -286,6 +286,10 @@ class CardBrowserViewModel(
     fun getCardIdAtPosition(position: Int): CardId = cards[position].id
 
     fun getRowAtPosition(position: Int) = cards[position]
+    fun invalidate() {
+        cards.clear()
+        selectNone()
+    }
 
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -276,6 +276,10 @@ class CardBrowserViewModel(
         sched.sortCards(selectedCardIds, position, 1, shuffle = false, shift = true)
     }.count
 
+    /** Returns the number of rows of the current result set  */
+    val rowCount: Int
+        get() = cards.size()
+
     fun getCardIdAtPosition(position: Int): CardId = cards[position].id
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -286,7 +286,14 @@ class CardBrowserViewModel(
     fun getCardIdAtPosition(position: Int): CardId = cards[position].id
 
     fun getRowAtPosition(position: Int) = cards[position]
-    fun invalidate() {
+
+    override fun onCleared() {
+        super.onCleared()
+        invalidate()
+    }
+
+    private fun invalidate() {
+        // TODO: this may no longer be needed now we call invalidate from onCleared
         cards.clear()
         selectNone()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -56,6 +56,9 @@ class CardBrowserViewModel(
 ) : ViewModel(), SharedPreferencesProvider by preferences {
     val cards = CardBrowser.CardCollection<CardBrowser.CardCache>()
 
+    /** The CardIds of all the cards in the results */
+    val allCardIds get() = cards.map { c -> c.id }.toLongArray()
+
     var searchTerms: String = ""
     var restrictOnDeck: String = ""
     var currentFlag = 0

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -287,6 +287,9 @@ class CardBrowserViewModel(
 
     fun getRowAtPosition(position: Int) = cards[position]
 
+    val cardIdToPositionMap: Map<CardId, Int>
+        get() = cards.mapIndexed { i, c -> c.id to i }.toMap()
+
     override fun onCleared() {
         super.onCleared()
         invalidate()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -285,6 +285,8 @@ class CardBrowserViewModel(
 
     fun getCardIdAtPosition(position: Int): CardId = cards[position].id
 
+    fun getRowAtPosition(position: Int) = cards[position]
+
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
         const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -287,6 +287,9 @@ class CardBrowserViewModel(
 
     fun getRowAtPosition(position: Int) = cards[position]
 
+    /** Given a card ID, returns a position-aware card */
+    fun findCardById(id: CardId): CardBrowser.CardCache? = cards.find { it.id == id }
+
     val cardIdToPositionMap: Map<CardId, Int>
         get() = cards.mapIndexed { i, c -> c.id to i }.toMap()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -331,7 +331,7 @@ class CardBrowserTest : RobolectricTest() {
         // check if all card flags turned to flag = 3
         assertThat(
             "All cards should be flagged",
-            cardBrowser.cardIds
+            cardBrowser.viewModel.allCardIds
                 .map { cardId -> getCardFlagAfterFlagChangeDone(cardBrowser, cardId) }
                 .all { flag1 -> flag1 == flagForAll }
         )
@@ -816,7 +816,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     private fun deleteCardAtPosition(browser: CardBrowser, positionToCorrupt: Int) {
-        removeCardFromCollection(browser.cardIds[positionToCorrupt])
+        removeCardFromCollection(browser.viewModel.allCardIds[positionToCorrupt])
         browser.clearCardData(positionToCorrupt)
     }
 
@@ -1017,13 +1017,3 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
         viewModel.selectRowAtPosition(pos)
     }
 }
-
-val CardBrowser.cardIds: LongArray
-    get() {
-        val cardsCopy = mCards.wrapped.toTypedArray()
-        val ret = LongArray(cardsCopy.size)
-        for (i in cardsCopy.indices) {
-            ret[i] = cardsCopy[i].id
-        }
-        return ret
-    }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1017,3 +1017,13 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
         viewModel.selectRowAtPosition(pos)
     }
 }
+
+val CardBrowser.cardIds: LongArray
+    get() {
+        val cardsCopy = mCards.wrapped.toTypedArray()
+        val ret = LongArray(cardsCopy.size)
+        for (i in cardsCopy.indices) {
+            ret[i] = cardsCopy[i].id
+        }
+        return ret
+    }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1017,3 +1017,6 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
         viewModel.selectRowAtPosition(pos)
     }
 }
+
+fun CardBrowser.getPropertiesForCardId(cardId: CardId): CardCache =
+    viewModel.cards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -85,7 +85,7 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun selectAllIsVisibleWhenCardsInDeck() {
         val browser = browserWithMultipleNotes
-        assertThat(browser.cardCount(), greaterThan(0L))
+        assertThat(browser.cardCount(), greaterThan(0))
         assertThat(browser.isShowingSelectAll, equalTo(true))
     }
 
@@ -148,7 +148,7 @@ class CardBrowserTest : RobolectricTest() {
         // Sometimes an async operation deletes a card, we clear the data and rerender it to simulate this
         deleteCardAtPosition(browser, 0)
         assertDoesNotThrowSuspend { browser.rerenderAllCards() }
-        assertThat(browser.cardCount(), equalTo(5L))
+        assertThat(browser.cardCount(), equalTo(5))
     }
 
     @Test
@@ -1009,8 +1009,8 @@ fun CardBrowser.replaceSelectionWith(positions: IntArray) {
 fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     // PREF: inefficient as the card flow is updated each iteration
     positions.forEach { pos ->
-        check(pos < mCards.size()) {
-            "Attempted to check card at index $pos. ${mCards.size()} cards available"
+        check(pos < cardCount) {
+            "Attempted to check card at index $pos. $cardCount cards available"
         }
         viewModel.selectRowAtPosition(pos)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1001,7 +1001,7 @@ class CardBrowserTest : RobolectricTest() {
 }
 
 fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =
-    viewModel.selectedRows.contains(mCards[i])
+    viewModel.selectedRows.contains(viewModel.getRowAtPosition(i))
 
 fun CardBrowser.replaceSelectionWith(positions: IntArray) {
     viewModel.selectNone()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -85,7 +85,7 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun selectAllIsVisibleWhenCardsInDeck() {
         val browser = browserWithMultipleNotes
-        assertThat(browser.cardCount(), greaterThan(0))
+        assertThat(browser.viewModel.rowCount, greaterThan(0))
         assertThat(browser.isShowingSelectAll, equalTo(true))
     }
 
@@ -148,7 +148,7 @@ class CardBrowserTest : RobolectricTest() {
         // Sometimes an async operation deletes a card, we clear the data and rerender it to simulate this
         deleteCardAtPosition(browser, 0)
         assertDoesNotThrowSuspend { browser.rerenderAllCards() }
-        assertThat(browser.cardCount(), equalTo(5))
+        assertThat(browser.viewModel.rowCount, equalTo(5))
     }
 
     @Test
@@ -162,7 +162,7 @@ class CardBrowserTest : RobolectricTest() {
         // ACT
         browser.rerenderAllCards()
         // ASSERT
-        assertThat(browser.cardCount(), equalTo(6L))
+        assertThat(browser.viewModel.rowCount, equalTo(6L))
         assertThat(
             "A checked card should have been removed",
             browser.viewModel.selectedRowCount(),
@@ -392,7 +392,7 @@ class CardBrowserTest : RobolectricTest() {
         val b = browserWithNoNewCards
         b.filterByTag("sketchy::(1)")
 
-        assertThat("tagged card should be returned", b.cardCount, equalTo(1))
+        assertThat("tagged card should be returned", b.viewModel.rowCount, equalTo(1))
     }
 
     @Test
@@ -409,7 +409,7 @@ class CardBrowserTest : RobolectricTest() {
         val b = browserWithNoNewCards
         b.filterByFlag(1)
 
-        assertThat("Flagged cards should be returned", b.cardCount, equalTo(2))
+        assertThat("Flagged cards should be returned", b.viewModel.rowCount, equalTo(2))
     }
 
     @Test
@@ -668,7 +668,7 @@ class CardBrowserTest : RobolectricTest() {
         )
         assertThat(
             "Results should only be from the selected deck",
-            cardBrowser.cardCount,
+            cardBrowser.viewModel.rowCount,
             equalTo(1)
         )
     }
@@ -737,10 +737,10 @@ class CardBrowserTest : RobolectricTest() {
             cardBrowser.selectedDeckNameForUi,
             equalTo("Test Deck")
         )
-        assertThat("Result should be empty", cardBrowser.cardCount, equalTo(0))
+        assertThat("Result should be empty", cardBrowser.viewModel.rowCount, equalTo(0))
 
         cardBrowser.searchAllDecks()
-        assertThat("Result should contain one card", cardBrowser.cardCount, equalTo(1))
+        assertThat("Result should contain one card", cardBrowser.viewModel.rowCount, equalTo(1))
     }
 
     @Test
@@ -751,9 +751,11 @@ class CardBrowserTest : RobolectricTest() {
 
         browserWithNoNewCards.apply {
             searchAllDecks()
-            assertThat("Result should contain 4 cards", cardCount, equalTo(4))
-            viewModel.setCardsOrNotes(NOTES)
-            assertThat("Result should contain 2 cards (one per note)", cardCount, equalTo(2))
+            with(viewModel) {
+                assertThat("Result should contain 4 cards", rowCount, equalTo(4))
+                setCardsOrNotes(NOTES)
+                assertThat("Result should contain 2 cards (one per note)", rowCount, equalTo(2))
+            }
         }
     }
 
@@ -942,14 +944,14 @@ class CardBrowserTest : RobolectricTest() {
 
         advanceRobolectricUiLooper()
         // check if we get both cards of each note
-        assertThat(cardBrowser.mCards.size(), equalTo(6))
+        assertThat(cardBrowser.viewModel.rowCount, equalTo(6))
 
         cardBrowser.viewModel.setCardsOrNotes(NOTES)
         cardBrowser.searchCards()
 
         // check if we get one card per note
         advanceRobolectricUiLooper()
-        assertThat(cardBrowser.mCards.size(), equalTo(3))
+        assertThat(cardBrowser.viewModel.rowCount, equalTo(3))
     }
 
     @Test
@@ -1009,8 +1011,8 @@ fun CardBrowser.replaceSelectionWith(positions: IntArray) {
 fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     // PREF: inefficient as the card flow is updated each iteration
     positions.forEach { pos ->
-        check(pos < cardCount) {
-            "Attempted to check card at index $pos. $cardCount cards available"
+        check(pos < viewModel.rowCount) {
+            "Attempted to check row at index $pos. ${viewModel.rowCount} rows available"
         }
         viewModel.selectRowAtPosition(pos)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1019,4 +1019,4 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
 }
 
 fun CardBrowser.getPropertiesForCardId(cardId: CardId): CardCache =
-    viewModel.cards.find { c -> c.id == cardId } ?: throw IllegalStateException(String.format(Locale.US, "Card '%d' not found", cardId))
+    viewModel.cards.find { c -> c.id == cardId } ?: throw IllegalStateException("Card '$cardId' not found")


### PR DESCRIPTION
## Purpose / Description
* split from https://github.com/ankidroid/Anki-Android/pull/14843/
  * This removes a number of references to `mCards`
  * We'll be changing this to type `CardOrNoteId` later, so combining reference methods is useful in reducing breakages  
* Reviewable, not mergeable as it's blocked on https://github.com/ankidroid/Anki-Android/pull/14900
  * After this goes in, some more `mCards` references may be removed

## How Has This Been Tested?
Unit test only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
