### PR TITLE
fix: navigator.getGamepads() does not work

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -718,7 +718,18 @@ abstract class AbstractFlashcardViewer :
                 return true
             }
         }
+
+        if (webView.handledGamepadKeyDown(keyCode, event)) {
+            return true
+        }
         return super.onKeyDown(keyCode, event)
+    }
+
+    override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
+        if (webView.handledGamepadKeyUp(keyCode, event)) {
+            return true
+        }
+        return super.onKeyUp(keyCode, event)
     }
 
     public override val currentCardId: CardId? get() = currentCard?.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gamepad.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gamepad.kt
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.cardviewer
+
+import android.view.KeyEvent
+import android.webkit.WebView
+
+/**
+ * Pass gamepad buttons to the WebView, after which `navigator.getGamepads()` displays the gamepad
+ *
+ * Issue 14975
+ *
+ * @return
+ * * `false` if the provided [WebView] is null
+ * * `false` if [keyCode] is NOT a gamepad button
+ * * `webView.onKeyUp(keyCode, keyEvent)` otherwise
+ */
+fun WebView?.handledGamepadKeyUp(keyCode: Int, keyEvent: KeyEvent): Boolean {
+    if (this == null) return false
+    if (!KeyEvent.isGamepadButton(keyCode)) return false
+    return this.onKeyUp(keyCode, keyEvent)
+}
+
+/**
+ * Pass gamepad buttons to the WebView, after which `navigator.getGamepads()` displays the gamepad
+ *
+ * Issue 14975
+ *
+ * @return
+ * * `false` if the provided [WebView] is null
+ * * `false` if [keyCode] is NOT a gamepad button
+ * * `webView.onKeyDown(keyCode, keyEvent)` otherwise
+ */
+fun WebView?.handledGamepadKeyDown(keyCode: Int, keyEvent: KeyEvent): Boolean {
+    if (this == null) return false
+    if (!KeyEvent.isGamepadButton(keyCode)) return false
+    return this.onKeyDown(keyCode, keyEvent)
+}


### PR DESCRIPTION
## Purpose / Description
* #14975
* button presses were not passed to the WebView
* `navigator.getGamepads()` requires seeing a button press before returning results
* therefore the array was `[null, null, null, null]`


## Fixes
* Fixes #14975

## Approach
To fix this, pass through unhandled gamepad inputs to the WebView

## How Has This Been Tested?
![Screenshot 2023-12-14 at 23 03 32](https://github.com/ankidroid/Anki-Android/assets/62114487/01dad1c1-a0a9-40a0-9d9b-a8f8a5a1bfdb)


## Learning (optional, can help others)
> To mitigate fingerprinting, getGamepads() returns an empty list before a gamepad user gesture has been seen. [FINGERPRINTING-GUIDANCE]

https://w3c.github.io/gamepad/#dom-navigator-getgamepads

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
