### PR TITLE
chore(deps): alter dependabot to propose javascript PRs on dependency-updates branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,12 @@ updates:
   ignore:
   # Ignore all Rust backend updates, these are always done as manual pulls
   - dependency-name: io.github.david-allison-1:anki-android-backend
+- package-ecosystem: npm
+  directory: "/tools/localization"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  target-branch: dependency-updates
+  labels:
+  - "dependencies"


### PR DESCRIPTION

## Purpose / Description

Noticed that our new javascript crowdin system is getting dependabot PRs to main branch vs dependency-updates, see #15198

## Approach

Make a new configuration stanza for the "npm" ecosystem (even though we use yarn, this is the key to use per docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem)

## How Has This Been Tested?

Can't really test dependabot but the next time it proposes something for `/tools/localization` it should be against the correct branch