### PR TITLE
feat: additional keyboard events

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -650,6 +650,13 @@ open class CardBrowser :
                     return true
                 }
             }
+            KeyEvent.KEYCODE_P -> {
+                if (event.isShiftPressed && event.isCtrlPressed) {
+                    Timber.i("Ctrl+Shift+P - Preview")
+                    onPreview()
+                    return true
+                }
+            }
         }
         return super.onKeyDown(keyCode, event)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -20,6 +20,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
@@ -32,7 +33,9 @@ import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.PreviewLayout
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
+import com.ichi2.utils.performClickIfEnabled
 import timber.log.Timber
 
 /**
@@ -152,6 +155,23 @@ class Previewer : AbstractFlashcardViewer() {
         previewLayout = PreviewLayout.createAndDisplay(this, toggleAnswerHandler)
         previewLayout!!.setOnNextCard { changePreviewedCard(true) }
         previewLayout!!.setOnPreviousCard { changePreviewedCard(false) }
+    }
+
+    @NeedsTest("handling: when valid and invalid")
+    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
+        when (keyCode) {
+            KeyEvent.KEYCODE_DPAD_LEFT -> {
+                Timber.i("Left pressed: previous card")
+                previewLayout?.prevCard?.performClickIfEnabled()
+                return true
+            }
+            KeyEvent.KEYCODE_DPAD_RIGHT -> {
+                Timber.i("Right pressed: next card")
+                previewLayout?.nextCard?.performClickIfEnabled()
+                return true
+            }
+        }
+        return super.onKeyDown(keyCode, event)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import android.view.View
+
+/** @see View.performClick */
+fun View.performClickIfEnabled() {
+    if (isEnabled) performClick()
+}


### PR DESCRIPTION
## Purpose / Description
* Requested by @sudomain

## How Has This Been Tested?
API 33 emulator

* could not test Ctrl+Shift+P in an emulator, but shift+P worked
* Previewer: left+ right worked, including holding + mashing the button
* We still have the issue with darkening the window when using keyboard commands

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
