### PR TITLE
fix: 400 error on first sync as sync endpoint is moved

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -194,6 +194,7 @@ private suspend fun handleNormalSync(
     auth: SyncAuth,
     syncMedia: Boolean
 ) {
+    var auth2 = auth
     val output = deckPicker.withProgress(
         extractProgress = {
             if (progress.hasNormalSync()) {
@@ -202,13 +203,14 @@ private suspend fun handleNormalSync(
         },
         onCancel = ::cancelSync
     ) {
-        withCol { syncCollection(auth, media = syncMedia) }
+        withCol { syncCollection(auth2, media = syncMedia) }
     }
 
     if (output.hasNewEndpoint()) {
         deckPicker.sharedPrefs().edit {
             putString(SyncPreferences.CURRENT_SYNC_URI, output.newEndpoint)
         }
+        auth2 = syncAuth { this.hkey = auth.hkey; endpoint = output.newEndpoint }
     }
     val mediaUsn = if (syncMedia) { output.serverMediaUsn } else { null }
 
@@ -225,11 +227,11 @@ private suspend fun handleNormalSync(
         }
 
         SyncCollectionResponse.ChangesRequired.FULL_DOWNLOAD -> {
-            handleDownload(deckPicker, auth, mediaUsn)
+            handleDownload(deckPicker, auth2, mediaUsn)
         }
 
         SyncCollectionResponse.ChangesRequired.FULL_UPLOAD -> {
-            handleUpload(deckPicker, auth, mediaUsn)
+            handleUpload(deckPicker, auth2, mediaUsn)
         }
 
         SyncCollectionResponse.ChangesRequired.FULL_SYNC -> {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Currently, the first time you sync with ankiweb it will typically redirect you to one of it's farm of servers with different hostnames

That endpoint change wasn't handled gracefully before resulting in a 400 error "missing original size"

## Fixes
* Fixes #14651

## Approach

Take @dae advice and if the endpoint is different, create a new sync auth object then use that for syncing

## How Has This Been Tested?

You can trigger the problem / simulate a first-login/first-sync by clearing all AnkiDroid data then logging in to AnkiWeb and attempting to sync. It will trigger the error without this patch

After applying this patch, it works the first time

## Learning (optional, can help others)
Sometimes I do not feel like I learned anything.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
