### PR TITLE
refactor(gestures): generalise 'Screen' 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.ctrl
 import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.shift
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding
+import com.ichi2.anki.reviewer.MappableBinding.*
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromPreference
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import java.util.*
@@ -78,6 +79,8 @@ enum class ViewerCommand(val resourceId: Int) {
             get() = Arrays.stream(values())
                 .flatMap { x: ViewerCommand -> x.defaultValue.stream() }
                 .collect(Collectors.toList())
+
+        fun fromPreferenceKey(key: String) = ViewerCommand.entries.first { it.preferenceKey == key }
     }
 
     val preferenceKey: String
@@ -122,8 +125,12 @@ enum class ViewerCommand(val resourceId: Int) {
 
     // If we use the serialised format, then this adds additional coupling to the properties.
     val defaultValue: List<MappableBinding>
-        get() = // If we use the serialised format, then this adds additional coupling to the properties.
-            when (this) {
+        get() {
+            // all of the default commands are currently for the Reviewer
+            fun keyCode(keycode: Int, side: CardSide, modifierKeys: ModifierKeys = ModifierKeys.none()) =
+                keyCode(keycode, Screen.Reviewer(side), modifierKeys)
+            fun unicode(c: Char, side: CardSide) = unicode(c, Screen.Reviewer(side))
+            return when (this) {
                 FLIP_OR_ANSWER_EASE1 -> from(
                     keyCode(KeyEvent.KEYCODE_BUTTON_Y, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_1, CardSide.ANSWER),
@@ -171,21 +178,18 @@ enum class ViewerCommand(val resourceId: Int) {
                 ADD_NOTE -> from(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
                 else -> ArrayList()
             }
+        }
 
-    private fun keyCode(keycode: Int, side: CardSide, keys: ModifierKeys): MappableBinding {
-        return MappableBinding(keyCode(keys, keycode), MappableBinding.Screen.Reviewer(side))
+    private fun keyCode(keycode: Int, screen: Screen, keys: ModifierKeys = ModifierKeys.none()): MappableBinding {
+        return MappableBinding(keyCode(keys, keycode), screen)
     }
 
-    private fun unicode(c: Char, side: CardSide): MappableBinding {
-        return MappableBinding(unicode(c), MappableBinding.Screen.Reviewer(side))
+    private fun unicode(c: Char, screen: Screen): MappableBinding {
+        return MappableBinding(unicode(c), screen)
     }
 
     private fun from(vararg bindings: MappableBinding): List<MappableBinding> {
         return ArrayList(listOf(*bindings))
-    }
-
-    private fun keyCode(keyCode: Int, side: CardSide): MappableBinding {
-        return MappableBinding(keyCode(keyCode), MappableBinding.Screen.Reviewer(side))
     }
 
     fun interface CommandProcessor {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -131,17 +131,17 @@ enum class ViewerCommand(val resourceId: Int) {
                 keyCode(keycode, Screen.Reviewer(side), modifierKeys)
             fun unicode(c: Char, side: CardSide) = unicode(c, Screen.Reviewer(side))
             return when (this) {
-                FLIP_OR_ANSWER_EASE1 -> from(
+                FLIP_OR_ANSWER_EASE1 -> listOf(
                     keyCode(KeyEvent.KEYCODE_BUTTON_Y, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_1, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.ANSWER)
                 )
-                FLIP_OR_ANSWER_EASE2 -> from(
+                FLIP_OR_ANSWER_EASE2 -> listOf(
                     keyCode(KeyEvent.KEYCODE_BUTTON_X, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_2, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.ANSWER)
                 )
-                FLIP_OR_ANSWER_EASE3 -> from(
+                FLIP_OR_ANSWER_EASE3 -> listOf(
                     keyCode(KeyEvent.KEYCODE_BUTTON_B, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_3, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.ANSWER),
@@ -150,33 +150,33 @@ enum class ViewerCommand(val resourceId: Int) {
                     keyCode(KeyEvent.KEYCODE_ENTER, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_ENTER, CardSide.ANSWER)
                 )
-                FLIP_OR_ANSWER_EASE4 -> from(
+                FLIP_OR_ANSWER_EASE4 -> listOf(
                     keyCode(KeyEvent.KEYCODE_BUTTON_A, CardSide.BOTH),
                     keyCode(KeyEvent.KEYCODE_4, CardSide.ANSWER),
                     keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.ANSWER)
                 )
-                EDIT -> from(keyCode(KeyEvent.KEYCODE_E, CardSide.BOTH))
-                MARK -> from(unicode('*', CardSide.BOTH))
-                BURY_CARD -> from(unicode('-', CardSide.BOTH))
-                BURY_NOTE -> from(unicode('=', CardSide.BOTH))
-                SUSPEND_CARD -> from(unicode('@', CardSide.BOTH))
-                SUSPEND_NOTE -> from(unicode('!', CardSide.BOTH))
-                PLAY_MEDIA -> from(keyCode(KeyEvent.KEYCODE_R, CardSide.BOTH), keyCode(KeyEvent.KEYCODE_F5, CardSide.BOTH))
-                REPLAY_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
-                RECORD_VOICE -> from(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
-                UNDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
-                REDO -> from(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH, ModifierKeys(shift = true, ctrl = true, alt = false)))
-                TOGGLE_FLAG_RED -> from(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_ORANGE -> from(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_GREEN -> from(keyCode(KeyEvent.KEYCODE_3, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_BLUE -> from(keyCode(KeyEvent.KEYCODE_4, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_PINK -> from(keyCode(KeyEvent.KEYCODE_5, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_5, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_TURQUOISE -> from(keyCode(KeyEvent.KEYCODE_6, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_6, CardSide.BOTH, ctrl()))
-                TOGGLE_FLAG_PURPLE -> from(keyCode(KeyEvent.KEYCODE_7, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_7, CardSide.BOTH, ctrl()))
-                SHOW_HINT -> from(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
-                SHOW_ALL_HINTS -> from(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
-                ADD_NOTE -> from(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
-                else -> ArrayList()
+                EDIT -> listOf(keyCode(KeyEvent.KEYCODE_E, CardSide.BOTH))
+                MARK -> listOf(unicode('*', CardSide.BOTH))
+                BURY_CARD -> listOf(unicode('-', CardSide.BOTH))
+                BURY_NOTE -> listOf(unicode('=', CardSide.BOTH))
+                SUSPEND_CARD -> listOf(unicode('@', CardSide.BOTH))
+                SUSPEND_NOTE -> listOf(unicode('!', CardSide.BOTH))
+                PLAY_MEDIA -> listOf(keyCode(KeyEvent.KEYCODE_R, CardSide.BOTH), keyCode(KeyEvent.KEYCODE_F5, CardSide.BOTH))
+                REPLAY_VOICE -> listOf(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
+                RECORD_VOICE -> listOf(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
+                UNDO -> listOf(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
+                REDO -> listOf(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH, ModifierKeys(shift = true, ctrl = true, alt = false)))
+                TOGGLE_FLAG_RED -> listOf(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_ORANGE -> listOf(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_GREEN -> listOf(keyCode(KeyEvent.KEYCODE_3, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_3, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_BLUE -> listOf(keyCode(KeyEvent.KEYCODE_4, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_4, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_PINK -> listOf(keyCode(KeyEvent.KEYCODE_5, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_5, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_TURQUOISE -> listOf(keyCode(KeyEvent.KEYCODE_6, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_6, CardSide.BOTH, ctrl()))
+                TOGGLE_FLAG_PURPLE -> listOf(keyCode(KeyEvent.KEYCODE_7, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_7, CardSide.BOTH, ctrl()))
+                SHOW_HINT -> listOf(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
+                SHOW_ALL_HINTS -> listOf(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
+                ADD_NOTE -> listOf(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
+                else -> emptyList()
             }
         }
 
@@ -186,10 +186,6 @@ enum class ViewerCommand(val resourceId: Int) {
 
     private fun unicode(c: Char, screen: Screen): MappableBinding {
         return MappableBinding(unicode(c), screen)
-    }
-
-    private fun from(vararg bindings: MappableBinding): List<MappableBinding> {
-        return ArrayList(listOf(*bindings))
     }
 
     fun interface CommandProcessor {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -29,16 +29,12 @@ class ControlsSettingsFragment : SettingsFragment() {
 
     @NeedsTest("Keys and titles in the XML layout are the same of the ViewerCommands")
     override fun initSubscreen() {
-        val commands = HashMap<String, ViewerCommand>()
-        ViewerCommand.entries.forEach { commands[it.preferenceKey] = it }
+        val commands = ViewerCommand.entries.associateBy { it.preferenceKey }
         // set defaultValue in the prefs creation.
         // if a preference is empty, it has a value like "1/"
         allPreferences()
             .filterIsInstance<ControlPreference>()
-            .forEach { pref ->
-                if (pref.value == null) {
-                    pref.value = commands[pref.key]?.defaultValue?.toPreferenceString()
-                }
-            }
+            .filter { pref -> pref.value == null }
+            .forEach { pref -> pref.value = commands[pref.key]?.defaultValue?.toPreferenceString() }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -33,7 +33,7 @@ import kotlin.collections.ArrayList
  * Also defines equality over bindings.
  * https://stackoverflow.com/questions/5453226/java-need-a-hash-map-where-one-supplies-a-function-to-do-the-hashing
  */
-class MappableBinding(val binding: Binding, private val screen: Screen) {
+class MappableBinding(val binding: Binding, val screen: Screen) {
     val isKey: Boolean get() = binding is KeyBinding
 
     override fun equals(other: Any?): Boolean {
@@ -128,8 +128,6 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
             }
 
             companion object {
-                @CheckResult
-                fun fromGesture(b: Binding): MappableBinding = MappableBinding(b, Reviewer(CardSide.BOTH))
                 fun fromString(s: String): MappableBinding {
                     val binding = s.substring(0, s.length - 1)
                     val b = Binding.fromString(binding)
@@ -153,7 +151,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
         const val PREF_SEPARATOR = '|'
 
         @CheckResult
-        fun fromGesture(gesture: Gesture): MappableBinding = MappableBinding(GestureInput(gesture), Screen.Reviewer(CardSide.BOTH))
+        fun fromGesture(gesture: Gesture, screen: (CardSide) -> Screen): MappableBinding = MappableBinding(GestureInput(gesture), screen(CardSide.BOTH))
 
         @CheckResult
         fun List<MappableBinding>.toPreferenceString(): String = this.mapNotNull { it.toPreferenceString() }
@@ -208,3 +206,7 @@ class MappableBinding(val binding: Binding, private val screen: Screen) {
         }
     }
 }
+
+@Suppress("UnusedReceiverParameter")
+val ViewerCommand.screenBuilder: (CardSide) -> MappableBinding.Screen
+    get() = { it -> MappableBinding.Screen.Reviewer(it) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PeripheralKeymap.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.Binding.Companion.possibleKeyBindings
 import com.ichi2.anki.reviewer.CardSide.Companion.fromAnswer
+import com.ichi2.anki.reviewer.MappableBinding.*
 import com.ichi2.anki.reviewer.MappableBinding.Companion.fromPreference
 import java.util.HashMap
 
@@ -44,7 +45,8 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
     }
 
     private fun add(command: ViewerCommand, preferences: SharedPreferences) {
-        val bindings: MutableList<MappableBinding> = fromPreference(preferences, command)
+        val bindings = fromPreference(preferences, command)
+            .filter { it.screen is Screen.Reviewer }
         for (b in bindings) {
             if (!b.isKey) {
                 continue
@@ -66,7 +68,11 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
         return false
     }
 
-    class KeyMap(private val processor: ViewerCommand.CommandProcessor, private val reviewerUI: ReviewerUi) {
+    class KeyMap(
+        private val processor: ViewerCommand.CommandProcessor,
+        private val reviewerUI: ReviewerUi,
+        private val screenBuilder: (CardSide) -> Screen
+    ) {
         val mBindingMap = HashMap<MappableBinding, ViewerCommand>()
 
         @Suppress("UNUSED_PARAMETER")
@@ -75,7 +81,7 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
             val bindings = possibleKeyBindings(event!!)
             val side = fromAnswer(reviewerUI.isDisplayingAnswer)
             for (b in bindings) {
-                val binding = MappableBinding(b, MappableBinding.Screen.Reviewer(side))
+                val binding = MappableBinding(b, screenBuilder(side))
                 val command = mBindingMap[binding] ?: continue
                 ret = ret or processor.executeCommand(command, fromGesture = null)
             }
@@ -92,6 +98,6 @@ class PeripheralKeymap(reviewerUi: ReviewerUi, commandProcessor: ViewerCommand.C
     }
 
     init {
-        mKeyMap = KeyMap(commandProcessor, reviewerUi)
+        mKeyMap = KeyMap(commandProcessor, reviewerUi) { Screen.Reviewer(it) }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
+import com.ichi2.anki.reviewer.screenBuilder
 import com.ichi2.libanki.Consts
 import com.ichi2.utils.HashUtil.hashSetInit
 import timber.log.Timber
@@ -336,7 +337,7 @@ object PreferenceUpgradeService {
                 Timber.i("Moving preference from '%s' to '%s'", oldGesturePreferenceKey, command.preferenceKey)
 
                 // add to the binding_COMMANDNAME preference
-                val mappableBinding = MappableBinding(binding, MappableBinding.Screen.Reviewer(CardSide.BOTH))
+                val mappableBinding = MappableBinding(binding, command.screenBuilder(CardSide.BOTH))
                 command.addBindingAtEnd(preferences, mappableBinding)
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.setPreference
 import com.ichi2.anki.reviewer.MappableBinding
+import com.ichi2.anki.reviewer.MappableBinding.Screen
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
 import com.ichi2.testutils.Flaky
@@ -298,7 +299,12 @@ class ReviewerNoParamTest : RobolectricTest() {
     /** Enables a gesture (without changing the overall setting of whether gestures are allowed)  */
     private fun enableGesture(gesture: Gesture) {
         val prefs = targetContext.sharedPrefs()
-        ViewerCommand.FLIP_OR_ANSWER_EASE1.addBinding(prefs, MappableBinding.fromGesture(gesture))
+        ViewerCommand.FLIP_OR_ANSWER_EASE1.addBinding(
+            prefs,
+            MappableBinding.fromGesture(gesture) {
+                Screen.Reviewer(it)
+            }
+        )
     }
 
     private fun startReviewerFullScreen(): ReviewerExt {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/GestureProcessorTest.kt
@@ -19,7 +19,9 @@ import android.content.SharedPreferences
 import android.view.ViewConfiguration
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.reviewer.MappableBinding
+import com.ichi2.anki.reviewer.MappableBinding.*
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
+import com.ichi2.anki.reviewer.screenBuilder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -47,7 +49,9 @@ class GestureProcessorTest : ViewerCommand.CommandProcessor {
     @Test
     fun integrationTest() {
         val prefs = mockk<SharedPreferences>(relaxed = true)
-        every { prefs.getString(ViewerCommand.SHOW_ANSWER.preferenceKey, null) } returns listOf(MappableBinding.fromGesture(Gesture.TAP_CENTER)).toPreferenceString()
+        every { prefs.getString(ViewerCommand.SHOW_ANSWER.preferenceKey, null) } returns
+            listOf(MappableBinding.fromGesture(Gesture.TAP_CENTER, ViewerCommand.SHOW_ANSWER.screenBuilder))
+                .toPreferenceString()
         every { prefs.getBoolean("gestureCornerTouch", any()) } returns true
         mSut.init(prefs)
         mSut.onTap(100, 100, 50f, 50f)


### PR DESCRIPTION
## Purpose / Description
* Prep to merge PR #12882

Our gesture system was set up to work with the Reviewer

The problem with this is that when we have two screens, a conflicting gesture between the screens doesn't matter

This extracts the Reviewer from most parts of the gesture implementation, so we can replace it with the Previewer when necessary

Note: The Previewer is a special case, other screens won't have a concept of a 'CardSide'

## Approach
* define a function: `(CardSide) -> Screen` and use that
  * This still assumes a `Viewer`
* or accept a `Screen` parameter 

## How Has This Been Tested?
The area is unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
