### PR TITLE
fix crash when sharing Export Collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -30,11 +30,15 @@ import anki.generic.Empty
 import anki.import_export.ExportLimit
 import anki.import_export.exportLimit
 import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.*
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.dialogs.ExportDialog.ExportDialogListener
 import com.ichi2.anki.dialogs.ExportDialogParams
 import com.ichi2.anki.dialogs.ExportReadyDialog.ExportReadyDialogListener
+import com.ichi2.anki.exportApkg
+import com.ichi2.anki.exportColpkg
+import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
@@ -289,8 +293,9 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
      * the mod of the collection and the time at which it occurred.
      * This will allow to check whether a recent export was made, hence scoped storage migration is safe.
      */
+    @NeedsTest("fix crash when sharing")
     private fun saveSuccessfulCollectionExportIfRelevant() {
-        if (!fileExportPath.endsWith(".colpkg")) return
+        if (::fileExportPath.isInitialized && !fileExportPath.endsWith(".colpkg")) return
         activity.sharedPrefs().edit {
             putLong(
                 LAST_SUCCESSFUL_EXPORT_AT_SECOND_KEY,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Crash when sharing an export collection

## Fixes
* Fixes  #15058

## Approach
This bug was introduced due to #14797  PR

## How Has This Been Tested?

Physical Device ( Realme 9 )

https://github.com/ankidroid/Anki-Android/assets/65113071/e7c6b97e-0dd7-43d1-bc24-dcf6973ec705



## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
