### PR TITLE
chore: speed up server & fix log spam

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -48,6 +48,10 @@ open class AnkiServer(
         return "http://127.0.0.1:$listeningPort/"
     }
 
+    // it's faster to serve local files without GZip. see 'page render' in logs
+    // This also removes 'W/System: A resource failed to call end.'
+    override fun useGzipWhenAccepted(r: Response?) = false
+
     override fun serve(session: IHTTPSession): Response {
         val uri = session.uri
         val mime = getMimeFromUri(uri)


### PR DESCRIPTION
## Description

I was frustrated by 10 new warnings per card flip on a standard 'Basic' card. There were no nice solutions, so this was a hack. It's also faster

```diff
- 02:31:01.890  System 	W  A resource failed to call close. 
- 02:31:01.892  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
- 02:31:01.893  System 	W  A resource failed to call end. 
```

## Fixes
* Fixes #14924

## Approach
* Perf test
* disable GZip, as it's spammy + slower

## Alternate approaches
1. Disable all logs for this issue globally
2. Reflection + `ViolationLogger` (a `@hide` interface)

----

1. seemed too heavy handed and required StrictMode changes 
2. seemed infeasible + short term

## How Has This Been Tested?
* https://github.com/ankidroid/Anki-Android/pull/15005

## Learning (optional, can help others)
Too much to mention here, see the issue.

A full investigation into `CloseGuard` source code, `VmPolicy`, and that you can't feasibly add a custom logger to the `VmPolicy`

I went into the internals of `GZIPOutputStream` and determined it wasn't possible to use it for the nanoHTTPD use case without providing a warning, therefore `NanoHTTPD` was very unlikely to want to fix this

Then realise disabling GZip is faster, so just do that

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
