### PR TITLE
refactor: extract 'CardBrowserLaunchOptions'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserLaunchOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserLaunchOptions.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.Intent
+import androidx.annotation.CheckResult
+
+/** How the [com.ichi2.anki.CardBrowser] can be launched */
+sealed interface CardBrowserLaunchOptions {
+    data class DeepLink(val search: String) : CardBrowserLaunchOptions
+    data class SearchQueryJs(val search: String, val allDecks: Boolean) : CardBrowserLaunchOptions
+
+    /** Opened from the 'Card Browser' system context menu ([Intent.ACTION_PROCESS_TEXT]) */
+    data class SystemContextMenu(val search: CharSequence) : CardBrowserLaunchOptions
+}
+
+@CheckResult
+fun Intent.toCardBrowserLaunchOptions(): CardBrowserLaunchOptions? {
+    // search card using deep links
+    data?.getQueryParameter("search")?.let {
+        return CardBrowserLaunchOptions.DeepLink(it)
+    }
+
+    // for intent coming from search query js api
+    getStringExtra("search_query")?.let {
+        return CardBrowserLaunchOptions.SearchQueryJs(it, getBooleanExtra("all_decks", false))
+    }
+
+    // Maybe we were called from ACTION_PROCESS_TEXT
+    if (Intent.ACTION_PROCESS_TEXT == action) {
+        val search = getCharSequenceExtra(Intent.EXTRA_PROCESS_TEXT)
+        if (search.isNullOrEmpty()) {
+            return null
+        }
+        return CardBrowserLaunchOptions.SystemContextMenu(search)
+    }
+
+    return null
+}


### PR DESCRIPTION
Handling will be moved into the ViewModel at a later time in which case the class is useful

* extract the concept from https://github.com/ankidroid/Anki-Android/pull/14843 

## How Has This Been Tested?
Tests, then opened the card browser and it still launched

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
