### PR TITLE
chore(dev): remove card.html

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1411,18 +1411,6 @@ abstract class AbstractFlashcardViewer :
             soundPlayer.loadCardSounds(currentCard!!, if (displayAnswer) Side.BACK else Side.FRONT)
         }
         cardContent = content.getTemplateHtml()
-        if (this.sharedPrefs().getBoolean("html_javascript_debugging", false)) {
-            try {
-                FileOutputStream(
-                    File(
-                        CollectionHelper.getCurrentAnkiDroidDirectory(this),
-                        "card.html"
-                    )
-                ).use { f -> f.write(cardContent!!.toByteArray()) }
-            } catch (e: IOException) {
-                Timber.d(e, "failed to save card")
-            }
-        }
         fillFlashcard()
         playSounds(false) // Play sounds if appropriate
     }


### PR DESCRIPTION
## Purpose / Description
Designed for debug, but:
* Unused by maintainers,
* Hard to access now app private directory is used

* `html_javascript_debugging` is still used

## Fixes
* Fixes #15109

## How Has This Been Tested?
⚠️ I haven't

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
