### PR TITLE
Fix collapsing AppBar on preferences screen

### DIFF
--- a/AnkiDroid/src/main/res/layout/preferences.xml
+++ b/AnkiDroid/src/main/res/layout/preferences.xml
@@ -26,6 +26,7 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appbar"
+        android:fitsSystemWindows="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 


### PR DESCRIPTION
Hopefully fixing https://github.com/ankidroid/Anki-Android/issues/14993

<!--- Please fill the necessary details below -->
## Purpose / Description
[AppBar is not being collapsed for some phones (mainly Pixels).](https://github.com/ankidroid/Anki-Android/issues/14993) 

## Fixes
* Fixes [AppBar is not being collapsed for some phones (mainly Pixels).](https://github.com/ankidroid/Anki-Android/issues/14993) 

## Approach
Add `android:fitsSystemWindows="true"` to the AppBarLayout (without removing it from CoordinatorLayout). 

## How Has This Been Tested?
Tested on my Pixel: it fixes the problem (discussion and video are in https://github.com/ankidroid/Anki-Android/issues/14993)

## Learning (optional, can help others)
Moving this string (`android:fitsSystemWindows="true"`) from the CoordinatorLayout to the AppBarLayout re-enables collapsing too, but introduces new bug: the status bar color stops being updated. 

Only using two `android:fitsSystemWindows="true"` in both places AppBar is being collapsed and the status bar changes color.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
