### PR TITLE
Enable "Include deck configs" option when exporting an apkg

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendExporting.kt
@@ -24,6 +24,7 @@ import com.ichi2.libanki.exportNotesCsv
 fun AnkiActivity.exportApkgPackage(
     exportPath: String,
     withScheduling: Boolean,
+    withDeckConfigs: Boolean,
     withMedia: Boolean,
     limit: ExportLimit
 ) {
@@ -34,7 +35,7 @@ fun AnkiActivity.exportApkgPackage(
             }
         }
         withProgress(extractProgress = onProgress) {
-            withCol { exportAnkiPackage(exportPath, withScheduling, withMedia, limit) }
+            withCol { exportAnkiPackage(exportPath, withScheduling, withDeckConfigs, withMedia, limit) }
         }
         val factory =
             (this@exportApkgPackage as ExportDialogsFactoryProvider).exportDialogsFactory()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -70,6 +70,7 @@ class ExportDialogFragment : DialogFragment() {
     private lateinit var decksSelectorContainer: FrameLayout
     private lateinit var collectionIncludeMedia: CheckBox
     private lateinit var apkgIncludeSchedule: CheckBox
+    private lateinit var apkgIncludeDeckConfigs: CheckBox
     private lateinit var apkgIncludeMedia: CheckBox
     private lateinit var notesIncludeHtml: CheckBox
     private lateinit var notesIncludeTags: CheckBox
@@ -210,6 +211,9 @@ class ExportDialogFragment : DialogFragment() {
         apkgIncludeMedia = findViewById<CheckBox>(R.id.export_apkg_media).apply {
             text = exportingIncludeMedia()
         }
+        apkgIncludeDeckConfigs = findViewById<CheckBox>(R.id.export_apkg_deck_configs).apply {
+            text = exportingIncludeDeckConfigs()
+        }
         apkgIncludeSchedule = findViewById<CheckBox>(R.id.export_apkg_schedule).apply {
             text = exportingIncludeSchedulingInformation()
         }
@@ -280,6 +284,7 @@ class ExportDialogFragment : DialogFragment() {
 
     private fun handleAnkiPackageExport() {
         val includeSchedule = apkgIncludeSchedule.isChecked
+        val includeDeckConfigs = apkgIncludeDeckConfigs.isChecked
         val includeMedia = apkgIncludeMedia.isChecked
         val limits = buildExportLimit()
         var packagePrefix = getNonCollectionNamePrefix()
@@ -292,6 +297,7 @@ class ExportDialogFragment : DialogFragment() {
         (requireActivity() as AnkiActivity).exportApkgPackage(
             exportPath = exportPath,
             withScheduling = includeSchedule,
+            withDeckConfigs = includeDeckConfigs,
             withMedia = includeMedia,
             limit = limits
         )

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
@@ -108,6 +108,7 @@ fun Collection.getImportAnkiPackagePresetsRaw(input: ByteArray): ByteArray {
 fun Collection.exportAnkiPackage(
     outPath: String,
     withScheduling: Boolean,
+    withDeckConfigs: Boolean,
     withMedia: Boolean,
     limit: ExportLimit,
     legacy: Boolean = true
@@ -116,7 +117,7 @@ fun Collection.exportAnkiPackage(
         this.withScheduling = withScheduling
         this.withMedia = withMedia
         this.legacy = legacy
-        this.withDeckConfigs = withScheduling
+        this.withDeckConfigs = withDeckConfigs
     }
     backend.exportAnkiPackage(outPath, options, limit)
 }

--- a/AnkiDroid/src/main/res/layout/dialog_export_options.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_export_options.xml
@@ -52,6 +52,12 @@
                 android:checked="true" />
 
             <CheckBox
+                android:id="@+id/export_apkg_deck_configs"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:checked="false" />
+
+            <CheckBox
                 android:id="@+id/export_apkg_media"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
## Purpose / Description
Implements one of the requested followups from #15167:

_The apkg export screen should expose an option to control whether deck configs are exported_

## How Has This Been Tested?

Not that much testing, but the changes are pretty small.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
