### PR TITLE
Color of Bottom Window changes based on the theme of the app.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -191,7 +191,7 @@ open class Reviewer :
         textBarReview = findViewById(R.id.review_number)
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
-        window!!.navigationBarColor = ThemeUtils.getThemeAttrColor(
+        window.navigationBarColor = ThemeUtils.getThemeAttrColor(
             this,
             R.attr.showAnswerColor
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -37,6 +37,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.*
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
+import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -190,6 +191,10 @@ open class Reviewer :
         textBarReview = findViewById(R.id.review_number)
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
+        window!!.navigationBarColor = ThemeUtils.getThemeAttrColor(
+            this,
+            R.attr.showAnswerColor
+        )
 
         startLoadingCollection()
     }

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -90,6 +90,7 @@
     <attr name="reviewCountColor" format="color"/>
     <attr name="zeroCountColor" format="color"/>
     <!-- Reviewer button backgrounds -->
+    <attr name="showAnswerColor" format="reference"/>
     <attr name="againButtonRef" format="reference"/>
     <attr name="hardButtonRef" format="reference"/>
     <attr name="goodButtonRef" format="reference"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -39,6 +39,7 @@
         <item name="reviewCountColor">@color/material_green_400</item>
         <item name="zeroCountColor">#202020</item>
         <!-- Reviewer colors -->
+        <item name="showAnswerColor">@color/theme_black_primary</item>
         <item name="topBarColor">@color/theme_black_primary</item>
         <item name="maxTimerColor">@color/material_red_300</item>
         <item name="answerButtonTextColor">@color/theme_black_primary_text</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -70,6 +70,7 @@
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
         <!-- Reviewer button drawables -->
+        <item name="showAnswerColor">@color/material_blue_grey_800</item>
         <item name="againButtonRef">@drawable/footer_button_again_dark</item>
         <item name="hardButtonRef">@drawable/footer_button_hard_dark</item>
         <item name="goodButtonRef">@drawable/footer_button_good_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -62,6 +62,7 @@
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
         <!-- Reviewer button drawables -->
+        <item name="showAnswerColor">@color/material_blue_grey_700</item>
         <item name="againButtonRef">@drawable/footer_button_again</item>
         <item name="hardButtonRef">@drawable/footer_button_hard</item>
         <item name="goodButtonRef">@drawable/footer_button_good</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -24,6 +24,7 @@
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_plain_primary_light</item>
         <!-- Reviewer button drawables -->
+        <item name="showAnswerColor">@color/theme_plain_primary</item>
         <item name="againButtonRef">@drawable/footer_button_all_plain</item>
         <item name="hardButtonRef">@drawable/footer_button_all_plain</item>
         <item name="goodButtonRef">@drawable/footer_button_all_plain</item>


### PR DESCRIPTION
## Fixes
* Fixes #14209

## Testing Instructions
 1. Change the theme of the app from (Hamburger Menu ---> Settings ---> Appearance ---> Select Theme)
 2. Choose the theme (Light, Plain, Black, Dark)
 3. Go to home. 
 4. Open any card and then check the show answer button color matches the theme of the app.
 5. Repeat step 1 till you test all theme (Light, Plain, Black, Dark)
 

## How Has This Been Tested?
This has been tested on physical device(Realme 3i) and on emulator (Google Pixel 3)

## Screenshots

**App Theme**

<br>

| Black Mode | Dark Mode | Light Mode | Plain Mode |
|------------|-----------|------------|------------|
| ![Black_Mode](https://github.com/ankidroid/Anki-Android/assets/60827173/0bb5c24f-c475-45f0-a417-c9151eb1e929) | ![Dark_Mode](https://github.com/ankidroid/Anki-Android/assets/60827173/6a9f193e-c2ec-4974-9d66-9c397902daf4) | ![Light_mode](https://github.com/ankidroid/Anki-Android/assets/60827173/c2cf08ac-e37f-465e-890f-3a16e4af6bb4) | ![Plain_Mode](https://github.com/ankidroid/Anki-Android/assets/60827173/0977b3c8-9557-4a11-9544-44392fdc217a) |


This is a second PR released as in first commit I messed up the force push. For historical comments review refer to 
* #15085