### PR TITLE
build(deps): adopt android gradle plugin 8.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.11.1'
-    ext.android_gradle_plugin = "8.1.4"
+    ext.android_gradle_plugin = "8.2.1"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
     ext.uiautomator_version = "2.3.0-beta01"
 


### PR DESCRIPTION
Not sure why dependabot did not propose this one, will investigate that separately

note that the android gradle plugin 8.2-stable series has a defect that does not allow setting the jacoco version, and pins it at 0.8.8

that is fine in all cases except where you want to use JDK21, which requires jacoco 0.8.11+.

this will be resolved in android gradle plugin 8.3-stable
