### PR TITLE
Speed up tap gestures

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -170,7 +170,6 @@ abstract class AbstractFlashcardViewer :
     // Preferences from the collection
     private var mShowNextReviewTime = false
     private var mIsSelecting = false
-    private var mTouchStarted = false
     private var mInAnswer = false
     private var mAnswerSoundsAdded = false
 
@@ -2143,9 +2142,6 @@ abstract class AbstractFlashcardViewer :
         }
 
         override fun onSingleTapUp(e: MotionEvent): Boolean {
-            if (mTouchStarted) {
-                mTouchStarted = false
-            }
             return false
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2089,6 +2089,9 @@ abstract class AbstractFlashcardViewer :
     }
 
     internal open inner class MyGestureDetector : SimpleOnGestureListener() {
+        /** Whether we need to wait for confirmation that a tap is not a double tap */
+        private val waitForDoubleTap get() = mGestureProcessor.isBound(Gesture.DOUBLE_TAP)
+
         override fun onFling(
             e1: MotionEvent?,
             e2: MotionEvent,
@@ -2141,11 +2144,17 @@ abstract class AbstractFlashcardViewer :
             return true
         }
 
-        override fun onSingleTapUp(e: MotionEvent): Boolean {
-            return false
+        override fun onDown(e: MotionEvent): Boolean {
+            if (waitForDoubleTap) return super.onDown(e)
+            return handleTap(e)
         }
 
         override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+            if (!waitForDoubleTap) return super.onSingleTapConfirmed(e)
+            return handleTap(e)
+        }
+
+        private fun handleTap(e: MotionEvent): Boolean {
             // Go back to immersive mode if the user had temporarily exited it (and ignore the tap gesture)
             if (onSingleTap()) {
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -101,12 +101,8 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
     }
 
     private fun execute(gesture: Gesture?): Boolean? {
-        val command = mapGestureToCommand(gesture)
-        return if (command != null) {
-            processor?.executeCommand(command, gesture)
-        } else {
-            false
-        }
+        val command = mapGestureToCommand(gesture) ?: return false
+        return processor?.executeCommand(command, gesture)
     }
 
     private fun mapGestureToCommand(gesture: Gesture?): ViewerCommand? {
@@ -136,14 +132,8 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
      * @return `false` if none of the gestures are bound. `true` otherwise
      */
     fun isBound(vararg gestures: Gesture): Boolean {
-        if (!isEnabled) {
-            return false
-        }
-        for (gesture in gestures) {
-            if (mapGestureToCommand(gesture) != null) {
-                return true
-            }
-        }
-        return false
+        if (!isEnabled) return false
+
+        return gestures.any { mapGestureToCommand(it) != null }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Tap gestures were slow because they were waiting for a double tap. If no double tap was mapped, this was an easy optimisation

## Approach
Check for a double tap gesture

## How Has This Been Tested?
My S21

## Learning (optional, can help others)
Our gesture processing code is still awful. Kotlin might be able to help this, but the problem is that we have multiple components which need to interact and potentially handle the gesture

This is made more complicated by FullScreen mode

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
