### PR TITLE
fix: mathjax render

### DIFF
--- a/AnkiDroid/src/main/assets/mathjax/conf.js
+++ b/AnkiDroid/src/main/assets/mathjax/conf.js
@@ -19,7 +19,7 @@ window.MathJax = {
     loader: {
         load: packagesForLoading(packages),
         paths: {
-            mathjax: "/assets/mathjax",
+            mathjax: "file:///android_asset/mathjax",
         },
     },
     startup: {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.TtsParser
 import com.ichi2.anki.cardviewer.SingleSoundSide.ANSWER
 import com.ichi2.anki.cardviewer.SingleSoundSide.QUESTION
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
 import com.ichi2.libanki.template.MathJax
 import net.ankiweb.rsdroid.RustCleanup
@@ -68,12 +69,13 @@ class CardHtml(
         }
     }
 
+    @NeedsTest("js files can be loaded with the specified sources")
     private fun getScripts(requiresMathjax: Boolean): String {
         return when (requiresMathjax) {
             false -> ""
             true ->
-                """        <script src="/assets/mathjax/conf.js"> </script>
-        <script src="/assets/mathjax/tex-chtml.js"> </script>"""
+                """        <script src="file:///android_asset/mathjax/conf.js"></script>
+        <script src="file:///android_asset/mathjax/tex-chtml.js"></script>"""
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I broke it

## Approach
Map mathjax back to android asset loading

## How Has This Been Tested?

Android 34 emulator:
- add mathjax to a card
- open it in the reviewer

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
