### PR TITLE
Warning when WebView (<77) is outdated

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -463,7 +463,9 @@ open class DeckPicker :
         Onboarding.DeckPicker(this, mRecyclerViewLayoutManager).onCreate()
 
         launchShowingHidingEssentialFileMigrationProgressDialog()
-        checkWebviewVersion()
+        if (BuildConfig.DEBUG) {
+            checkWebviewVersion()
+        }
     }
 
     private fun hasShownAppIntro(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -487,9 +487,10 @@ open class DeckPicker :
 
     /**
      * Check if the current WebView version is older than the last supported version and if it is,
-     * inform the user with a snackbar.
+     * inform the developer with a snackbar.
      */
     private fun checkWebviewVersion() {
+        // Doesn't need to be translated as it's debug only
         // Specifically check for Android System WebView
         try {
             val androidSystemWebViewPackage = "com.google.android.webview"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -484,59 +484,23 @@ open class DeckPicker :
     }
 
     /**
-     * Check if the current WebView version is older than the last supported version, inform the
-     * user with an alarm dialog if it is and provide options to update it.
+     * Check if the current WebView version is older than the last supported version and if it is,
+     * inform the user with a snackbar.
      */
     private fun checkWebviewVersion() {
         // Specifically check for Android System WebView
-        val androidSystemWebViewPackage = "com.google.android.webview"
         try {
+            val androidSystemWebViewPackage = "com.google.android.webview"
             val webviewPackageInfo = packageManager.getPackageInfo(androidSystemWebViewPackage, 0)
             val versionCode = webviewPackageInfo.versionName.split(".")[0].toInt()
             if (versionCode < OLDEST_WORKING_WEBVIEW_VERSION) {
-                val alertDialogBuilder = AlertDialog.Builder(this)
-                val dialogMessage = "The WebView version $versionCode is outdated (<$OLDEST_WORKING_WEBVIEW_VERSION)."
-                val playStoreURL = "https://play.google.com/store/apps/details?id=com.google.android.webview"
-                val updateGuideURL = "https://gist.github.com/ppoffice/9ce9790708eeabbec1281467e25139e4#file-readme-md"
-                alertDialogBuilder.apply {
-                    setMessage(dialogMessage)
-                    setPositiveButton("Update from Play Store") { _, _ ->
-                        val playStoreIntent = Intent(Intent.ACTION_VIEW).apply {
-                            data = Uri.parse(playStoreURL)
-                        }
-                        startActivity(playStoreIntent)
-                    }
-                    setNegativeButton("Open update guide") { _, _ ->
-                        val guideIntent = Intent(Intent.ACTION_VIEW).apply {
-                            data = Uri.parse(updateGuideURL)
-                        }
-                        startActivity(guideIntent)
-                    }
-                    setNeutralButton("Dismiss") { dialog, _ ->
-                        dialog.dismiss()
-                    }
-                    setTitle("Update WebView")
-                    create().show()
-                }
+                val snackbarMessage =
+                    "The WebView version $versionCode is outdated (<$OLDEST_WORKING_WEBVIEW_VERSION)."
+                showSnackbar(snackbarMessage, Snackbar.LENGTH_INDEFINITE)
             }
-        } catch (e: PackageManager.NameNotFoundException) {
-            val alertDialogBuilder = AlertDialog.Builder(this)
-            val dialogMessage = String.format("No Android System Webview found.")
-            val stackOverFlowURL = "https://stackoverflow.com/a/66560291"
-            alertDialogBuilder.apply {
-                setMessage(dialogMessage)
-                setPositiveButton("Info (StackOverFlow)") { _, _ ->
-                    val stackOverFlowIntent = Intent(Intent.ACTION_VIEW).apply {
-                        data = Uri.parse(stackOverFlowURL)
-                    }
-                    startActivity(stackOverFlowIntent)
-                }
-                setNegativeButton("Dismiss") { dialog, _ ->
-                    dialog.dismiss()
-                }
-                setTitle("Missing WebView")
-                create().show()
-            }
+        } catch (_: PackageManager.NameNotFoundException) {
+            val snackbarMessage = "No Android System WebView found"
+            showSnackbar(snackbarMessage, Snackbar.LENGTH_INDEFINITE)
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Alert the developer when the WebView version is too old to support Anki HTML pages.

## Fixes
* Fixes #14702 

## Approach
Show a Snackbar with a warning if the Android WebView version is detected to be older than the oldest supported version (currently version 77).
<img width="216" alt="OldWebViewWarning" src="https://github.com/ankidroid/Anki-Android/assets/87513231/214afe98-da71-4021-8fbb-903ae2f3adc9">


## How Has This Been Tested?
I tried it with two separate emulators, one with a WebView version <77, one emulator with a newer version and a physical phone, and the warning appears as it should.
I also ran the gradlew jacocoTestReport. It keeps failing for a few tests but they're always different ones and I can't find the connection to the code I added, so if anyone knows why tests are failing, please tell me, and I will fix it. I'm using the Medium Phone Emulator in Android Studio with API version 24 (Android 7) to test.

## Learning (optional, can help others)
It's not possible to update the WebView version on Android 5 through the Google Play Store ([more info](https://stackoverflow.com/questions/30019960/how-to-upgrade-androids-webview-in-emulator-android-5))


## Checklist
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
