### PR TITLE
test: wait for deck to load before clicking on it

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -102,6 +102,7 @@ class ReviewerTest : InstrumentedTest() {
     }
 
     private fun clickOnDeckWithName(deckName: String) {
+        onView(withId(R.id.files)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
         onView(withId(R.id.files)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(withText(deckName)),


### PR DESCRIPTION
## Purpose / Description
Sometimes, after adding a card to the database, the deck that gets created takes awhile to load when in the Deck Picker screen. We should wait and check to make sure that the deck is there before clicking on it

Hence, we sometimes see the failure:

```
com.ichi2.anki.ReviewerTest > testCustomSchedulerWithCustomData[test(AVD) - 11] FAILED 
	androidx.test.espresso.PerformException: Error performing 'performing ViewAction: single click on item matching: holder with view: (view is an instance of android.view.ViewGroup and has descendant matching an instance of android.widget.TextView and view.getText() with or without transformation to match: is "Default")' on view 'view.getId() is <2131296705/com.ichi2.anki.debug:id/files>'.
	at androidx.test.espresso.PerformException$Builder.build(PerformException.java:1)
```

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/14940

## Approach
Call `onView(withId(R.id.files)).checkWithTimeout(matches(hasDescendant(withText(deckName))))` which makes sure the RecyclerView has the deck as an item before clicking on it.

## How Has This Been Tested?

Passes on Android Studio using `2.7_QVGA_API_34` emulator

![image](https://github.com/ankidroid/Anki-Android/assets/85209455/ae83a4a9-73a4-44aa-9206-26ee05993f0a)


## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
