### PR TITLE
fix: Deck Options: "Back" works incorrectly if the manual is open

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -467,7 +467,7 @@ abstract class AbstractFlashcardViewer :
     }
 
     /** Invoked by [CardViewerWebClient.onPageFinished] */
-    override fun onPageFinished() {
+    override fun onPageFinished(view: WebView) {
         // intentionally blank
     }
 
@@ -2451,7 +2451,7 @@ abstract class AbstractFlashcardViewer :
             pageRenderStopwatch.logElapsed()
             Timber.d("Java onPageFinished triggered: %s", url)
             // onPageFinished will be called multiple times if the WebView redirects by setting window.location.href
-            onPageFinishedCallback?.onPageFinished()
+            onPageFinishedCallback?.onPageFinished(view)
             view.loadUrl("javascript:onPageFinished();")
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -122,7 +122,8 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
     }
 
     protected open fun onActionBarBackPressed(): Boolean {
-        finish()
+        Timber.v("onActionBarBackPressed")
+        onBackPressedDispatcher.onBackPressed()
         return true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnPageFinishedCallback.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnPageFinishedCallback.kt
@@ -16,9 +16,12 @@
 
 package com.ichi2.anki
 
+import android.webkit.WebView
+
 /**
  * Intended to be used with [android.webkit.WebViewClient.onPageFinished]
  */
-interface OnPageFinishedCallback {
-    fun onPageFinished()
+fun interface OnPageFinishedCallback {
+    /** @see android.webkit.WebViewClient.onPageFinished */
+    fun onPageFinished(view: WebView)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -32,6 +32,7 @@ import android.os.Parcelable
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.*
+import android.webkit.WebView
 import android.widget.*
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.*
@@ -1026,8 +1027,8 @@ open class Reviewer :
         }
     }
 
-    override fun onPageFinished() {
-        super.onPageFinished()
+    override fun onPageFinished(view: WebView) {
+        super.onPageFinished(view)
         onFlagChanged()
         onMarkChanged()
         if (!displayAnswer) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -21,6 +21,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.core.view.isVisible
 import com.google.android.material.color.MaterialColors
+import com.ichi2.anki.OnPageFinishedCallback
 import com.ichi2.utils.toRGBHex
 import timber.log.Timber
 
@@ -31,6 +32,8 @@ open class PageWebViewClient : WebViewClient() {
 
     /** Wait for the provided promise to complete before showing the WebView */
     open val promiseToWaitFor: String? = null
+
+    var onPageFinishedCallback: OnPageFinishedCallback? = null
 
     override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
         super.onPageStarted(view, url, favicon)
@@ -45,7 +48,7 @@ open class PageWebViewClient : WebViewClient() {
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         if (view == null) return
-
+        onPageFinishedCallback?.onPageFinished(view)
         if (promiseToWaitFor == null) {
             /** [PageFragment.webView] is invisible by default to avoid flashes while
              * the page is loaded, and can be made visible again after it finishes loading */


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* #15130

## Fixes
* Fixes #15130
 
## Approach
* onBackPressedDispatcher

## How Has This Been Tested?
API 33 emulator:
* Manage Note Types + Reviewer to ensure no breakage
* Deck Options - pressing back goes back
* Deck Options - pressing back when on manual goes back to options

[15130.webm](https://github.com/ankidroid/Anki-Android/assets/62114487/099c585b-f411-44b2-ba59-601190c53f5b)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
