### PR TITLE
Revert "libanki: addPlayButtons() and rename addPlayIcons()"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -234,7 +234,7 @@ class Sound(private val soundPlayer: SoundPlayer, private val soundDir: String) 
          * @return -- the same content but in a format that will render working play buttons when audio was embedded
          */
         fun expandSounds(content: String): String {
-            return avRefsToPlayIcons(content)
+            return addPlayIcons(content)
         }
 
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -24,7 +24,6 @@
 
 package com.ichi2.libanki
 
-import anki.config.ConfigKey
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.utils.KotlinCleanup
@@ -47,6 +46,8 @@ data class TTSTag(
 
 /**
  * Contains the filename inside a [sound:...] tag.
+ *
+ * Video files also use [sound:...].
  */
 data class SoundOrVideoTag(val filename: String) : AvTag()
 
@@ -60,28 +61,16 @@ val AV_PLAYLINK_RE = Regex("playsound:(.):(\\d+)")
 
 fun stripAvRefs(text: String) = AV_REF_RE.replace(text, "")
 
-/** Return card text with play buttons added, or stripped. */
-suspend fun addPlayButtons(text: String): String {
-    return if (withCol { config.getBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS) }) {
-        stripAvRefs(text)
-    } else {
-        avRefsToPlayIcons(text)
-    }
-}
-
-/** Add play icons into the HTML */
-fun avRefsToPlayIcons(text: String): String {
-    return AV_REF_RE.replace(text) { match ->
+fun addPlayIcons(content: String): String {
+    return AV_REF_RE.replace(content) { match ->
         val groups = match.groupValues
         val side = groups[2]
         val index = groups[3]
         val playsound = "playsound:$side:$index"
-        """<a class="replay-button soundLink" href=$playsound>
-    <svg class="playImage" viewBox="0 0 64 64" version="1.1">
-        <circle cx="32" cy="32" r="29" />
-        <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" />
-    </svg>
-</a>"""
+        """<a class='replay-button replaybutton' href="$playsound"><span>
+                    <svg viewBox="0 0 64 64"><circle cx="32" cy="32" r="29" fill = "lightgrey"/>
+                    <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" fill=black />Replay</svg>
+                    </span></a>"""
     }
 }
 


### PR DESCRIPTION
This reverts commit 776539e0147ebb8eff988b9b4092b65c68f369c1.

Play icons were changed to large black circles

## How Has This Been Tested?
**Before**
![image](https://github.com/ankidroid/Anki-Android/assets/62114487/eba31363-d125-4154-acd4-d7e023ab063e)

**After**
![image](https://github.com/ankidroid/Anki-Android/assets/62114487/5f960ca6-a705-4c5f-95d6-d7bbc2d2479b)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
