### PR TITLE
fix: typedLanguageIsSet

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -238,6 +238,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     }
 
     @Test
+    @RunInBackground // viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4) does not guarantee completion
     fun typedLanguageIsSet() = runTest {
         val withLanguage = StdModels.BASIC_TYPING_MODEL.add(col, "a")
         val normal = StdModels.BASIC_TYPING_MODEL.add(col, "b")
@@ -251,7 +252,10 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         assertThat("A model with a language hint (japanese) should use it", viewer.hintLocale, equalTo("ja"))
 
-        showNextCard(viewer)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
+        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
+        // requires @RunInBackground ! - the above calls do not guarantee execution completion
+        waitForAsyncTasksToComplete()
 
         assertThat("A default model should have no preference", viewer.hintLocale, nullValue())
     }
@@ -324,13 +328,6 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     private fun getViewerContent(): String? {
         // PERF: Optimise this to not create a new viewer each time
         return getViewer(addCard = false).cardContent
-    }
-
-    private fun showNextCard(viewer: NonAbstractFlashcardViewer) {
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
-        waitForAsyncTasksToComplete()
-        viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
-        waitForAsyncTasksToComplete()
     }
 
     @get:CheckResult

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.setMain
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
+import timber.log.Timber
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration.Companion.milliseconds
@@ -175,12 +176,16 @@ interface TestClass {
     fun runTest(
         context: CoroutineContext = EmptyCoroutineContext,
         dispatchTimeoutMs: Long = 60_000L,
+        times: Int = 1,
         testBody: suspend TestScope.() -> Unit
     ) {
         Dispatchers.setMain(UnconfinedTestDispatcher())
-        kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs.milliseconds) {
-            CollectionManager.setTestDispatcher(UnconfinedTestDispatcher(testScheduler))
-            testBody()
+        repeat(times) {
+            if (times != 1) Timber.d("------ Executing test $it/$times ------")
+            kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs.milliseconds) {
+                CollectionManager.setTestDispatcher(UnconfinedTestDispatcher(testScheduler))
+                testBody()
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Issue was with typedLanguageIsSet on Ubuntu: `"A default model should have no preference"`

This was caused by `showNextCard` not completing

Because `waitForAsyncTasksToComplete` had no effect if `@RunInBackground` was not set

## Fixes
* Fixes #15098

## Approach
* I modified `runTest` to accept a `times` parameter
* Fixed the code to handle multiple runs
* Diagnosed, then fixed the issue


## How Has This Been Tested?
CI only

## Learning
`viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)` does not block

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
