### PR TITLE
cleanup: add test method helpers

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -36,12 +36,10 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiGetNextTimeTest() = runTest {
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         val jsapi = reviewer.jsApi
@@ -71,12 +69,10 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiTestCurrentCard() = runTest {
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         val jsapi = reviewer.jsApi
@@ -183,12 +179,10 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiJsUiTest() = runTest {
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         val jsapi = reviewer.jsApi
@@ -227,12 +221,10 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiMarkAndFlagCardTest() = runTest {
         // js api test for marking and flagging card
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         val jsapi = reviewer.jsApi
@@ -289,8 +281,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         // count number of notes, if buried or suspended then
         // in scheduling the count will be less than previous scheduling
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
@@ -298,7 +289,6 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         addNoteUsingBasicModel("Anki", "Droid")
         addNoteUsingBasicModel("Test Card", "Bury and Suspend Card")
         addNoteUsingBasicModel("Test Note", "Bury and Suspend Note")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         val jsapi = reviewer.jsApi
@@ -361,13 +351,11 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiSetCardDueTest() = runTest {
         TimeManager.reset()
         val models = col.notetypes
-        val decks = col.decks
-        val didA = addDeck("Test")
+        val didA = addDeck("Test", setAsSelected = true)
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didA)
         addNoteUsingBasicModel("foo", "bar")
         addNoteUsingBasicModel("baz", "bak")
-        decks.select(didA)
 
         val reviewer: Reviewer = startReviewer()
         waitForAsyncTasksToComplete()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -502,9 +502,7 @@ class CardBrowserTest : RobolectricTest() {
     /** 7420  */
     @Test
     fun addCardDeckISetIfDeckIsSelectedOnOpen() {
-        val initialDid = addDeck("NotDefault")
-
-        col.decks.select(initialDid)
+        val initialDid = addDeck("NotDefault", setAsSelected = true)
 
         val b = browserWithNoNewCards
 
@@ -662,8 +660,7 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun checkSearchString() = runTest {
         addNoteUsingBasicModel("Hello", "John")
-        val deck = addDeck("Deck 1")
-        col.decks.select(deck)
+        val deck = addDeck("Deck 1", setAsSelected = true)
         val c2 = addNoteUsingBasicModel("New", "world").firstCard()
         c2.did = deck
         c2.col.updateCard(c2, skipUndoEntry = true)
@@ -734,8 +731,7 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun checkIfSearchAllDecksWorks() = runTest {
         addNoteUsingBasicModel("Hello", "World")
-        val deck = addDeck("Test Deck")
-        col.decks.select(deck)
+        val deck = addDeck("Test Deck", setAsSelected = true)
         val c2 = addNoteUsingBasicModel("Front", "Back").firstCard()
         c2.did = deck
         c2.col.updateCard(c2, skipUndoEntry = true)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -541,11 +541,10 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     @Config(qualifiers = "en")
     fun resetDataTest() = runTest {
-        addNoteUsingBasicModel("Hello", "World").firstCard().apply {
+        addNoteUsingBasicModel("Hello", "World").firstCard().update {
             due = 5
             queue = Consts.QUEUE_TYPE_REV
             type = Consts.CARD_TYPE_REV
-            col.updateCard(this, skipUndoEntry = true)
         }
 
         val b = browserWithNoNewCards
@@ -660,10 +659,9 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun checkSearchString() = runTest {
         addNoteUsingBasicModel("Hello", "John")
-        val deck = addDeck("Deck 1", setAsSelected = true)
-        val c2 = addNoteUsingBasicModel("New", "world").firstCard()
-        c2.did = deck
-        c2.col.updateCard(c2, skipUndoEntry = true)
+        addNoteUsingBasicModel("New", "world").firstCard().update {
+            did = addDeck("Deck 1", setAsSelected = true)
+        }
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("world or hello")
@@ -731,10 +729,9 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun checkIfSearchAllDecksWorks() = runTest {
         addNoteUsingBasicModel("Hello", "World")
-        val deck = addDeck("Test Deck", setAsSelected = true)
-        val c2 = addNoteUsingBasicModel("Front", "Back").firstCard()
-        c2.did = deck
-        c2.col.updateCard(c2, skipUndoEntry = true)
+        addNoteUsingBasicModel("Front", "Back").firstCard().update {
+            did = addDeck("Test Deck", setAsSelected = true)
+        }
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("Hello")
@@ -812,9 +809,9 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     private fun flagCardForNote(n: Note, flag: Flag) {
-        val c = n.firstCard()
-        c.setUserFlag(flag)
-        c.col.updateCard(c, skipUndoEntry = true)
+        n.firstCard().update {
+            setUserFlag(flag)
+        }
     }
 
     private fun selectDefaultDeck() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -20,6 +20,7 @@ import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Previewer.Companion.toIntent
 import com.ichi2.libanki.Card
+import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -170,10 +171,9 @@ class PreviewerTest : RobolectricTest() {
         return getPreviewerPreviewingList(arrayList, c)
     }
 
+    @KotlinCleanup("extension function")
     private fun setDeck(@Suppress("SameParameterValue") name: String, card: Card) {
-        val did = addDeck(name)
-        card.did = did
-        card.col.updateCard(card, skipUndoEntry = true)
+        card.update { did = addDeck(name) }
     }
 
     private fun getPreviewerPreviewingList(cardIds: LongArray, c: Array<Card?>): Previewer {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -37,6 +37,7 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.Flaky
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.OS
+import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.deepClone
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -369,11 +370,13 @@ class ReviewerTest : RobolectricTest() {
         return startReviewer(this, clazz)
     }
 
+    @KotlinCleanup("use extension function")
     private fun moveToReviewQueue(reviewCard: Card) {
-        reviewCard.queue = Consts.QUEUE_TYPE_REV
-        reviewCard.type = Consts.CARD_TYPE_REV
-        reviewCard.due = 0
-        reviewCard.col.updateCard(reviewCard, skipUndoEntry = true)
+        reviewCard.update {
+            queue = Consts.QUEUE_TYPE_REV
+            type = Consts.CARD_TYPE_REV
+            due = 0
+        }
     }
 
     private class ReviewerForMenuItems : Reviewer() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -190,15 +190,13 @@ class ReviewerTest : RobolectricTest() {
     @Test
     fun jsAnkiGetDeckName() = runTest {
         val models = col.notetypes
-        val decks = col.decks
 
         val didAb = addDeck("A::B")
         val basic = models.byName(AnkiDroidApp.appResources.getString(R.string.basic_model_name))
         basic!!.put("did", didAb)
         addNoteUsingBasicModel("foo", "bar")
 
-        val didA = addDeck("A")
-        decks.select(didA)
+        addDeck("A", setAsSelected = true)
 
         val reviewer = startReviewer()
         val javaScriptFunction = reviewer.jsApi

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -255,9 +255,7 @@ class NoteServiceTest : RobolectricTest() {
         assertEquals(175, NoteService.avgEase(note))
 
         // test case: all cards are new
-        for (card in note.cards()) {
-            card.update { type = Consts.CARD_TYPE_NEW }
-        }
+        note.updateCards { type = Consts.CARD_TYPE_NEW }
         // no cards are rev, so avg ease cannot be calculated
         assertEquals(null, NoteService.avgEase(note))
     }
@@ -289,9 +287,7 @@ class NoteServiceTest : RobolectricTest() {
         assertEquals(1750, NoteService.avgInterval(note))
 
         // case: all cards are new or learning
-        for (card in note.cards()) {
-            card.update { type = newOrLearningList.shuffled().first() }
-        }
+        note.updateCards { type = newOrLearningList.shuffled().first() }
 
         // no cards are rev or relearning, so avg interval cannot be calculated
         assertEquals(null, NoteService.avgInterval(note))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -239,27 +239,24 @@ class NoteServiceTest : RobolectricTest() {
         val note = addNoteUsingModelName("Cloze", "{{c1::Hello}}{{c2::World}}{{c3::foo}}{{c4::bar}}", "extra")
         // factor for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {
-            card.apply {
+            card.update {
                 type = Consts.CARD_TYPE_REV
                 factor = 3000 / (i + 1)
-                col.updateCard(this, skipUndoEntry = true)
             }
         }
         // avg ease = (3000/10 + 1500/10 + 100/10 + 750/10) / 4 = [156.25] = 156
         assertEquals(156, NoteService.avgEase(note))
 
         // test case: one card is new
-        note.cards()[2].apply {
+        note.cards()[2].update {
             type = Consts.CARD_TYPE_NEW
-            col.updateCard(this, skipUndoEntry = true)
         }
         // avg ease = (3000/10 + 1500/10 + 750/10) / 3 = [175] = 175
         assertEquals(175, NoteService.avgEase(note))
 
         // test case: all cards are new
         for (card in note.cards()) {
-            card.type = Consts.CARD_TYPE_NEW
-            card.col.updateCard(card, skipUndoEntry = true)
+            card.update { type = Consts.CARD_TYPE_NEW }
         }
         // no cards are rev, so avg ease cannot be calculated
         assertEquals(null, NoteService.avgEase(note))
@@ -274,10 +271,9 @@ class NoteServiceTest : RobolectricTest() {
 
         // interval for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {
-            card.apply {
+            card.update {
                 type = reviewOrRelearningList.shuffled().first()
                 ivl = 3000 / (i + 1)
-                col.updateCard(this, skipUndoEntry = true)
             }
         }
 
@@ -285,9 +281,8 @@ class NoteServiceTest : RobolectricTest() {
         assertEquals(1562, NoteService.avgInterval(note))
 
         // case: one card is new or learning
-        note.cards()[2].apply {
+        note.cards()[2].update {
             type = newOrLearningList.shuffled().first()
-            col.updateCard(this, skipUndoEntry = true)
         }
 
         // avg interval = (3000 + 1500 + 750) / 3 = [1750] = 1750
@@ -295,8 +290,7 @@ class NoteServiceTest : RobolectricTest() {
 
         // case: all cards are new or learning
         for (card in note.cards()) {
-            card.type = newOrLearningList.shuffled().first()
-            card.col.updateCard(card, skipUndoEntry = true)
+            card.update { type = newOrLearningList.shuffled().first() }
         }
 
         // no cards are rev or relearning, so avg interval cannot be calculated

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -35,8 +35,7 @@ class CollectionTest : JvmTest() {
         val n = addNoteUsingModelName("Cloze", "{{c1::Hello}} {{c2::World}}", "Extra")
         val did = addDeck("Testing")
         for (c in n.cards()) {
-            c.did = did
-            c.col.updateCard(c, skipUndoEntry = true)
+            c.update { this.did = did }
         }
         assertThat("two cloze notes should be generated", n.numberOfCards(), equalTo(2))
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -34,9 +34,7 @@ class CollectionTest : JvmTest() {
         // Technically, editing a card with conditional fields can also cause this, but cloze cards are much more common
         val n = addNoteUsingModelName("Cloze", "{{c1::Hello}} {{c2::World}}", "Extra")
         val did = addDeck("Testing")
-        for (c in n.cards()) {
-            c.update { this.did = did }
-        }
+        n.updateCards { this.did = did }
         assertThat("two cloze notes should be generated", n.numberOfCards(), equalTo(2))
 
         // create card 3

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -151,10 +151,7 @@ class DecksTest : JvmTest() {
     @Test
     fun curDeckIsLong() {
         // Regression for #8092
-        val col = col
-        val decks = col.decks
-        val id = addDeck("test")
-        decks.select(id)
+        addDeck("test", setAsSelected = true)
         assertDoesNotThrow("curDeck should be saved as a long. A deck id.") {
             col.config.get<DeckId>(
                 CURRENT_DECK

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -171,22 +171,23 @@ class FinderTest : JvmTest() {
         assertEquals(0, col.findCards("\"are goats\"").size)
         assertEquals(1, col.findCards("\"goats are\"").size)
         // card states
-        var c = note.cards()[0]
-        c.due = 999999
-        c.queue = QUEUE_TYPE_REV
-        c.type = CARD_TYPE_REV
+        var c = note.cards()[0].apply {
+            due = 999999
+            queue = QUEUE_TYPE_REV
+            type = CARD_TYPE_REV
+        }
         assertEquals(0, col.findCards("is:review").size)
         c.col.updateCard(c, skipUndoEntry = true)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:review"))
         assertEquals(0, col.findCards("is:due").size)
-        c.due = 0
-        c.queue = QUEUE_TYPE_REV
-        c.col.updateCard(c, skipUndoEntry = true)
+        c.update {
+            due = 0
+            queue = QUEUE_TYPE_REV
+        }
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:due"))
         assertEquals(4, col.findCards("-is:due").size)
-        c.queue = QUEUE_TYPE_SUSPENDED
         // ensure this card gets a later mod time
-        c.col.updateCard(c, skipUndoEntry = true)
+        c.update { queue = QUEUE_TYPE_SUSPENDED }
         col.db.execute("update cards set mod = mod + 1 where id = ?", c.id)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:suspended"))
         // nids

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
@@ -36,8 +36,7 @@ class FlagTest : JvmTest() {
 
         // make sure higher bits are preserved
         val origBits = 0b101 shl 3
-        c.setFlag(origBits)
-        c.col.updateCard(c, skipUndoEntry = true)
+        c.update { setFlag(origBits) }
         // no flags to start with
         assertEquals(0, c.userFlag())
         assertEquals(1, col.findCards("flag:0").size)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -17,6 +17,7 @@
 package com.ichi2.testutils
 
 import com.ichi2.anki.CollectionManager
+import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckConfig
@@ -147,8 +148,7 @@ interface TestClass {
         check(deckId != null) { "$deckName not found" }
 
         this.cards().forEach { card ->
-            card.did = deckId
-            col.updateCard(card, skipUndoEntry = true)
+            card.update { did = deckId }
         }
     }
 
@@ -157,6 +157,13 @@ interface TestClass {
         val deckConfig = col.decks.confForDid(deckId)
         function(deckConfig)
         col.decks.save(deckConfig)
+    }
+
+    /** Helper method to update a card */
+    fun Card.update(update: Card.() -> Unit): Card {
+        this.apply(update)
+        this@TestClass.col.updateCard(this, skipUndoEntry = true)
+        return this
     }
 
     /** * A wrapper around the standard [kotlinx.coroutines.test.runTest] that

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -147,9 +147,7 @@ interface TestClass {
         }
         check(deckId != null) { "$deckName not found" }
 
-        this.cards().forEach { card ->
-            card.update { did = deckId }
-        }
+        updateCards { did = deckId }
     }
 
     /** helper method to update deck config */
@@ -159,9 +157,15 @@ interface TestClass {
         col.decks.save(deckConfig)
     }
 
+    /** Helper method to all cards of a note */
+    fun Note.updateCards(update: Card.() -> Unit): Note {
+        cards().forEach { it.update(update) }
+        return this
+    }
+
     /** Helper method to update a card */
     fun Card.update(update: Card.() -> Unit): Card {
-        this.apply(update)
+        update(this)
         this@TestClass.col.updateCard(this, skipUndoEntry = true)
         return this
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -117,9 +117,11 @@ interface TestClass {
         col
     }
 
-    fun addDeck(deckName: String?): DeckId {
+    fun addDeck(deckName: String?, setAsSelected: Boolean = false): DeckId {
         return try {
-            col.decks.id(deckName!!)
+            col.decks.id(deckName!!).also { did ->
+                if (setAsSelected) col.decks.select(did)
+            }
         } catch (filteredAncestor: BackendDeckIsFilteredException) {
             throw RuntimeException(filteredAncestor)
         }


### PR DESCRIPTION
## Purpose / Description
I added these to the CardBrowser refactor and generally found them useful

* `addDeck("", setAsSelected = )`
* `Card.update`
* `Note.updateCards`

## How Has This Been Tested?
Test-only

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
