### PR TITLE
Dependency updates 20240111

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -355,7 +355,7 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.12.0'
     implementation 'com.arcao:slf4j-timber:3.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'
-    implementation 'org.jsoup:jsoup:1.17.1'
+    implementation 'org.jsoup:jsoup:1.17.2'
     implementation "com.github.zafarkhaja:java-semver:0.9.0" // For AnkiDroid JS API Versioning
     implementation 'com.drakeet.drawer:drawer:1.0.3'
     implementation 'uk.co.samuelwall:material-tap-target-prompt:3.3.2'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -386,7 +386,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "io.mockk:mockk:1.13.9"
-    testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
+    testImplementation 'org.apache.commons:commons-exec:1.4.0' // obtaining the OS
     testImplementation("androidx.fragment:fragment-testing:$fragments_version")
     // in a JvmTest we need org.json.JSONObject to not be mocked
     testImplementation 'org.json:json:20231013'

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -362,7 +362,7 @@ dependencies {
     implementation 'com.github.mrudultora:Colorpicker:1.2.0'
     implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlin_version"
     implementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
-    implementation 'com.github.ByteHamster:SearchPreference:2.4.0'
+    implementation 'com.github.ByteHamster:SearchPreference:2.5.0'
 
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp
     // and there's no no-op version for release build. Usage has been disabled for release

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -367,7 +367,7 @@ dependencies {
     // Cannot use debugImplementation since classes need to be imported in AnkiDroidApp
     // and there's no no-op version for release build. Usage has been disabled for release
     // build via AnkiDroidApp.
-    implementation 'com.squareup.leakcanary:leakcanary-android:2.12'
+    implementation 'com.squareup.leakcanary:leakcanary-android:2.13'
 
     // A path for a testing library which provide Parameterized Test
     testImplementation "org.junit.jupiter:junit-jupiter:$junit_version"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -326,7 +326,7 @@ dependencies {
 
     // Backend libraries
 
-    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.25.1' // This is required when loading from a file
+    implementation 'com.google.protobuf:protobuf-kotlin-lite:3.25.2' // This is required when loading from a file
 
     Properties localProperties = new Properties()
     if (project.rootProject.file('local.properties').exists()) {

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -385,7 +385,7 @@ dependencies {
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation "org.jetbrains.kotlin:kotlin-test-junit5:$kotlin_version"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
-    testImplementation "io.mockk:mockk:1.13.8"
+    testImplementation "io.mockk:mockk:1.13.9"
     testImplementation 'org.apache.commons:commons-exec:1.3' // obtaining the OS
     testImplementation("androidx.fragment:fragment-testing:$fragments_version")
     // in a JvmTest we need org.json.JSONObject to not be mocked

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -356,7 +356,7 @@ dependencies {
     implementation 'com.arcao:slf4j-timber:3.1'
     implementation 'com.jakewharton.timber:timber:5.0.1'
     implementation 'org.jsoup:jsoup:1.17.2'
-    implementation "com.github.zafarkhaja:java-semver:0.9.0" // For AnkiDroid JS API Versioning
+    implementation "com.github.zafarkhaja:java-semver:0.10.0" // For AnkiDroid JS API Versioning
     implementation 'com.drakeet.drawer:drawer:1.0.3'
     implementation 'uk.co.samuelwall:material-tap-target-prompt:3.3.2'
     implementation 'com.github.mrudultora:Colorpicker:1.2.0'

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -132,8 +132,8 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                 }
                 return false
             }
-            val versionCurrent = Version.valueOf(AnkiDroidJsAPIConstants.sCurrentJsApiVersion)
-            val versionSupplied = Version.valueOf(apiVer)
+            val versionCurrent = Version.parse(AnkiDroidJsAPIConstants.sCurrentJsApiVersion)
+            val versionSupplied = Version.parse(apiVer)
 
             /*
             * if api major version equals to supplied major version then return true and also check for minor version and patch version
@@ -144,11 +144,11 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                 versionSupplied == versionCurrent -> {
                     true
                 }
-                versionSupplied.lessThan(versionCurrent) -> {
+                versionSupplied.isLowerThan(versionCurrent) -> {
                     activity.runOnUiThread {
                         activity.showSnackbar(context.getString(R.string.update_js_api_version, apiDevContact))
                     }
-                    versionSupplied.greaterThanOrEqualTo(Version.valueOf(AnkiDroidJsAPIConstants.sMinimumJsApiVersion))
+                    versionSupplied.isHigherThanOrEquivalentTo(Version.parse(AnkiDroidJsAPIConstants.sMinimumJsApiVersion))
                 }
                 else -> {
                     activity.runOnUiThread {

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy
 buildscript {
     // The version for the Kotlin plugin and dependencies
     // If changing this, make sure to update org.jetbrains.kotlin.plugin.serialization version too
-    ext.kotlin_version = '1.9.21'
+    ext.kotlin_version = '1.9.22'
     ext.lint_version = '31.1.1'
     ext.acra_version = '5.11.3'
     ext.ankidroid_backend_version = '0.1.34-anki23.12.1'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
     ext.androidx_test_version = '1.5.0'
     ext.androidx_test_junit_version = '1.1.5'
     ext.robolectric_version = '4.11.1'
-    ext.android_gradle_plugin = "8.1.4"
+    ext.android_gradle_plugin = "8.2.1"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
     ext.uiautomator_version = "2.3.0-beta01"
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     ext.robolectric_version = '4.11.1'
     ext.android_gradle_plugin = "8.1.4"
     ext.dokka_version = "1.9.10" // not the same with kotlin version!
-    ext.uiautomator_version = "2.3.0-alpha05"
+    ext.uiautomator_version = "2.3.0-beta01"
 
     configurations.configureEach {
         resolutionStrategy.eachDependency { details ->

--- a/tools/localization/yarn.lock
+++ b/tools/localization/yarn.lock
@@ -1845,9 +1845,9 @@ flatted@^3.2.9:
   integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
 
 follow-redirects@^1.15.0:
-  version "1.15.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
-  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
+  version "1.15.4"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.4.tgz#cdc7d308bf6493126b17ea2191ea0ccf3e535adf"
+  integrity sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==
 
 for-each@^0.3.3:
   version "0.3.3"


### PR DESCRIPTION

Mostly standard dependency updates except the last three:

1- manual PR of android gradle plugin from 8.1.4 to 8.2.1 because dependabot wasn't doing them, I believe we confused it earlier with PR closes on other android-gradle-plugin work. I believe that will self-resolve in future
2- deprecation fixup for the semver package to get it in
3- altered dependabot configuration for `/tools/localization` javascript package so it PRs against dependency-updates branch but only after I noticed it was PRing to main. Manually fixed this one up