### PR TITLE
fix Browser Options dialog color

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -26,6 +26,7 @@
         <item name="android:windowBackground">@color/material_theme_grey</item>
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
         <item name="colorSurfaceContainer">@color/faded_primary</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
         <!-- Widget colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -12,6 +12,7 @@
         <item name="colorOnPrimaryContainer">@color/white</item> <!-- FAB icons -->
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
         <item name="colorSurfaceContainer">@color/faded_primary</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It was purple

## Fixes
* Fixes the color issue

## Approach
When I tried to search for an existing issue I find #15014 and so I followed its approach

## How Has This Been Tested?

I opened the dialog in the Android 12 emulator

#### Before

![Screenshot_20240103_151427](https://github.com/ankidroid/Anki-Android/assets/154519856/a2dcc49f-0ca6-4519-8010-5b6850fa6e61)

#### After

![Screenshot_20240103_152117](https://github.com/ankidroid/Anki-Android/assets/154519856/f40faba4-3b76-42fd-89ff-c03e5850dd1b)
![Screenshot_20240103_152021](https://github.com/ankidroid/Anki-Android/assets/154519856/c6f92e44-bbc4-462f-a69b-1c9fe9abea14)


## Learning (optional, can help others)
_Describe the research stage_

here's the dialog background attribute

https://github.com/material-components/material-components-android/blob/master/docs/components/Dialog.md#container-attributes

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
