### PR TITLE
fix: previewer crash when cast to CardTemplatePreviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1579,10 +1579,6 @@ open class Reviewer :
         }
     }
 
-    override fun javaScriptFunction(): AnkiDroidJsAPI {
-        return AnkiDroidJsAPI(this)
-    }
-
     override fun getCardDataForJsApi(): AnkiDroidJsAPI.CardDataForJsApi {
         val cardDataForJsAPI = AnkiDroidJsAPI.CardDataForJsApi().apply {
             newCardCount = mNewCount.toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki
 
-import androidx.fragment.app.FragmentActivity
 import anki.frontend.SetSchedulingStatesRequest
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.utils.AssetHelper
@@ -24,13 +23,9 @@ import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
 
-class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiServer(activity) {
+class ReviewerServer(activity: AbstractFlashcardViewer, private val mediaDir: String) : AnkiServer(activity) {
     var reviewerHtml: String = ""
-    private val jsApi = if (activity is Reviewer) {
-        reviewer().javaScriptFunction()
-    } else {
-        cardTemplatePreviewer().javaScriptFunction()
-    }
+    private val jsApi = activity.javaScriptFunction()
 
     override fun start() {
         super.start()
@@ -100,10 +95,6 @@ class ReviewerServer(activity: FragmentActivity, val mediaDir: String) : AnkiSer
 
     private fun reviewer(): Reviewer {
         return (activity as Reviewer)
-    }
-
-    private fun cardTemplatePreviewer(): CardTemplatePreviewer {
-        return (activity as CardTemplatePreviewer)
     }
 
     private fun getSchedulingStatesWithContext(): ByteArray {


### PR DESCRIPTION
## Fixes
* Fixes #14928

## Approach
handle class inheritors better

## How Has This Been Tested?

Open the previewer and don't crash
