### PR TITLE
New Dev: Extract non-functional refactors

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -942,12 +942,12 @@ class ContentProviderTest : InstrumentedTest() {
         var nextCard: Card? = null
         for (i in 0..9) { // minimizing fails, when sched.reset() randomly chooses between multiple cards
             nextCard = sched.card
-            if (nextCard != null && nextCard.note().id == noteID && nextCard.ord == cardOrd) break
+            if (nextCard != null && nextCard.nid == noteID && nextCard.ord == cardOrd) break
         }
         assertNotNull("Check that there actually is a next scheduled card", nextCard)
         assertEquals(
             "Check that received card and actual card have same note id",
-            nextCard!!.note().id,
+            nextCard!!.nid,
             noteID
         )
         assertEquals(
@@ -994,7 +994,7 @@ class ContentProviderTest : InstrumentedTest() {
             var nextCard: Card? = null
             for (i in 0..9) { // minimizing fails, when sched.reset() randomly chooses between multiple cards
                 nextCard = sched.card
-                if (nextCard != null && nextCard.note().id == noteID && nextCard.ord == cardOrd) break
+                if (nextCard != null && nextCard.nid == noteID && nextCard.ord == cardOrd) break
                 try {
                     Thread.sleep(500)
                 } catch (e: Exception) {
@@ -1004,7 +1004,7 @@ class ContentProviderTest : InstrumentedTest() {
             assertNotNull("Check that there actually is a next scheduled card", nextCard)
             assertEquals(
                 "Check that received card and actual card have same note id",
-                nextCard!!.note().id,
+                nextCard!!.nid,
                 noteID
             )
             assertEquals(
@@ -1054,7 +1054,7 @@ class ContentProviderTest : InstrumentedTest() {
         assertEquals("card is initial new", Consts.CARD_TYPE_NEW, card.queue)
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
         val earlyGraduatingEase = AbstractFlashcardViewer.EASE_4
         val values = ContentValues().apply {
@@ -1072,7 +1072,7 @@ class ContentProviderTest : InstrumentedTest() {
         }
         val newCard = col.sched.card
         if (newCard != null) {
-            if (newCard.note().id == card.note().id && newCard.ord == card.ord) {
+            if (newCard.nid == card.nid && newCard.ord == card.ord) {
                 fail("Next scheduled card has not changed")
             }
         }
@@ -1106,7 +1106,7 @@ class ContentProviderTest : InstrumentedTest() {
         // -----------------------
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
         val bury = 1
         val values = ContentValues().apply {
@@ -1156,7 +1156,7 @@ class ContentProviderTest : InstrumentedTest() {
         // --------------------------
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
-        val noteId = card.note().id
+        val noteId = card.nid
         val cardOrd = card.ord
 
         @KotlinCleanup("rename, while valid suspend is a kotlin soft keyword")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -358,7 +358,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
             val fieldsData = s.card.note().fields
             val fieldsName = s.card.model().fieldsNames
 
-            val noteId = s.card.note().id
+            val noteId = s.card.nid
             val cardId = s.card.id
             jsonObject.put("cardId", cardId)
             jsonObject.put("noteId", noteId)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1988,7 +1988,7 @@ open class CardBrowser :
                 CardBrowserColumn.DUE -> card.dueString
                 CardBrowserColumn.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 CardBrowserColumn.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note().mod.toLong())
-                CardBrowserColumn.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.note().id)
+                CardBrowserColumn.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)
                 CardBrowserColumn.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note().mod)
                 CardBrowserColumn.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
                 CardBrowserColumn.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1981,7 +1981,7 @@ open class CardBrowser :
                 CardBrowserColumn.FLAGS -> Integer.valueOf(card.userFlag()).toString()
                 CardBrowserColumn.SUSPENDED -> if (card.queue == Consts.QUEUE_TYPE_SUSPENDED) "True" else "False"
                 CardBrowserColumn.MARKED -> if (isMarked(card.note())) "marked" else null
-                CardBrowserColumn.SFLD -> card.note().sFld
+                CardBrowserColumn.SFLD -> card.note().sFld()
                 CardBrowserColumn.DECK -> col.decks.name(card.did)
                 CardBrowserColumn.TAGS -> card.note().stringTags()
                 CardBrowserColumn.CARD -> if (inCardMode) card.template().optString("name") else "${card.note().numberOfCards()}"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1773,9 +1773,9 @@ open class CardBrowser :
             // Draw the content in the columns
             val card = getItem(position)
             (v.tag as Array<*>)
-                .forEachIndexed { i, col ->
-                    setFont(col as TextView) // set font for column
-                    col.text = card.getColumnHeaderText(fromKeys[i]) // set text for column
+                .forEachIndexed { i, column ->
+                    setFont(column as TextView) // set font for column
+                    column.text = card.getColumnHeaderText(fromKeys[i]) // set text for column
                 }
             // set card's background color
             val backgroundColor: Int = MaterialColors.getColor(this@CardBrowser, card.color, 0)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1985,7 +1985,7 @@ open class CardBrowser :
                 CardBrowserColumn.DECK -> col.decks.name(card.did)
                 CardBrowserColumn.TAGS -> card.note().stringTags()
                 CardBrowserColumn.CARD -> if (inCardMode) card.template().optString("name") else "${card.note().numberOfCards()}"
-                CardBrowserColumn.DUE -> card.dueString
+                CardBrowserColumn.DUE -> card.dueString()
                 CardBrowserColumn.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 CardBrowserColumn.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note().mod.toLong())
                 CardBrowserColumn.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1293,8 +1293,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         )
         // Also pass the note id and ord if not adding new note
         if (!addNote && mCurrentEditedCard != null) {
-            intent.putExtra("noteId", mCurrentEditedCard!!.note().id)
-            Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard!!.note().id)
+            intent.putExtra("noteId", mCurrentEditedCard!!.nid)
+            Timber.d("showCardTemplateEditor() with note %s", mCurrentEditedCard!!.nid)
             intent.putExtra("ordId", mCurrentEditedCard!!.ord)
             Timber.d("showCardTemplateEditor() with ord %s", mCurrentEditedCard!!.ord)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -120,7 +120,7 @@ class CardHtml(
         fun legacyGetTtsTags(card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
             val cardSideContent: String = when (cardSide) {
                 QUESTION -> card.question(true)
-                ANSWER -> card.pureAnswer
+                ANSWER -> card.pureAnswer()
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -66,7 +66,7 @@ class TTS {
      * @param qa   The card question or card answer
      */
     fun selectTts(context: Context, card: Card, qa: SoundSide) {
-        val textToRead = if (qa == SoundSide.QUESTION) card.question(true) else card.pureAnswer
+        val textToRead = if (qa == SoundSide.QUESTION) card.question(true) else card.pureAnswer()
         // get the text from the card
         ReadText.selectTts(
             getTextForTts(context, textToRead),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1049,7 +1049,7 @@ class CardContentProvider : ContentProvider() {
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
-                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.note().id)
+                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.nid)
                 FlashCardsContract.Card.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.Card.CARD_NAME -> rb.add(cardName)
                 FlashCardsContract.Card.DECK_ID -> rb.add(currentCard.did)
@@ -1067,7 +1067,7 @@ class CardContentProvider : ContentProvider() {
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
-                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.note().id)
+                FlashCardsContract.Card.NOTE_ID -> rb.add(currentCard.nid)
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1057,7 +1057,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
                 FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple())
                 FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.renderOutput(false).answerText)
-                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer)
+                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -284,20 +284,19 @@ open class Card : Cloneable {
         return renderOutput().questionText
     }
 
-    /*
-     * Returns the answer with anything before the <hr id=answer> tag removed
+    /**
+     * Returns the answer with anything before the `<hr id=answer>` tag removed
      */
-    val pureAnswer: String
-        get() {
-            val s = renderOutput().answerText
-            for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
-                val pos = s.indexOf(target)
-                if (pos == -1) continue
-                return s.substring(pos + target.length).trim { it <= ' ' }
-            }
-            // neither found
-            return s
+    fun pureAnswer(): String {
+        val s = renderOutput().answerText
+        for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
+            val pos = s.indexOf(target)
+            if (pos == -1) continue
+            return s.substring(pos + target.length).trim { it <= ' ' }
         }
+        // neither found
+        return s
+    }
 
     /**
      * Save the currently elapsed reviewing time so it can be restored on resume.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -389,14 +389,13 @@ open class Card : Cloneable {
     }
 
     // not in Anki.
-    val dueString: String
-        get() {
-            var t = nextDue()
-            if (queue < 0) {
-                t = "($t)"
-            }
-            return t
+    fun dueString(): String {
+        var t = nextDue()
+        if (queue < 0) {
+            t = "($t)"
         }
+        return t
+    }
 
     // as in Anki aqt/browser.py
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -261,8 +261,7 @@ class Note : Cloneable {
         return DupeOrEmpty.CORRECT
     }
 
-    val sFld: String
-        get() = col.db.queryString("SELECT sfld FROM notes WHERE id = ?", this.id)
+    fun sFld(): String = col.db.queryString("SELECT sfld FROM notes WHERE id = ?", this.id)
 
     fun setField(index: Int, value: String) {
         fields[index] = value

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -43,7 +43,7 @@ class CardTest : JvmTest() {
         col.addNote(note)
         val card = note.cards()[0]
 
-        assertThat(card.pureAnswer, equalTo("2"))
+        assertThat(card.pureAnswer(), equalTo("2"))
     }
 
     /******************

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -248,82 +248,82 @@ class CardTest : JvmTest() {
         c.due = 27L
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("27", c.nextDue())
-        assertEquals("(27)", c.dueString)
+        assertEquals("(27)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_NEW
         c.due = 27L
         assertEquals("27", c.nextDue())
-        assertEquals("27", c.dueString)
+        assertEquals("27", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("27", c.nextDue())
-        assertEquals("27", c.dueString)
+        assertEquals("27", c.dueString())
         c.type = Consts.CARD_TYPE_LRN
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
         assertEquals("3/19/21", c.nextDue())
-        assertEquals("3/19/21", c.dueString)
+        assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_REV
         c.due = 20
         //  Since tests run the 7th of august, in 20 days we are the 27th of august 2020
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("(8/27/20)", c.dueString)
+        assertEquals("(8/27/20)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_REV
         assertEquals("8/27/20", c.nextDue())
-        assertEquals("8/27/20", c.dueString)
+        assertEquals("8/27/20", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
         c.type = Consts.CARD_TYPE_RELEARNING
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SUSPENDED
         assertEquals("", c.nextDue())
-        assertEquals("()", c.dueString)
+        assertEquals("()", c.dueString())
         c.queue = Consts.QUEUE_TYPE_LRN
         c.due = id
         assertEquals("3/19/21", c.nextDue())
-        assertEquals("3/19/21", c.dueString)
+        assertEquals("3/19/21", c.dueString())
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         assertEquals("", c.nextDue())
-        assertEquals("", c.dueString)
+        assertEquals("", c.dueString())
 
         // Dynamic deck
         val dyn = decks.newDyn("dyn")
         c.oDid = c.did
         c.did = dyn
         assertEquals("(filtered)", c.nextDue())
-        assertEquals("(filtered)", c.dueString)
+        assertEquals("(filtered)", c.dueString())
         c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
         assertEquals("(filtered)", c.nextDue())
-        assertEquals("((filtered))", c.dueString)
+        assertEquals("((filtered))", c.dueString())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
@@ -34,9 +34,9 @@ import kotlin.random.Random
 object CollectionDBCorruption {
     // It writes 100 bytes at position 100 to 199
     private fun corrupt(path: String) {
-        RandomAccessFile(File(path), "rw").use { col ->
-            col.seek(100)
-            col.write(Random.nextBytes(100))
+        RandomAccessFile(File(path), "rw").use { collectionFile ->
+            collectionFile.seek(100)
+            collectionFile.write(Random.nextBytes(100))
         }
 
         assert(File(path).length() != 0L)


### PR DESCRIPTION
* Extracted from https://github.com/ankidroid/Anki-Android/pull/13936/
  * I didn't want to see the effort go to waste 

Up to https://github.com/ankidroid/Anki-Android/pull/13936/commits/5f01180be25f13eae46aad1fc78caf122a620f8a

A large number of commits were no longer applicable. A number of commits were not selected, as they affected classes which would retain a `col` parameter, such as `sched`

Each commit is linked to the 'original'

The aim of these commits is primarily to convert `val` -> `fun`. This is prep work to remove `col` as a variable from the non-manager classes in `libAnki`, such as `Card` and `Note`: we may retain a reference to these classes after `withCol` has completed
