### PR TITLE
tests: use shared-preferences-mock

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -390,6 +390,7 @@ dependencies {
     testImplementation("androidx.fragment:fragment-testing:$fragments_version")
     // in a JvmTest we need org.json.JSONObject to not be mocked
     testImplementation 'org.json:json:20231013'
+    testImplementation 'io.github.ivanshafran:shared-preferences-mock:1.2.4'
     // May need a resolution strategy for support libs to our versions
     androidTestImplementation "androidx.test.espresso:espresso-core:$espresso_version"
     androidTestImplementation("androidx.test.espresso:espresso-contrib:$espresso_version") {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnalyticsTest.kt
@@ -16,12 +16,13 @@
 package com.ichi2.anki
 
 import android.content.Context
-import android.content.SharedPreferences
 import android.content.res.Resources
 import android.preference.*
+import androidx.core.content.edit
 import com.brsanthu.googleanalytics.GoogleAnalytics
 import com.brsanthu.googleanalytics.GoogleAnalyticsBuilder
 import com.brsanthu.googleanalytics.request.ExceptionHit
+import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.analytics.UsageAnalytics
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -39,11 +40,11 @@ class AnalyticsTest {
     @Mock
     private lateinit var mockResources: Resources
 
-    @Mock
-    private lateinit var mockSharedPreferences: SharedPreferences
-
-    @Mock
-    private lateinit var mockSharedPreferencesEditor: SharedPreferences.Editor
+    private val sharedPreferences = SPMockBuilder().createSharedPreferences().apply {
+        edit {
+            putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true)
+        }
+    }
 
     @Before
     fun setUp() {
@@ -62,13 +63,7 @@ class AnalyticsTest {
         whenever(mockContext.packageName)
             .thenReturn("mock_context")
         whenever(mockContext.getSharedPreferences("mock_context_preferences", Context.MODE_PRIVATE))
-            .thenReturn(mockSharedPreferences)
-        whenever(mockSharedPreferences.getBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, false))
-            .thenReturn(true)
-        whenever(mockSharedPreferencesEditor.putBoolean(UsageAnalytics.ANALYTICS_OPTIN_KEY, true))
-            .thenReturn(mockSharedPreferencesEditor)
-        whenever(mockSharedPreferences.edit())
-            .thenReturn(mockSharedPreferencesEditor)
+            .thenReturn(sharedPreferences)
     }
 
     private class SpyGoogleAnalyticsBuilder : GoogleAnalyticsBuilder() {
@@ -89,7 +84,7 @@ class AnalyticsTest {
         mockStatic(PreferenceManager::class.java).use { _ ->
             mockStatic(GoogleAnalytics::class.java).use { _ ->
                 whenever(PreferenceManager.getDefaultSharedPreferences(any()))
-                    .thenReturn(mockSharedPreferences)
+                    .thenReturn(sharedPreferences)
                 whenever(GoogleAnalytics.builder())
                     .thenReturn(SpyGoogleAnalyticsBuilder())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -17,6 +17,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Storage
 import com.ichi2.testutils.*
 import com.ichi2.testutils.libanki.buryNewSiblings
+import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.ResourceLoader
 import org.apache.commons.exec.OS
 import org.hamcrest.MatcherAssert.assertThat
@@ -35,6 +36,7 @@ import java.io.File
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 
+@KotlinCleanup("SPMockBuilder")
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class DeckPickerTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
@@ -19,6 +19,7 @@ import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.preferences.PreferenceTestUtils
+import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.Test
@@ -41,6 +42,7 @@ class ActionButtonStatusTest : RobolectricTest() {
         )
     }
 
+    @KotlinCleanup("Use SPMockBuilder")
     private val customButtonsExpectedKeys: Set<String>
         get() {
             val preferences = mock(SharedPreferences::class.java)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -15,8 +15,8 @@
  */
 package com.ichi2.anki.reviewer
 
-import android.content.SharedPreferences
 import android.view.KeyEvent
+import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.cardviewer.ViewerCommand
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -31,7 +31,7 @@ class PeripheralKeymapTest {
         val processed: MutableList<ViewerCommand> = ArrayList()
 
         val peripheralKeymap = PeripheralKeymap(MockReviewerUi()) { e: ViewerCommand, _ -> processed.add(e) }
-        peripheralKeymap.setup(mock(SharedPreferences::class.java))
+        peripheralKeymap.setup(SPMockBuilder().createSharedPreferences())
         val event = mock(KeyEvent::class.java)
         whenever(event.unicodeChar).thenReturn(0)
         whenever(event.isCtrlPressed).thenReturn(true)

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/PreferenceExtensionsTest.kt
@@ -16,46 +16,27 @@
 package com.ichi2.preferences
 
 import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyString
-import org.mockito.ArgumentMatchers.eq
-import org.mockito.Mock
-import org.mockito.Mockito
-import org.mockito.MockitoAnnotations
 import java.lang.RuntimeException
 import java.util.function.Supplier
 
 // Unknown issue: @CheckResult should provide warnings on this class when return value is unused, but doesn't.
 class PreferenceExtensionsTest {
-    @Mock
-    lateinit var mockPreferences: SharedPreferences
+    private val mockPreferences: SharedPreferences = SPMockBuilder().createSharedPreferences().apply {
+        edit {
+            putString(VALID_KEY, VALID_RESULT)
+        }
+    }
 
-    @Mock
-    private val mockEditor: SharedPreferences.Editor? = null
     private fun getOrSetString(key: String, supplier: Supplier<String>): String {
         return mockPreferences.getOrSetString(key, supplier)
     }
-
-    @Before
-    fun setUp() {
-        MockitoAnnotations.openMocks(this)
-        Mockito.`when`(mockPreferences.contains(VALID_KEY)).thenReturn(true)
-        Mockito.`when`(
-            mockPreferences.getString(eq(VALID_KEY), anyString())
-        ).thenReturn(
-            VALID_RESULT
-        )
-        Mockito.`when`(mockPreferences.edit()).thenReturn(mockEditor)
-        Mockito.`when`(
-            mockEditor!!.putString(anyString(), anyString())
-        ).thenReturn(mockEditor)
-    }
-
-    private val forMissingKey: String?
-        get() = getOrSetString(MISSING_KEY) { LAMBDA_RETURN }
 
     @Test
     fun existingKeyReturnsMappedValue() {
@@ -65,18 +46,18 @@ class PreferenceExtensionsTest {
 
     @Test
     fun missingKeyReturnsLambdaValue() {
-        val ret = forMissingKey
+        val ret = getOrSetString(MISSING_KEY) { LAMBDA_RETURN }
         assertEquals(ret, LAMBDA_RETURN)
     }
 
     @Test
     fun missingKeySetsPreference() {
-        forMissingKey
-        Mockito.verify(mockEditor)?.putString(MISSING_KEY, LAMBDA_RETURN)
-        Mockito.verify(mockEditor)?.apply()
+        getOrSetString(MISSING_KEY) { LAMBDA_RETURN }
+        assertThat(mockPreferences.getString(MISSING_KEY, null), equalTo(LAMBDA_RETURN))
     }
 
     @SuppressWarnings("unused")
+    @Test
     fun noLambdaExceptionIfKeyExists() {
         assertDoesNotThrow { getOrSetString(VALID_KEY, EXCEPTION_SUPPLIER) }
     }


### PR DESCRIPTION
Shaves a second off test execution

API is much easier to use.

I cut this out from the Card Browser refactor, but this might not get used here

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
