### PR TITLE
feat: use the backend's congrats screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -68,6 +68,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.model.CardStateFilter
+import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.reviewer.*
@@ -508,7 +509,7 @@ abstract class AbstractFlashcardViewer :
             closeReviewer(RESULT_NO_MORE_CARDS)
             // When launched with a shortcut, we want to display a message when finishing
             if (intent.getBooleanExtra(EXTRA_STARTED_WITH_SHORTCUT, false)) {
-                showThemedToast(baseContext, R.string.studyoptions_congrats_finished, false)
+                startActivity(CongratsPage.getIntent(this))
             }
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -77,7 +77,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
     private lateinit var textTodayRev: TextView
     private lateinit var textNewTotal: TextView
     private lateinit var textTotal: TextView
-    private lateinit var textCongratsMessage: TextView
     private var mToolbar: Toolbar? = null
 
     // Flag to indicate if the fragment should load the deck options immediately after it loads
@@ -207,7 +206,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
         // make links clickable
         textDeckDescription.movementMethod = LinkMovementMethod.getInstance()
         buttonStart = studyOptionsView.findViewById(R.id.studyoptions_start)
-        textCongratsMessage = studyOptionsView.findViewById(R.id.studyoptions_congrats_message)
         // Code common to both fragmented and non-fragmented view
         textTodayNew = studyOptionsView.findViewById(R.id.studyoptions_new)
         textTodayLrn = studyOptionsView.findViewById(R.id.studyoptions_lrn)
@@ -570,8 +568,6 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             if (result.numberOfCardsInDeck == 0 && !isDynamic) {
                 mCurrentContentView = CONTENT_EMPTY
                 deckInfoLayout.visibility = View.VISIBLE
-                textCongratsMessage.visibility = View.VISIBLE
-                textCongratsMessage.setText(R.string.studyoptions_empty)
                 buttonStart.visibility = View.GONE
             } else if (result.newCardsToday + result.lrnCardsToday + result.revCardsToday == 0) {
                 mCurrentContentView = CONTENT_CONGRATS
@@ -582,12 +578,9 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                 } else {
                     buttonStart.visibility = View.GONE
                 }
-                textCongratsMessage.visibility = View.VISIBLE
-                textCongratsMessage.text = col.sched.finishedMsg()
             } else {
                 mCurrentContentView = CONTENT_STUDY_OPTIONS
                 deckInfoLayout.visibility = View.VISIBLE
-                textCongratsMessage.visibility = View.GONE
                 buttonStart.visibility = View.VISIBLE
                 buttonStart.setText(R.string.studyoptions_start)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -93,6 +93,7 @@ open class AnkiServer(
             "setWantsAbort" -> CollectionManager.getBackend().setWantsAbortRaw(bytes)
             "evaluateWeights" -> withCol { evaluateWeightsRaw(bytes) }
             "latestProgress" -> CollectionManager.getBackend().latestProgressRaw(bytes)
+            "congratsInfo" -> withCol { congratsInfoRaw(bytes) }
             else -> { throw Exception("unhandled request: $methodName") }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2023 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.content.Context
+import android.content.Intent
+
+class CongratsPage : PageFragment() {
+    override val title: Int? = null
+    override val pageName = "congrats"
+    override var webViewClient: PageWebViewClient = PageWebViewClient()
+    override var webChromeClient: PageChromeClient = PageChromeClient()
+
+    companion object {
+        fun getIntent(context: Context): Intent {
+            return PagesActivity.getIntent(context, CongratsPage::class)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -32,7 +32,7 @@ import timber.log.Timber
 abstract class PageFragment : Fragment() {
     @get:StringRes
     /** Title string resource of the page */
-    abstract val title: Int
+    abstract val title: Int?
     abstract val pageName: String
     abstract var webViewClient: PageWebViewClient
     abstract var webChromeClient: PageChromeClient

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -18,6 +18,9 @@ package com.ichi2.anki.pages
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.view.isVisible
+import com.google.android.material.color.MaterialColors
+import com.ichi2.anki.R
+import com.ichi2.utils.toRGBHex
 
 /**
  * Base WebViewClient to be used on [PageFragment]
@@ -25,8 +28,13 @@ import androidx.core.view.isVisible
 open class PageWebViewClient : WebViewClient() {
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
-        /** [PageFragment.webView] is invisible by default to avoid flashes while
-         * the page is loaded, and can be made visible again after it finishes loading */
-        view?.isVisible = true
+        view?.let { webView ->
+            val bgColor = MaterialColors.getColor(webView, android.R.attr.colorBackground).toRGBHex()
+            webView.evaluateJavascript("document.body.style.backgroundColor = '$bgColor';") {}
+
+            /** [PageFragment.webView] is invisible by default to avoid flashes while
+             * the page is loaded, and can be made visible again after it finishes loading */
+            view.isVisible = true
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
@@ -64,7 +64,7 @@ class PagesActivity : AnkiActivity() {
         supportFragmentManager.commit {
             replace(R.id.page_container, pageFragment)
         }
-        setTitle(pageFragment.title)
+        setTitle(pageFragment.title ?: R.string.empty_string)
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -27,6 +27,7 @@ import anki.card_rendering.EmptyCardsReport
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
 import anki.config.ConfigKey
+import anki.scheduler.CongratsInfoResponse
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
@@ -714,5 +715,17 @@ open class Collection(
         // the call appears to be non-deterministic. Sort ascending
         return backend.clozeNumbersInNote(n.toBackendNote())
             .sorted()
+    }
+
+    // TODO either support bridgeCommand here
+    //   or replace it with POST requests in Anki Desktop (preferable)
+    //   https://github.com/ankidroid/Anki-Android/issues/14361#issuecomment-1701946364
+    fun congratsInfoRaw(input: ByteArray): ByteArray {
+        val byteArray = backend.congratsInfoRaw(input = input)
+        val response = CongratsInfoResponse.parseFrom(byteArray)
+        return CongratsInfoResponse.newBuilder(response)
+            .setBridgeCommandsSupported(false)
+            .build()
+            .toByteArray()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -17,9 +17,6 @@
 package com.ichi2.libanki.sched
 
 import android.app.Activity
-import android.graphics.Typeface
-import android.text.SpannableStringBuilder
-import android.text.style.StyleSpan
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import anki.ankidroid.schedTimingTodayLegacyRequest
@@ -42,7 +39,6 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.utils.TimeManager.time
-import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 
 data class CurrentQueueState(
@@ -423,42 +419,6 @@ open class Scheduler(val col: Collection) {
 
     fun deckTree(includeCounts: Boolean): DeckNode {
         return DeckNode(col.backend.deckTree(now = if (includeCounts) time.intTime() else 0), "")
-    }
-
-    /**
-     * @param context Some Context to access the lang
-     * @return A message to show to user when they reviewed the last card. Let them know if they can see learning card later today
-     * or if they could see more card today by extending review.
-     */
-    @RustCleanup("remove once new congrats screen is the default")
-    fun finishedMsg(): CharSequence {
-        val sb = SpannableStringBuilder()
-        sb.append(col.tr.schedulingCongratulationsFinished())
-        val boldSpan = StyleSpan(Typeface.BOLD)
-        sb.setSpan(boldSpan, 0, sb.length, 0)
-        sb.append(nextDueMsg())
-        return sb
-    }
-
-    fun nextDueMsg(): String {
-        val sb = StringBuilder()
-        if (revDue()) {
-            sb.append("\n\n")
-            sb.append(col.tr.schedulingTodayReviewLimitReached())
-        }
-        if (newDue()) {
-            sb.append("\n\n")
-            sb.append(col.tr.schedulingTodayNewLimitReached())
-        }
-        if (haveBuriedInCurrentDeck()) {
-            sb.append("\n\n")
-            sb.append(col.tr.schedulingBuriedCardsFound(col.tr.schedulingUnburyThem()))
-        }
-        if (col.decks.current().isNormal) {
-            sb.append("\n\n")
-            sb.append(col.tr.schedulingHowToCustomStudy(col.tr.schedulingCustomStudy()))
-        }
-        return sb.toString()
     }
 
     fun deckLimit(): String {

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -161,16 +161,6 @@
                     android:layout_alignParentBottom="true"
                     android:layout_centerHorizontal="true"
                     android:orientation="vertical">
-                    <com.ichi2.ui.FixedTextView
-                        android:id="@+id/studyoptions_congrats_message"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:minLines="2"
-                        android:layout_gravity="center_horizontal"
-                        android:gravity="center"
-                        android:paddingLeft="2dp"
-                        android:paddingRight="2dp"
-                        android:paddingBottom="8dp"/>
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/studyoptions_start"
                         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -117,7 +117,6 @@
     <string name="search_deck" comment="Deck search for selecting it">Deck Search</string>
     <string name="search_for_download_deck" comment="Deck search value for downloading deck">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
-    <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -36,7 +36,6 @@
     <!-- DeckPicker.kt -->
     <string name="expand">Expand</string>
     <string name="collapse">Collapse</string>
-    <string name="study_more">Study more</string>
     <plurals name="reviewer_window_title">
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
@@ -119,9 +118,6 @@
     <string name="search_for_download_deck" comment="Deck search value for downloading deck">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_empty">This deck is empty. Press the + button to add new content.</string>
-    <string name="studyoptions_limit_reached">Daily study limit reached</string>
-    <string name="studyoptions_empty_schedule">No cards scheduled to study</string>
-    <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -45,7 +45,6 @@ import org.mockito.Mockito.*
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
-import org.robolectric.shadows.ShadowToast
 import java.util.*
 import java.util.stream.Stream
 import com.ichi2.anim.ActivityTransitionAnimation.Direction as Direction
@@ -250,14 +249,6 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         assertThat("no auto answer after pause", viewer.hasAutomaticAnswerQueued(), equalTo(false))
         viewer.mOnRenderProcessGoneDelegate.onRenderProcessGone(viewer.webView!!, mock(RenderProcessGoneDetail::class.java))
         assertThat("no auto answer after onRenderProcessGone when paused", viewer.hasAutomaticAnswerQueued(), equalTo(false))
-    }
-
-    @Test
-    fun shortcutShowsToastOnFinish() = runTest {
-        val viewer: NonAbstractFlashcardViewer = getViewer(true, true)
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
-        assertEquals(getResourceString(R.string.studyoptions_congrats_finished), ShadowToast.getTextOfLatestToast())
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -618,47 +618,6 @@ open class SchedulerTest : JvmTest() {
 
     @Test
     @Throws(Exception::class)
-    fun test_finishedV2() {
-        val col = col
-        // nothing due
-        MatcherAssert.assertThat(
-            col.sched.finishedMsg().toString(),
-            Matchers.containsString("Congratulations")
-        )
-        MatcherAssert.assertThat(
-            col.sched.finishedMsg().toString(),
-            Matchers.not(
-                Matchers.containsString("limit")
-            )
-        )
-        val note = col.newNote()
-        note.setItem("Front", "one")
-        note.setItem("Back", "two")
-        col.addNote(note)
-        // have a new card
-        MatcherAssert.assertThat(
-            col.sched.finishedMsg().toString(),
-            Matchers.containsString("new cards available")
-        )
-        // turn it into a review
-        val c = note.cards()[0]
-        c.startTimer()
-        col.sched.answerCard(c, BUTTON_THREE)
-        // nothing should be due tomorrow, as it's due in a week
-        MatcherAssert.assertThat(
-            col.sched.finishedMsg().toString(),
-            Matchers.containsString("Congratulations")
-        )
-        MatcherAssert.assertThat(
-            col.sched.finishedMsg().toString(),
-            Matchers.not(
-                Matchers.containsString("limit")
-            )
-        )
-    }
-
-    @Test
-    @Throws(Exception::class)
     fun test_nextIvlV2() {
         val col = col
         val note = col.newNote()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #14361 
* Fixes https://github.com/ankidroid/Anki-Android/issues/14662

## Approach
Add the congrats screen from Anki Desktop.

Note that a part of the original screen isn't shown because we don't support (and [ideally shouldn't](https://github.com/ankidroid/Anki-Android/issues/14361#issuecomment-1701946364)) `bridgeCommand`, which is a legacy python-javascript bridge used in the desktop version.

I actually tried to do replace it with POST requests in the desktop's repo, but got some trouble when trying to build the string with a link calling the backend method in Svelte, which is probably due to my limited knowledge about Js/Svelte/How Anki Desktop works

So I left a TODO, which sould suffice for now

## How Has This Been Tested?

Emulator 31

[faded.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/d57f83ea-e475-496b-a2ef-f5fca3d87a2d)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
