### PR TITLE
fix: Deck Options screen flickers in dark mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -44,6 +44,9 @@ class DeckOptions : PageFragment() {
     }
 
     class DeckOptionsWebClient(val deckId: Long) : PageWebViewClient() {
+        override val promiseToWaitFor: String
+            get() = "\$deckOptions"
+
         override fun onPageFinished(view: WebView?, url: String?) {
             // from upstream: https://github.com/ankitects/anki/blob/678c354fed4d98c0a8ef84fb7981ee085bd744a7/qt/aqt/deckoptions.py#L55
             view!!.evaluateJavascript("const \$deckOptions = anki.setupDeckOptions($deckId);") {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -15,23 +15,33 @@
  */
 package com.ichi2.anki.pages
 
+import android.graphics.Bitmap
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.view.isVisible
 import com.google.android.material.color.MaterialColors
-import com.ichi2.anki.R
 import com.ichi2.utils.toRGBHex
+import timber.log.Timber
 
 /**
  * Base WebViewClient to be used on [PageFragment]
  */
 open class PageWebViewClient : WebViewClient() {
+
+    override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+        super.onPageStarted(view, url, favicon)
+        view?.let { webView ->
+            // 14194: background-color should be set before onPageFinished to stop a white flash
+            val bgColor = MaterialColors.getColor(webView, android.R.attr.colorBackground).toRGBHex()
+            webView.evaluateJavascript("""document.body.style.setProperty("background-color", "$bgColor", "important")""") {
+                Timber.v("backgroundColor set")
+            }
+        }
+    }
+
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         view?.let { webView ->
-            val bgColor = MaterialColors.getColor(webView, android.R.attr.colorBackground).toRGBHex()
-            webView.evaluateJavascript("document.body.style.backgroundColor = '$bgColor';") {}
-
             /** [PageFragment.webView] is invisible by default to avoid flashes while
              * the page is loaded, and can be made visible again after it finishes loading */
             webView.isVisible = true


### PR DESCRIPTION
## Purpose / Description
There were two flickers:

1. The screen flickered white
2. The screen flickered the wrong shade of black

## Fixes
* Fixes #14194

## Approach
1. was easy: move the code to set the background color to `onPageStarted`
2. More difficult: I made the screen wait for `anki.setupDeckOptions` to return


## How Has This Been Tested?
Samsung S21, Android 14. I also tested in light mode, and that we didn't break stats

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
