### PR TITLE
feat: handle type-in answers in the new previewer 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.previewer
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.material.color.MaterialColors.getColor
@@ -37,9 +36,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -65,15 +63,15 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     private lateinit var currentCard: Card
 
     init {
-        currentIndex
-            .onEach { index ->
+        launchCatching {
+            currentIndex.collectLatest { index ->
                 currentCard = withCol { getCard(selectedCardIds[index]) }
                 showQuestion()
                 if (backsideOnly.value) {
                     showAnswer()
                 }
             }
-            .launchIn(viewModelScope)
+        }
     }
 
     fun toggleBacksideOnly() {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -749,4 +749,12 @@ open class Collection(
             .build()
             .toByteArray()
     }
+
+    fun compareAnswer(expected: String, provided: String): String {
+        return backend.compareAnswer(expected = expected, provided = provided)
+    }
+
+    fun extractClozeForTyping(text: String, ordinal: Int): String {
+        return backend.extractClozeForTyping(text = text, ordinal = ordinal)
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -157,7 +157,7 @@ class Note : Cloneable {
         return result
     }
 
-    private fun fieldOrd(key: String): Int {
+    private fun fieldIndex(key: String): Int {
         val fieldPair = fMap!![key]
             ?: throw IllegalArgumentException(
                 String.format(
@@ -169,11 +169,11 @@ class Note : Cloneable {
     }
 
     fun getItem(key: String): String {
-        return fields[fieldOrd(key)]
+        return fields[fieldIndex(key)]
     }
 
     fun setItem(key: String, value: String) {
-        fields[fieldOrd(key)] = value
+        fields[fieldIndex(key)] = value
     }
 
     operator fun contains(key: String): Boolean {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.jupiter.api.Test
+
+class PreviewerViewModelTest {
+    @Test
+    fun `type answer fields are removed in questions`() {
+        assertThat(
+            PreviewerViewModel.typeAnsQuestionFilter("creu [[type:leu]]"),
+            equalTo("creu ")
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
the desktop previewer doesn't show type-in answer previews (https://docs.ankiweb.net/templates/fields.html#checking-your-answer), neither AnkiMobile does

AnkiDroid currently has a TextInput to insert the answer and check it when the answer is shown

For the new previewer, I'm going with a midterm of not showing the type box in the question like Anki Desktop/Mobile, since the previewer goal should only be previewing stuff, but showing the result in the answer so the user can preview what they want

## Approach
On the commits

## How Has This Been Tested?

Emulator 31:

[type answer.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/c116467e-e05a-4a38-b83b-dddd5f024a85)


## Learning (optional, can help others)

Part of the desktop reviewer's code is 11 years old 😯.

Also, I should be less lazy and write more tests, but the Android Studio slowness make me lazier

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
