### PR TITLE
add deck title back

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -534,7 +534,9 @@ abstract class AbstractFlashcardViewer :
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
         mGestureDetectorImpl = LinkDetectingGestureDetector()
         TtsVoicesFieldFilter.ensureApplied()
-        supportActionBar?.setDisplayShowTitleEnabled(false)
+        if (!sharedPrefs().getBoolean("showDeckTitle", false)) {
+            supportActionBar?.setDisplayShowTitleEnabled(false)
+        }
     }
 
     protected open fun getContentViewAttr(fullscreenMode: FullScreenMode): Int {
@@ -1287,6 +1289,9 @@ abstract class AbstractFlashcardViewer :
 
     private fun updateDeckName() {
         if (currentCard == null) return
+        if (sharedPrefs().getBoolean("showDeckTitle", false)) {
+            supportActionBar?.title = Decks.basename(getColUnsafe.decks.name(currentCard!!.did))
+        }
         if (!prefShowTopbar) {
             topBarLayout!!.visibility = View.GONE
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -488,6 +488,7 @@ object UsageAnalytics {
         "showProgress", // Show remaining
         "showAudioPlayButtons", // Show play buttons on cards with audio (reversed in collection: HIDE_AUDIO_PLAY_BUTTONS)
         "card_browser_show_media_filenames", // Display filenames in card browser
+        "showDeckTitle", // Show deck title
         // Controls
         "gestures", // Enable gestures
         "gestureCornerTouch", // 9-point touch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -95,6 +95,7 @@ object PreferenceUpgradeService {
                 yield(RemoveBackupMax())
                 yield(RemoveInCardsMode())
                 yield(RemoveReviewerETA())
+                yield(SetShowDeckTitle())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -460,6 +461,15 @@ object PreferenceUpgradeService {
         internal class RemoveReviewerETA : PreferenceUpgrade(15) {
             override fun upgrade(preferences: SharedPreferences) =
                 preferences.edit { remove("showETA") }
+        }
+
+        /** default to true for existing users  */
+        internal class SetShowDeckTitle : PreferenceUpgrade(16) {
+            override fun upgrade(preferences: SharedPreferences) {
+                if (!preferences.contains("showDeckTitle")) {
+                    preferences.edit { putBoolean("showDeckTitle", true) }
+                }
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -186,6 +186,7 @@
 
     <!-- Appearance settings -->
     <string name="pref_cat_reviewer" maxLength="41">Reviewer</string>
+    <string name="show_deck_title" maxLength="41">Show deck title</string>
     <string name="accessibility" maxLength="41">Accessibility</string>
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -46,6 +46,7 @@
     <string name="show_progress_preference">showProgress</string>
     <string name="show_audio_play_buttons_key">showAudioPlayButtons</string>
     <string name="pref_card_browser_font_scale_key">relativeCardBrowserFontSize</string>
+    <string name="show_deck_title_key">showDeckTitle</string>
     <!-- App bar buttons -->
     <string name="pref_app_bar_buttons_screen_key">appBarButtonsScreen</string>
     <string name="reset_custom_buttons_key">reset_custom_buttons</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -110,6 +110,10 @@
             android:defaultValue="true"
             tools:title="Show play buttons on cards with audio"
             />
+        <SwitchPreferenceCompat
+            android:key="@string/show_deck_title_key"
+            android:defaultValue="false"
+            android:title="@string/show_deck_title"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/card_browser">
         <SwitchPreferenceCompat


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
#15147 

## Fixes
* Fixes #15147 

## Approach
Add a setting

## How Has This Been Tested?

Android 34 emulator: I upgraded the app to see if the setting defaulted to true and reinstalled to see if it defaulted to false

Then I looked if the deck title was showing correctly when enabled and not showing when disabled

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
