### PR TITLE
fix : Add icon for replay voice in media controls

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_replay.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_replay.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+  <path
+      android:fillColor="#FFF"
+      android:pathData="M480,880q-75,0 -140.5,-28.5t-114,-77q-48.5,-48.5 -77,-114T120,520h80q0,117 81.5,198.5T480,800q117,0 198.5,-81.5T760,520q0,-117 -81.5,-198.5T480,240h-6l62,62 -56,58 -160,-160 160,-160 56,58 -62,62h6q75,0 140.5,28.5t114,77q48.5,48.5 77,114T840,520q0,75 -28.5,140.5t-77,114q-48.5,48.5 -114,77T480,880Z"/>
+</vector>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -209,6 +209,7 @@
         <com.ichi2.preferences.ControlPreference
             android:key="@string/replay_voice_command_key"
             android:title="@string/replay_voice"
+            android:icon="@drawable/ic_replay"
             />
     </PreferenceCategory>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
fix : Add icon for replay voice in media controls

## Approach
Add `xml` file and attach it to the preference.

## How Has This Been Tested?

||||
|:----------------------------------------:|:-----------------------------------------:|:-----------------------------------------: |
| ![Imgur](https://github.com/ankidroid/Anki-Android/assets/76740999/94c2a359-8e5a-4199-b9fe-cc10200e22a6) | ![Imgur](https://github.com/ankidroid/Anki-Android/assets/76740999/3aa77d5a-f849-4b75-ae84-4624c54954dc) | ![Imgur](https://github.com/ankidroid/Anki-Android/assets/76740999/3a36bd65-720a-44e4-9638-bd412ff6c800) |
| ![Imgur](https://github.com/ankidroid/Anki-Android/assets/76740999/6494b6fb-4d31-4281-b05a-5e08477ae25c)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
