### PR TITLE
Enhancement: allow the user to change the text size of deck title and the bold effect

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -533,6 +533,8 @@ object UsageAnalytics {
         "binding_RESCHEDULE_NOTE",
         // Accessibility
         "cardZoom",
+        "deckTitleZoom",
+        "deckTitleBold",
         "imageZoom",
         "answerButtonSize",
         "showLargeAnswerButtons",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.widgets
 
 import android.content.Context
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.view.LayoutInflater
 import android.view.View
@@ -28,6 +29,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.sched.DeckNode
 import com.ichi2.utils.KotlinCleanup
@@ -191,7 +193,15 @@ class DeckAdapter(private val layoutInflater: LayoutInflater, context: Context) 
             holder.deckLayout.setBackgroundResource(ta.getResourceId(0, 0))
             ta.recycle()
         }
-        // Set deck name and colour. Filtered decks have their own colour
+        // Setting the text size and style using the preferences set by user or the default ones
+        holder.deckName.textSize = holder.deckName.context.sharedPrefs().getInt("deckTitleZoom", 20).toFloat()
+        val isBoldText = holder.deckName.context.sharedPrefs().getBoolean("deckTitleBold", true)
+        if (isBoldText) {
+            holder.deckName.setTypeface(holder.deckName.typeface, Typeface.BOLD)
+        } else {
+            holder.deckName.setTypeface(holder.deckName.typeface, Typeface.NORMAL)
+        }
+
         holder.deckName.text = node.lastDeckNameComponent
         val filtered =
             node.filtered

--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -58,8 +58,6 @@
             android:maxLines="2"
             android:ellipsize="end"
             android:textColor="?android:textColorPrimary"
-            android:textSize="20sp"
-            android:textStyle="bold"
             tools:text="Deck name" />
     </LinearLayout>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -28,6 +28,7 @@
     </plurals>
     <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"
         name="pref_summary_percentage">%s\%%</string>
+    <string  name="pref_summary_text">%s\sp</string>
     <string name="pref_search_no_results">No results</string>
 
     <!-- preferences.xml categories-->
@@ -57,6 +58,8 @@
     <string name="reset_confirmation">All states reset</string>
     <string name="card_zoom" maxLength="41">Card zoom</string>
     <string name="image_zoom" maxLength="41">Image zoom</string>
+    <string name="deck_title_zoom" maxLength="41">Deck title zoom</string>
+    <string name="deck_title_bold" maxLength="41">Deck title bold</string>
     <string name="button_size" maxLength="41">Answer button size</string>
     <string name="card_browser_font_size" maxLength="41">Card browser font scaling</string>
     <string name="card_browser_hide_media" maxLength="41">Display filenames in card browser</string>
@@ -152,6 +155,7 @@
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>
     <string name="show_large_answer_buttons_summ">Show answer button in 2 rows</string>
+    <string name="deck_bold_summ">Deck text title bold effect</string>
     <string name="show_top_bar" maxLength="41">Show top bar</string>
     <string name="show_top_bar_summ">Show card counts, flag and mark in top bar</string>
     <string name="show_progress" maxLength="41">Show remaining</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -119,6 +119,8 @@
     <string name="pref_accessibility_screen_key">accessibilityScreen</string>
     <string name="card_zoom_preference">cardZoom</string>
     <string name="image_zoom_preference">imageZoom</string>
+    <string name="deck_title_zoom_preference">deckTitleZoom</string>
+    <string name="deck_title_bold_preference">deckTitleBold</string>
     <string name="answer_button_size_preference">answerButtonSize</string>
     <string name="show_large_answer_buttons_preference">showLargeAnswerButtons</string>
     <string name="pref_card_minimal_click_time">showCardAnswerButtonTime</string>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -35,6 +35,19 @@
         android:stepSize="10"
         app:displayFormat="@string/pref_summary_percentage"/>
     <com.ichi2.preferences.SliderPreference
+        android:key="@string/deck_title_zoom_preference"
+        android:title="@string/deck_title_zoom"
+        android:defaultValue="20"
+        android:valueFrom="12"
+        android:valueTo="30"
+        android:stepSize="1"
+        app:displayFormat="@string/pref_summary_text"/>
+    <SwitchPreferenceCompat
+        android:key="@string/deck_title_bold_preference"
+        android:defaultValue="true"
+        android:summary="@string/deck_bold_summ"
+        android:title="@string/deck_title_bold"/>
+    <com.ichi2.preferences.SliderPreference
         android:title="@string/button_size"
         android:key="@string/answer_button_size_preference"
         app:defaultValue="100"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This would allow the user to change the deck title size or the bold effect if they want to as request by the AnkiDroid user and we accepted the feature request though the ability to change color is not taken care of in this PR, we should discuss the color scheme and go for a another PR (if we even want to allow the color to be changed )

## Fixes
* Fixes #14927

## Approach
Added two new preferences in the settings 

## How Has This Been Tested?
Tested on oneplus nord ce and google emualtor 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/abd6415d-1282-44ce-a497-1ad1cc4fa2a4)

in case it is increased to 26sp
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/58c7ee9b-5bf3-4b59-a9f2-7be63bb49e40)

removing the bold effect 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/1231dc2e-b7a2-496b-8821-31caf7e97465)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
