### PR TITLE
8602 remove dead code from start activity for result migration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -204,35 +204,6 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         enableActivityAnimation(animation)
     }
 
-    @Deprecated("")
-    @Suppress("DEPRECATION") // startActivityForResult
-    override fun startActivityForResult(intent: Intent, requestCode: Int) {
-        try {
-            super.startActivityForResult(intent, requestCode)
-        } catch (e: ActivityNotFoundException) {
-            Timber.w(e)
-            this.showSnackbar(R.string.activity_start_failed)
-        }
-    }
-
-    @Suppress("DEPRECATION") // startActivityForResult
-    fun startActivityForResultWithoutAnimation(intent: Intent, requestCode: Int) {
-        disableIntentAnimation(intent)
-        startActivityForResult(intent, requestCode)
-        disableActivityAnimation()
-    }
-
-    @Suppress("DEPRECATION") // startActivityForResult
-    fun startActivityForResultWithAnimation(
-        intent: Intent,
-        requestCode: Int,
-        animation: Direction
-    ) {
-        enableIntentAnimation(intent)
-        startActivityForResult(intent, requestCode)
-        enableActivityAnimation(animation)
-    }
-
     private fun launchActivityForResult(
         intent: Intent?,
         launcher: ActivityResultLauncher<Intent?>,
@@ -578,7 +549,6 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         )
 
     companion object {
-        const val REQUEST_REVIEW = 901
         const val DIALOG_FRAGMENT_TAG = "dialog"
 
         /** Extra key to set the finish animation of an activity  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -66,7 +66,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         fun onExtendStudyLimits()
         fun showDialogFragment(newFragment: DialogFragment)
         fun dismissAllDialogFragments()
-        fun startActivityForResultWithoutAnimation(intent: Intent, requestCode: Int)
+        fun startActivityWithoutAnimation(intent: Intent)
     }
 
     fun withArguments(contextMenuAttribute: ContextMenuAttribute<*>, did: DeckId, jumpToReviewer: Boolean = false): CustomStudyDialog {
@@ -490,7 +490,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
 
     private fun onLimitsExtended(jumpToReviewer: Boolean) {
         if (jumpToReviewer) {
-            customStudyListener?.startActivityForResultWithoutAnimation(Intent(requireContext(), Reviewer::class.java), AnkiActivity.REQUEST_REVIEW)
+            customStudyListener?.startActivityWithoutAnimation(Intent(requireContext(), Reviewer::class.java))
         } else {
             customStudyListener?.onExtendStudyLimits()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -257,17 +257,6 @@ class MultimediaEditFieldActivity : AnkiActivity(), OnRequestPermissionsResultCa
         }
     }
 
-    @Deprecated("Deprecated in Java")
-    @Suppress("deprecation") // onActivityResult
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        Timber.d("onActivityResult()")
-        if (fieldController != null) {
-            fieldController!!.onActivityResult(requestCode, resultCode, data)
-        }
-        super.onActivityResult(requestCode, resultCode, data)
-        invalidateOptionsMenu()
-    }
-
     private fun recreateEditingUIUsingCachedRequest() {
         Timber.d("recreateEditingUIUsingCachedRequest()")
         if (mCurrentChangeRequest == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -411,15 +411,6 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        // TODO: Delete function from interface once migration is complete. See below comment.
-        // Do Nothing
-        // the only reference to this function is in
-        // MultimediaEditFieldActivity::onActivityResult, and that's still only being used because
-        // BasicMediaClipFieldController hasn't been migrated over to the
-        // start register for activity result API yet.
-    }
-
     private fun cancelImageCapture() {
         if (!mPreviousImagePath.isNullOrEmpty()) {
             revertToPreviousImage()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -37,7 +37,6 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.ExceptionUtil.executeSafe
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 
@@ -102,14 +101,6 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
             selectMediaLauncher,
             ActivityTransitionAnimation.Direction.NONE
         )
-    }
-
-    @KotlinCleanup("make data non-null")
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        // TODO: Delete function from interface once migration is complete. See below comment.
-        // Do Nothing
-        // once everything is migrated over to the register for activity results api,
-        // this will no longer be needed
     }
 
     override fun setEditingActivity(activity: MultimediaEditFieldActivity) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicTextFieldController.kt
@@ -21,7 +21,6 @@ package com.ichi2.anki.multimediacard.fields
 
 import android.content.Context
 import android.content.DialogInterface
-import android.content.Intent
 import android.widget.Button
 import android.widget.EditText
 import android.widget.LinearLayout
@@ -107,15 +106,6 @@ class BasicTextFieldController : FieldControllerBase(), IFieldController, Dialog
                 fragment.show(mActivity.supportFragmentManager, "pick.clone")
             }
         }
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see com.ichi2.anki.IFieldController#onActivityResult(int, int, android.content.Intent) When activity started
-     * from here returns, the MultimediaEditFieldActivity passes control here back. And the results from the started before
-     * activity are received.
-     */
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
     }
 
     override fun onFocusLost() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IFieldController.kt
@@ -20,7 +20,6 @@
 package com.ichi2.anki.multimediacard.fields
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.widget.LinearLayout
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
@@ -59,10 +58,6 @@ interface IFieldController {
 
     // Layout is vertical inside a scroll view already
     fun createUI(context: Context, layout: LinearLayout)
-
-    // If the controller ever starts an activity for result, this is going to be
-    // called back on result.
-    fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?)
 
     // Called when the controller has stopped showing the field in favor of another one
     fun onFocusLost()

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -17,7 +17,6 @@ package com.ichi2.audio
 
 import android.app.Activity
 import android.content.Context
-import android.content.Intent
 import android.content.res.Configuration
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -238,10 +237,6 @@ class AudioRecordingController :
             }
             audioTimeView.text = DEFAULT_TIME
         }
-    }
-
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        // do nothing
     }
 
     private fun startRecording(context: Context, audioPath: String) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

After #14912 and #14915 were merged, some dead code was created around the deprecated `startActivityForResult` functionality.

- In `CustomStudyListener`, changed `startActivityForResultWithoutAnimation` to just `startActivityWithoutAnimation`. The only instance of this being used was in `CustomStudyDialog::onLimitsExtended`, and the request code (`AnkiActivity.REQUEST_REVIEW`) was not being used anywhere else, i.e., the result if there ever was one was not getting captured for processing.
- From the `CustomStudyListener` change, this allowed for the removal of `startActivityForResult`, `startActivityForResultWithoutAnimation`, and `startActivityForResultWithAnimation` from AnkiActivity
- Removed the `IFieldController::onActivityResult` function. All the controllers that implemented the interface now just had a do-nothing impl for it since the migration over to using the register for activity result API.
- The `onActivityResult` override in `MultimediaEditFieldActivity` is no longer needed now either after the migration.


## Fixes
- Fixes: #8602 

## How Has This Been Tested?

I ran unit tests and I manually tested the functionality on an emulator for any regression.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
