### PR TITLE
fix: runtime error handling in custom scheduling 

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.testutil.notificationPermission
 import com.ichi2.libanki.Collection
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -92,7 +91,6 @@ class ReviewerTest : InstrumentedTest() {
     }
 
     @Test
-    @Ignore("15035")
     fun testCustomSchedulerWithRuntimeError() {
         // Issue 15035 - runtime errors weren't handled
         col.cardStateCustomizer = "states.this_is_not_defined.normal.review = 12;"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2456,6 +2456,9 @@ abstract class AbstractFlashcardViewer :
                 }
                 return true
             }
+            if (url.startsWith("state-mutation-error:")) {
+                onStateMutationError()
+            }
             if (url.startsWith("tts-voices:")) {
                 showDialogFragment(TtsVoicesDialogFragment())
                 return true
@@ -2681,6 +2684,10 @@ abstract class AbstractFlashcardViewer :
         override fun onRenderProcessGone(view: WebView, detail: RenderProcessGoneDetail): Boolean {
             return mOnRenderProcessGoneDelegate.onRenderProcessGone(view, detail)
         }
+    }
+
+    protected open fun onStateMutationError() {
+        Timber.w("state mutation error, see console log")
     }
 
     private fun displayCouldNotFindMediaSnackbar(filename: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1099,7 +1099,7 @@ open class Reviewer :
         webView?.evaluateJavascript(
             """
         anki.mutateNextCardStates('$key', async (states, customData, ctx) => {{ $js }})
-            .catch(err => console.log(err));
+            .catch(err => { console.log(err); window.location.href = "state-mutation-error:"; });
 """
         ) { result ->
             if ("null" == result) {
@@ -1108,6 +1108,11 @@ open class Reviewer :
                 statesMutated = true
             }
         }
+    }
+
+    override fun onStateMutationError() {
+        super.onStateMutationError()
+        statesMutated = true
     }
 
     override fun initLayout() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1098,7 +1098,7 @@ open class Reviewer :
         val js = state.customSchedulingJs
         webView?.evaluateJavascript(
             """
-        anki.mutateNextCardStates('$key', async (states, customData, ctx) => {{ $js }})
+        anki.mutateNextCardStates('$key', async (states, customData, ctx) => { $js })
             .catch(err => { console.log(err); window.location.href = "state-mutation-error:"; });
 """
         ) { result ->


### PR DESCRIPTION
## Purpose / Description
* our custom scheduling code handled syntax error, but not runtime errors

* Cause: https://github.com/ankidroid/Anki-Android/pull/14899

## Fixes
* Fixes #15035

## Approach
* define a URL
* access the URL via: `window.location.href = "state-mutation-error:"`
* set `statesMutated` if the URL is accessed

## How Has This Been Tested?
API 33 emulator, and tests added

## Learning (optional, can help others)

* https://faqs.ankiweb.net/the-2021-scheduler.html#add-ons-and-custom-scheduling
* Custom Study defines a different set of properties, hence the failure
* Python escaping: https://stackoverflow.com/q/5466451/

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
