### PR TITLE
fix: allow seeking videos

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReviewerServer.kt
@@ -18,6 +18,8 @@ package com.ichi2.anki
 
 import anki.frontend.SetSchedulingStatesRequest
 import com.ichi2.anki.pages.AnkiServer
+import com.ichi2.anki.pages.RangeHeader
+import com.ichi2.anki.pages.toInputStream
 import com.ichi2.utils.AssetHelper
 import timber.log.Timber
 import java.io.File
@@ -58,10 +60,24 @@ class ReviewerServer(activity: AbstractFlashcardViewer, private val mediaDir: St
             // fall back to looking in media folder
             val file = File(mediaDir, uri.substring(1))
             if (file.exists()) {
-                val inputStream = FileInputStream(file)
+                val rangeHeader = RangeHeader.from(session, defaultEnd = file.length() - 1)
                 val mimeType = AssetHelper.guessMimeType(uri)
-                Timber.v("OK: $uri")
-                return newChunkedResponse(Response.Status.OK, mimeType, inputStream)
+                return if (rangeHeader != null) {
+                    val (start, end) = rangeHeader
+                    newFixedLengthResponse(
+                        Response.Status.PARTIAL_CONTENT,
+                        mimeType,
+                        file.toInputStream(rangeHeader),
+                        rangeHeader.contentLength
+                    ).apply {
+                        addHeader("Content-Range", "bytes $start-$end/${file.length()}")
+                        addHeader("Accept-Ranges", "bytes")
+                    }
+                } else {
+                    val inputStream = FileInputStream(file)
+                    Timber.v("OK: $uri")
+                    newChunkedResponse(Response.Status.OK, mimeType, inputStream)
+                }
                 // probably don't need this anymore
                 // resp.addHeader("Access-Control-Allow-Origin", "*")
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/RangeHeader.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/RangeHeader.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import fi.iki.elonen.NanoHTTPD.IHTTPSession
+import java.io.File
+import java.io.InputStream
+import java.io.RandomAccessFile
+import java.nio.channels.Channels
+
+/**
+ * Handles the "range" header in a HTTP Request
+ */
+data class RangeHeader(val start: Long, val end: Long) {
+    val contentLength: Long get() = end - start + 1
+
+    companion object {
+        fun from(session: IHTTPSession, defaultEnd: Long): RangeHeader? {
+            val range = session.headers["range"]?.trim() ?: return null
+            val numbers = range.substring("bytes=".length).split('-')
+            val unspecifiedEnd = numbers.getOrNull(1).isNullOrEmpty()
+            return RangeHeader(
+                start = numbers[0].toLong(),
+                end = if (unspecifiedEnd) defaultEnd else numbers[1].toLong()
+            )
+        }
+    }
+}
+
+fun File.toInputStream(header: RangeHeader): InputStream {
+    // PERF: Test to see if a custom FileInputStream + available() would be faster
+    val randomAccessFile = RandomAccessFile(this, "r")
+    return Channels.newInputStream(randomAccessFile.channel).also {
+        it.skip(header.start)
+    }
+}


### PR DESCRIPTION
## Purpose / Description

## Fixes
* Fixes #14490

## Approach
This implements HTTP 206 partial content responses

We accept a range header, determine the start/end that the client would like, and return that subset of the file

## How Has This Been Tested?
https://github.com/ankidroid/Anki-Android/assets/62114487/4f7c20df-e5a6-42de-9119-af09eacae9ad

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
