### PR TITLE
test(ci): ignore merge queue branch push events

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
         type: string
   pull_request:
   push:
+    # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   merge_group:
 
 concurrency:

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -9,6 +9,9 @@ on:
         type: string
   pull_request:
   push:
+    # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   merge_group:
 
 concurrency:

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -9,6 +9,9 @@ on:
         type: string
   pull_request:
   push:
+    # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
+    branches-ignore:
+      - 'gh-readonly-queue/**'
   merge_group:
 
 concurrency:


### PR DESCRIPTION

## Purpose / Description

otherwise the concurrency gate means the push events and merge_group events enter into a race which results in merge queue failure at times

## Fixes

Issue noted on Discord by @BrayanDSO 

## Approach

Investigate the "checkout" step of workflow runs from both the push event and the merge_group event, notice that they have the same "github_ref" value, which implies the concurrency key will evaluate to the same value

Deduce that there is a concurrency race between the runs from the two events, decide to ignore merge_group branches from the push event so there is no longer a race

## How Has This Been Tested?

It has not been tested, just deduced - we'll see how it works in practice. Hopefully it works

## Learning (optional, can help others)

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
