### PR TITLE
fix: 'Statistics' crashes on open 

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesActivityTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesActivityTest.kt
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("UnusedReceiverParameter")
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.pages.CardInfo.Companion.toIntent
+import com.ichi2.anki.pages.CardInfoDestination
+import com.ichi2.anki.pages.DeckOptions
+import com.ichi2.anki.pages.PageFragment
+import com.ichi2.anki.pages.PagesActivity
+import com.ichi2.anki.pages.Statistics
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.Card
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Assume.assumeThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+@NeedsTest("extend this for all activities - Issue 15009")
+class PagesActivityTest : InstrumentedTest() {
+    @JvmField // required for Parameter
+    @Parameterized.Parameter
+    var intentBuilder: (PagesActivityTest.(Context) -> Intent)? = null
+
+    @JvmField // required for Parameter
+    @Parameterized.Parameter(1)
+    var name: String? = null
+
+    var card: Card? = null
+
+    @Test
+    fun activityOpens() {
+        val intent = intentBuilder!!.invoke(this, testContext)
+        ActivityScenario.launch<PagesActivity>(intent).use { activity ->
+            // this can fail on a real device if the screen is off
+            assertThat("state is RESUMED", activity.state == Lifecycle.State.RESUMED)
+        }
+        card?.let {
+            col.backend.removeNotes(noteIds = listOf(it.nid), cardIds = listOf(it.id))
+        }
+    }
+
+    companion object {
+        @Parameterized.Parameters(name = "{1}")
+        @JvmStatic // required for initParameters
+        fun initParameters(): Collection<Array<out Any>> {
+            /** See [PageFragment] */
+            val intents = listOf<Pair<PagesActivityTest.(Context) -> Intent, String>>(
+                Pair(PagesActivityTest::getStatistics, "Statistics"),
+                Pair(PagesActivityTest::getCardInfo, "CardInfo"),
+                Pair(PagesActivityTest::getCongratsPage, "CongratsPage"),
+                Pair(PagesActivityTest::getDeckOptions, "DeckOptions"),
+                // the following need a file path
+                Pair(PagesActivityTest::needsPath, "AnkiPackageImporterFragment"),
+                Pair(PagesActivityTest::needsPath, "CsvImporter"),
+                Pair(PagesActivityTest::needsPath, "ImageOcclusion")
+            )
+
+            return intents.map { arrayOf(it.first, it.second) }
+        }
+    }
+}
+
+fun PagesActivityTest.getStatistics(context: Context): Intent {
+    return Statistics.getIntent(context)
+}
+
+fun PagesActivityTest.getCardInfo(context: Context): Intent {
+    return addNoteUsingBasicModel().firstCard().let { card ->
+        this.card = card
+        CardInfoDestination(card.id).toIntent(context)
+    }
+}
+
+fun PagesActivityTest.getCongratsPage(context: Context): Intent {
+    return addNoteUsingBasicModel().firstCard().let { card ->
+        this.card = card
+        CardInfoDestination(card.id).toIntent(context)
+    }
+}
+fun PagesActivityTest.getDeckOptions(context: Context): Intent {
+    return DeckOptions.getIntent(context, col.decks.allNamesAndIds().first().id)
+}
+
+fun PagesActivityTest.needsPath(@Suppress("UNUSED_PARAMETER") context: Context): Intent {
+    assumeThat("not implemented: path needed", false, equalTo(true))
+    TODO()
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.fail
 
 abstract class InstrumentedTest {
-    protected val col: Collection
+    internal val col: Collection
         get() = CollectionHelper.instance.getColUnsafe(testContext)!!
 
     @get:Throws(IOException::class)
@@ -153,7 +153,7 @@ abstract class InstrumentedTest {
     }
 
     @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
-    protected fun addNoteUsingBasicModel(front: String, back: String): Note {
+    internal fun addNoteUsingBasicModel(front: String = "Front", back: String = "Back"): Note {
         return addNoteUsingModelName("Basic", front, back)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -27,6 +27,8 @@ import timber.log.Timber
 
 /**
  * Base class for displaying Anki HTML pages
+ *
+ * @see [PagesActivity]
  */
 abstract class PageFragment : Fragment() {
     abstract val title: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PagesActivity.kt
@@ -61,12 +61,11 @@ class PagesActivity : AnkiActivity() {
         val pageFragment = getInstanceFromClassName<PageFragment>(pageClassName).apply {
             arguments = intent.getBundleExtra(EXTRA_PAGE_ARGS)
         }
+        supportFragmentManager.addFragmentOnAttachListener { _, _ -> this.title = pageFragment.title }
         supportFragmentManager.commit {
             replace(R.id.page_container, pageFragment)
         }
-        title = pageFragment.title
     }
-
     override fun onDestroy() {
         super.onDestroy()
         /** Stop running the server if the activity is destroyed.


### PR DESCRIPTION
## Purpose / Description
* #15009

## Fixes
* Fixes #15009

## Approach
* `supportFragmentManager.addFragmentOnAttachListener`

## How Has This Been Tested?
Unit tested

## Learning (optional, can help others)
Still need regression tests, but this is at least a little better

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
