### PR TITLE
feat: add backend version info in useful places

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -40,6 +40,7 @@ import com.ichi2.utils.show
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
+import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
 class AboutFragment : Fragment() {
     override fun onCreateView(
@@ -57,6 +58,10 @@ class AboutFragment : Fragment() {
         // Version text
         layoutView.findViewById<TextView>(R.id.about_version).text =
             pkgVersionName
+
+        // Backend version text
+        layoutView.findViewById<TextView>(R.id.about_backend).text =
+            "(anki " + BackendBuildConfig.ANKI_DESKTOP_VERSION + " / " + BackendBuildConfig.ANKI_COMMIT_HASH.subSequence(0, 8) + ")"
 
         // Logo secret
         layoutView.findViewById<ImageView>(R.id.about_app_logo)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CrashReportService
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import org.acra.util.Installation
+import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
 object DebugInfoService {
     fun getDebugInfo(info: Context): String {
@@ -30,7 +31,7 @@ object DebugInfoService {
         return """
                AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
                
-               Backend Version = ${BuildConfig.BACKEND_VERSION}
+               Backend Version = ${BuildConfig.BACKEND_VERSION} (${BackendBuildConfig.ANKI_DESKTOP_VERSION} ${BackendBuildConfig.ANKI_COMMIT_HASH})
               
                Android Version = ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})
                

--- a/AnkiDroid/src/main/res/layout/about_layout.xml
+++ b/AnkiDroid/src/main/res/layout/about_layout.xml
@@ -19,6 +19,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:fadeScrollbars="false"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 <LinearLayout

--- a/AnkiDroid/src/main/res/layout/about_layout.xml
+++ b/AnkiDroid/src/main/res/layout/about_layout.xml
@@ -55,8 +55,15 @@
         style="?android:textAppearanceSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="14dp"
         tools:text="13 Apr 2023" />
+
+    <TextView
+        android:id="@+id/about_backend"
+        style="?android:textAppearanceSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="14dp"
+        tools:text="(anki 23.10.1 / be74babb0)" />
 
     <TextView
         android:id="@+id/about_contributors_title"

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     ext.kotlin_version = '1.9.21'
     ext.lint_version = '31.1.1'
     ext.acra_version = '5.11.3'
-    ext.ankidroid_backend_version = '0.1.30-anki23.10.1'
+    ext.ankidroid_backend_version = '0.1.31-anki23.10.1'
     ext.hamcrest_version = '2.2'
     ext.junit_version = '5.10.1'
     ext.coroutines_version = '1.7.3'


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

@user1823 asserted that it can be a little confusing trying to figure out which backend version was in use inside AnkiDroid, even to the point of the user-visible name of the version (e.g. "23.10.1") being ambiguous as that name changed a couple times during the alpha series such that the commit hash was the only *true* disambiguator

I'm inclined to agree, and also agree with the separate point that including it on debug information only (which has to be pasted somewhere so it is visible) is not that helpful as users cannot easily see it, so they cannot easily reason about it or use the information for user-to-user help or self-help

This is important because there *are* incompatibilities across other parts of anki ecosystem when the versions don't match so determining backend version is user-useful.

## Fixes
* Fixes #14909 

## Approach

- adopt the latest backend version which David has helpfully included backend information in
- add the backend information to the debug clipboard copy
- add the backend info as a new spot in the about pref layout and populate it - note this is not translatable or LTR but I do not think it needs to be nor should be: "anki" is a proper noun, not translatable and the rest is version numbers)

Note that I chose a 9-char shorthash of the github anki backend commit. I believe that is sufficiently non-ambiguous (github uses 8 normally, gitlab uses 9 apparently) while not  having the hash visually dominate the text line

## How Has This Been Tested?

Here's what it looks like now, one little extra line:

![image](https://github.com/ankidroid/Anki-Android/assets/782704/5697d80b-7870-4cd4-a73d-fd75809d3536)


Here is the debug paste:

```
AnkiDroid Version = 2.17alpha9-debug (be74bafb0e62672d4debf0cf9c0df43db5c0ae33)

Backend Version = 0.1.31-anki23.10.1 (23.10.1 fac9e0ee1436ba5ac3366c72dd9394a6e692b1cf)

Android Version = 13 (SDK 33)

ProductFlavor = amazon

Manufacturer = Google

Model = sdk_gphone64_x86_64

Hardware = ranchu

Webview User Agent = Mozilla/5.0 (Linux; Android 13; sdk_gphone64_x86_64 Build/TE1A.220922.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/119.0.6045.193 Mobile Safari/537.36

ACRA UUID = c6cbfc42-08d1-4fd3-a02a-f52a661db600

Crash Reports Enabled = false
```

## Learning (optional, can help others)
Nothing technical, and it's not a new lesson, but multi-person collaboration is always enjoyable

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
