### PR TITLE
fix: do not select deck in the CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -462,7 +462,7 @@ open class CardBrowser :
             .filterNotNull()
             .onEach { deckId ->
                 // this handles ALL_DECKS_ID
-                deckSpinnerSelection!!.selectDeckById(deckId, true)
+                deckSpinnerSelection!!.selectDeckById(deckId, false)
                 searchCards()
             }
             .launchIn(lifecycleScope)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -63,6 +63,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 @NeedsTest("reverseDirectionFlow/sortTypeFlow are not updated on .launch { }")
+@NeedsTest("13442: selected deck is not changed, as this affects the reviewer")
 class CardBrowserViewModel(
     private val lastDeckIdRepository: LastDeckIdRepository,
     preferences: SharedPreferencesProvider

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.browser
 import android.content.Context
 import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CardBrowser
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 
@@ -42,7 +41,7 @@ class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
             .takeUnless { it == Decks.NOT_FOUND_DECK_ID }
         set(value) =
             if (value == null) {
-                CardBrowser.clearLastDeckId()
+                clearLastDeckId()
             } else {
                 AnkiDroidApp.instance.getSharedPreferences(PERSISTENT_STATE_FILE, 0).edit {
                     putLong(LAST_DECK_ID_KEY, value)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/LastDeckIdRepository.kt
@@ -31,6 +31,9 @@ interface LastDeckIdRepository {
  * Saves the last selected [DeckId] in the Card Browser
  *
  * This exists as the old code used [PERSISTENT_STATE_FILE], rather than [AnkiDroidApp.sharedPrefs]
+ *
+ * [Decks.select] is not used in the Card Browser: this can be launched from a review session and
+ * should not affect the session
  */
 class SharedPreferencesLastDeckIdRepository : LastDeckIdRepository {
     override var lastDeckId: DeckId?


### PR DESCRIPTION
## Purpose / Description
* #13442

## Fixes
* Fixes #13442

## Approach
* stop selecting the deck + add documentation

## How Has This Been Tested?
API 33 emulator. Trusting CI for unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
