### PR TITLE
test: fix JNI critical lock held error in instrumentation tests

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTest.kt
@@ -28,7 +28,6 @@ import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
 import org.junit.rules.TestRule
-import java.util.ArrayList
 
 abstract class NoteEditorTest protected constructor() {
     @get:Rule


### PR DESCRIPTION
## Purpose / Description
Sometimes the emulator tests are failing because the application gets forcibly killed by Android. In the logs, we are seeing

    JNI critical lock held for 33.004ms on
    Thread[1,tid=3832,Runnable,Thread*=0x741a9345dbe0,peer=0x71cf55b8,"main"]

which seem to indicate that the Rust backend and database connections to the collection are leaking across tests and are causing a deadlock. To fix this, we make sure to discard the Rust backend and close the collection after each test

## Fixes
* https://github.com/ankidroid/Anki-Android/issues/14940

## Approach

Using the setup/teardown code from RobolectricTest as a reference: https://github.com/ankidroid/Anki-Android/blob/0f8bfbd7fde9640343093615182abb6f43b9763a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt#L94-L177 we close the collection and rust backend after each test

## How Has This Been Tested?

Running `gradlew jacocoAndroidTestReport` passes on my machine with emulator `2.7 QVGA API 34`

## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
