### PR TITLE
cleanup: FlashardViewer - remove 'controlBlocked'

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
@@ -21,8 +21,6 @@ class MockReviewerUi : ReviewerUi {
     override var isDisplayingAnswer = false
         private set
 
-    override val isControlBlocked: Boolean = false
-
     companion object {
         fun displayingAnswer(): ReviewerUi {
             val mockReviewerUi = MockReviewerUi()

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/MockReviewerUi.kt
@@ -16,14 +16,10 @@
 package com.ichi2.anki.testutil
 
 import com.ichi2.anki.reviewer.ReviewerUi
-import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 
 class MockReviewerUi : ReviewerUi {
     override var isDisplayingAnswer = false
         private set
-
-    override val controlBlocked: ControlBlock?
-        get() = null
 
     override val isControlBlocked: Boolean = false
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1683,30 +1683,6 @@ abstract class AbstractFlashcardViewer :
         invalidateOptionsMenu()
     }
 
-    /**
-     * @param quick Whether we expect the control to come back quickly
-     */
-    @VisibleForTesting
-    protected open fun blockControls(quick: Boolean) {
-        controlBlocked = if (quick) {
-            ControlBlock.QUICK
-        } else {
-            ControlBlock.SLOW
-        }
-        mCardFrame!!.isEnabled = false
-        flipCardLayout!!.isEnabled = false
-        mTouchLayer!!.visibility = View.INVISIBLE
-        mInAnswer = true
-        easeButton1!!.blockBasedOnEase(mCurrentEase)
-        easeButton2!!.blockBasedOnEase(mCurrentEase)
-        easeButton3!!.blockBasedOnEase(mCurrentEase)
-        easeButton4!!.blockBasedOnEase(mCurrentEase)
-        if (typeAnswer!!.validForEditText()) {
-            answerField!!.isEnabled = false
-        }
-        invalidateOptionsMenu()
-    }
-
     fun buryCard(): Boolean {
         launchCatchingTask {
             withProgress {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1736,126 +1736,122 @@ abstract class AbstractFlashcardViewer :
     }
 
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
-        return if (isControlBlocked && which !== ViewerCommand.EXIT) {
-            false
-        } else {
-            when (which) {
-                ViewerCommand.SHOW_ANSWER -> {
-                    if (displayAnswer) {
-                        return false
-                    }
-                    displayCardAnswer()
-                    true
+        return when (which) {
+            ViewerCommand.SHOW_ANSWER -> {
+                if (displayAnswer) {
+                    return false
                 }
+                displayCardAnswer()
+                true
+            }
 
-                ViewerCommand.FLIP_OR_ANSWER_EASE1 -> {
-                    flipOrAnswerCard(EASE_1)
-                    true
-                }
+            ViewerCommand.FLIP_OR_ANSWER_EASE1 -> {
+                flipOrAnswerCard(EASE_1)
+                true
+            }
 
-                ViewerCommand.FLIP_OR_ANSWER_EASE2 -> {
-                    flipOrAnswerCard(EASE_2)
-                    true
-                }
+            ViewerCommand.FLIP_OR_ANSWER_EASE2 -> {
+                flipOrAnswerCard(EASE_2)
+                true
+            }
 
-                ViewerCommand.FLIP_OR_ANSWER_EASE3 -> {
-                    flipOrAnswerCard(EASE_3)
-                    true
-                }
+            ViewerCommand.FLIP_OR_ANSWER_EASE3 -> {
+                flipOrAnswerCard(EASE_3)
+                true
+            }
 
-                ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
-                    flipOrAnswerCard(EASE_4)
-                    true
-                }
+            ViewerCommand.FLIP_OR_ANSWER_EASE4 -> {
+                flipOrAnswerCard(EASE_4)
+                true
+            }
 
-                ViewerCommand.EXIT -> {
-                    closeReviewer(RESULT_DEFAULT)
-                    true
-                }
+            ViewerCommand.EXIT -> {
+                closeReviewer(RESULT_DEFAULT)
+                true
+            }
 
-                ViewerCommand.UNDO -> {
-                    undo()
-                    true
-                }
+            ViewerCommand.UNDO -> {
+                undo()
+                true
+            }
 
-                ViewerCommand.EDIT -> {
-                    editCard(fromGesture)
-                    true
-                }
+            ViewerCommand.EDIT -> {
+                editCard(fromGesture)
+                true
+            }
 
-                ViewerCommand.TAG -> {
-                    showTagsDialog()
-                    true
-                }
+            ViewerCommand.TAG -> {
+                showTagsDialog()
+                true
+            }
 
-                ViewerCommand.BURY_CARD -> buryCard()
-                ViewerCommand.BURY_NOTE -> buryNote()
-                ViewerCommand.SUSPEND_CARD -> suspendCard()
-                ViewerCommand.SUSPEND_NOTE -> suspendNote()
-                ViewerCommand.DELETE -> {
-                    showDeleteNoteDialog()
-                    true
-                }
+            ViewerCommand.BURY_CARD -> buryCard()
+            ViewerCommand.BURY_NOTE -> buryNote()
+            ViewerCommand.SUSPEND_CARD -> suspendCard()
+            ViewerCommand.SUSPEND_NOTE -> suspendNote()
+            ViewerCommand.DELETE -> {
+                showDeleteNoteDialog()
+                true
+            }
 
-                ViewerCommand.PLAY_MEDIA -> {
-                    playSounds(true)
-                    true
-                }
+            ViewerCommand.PLAY_MEDIA -> {
+                playSounds(true)
+                true
+            }
 
-                ViewerCommand.PAGE_UP -> {
-                    onPageUp()
-                    true
-                }
+            ViewerCommand.PAGE_UP -> {
+                onPageUp()
+                true
+            }
 
-                ViewerCommand.PAGE_DOWN -> {
-                    onPageDown()
-                    true
-                }
+            ViewerCommand.PAGE_DOWN -> {
+                onPageDown()
+                true
+            }
 
-                ViewerCommand.ABORT_AND_SYNC -> {
-                    abortAndSync()
-                    true
-                }
+            ViewerCommand.ABORT_AND_SYNC -> {
+                abortAndSync()
+                true
+            }
 
-                ViewerCommand.RECORD_VOICE -> {
-                    recordVoice()
-                    true
-                }
+            ViewerCommand.RECORD_VOICE -> {
+                recordVoice()
+                true
+            }
 
-                ViewerCommand.REPLAY_VOICE -> {
-                    replayVoice()
-                    true
-                }
+            ViewerCommand.REPLAY_VOICE -> {
+                replayVoice()
+                true
+            }
 
-                ViewerCommand.TOGGLE_WHITEBOARD -> {
-                    toggleWhiteboard()
-                    true
-                }
+            ViewerCommand.TOGGLE_WHITEBOARD -> {
+                toggleWhiteboard()
+                true
+            }
 
-                ViewerCommand.CLEAR_WHITEBOARD -> {
-                    clearWhiteboard()
-                    true
-                }
+            ViewerCommand.CLEAR_WHITEBOARD -> {
+                clearWhiteboard()
+                true
+            }
 
-                ViewerCommand.CHANGE_WHITEBOARD_PEN_COLOR -> {
-                    changeWhiteboardPenColor()
-                    true
-                }
+            ViewerCommand.CHANGE_WHITEBOARD_PEN_COLOR -> {
+                changeWhiteboardPenColor()
+                true
+            }
 
-                ViewerCommand.SHOW_HINT -> {
-                    loadUrlInViewer("javascript: showHint();")
-                    true
-                }
+            ViewerCommand.SHOW_HINT -> {
+                loadUrlInViewer("javascript: showHint();")
+                true
+            }
 
-                ViewerCommand.SHOW_ALL_HINTS -> {
-                    loadUrlInViewer("javascript: showAllHints();")
-                    true
-                }
+            ViewerCommand.SHOW_ALL_HINTS -> {
+                loadUrlInViewer("javascript: showAllHints();")
+                true
+            }
 
-                else -> {
-                    Timber.w("Unknown command requested: %s", which)
-                    false
-                }
+            else -> {
+                Timber.w("Unknown command requested: %s", which)
+                false
             }
         }
     }
@@ -2668,9 +2664,6 @@ abstract class AbstractFlashcardViewer :
 
     val isDisplayingAnswer
         get() = displayAnswer
-
-    open val isControlBlocked: Boolean
-        get() = false
 
     internal fun showTagsDialog() {
         val tags = ArrayList(getColUnsafe.tags.all())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -75,7 +75,6 @@ import com.ichi2.anki.reviewer.*
 import com.ichi2.anki.reviewer.AutomaticAnswer.AutomaticallyAnswered
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.DEFAULT
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.fromPreference
-import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 import com.ichi2.anki.servicelayer.LanguageHintService.applyLanguageHint
 import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.services.migrationServiceWhileStartedOrNull
@@ -252,9 +251,6 @@ abstract class AbstractFlashcardViewer :
 
     /** Lock to allow thread-safe regeneration of mCard  */
     private val mCardLock: ReadWriteLock = ReentrantReadWriteLock()
-
-    /** whether controls are currently blocked, and how long we expect them to be  */
-    open var controlBlocked = ControlBlock.SLOW
 
     /** Preference: Whether the user wants press back twice to return to the main screen"  */
     private var mExitViaDoubleTapBack = false
@@ -1668,7 +1664,6 @@ abstract class AbstractFlashcardViewer :
     }
 
     protected open fun unblockControls() {
-        controlBlocked = ControlBlock.UNBLOCKED
         mCardFrame!!.isEnabled = true
         flipCardLayout?.isEnabled = true
         easeButton1?.unblockBasedOnEase(mCurrentEase)
@@ -2675,7 +2670,7 @@ abstract class AbstractFlashcardViewer :
         get() = displayAnswer
 
     open val isControlBlocked: Boolean
-        get() = controlBlocked !== ControlBlock.UNBLOCKED
+        get() = false
 
     internal fun showTagsDialog() {
         val tags = ArrayList(getColUnsafe.tags.all())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -549,13 +549,6 @@ open class Reviewer :
         super.unblockControls()
     }
 
-    public override fun blockControls(quick: Boolean) {
-        if (prefWhiteboard && whiteboard != null) {
-            whiteboard!!.isEnabled = false
-        }
-        super.blockControls(quick)
-    }
-
     override fun closeReviewer(result: Int) {
         // Stop the mic recording if still pending
         audioView?.notifyStopRecord()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -151,7 +151,7 @@ open class Reviewer :
     // Preferences from the collection
     private var mShowRemainingCardCount = false
     private var stopTimerOnAnswer = false
-    private val mActionButtons = ActionButtons(this)
+    private val mActionButtons = ActionButtons()
     private lateinit var mToolbar: Toolbar
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -688,7 +688,7 @@ open class Reviewer :
         menuInflater.inflate(R.menu.reviewer, menu)
         displayIcons(menu)
         mActionButtons.setCustomButtonsStatus(menu)
-        var alpha = if (super.controlBlocked !== ReviewerUi.ControlBlock.SLOW) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
+        var alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
         val markCardIcon = menu.findItem(R.id.action_mark_card)
         if (currentCard != null && isMarked(currentCard!!.note())) {
             markCardIcon.setTitle(R.string.menu_unmark_note).setIcon(R.drawable.ic_star_white)
@@ -725,7 +725,7 @@ open class Reviewer :
             undoIconId = R.drawable.ic_undo_white
             undoEnabled = colIsOpenUnsafe() && getColUnsafe.undoAvailable()
         }
-        val alphaUndo = if (undoEnabled && super.controlBlocked !== ReviewerUi.ControlBlock.SLOW) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
+        val alphaUndo = Themes.ALPHA_ICON_ENABLED_LIGHT
         val undoIcon = menu.findItem(R.id.action_undo)
         undoIcon.setIcon(undoIconId)
         undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
@@ -839,7 +839,7 @@ open class Reviewer :
             buryIcon.setIcon(R.drawable.ic_flip_to_back_white)
             buryIcon.setTitle(R.string.menu_bury_card)
         }
-        alpha = if (super.controlBlocked !== ReviewerUi.ControlBlock.SLOW) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
+        alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
         buryIcon.iconAlpha = alpha
         suspendIcon.iconAlpha = alpha
         MenuItemCompat.setActionProvider(menu.findItem(R.id.action_schedule), ScheduleProvider(this))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1155,9 +1155,6 @@ open class Reviewer :
     }
 
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {
-        if (isControlBlocked && which !== ViewerCommand.EXIT) {
-            return false
-        }
         when (which) {
             ViewerCommand.TOGGLE_FLAG_RED -> {
                 toggleFlag(Flag.RED)
@@ -1418,7 +1415,7 @@ open class Reviewer :
      */
     @KotlinCleanup("mCurrentCard handling")
     private fun suspendNoteAvailable(): Boolean {
-        return if (currentCard == null || isControlBlocked) {
+        return if (currentCard == null) {
             false
         } else {
             getColUnsafe.db.queryScalar(
@@ -1432,7 +1429,7 @@ open class Reviewer :
 
     @KotlinCleanup("mCurrentCard handling")
     private fun buryNoteAvailable(): Boolean {
-        return if (currentCard == null || isControlBlocked) {
+        return if (currentCard == null) {
             false
         } else {
             getColUnsafe.db.queryScalar(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -70,7 +70,7 @@ class ActionButtonStatus(private val reviewerUi: ReviewerUi) {
                 val item = menu.findItem(itemId)
                 item.setShowAsAction(value)
                 val icon = item.icon
-                item.isEnabled = !reviewerUi.isControlBlocked
+                item.isEnabled = true
                 if (icon != null) {
                     /* Ideally, we want to give feedback to users that
                     buttons are disabled.  However, some actions are

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -21,7 +21,6 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.annotation.IdRes
 import com.ichi2.anki.R
-import com.ichi2.themes.Themes
 import com.ichi2.utils.HashUtil.hashMapInit
 
 // loads of unboxing issues, which are safe
@@ -69,22 +68,6 @@ class ActionButtonStatus {
             if (value != MENU_DISABLED) {
                 val item = menu.findItem(itemId)
                 item.setShowAsAction(value)
-                val icon = item.icon
-                item.isEnabled = true
-                if (icon != null) {
-                    /* Ideally, we want to give feedback to users that
-                    buttons are disabled.  However, some actions are
-                    expected to be so quick that the visual feedback
-                    is useless and is only seen as a flickering.
-
-                    We use a heuristic to decide whether the next card
-                    will appear quickly or slowly.  We change the
-                    color only if the buttons are blocked and we
-                    expect the next card to take time to arrive.
-                    */
-                    val mutableIcon = icon.mutate()
-                    mutableIcon.alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
-                }
             } else {
                 menu.findItem(itemId).isVisible = false
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -25,7 +25,7 @@ import com.ichi2.themes.Themes
 import com.ichi2.utils.HashUtil.hashMapInit
 
 // loads of unboxing issues, which are safe
-class ActionButtonStatus(private val reviewerUi: ReviewerUi) {
+class ActionButtonStatus {
     /**
      * Custom button allocation
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -83,11 +83,7 @@ class ActionButtonStatus(private val reviewerUi: ReviewerUi) {
                     expect the next card to take time to arrive.
                     */
                     val mutableIcon = icon.mutate()
-                    if (reviewerUi.controlBlocked == ReviewerUi.ControlBlock.SLOW) {
-                        mutableIcon.alpha = Themes.ALPHA_ICON_DISABLED_LIGHT
-                    } else {
-                        mutableIcon.alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
-                    }
+                    mutableIcon.alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
                 }
             } else {
                 menu.findItem(itemId).isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtons.kt
@@ -21,10 +21,10 @@ import androidx.annotation.IdRes
 import androidx.appcompat.view.menu.MenuItemImpl
 import com.ichi2.anki.R
 
-class ActionButtons(reviewerUi: ReviewerUi) {
+class ActionButtons {
     // DEFECT: This should be private - it breaks the law of demeter, but it'll be a large refactoring to get
     // to this point
-    val status: ActionButtonStatus = ActionButtonStatus(reviewerUi)
+    val status: ActionButtonStatus = ActionButtonStatus()
     private var mMenu: Menu? = null
     fun setup(preferences: SharedPreferences) {
         status.setup(preferences)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
@@ -17,6 +17,5 @@
 package com.ichi2.anki.reviewer
 
 interface ReviewerUi {
-    val isControlBlocked: Boolean
     val isDisplayingAnswer: Boolean
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
@@ -17,23 +17,6 @@
 package com.ichi2.anki.reviewer
 
 interface ReviewerUi {
-    /** How to block UI buttons.  */
-    enum class ControlBlock {
-        /** Buttons are functional */
-        UNBLOCKED,
-
-        /**Don't record click; as it's ambiguous whether it would apply to next or previous card.
-         * We expect the next card load quickly, so no need to give visual feedback to user,
-         * which would be considered as flickering.  */
-        QUICK,
-
-        /**Don't record click; as it's ambiguous whether it would apply to next or previous card.
-         * We expect the next card may take time to load, as scheduler needs to recompute its queues;
-         * so we show the button get deactivated.  */
-        SLOW
-    }
-
-    val controlBlocked: ControlBlock?
     val isControlBlocked: Boolean
     val isDisplayingAnswer: Boolean
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.cardviewer.ViewerCommand.*
-import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 import com.ichi2.libanki.Card
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -191,15 +190,6 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         override fun performReload() {
             // intentionally blank
         }
-
-        override var controlBlocked: ControlBlock
-            get() = ControlBlock.UNBLOCKED
-            set(controlBlocked) {
-                super.controlBlocked = controlBlocked
-            }
-
-        override val isControlBlocked: Boolean
-            get() = controlBlocked !== ControlBlock.UNBLOCKED
 
         override fun onFlag(card: Card?, flag: Flag) {
             lastFlag = flag.code

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_2
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_3
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_4
 import com.ichi2.anki.cardviewer.Gesture
-import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 import com.ichi2.libanki.Card
 import kotlinx.coroutines.Job
 import org.hamcrest.MatcherAssert.assertThat
@@ -184,16 +183,6 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
     }
 
     @Test
-    fun pressingUndoDoesNothingIfControlsAreBlocked() {
-        // We pick an arbitrary action to ensure that nothing happens if controls are blocked
-        val underTest = KeyboardInputTestReviewer.displayingQuestion()
-            .withUndoAvailable(true)
-            .withControlsBlocked(ControlBlock.SLOW)
-        underTest.handleUnicodeKeyPress('z')
-        assertThat("Undo should not be called as control are blocked", !underTest.undoCalled)
-    }
-
-    @Test
     fun defaultKeyboardInputsFlipAndAnswersCard() {
         // Issue 14214
         val underTest = KeyboardInputTestReviewer.displayingQuestion()
@@ -230,15 +219,10 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
             private set
         var replayAudioCalled = false
             private set
-        override var controlBlocked = ControlBlock.UNBLOCKED
 
         private val cardFlips = mutableListOf<String>()
         override val isDrawerOpen: Boolean
             get() = false
-        fun withControlsBlocked(value: ControlBlock): KeyboardInputTestReviewer {
-            controlBlocked = value
-            return this
-        }
 
         fun displayAnswerForTest() {
             displayAnswer = true

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -20,11 +20,9 @@ import android.view.Menu
 import androidx.core.content.edit
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_DEFAULT
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.formatApiResult
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.getDataFromRequest
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.jsApiContract
-import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.cardviewer.ViewerCommand.FLIP_OR_ANSWER_EASE1
 import com.ichi2.anki.cardviewer.ViewerCommand.MARK
 import com.ichi2.anki.preferences.PreferenceTestUtils
@@ -69,21 +67,6 @@ class ReviewerTest : RobolectricTest() {
                     reviewer.getColUnsafe
                 )
             }
-        }
-    }
-
-    @Ignore("flaky")
-    @Test
-    @RunInBackground
-    @Flaky(os = OS.WINDOWS, "startUp: BackendCollectionAlreadyOpenException")
-    fun exitCommandWorksAfterControlsAreBlocked() {
-        ensureCollectionLoadIsSynchronous()
-        ActivityScenario.launchActivityForResult(Reviewer::class.java).use { scenario ->
-            scenario.onActivity { reviewer: Reviewer ->
-                reviewer.blockControls(true)
-                reviewer.executeCommand(ViewerCommand.EXIT)
-            }
-            assertThat(scenario.result.resultCode, equalTo(RESULT_DEFAULT))
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
@@ -50,7 +50,7 @@ class ActionButtonStatusTest : RobolectricTest() {
                 ret.add(key)
                 "0"
             }
-            val status = ActionButtonStatus(mock(ReviewerUi::class.java))
+            val status = ActionButtonStatus()
             status.setup(preferences)
             return ret
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -47,8 +47,6 @@ class PeripheralKeymapTest {
     }
 
     private class MockReviewerUi : ReviewerUi {
-        override val isControlBlocked = false
-
         override val isDisplayingAnswer: Boolean
             get() = false
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.reviewer
 import android.content.SharedPreferences
 import android.view.KeyEvent
 import com.ichi2.anki.cardviewer.ViewerCommand
-import com.ichi2.anki.reviewer.ReviewerUi.ControlBlock
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
@@ -48,9 +47,6 @@ class PeripheralKeymapTest {
     }
 
     private class MockReviewerUi : ReviewerUi {
-        override val controlBlocked: ControlBlock?
-            get() = null
-
         override val isControlBlocked = false
 
         override val isDisplayingAnswer: Boolean


### PR DESCRIPTION
No longer used in the new backend + `suspend` functions.

No calls were made to `blockControls`, and everything else passed through this

I suspect unrelated to https://github.com/ankidroid/Anki-Android/issues/14708

But it'll provide a small speedup anyway

## How Has This Been Tested?
Flipped a card on an API 33 emulator, and trusting CI

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
