### PR TITLE
refactor: CardBrowser - searchTerms

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -756,7 +756,7 @@ open class CardBrowser :
                 })
             }
             // Fixes #6500 - keep the search consistent if coming back from note editor
-            // Fixes #9010 - consistent search after drawer change calls invalidateOptionsMenu (mTempSearchQuery)
+            // Fixes #9010 - consistent search after drawer change calls invalidateOptionsMenu
             if (!viewModel.tempSearchQuery.isNullOrEmpty() || viewModel.searchTerms.isNotEmpty()) {
                 searchItem!!.expandActionView() // This calls mSearchView.setOnSearchClickListener
                 val toUse = if (!viewModel.tempSearchQuery.isNullOrEmpty()) viewModel.tempSearchQuery else viewModel.searchTerms

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -148,9 +148,9 @@ open class CardBrowser :
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var cardsAdapter: MultiColumnListAdapter
 
-    private var searchTerms
+    private val searchTerms
         get() = viewModel.searchTerms
-        set(value) { viewModel.searchTerms = value }
+
     private lateinit var tagsDialogFactory: TagsDialogFactory
     private var searchItem: MenuItem? = null
     private var saveSearchItem: MenuItem? = null
@@ -409,6 +409,9 @@ open class CardBrowser :
             }
         }
         onboarding.onCreate()
+
+        viewModel.flowOfSearchTerms
+            .launchCollectionInLifecycleScope { searchCards() }
 
         viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope { cardsAdapter.notifyDataSetChanged() }
 
@@ -2135,8 +2138,7 @@ open class CardBrowser :
 
     @VisibleForTesting
     fun searchCards(searchQuery: String) {
-        searchTerms = searchQuery
-        searchCards()
+        viewModel.setSearchTerms(searchQuery)
     }
 
     override fun opExecuted(changes: OpChanges, handler: Any?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -733,24 +733,25 @@ open class CardBrowser :
                     return true
                 }
             })
-            searchView = searchItem!!.actionView as CardBrowserSearchView
-            searchView!!.setMaxWidth(Integer.MAX_VALUE)
-            searchView!!.queryHint = resources.getString(R.string.deck_conf_cram_search)
-            searchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-                override fun onQueryTextChange(newText: String): Boolean {
-                    if (searchView!!.shouldIgnoreValueChange()) {
+            searchView = (searchItem!!.actionView as CardBrowserSearchView).apply {
+                queryHint = resources.getString(R.string.deck_conf_cram_search)
+                setMaxWidth(Integer.MAX_VALUE)
+                setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+                    override fun onQueryTextChange(newText: String): Boolean {
+                        if (this@apply.shouldIgnoreValueChange()) {
+                            return true
+                        }
+                        viewModel.updateQueryText(newText)
                         return true
                     }
-                    viewModel.updateQueryText(newText)
-                    return true
-                }
 
-                override fun onQueryTextSubmit(query: String): Boolean {
-                    searchCards(searchView!!.query.toString())
-                    searchView!!.clearFocus()
-                    return true
-                }
-            })
+                    override fun onQueryTextSubmit(query: String): Boolean {
+                        searchCards(query)
+                        searchView!!.clearFocus()
+                        return true
+                    }
+                })
+            }
             // Fixes #6500 - keep the search consistent if coming back from note editor
             // Fixes #9010 - consistent search after drawer change calls invalidateOptionsMenu (mTempSearchQuery)
             if (!viewModel.tempSearchQuery.isNullOrEmpty() || viewModel.searchTerms.isNotEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1354,23 +1354,11 @@ open class CardBrowser :
             searchView!!.setQuery(viewModel.searchTerms, false)
             searchItem!!.expandActionView()
         }
-        val searchText: String = if (viewModel.searchTerms.contains("deck:")) {
-            "($viewModel.searchTerms)"
-        } else {
-            if ("" != viewModel.searchTerms) "${viewModel.restrictOnDeck}(${viewModel.searchTerms})" else viewModel.restrictOnDeck
-        }
         // clear the existing card list
         cards.reset()
         cardsAdapter.notifyDataSetChanged()
-        val order = viewModel.order.toSortOrder()
         launchCatchingTask {
-            Timber.d("performing search")
-            val cards = withProgress { searchForCards(searchText, order, viewModel.cardsOrNotes) }
-            Timber.d("Search returned %d cards", cards.size)
-            // Render the first few items
-            for (i in 0 until min(numCardsToRender(), cards.size)) {
-                cards[i].load(false, viewModel.column1Index, viewModel.column2Index)
-            }
+            val cards = withProgress { viewModel.searchForCards(numCardsToRender()) }
             redrawAfterSearch(cards)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -108,7 +108,6 @@ import java.util.*
 import java.util.function.Consumer
 import kotlin.math.abs
 import kotlin.math.ceil
-import kotlin.math.min
 
 @Suppress("LeakingThis")
 // The class is only 'open' due to testing
@@ -305,9 +304,11 @@ open class CardBrowser :
     private val selectedRowIds: List<CardId>
         get() = viewModel.selectedRowIds
 
+    @NeedsTest("search bar is set after selecting a saved search as first action")
     private fun searchForQuery(query: String) {
-        searchView!!.setQuery(query, true)
+        // setQuery before expand does not set the view's value
         searchItem!!.expandActionView()
+        searchView!!.setQuery(query, true)
     }
 
     private fun canPerformCardInfo(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1352,13 +1352,12 @@ open class CardBrowser :
         cards.reset()
         cardsAdapter.notifyDataSetChanged()
         launchCatchingTask {
-            val cards = withProgress { viewModel.searchForCards(numCardsToRender()) }
-            redrawAfterSearch(cards)
+            withProgress { viewModel.searchForCards(numCardsToRender()) }
+            redrawAfterSearch()
         }
     }
 
-    fun redrawAfterSearch(cards: MutableList<CardCache>) {
-        this.cards.replaceWith(cards)
+    fun redrawAfterSearch() {
         Timber.i("CardBrowser:: Completed searchCards() Successfully")
         updateList()
         /*check whether mSearchView is initialized as it is lateinit property.*/

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -261,9 +261,8 @@ open class CardBrowser :
             launchCatchingTask {
                 viewModel.savedSearches()[searchName]?.also { savedSearch ->
                     Timber.d("OnSelection using search terms: %s", savedSearch)
-                    searchView!!.setQuery(savedSearch, false)
+                    searchView!!.setQuery(savedSearch, true)
                     searchItem!!.expandActionView()
-                    searchCards(savedSearch)
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -264,10 +264,9 @@ open class CardBrowser :
             launchCatchingTask {
                 viewModel.savedSearches()[searchName]?.apply {
                     Timber.d("OnSelection using search terms: %s", this)
-                    searchTerms = this
                     searchView!!.setQuery(this, false)
                     searchItem!!.expandActionView()
-                    searchCards()
+                    searchCards(this)
                 }
             }
         }
@@ -309,11 +308,10 @@ open class CardBrowser :
     }
 
     private fun onSearch() {
-        searchTerms = searchView!!.query.toString()
         if (searchTerms.isEmpty()) {
             searchView!!.queryHint = resources.getString(R.string.deck_conf_cram_search)
         }
-        searchCards()
+        searchCards(searchView!!.query.toString())
     }
 
     private val selectedRowIds: List<CardId>
@@ -389,15 +387,13 @@ open class CardBrowser :
 
         when (val options = launchOptions) {
             is CardBrowserLaunchOptions.DeepLink -> {
-                searchTerms = options.search
-                searchCards()
+                searchCards(options.search)
             }
             is CardBrowserLaunchOptions.SearchQueryJs -> {
-                searchTerms = options.search
                 if (options.allDecks) {
                     onDeckSelected(SelectableDeck(ALL_DECKS_ID, getString(R.string.card_browser_all_decks)))
                 }
-                searchCards()
+                searchCards(options.search)
             }
             else -> {} // Context Menu handled in onCreateOptionsMenu
         }
@@ -443,9 +439,8 @@ open class CardBrowser :
         viewModel.flowOfFilterQuery
             .launchCollectionInLifecycleScope { filterQuery ->
                 searchView!!.setQuery("", false)
-                searchTerms = filterQuery
-                searchView!!.setQuery(searchTerms, true)
-                searchCards()
+                searchView!!.setQuery(filterQuery, true)
+                searchCards(filterQuery)
             }
 
         viewModel.flowOfDeckId
@@ -741,9 +736,8 @@ open class CardBrowser :
                 override fun onMenuItemActionCollapse(item: MenuItem): Boolean {
                     viewModel.setSearchQueryExpanded(false)
                     // SearchView doesn't support empty queries so we always reset the search when collapsing
-                    searchTerms = ""
-                    searchView!!.setQuery(searchTerms, false)
-                    searchCards()
+                    searchView!!.setQuery("", false)
+                    searchCards("")
                     return true
                 }
             })
@@ -1328,13 +1322,12 @@ open class CardBrowser :
 
     public override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        searchTerms = savedInstanceState.getString("mSearchTerms", "")
         oldCardId = savedInstanceState.getLong("mOldCardId")
         oldCardTopOffset = savedInstanceState.getInt("mOldCardTopOffset")
         shouldRestoreScroll = savedInstanceState.getBoolean("mShouldRestoreScroll")
         postAutoScroll = savedInstanceState.getBoolean("mPostAutoScroll")
         lastSelectedPosition = savedInstanceState.getInt("mLastSelectedPosition")
-        searchCards()
+        searchCards(savedInstanceState.getString("mSearchTerms", ""))
     }
 
     private fun invalidate() {
@@ -1343,9 +1336,10 @@ open class CardBrowser :
 
     private fun forceRefreshSearch(useSearchTextValue: Boolean = false) {
         if (useSearchTextValue && searchView != null) {
-            searchTerms = searchView!!.query.toString()
+            searchCards(searchView!!.query.toString())
+        } else {
+            searchCards()
         }
-        searchCards()
     }
 
     @RustCleanup("remove card cache; switch to RecyclerView and browserRowForId (#11889)")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -261,8 +261,7 @@ open class CardBrowser :
             launchCatchingTask {
                 viewModel.savedSearches()[searchName]?.also { savedSearch ->
                     Timber.d("OnSelection using search terms: %s", savedSearch)
-                    searchView!!.setQuery(savedSearch, true)
-                    searchItem!!.expandActionView()
+                    searchForQuery(savedSearch)
                 }
             }
         }
@@ -312,6 +311,11 @@ open class CardBrowser :
 
     private val selectedRowIds: List<CardId>
         get() = viewModel.selectedRowIds
+
+    private fun searchForQuery(query: String) {
+        searchView!!.setQuery(query, true)
+        searchItem!!.expandActionView()
+    }
 
     private fun canPerformCardInfo(): Boolean {
         return viewModel.selectedRowCount() == 1
@@ -436,11 +440,7 @@ open class CardBrowser :
             .launchCollectionInLifecycleScope { index -> cardsAdapter.updateMapping { it[1] = COLUMN2_KEYS[index] } }
 
         viewModel.flowOfFilterQuery
-            .launchCollectionInLifecycleScope { filterQuery ->
-                searchView!!.setQuery("", false)
-                searchView!!.setQuery(filterQuery, true)
-                searchCards(filterQuery)
-            }
+            .launchCollectionInLifecycleScope { filterQuery -> searchForQuery(filterQuery) }
 
         viewModel.flowOfDeckId
             .launchCollectionInLifecycleScope { deckId ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -302,13 +302,6 @@ open class CardBrowser :
         }
     }
 
-    private fun onSearch() {
-        if (viewModel.searchTerms.isEmpty()) {
-            searchView!!.queryHint = resources.getString(R.string.deck_conf_cram_search)
-        }
-        searchCards(searchView!!.query.toString())
-    }
-
     private val selectedRowIds: List<CardId>
         get() = viewModel.selectedRowIds
 
@@ -742,6 +735,7 @@ open class CardBrowser :
             })
             searchView = searchItem!!.actionView as CardBrowserSearchView
             searchView!!.setMaxWidth(Integer.MAX_VALUE)
+            searchView!!.queryHint = resources.getString(R.string.deck_conf_cram_search)
             searchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (searchView!!.shouldIgnoreValueChange()) {
@@ -752,7 +746,7 @@ open class CardBrowser :
                 }
 
                 override fun onQueryTextSubmit(query: String): Boolean {
-                    onSearch()
+                    searchCards(searchView!!.query.toString())
                     searchView!!.clearFocus()
                     return true
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -262,11 +262,11 @@ open class CardBrowser :
         override fun onSelection(searchName: String) {
             Timber.d("OnSelection using search named: %s", searchName)
             launchCatchingTask {
-                viewModel.savedSearches()[searchName]?.apply {
-                    Timber.d("OnSelection using search terms: %s", this)
-                    searchView!!.setQuery(this, false)
+                viewModel.savedSearches()[searchName]?.also { savedSearch ->
+                    Timber.d("OnSelection using search terms: %s", savedSearch)
+                    searchView!!.setQuery(savedSearch, false)
                     searchItem!!.expandActionView()
-                    searchCards(this)
+                    searchCards(savedSearch)
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -647,11 +647,6 @@ open class CardBrowser :
         cardsAdapter.notifyDataSetChanged()
     }
 
-    @VisibleForTesting
-    suspend fun selectAllDecks() {
-        viewModel.setDeckId(ALL_DECKS_ID)
-    }
-
     /** Opens the note editor for a card.
      * We use the Card ID to specify the preview target  */
     @NeedsTest("note edits are saved")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -470,6 +470,9 @@ open class CardBrowser :
                 invalidateOptionsMenu()
             }
 
+        viewModel.flowOfCardsUpdated
+            .launchCollectionInLifecycleScope { cardsAdapter.notifyDataSetChanged() }
+
         viewModel.flowOfInitCompleted
             .launchCollectionInLifecycleScope { completed -> if (completed) searchCards() }
     }
@@ -1348,9 +1351,6 @@ open class CardBrowser :
             searchView!!.setQuery(viewModel.searchTerms, false)
             searchItem!!.expandActionView()
         }
-        // clear the existing card list
-        cards.reset()
-        cardsAdapter.notifyDataSetChanged()
         launchCatchingTask {
             withProgress { viewModel.searchForCards(numCardsToRender()) }
             redrawAfterSearch()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -548,6 +548,11 @@ class CardBrowserViewModel(
 
     fun setSearchTerms(searchQuery: String) = flowOfSearchTerms.update { searchQuery }
 
+    /** @see com.ichi2.anki.searchForCards */
+    suspend fun searchForCards(query: String): MutableList<CardBrowser.CardCache> {
+        return com.ichi2.anki.searchForCards(query, order.toSortOrder(), cardsOrNotes)
+    }
+
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
         const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -564,6 +564,7 @@ class CardBrowserViewModel(
         for (i in 0 until min(numCardsToRender, cards.size)) {
             cards[i].load(false, column1Index, column2Index)
         }
+        this.cards.replaceWith(cards)
         return cards
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -81,7 +81,8 @@ class CardBrowserViewModel(
     /** The CardIds of all the cards in the results */
     val allCardIds get() = cards.map { c -> c.id }
 
-    var searchTerms: String = ""
+    val flowOfSearchTerms = MutableStateFlow("")
+    val searchTerms get() = flowOfSearchTerms.value
     var restrictOnDeck: String = ""
         private set
     var currentFlag = Flag.NONE
@@ -544,6 +545,8 @@ class CardBrowserViewModel(
      * Turn off [Multi-Select Mode][isInMultiSelectMode] and return to normal state
      */
     fun endMultiSelectMode() = selectNone()
+
+    fun setSearchTerms(searchQuery: String) = flowOfSearchTerms.update { searchQuery }
 
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -76,6 +76,10 @@ class CardBrowserViewModel(
     private val cacheDir: File,
     preferences: SharedPreferencesProvider
 ) : ViewModel(), SharedPreferencesProvider by preferences {
+
+    // temporary flow for refactoring - called when cards are cleared
+    val flowOfCardsUpdated = MutableSharedFlow<Unit>()
+
     val cards = CardBrowser.CardCollection<CardBrowser.CardCache>()
 
     /** The CardIds of all the cards in the results */
@@ -551,6 +555,9 @@ class CardBrowserViewModel(
      * @see com.ichi2.anki.searchForCards
      */
     suspend fun searchForCards(numCardsToRender: Int): MutableList<CardBrowser.CardCache> {
+        // update the UI while we're searching
+        clearCardsList()
+
         val query: String = if (searchTerms.contains("deck:")) {
             "($searchTerms)"
         } else {
@@ -566,6 +573,11 @@ class CardBrowserViewModel(
         }
         this.cards.replaceWith(cards)
         return cards
+    }
+
+    private suspend fun clearCardsList() {
+        cards.reset()
+        flowOfCardsUpdated.emit(Unit)
     }
 
     companion object {


### PR DESCRIPTION
* Split from #14843

This completes the move of a sufficient subset of state to the ViewModel. This also starts restructuring search such that it is driven by the ViewModel, rather than driven by the UI

* Blocked on #15077
* Blocked on #15094