### PR TITLE
refactor: Browser lastDeckId/restrictOnDeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -462,7 +462,11 @@ open class CardBrowser :
         viewModel.lastDeckIdFlow
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .filterNotNull()
-            .onEach { searchCards() }
+            .onEach { deckId ->
+                // this handles ALL_DECKS_ID
+                deckSpinnerSelection!!.selectDeckById(deckId, true)
+                searchCards()
+            }
             .launchIn(lifecycleScope)
     }
 
@@ -562,7 +566,6 @@ open class CardBrowser :
     }
 
     fun selectDeckAndSave(deckId: DeckId) {
-        deckSpinnerSelection!!.selectDeckById(deckId, true)
         mRestrictOnDeck = if (deckId == ALL_DECKS_ID) {
             ""
         } else {
@@ -637,7 +640,6 @@ open class CardBrowser :
 
     @VisibleForTesting
     fun selectAllDecks() {
-        deckSpinnerSelection!!.selectAllDecks()
         mRestrictOnDeck = ""
         viewModel.lastDeckId = ALL_DECKS_ID
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -89,6 +89,7 @@ import com.ichi2.utils.HandlerUtils.postDelayedOnNewHandler
 import com.ichi2.utils.TagsUtil.getUpdatedTags
 import com.ichi2.widget.WidgetStatus.updateInBackground
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import net.ankiweb.rsdroid.RustCleanup
@@ -458,6 +459,12 @@ open class CardBrowser :
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { index -> cardsAdapter.updateMapping { it[1] = COLUMN2_KEYS[index] } }
             .launchIn(lifecycleScope)
+
+        viewModel.lastDeckIdFlow
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .filterNotNull()
+            .onEach { searchCards() }
+            .launchIn(lifecycleScope)
     }
 
     fun searchWithFilterQuery(filterQuery: String) {
@@ -566,7 +573,6 @@ open class CardBrowser :
             "deck:\"$deckName\" "
         }
         viewModel.lastDeckId = deckId
-        searchCards()
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
@@ -637,7 +643,6 @@ open class CardBrowser :
         deckSpinnerSelection!!.selectAllDecks()
         mRestrictOnDeck = ""
         viewModel.lastDeckId = ALL_DECKS_ID
-        searchCards()
     }
 
     /** Opens the note editor for a card.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -112,7 +112,6 @@ open class CardBrowser :
         deck?.let {
             val deckId = deck.deckId
             deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
-            deckSpinnerSelection!!.selectDeckById(deckId, true)
             selectDeckAndSave(deckId)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -554,13 +554,11 @@ open class CardBrowser :
         deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
         selectDeckAndSave(deckId)
 
-        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
-        if (viewModel.lastDeckId == ALL_DECKS_ID) {
-            selectAllDecks()
-        } else if (viewModel.lastDeckId != null && col.decks.get(viewModel.lastDeckId!!) != null) {
-            deckSpinnerSelection!!.selectDeckById(viewModel.lastDeckId!!, false)
-        } else {
-            deckSpinnerSelection!!.selectDeckById(col.decks.selected(), false)
+        launchCatchingTask {
+            when (viewModel.getInitialDeck()) {
+                ALL_DECKS_ID -> selectAllDecks()
+                else -> deckSpinnerSelection!!.selectDeckById(viewModel.lastDeckId!!, false)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -357,11 +357,6 @@ open class CardBrowser :
         }
     }
 
-    @get:VisibleForTesting
-    var lastDeckId: DeckId?
-        get() = viewModel.lastDeckId
-        set(value) { viewModel.lastDeckId = value }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -553,10 +548,10 @@ open class CardBrowser :
         selectDeckAndSave(deckId)
 
         // If a valid value for last deck exists then use it, otherwise use libanki selected deck
-        if (lastDeckId != null && lastDeckId == ALL_DECKS_ID) {
+        if (viewModel.lastDeckId == ALL_DECKS_ID) {
             selectAllDecks()
-        } else if (lastDeckId != null && col.decks.get(lastDeckId!!) != null) {
-            deckSpinnerSelection!!.selectDeckById(lastDeckId!!, false)
+        } else if (viewModel.lastDeckId != null && col.decks.get(viewModel.lastDeckId!!) != null) {
+            deckSpinnerSelection!!.selectDeckById(viewModel.lastDeckId!!, false)
         } else {
             deckSpinnerSelection!!.selectDeckById(col.decks.selected(), false)
         }
@@ -570,7 +565,7 @@ open class CardBrowser :
             val deckName = getColUnsafe.decks.name(deckId)
             "deck:\"$deckName\" "
         }
-        lastDeckId = deckId
+        viewModel.lastDeckId = deckId
         searchCards()
     }
 
@@ -641,7 +636,7 @@ open class CardBrowser :
     fun selectAllDecks() {
         deckSpinnerSelection!!.selectAllDecks()
         mRestrictOnDeck = ""
-        lastDeckId = ALL_DECKS_ID
+        viewModel.lastDeckId = ALL_DECKS_ID
         searchCards()
     }
 
@@ -1281,8 +1276,8 @@ open class CardBrowser :
         get() {
             val intent = Intent(this@CardBrowser, NoteEditor::class.java)
             intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_ADD)
-            if (lastDeckId?.let { id -> id > 0 } == true) {
-                intent.putExtra(NoteEditor.EXTRA_DID, lastDeckId)
+            if (viewModel.lastDeckId?.let { id -> id > 0 } == true) {
+                intent.putExtra(NoteEditor.EXTRA_DID, viewModel.lastDeckId)
             }
             intent.putExtra(NoteEditor.EXTRA_TEXT_FROM_SEARCH_VIEW, mSearchTerms)
             return intent
@@ -1634,7 +1629,7 @@ open class CardBrowser :
         return v?.top ?: 0
     }
 
-    fun hasSelectedAllDecks(): Boolean = lastDeckId == ALL_DECKS_ID
+    fun hasSelectedAllDecks(): Boolean = viewModel.lastDeckId == ALL_DECKS_ID
 
     fun searchAllDecks() {
         // all we need to do is select all decks
@@ -1648,10 +1643,10 @@ open class CardBrowser :
      */
     val selectedDeckNameForUi: String
         get() = try {
-            when (lastDeckId) {
+            when (val deckId = viewModel.lastDeckId) {
                 null -> getString(R.string.card_browser_unknown_deck_name)
                 ALL_DECKS_ID -> getString(R.string.card_browser_all_decks)
-                else -> getColUnsafe.decks.name(lastDeckId!!)
+                else -> getColUnsafe.decks.name(deckId)
             }
         } catch (e: Exception) {
             Timber.w(e, "Unable to get selected deck name")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -45,7 +45,6 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.browser.CardBrowserLaunchOptions
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModel.*
-import com.ichi2.anki.browser.LastDeckIdRepository
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
@@ -124,8 +123,6 @@ open class CardBrowser :
     private enum class TagsDialogListenerAction {
         FILTER, EDIT_TAGS
     }
-
-    private val lastDeckIdRepository: LastDeckIdRepository = SharedPreferencesLastDeckIdRepository()
 
     lateinit var viewModel: CardBrowserViewModel
 
@@ -362,8 +359,8 @@ open class CardBrowser :
 
     @get:VisibleForTesting
     var lastDeckId: DeckId?
-        get() = lastDeckIdRepository.lastDeckId
-        set(value) { lastDeckIdRepository.lastDeckId = value }
+        get() = viewModel.lastDeckId
+        set(value) { viewModel.lastDeckId = value }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -1906,7 +1903,7 @@ open class CardBrowser :
      */
     private fun createViewModel() = ViewModelProvider(
         viewModelStore,
-        CardBrowserViewModel.factory(),
+        CardBrowserViewModel.factory(SharedPreferencesLastDeckIdRepository()),
         defaultViewModelCreationExtras
     )[CardBrowserViewModel::class.java]
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -456,7 +456,7 @@ open class CardBrowser :
             .onEach { index -> cardsAdapter.updateMapping { it[1] = COLUMN2_KEYS[index] } }
             .launchIn(lifecycleScope)
 
-        viewModel.lastDeckIdFlow
+        viewModel.deckIdFlow
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .filterNotNull()
             .onEach { deckId ->
@@ -564,7 +564,7 @@ open class CardBrowser :
     }
 
     suspend fun selectDeckAndSave(deckId: DeckId) {
-        viewModel.setLastDeckId(deckId)
+        viewModel.setDeckId(deckId)
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
@@ -632,7 +632,7 @@ open class CardBrowser :
 
     @VisibleForTesting
     suspend fun selectAllDecks() {
-        viewModel.setLastDeckId(ALL_DECKS_ID)
+        viewModel.setDeckId(ALL_DECKS_ID)
     }
 
     /** Opens the note editor for a card.
@@ -1628,7 +1628,7 @@ open class CardBrowser :
 
     fun searchAllDecks() = launchCatchingTask {
         // all we need to do is select all decks
-        viewModel.setLastDeckId(ALL_DECKS_ID)
+        viewModel.setDeckId(ALL_DECKS_ID)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -118,7 +118,7 @@ class CardBrowserViewModel(
     val lastDeckId: DeckId?
         get() = lastDeckIdRepository.lastDeckId
 
-    suspend fun setLastDeckId(deckId: DeckId) {
+    suspend fun setDeckId(deckId: DeckId) {
         lastDeckIdRepository.lastDeckId = deckId
         restrictOnDeck = if (deckId == ALL_DECKS_ID) {
             ""
@@ -126,10 +126,10 @@ class CardBrowserViewModel(
             val deckName = withCol { decks.name(deckId) }
             "deck:\"$deckName\" "
         }
-        lastDeckIdFlow.update { deckId }
+        deckIdFlow.update { deckId }
     }
 
-    val lastDeckIdFlow = MutableStateFlow(lastDeckId)
+    val deckIdFlow = MutableStateFlow(lastDeckId)
 
     val cardInfoDestination: CardInfoDestination?
         get() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -69,6 +69,7 @@ class CardBrowserViewModel(
 
     var searchTerms: String = ""
     var restrictOnDeck: String = ""
+        private set
     var currentFlag = 0
 
     /**
@@ -114,12 +115,19 @@ class CardBrowserViewModel(
         get() = selectedRows.map { c -> c.id }
     var lastSelectedPosition = 0
 
-    var lastDeckId: DeckId?
+    val lastDeckId: DeckId?
         get() = lastDeckIdRepository.lastDeckId
-        set(value) {
-            lastDeckIdRepository.lastDeckId = value
-            lastDeckIdFlow.update { value }
+
+    suspend fun setLastDeckId(deckId: DeckId) {
+        lastDeckIdRepository.lastDeckId = deckId
+        restrictOnDeck = if (deckId == ALL_DECKS_ID) {
+            ""
+        } else {
+            val deckName = withCol { decks.name(deckId) }
+            "deck:\"$deckName\" "
         }
+        lastDeckIdFlow.update { deckId }
+    }
 
     val lastDeckIdFlow = MutableStateFlow(lastDeckId)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -115,7 +115,12 @@ class CardBrowserViewModel(
 
     var lastDeckId: DeckId?
         get() = lastDeckIdRepository.lastDeckId
-        set(value) { lastDeckIdRepository.lastDeckId = value }
+        set(value) {
+            lastDeckIdRepository.lastDeckId = value
+            lastDeckIdFlow.update { value }
+        }
+
+    val lastDeckIdFlow = MutableStateFlow(lastDeckId)
 
     val cardInfoDestination: CardInfoDestination?
         get() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -25,6 +25,7 @@ import androidx.lifecycle.viewmodel.viewModelFactory
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.DeckSpinnerSelection.Companion.ALL_DECKS_ID
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.ExportDialogParams
 import com.ichi2.anki.export.ExportType
@@ -127,6 +128,21 @@ class CardBrowserViewModel(
             val firstSelectedCard = selectedCardIds.firstOrNull() ?: return null
             return CardInfoDestination(firstSelectedCard)
         }
+
+    suspend fun getInitialDeck(): DeckId {
+        // TODO: Handle the launch intent
+        val lastDeckId = lastDeckId
+        if (lastDeckId == ALL_DECKS_ID) {
+            return ALL_DECKS_ID
+        }
+
+        // If a valid value for last deck exists then use it, otherwise use libanki selected deck
+        return if (lastDeckId != null && withCol { decks.get(lastDeckId) != null }) {
+            lastDeckId
+        } else {
+            withCol { decks.selected() }
+        }
+    }
 
     private val initCompletedFlow = MutableStateFlow(false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.servicelayer.CardService
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts
+import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -57,6 +58,7 @@ import kotlin.math.min
 
 @NeedsTest("reverseDirectionFlow/sortTypeFlow are not updated on .launch { }")
 class CardBrowserViewModel(
+    private val lastDeckIdRepository: LastDeckIdRepository,
     preferences: SharedPreferencesProvider
 ) : ViewModel(), SharedPreferencesProvider by preferences {
     val cards = CardBrowser.CardCollection<CardBrowser.CardCache>()
@@ -110,6 +112,10 @@ class CardBrowserViewModel(
     val selectedCardIds: List<Long>
         get() = selectedRows.map { c -> c.id }
     var lastSelectedPosition = 0
+
+    var lastDeckId: DeckId?
+        get() = lastDeckIdRepository.lastDeckId
+        set(value) { lastDeckIdRepository.lastDeckId = value }
 
     val cardInfoDestination: CardInfoDestination?
         get() {
@@ -395,9 +401,12 @@ class CardBrowserViewModel(
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
         const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"
-        fun factory(preferencesProvider: SharedPreferencesProvider? = null) = viewModelFactory {
+        fun factory(lastDeckIdRepository: LastDeckIdRepository, preferencesProvider: SharedPreferencesProvider? = null) = viewModelFactory {
             initializer {
-                CardBrowserViewModel(preferencesProvider ?: AnkiDroidApp.sharedPreferencesProvider)
+                CardBrowserViewModel(
+                    lastDeckIdRepository,
+                    preferencesProvider ?: AnkiDroidApp.sharedPreferencesProvider
+                )
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.Context
+import androidx.core.content.edit
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CardBrowser
+import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.Decks
+
+interface LastDeckIdRepository {
+    var lastDeckId: DeckId?
+}
+
+class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
+    override var lastDeckId: DeckId?
+        get() = AnkiDroidApp.instance.getSharedPreferences(PERSISTENT_STATE_FILE, 0)
+            .getLong(LAST_DECK_ID_KEY, Decks.NOT_FOUND_DECK_ID)
+            .takeUnless { it == Decks.NOT_FOUND_DECK_ID }
+        set(value) =
+            if (value == null) {
+                CardBrowser.clearLastDeckId()
+            } else {
+                AnkiDroidApp.instance.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
+                    putLong(LAST_DECK_ID_KEY, value)
+                }
+            }
+
+    companion object {
+        fun clearLastDeckId() {
+            val context: Context = AnkiDroidApp.instance
+            context.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
+                remove(LAST_DECK_ID_KEY)
+            }
+        }
+
+        private const val PERSISTENT_STATE_FILE = "DeckPickerState"
+        private const val LAST_DECK_ID_KEY = "lastDeckId"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
@@ -27,6 +27,11 @@ interface LastDeckIdRepository {
     var lastDeckId: DeckId?
 }
 
+/**
+ * Saves the last selected [DeckId] in the Card Browser
+ *
+ * This exists as the old code used [PERSISTENT_STATE_FILE], rather than [AnkiDroidApp.sharedPrefs]
+ */
 class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
     override var lastDeckId: DeckId?
         get() = AnkiDroidApp.instance.getSharedPreferences(PERSISTENT_STATE_FILE, 0)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -470,7 +470,7 @@ class CardBrowserTest : RobolectricTest() {
 
         assertThat("All decks should not be selected", b.hasSelectedAllDecks(), equalTo(false))
 
-        b.viewModel.setLastDeckId(ALL_DECKS_ID)
+        b.viewModel.setDeckId(ALL_DECKS_ID)
 
         assertThat("All decks should be selected", b.hasSelectedAllDecks(), equalTo(true))
 
@@ -492,7 +492,7 @@ class CardBrowserTest : RobolectricTest() {
             not(equalTo(targetDid))
         )
 
-        b.viewModel.setLastDeckId(targetDid)
+        b.viewModel.setDeckId(targetDid)
 
         assertThat("The target deck should be selected", b.lastDeckId, equalTo(targetDid))
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1064,3 +1064,6 @@ fun ListView.getViewByPosition(pos: Int): View {
         }
     }
 }
+
+val CardBrowser.lastDeckId
+    get() = viewModel.lastDeckId

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -28,6 +28,7 @@ import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CardBrowser.CardCache
+import com.ichi2.anki.DeckSpinnerSelection.Companion.ALL_DECKS_ID
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_1_KEY
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_2_KEY
 import com.ichi2.anki.introduction.hasCollectionStoragePermissions
@@ -462,14 +463,14 @@ class CardBrowserTest : RobolectricTest() {
 
     /** 7420  */
     @Test
-    fun addCardDeckIsNotSetIfAllDecksSelectedAfterLoad() {
+    fun addCardDeckIsNotSetIfAllDecksSelectedAfterLoad() = runTest {
         addDeck("NotDefault")
 
         val b = browserWithNoNewCards
 
         assertThat("All decks should not be selected", b.hasSelectedAllDecks(), equalTo(false))
 
-        b.selectAllDecks()
+        b.viewModel.setLastDeckId(ALL_DECKS_ID)
 
         assertThat("All decks should be selected", b.hasSelectedAllDecks(), equalTo(true))
 
@@ -480,7 +481,7 @@ class CardBrowserTest : RobolectricTest() {
 
     /** 7420  */
     @Test
-    fun addCardDeckISetIfDeckIsSelected() {
+    fun addCardDeckISetIfDeckIsSelected() = runTest {
         val targetDid = addDeck("NotDefault")
 
         val b = browserWithNoNewCards
@@ -491,7 +492,7 @@ class CardBrowserTest : RobolectricTest() {
             not(equalTo(targetDid))
         )
 
-        b.selectDeckAndSave(targetDid)
+        b.viewModel.setLastDeckId(targetDid)
 
         assertThat("The target deck should be selected", b.lastDeckId, equalTo(targetDid))
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -38,7 +38,10 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     private fun runViewModelTest(testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
-        val viewModel = CardBrowserViewModel(AnkiDroidApp.sharedPreferencesProvider)
+        val viewModel = CardBrowserViewModel(
+            lastDeckIdRepository = SharedPreferencesLastDeckIdRepository(),
+            preferences = AnkiDroidApp.sharedPreferencesProvider
+        )
         testBody(viewModel)
     }
 }


### PR DESCRIPTION
## Purpose / Description
* Split from https://github.com/ankidroid/Anki-Android/pull/14843, partially, partially rewritten


## Approach
⚠️ One of the more risky refactors
* We want to start moving `searchCards` into an output of the flows
* Once these are all outputs of the flows, we can move it to a combined flow inside the ViewModel

----

* Extract repository
* Extract lastDeckId to viewmodel
* Extract to flow
* Continue to extract
* Extract `mRestrictOnDeck`

## How Has This Been Tested?
Unit tests + manual testing on API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
