### PR TITLE
feat: Joystick/Trigger/MotionEvent handling

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -9,9 +9,12 @@
       <w>CrowdIn</w>
       <w>DOWNGRADABLE</w>
       <w>Glosbe</w>
+      <w>HSCROLL</w>
+      <w>LTRIGGER</w>
       <w>NONINFRINGEMENT</w>
       <w>Notetypes</w>
       <w>Pictogrammers</w>
+      <w>RTRIGGER</w>
       <w>SuperMemo</w>
       <w>Unbury</w>
       <w>acos</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -227,6 +227,10 @@ abstract class AbstractFlashcardViewer :
      */
     protected val mGestureProcessor = GestureProcessor(this)
 
+    /** Handle joysticks/pedals */
+    // needs to be lateinit due to a reliance on Context
+    protected lateinit var motionEventHandler: MotionEventHandler
+
     @get:VisibleForTesting
     var cardContent: String? = null
         private set
@@ -536,6 +540,7 @@ abstract class AbstractFlashcardViewer :
         restorePreferences()
         mTagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         super.onCreate(savedInstanceState)
+        motionEventHandler = MotionEventHandler.createInstance(this)
 
         // Issue 14142: The reviewer had a focus highlight after answering using a keyboard.
         // This theme removes the highlight, but there is likely a better way.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -893,6 +893,13 @@ open class Reviewer :
         }
     }
 
+    override fun onGenericMotionEvent(event: MotionEvent?): Boolean {
+        if (motionEventHandler.onGenericMotionEvent(event)) {
+            return true
+        }
+        return super.onGenericMotionEvent(event)
+    }
+
     override fun canAccessScheduler(): Boolean {
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.Binding.*
+import com.ichi2.utils.hash
 import timber.log.Timber
 import java.util.*
 import kotlin.collections.ArrayList
@@ -44,6 +45,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
             binding is KeyCode && otherBinding is KeyCode -> binding.keycode == otherBinding.keycode && modifierEquals(otherBinding)
             binding is UnicodeCharacter && otherBinding is UnicodeCharacter -> binding.unicodeCharacter == otherBinding.unicodeCharacter && modifierEquals(otherBinding)
             binding is GestureInput && otherBinding is GestureInput -> binding.gesture == otherBinding.gesture
+            binding is AxisButtonBinding && otherBinding is AxisButtonBinding -> binding.axis == otherBinding.axis && binding.threshold == otherBinding.threshold
             else -> false
         }
         if (!bindingEquals) {
@@ -59,6 +61,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
             is KeyCode -> binding.keycode
             is UnicodeCharacter -> binding.unicodeCharacter
             is GestureInput -> binding.gesture
+            is AxisButtonBinding -> hash(binding.axis.motionEventValue, binding.threshold.toInt())
             else -> 0
         }
         return Objects.hash(bindingHash, screen.prefix)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
@@ -1,0 +1,244 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewer
+
+import android.content.Context
+import android.view.MotionEvent
+import com.ichi2.anki.AbstractFlashcardViewer
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.preferences.sharedPrefs
+import timber.log.Timber
+
+/**
+ * Handles motion events, such as joystick/pedal input and converts them to [ViewerCommand]s
+ *
+ * A [MotionEvent] is a **batched** collection of [actions][MotionEvent.getAction] ond [axes][Axis]
+ *
+ * Axes can either be bidirectional, or unidirectional. AnkiDroid allows a user to define an action
+ * which occurs if the extreme of an axis [-1, 1] is met
+ */
+class MotionEventHandler(
+    private val commandProcessor: ViewerCommand.CommandProcessor,
+    private val detectors: List<SingleAxisDetector>
+) {
+    data class SingleAxisDetector(val axis: Axis, val command: ViewerCommand, val threshold: Float) {
+        constructor(command: ViewerCommand, binding: Binding.AxisButtonBinding) : this(
+            command = command,
+            axis = binding.axis,
+            threshold = binding.threshold
+        )
+
+        /** If the command has been executed and we have not returned lower than the threshold */
+        private var sentCommand: Boolean = false
+
+        /**
+         * If multiple events above the threshold are obtained, only return 1 command
+         * until the value is under the threshold
+         */
+        private val debouncedCommand: ViewerCommand?
+            get() {
+                if (sentCommand) return null
+                sentCommand = true
+                return command
+            }
+
+        /**
+         * Given a [MotionEvent], determine whether we've reached [threshold].
+         *
+         * If we have, and [command] has not been sent in the period that we reached the threshold
+         * then send the command once and wait for the value to go back under the threshold
+         *
+         * @return [command] or `null`
+         */
+        fun getCommand(ev: MotionEvent): ViewerCommand? {
+            // TODO: We may need to handle historical events as well
+            val value = ev.getAxisValue(axis.motionEventValue)
+            when {
+                threshold > 0 -> { if (value >= threshold) return debouncedCommand }
+                threshold < 0 -> { if (value <= threshold) return debouncedCommand }
+            }
+            sentCommand = false
+            return null
+        }
+
+        fun toDisplayString(context: Context) = Binding.AxisButtonBinding(axis, threshold).toDisplayString(context)
+    }
+
+    /**
+     * Accepts a [MotionEvent] and determines if one or more commands need to be executed
+     * @return whether one or more commands were executed
+     */
+    fun onGenericMotionEvent(ev: MotionEvent?): Boolean {
+        if (ev == null || !detectors.any()) return false
+
+        var processed = false
+        for (detector in detectors) {
+            val command = detector.getCommand(ev) ?: continue
+            processed = true
+            Timber.v("executing command: %s due to %s", command, detector.toDisplayString(AnkiDroidApp.instance))
+            this.commandProcessor.executeCommand(command, null)
+        }
+        return processed
+    }
+
+    companion object {
+        fun createInstance(viewer: AbstractFlashcardViewer): MotionEventHandler {
+            val handlers = getAxisButtonBindings(viewer).toList()
+            Timber.d("setting up %d motion handlers", handlers.size)
+            return MotionEventHandler(viewer, handlers)
+        }
+
+        private fun getAxisButtonBindings(context: Context) = sequence {
+            for ((command, bindings) in MappableBinding.allMappings(context.sharedPrefs())) {
+                for (binding in bindings.map { it.binding }.filterIsInstance<Binding.AxisButtonBinding>()) {
+                    yield(SingleAxisDetector(command, binding))
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A type of movement, typically a Joystick/Trigger on a gamepad
+ *
+ * Constants used in [MotionEvent.getAxisValue]. Axes can be in a bidirectional range [-1, 1]
+ * @see MotionEvent
+ */
+enum class Axis(val motionEventValue: Int) {
+    /** @see MotionEvent.AXIS_X */
+    X(MotionEvent.AXIS_X),
+
+    /** @see MotionEvent.AXIS_Y */
+    Y(MotionEvent.AXIS_Y),
+
+    /** @see MotionEvent.AXIS_Z */
+    Z(MotionEvent.AXIS_Z),
+
+    /** @see MotionEvent.AXIS_RZ */
+    RZ(MotionEvent.AXIS_RZ),
+
+    /** @see MotionEvent.AXIS_BRAKE */
+    BRAKE(MotionEvent.AXIS_BRAKE),
+
+    /** @see MotionEvent.AXIS_GAS */
+    GAS(MotionEvent.AXIS_GAS),
+
+    /** @see MotionEvent.AXIS_RTRIGGER */
+    R_TRIGGER(MotionEvent.AXIS_RTRIGGER),
+
+    /** @see MotionEvent.AXIS_LTRIGGER */
+    L_TRIGGER(MotionEvent.AXIS_LTRIGGER),
+
+    /** @see MotionEvent.AXIS_DISTANCE */
+    DISTANCE(MotionEvent.AXIS_DISTANCE),
+
+    /** @see MotionEvent.AXIS_GENERIC_1 */
+    GENERIC_1(MotionEvent.AXIS_GENERIC_1),
+
+    /** @see MotionEvent.AXIS_GENERIC_2 */
+    GENERIC_2(MotionEvent.AXIS_GENERIC_2),
+
+    /** @see MotionEvent.AXIS_GENERIC_3 */
+    GENERIC_3(MotionEvent.AXIS_GENERIC_3),
+
+    /** @see MotionEvent.AXIS_GENERIC_4 */
+    GENERIC_4(MotionEvent.AXIS_GENERIC_4),
+
+    /** @see MotionEvent.AXIS_GENERIC_5 */
+    GENERIC_5(MotionEvent.AXIS_GENERIC_5),
+
+    /** @see MotionEvent.AXIS_GENERIC_6 */
+    GENERIC_6(MotionEvent.AXIS_GENERIC_6),
+
+    /** @see MotionEvent.AXIS_GENERIC_7 */
+    GENERIC_7(MotionEvent.AXIS_GENERIC_7),
+
+    /** @see MotionEvent.AXIS_GENERIC_8 */
+    GENERIC_8(MotionEvent.AXIS_GENERIC_8),
+
+    /** @see MotionEvent.AXIS_GENERIC_9 */
+    GENERIC_9(MotionEvent.AXIS_GENERIC_9),
+
+    /** @see MotionEvent.AXIS_GENERIC_10 */
+    GENERIC_10(MotionEvent.AXIS_GENERIC_10),
+
+    /** @see MotionEvent.AXIS_GENERIC_11 */
+    GENERIC_11(MotionEvent.AXIS_GENERIC_11),
+
+    /** @see MotionEvent.AXIS_GENERIC_12 */
+    GENERIC_12(MotionEvent.AXIS_GENERIC_12),
+
+    /** @see MotionEvent.AXIS_GENERIC_13 */
+    GENERIC_13(MotionEvent.AXIS_GENERIC_13),
+
+    /** @see MotionEvent.AXIS_GENERIC_14 */
+    GENERIC_14(MotionEvent.AXIS_GENERIC_14),
+
+    /** @see MotionEvent.AXIS_GENERIC_15 */
+    GENERIC_15(MotionEvent.AXIS_GENERIC_15),
+
+    /** @see MotionEvent.AXIS_GENERIC_16 */
+    GENERIC_16(MotionEvent.AXIS_GENERIC_16),
+
+    /** @see MotionEvent.AXIS_HSCROLL */
+    H_SCROLL(MotionEvent.AXIS_HSCROLL),
+
+    /** @see MotionEvent.AXIS_ORIENTATION */
+    ORIENTATION(MotionEvent.AXIS_ORIENTATION),
+
+    /** @see MotionEvent.AXIS_PRESSURE */
+    PRESSURE(MotionEvent.AXIS_PRESSURE),
+
+    /** @see MotionEvent.AXIS_RUDDER */
+    RUDDER(MotionEvent.AXIS_RUDDER),
+
+    /** @see MotionEvent.AXIS_RX */
+    RX(MotionEvent.AXIS_RX),
+
+    /** @see MotionEvent.AXIS_RY */
+    RY(MotionEvent.AXIS_RY),
+
+    /** @see MotionEvent.AXIS_HAT_X */
+    HAT_X(MotionEvent.AXIS_HAT_X),
+
+    /** @see MotionEvent.AXIS_HAT_Y */
+    HAT_Y(MotionEvent.AXIS_HAT_Y)
+
+    //  API Level 24:
+    //  AXIS_RELATIVE_X,
+    //  AXIS_RELATIVE_Y,
+
+    //  API Level 34:
+    //  AXIS_GESTURE_X_OFFSET,
+    //  AXIS_GESTURE_Y_OFFSET,
+    //  AXIS_GESTURE_PINCH_SCALE_FACTOR,
+    //  AXIS_GESTURE_SCROLL_X_DISTANCE,
+    //  AXIS_GESTURE_SCROLL_Y_DISTANCE,
+    ;
+
+    /**
+     * @return `AXIS_X` etc...
+     * @see MotionEvent.axisToString
+     */
+    override fun toString(): String = MotionEvent.axisToString(this.motionEventValue)
+
+    companion object {
+        /** @throws NoSuchElementException if [value] is invalid */
+        fun fromInt(value: Int): Axis = Axis.entries.single { it.motionEventValue == value }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.compat.CompatHelper
 import timber.log.Timber
 
 /**
@@ -217,18 +218,29 @@ enum class Axis(val motionEventValue: Int) {
     HAT_X(MotionEvent.AXIS_HAT_X),
 
     /** @see MotionEvent.AXIS_HAT_Y */
-    HAT_Y(MotionEvent.AXIS_HAT_Y)
+    HAT_Y(MotionEvent.AXIS_HAT_Y),
 
-    //  API Level 24:
-    //  AXIS_RELATIVE_X,
-    //  AXIS_RELATIVE_Y,
+    /** @see MotionEvent.AXIS_RELATIVE_X */
+    AXIS_RELATIVE_X(CompatHelper.compat.AXIS_RELATIVE_X),
 
-    //  API Level 34:
-    //  AXIS_GESTURE_X_OFFSET,
-    //  AXIS_GESTURE_Y_OFFSET,
-    //  AXIS_GESTURE_PINCH_SCALE_FACTOR,
-    //  AXIS_GESTURE_SCROLL_X_DISTANCE,
-    //  AXIS_GESTURE_SCROLL_Y_DISTANCE,
+    /** @see MotionEvent.AXIS_RELATIVE_Y */
+    AXIS_RELATIVE_Y(CompatHelper.compat.AXIS_RELATIVE_Y),
+
+    /** @see MotionEvent.AXIS_GESTURE_X_OFFSET */
+    AXIS_GESTURE_X_OFFSET(CompatHelper.compat.AXIS_GESTURE_X_OFFSET),
+
+    /** @see MotionEvent.AXIS_GESTURE_Y_OFFSET */
+    AXIS_GESTURE_Y_OFFSET(CompatHelper.compat.AXIS_GESTURE_Y_OFFSET),
+
+    /** @see MotionEvent.AXIS_GESTURE_PINCH_SCALE_FACTOR */
+    AXIS_GESTURE_PINCH_SCALE_FACTOR(CompatHelper.compat.AXIS_GESTURE_PINCH_SCALE_FACTOR),
+
+    /** @see MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE */
+    AXIS_GESTURE_SCROLL_X_DISTANCE(CompatHelper.compat.AXIS_GESTURE_SCROLL_X_DISTANCE),
+
+    /** @see MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE */
+    AXIS_GESTURE_SCROLL_Y_DISTANCE(CompatHelper.compat.AXIS_GESTURE_SCROLL_Y_DISTANCE)
+
     ;
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -201,4 +201,25 @@ interface Compat {
      */
     @CheckResult
     fun normalize(locale: Locale): Locale
+
+    @Suppress("PropertyName")
+    val AXIS_RELATIVE_X: Int
+
+    @Suppress("PropertyName")
+    val AXIS_RELATIVE_Y: Int
+
+    @Suppress("PropertyName")
+    val AXIS_GESTURE_X_OFFSET: Int
+
+    @Suppress("PropertyName")
+    val AXIS_GESTURE_Y_OFFSET: Int
+
+    @Suppress("PropertyName")
+    val AXIS_GESTURE_PINCH_SCALE_FACTOR: Int
+
+    @Suppress("PropertyName")
+    val AXIS_GESTURE_SCROLL_X_DISTANCE: Int
+
+    @Suppress("PropertyName")
+    val AXIS_GESTURE_SCROLL_Y_DISTANCE: Int
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -42,6 +42,7 @@ class CompatHelper private constructor() {
 
     // Note: Needs ": Compat" or the type system assumes `Compat21`
     private val compatValue: Compat = when {
+        sdkVersion >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> CompatV34()
         sdkVersion >= Build.VERSION_CODES.TIRAMISU -> CompatV33()
         sdkVersion >= Build.VERSION_CODES.S -> CompatV31()
         sdkVersion >= Build.VERSION_CODES.Q -> CompatV29()

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
@@ -253,6 +253,15 @@ open class CompatV23 : Compat {
         // convert back from this key to a two-letter mapping
         return twoLetterSystemLocaleMapping[iso3Code] ?: locale
     }
+
+    override val AXIS_RELATIVE_X: Int = 27
+    override val AXIS_RELATIVE_Y: Int = 28
+    override val AXIS_GESTURE_X_OFFSET: Int = 48
+    override val AXIS_GESTURE_Y_OFFSET: Int = 49
+    override val AXIS_GESTURE_SCROLL_X_DISTANCE: Int = 50
+    override val AXIS_GESTURE_SCROLL_Y_DISTANCE: Int = 51
+    override val AXIS_GESTURE_PINCH_SCALE_FACTOR: Int = 52
+
     companion object {
         /**
          * Maps from the ISO 3 code of a locale to the locale in

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
@@ -18,6 +18,7 @@ package com.ichi2.compat
 
 import android.annotation.TargetApi
 import android.icu.util.ULocale
+import android.view.MotionEvent
 import com.ichi2.utils.isRobolectric
 import timber.log.Timber
 import java.util.Locale
@@ -38,4 +39,7 @@ open class CompatV24 : CompatV23(), Compat {
             locale
         }
     }
+
+    override val AXIS_RELATIVE_X: Int = MotionEvent.AXIS_RELATIVE_X
+    override val AXIS_RELATIVE_Y: Int = MotionEvent.AXIS_RELATIVE_Y
 }

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV34.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV34.kt
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import android.annotation.TargetApi
+import android.view.MotionEvent
+
+@TargetApi(34)
+open class CompatV34 : CompatV33(), Compat {
+    override val AXIS_GESTURE_X_OFFSET = MotionEvent.AXIS_GESTURE_X_OFFSET
+    override val AXIS_GESTURE_Y_OFFSET = MotionEvent.AXIS_GESTURE_Y_OFFSET
+    override val AXIS_GESTURE_SCROLL_X_DISTANCE = MotionEvent.AXIS_GESTURE_SCROLL_X_DISTANCE
+    override val AXIS_GESTURE_SCROLL_Y_DISTANCE = MotionEvent.AXIS_GESTURE_SCROLL_Y_DISTANCE
+    override val AXIS_GESTURE_PINCH_SCALE_FACTOR = MotionEvent.AXIS_GESTURE_PINCH_SCALE_FACTOR
+}

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisPicker.kt
@@ -1,0 +1,116 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import com.ichi2.anki.R
+import com.ichi2.anki.reviewer.Axis
+import com.ichi2.anki.reviewer.Binding
+import timber.log.Timber
+
+/**
+ * Listens to [joystick input][View.onGenericMotionEvent], if motion is detected on an [Axis],
+ * show the axis as selectable and mappable to a [Binding.AxisButtonBinding]
+ *
+ * If an Axis has two extremities, a user may select one of these.
+ *
+ * @see AxisSelector
+ */
+class AxisPicker(val rootLayout: ConstraintLayout) {
+    // DDisplays a message asking a user to provide input to the screen
+    // We use a TextView to listen due to issues with handling AXIS_BRAKE and AXIS_GAS
+    // When listening to 'rootLayout', these axes are ONLY detected after another joystick is moved
+    private val textView: TextView = rootLayout.findViewById(R.id.axis_picker_selected_axis)
+
+    /** Contains [availableAxes], initially invisible */
+    private val availableAxesContainer: View = rootLayout.findViewById(R.id.axis_picker_scrollview)
+
+    /** Where [AxisSelector] are added dynamically if motion is detected*/
+    private val availableAxes: LinearLayout = rootLayout.findViewById(R.id.axis_picker_available_axes)
+
+    private val context: Context get() = rootLayout.context
+
+    /** Maps from an [Axis] to the [AxisSelector] displaying + allowing selection of it */
+    private val axisMap = mutableMapOf<Axis, AxisSelector>()
+
+    private var onBindingChangedListener: ((Binding) -> Unit)? = null
+
+    fun setBindingChangedListener(listener: (Binding) -> Unit) {
+        onBindingChangedListener = listener
+    }
+
+    init {
+        textView.requestFocus()
+        textView.setOnGenericMotionListener { _, event -> handleMotionEvent(event) }
+    }
+
+    @Suppress("SameReturnValue")
+    private fun handleMotionEvent(event: MotionEvent?): Boolean {
+        if (event == null) return true
+        Timber.w("handleMotionEvent")
+
+        for (axis in Axis.entries) {
+            val axisValue = event.getAxisValue(axis.motionEventValue)
+            // if we've NEVER had a non-zero value, ignore it
+            if (axisValue == 0f && !axisMap.containsKey(axis)) continue
+
+            // if we have a non-zero value, create the view if it doesn't already exist
+            val axisSelector = getOrCreateAxisSelector(axis)
+            // and update its value
+            axisSelector.value = axisValue
+        }
+
+        return true
+    }
+
+    private fun getOrCreateAxisSelector(axis: Axis): AxisSelector {
+        // if we've already added the control, return it
+        axisMap[axis]?.let { return it }
+
+        // when adding the first control, we want to make the
+        // available axes visible, so the user can see their current values
+        availableAxesContainer.visibility = View.VISIBLE
+        // we also want to hide the TextView, but we can't make it invisible as it's
+        // providing our input events. Blanking the text has the same effect
+        textView.text = ""
+
+        // setup & return the control
+        return AxisSelector(context).also { view ->
+            view.axis = axis
+            view.setOnExtremitySelectedListener { binding ->
+                Timber.d("selected binding %s", binding)
+                onBindingChangedListener?.invoke(binding)
+            }
+
+            axisMap[axis] = view
+            availableAxes.addView(view)
+        }
+    }
+
+    companion object {
+        fun inflate(context: Context): AxisPicker {
+            val layout = LayoutInflater.from(context).inflate(R.layout.dialog_axis_picker, null)
+            return AxisPicker(layout as ConstraintLayout)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisSelector.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisSelector.kt
@@ -1,0 +1,128 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.TextView
+import com.ichi2.anki.R
+import com.ichi2.anki.reviewer.Axis
+import com.ichi2.anki.reviewer.Binding
+import timber.log.Timber
+
+/**
+ * Displays live values of an [Axis] (joystick/trigger), and allows selection of a binding if an
+ * [extremity][AxisValueDisplay.isExtremity] has been received
+ *
+ * The [name] of the Axis (AXIS_X)
+ *
+ * The [value] of the Axis [-1, 1]
+ *   - If a value hits an extremity, the display changes color. See [AxisValueDisplay]
+ *
+ * Two buttons: [minButton] and [maxButton]
+ *   - If an [extremity][AxisValueDisplay.isExtremity] is reached, these are activated
+ *   - Calls [onExtremitySelectedListener] if tapped
+ *
+ * @see R.layout.axis_display
+ * @see AxisValueDisplay
+ */
+class AxisSelector : LinearLayout {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(
+        context,
+        attrs,
+        defStyle
+    )
+
+    private val name: TextView
+    private val minButton: Button
+    private val axisDisplay: AxisValueDisplay
+    private val maxButton: Button
+
+    private var onExtremitySelectedListener: ((Binding.AxisButtonBinding) -> Unit)? = null
+
+    init {
+        val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+        inflater.inflate(R.layout.axis_display, this, true)
+        name = findViewById(R.id.axis_name)
+        minButton = findViewById(R.id.select_min_extremity)
+        axisDisplay = findViewById(R.id.axis_value)
+        maxButton = findViewById(R.id.select_max_extremity)
+
+        // Disabling buttons ensures that a user cannot map a negative value on a unidirectional
+        // axis, such as the triggers on my 8BitDo
+        // It's hard to know if an axis is single, or multidimensional until we've received input
+        axisDisplay.setExtremityListener { valueAtExtremity ->
+            when (valueAtExtremity) {
+                -1f -> enableMinButton()
+                1f -> enableMaxButton()
+            }
+        }
+
+        // call onExtremitySelectedListener
+        minButton.setOnClickListener { selectMinimumValue() }
+        maxButton.setOnClickListener { selectMaximumValue() }
+    }
+
+    private fun selectMaximumValue() {
+        Timber.i("%s: max pressed", axis)
+        onExtremitySelectedListener?.invoke(Binding.AxisButtonBinding(axis!!, 1f))
+    }
+
+    private fun selectMinimumValue() {
+        Timber.i("%s: min pressed", axis)
+        onExtremitySelectedListener?.invoke(Binding.AxisButtonBinding(axis!!, -1f))
+    }
+
+    private fun enableMaxButton() {
+        if (maxButton.isEnabled) return
+        Timber.i("%s: max button enabled", axis)
+        maxButton.isEnabled = true
+    }
+
+    private fun enableMinButton() {
+        if (minButton.isEnabled) return
+        Timber.i("%s: min button enabled", axis)
+        minButton.isEnabled = true
+    }
+
+    /**
+     * The [Axis] that this control applies to
+     *
+     * should be lateinit + non-null
+     */
+    var axis: Axis? = null
+        set(value) {
+            field = value
+            text = value.toString()
+        }
+
+    /** The name of the axis */
+    var text: String
+        get() = name.text.toString()
+        private set(value) { name.text = value }
+
+    var value: Float by axisDisplay::value
+
+    fun setOnExtremitySelectedListener(listener: ((Binding.AxisButtonBinding) -> Unit)?) {
+        onExtremitySelectedListener = listener
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.View
+import com.google.android.material.color.MaterialColors
+import com.ichi2.utils.dpToPixels
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+typealias MeasureSpecValue = Int
+
+/**
+ * Displays the [value] of a given axis on a [-1, 1] scale using a colored bar
+ *
+ * If the value is [an extremity][isExtremity], the color of the bar is changed
+ *
+ * Invokes [extremityListener] each time an 'extreme' value is provided
+ */
+class AxisValueDisplay(context: Context, attrs: AttributeSet? = null) : View(context, attrs) {
+
+    /** Called when [isExtremity] returns true */
+    private var extremityListener: ((value: Float) -> Unit)? = null
+
+    /** The default color of the value of an axis when not at an extreme */
+    private val normalPaint = Paint().apply {
+        color = Color.BLUE
+    }
+
+    /** The color when an axis is at {-1, 1} and is selectable */
+    private val extremityPaint = Paint().apply {
+        color = Color.GREEN
+    }
+
+    /** The current value */
+    var value = 0f
+        set(value) {
+            field = value
+            this.postInvalidate()
+            text = String.format("%.3f", value)
+            if (isExtremity) {
+                extremityListener?.invoke(field)
+            }
+        }
+
+    /** Pre-calculated value to speed up calls to [onDraw] */
+    private var text: String = ""
+
+    /** @return [value] is -1 or 1 */
+    private val isExtremity get() = abs(value) == 1f
+
+    /** The current color of the bar */
+    private val barPaint get() = if (isExtremity) extremityPaint else normalPaint
+
+    /** [Paint] for the text displaying the [value] */
+    private val textPaint = Paint().apply {
+        textAlign = Paint.Align.CENTER
+        textSize = dpToPixels(20f).toFloat()
+        color = MaterialColors.getColor(context, android.R.attr.textColor, 0)
+    }
+
+    /** stores text dimensions, used for centering text */
+    private val textBounds = Rect()
+
+    private val controlHeight = dpToPixels(40f)
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val width = widthMeasureSpec.constrainTo(suggestedMinimumWidth)
+        val height = heightMeasureSpec.constrainTo(controlHeight)
+        setMeasuredDimension(width, height)
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+
+        // draws a bar so a value of 0 is in the middle, -1 is on the left, and +1 is on the right
+        val halfway = width / 2f
+        val left = min(halfway + halfway * value, halfway)
+        val right = max(halfway, halfway + halfway * value)
+
+        canvas.drawRect(left, 0f, right, height.toFloat(), barPaint)
+
+        // https://stackoverflow.com/a/24969713/
+        // draw text in the center horizontally + vertically, handling font & bounding box
+        textBounds.updateAsTextBounds(textPaint, text)
+        canvas.drawText(text, halfway, height.toFloat() / 2 - textBounds.exactCenterY(), textPaint)
+    }
+
+    fun setExtremityListener(listener: (value: Float) -> Unit) {
+        this.extremityListener = listener
+    }
+}
+
+/** Handles [View.MeasureSpec] constraints to provide a height/width given a desired value */
+private fun MeasureSpecValue.constrainTo(desiredValue: Int): Int {
+    // https://stackoverflow.com/a/12267248
+    val mode = View.MeasureSpec.getMode(this)
+    val size = View.MeasureSpec.getSize(this)
+
+    return when (mode) {
+        View.MeasureSpec.EXACTLY -> { size }
+        View.MeasureSpec.AT_MOST -> { min(desiredValue, size) }
+        else -> { desiredValue }
+    }
+}
+
+/**
+ * Updates the receiver with the smallest boundary which would accept [text] & [paint]
+ * @see [Paint.getTextBounds]
+ */
+private fun Rect.updateAsTextBounds(paint: Paint, text: String) =
+    paint.getTextBounds(text, 0, text.length, this)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
@@ -20,6 +20,8 @@ import android.content.Context
 import android.graphics.Point
 import android.view.Window
 import android.view.WindowManager
+import com.ichi2.anki.AnkiDroidApp
+import kotlin.math.roundToInt
 
 object DisplayUtils {
 
@@ -42,4 +44,9 @@ object DisplayUtils {
     fun resizeWhenSoftInputShown(window: Window) {
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
+}
+
+fun dpToPixels(dp: Float): Int {
+    val scale = AnkiDroidApp.instance.resources.displayMetrics.density
+    return (dp * scale).roundToInt()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -36,3 +36,6 @@ object HashUtil {
         return HashMap(capacity(size))
     }
 }
+
+/** Provides a hashcode given a series of ints */
+fun hash(vararg values: Int): Int = values.fold(0) { acc, value -> 31 * acc + value }

--- a/AnkiDroid/src/main/res/layout/axis_display.xml
+++ b/AnkiDroid/src/main/res/layout/axis_display.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingBottom="8dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/axis_name"
+        android:paddingStart="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="20sp"
+        tools:text="AXIS_X" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/select_min_extremity"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+
+        app:icon="@drawable/ic_add"
+        app:iconSize="24dp"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorControlNormal"
+
+        android:background="?attr/selectableItemBackground"
+
+        android:enabled="false"
+
+        app:layout_constraintTop_toBottomOf="@id/axis_name"
+        app:layout_constraintStart_toStartOf="parent"
+
+        app:shapeAppearance="?attr/shapeAppearanceCornerLarge"/>
+
+
+    <com.ichi2.ui.AxisValueDisplay
+        android:id="@+id/axis_value"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/select_min_extremity"
+        app:layout_constraintEnd_toStartOf="@id/select_max_extremity"
+        app:layout_constraintStart_toEndOf="@id/select_min_extremity"
+        app:layout_constraintTop_toBottomOf="@id/axis_name" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/select_max_extremity"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+
+        app:icon="@drawable/ic_add"
+        app:iconSize="24dp"
+        app:iconPadding="0dp"
+        app:iconGravity="textStart"
+        app:iconTint="?attr/colorControlNormal"
+
+        android:background="?attr/selectableItemBackground"
+
+        android:enabled="false"
+
+        app:layout_constraintTop_toBottomOf="@id/axis_name"
+        app:layout_constraintStart_toEndOf="@id/axis_value"
+        app:layout_constraintEnd_toEndOf="parent"
+
+        app:shapeAppearance="?attr/shapeAppearanceCornerLarge" />
+
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/axis_picker_selected_axis"
+        app:layout_constraintDimensionRatio="w,1:1"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="center"
+        android:textSize="24sp"
+        android:textAlignment="center"
+        android:text="@string/axis_picker_move_joystick"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <ScrollView
+        android:id="@+id/axis_picker_scrollview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        >
+        <LinearLayout
+            android:id="@+id/axis_picker_available_axes"
+            android:layout_width="match_parent"
+            android:orientation="vertical"
+            android:layout_height="0dp"/>
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -262,6 +262,8 @@
     <string name="binding_add_key">Add key</string>
     <string name="binding_replace_key">Replace key</string>
     <string name="key_picker_default_press_key">Press a key</string>
+    <string name="binding_add_axis">Add joystick/motion controller</string>
+    <string name="axis_picker_move_joystick">Move a joystick/motion controller</string>
 
     <!-- Select card side -->
     <string name="card_side_selection_title">Select card side</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingAndroidTest.kt
@@ -55,6 +55,12 @@ class BindingAndroidTest : RobolectricTest() {
     }
 
     @Test
+    fun `motion event serde`() {
+        assertBindingEquals(axis(Axis.X, 1.0f), axisBindingFromString("0 1.0"))
+        assertBindingEquals(axis(Axis.Y, -1.0f), axisBindingFromString("1 -1.0"))
+    }
+
+    @Test
     @Config(qualifiers = "en")
     fun gesture_toDisplayString() {
         assertEquals("${BindingTest.gesturePrefix} Touch top", Binding.gesture(Gesture.TAP_TOP).toDisplayString())
@@ -70,3 +76,8 @@ class BindingAndroidTest : RobolectricTest() {
         assertEquals(first, second)
     }
 }
+
+private fun axis(axis: Axis, fl: Float) = Binding.AxisButtonBinding(axis, fl)
+
+private fun axisBindingFromString(suffix: String) =
+    Binding.fromString(BindingTest.joystickPrefix + suffix)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -91,6 +91,7 @@ class BindingTest {
         const val gesturePrefix = '\u235D'
         const val keyPrefix = '\u2328'
         const val unicodePrefix = '\u2705'
+        const val joystickPrefix = '◯'
 
         fun allModifierKeys() = Binding.ModifierKeys(true, true, true)
 


### PR DESCRIPTION
## Purpose / Description
We want to be able to map joystick/trigger inputs to commands

This only handles them as button presses, not allowing scrolling

## Fixes
* Fixes #14282
* Fixes #14965

## Approach
1) Define a screen which listens for motion events and adds a visual selector to the screen if these are detected
2) Define an Axis: the Android MotionEvent works on a historical basis allowing us to specify an axis and obtain the historical values of the MotionEvent
3) Define a threshold: some MotionEvents are unidirectional (pedals/triggers), others are bidirectional X-Axis on a joystick  this can either be -1.0 or 1.0 (displayed as `[+]` or `[-]`)
4) An AxisButtonBinding is defined as the tuple (Axis, Threshold)
5) Ensure the listener screen only allows selecting an Axis if
   the threshold has been reached (to stop a user selecting [-] on
   a pedal/trigger
6) Check for duplicates and save
7) Load + detect the events in the Reviewer, call a ViewerCommand

## How Has This Been Tested?
Manually with Samsung S21 + 8BitDo Ultimate 2.4Ghz

**Setting**
![joystick_setting_display](https://github.com/ankidroid/Anki-Android/assets/62114487/23284873-b8d8-4d2a-b6d8-89026fe086ec)


**Selection screen**
![joytick_select_pre](https://github.com/ankidroid/Anki-Android/assets/62114487/8c5682a0-2648-4147-8a81-e585c1f0a971)

**setting a value before an axis was moved**
![joystick_select_initial](https://github.com/ankidroid/Anki-Android/assets/62114487/ec7f0539-9560-4e36-a617-bdd22dfd2f43)

**setting a value**
![joystick_set_value_center](https://github.com/ankidroid/Anki-Android/assets/62114487/ea27463b-48f6-415a-a29f-9d21eea965b9)


## Learning

* https://github.com/ankidroid/Anki-Android/issues/14282#issuecomment-1831119897
* Lots of comments in the code: `MotionEvent` batches events and doesn't seem to allow a user to determine which axes it contains. Therefore we need to check all possible axes which feels like a waste
* It didn't feel like we got framedrops when doing a lot of work in `AxisSelector`, so it's still fast
* Defining a group of controls as a `LinearLayout` in `AxisSelector`
* Android keeps on adding more `AXIS` values, we don't support them yet
* Centering text via `onDraw`: https://stackoverflow.com/a/24969713/
* `MeasureSpec` usage: https://stackoverflow.com/a/12267248

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
