### PR TITLE
fix: Card template editor colors

### DIFF
--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -47,6 +47,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         style="@style/BottomNavigationViewStyle"
+        android:background="?attr/appBarColor"
         app:menu="@menu/card_template_editor_navigation_bar_menu"
         />
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -120,13 +120,10 @@
 
     <style name="BottomNavigationViewStyle" parent="@style/Widget.Material3.BottomNavigationView">
         <item name="materialThemeOverlay">@style/ThemeOverlay.App.BottomNavigationView</item>
-        <item name="elevation">0dp</item> <!-- Prevent slight changes of surface color -->
     </style>
     <style name="ThemeOverlay.App.BottomNavigationView" parent="">
-        <item name="colorPrimary">#afff</item> <!-- Ripple & other things -->
         <item name="colorSecondaryContainer">#fff</item> <!-- Selected item indicator -->
         <item name="colorOnSecondaryContainer">?attr/tabLayoutBackgroundColor</item> <!-- Active icon -->
-        <item name="colorSurface">?attr/tabLayoutBackgroundColor</item> <!-- Container background -->
         <item name="colorOnSurface">#fff</item> <!-- Active icon -->
         <item name="colorOnSurfaceVariant">#fff</item> <!-- Inactive icon & label -->
         <item name="textAppearanceTitleSmall">@style/TextAppearance.Material3.TitleSmall</item>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -111,10 +111,11 @@
         <item name="tabTextAppearance">@style/TextAppearance.Material3.LabelLarge</item>
         <item name="tabIndicator">@drawable/tab_layout_indicator_floating_pill</item>
         <item name="tabIndicatorHeight">14dp</item>
+        <item name="tabTextColor">@color/white</item>
+        <item name="tabIndicatorColor">@color/white</item>
     </style>
     <style name="ThemeOverlay.App.TabLayout" parent="">
         <item name="colorSurface">?attr/tabLayoutBackgroundColor</item> <!-- Background -->
-        <item name="colorPrimary">@color/white</item> <!-- Selected text color -->
         <item name="colorOnSurfaceVariant">#cfff</item> <!-- Not selected text color -->
     </style>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Material 1.11 or maybe I broke the card template editor colors

## How Has This Been Tested?

Emulator 30: open the card template editor

### Before

![Screenshot_20231228_201858](https://github.com/ankidroid/Anki-Android/assets/69634269/bd457682-4899-4c6b-8199-81902f454b3c)


### After

![Screenshot_20231228_202004](https://github.com/ankidroid/Anki-Android/assets/69634269/b3fd3156-30b0-4c25-9e43-963ce81c5be6)

![Screenshot_20231228_202020](https://github.com/ankidroid/Anki-Android/assets/69634269/e6ce326b-3b96-4387-97b7-1f5debdceeb7)

![Screenshot_20231228_202047](https://github.com/ankidroid/Anki-Android/assets/69634269/2fafd474-df79-45dc-8da3-1e49f0411aed)

![Screenshot_20231228_202108](https://github.com/ankidroid/Anki-Android/assets/69634269/20f8658b-2e34-4ec9-b9a1-9122fdda7e36)

## Learning (optional, can help others)

TabLayout have some specific attributes (ref: https://github.com/material-components/material-components-android/blob/master/docs/components/Tabs.md)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
