### PR TITLE
Disable the save button and previewer button if note type is `Image occlusion`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -986,8 +986,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         menuInflater.inflate(R.menu.note_editor, menu)
         if (addNote) {
             menu.findItem(R.id.action_copy_note).isVisible = false
-            menu.findItem(R.id.action_save).isVisible = allowSaveAndPreview()
-            menu.findItem(R.id.action_preview).isVisible = allowSaveAndPreview()
+            val iconVisible = allowSaveAndPreview()
+            menu.findItem(R.id.action_save).isVisible = iconVisible
+            menu.findItem(R.id.action_preview).isVisible = iconVisible
         } else {
             menu.findItem(R.id.action_add_note_from_note_editor).isVisible = true
         }
@@ -1015,7 +1016,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
      * When using the options such as image occlusion we don't need the menu's save/preview
      * option to save/preview the card as it has a built in option and the user is notified
      * when the card is saved successfully
-     * **/
+     */
     private fun allowSaveAndPreview(): Boolean = when {
         addNote && currentNotetypeIsImageOcclusion() -> false
         else -> true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -650,7 +650,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
         when (keyCode) {
             KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_ENTER -> if (event.isCtrlPressed) {
-                launchCatchingTask { saveNote() }
+                // disable it in case of image occlusion
+                if (!currentNotetypeIsImageOcclusion()) launchCatchingTask { saveNote() }
             }
             KeyEvent.KEYCODE_D -> // null check in case Spinner is moved into options menu in the future
                 if (event.isCtrlPressed) {
@@ -995,6 +996,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
             }
         }
+        menu.findItem(R.id.action_save).isVisible = !currentNotetypeIsImageOcclusion()
         menu.findItem(R.id.action_show_toolbar).isChecked =
             !shouldHideToolbar()
         menu.findItem(R.id.action_capitalize).isChecked =
@@ -2025,6 +2027,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
             // If a new column was selected then change the key used to map from mCards to the column TextView
             // Timber.i("NoteEditor:: onItemSelected() fired on mNoteTypeSpinner");
+            invalidateMenu()
             val oldModelId = getColUnsafe.notetypes.current().getLong("id")
             val newId = mAllModelIds!![pos]
             Timber.i("Changing note type to '%d", newId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -651,7 +651,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         when (keyCode) {
             KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_ENTER -> if (event.isCtrlPressed) {
                 // disable it in case of image occlusion
-                if (!currentNotetypeIsImageOcclusion()) launchCatchingTask { saveNote() }
+                if (addNote && !canSave()) {
+                    launchCatchingTask { saveNote() }
+                } else {
+                    launchCatchingTask { saveNote() }
+                }
             }
             KeyEvent.KEYCODE_D -> // null check in case Spinner is moved into options menu in the future
                 if (event.isCtrlPressed) {
@@ -678,7 +682,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             KeyEvent.KEYCODE_P -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+P: Preview Pressed")
-                    performPreview()
+                    if (addNote && !canSave()) {
+                        performPreview()
+                    } else {
+                        performPreview()
+                    }
                 }
             }
             else -> {}
@@ -982,6 +990,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         menuInflater.inflate(R.menu.note_editor, menu)
         if (addNote) {
             menu.findItem(R.id.action_copy_note).isVisible = false
+            menu.findItem(R.id.action_save).isVisible = !canSave()
+            menu.findItem(R.id.action_preview).isVisible = !canSave()
         } else {
             menu.findItem(R.id.action_add_note_from_note_editor).isVisible = true
         }
@@ -996,7 +1006,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 }
             }
         }
-        menu.findItem(R.id.action_save).isVisible = !currentNotetypeIsImageOcclusion()
         menu.findItem(R.id.action_show_toolbar).isChecked =
             !shouldHideToolbar()
         menu.findItem(R.id.action_capitalize).isChecked =
@@ -1004,6 +1013,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         menu.findItem(R.id.action_scroll_toolbar).isChecked =
             this.sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
         return super.onCreateOptionsMenu(menu)
+    }
+
+    fun canSave(): Boolean {
+        // we can further extend it if required refer :https://github.com/ankidroid/Anki-Android/pull/15030#discussion_r1431330266
+        return currentNotetypeIsImageOcclusion()
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -1015,12 +1029,20 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_preview -> {
                 Timber.i("NoteEditor:: Preview button pressed")
-                performPreview()
+                if (addNote && !canSave()) {
+                    performPreview()
+                } else {
+                    performPreview()
+                }
                 return true
             }
             R.id.action_save -> {
                 Timber.i("NoteEditor:: Save note button pressed")
-                launchCatchingTask { saveNote() }
+                if (addNote && !canSave()) {
+                    launchCatchingTask { saveNote() }
+                } else {
+                    launchCatchingTask { saveNote() }
+                }
                 return true
             }
             R.id.action_add_note_from_note_editor -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -651,7 +651,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         when (keyCode) {
             KeyEvent.KEYCODE_NUMPAD_ENTER, KeyEvent.KEYCODE_ENTER -> if (event.isCtrlPressed) {
                 // disable it in case of image occlusion
-                if (addNote && !canSave()) {
+                if (canSave()) {
                     launchCatchingTask { saveNote() }
                 }
             }
@@ -680,7 +680,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             KeyEvent.KEYCODE_P -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+P: Preview Pressed")
-                    if (addNote && !canSave()) {
+                    if (canSave()) {
                         performPreview()
                     }
                 }
@@ -986,15 +986,15 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         menuInflater.inflate(R.menu.note_editor, menu)
         if (addNote) {
             menu.findItem(R.id.action_copy_note).isVisible = false
-            menu.findItem(R.id.action_save).isVisible = !canSave()
-            menu.findItem(R.id.action_preview).isVisible = !canSave()
+            menu.findItem(R.id.action_save).isVisible = canSave()
+            menu.findItem(R.id.action_preview).isVisible = canSave()
         } else {
             menu.findItem(R.id.action_add_note_from_note_editor).isVisible = true
         }
         if (mEditFields != null) {
             for (i in mEditFields!!.indices) {
                 val fieldText = mEditFields!![i]!!.text
-                if (fieldText != null && fieldText.isNotEmpty()) {
+                if (!fieldText.isNullOrEmpty()) {
                     menu.findItem(R.id.action_copy_note).isEnabled = true
                     break
                 } else if (i == mEditFields!!.size - 1) {
@@ -1011,9 +1011,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         return super.onCreateOptionsMenu(menu)
     }
 
-    fun canSave(): Boolean {
-        // we can further extend it if required refer :https://github.com/ankidroid/Anki-Android/pull/15030#discussion_r1431330266
-        return currentNotetypeIsImageOcclusion()
+    private fun canSave(): Boolean = when {
+        addNote && currentNotetypeIsImageOcclusion() -> false
+        else -> true
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -1025,14 +1025,14 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             R.id.action_preview -> {
                 Timber.i("NoteEditor:: Preview button pressed")
-                if (addNote && !canSave()) {
+                if (canSave()) {
                     performPreview()
                 }
                 return true
             }
             R.id.action_save -> {
                 Timber.i("NoteEditor:: Save note button pressed")
-                if (addNote && !canSave()) {
+                if (canSave()) {
                     launchCatchingTask { saveNote() }
                 }
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -653,8 +653,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 // disable it in case of image occlusion
                 if (addNote && !canSave()) {
                     launchCatchingTask { saveNote() }
-                } else {
-                    launchCatchingTask { saveNote() }
                 }
             }
             KeyEvent.KEYCODE_D -> // null check in case Spinner is moved into options menu in the future
@@ -683,8 +681,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+P: Preview Pressed")
                     if (addNote && !canSave()) {
-                        performPreview()
-                    } else {
                         performPreview()
                     }
                 }
@@ -1031,16 +1027,12 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 Timber.i("NoteEditor:: Preview button pressed")
                 if (addNote && !canSave()) {
                     performPreview()
-                } else {
-                    performPreview()
                 }
                 return true
             }
             R.id.action_save -> {
                 Timber.i("NoteEditor:: Save note button pressed")
                 if (addNote && !canSave()) {
-                    launchCatchingTask { saveNote() }
-                } else {
                     launchCatchingTask { saveNote() }
                 }
                 return true


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When in image occlusion mode hide the save button as the note is already saved when adding the image and the user is notified 

## Fixes
* Fixes #15025


## How Has This Been Tested?
tested on google emulator 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/f349458a-76f9-4ef4-92c5-5c12ae938e80)

![image](https://github.com/ankidroid/Anki-Android/assets/48384865/e8e12354-95f7-4719-8c2e-8acd1db62f71)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
