### PR TITLE
build(deps): AGP 8.2.2 w/JDK21 compatibility, switch CI to JDK21

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,13 +32,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17 now, force it everywhere
-
-      - name: Verify JDK17
-        # Default JDK varies depending on different runner flavors, make sure we are on 17
-        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '17.0'
-        shell: bash
+          java-version: "21"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17, also change jitpack.yml
-
-      - name: Verify JDK17
-        # Default JDK varies depending on different runner flavors, make sure we are on 17
-        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '17.0'
-        shell: bash
+          java-version: "21"
 
       - name: Install Release Utilities
         run: |

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -44,13 +44,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17 now, force it everywhere
-
-      - name: Verify JDK17
-        # Default JDK varies depending on different runner flavors, make sure we are on 17
-        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '17.0'
-        shell: bash
+          java-version: "21"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -46,13 +46,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17 now, force it everywhere
-
-      - name: Verify JDK17
-        # Default JDK varies depending on different runner flavors, make sure we are on 17
-        # Run a check that exits with error unless it is 17 version to future-proof against unexpected upgrades
-        run: java -fullversion 2>&1 | grep '17.0'
-        shell: bash
+          java-version: "21"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "17" # newer libraries require 17 now, force it everywhere
+          java-version: "21"
 
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v1

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.11.1'
-    ext.android_gradle_plugin = "8.2.1"
+    ext.android_gradle_plugin = "8.2.2"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
     ext.uiautomator_version = "2.3.0-beta01"
 


### PR DESCRIPTION
I think JDK21 will work now that AGP 8.2.2 is out, it appears to work for me locally.

Success criteria is nothing different in the logs then the JDK17 logs - this should be undetectable by anyone basically