### PR TITLE
fix: play buttons being shown as big black buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/SoundKt.kt
@@ -76,12 +76,12 @@ fun avRefsToPlayIcons(text: String): String {
         val side = groups[2]
         val index = groups[3]
         val playsound = "playsound:$side:$index"
-        """<a class="replay-button soundLink" href=$playsound>
+        """<a class="replay-button soundLink" href=$playsound><span>
     <svg class="playImage" viewBox="0 0 64 64" version="1.1">
-        <circle cx="32" cy="32" r="29" />
-        <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" />
+        <circle cx="32" cy="32" r="29" fill="lightgrey"/>
+        <path d="M56.502,32.301l-37.502,20.101l0.329,-40.804l37.173,20.703Z" fill="black"/>Replay
     </svg>
-</a>"""
+</span></a>"""
     }
 }
 


### PR DESCRIPTION
## Purpose / Description
avRefsToPlayIcons was modified to match the desktop code, which works well in the new previewer because it also uses the desktop code.

The issue is that I tested if there were regressions in the reviewer with a deck that has a custom `.replayButton` style and I didn't know that. This way, I caused these big black circles

![image](https://github.com/ankidroid/Anki-Android/assets/69634269/39d4ccf2-8a0a-44c2-b5a0-8f7e322913f1)


## Fixes
* Closes #15001

## Approach
Add back `fill` to the play button SVG, since our current reviewer don't handle that by itself, and add back a `<span>` tag inside the button because `flashcard.css` needs that

## How Has This Been Tested?

Emulator 31: open a card with an audio file

![image](https://github.com/ankidroid/Anki-Android/assets/69634269/69f4a1c4-527e-4bd6-ac21-99c826f6258c)


## Learning (optional, can help others)

Check the css style of the decks you download

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
