### PR TITLE
fix: crash & overlapping sounds if quickly changing cards in Previewer 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -121,6 +121,7 @@ class AndroidTtsPlayer(private val context: Context, private val voices: List<Tt
             } ?: return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.failure(TtsErrorCode.APP_TTS_INIT_FAILED))
 
             Timber.d("tts text '%s' to be played for locale (%s)", tag.fieldText, tag.lang)
+            continuation.ensureActive()
             tts.speak(tag.fieldText, TextToSpeech.QUEUE_FLUSH, bundleFlyweight, "stringId")
 
             continuation.invokeOnCancellation {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -37,6 +37,7 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -416,4 +417,14 @@ suspend fun AnkiActivity.userAcceptsSchemaChange(): Boolean {
         withCol { modSchemaNoCheck() }
     }
     return hasAcceptedSchemaChange
+}
+
+/**
+ * Ensures that current continuation is not [cancelled][CancellableContinuation.isCancelled].
+ *
+ * @throws [CancellationException] if canceled. This does not contain the original cancellation cause
+*/
+fun <T> CancellableContinuation<T>.ensureActive() {
+    // we can't use .isActive here, or the exception would take precedence over a resumed exception
+    if (isCancelled) throw CancellationException()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -175,8 +175,8 @@ class SoundPlayer(
     }
 
     suspend fun stopSounds() {
-        Timber.i("stopping sounds")
-        cancelPlaySoundsJob()
+        if (playSoundsJob != null) Timber.i("stopping sounds")
+        cancelPlaySoundsJob(playSoundsJob)
     }
 
     override fun close() {
@@ -254,11 +254,13 @@ class SoundPlayer(
                 CONTINUE_AUDIO -> return@withContext true
                 RETRY_AUDIO -> {
                     try {
+                        Timber.i("retrying audio")
                         play()
+                        Timber.i("retry succeeded")
                     } catch (e: CancellationException) {
                         throw e
                     } catch (e: Exception) {
-                        Timber.w("failed to replay audio", e)
+                        Timber.w("retry audio failed", e)
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -402,7 +402,9 @@ fun AbstractFlashcardViewer.createSoundErrorListener(baseUri: String): SoundErro
         override fun onError(uri: Uri): SoundErrorBehavior {
             try {
                 val file = uri.toFile()
-                if (file.exists()) return CONTINUE_AUDIO
+                // There is a multitude of transient issues with the MediaPlayer. (1, -1001) for example
+                // Retrying fixes most of these
+                if (file.exists()) return RETRY_AUDIO
                 // file doesn't exist - may be due to scoped storage
                 if (handleStorageMigrationError(file)) {
                     return RETRY_AUDIO

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -255,6 +255,8 @@ class SoundPlayer(
                 RETRY_AUDIO -> {
                     try {
                         play()
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (e: Exception) {
                         Timber.w("failed to replay audio", e)
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -26,7 +26,6 @@ import androidx.media.AudioManagerCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.ensureActive
 import com.ichi2.libanki.SoundOrVideoTag
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import kotlin.coroutines.resume
@@ -93,6 +92,7 @@ class SoundTagPlayer(private val soundUriBase: String) {
             try {
                 awaitSetDataSource(soundUri)
             } catch (e: Exception) {
+                continuation.ensureActive()
                 val continuationBehavior = soundErrorListener.onError(soundUri)
                 val exception = SoundException(continuationBehavior, e)
                 return@suspendCancellableCoroutine continuation.resumeWithException(exception)
@@ -100,6 +100,7 @@ class SoundTagPlayer(private val soundUriBase: String) {
 
             requestAudioFocus()
             continuation.ensureActive()
+            Timber.d("starting sound tag")
             start()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -24,7 +24,9 @@ import android.net.Uri
 import androidx.media.AudioFocusRequestCompat
 import androidx.media.AudioManagerCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.ensureActive
 import com.ichi2.libanki.SoundOrVideoTag
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import kotlin.coroutines.resume
@@ -97,6 +99,7 @@ class SoundTagPlayer(private val soundUriBase: String) {
             }
 
             requestAudioFocus()
+            continuation.ensureActive()
             start()
         }
     }


### PR DESCRIPTION
## Purpose / Description
* #15103
* I then found that after fixing it, I could get two sounds playing at the same time
* I then found that after transient errors, sounds didn't play

## Fixes
* Fixes #15103
* Fixes #15133

## Approach
* Gate `resume` calls with a check on the completion status of the continuation
* Check the active status of the continuation before executing slow operations
* set `playSoundsJob` correctly
* use `RETRY_AUDIO` as a crutch
* maintain a list of `currentUtterance/cancelledUtterances` in the TTS class

## How Has This Been Tested?
API 33 emulator

## Learning (optional, can help others)
The Previewer is a GREAT stress test of the workings of the Sound Player

* Obvious, but `resumeWithException` can't be called if `resume()` was called
* There is a lot of nuance to the MediaPlayer - `RETRY_AUDIO` is a crutch which completely fixes the issues
* TTS: `speak()`, then `stop()` won't stop audio if we are before `onStart()`
  * But if we're AFTER playing a different set of audio, it will stop that 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
