### PR TITLE
fix: whiteboard not drawing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -33,6 +33,7 @@ import androidx.core.content.edit
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.getTimestamp
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.utils.Time
 import com.ichi2.themes.Themes.currentTheme
@@ -48,6 +49,7 @@ import kotlin.math.max
  * Whiteboard allowing the user to draw the card's answer on the touchscreen.
  */
 @SuppressLint("ViewConstructor")
+@NeedsTest("15176 ensure whiteboard drawing works")
 class Whiteboard(activity: AnkiActivity, private val handleMultiTouch: Boolean, inverted: Boolean) : View(activity, null) {
     private val paint: Paint
     private val undo = UndoList()
@@ -253,10 +255,10 @@ class Whiteboard(activity: AnkiActivity, private val handleMultiTouch: Boolean, 
     }
 
     private fun drawAlong(x: Float, y: Float) {
-        val dx = abs(x - x)
-        val dy = abs(y - y)
+        val dx = abs(x - this.x)
+        val dy = abs(y - this.y)
         if (dx >= TOUCH_TOLERANCE || dy >= TOUCH_TOLERANCE) {
-            path.quadTo(x, y, (x + x) / 2, (y + y) / 2)
+            path.quadTo(this.x, this.y, (this.x + x) / 2, (this.y + y) / 2)
             this.x = x
             this.y = y
         }


### PR DESCRIPTION
## Purpose / Description
`x` and `y` were both parameters and variables, these were wrongly identified

## Fixes
* Fixes #15176

## Approach
use `this`

## How Has This Been Tested?
API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
