### PR TITLE
Kotlin Cleanup

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -75,10 +75,6 @@ class ContentProviderTest : InstrumentedTest() {
      * Initially create one note for each model.
      */
     @Before
-    @Throws(
-        Exception::class
-    )
-    @KotlinCleanup("remove 'requireNoNulls' and fix mDummyFields")
     fun setUp() {
         Timber.i("setUp()")
         mCreatedNotes = ArrayList()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -424,9 +424,8 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
      * @param message
      * @param reload flag which forces app to be restarted when true
      */
-    @KotlinCleanup("make message non-null")
     open fun showSimpleMessageDialog(
-        message: String?,
+        message: String,
         title: String = "",
         reload: Boolean = false
     ) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -46,6 +46,7 @@ import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.utils.FragmentFactoryUtils.instantiate
 import com.ichi2.utils.HtmlUtils.convertNewlinesToHtml
 import kotlinx.coroutines.Job
+import org.intellij.lang.annotations.Language
 import timber.log.Timber
 
 class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
@@ -671,7 +672,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
         }
 
         @VisibleForTesting
-        fun formatDescription(desc: String): Spanned {
+        fun formatDescription(@Language("HTML") desc: String): Spanned {
             // #5715: In deck description, ignore what is in style and script tag
             // Since we don't currently execute the JS/CSS, it's not worth displaying.
             val withStrippedTags = Utils.stripHTMLScriptAndStyleTags(desc)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -18,6 +18,7 @@ package com.ichi2.libanki
 
 import androidx.annotation.CheckResult
 import com.ichi2.utils.*
+import org.intellij.lang.annotations.Language
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.HashSet
@@ -52,7 +53,7 @@ class NotetypeJson : JSONObject {
     /**
      * Creates a model object form json string
      */
-    constructor(json: String) : super(json)
+    constructor(@Language("json") json: String) : super(json)
 
     @CheckResult
     fun deepClone(): NotetypeJson {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -15,43 +15,36 @@
  */
 package com.ichi2.anki
 
-import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.testutils.ActivityList
-import com.ichi2.testutils.ActivityList.ActivityLaunchParam
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.*
-import java.util.stream.Collectors
-import kotlin.Throws
 
 @RunWith(AndroidJUnit4::class)
 class ActivityStartupMetaTest : RobolectricTest() {
     @Test
-    @Throws(PackageManager.NameNotFoundException::class)
-    @KotlinCleanup("remove throws; remove stream(), remove : String")
     fun ensureAllActivitiesAreTested() {
         // if this fails, you may need to add the missing activity to ActivityList.allActivitiesAndIntents()
 
         // we can't access this in a static context
         val packageInfo = targetContext.getPackageInfoCompat(targetContext.packageName, PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong())) ?: throw IllegalStateException("getPackageInfo failed")
         val manifestActivities = packageInfo.activities
-        val testedActivityClassNames = ActivityList.allActivitiesAndIntents().stream().map { obj: ActivityLaunchParam -> obj.className }.collect(Collectors.toSet())
-        val manifestActivityNames = Arrays.stream(manifestActivities)
-            .map { x: ActivityInfo -> x.name }
-            .filter { x: String -> x != "com.ichi2.anki.TestCardTemplatePreviewer" }
-            .filter { x: String -> x != "com.ichi2.anki.AnkiCardContextMenuAction" }
-            .filter { x: String -> x != "com.ichi2.anki.analytics.AnkiDroidCrashReportDialog" }
-            .filter { x: String -> !x.startsWith("androidx") }
-            .filter { x: String -> !x.startsWith("org.acra") }
-            .filter { x: String -> !x.startsWith("leakcanary.internal") }
-            .toArray()
+        val testedActivityClassNames = ActivityList.allActivitiesAndIntents().map { it.className }.toSet()
+        val manifestActivityNames = manifestActivities
+            .map { it.name }
+            .filter { it != "com.ichi2.anki.TestCardTemplatePreviewer" }
+            .filter { it != "com.ichi2.anki.AnkiCardContextMenuAction" }
+            .filter { it != "com.ichi2.anki.analytics.AnkiDroidCrashReportDialog" }
+            .filter { !it.startsWith("androidx") }
+            .filter { !it.startsWith("org.acra") }
+            .filter { !it.startsWith("leakcanary.internal") }
+            .toTypedArray()
         MatcherAssert.assertThat(testedActivityClassNames, Matchers.containsInAnyOrder(*manifestActivityNames))
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplatePreviewerTest.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.servicelayer.NoteService.getFieldsAsBundleForPreview
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Sound
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.stringIterable
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
@@ -434,9 +433,8 @@ class CardTemplatePreviewerTest : RobolectricTest() {
         return n.cards()[0]
     }
 
-    @KotlinCleanup("Override fieldText in constructor and remove text")
-    private inner class Field(override val ord: Int, private val text: String) : NoteService.NoteField {
+    private inner class Field(
+        override val ord: Int,
         override val fieldText: String
-            get() = text
-    }
+    ) : NoteService.NoteField
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -13,6 +13,8 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+@file:Suppress("SameParameterValue")
+
 package com.ichi2.anki
 
 import android.app.Activity
@@ -32,8 +34,6 @@ import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
-import com.ichi2.utils.KotlinCleanup
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Ignore
@@ -45,9 +45,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(AndroidJUnit4::class)
-@KotlinCleanup("IDE lint")
 class NoteEditorTest : RobolectricTest() {
     @Test
     @Config(qualifiers = "en")
@@ -193,8 +191,6 @@ class NoteEditorTest : RobolectricTest() {
 
     @Test
     fun copyNoteCopiesDeckId() {
-        // value returned if deck not found
-        val DECK_ID_NOT_FOUND = -404
         val currentDid = addDeck("Basic::Test")
         col.config.set(CURRENT_DECK, currentDid)
         val n = super.addNoteUsingBasicModel("Test", "Note")
@@ -204,7 +200,7 @@ class NoteEditorTest : RobolectricTest() {
         val copyNoteIntent = getCopyNoteIntent(editor)
         val newNoteEditor = super.startActivityNormallyOpenCollectionWithIntent(NoteEditor::class.java, copyNoteIntent)
         assertThat("Selected deck ID should be the current deck id", editor.deckId, equalTo(currentDid))
-        assertThat("Deck ID in the intent should be the selected deck id", copyNoteIntent.getLongExtra(NoteEditor.EXTRA_DID, DECK_ID_NOT_FOUND.toLong()), equalTo(currentDid))
+        assertThat("Deck ID in the intent should be the selected deck id", copyNoteIntent.getLongExtra(NoteEditor.EXTRA_DID, -404L), equalTo(currentDid))
         assertThat("Deck ID in the new note should be the ID provided in the intent", newNoteEditor.deckId, equalTo(currentDid))
     }
 
@@ -438,7 +434,6 @@ class NoteEditorTest : RobolectricTest() {
         private val mNotetype: NotetypeJson
         private var mFirstField: String? = null
         private var mSecondField: String? = null
-        private var mThirdField: String? = null
         fun build(): NoteEditor {
             val editor = build(NoteEditor::class.java)
             advanceRobolectricLooper()
@@ -459,9 +454,6 @@ class NoteEditorTest : RobolectricTest() {
             if (mSecondField != null) {
                 noteEditor.setFieldValueFromUi(1, mSecondField)
             }
-            if (mThirdField != null) {
-                noteEditor.setFieldValueFromUi(2, mThirdField)
-            }
             return noteEditor
         }
 
@@ -476,11 +468,6 @@ class NoteEditorTest : RobolectricTest() {
 
         fun withSecondField(text: String?): NoteEditorTestBuilder {
             mSecondField = text
-            return this
-        }
-
-        fun withThirdField(text: String?): NoteEditorTestBuilder {
-            mThirdField = text
             return this
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/StudyOptionsFragmentTest.kt
@@ -17,13 +17,11 @@ package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.StudyOptionsFragment.Companion.formatDescription
-import com.ichi2.utils.KotlinCleanup
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class) // required for String -> Spannable conversion in formatDescription
-@KotlinCleanup("add @Language to fromDescription")
 class StudyOptionsFragmentTest {
     // Fixes for #5715: In deck description, ignore what is in style and script tag
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -21,17 +21,14 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.ImageField
 import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.servicelayer.NoteService
-import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.createTransientFile
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.io.FileMatchers.*
 import org.junit.Assert.*
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -45,14 +42,6 @@ import java.io.IOException
 class NoteServiceTest : RobolectricTest() {
     override fun useInMemoryDatabase(): Boolean = false
 
-    @KotlinCleanup("lateinit")
-    var testCol: Collection? = null
-
-    @Before
-    fun before() {
-        testCol = col
-    }
-
     // temporary directory to test importMediaToDirectory function
     @get:Rule
     var directory = TemporaryFolder()
@@ -63,12 +52,12 @@ class NoteServiceTest : RobolectricTest() {
     // tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote
     @Test
     fun updateJsonNoteTest() {
-        val testModel = testCol!!.notetypes.byName("Basic")
+        val testModel = col.notetypes.byName("Basic")
         val multiMediaNote: IMultimediaEditableNote? = NoteService.createEmptyNote(testModel!!)
         multiMediaNote!!.getField(0)!!.text = "foo"
         multiMediaNote.getField(1)!!.text = "bar"
 
-        val basicNote = Note(testCol!!, testModel).apply {
+        val basicNote = Note(col, testModel).apply {
             setField(0, "this should be changed to foo")
             setField(1, "this should be changed to bar")
         }
@@ -87,7 +76,7 @@ class NoteServiceTest : RobolectricTest() {
 
         // model with ID 45
         testNotetype = NotetypeJson("""{"flds": [{"name": "foo bar", "ord": "1"}], "id": "45"}""")
-        val noteWithID45 = Note(testCol!!, testNotetype)
+        val noteWithID45 = Note(col, testNotetype)
         val expectedException: Throwable = assertThrows(RuntimeException::class.java) { NoteService.updateJsonNoteFromMultimediaNote(multiMediaNoteWithID42, noteWithID45) }
         assertEquals(expectedException.message, "Source and Destination Note ID do not match.")
     }
@@ -103,9 +92,9 @@ class NoteServiceTest : RobolectricTest() {
         val audioField = MediaClipField()
         audioField.audioPath = fileAudio.absolutePath
 
-        NoteService.importMediaToDirectory(testCol!!, audioField)
+        NoteService.importMediaToDirectory(col, audioField)
 
-        val outFile = File(testCol!!.media.dir, fileAudio.name)
+        val outFile = File(col.media.dir, fileAudio.name)
 
         assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", outFile, aFileWithAbsolutePath(equalTo(audioField.audioPath)))
     }
@@ -122,9 +111,9 @@ class NoteServiceTest : RobolectricTest() {
         val imgField = ImageField()
         imgField.extraImagePathRef = fileImage.absolutePath
 
-        NoteService.importMediaToDirectory(testCol!!, imgField)
+        NoteService.importMediaToDirectory(col, imgField)
 
-        val outFile = File(testCol!!.media.dir, fileImage.name)
+        val outFile = File(col.media.dir, fileImage.name)
 
         assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", outFile, aFileWithAbsolutePath(equalTo(imgField.extraImagePathRef)))
     }
@@ -159,14 +148,14 @@ class NoteServiceTest : RobolectricTest() {
         val fld3 = MediaClipField()
         fld3.audioPath = f1.absolutePath
 
-        Timber.e("media folder is %s %b", testCol!!.media.dir, File(testCol!!.media.dir).exists())
-        NoteService.importMediaToDirectory(testCol!!, fld1)
-        val o1 = File(testCol!!.media.dir, f1.name)
+        Timber.e("media folder is %s %b", col.media.dir, File(col.media.dir).exists())
+        NoteService.importMediaToDirectory(col, fld1)
+        val o1 = File(col.media.dir, f1.name)
 
-        NoteService.importMediaToDirectory(testCol!!, fld2)
-        val o2 = File(testCol!!.media.dir, f2.name)
+        NoteService.importMediaToDirectory(col, fld2)
+        val o2 = File(col.media.dir, f2.name)
 
-        NoteService.importMediaToDirectory(testCol!!, fld3)
+        NoteService.importMediaToDirectory(col, fld3)
         // creating a third outfile isn't necessary because it should be equal to the first one
 
         assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld1.audioPath)))
@@ -196,13 +185,13 @@ class NoteServiceTest : RobolectricTest() {
         val fld3 = ImageField()
         fld3.extraImagePathRef = f1.absolutePath
 
-        NoteService.importMediaToDirectory(testCol!!, fld1)
-        val o1 = File(testCol!!.media.dir, f1.name)
+        NoteService.importMediaToDirectory(col, fld1)
+        val o1 = File(col.media.dir, f1.name)
 
-        NoteService.importMediaToDirectory(testCol!!, fld2)
-        val o2 = File(testCol!!.media.dir, f2.name)
+        NoteService.importMediaToDirectory(col, fld2)
+        val o2 = File(col.media.dir, f2.name)
 
-        NoteService.importMediaToDirectory(testCol!!, fld3)
+        NoteService.importMediaToDirectory(col, fld3)
         // creating a third outfile isn't necessary because it should be equal to the first one
 
         assertThat("path should be equal to new file made in NoteService.importMediaToDirectory", o1, aFileWithAbsolutePath(equalTo(fld1.extraImagePathRef)))
@@ -224,7 +213,7 @@ class NoteServiceTest : RobolectricTest() {
             hasTemporaryMedia = true
         }
 
-        NoteService.importMediaToDirectory(testCol!!, field)
+        NoteService.importMediaToDirectory(col, field)
 
         assertThat("Audio temporary file should have been deleted after importing", file, not(anExistingFile()))
     }
@@ -239,7 +228,7 @@ class NoteServiceTest : RobolectricTest() {
             hasTemporaryMedia = true
         }
 
-        NoteService.importMediaToDirectory(testCol!!, field)
+        NoteService.importMediaToDirectory(col, field)
 
         assertThat("Image temporary file should have been deleted after importing", file, not(anExistingFile()))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -41,7 +41,6 @@ import java.io.File
 import java.io.FileWriter
 import java.io.IOException
 
-@KotlinCleanup("have Model constructor accent @Language('JSON')")
 @RunWith(AndroidJUnit4::class)
 class NoteServiceTest : RobolectricTest() {
     override fun useInMemoryDatabase(): Boolean = false
@@ -83,11 +82,11 @@ class NoteServiceTest : RobolectricTest() {
     @Test
     fun updateJsonNoteRuntimeErrorTest() {
         // model with ID 42
-        var testNotetype = NotetypeJson("{\"flds\": [{\"name\": \"foo bar\", \"ord\": \"1\"}], \"id\": \"42\"}")
+        var testNotetype = NotetypeJson("""{"flds": [{"name": "foo bar", "ord": "1"}], "id": "42"}""")
         val multiMediaNoteWithID42: IMultimediaEditableNote? = NoteService.createEmptyNote(testNotetype)
 
         // model with ID 45
-        testNotetype = NotetypeJson("{\"flds\": [{\"name\": \"foo bar\", \"ord\": \"1\"}], \"id\": \"45\"}")
+        testNotetype = NotetypeJson("""{"flds": [{"name": "foo bar", "ord": "1"}], "id": "45"}""")
         val noteWithID45 = Note(testCol!!, testNotetype)
         val expectedException: Throwable = assertThrows(RuntimeException::class.java) { NoteService.updateJsonNoteFromMultimediaNote(multiMediaNoteWithID42, noteWithID45) }
         assertEquals(expectedException.message, "Source and Destination Note ID do not match.")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@KotlinCleanup("removeFormattingFromMathjax was imported to stop bug in Kotlin: java.lang.NoSuchFieldError: INSTANCE")
 @KotlinCleanup("add testing function returning c.models.byName(\"Cloze\")")
 class MathJaxClozeTest : JvmTest() {
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/MathJaxClozeTest.kt
@@ -5,7 +5,6 @@ package com.ichi2.libanki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.libanki.template.MathJax
 import com.ichi2.testutils.JvmTest
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Assert.*
@@ -13,16 +12,11 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-@KotlinCleanup("add testing function returning c.models.byName(\"Cloze\")")
 class MathJaxClozeTest : JvmTest() {
 
     @Test
     fun verifyMathJaxClozeCards() {
-        val c = col
-
-        val note = c.newNote(c.notetypes.byName("Cloze")!!)
-        note.setItem("Text", "{{c1::ok}} \\(2^2\\) {{c2::not ok}} \\(2^{{c3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}")
-        c.addNote(note)
+        val note = addCloseNote("{{c1::ok}} \\(2^2\\) {{c2::not ok}} \\(2^{{c3::2}}\\) \\(x^3\\) {{c4::blah}} {{c5::text with \\(x^2\\) jax}}")
         assertEquals(5, note.numberOfCards())
 
         val cards = note.cards()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -17,7 +17,6 @@ package com.ichi2.testutils
 
 import android.annotation.SuppressLint
 import com.ichi2.libanki.utils.Time
-import com.ichi2.utils.KotlinCleanup
 import java.util.*
 
 /** @param [step] Number of milliseconds between each call.
@@ -75,21 +74,6 @@ open class MockTime(initTime: Long, private val step: Int = 0) : Time() {
 
     companion object {
         /**
-         * Allow to get a timestamp which is independent of place where test occurs. MS are set to 0
-         * @param year Year
-         * @param month Month, 0-based
-         * @param date, day of month
-         * @param hourOfDay, hour, from 0 to 23
-         * @param minute, from 0 to 59
-         * @param second, From 0 to 59
-         * @return the time stamp of this instant in GMT calendar
-         */
-        @KotlinCleanup("After Kotlin Conversion, use default argument and remove this")
-        fun timeStamp(year: Int, month: Int, date: Int, hourOfDay: Int, minute: Int, second: Int): Long {
-            return timeStamp(year, month, date, hourOfDay, minute, second, 0)
-        }
-
-        /**
          * Allow to get a timestamp which is independent of place where test occurs.
          * @param year Year
          * @param month Month, 0-based
@@ -101,7 +85,7 @@ open class MockTime(initTime: Long, private val step: Int = 0) : Time() {
          * @return the time stamp of this instant in GMT calendar
          */
         @SuppressLint("DirectGregorianInstantiation")
-        fun timeStamp(year: Int, month: Int, date: Int, hourOfDay: Int, minute: Int, second: Int, milliseconds: Int): Long {
+        fun timeStamp(year: Int, month: Int, date: Int, hourOfDay: Int, minute: Int, second: Int, milliseconds: Int = 0): Long {
             val timeZone = TimeZone.getTimeZone("GMT")
             val gregorianCalendar: Calendar = GregorianCalendar(year, month, date, hourOfDay, minute, second)
             gregorianCalendar.timeZone = timeZone

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -61,6 +61,12 @@ interface TestClass {
         return addNoteUsingModelName("Basic (type in the answer)", front, back)
     }
 
+    fun addCloseNote(text: String, extra: String = "Extra"): Note =
+        col.newNote(col.notetypes.byName("Cloze")!!).apply {
+            setItem("Text", text)
+            col.addNote(this)
+        }
+
     fun addNoteUsingModelName(name: String?, vararg fields: String): Note {
         val model = col.notetypes.byName((name)!!)
             ?: throw IllegalArgumentException("Could not find model '$name'")


### PR DESCRIPTION
Mentioned that we should eventually get `KotlinCleanup` down to 0 refs in Discord.

Hadn't done proper cleanup work on it in a while, so did some easy changes. 185 -> 167 references.

Learning:

* `@Language("mustache")` is almost good for displaying cloze templates
* `@Language("json")` works much better with `"""` strings

* Linkage: https://github.com/ankidroid/Anki-Android/pull/14883
