### PR TITLE
Updated MaterialDialog to AlertDialog in SharedDecksDownloadFragment.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -468,18 +468,19 @@ class SharedDecksDownloadFragment : Fragment() {
 
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
-        AlertDialog.Builder(requireContext()).apply {
+        downloadCancelConfirmationDialog = AlertDialog.Builder(requireContext()).apply {
             setTitle(R.string.cancel_download_question_title)
-            setPositiveButton(R.string.dialog_yes) { _, _: Int ->
+            setPositiveButton(R.string.dialog_yes) { _, _ ->
                 mDownloadManager.remove(mDownloadId)
                 unregisterReceiver()
                 isDownloadInProgress = false
                 activity?.onBackPressed()
             }
-            setNegativeButton(R.string.dialog_no) { _, _: Int ->
+            setNegativeButton(R.string.dialog_no) { _, _ ->
                 downloadCancelConfirmationDialog?.dismiss()
             }
-        }.create().show()
+        }.create()
+        downloadCancelConfirmationDialog?.show()
     }
 
     private fun removeCancelConfirmationDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -77,7 +77,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     var isDownloadInProgress = false
 
-    private var DownloadCancelConfirmationDialog: AlertDialog? = null
+    private var downloadCancelConfirmationDialog: AlertDialog? = null
 
     companion object {
         const val DOWNLOAD_PROGRESS_CHECK_DELAY = 1000L
@@ -478,14 +478,14 @@ class SharedDecksDownloadFragment : Fragment() {
                 activity?.onBackPressed()
             }
             setNegativeButton(R.string.dialog_no) { _, _: Int ->
-                DownloadCancelConfirmationDialog?.dismiss()
+                downloadCancelConfirmationDialog?.dismiss()
             }
         }
-        DownloadCancelConfirmationDialog = builder.create()
-        DownloadCancelConfirmationDialog?.show()
+        downloadCancelConfirmationDialog = builder.create()
+        downloadCancelConfirmationDialog?.show()
     }
 
     private fun removeCancelConfirmationDialog() {
-        DownloadCancelConfirmationDialog?.dismiss()
+        downloadCancelConfirmationDialog?.dismiss()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki
 
-import android.app.AlertDialog
 import android.app.DownloadManager
 import android.content.*
 import android.net.Uri
@@ -32,6 +31,7 @@ import android.webkit.URLUtil
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
@@ -468,7 +468,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
-        val builder = AlertDialog.Builder(context)
+        val builder = AlertDialog.Builder(requireContext())
         builder.apply {
             setTitle(R.string.cancel_download_question_title)
             setPositiveButton(R.string.dialog_yes) { _, _: Int ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -468,8 +468,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
-        val builder = AlertDialog.Builder(requireContext())
-        builder.apply {
+        AlertDialog.Builder(requireContext()).apply {
             setTitle(R.string.cancel_download_question_title)
             setPositiveButton(R.string.dialog_yes) { _, _: Int ->
                 mDownloadManager.remove(mDownloadId)
@@ -480,9 +479,7 @@ class SharedDecksDownloadFragment : Fragment() {
             setNegativeButton(R.string.dialog_no) { _, _: Int ->
                 downloadCancelConfirmationDialog?.dismiss()
             }
-        }
-        downloadCancelConfirmationDialog = builder.create()
-        downloadCancelConfirmationDialog?.show()
+        }.create().show()
     }
 
     private fun removeCancelConfirmationDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -77,7 +77,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     var isDownloadInProgress = false
 
-    private var mDownloadCancelConfirmationDialog: AlertDialog? = null
+    private var DownloadCancelConfirmationDialog: AlertDialog? = null
 
     companion object {
         const val DOWNLOAD_PROGRESS_CHECK_DELAY = 1000L
@@ -478,15 +478,14 @@ class SharedDecksDownloadFragment : Fragment() {
                 activity?.onBackPressed()
             }
             setNegativeButton(R.string.dialog_no) { _, _: Int ->
-                // Perform action on negative button click
-                mDownloadCancelConfirmationDialog?.dismiss()
+                DownloadCancelConfirmationDialog?.dismiss()
             }
         }
-        mDownloadCancelConfirmationDialog = builder.create()
-        mDownloadCancelConfirmationDialog?.show()
+        DownloadCancelConfirmationDialog = builder.create()
+        DownloadCancelConfirmationDialog?.show()
     }
 
     private fun removeCancelConfirmationDialog() {
-        mDownloadCancelConfirmationDialog?.dismiss()
+        DownloadCancelConfirmationDialog?.dismiss()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -471,7 +471,7 @@ class SharedDecksDownloadFragment : Fragment() {
         val builder = AlertDialog.Builder(context)
         builder.apply {
             setTitle(R.string.cancel_download_question_title)
-            setPositiveButton("Yes") { _, _: Int ->
+            setPositiveButton(R.string.dialog_yes) { _, _: Int ->
                 mDownloadManager.remove(mDownloadId)
                 unregisterReceiver()
                 isDownloadInProgress = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.anki
 
+import android.app.AlertDialog
 import android.app.DownloadManager
 import android.content.*
 import android.net.Uri
@@ -33,7 +34,6 @@ import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -77,7 +77,7 @@ class SharedDecksDownloadFragment : Fragment() {
 
     var isDownloadInProgress = false
 
-    private var mDownloadCancelConfirmationDialog: MaterialDialog? = null
+    private var mDownloadCancelConfirmationDialog: AlertDialog? = null
 
     companion object {
         const val DOWNLOAD_PROGRESS_CHECK_DELAY = 1000L
@@ -468,20 +468,22 @@ class SharedDecksDownloadFragment : Fragment() {
 
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
-        mDownloadCancelConfirmationDialog = context?.let {
-            MaterialDialog(it).show {
-                title(R.string.cancel_download_question_title)
-                positiveButton(R.string.dialog_yes) {
-                    mDownloadManager.remove(mDownloadId)
-                    unregisterReceiver()
-                    isDownloadInProgress = false
-                    activity?.onBackPressed()
-                }
-                negativeButton(R.string.dialog_no) {
-                    dismiss()
-                }
+        val builder = AlertDialog.Builder(context)
+        builder.apply {
+            setTitle(R.string.cancel_download_question_title)
+            setPositiveButton("Yes") { _, _: Int ->
+                mDownloadManager.remove(mDownloadId)
+                unregisterReceiver()
+                isDownloadInProgress = false
+                activity?.onBackPressed()
+            }
+            setNegativeButton(R.string.dialog_no) { _, _: Int ->
+                // Perform action on negative button click
+                mDownloadCancelConfirmationDialog?.dismiss()
             }
         }
+        mDownloadCancelConfirmationDialog = builder.create()
+        mDownloadCancelConfirmationDialog?.show()
     }
 
     private fun removeCancelConfirmationDialog() {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Deprecate MaterialDialog and use AlertDialog instead https://github.com/ankidroid/Anki-Android/issues/13315

## Fixes
Replaced MaterialDialog with AlertDialog.Builder under one function showCancelConfirmationDialog() of SharedDecksDownloadFragment.kt.

## Approach
Used AlertDialog 

## How Has This Been Tested?

I tested on my physical device by going inside "get shared decks" choosing any shared decks downloading it and clicking cancel to see the alert dialog which I changed. Changes are done as mentioned there is no difference in the dialog but changed the code to MaterialDilog to AlertDialog.



## Learning (optional, can help others)
Googled the official documentary for the AlertDialog.
https://developer.android.com/reference/android/app/AlertDialog.Builder

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
