### PR TITLE
move DeckPickerBackupNoSpaceLeftDialog to alert dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -17,26 +17,30 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
-import com.afollestad.materialdialogs.MaterialDialog
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.utils.message
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.title
 
 class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
         val res = resources
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
-        return MaterialDialog(requireActivity()).show {
+        val dialog = AlertDialog.Builder(requireContext()).apply {
             title(R.string.storage_almost_full_title)
             message(text = res.getString(R.string.storage_warning, space / 1024 / 1024))
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finish()
             }
-            cancelable(true)
-            setOnCancelListener { (activity as DeckPicker).finish() }
+        }.create()
+        return dialog.apply {
+            setCanceledOnTouchOutside(false)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
@@ -32,14 +33,13 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
         super.onCreate(savedInstanceState)
         val res = resources
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
-        val dialog = AlertDialog.Builder(requireContext()).apply {
+        return AlertDialog.Builder(requireContext()).apply {
             title(R.string.storage_almost_full_title)
             message(text = res.getString(R.string.storage_warning, space / 1024 / 1024))
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finish()
             }
-        }.create()
-        return dialog.apply {
+        }.create {
             setCanceledOnTouchOutside(false)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -130,6 +130,13 @@ inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): Aler
 }
 
 /**
+ * Creates an [AlertDialog], then executes [block] with it
+ */
+fun AlertDialog.Builder.create(block: AlertDialog.() -> Unit): AlertDialog = create().apply {
+    block()
+}
+
+/**
  * Adds a checkbox to the dialog, whilst continuing to display the value of [message]
  * @param stringRes The string resource to display for the checkbox label.
  * @param text The literal string to display for the checkbox label.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes part of #13315 

## Approach
move to AlertDialog. I couldn't fix the cancel listener not working, so I disabled cancelling with outside touches. I think that this is a good idea because it avoids closing the app by accident

## How Has This Been Tested?

I tested in Android 12 emulator by adding this line to the app startup:

showDialogFragment(DeckPickerBackupNoSpaceLeftDialog.newInstance())


![Screenshot_20240103_111015](https://github.com/ankidroid/Anki-Android/assets/154519856/e7b366b3-a7af-4fd3-a375-19166856265d)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
