### PR TITLE
fix(cardbrowser): deck restriction not set

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -558,12 +558,9 @@ open class CardBrowser :
         deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
 
         launchCatchingTask {
-            val deckId = withCol { decks.selected() }
-            // WARN: This is required to set `restrictOnDeck`
-            selectDeckAndSave(deckId)
-            when (viewModel.getInitialDeck()) {
+            when (val deckId = viewModel.getInitialDeck()) {
                 ALL_DECKS_ID -> selectAllDecks()
-                else -> deckSpinnerSelection!!.selectDeckById(viewModel.lastDeckId!!, false)
+                else -> deckSpinnerSelection!!.selectDeckById(deckId, false)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -123,6 +123,7 @@ class CardBrowserViewModel(
         get() = lastDeckIdRepository.lastDeckId
 
     suspend fun setDeckId(deckId: DeckId) {
+        Timber.i("setting deck: %d", deckId)
         lastDeckIdRepository.lastDeckId = deckId
         restrictOnDeck = if (deckId == ALL_DECKS_ID) {
             ""
@@ -134,6 +135,7 @@ class CardBrowserViewModel(
     }
 
     val deckIdFlow = MutableStateFlow(lastDeckId)
+    val deckId get() = deckIdFlow.value
 
     val cardInfoDestination: CardInfoDestination?
         get() {
@@ -186,6 +188,8 @@ class CardBrowserViewModel(
             .launchIn(viewModelScope)
 
         viewModelScope.launch {
+            // PERF: slightly inefficient if the source was lastDeckId
+            setDeckId(getInitialDeck())
             val cardsOrNotes = withCol { CardsOrNotes.fromCollection(this) }
             cardsOrNotesFlow.update { cardsOrNotes }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1021,6 +1021,31 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("deselect row: tap", viewModel.selectedRowCount(), equalTo(1))
         }
     }
+
+    @Test
+    fun `deck id is remembered - issue 15072`() = runTest {
+        // WARN: This doesn't mirror reality due to the use of coroutines
+        // in the issue, selectDeckAndSave() was called AFTER the search had been performed
+        // due to this being called immediately in a test-based context
+
+        // We're going to move this functionality entirely to the ViewModel over the next few weeks
+        // so this test should be updated and working after the refactorings are completed
+        addNoteUsingBasicModel().moveToDeck("First")
+        addNoteUsingBasicModel().moveToDeck("Second")
+
+        val secondDeckId = requireNotNull(col.decks.idForName("Second"))
+
+        browserWithNoNewCards.apply {
+            selectDeckAndSave(secondDeckId)
+            assertThat(viewModel.deckId, equalTo(secondDeckId))
+            finish()
+        }
+
+        browserWithNoNewCards.apply {
+            assertThat("deckId is remembered", viewModel.deckId, equalTo(secondDeckId))
+            assertThat("deckId is searched", viewModel.rowCount, equalTo(1))
+        }
+    }
 }
 
 fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -135,6 +135,20 @@ interface TestClass {
     /** Adds [count] notes in the same deck with the same front & back */
     fun addNotes(count: Int): List<Note> = (0..count).map { addNoteUsingBasicModel() }
 
+    fun Note.moveToDeck(deckName: String, createDeckIfMissing: Boolean = true) {
+        val deckId: DeckId? = if (createDeckIfMissing) {
+            col.decks.id(deckName)
+        } else {
+            col.decks.idForName(deckName)
+        }
+        check(deckId != null) { "$deckName not found" }
+
+        this.cards().forEach { card ->
+            card.did = deckId
+            col.updateCard(card, skipUndoEntry = true)
+        }
+    }
+
     /** helper method to update deck config */
     fun updateDeckConfig(deckId: DeckId, function: DeckConfig.() -> Unit) {
         val deckConfig = col.decks.confForDid(deckId)


### PR DESCRIPTION
## Purpose / Description
* #15072

`restrictOnDeck` was sometimes set AFTER a search had occurred

Therefore the UI a deck but the search was for 'All Decks'

## Fixes
* Fixes #15072

## Approach
* Add a no-op test which will work once we've fully moved to the ViewModel
* set `restrictOnDeck` + `deckId` inside `viewmodel.init{}`

## How Has This Been Tested?
API 33 emulator, using steps in the issue.

The unit test passed BEFORE the fix was in place

## Learning (optional, can help others)
We're in the awkward position where we're not fully in the ViewModel, so there are some orderings of `suspend` operations which are close to untestable. This will be resolved at a later basis when everything occurs in one task in `ViewModel.init { }`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
