### PR TITLE
fix: CardBrowser - click row to deselect

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -544,7 +544,7 @@ open class CardBrowser :
                 // click on whole cell triggers select
                 val cb = view!!.findViewById<CheckBox>(R.id.card_checkbox)
                 cb.toggle()
-                viewModel.selectRowAtPosition(position)
+                viewModel.toggleRowSelectionAtPosition(position)
             } else {
                 // load up the card selected on the list
                 val clickedCardId = viewModel.getCardIdAtPosition(position)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -46,6 +46,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.jetbrains.annotations.VisibleForTesting
 import timber.log.Timber
 import java.util.Collections
 import kotlin.math.max
@@ -197,6 +198,7 @@ class CardBrowserViewModel(
         refreshSelectedRowsFlow()
     }
 
+    @VisibleForTesting
     fun selectRowAtPosition(pos: Int) {
         if (_selectedRows.add(cards[pos])) {
             refreshSelectedRowsFlow()


### PR DESCRIPTION
## Purpose / Description
Clicking the checkbox worked, the row didn't
* Fixes #14952
 
## Cause
* 8e157576dcdb1c2dcf5b445badbef8b8983f8276 - squashed
* (2de159a627923a1f9b25c5d189edeeccfae4fdd2) - individual

## Fixes
* Fixes #14952

## How Has This Been Tested?
Unit tests

## Learning
* We need[ed] more tests, we now have them
* I'm liking Kotlin more and more - the code would have been so much worse in Android-style Java

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
