### PR TITLE
fix: new previewer not showing when only one card is previewed + change buttons behavior to match Anki Desktop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.getViewerAssetLoader
 import com.ichi2.anki.pages.AnkiServer.Companion.LOCALHOST
 import com.ichi2.anki.previewer.PreviewerViewModel.Companion.stdHtml
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.themes.Themes
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.launchIn
@@ -180,11 +181,10 @@ class PreviewerFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                 }
         }
 
+        @NeedsTest("webview don't vanish when only one card is in the list")
         if (cardsCount == 1) {
             slider.visibility = View.GONE
             progressIndicator.visibility = View.GONE
-            nextButton.visibility = View.GONE
-            previousButton.visibility = View.GONE
         }
 
         slider.apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -202,8 +202,14 @@ class PreviewerFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             )
         }
 
+        lifecycleScope.launch {
+            viewModel.isNextButtonEnabled.collectLatest {
+                nextButton.isEnabled = it
+            }
+        }
+
         nextButton.setOnClickListener {
-            viewModel.launchCatching { showAnswerOrNextCard() }
+            viewModel.onNextButtonClick()
         }
 
         lifecycleScope.launch {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -194,9 +194,7 @@ class PreviewerFragment : Fragment(), Toolbar.OnMenuItemClickListener {
                     override fun onStartTrackingTouch(slider: Slider) {}
 
                     override fun onStopTrackingTouch(slider: Slider) {
-                        viewModel.launchCatching {
-                            displayCard(value.toInt() - 1)
-                        }
+                        viewModel.currentIndex.tryEmit(slider.value.toInt() - 1)
                     }
                 }
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -206,8 +206,14 @@ class PreviewerFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             viewModel.launchCatching { showAnswerOrNextCard() }
         }
 
+        lifecycleScope.launch {
+            viewModel.isBackButtonEnabled.collectLatest {
+                previousButton.isEnabled = it
+            }
+        }
+
         previousButton.setOnClickListener {
-            viewModel.launchCatching { showAnswerOrPreviousCard() }
+            viewModel.onPreviousButtonClick()
         }
 
         view.findViewById<MaterialToolbar>(R.id.toolbar).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -58,6 +58,9 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         combine(currentIndex, showingAnswer, backsideOnly) { index, showingAnswer, isBackSideOnly ->
             index != 0 || (showingAnswer && !isBackSideOnly)
         }
+    val isNextButtonEnabled = combine(currentIndex, showingAnswer) { index, showingAnswer ->
+        index != selectedCardIds.lastIndex || !showingAnswer
+    }
 
     private lateinit var currentCard: Card
 
@@ -163,11 +166,17 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         currentIndex.emit(index)
     }
 
-    suspend fun showAnswerOrNextCard() {
-        if (!showingAnswer.value && !backsideOnly.value) {
-            showAnswer()
-        } else {
-            displayCard(currentIndex.value + 1)
+    /**
+     * Shows the current card's answer
+     * or the next question if the answer is already being shown
+     */
+    fun onNextButtonClick() {
+        launchCatching {
+            if (!showingAnswer.value && !backsideOnly.value) {
+                showAnswer()
+            } else {
+                currentIndex.update { it + 1 }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.previewer
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.material.color.MaterialColors.getColor
@@ -36,6 +37,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
@@ -51,6 +54,18 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     private val showingAnswer = MutableStateFlow(false)
 
     private lateinit var currentCard: Card
+
+    init {
+        currentIndex
+            .onEach { index ->
+                currentCard = withCol { getCard(selectedCardIds[index]) }
+                showQuestion()
+                if (backsideOnly.value) {
+                    showAnswer()
+                }
+            }
+            .launchIn(viewModelScope)
+    }
 
     fun toggleBacksideOnly() {
         Timber.v("toggleBacksideOnly() %b", !backsideOnly.value)
@@ -140,11 +155,6 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
             return
         }
         currentIndex.emit(index)
-        currentCard = withCol { getCard(selectedCardIds[index]) }
-        showQuestion()
-        if (backsideOnly.value) {
-            showAnswer()
-        }
     }
 
     private suspend fun showAnswerOrDisplayCard(index: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -159,13 +159,6 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         return addPlayButtons(withCol { media.escapeMediaFilenames(text) })
     }
 
-    suspend fun displayCard(index: Int) {
-        if (index !in 0..selectedCardIds.lastIndex) {
-            return
-        }
-        currentIndex.emit(index)
-    }
-
     /**
      * Shows the current card's answer
      * or the next question if the answer is already being shown
@@ -194,7 +187,7 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         }
     }
 
-    fun launchCatching(block: suspend PreviewerViewModel.() -> Unit): Job {
+    private fun launchCatching(block: suspend PreviewerViewModel.() -> Unit): Job {
         return launchCatching(block, Dispatchers.IO) { message ->
             onError.emit(message)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -163,11 +163,11 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         currentIndex.emit(index)
     }
 
-    private suspend fun showAnswerOrDisplayCard(index: Int) {
+    suspend fun showAnswerOrNextCard() {
         if (!showingAnswer.value && !backsideOnly.value) {
             showAnswer()
         } else {
-            displayCard(index)
+            displayCard(currentIndex.value + 1)
         }
     }
 
@@ -183,10 +183,6 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
                 showQuestion()
             }
         }
-    }
-
-    suspend fun showAnswerOrNextCard() {
-        showAnswerOrDisplayCard(currentIndex.value + 1)
     }
 
     fun launchCatching(block: suspend PreviewerViewModel.() -> Unit): Job {
@@ -226,12 +222,22 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
             }
 
             val colors = if (!nightMode) {
-                val canvasColor = getColor(context, android.R.attr.colorBackground, android.R.color.white).toRGBHex()
-                val fgColor = getColor(context, android.R.attr.textColor, android.R.color.black).toRGBHex()
+                val canvasColor = getColor(
+                    context,
+                    android.R.attr.colorBackground,
+                    android.R.color.white
+                ).toRGBHex()
+                val fgColor =
+                    getColor(context, android.R.attr.textColor, android.R.color.black).toRGBHex()
                 ":root { --canvas: $canvasColor ; --fg: $fgColor; }"
             } else {
-                val canvasColor = getColor(context, android.R.attr.colorBackground, android.R.color.black).toRGBHex()
-                val fgColor = getColor(context, android.R.attr.textColor, android.R.color.white).toRGBHex()
+                val canvasColor = getColor(
+                    context,
+                    android.R.attr.colorBackground,
+                    android.R.color.black
+                ).toRGBHex()
+                val fgColor =
+                    getColor(context, android.R.attr.textColor, android.R.color.white).toRGBHex()
                 ":root[class*=night-mode] { --canvas: $canvasColor; --fg: $fgColor; }"
             }
 
@@ -264,7 +270,10 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
         }
 
         /** @return body classes used when showing a card */
-        fun bodyClassForCardOrd(cardOrd: Int, nightMode: Boolean = Themes.currentTheme.isNightMode): String {
+        fun bodyClassForCardOrd(
+            cardOrd: Int,
+            nightMode: Boolean = Themes.currentTheme.isNightMode
+        ): String {
             return "card card${cardOrd + 1} ${bodyClass(nightMode)}"
         }
 

--- a/AnkiDroid/src/main/res/layout/previewer.xml
+++ b/AnkiDroid/src/main/res/layout/previewer.xml
@@ -60,10 +60,8 @@
             app:icon="@drawable/ic_baseline_chevron_left_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/progress_indicator"
             app:layout_constraintTop_toBottomOf="@id/slider"
-            app:iconSize="32dp"
-            />
+            app:iconSize="32dp" />
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/progress_indicator"
@@ -74,8 +72,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/slider"
             tools:text="421/732"
-            android:gravity="center_horizontal"/>
-
+            android:gravity="center_horizontal" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/show_next"
@@ -86,7 +83,6 @@
             app:icon="@drawable/ic_baseline_chevron_right_24"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@id/progress_indicator"
             app:layout_constraintTop_toBottomOf="@id/slider"
             app:iconSize="32dp" />
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

## Approach
In the commits

## How Has This Been Tested?

Emulator 31

#### 1 card tests

[Screen_recording_20240102_223124.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/efc74297-f850-4eb9-9021-857bb3146a32)

#### more than 1 card tests

[he.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/206cd7d0-08b9-42b4-bbdf-67becf1454bb)

## Learning (optional, can help others)

Views vanish if their constraints are gone

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
