### PR TITLE
feat: redirect to login if AnkiWeb sends 429 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -33,6 +33,8 @@ import java.io.Serializable
 
 /**
  * Browse AnkiWeb shared decks with the functionality to download and import them.
+ *
+ * @see SharedDecksDownloadFragment
  */
 class SharedDecksActivity : AnkiActivity() {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -45,7 +45,7 @@ import kotlin.math.abs
 
 /**
  * Used when a download is captured from AnkiWeb shared decks WebView.
- * Only for downloads started via SharedDecksActivity.
+ * Only for downloads started via [SharedDecksActivity].
  *
  * Only one download is supported at a time, since importing multiple decks
  * simultaneously is not supported.

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -441,4 +441,6 @@ voice. The parameter is a technical error code such as 'ERROR_NOT_INSTALLED_YET'
 opening the system text to speech settings fails">
         Failed to open text to speech settings
     </string>
+
+    <string name="shared_decks_login_required">Please log in to download more decks</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -128,6 +128,8 @@
     <string name="link_third_party_api_apps">https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps</string>
     <string name="link_faq_invalid_protocol_relative">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-do-my-images-need-a-protocol</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
+    <string name="shared_decks_login_url">https://ankiweb.net/account/login</string>
+    <string name="shared_decks_sign_up_url">https://ankiweb.net/account/signup</string>
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
     <string name="resetpw_url">https://ankiweb.net/account/resetpw</string>
     <string name="register_url">https://ankiweb.net/account/register</string>


### PR DESCRIPTION
## Purpose / Description
Users were confused by the AnkiWeb "Please log in to perform more searches"

Fairly common question. Example:
* https://forums.ankiweb.net/t/i-cant-search-and-download-the-shared-decks/38526/2

## Approach
There are 2 HTTP 429s sent:

* on search
* on clicking "Download"

Handle them both, and redirect the user to the login screen

## How Has This Been Tested?

<details>

<summary>Screenshots</summary>

![Screenshot 2023-12-18 at 19 39 43](https://github.com/ankidroid/Anki-Android/assets/62114487/952655a6-8d46-4ead-8ce2-72146ac102b7)

![Screenshot 2023-12-18 at 19 09 59](https://github.com/ankidroid/Anki-Android/assets/62114487/59c855f2-b58a-4401-85b8-2a100b5834a4)

</details>

## Learning (optional, can help others)
⚠️ This still isn't great, as it redirects the user to their decks, rather than back to their search, but it's better than it was

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
