### PR TITLE
fix editor shift tab

### DIFF
--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -43,6 +43,7 @@
 
     <ImageButton
         android:id="@+id/id_expand_button"
+        android:nextFocusForward="@id/id_note_editText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:gravity="end|center_vertical"
@@ -61,7 +62,6 @@
         android:id="@+id/id_note_editText"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:nextFocusForward="@id/id_media_button"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/multimedia_barrier"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* Fixes #15135

## Fixes
* Fixes #15135

## Approach
go to the text field after the expand button and remove it from the text field to avoid cycling

## How Has This Been Tested?

Android 34 emulator

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
