### PR TITLE
move ConfirmationDialog to material

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -17,9 +17,13 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
-import com.afollestad.materialdialogs.MaterialDialog
 import com.ichi2.anki.R
+import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.title
 
 /**
  * This is a reusable convenience class which makes it easy to show a confirmation dialog as a DialogFragment.
@@ -47,11 +51,11 @@ class ConfirmationDialog : DialogFragment() {
         mCancel = cancel
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
         val res = requireActivity().resources
         val title = requireArguments().getString("title")
-        return MaterialDialog(requireActivity()).show {
+        return AlertDialog.Builder(requireContext()).apply {
             title(text = (if ("" == title) res.getString(R.string.app_name) else title)!!)
             message(text = requireArguments().getString("message")!!)
             positiveButton(R.string.dialog_ok) {
@@ -60,6 +64,6 @@ class ConfirmationDialog : DialogFragment() {
             negativeButton(R.string.dialog_cancel) {
                 mCancel.run()
             }
-        }
+        }.create()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -22,7 +22,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.afollestad.materialdialogs.WhichButton
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.assertFalse
@@ -142,8 +141,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         val shadowTestEditor = shadowOf(testEditor)
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getMaterialDialogText(true))
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getAlertDialogText(true))
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertEquals("Model should have 1 template now", 1, testEditor.tempModel?.templateCount)
@@ -249,8 +248,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         val shadowTestEditor = shadowOf(testEditor)
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
         advanceRobolectricLooperWithSleep()
-        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getMaterialDialogText(true))
-        clickMaterialDialogButton(WhichButton.NEGATIVE, true)
+        assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getAlertDialogText(true))
+        clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
         assertFalse("Model should not have changed", testEditor.modelHasChanged())
 
@@ -341,9 +340,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.NEGATIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, true)
         advanceRobolectricLooperWithSleep()
         assertNotNull("Cannot delete template?", col.notetypes.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
         assertNotNull("Cannot delete template?", col.notetypes.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(1)))
@@ -395,9 +394,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 1"),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         advanceRobolectricLooperWithSleep()
         testEditor.viewPager.currentItem = 0
@@ -406,9 +405,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
 
         // - assert can delete any 1 or 2 Card templates but not all
@@ -468,9 +467,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 1, 1, "Card 2"),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertNotNull("Cannot delete template?", col.notetypes.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
@@ -494,9 +493,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about deleting template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_delete, 0, 0, "Card 2"),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
         assertTrue("Model should have changed", testEditor.modelHasChanged())
         assertNotNull("Cannot delete template?", col.notetypes.getCardIdsForModel(collectionBasicModelOriginal.getLong("id"), intArrayOf(0)))
@@ -600,9 +599,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals(
             "Did not show dialog about adding template and it's card?",
             getQuantityString(R.plurals.card_template_editor_confirm_add, numAffectedCards, numAffectedCards),
-            getMaterialDialogText(true)
+            getAlertDialogText(true)
         )
-        clickMaterialDialogButton(WhichButton.POSITIVE, true)
+        clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
     }
 
     private fun getModelCardCount(notetype: NotetypeJson): Int {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -30,9 +30,6 @@ import androidx.fragment.app.DialogFragment
 import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.WhichButton
-import com.afollestad.materialdialogs.actions.getActionButton
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity
 import com.ichi2.anki.preferences.sharedPrefs
@@ -171,14 +168,6 @@ open class RobolectricTest : AndroidTest {
         runBlocking { CollectionManager.discardBackend() }
     }
 
-    protected fun clickMaterialDialogButton(button: WhichButton, @Suppress("SameParameterValue") checkDismissed: Boolean) {
-        val dialog = ShadowDialog.getLatestDialog() as MaterialDialog
-        dialog.getActionButton(button).performClick()
-        if (checkDismissed) {
-            Assert.assertTrue("Dialog not dismissed?", Shadows.shadowOf(dialog).hasBeenDismissed())
-        }
-    }
-
     /**
      * Click on a dialog button for an AlertDialog dialog box. Replaces the above helper.
      */
@@ -192,20 +181,6 @@ open class RobolectricTest : AndroidTest {
         if (checkDismissed) {
             Assert.assertTrue("Dialog not dismissed?", Shadows.shadowOf(dialog).hasBeenDismissed())
         }
-    }
-
-    /**
-     * Get the current dialog text. Will return null if no dialog visible *or* if you check for dismissed and it has been dismissed
-     *
-     * @param checkDismissed true if you want to check for dismissed, will return null even if dialog exists but has been dismissed
-     */
-    protected fun getMaterialDialogText(@Suppress("SameParameterValue") checkDismissed: Boolean): String? {
-        val dialog: MaterialDialog = ShadowDialog.getLatestDialog() as MaterialDialog
-        if (checkDismissed && Shadows.shadowOf(dialog).hasBeenDismissed()) {
-            Timber.e("The latest dialog has already been dismissed.")
-            return null
-        }
-        return dialog.view.contentLayout.findViewById<TextView>(com.afollestad.materialdialogs.R.id.md_text_message).text.toString()
     }
 
     /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes part of #13315 

## Approach
use AlertDialog

## How Has This Been Tested?

In Android 12 emulator I opened some confirmation dialogs like the regress progress and the add card in card template editor

![Screenshot_20240103_110236](https://github.com/ankidroid/Anki-Android/assets/154519856/0285a93c-f612-48c9-aa72-58820222b8b8)

![Screenshot_20240103_110022](https://github.com/ankidroid/Anki-Android/assets/154519856/412f2a1d-a2fe-4251-bbad-efc2376a7cc5)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
