### PR TITLE
feat: implement  Congrats screen links and deck options button

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1327,6 +1327,6 @@ class ContentProviderTest : InstrumentedTest() {
  */
 fun Scheduler.unburyCards() {
     for (did in col.decks.allNamesAndIds().map { it.id }) {
-        unburyCardsForDeck(did)
+        unburyDeck(did)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -545,7 +545,7 @@ open class DeckPicker :
             }
             DeckPickerContextMenuOption.UNBURY -> {
                 Timber.i("ContextMenu: Unbury deck selected")
-                getColUnsafe.sched.unburyCardsForDeck(deckId)
+                getColUnsafe.sched.unburyDeck(deckId)
                 onRequireDeckListUpdate()
                 dismissAllDialogFragments()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -245,7 +245,9 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             R.id.action_unbury -> {
                 Timber.i("StudyOptionsFragment:: unbury button pressed")
-                col!!.sched.unburyCardsForDeck()
+                launchCatchingTask {
+                    withCol { sched.unburyDeck(decks.getCurrentId()) }
+                }
                 refreshInterface(true)
                 item.isVisible = false
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -21,22 +21,26 @@ import android.os.Bundle
 import android.view.View
 import android.webkit.JavascriptInterface
 import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.OnPageFinishedCallback
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.launchCatching
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
-class CongratsPage : PageFragment() {
+class CongratsPage : PageFragment(), CustomStudyDialog.CustomStudyListener {
     override val title: String = ""
     override val pageName = "congrats"
 
@@ -77,6 +81,7 @@ class CongratsPage : PageFragment() {
         fun bridgeCommand(request: String) {
             when (request) {
                 "unbury" -> viewModel.onUnbury()
+                "customStudy" -> onStudyMore()
             }
         }
     }
@@ -87,6 +92,43 @@ class CongratsPage : PageFragment() {
         }
         startActivity(intent, null)
         requireActivity().finish()
+    }
+
+    private fun onStudyMore() {
+        val col = CollectionManager.getColUnsafe()
+        val dialogFragment = CustomStudyDialog(CollectionManager.getColUnsafe(), this).withArguments(
+            CustomStudyDialog.ContextMenuConfiguration.STANDARD,
+            col.decks.selected()
+        )
+        dialogFragment.show(childFragmentManager, null)
+    }
+
+    /******************************** CustomStudyListener methods ********************************/
+    override fun onExtendStudyLimits() {
+        Timber.v("CustomStudyListener::onExtendStudyLimits()")
+        openStudyOptionsAndFinish()
+    }
+
+    override fun showDialogFragment(newFragment: DialogFragment) {
+        Timber.v("CustomStudyListener::showDialogFragment()")
+        newFragment.show(childFragmentManager, null)
+    }
+
+    override fun onCreateCustomStudySession() {
+        Timber.v("CustomStudyListener::onCreateCustomStudySession()")
+        openStudyOptionsAndFinish()
+    }
+
+    override fun showProgressBar() {
+        Timber.v("CustomStudyListener::showProgressBar() - not handled")
+    }
+
+    override fun dismissAllDialogFragments() {
+        Timber.v("CustomStudyListener::dismissAllDialogFragments() - not handled")
+    }
+
+    override fun hideProgressBar() {
+        Timber.v("CustomStudyListener::hideProgressBar() - not handled")
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -17,11 +17,37 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.webkit.JavascriptInterface
+import com.ichi2.anki.OnPageFinishedCallback
 import com.ichi2.anki.SingleFragmentActivity
 
 class CongratsPage : PageFragment() {
     override val title: String = ""
     override val pageName = "congrats"
+
+    override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
+        return super.onCreateWebViewClient(savedInstanceState).also { client ->
+            client.onPageFinishedCallback = OnPageFinishedCallback { webView ->
+                webView.evaluateJavascript(
+                    "bridgeCommand = function(request){ ankidroid.bridgeCommand(request); };"
+                ) {}
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        webView.addJavascriptInterface(BridgeCommand(), "ankidroid")
+    }
+
+    inner class BridgeCommand {
+        @JavascriptInterface
+        fun bridgeCommand(request: String) {
+            TODO("$request will be handled in the next commit ;)")
+        }
+    }
 
     companion object {
         fun getIntent(context: Context): Intent {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -20,12 +20,27 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.webkit.JavascriptInterface
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.OnPageFinishedCallback
+import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.StudyOptionsActivity
+import com.ichi2.anki.launchCatching
+import com.ichi2.libanki.undoableOp
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class CongratsPage : PageFragment() {
     override val title: String = ""
     override val pageName = "congrats"
+
+    private val viewModel by viewModels<CongratsViewModel>()
 
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
         return super.onCreateWebViewClient(savedInstanceState).also { client ->
@@ -39,19 +54,58 @@ class CongratsPage : PageFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        viewModel.onError
+            .flowWithLifecycle(lifecycle)
+            .onEach { errorMessage ->
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.vague_error)
+                    .setMessage(errorMessage)
+                    .show()
+            }
+            .launchIn(lifecycleScope)
+
+        viewModel.openStudyOptions
+            .onEach { openStudyOptionsAndFinish() }
+            .launchIn(lifecycleScope)
+
         webView.addJavascriptInterface(BridgeCommand(), "ankidroid")
     }
 
     inner class BridgeCommand {
         @JavascriptInterface
         fun bridgeCommand(request: String) {
-            TODO("$request will be handled in the next commit ;)")
+            when (request) {
+                "unbury" -> viewModel.onUnbury()
+            }
         }
+    }
+
+    private fun openStudyOptionsAndFinish() {
+        val intent = Intent(requireContext(), StudyOptionsActivity::class.java).apply {
+            putExtra("withDeckOptions", false)
+        }
+        startActivity(intent, null)
+        requireActivity().finish()
     }
 
     companion object {
         fun getIntent(context: Context): Intent {
             return SingleFragmentActivity.getIntent(context, CongratsPage::class)
+        }
+    }
+}
+
+class CongratsViewModel : ViewModel(), OnErrorListener {
+    override val onError = MutableSharedFlow<String>()
+    val openStudyOptions = MutableSharedFlow<Boolean>()
+
+    fun onUnbury() {
+        launchCatching {
+            undoableOp {
+                sched.unburyDeck(decks.getCurrentId())
+            }
+            openStudyOptions.emit(true)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.LanguageUtils
+import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.launchCatching
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
@@ -33,8 +34,6 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.Sound.addPlayButtons
 import com.ichi2.themes.Themes
 import com.ichi2.utils.toRGBHex
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
@@ -46,9 +45,12 @@ import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
 import timber.log.Timber
 
-class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int) : ViewModel() {
+class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int) :
+    ViewModel(),
+    OnErrorListener {
+
+    override val onError = MutableSharedFlow<String>()
     val eval = MutableSharedFlow<String>()
-    val onError = MutableSharedFlow<String>()
     val currentIndex = MutableStateFlow(firstIndex)
     val backsideOnly = MutableStateFlow(false)
     val isMarked = MutableStateFlow(false)
@@ -184,12 +186,6 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
             } else if (showingAnswer.value && !backsideOnly.value) {
                 showQuestion()
             }
-        }
-    }
-
-    private fun launchCatching(block: suspend PreviewerViewModel.() -> Unit): Job {
-        return launchCatching(block, Dispatchers.IO) { message ->
-            onError.emit(message)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -27,7 +27,6 @@ import anki.card_rendering.EmptyCardsReport
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
 import anki.config.ConfigKey
-import anki.scheduler.CongratsInfoResponse
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
@@ -738,15 +737,7 @@ open class Collection(
         return backend.updateImageOcclusionNoteRaw(input = input)
     }
 
-    // TODO either support bridgeCommand here
-    //   or replace it with POST requests in Anki Desktop (preferable)
-    //   https://github.com/ankidroid/Anki-Android/issues/14361#issuecomment-1701946364
     fun congratsInfoRaw(input: ByteArray): ByteArray {
-        val byteArray = backend.congratsInfoRaw(input = input)
-        val response = CongratsInfoResponse.parseFrom(byteArray)
-        return CongratsInfoResponse.newBuilder(response)
-            .setBridgeCommandsSupported(false)
-            .build()
-            .toByteArray()
+        return backend.congratsInfoRaw(input = input)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -206,10 +206,11 @@ class Decks(private val col: Collection) {
         return result
     }
 
-    /** The currently selected did. */
-    fun selected(): DeckId {
-        return this.col.backend.getCurrentDeck().id
-    }
+    /** @return The currently selected deck ID. */
+    fun getCurrentId(): DeckId = col.backend.getCurrentDeck().id
+
+    /** @return The currently selected deck ID. */
+    fun selected(): DeckId = getCurrentId()
 
     fun current(): Deck {
         return this.get(this.selected()) ?: this.get(1)!!

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -39,6 +39,7 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.utils.TimeManager.time
+import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 
 data class CurrentQueueState(
@@ -254,45 +255,12 @@ open class Scheduler(val col: Collection) {
         )
     }
 
-    /**
-     * Unbury cards.
-     * @param type Which kind of cards should be unburied. See [UnburyType]
-     * @param did: the deck whose cards must be unburied
-     */
-    open fun unburyCardsForDeck(did: DeckId, type: UnburyType = UnburyType.ALL) {
-        val mode = when (type) {
-            UnburyType.ALL -> UnburyDeckRequest.Mode.ALL
-            UnburyType.MANUAL -> UnburyDeckRequest.Mode.USER_ONLY
-            UnburyType.SIBLINGS -> UnburyDeckRequest.Mode.SCHED_ONLY
-        }
-        col.backend.unburyDeck(deckId = did, mode = mode)
-    }
-
-    /**
-     * Parameter to describe what kind of cards must be unburied.
-     */
-    enum class UnburyType {
-        /**
-         * Represents all buried cards
-         */
-        ALL,
-
-        /**
-         * Represents cards that have been buried explicitly by the user using the reviewer
-         */
-        MANUAL,
-
-        /**
-         * Represents cards that were buried because they are the siblings of a reviewed cards.
-         */
-        SIBLINGS
-    }
-
-    /**
-     * Unbury all buried cards in selected decks
-     */
-    fun unburyCardsForDeck(type: UnburyType = UnburyType.ALL) {
-        unburyCardsForDeck(col.decks.selected(), type)
+    @RustCleanup("check if callers use the correct UnburyDeckRequest.Mode for their cases")
+    fun unburyDeck(
+        deckId: DeckId,
+        mode: UnburyDeckRequest.Mode = UnburyDeckRequest.Mode.ALL
+    ): OpChanges {
+        return col.backend.unburyDeck(deckId, mode)
     }
 
     /**

--- a/AnkiDroid/src/main/res/menu/congrats.xml
+++ b/AnkiDroid/src/main/res/menu/congrats.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+
+  This program is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License as published by the Free Software
+  Foundation; either version 3 of the License, or (at your option) any later
+  version.
+
+  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_open_deck_options"
+        android:title="@string/menu__deck_options"
+        android:icon="@drawable/ic_tune_white"
+        app:showAsAction="ifRoom"/>
+</menu>

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.scheduler.UnburyDeckRequest
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.Consts.BUTTON_FOUR
 import com.ichi2.libanki.Consts.BUTTON_ONE
@@ -36,7 +37,6 @@ import com.ichi2.libanki.Consts.STARTING_FACTOR
 import com.ichi2.libanki.Consts.SYNC_VER
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.Counts
-import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.testutils.AnkiAssert
@@ -685,6 +685,7 @@ open class SchedulerTest : JvmTest() {
         note.setItem("Front", "two")
         col.addNote(note)
         val c2 = note.cards()[0]
+        val did = col.decks.getCurrentId()
         // burying
         col.sched.buryCards(listOf(c.id), true)
         c.load()
@@ -693,16 +694,16 @@ open class SchedulerTest : JvmTest() {
         c2.load()
         Assert.assertEquals(QUEUE_TYPE_SIBLING_BURIED, c2.queue)
         assertNull(col.sched.card)
-        col.sched.unburyCardsForDeck(Scheduler.UnburyType.MANUAL)
+        col.sched.unburyDeck(did, UnburyDeckRequest.Mode.USER_ONLY)
         c.load()
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
         c2.load()
         Assert.assertEquals(QUEUE_TYPE_SIBLING_BURIED, c2.queue)
-        col.sched.unburyCardsForDeck(Scheduler.UnburyType.SIBLINGS)
+        col.sched.unburyDeck(did, UnburyDeckRequest.Mode.SCHED_ONLY)
         c2.load()
         Assert.assertEquals(QUEUE_TYPE_NEW, c2.queue)
         col.sched.buryCards(listOf(c.id, c2.id))
-        col.sched.unburyCardsForDeck(Scheduler.UnburyType.ALL)
+        col.sched.unburyDeck(did, UnburyDeckRequest.Mode.ALL)
         Assert.assertEquals(Counts(2, 0, 0), col.sched.counts())
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

## Fixes
* Fixes most of #14955. 

Only pending thing is the button leading to the deck description. I haven't added the `Unbury` and `Custom study` buttons because I think that the links are sufficient

## Approach
In the commits

## How Has This Been Tested?

Emulator 31:

[Screen_recording_20240112_213816.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/25fa0a7d-a068-4f85-bd09-4b099f2444b8)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
