### PR TITLE
fix: show sync errors to user but no crash report

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -55,17 +55,24 @@ suspend fun <T> FragmentActivity.runCatchingTask(
 ): T? {
     try {
         return block()
-    } catch (cancellationException: CancellationException) {
-        throw cancellationException // CancellationException should be re-thrown to propagate it to the parent coroutine
-    } catch (exc: BackendInterruptedException) {
-        Timber.e(exc, errorMessage)
-        exc.localizedMessage?.let { showSnackbar(it) }
-    } catch (exc: BackendException) {
-        Timber.e(exc, errorMessage)
-        showError(this, exc.localizedMessage!!, exc)
     } catch (exc: Exception) {
-        Timber.e(exc, errorMessage)
-        showError(this, exc.toString(), exc)
+        when (exc) {
+            is CancellationException -> {
+                throw exc // CancellationException should be re-thrown to propagate it to the parent coroutine
+            }
+            is BackendInterruptedException -> {
+                Timber.e(exc, errorMessage)
+                exc.localizedMessage?.let { showSnackbar(it) }
+            }
+            is BackendException -> {
+                Timber.e(exc, errorMessage)
+                showError(this, exc.localizedMessage!!, exc)
+            }
+            else -> {
+                Timber.e(exc, errorMessage)
+                showError(this, exc.toString(), exc)
+            }
+        }
     }
     return null
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -63,7 +63,7 @@ suspend fun <T> FragmentActivity.runCatchingTask(
                 throw exc // CancellationException should be re-thrown to propagate it to the parent coroutine
             }
             is BackendInterruptedException -> {
-                Timber.e(exc, errorMessage)
+                Timber.w(exc, errorMessage)
                 exc.localizedMessage?.let { showSnackbar(it) }
             }
             is BackendNetworkException, is BackendSyncException -> {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Our acralyzer crash database is pretty full of backend sync exceptions.

They fall largely into 3 categories:

- some sort of HTTP / network error -> BackendNetworkException
- account needs to be reconfirmed error -> BackendSyncException
- a grab bag category that has things like "only one copy of anki may sync at a time, come back later" etc -> frequently BackendSyncException

## Fixes
* Fixes no issue was logged but it was discussed - sync errors in general shouldn't generate a crash report and they are a *huge* percentage of our crash reports

## Approach

**UPDATED from original push**

1- refactor exception handler in `launchCatchingTask` for multi-exception-type + same-handling-block ability
2- add ability for CoroutineHelpers existing error display to only send crash reports optionally, but default to old behavior
3- catch for 2 specific exception types I know we don't want in our crash database, and toggle off crash report for them

## How Has This Been Tested?

Turn off internet on emulator and see where the errors go - it was a surprise I was not able to catch them in the DeckPicker.doSync ! `launchCatchingTask` was the only place control flow was reliable

So original attempt was scrapped and I worked through it in `launchCatchingTask`

## Learning

Untested code is crap every time, at least when I produce it. Original approach was approved and ready to merge but it did not stand up to actual scrutiny. Glad my reptile brain (which has learned this my-untested-code-is-crap lesson before...) wouldn't let me hit the green button until I'd really tested it, even for my own code

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
