### PR TITLE
audio recorder functionality improvement

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,8 +74,6 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.audio.AudioRecordingController
 import com.ichi2.audio.AudioRecordingController.Companion.generateTempAudioFile
-import com.ichi2.audio.AudioRecordingController.Companion.isPaused
-import com.ichi2.audio.AudioRecordingController.Companion.isPlaying
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
 import com.ichi2.audio.AudioRecordingController.Companion.isSaved
 import com.ichi2.audio.AudioRecordingController.Companion.setReviewerStatus
@@ -559,16 +557,7 @@ open class Reviewer :
         if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.clear()
         }
-        try {
-            if (isPlaying) {
-                audioRecordingController!!.discardAudio()
-            }
-            if (isRecording || isPaused) {
-                audioRecordingController!!.clearRecording()
-            }
-        } catch (e: Exception) {
-            Timber.d("Unable to reset the audio recorder", e)
-        }
+        audioRecordingController?.updateUIForNewCard()
     }
 
     override fun unblockControls() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,6 +74,8 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.audio.AudioRecordingController
 import com.ichi2.audio.AudioRecordingController.Companion.generateTempAudioFile
+import com.ichi2.audio.AudioRecordingController.Companion.isPaused
+import com.ichi2.audio.AudioRecordingController.Companion.isPlaying
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
 import com.ichi2.audio.AudioRecordingController.Companion.isSaved
 import com.ichi2.audio.AudioRecordingController.Companion.setReviewerStatus
@@ -556,6 +558,16 @@ open class Reviewer :
         super.updateForNewCard()
         if (prefWhiteboard && whiteboard != null) {
             whiteboard!!.clear()
+        }
+        try {
+            if (isPlaying) {
+                audioRecordingController!!.discardAudio()
+            }
+            if (isRecording || isPaused) {
+                audioRecordingController!!.clearRecording()
+            }
+        } catch (e: Exception) {
+            Timber.d("Unable to reset the audio recorder", e)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,8 +74,8 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.audio.AudioRecordingController
 import com.ichi2.audio.AudioRecordingController.Companion.generateTempAudioFile
+import com.ichi2.audio.AudioRecordingController.Companion.isAudioRecordingSaved
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
-import com.ichi2.audio.AudioRecordingController.Companion.isSaved
 import com.ichi2.audio.AudioRecordingController.Companion.setReviewerStatus
 import com.ichi2.audio.AudioRecordingController.Companion.tempAudioPath
 import com.ichi2.libanki.*
@@ -527,7 +527,7 @@ open class Reviewer :
         if (!openMicToolbar()) {
             return
         }
-        if (isSaved) {
+        if (isAudioRecordingSaved) {
             audioRecordingController?.playPausePlayer()
         } else {
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -105,7 +105,7 @@ class MultimediaEditFieldActivity :
     // in case media is saved by view button then allows it to be inserted into the filed
     private fun onBack() {
         findViewById<Toolbar>(R.id.toolbar).setNavigationOnClickListener {
-            if (isAudioUIInitialized && isAudioRecordingSaved) {
+            if (isAudioUIInitialized) {
                 done()
             } else {
                 saveAndExit()
@@ -153,6 +153,8 @@ class MultimediaEditFieldActivity :
 
         // Permissions are checked async, save our current state to allow continuation
         currentChangeRequest = newUI
+
+        if (isAudioUIInitialized) audioRecordingController.onViewFocusChanged()
 
         // If we went through the permission check once, we don't need to do it again.
         // As we only get here a second time if we have the required permissions
@@ -206,6 +208,9 @@ class MultimediaEditFieldActivity :
             }
             R.id.multimedia_edit_field_done -> {
                 Timber.i("Save button pressed")
+                if (isAudioUIInitialized && isRecording) {
+                    audioRecordingController.stopAndSaveRecording()
+                }
                 done()
                 return true
             }
@@ -215,9 +220,6 @@ class MultimediaEditFieldActivity :
 
     @KotlinCleanup("rename: bChangeToText")
     private fun done() {
-        if (isAudioUIInitialized) {
-            if (isRecording) audioRecordingController.stopAndSaveRecording()
-        }
         var bChangeToText = false
         if (field.type === EFieldType.IMAGE) {
             if (field.imagePath == null) {
@@ -235,7 +237,7 @@ class MultimediaEditFieldActivity :
                     }
                 }
             }
-        } else if (field.type === EFieldType.AUDIO_RECORDING) {
+        } else if (field.type === EFieldType.AUDIO_RECORDING && isAudioRecordingSaved) {
             if (field.audioPath == null) {
                 bChangeToText = true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -16,9 +16,11 @@
 package com.ichi2.audio
 
 import android.app.Activity
+import android.app.Application
 import android.content.Context
 import android.content.res.Configuration
 import android.media.MediaPlayer
+import android.os.Bundle
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.OrientationEventListener
@@ -72,9 +74,7 @@ class AudioRecordingController :
     private lateinit var audioWaveform: AudioWaveform
     private lateinit var audioProgressBar: LinearProgressIndicator
     lateinit var context: Context
-    private var isPaused = false
     private var isCleared = false
-    private var isPlaying = false
     private lateinit var cancelAudioRecordingButton: MaterialButton
     private lateinit var playAudioButtonLayout: LinearLayout
     private lateinit var recordAudioButtonLayout: LinearLayout
@@ -150,6 +150,8 @@ class AudioRecordingController :
         cancelAudioRecordingButton.isEnabled = false
         saveButton.isEnabled = false
 
+        saveButton.setIconResource(if (!inEditField) R.drawable.ic_done_white else R.drawable.ic_save_white)
+
         if (audioPlayer == null) {
             Timber.d("Creating media player for playback")
             audioPlayer = MediaPlayer()
@@ -173,37 +175,11 @@ class AudioRecordingController :
         }
 
         cancelAudioRecordingButton.setOnClickListener {
-            CompatHelper.compat.vibrate(context, 20)
-            isCleared = true
             clearRecording()
         }
 
         discardRecordingButton.setOnClickListener {
-            CompatHelper.compat.vibrate(context, 20)
-            recordButton.apply {
-                iconTint = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
-                strokeColor = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
-                setIconResource(R.drawable.ic_record)
-            }
-            playAudioButton.apply {
-                setIconResource(R.drawable.round_play_arrow_24)
-                iconTint = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
-                strokeColor = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
-            }
-            cancelAudioRecordingButton.isEnabled = false
-            tempAudioPath = generateTempAudioFile(context).also { tempAudioPath = it }
-            audioTimeView.text = DEFAULT_TIME
-            audioWaveform.clear()
-            isPaused = false
-            isCleared = true
-            isRecording = false
-            audioTimer.stop()
-            audioPlayer?.stop()
-            audioPlayer?.release()
-            audioTimer = AudioTimer(this, this)
-            saveButton.isEnabled = false
-            playAudioButtonLayout.visibility = View.GONE
-            recordAudioButtonLayout.visibility = View.VISIBLE
+            discardAudio()
         }
         orientationEventListener = object : OrientationEventListener(context) {
             override fun onOrientationChanged(orientation: Int) {
@@ -220,6 +196,81 @@ class AudioRecordingController :
             }
         }
         orientationEventListener?.enable()
+
+        (context as? Activity)?.let { activity ->
+            activity.application.registerActivityLifecycleCallbacks(object : Application.ActivityLifecycleCallbacks {
+                override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+                    // Not needed
+                }
+
+                override fun onActivityStarted(activity: Activity) {
+                    // Not needed
+                }
+
+                override fun onActivityResumed(activity: Activity) {
+                    // not needed
+                }
+
+                override fun onActivityPaused(activity: Activity) {
+                    if (activity == context) {
+                        onViewFocusChanged()
+                    }
+                }
+
+                override fun onActivityStopped(activity: Activity) {
+                    // Not needed
+                }
+
+                override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+                    // Not needed
+                }
+
+                override fun onActivityDestroyed(activity: Activity) {
+                    // not needed
+                }
+            })
+        }
+    }
+
+    private fun onViewFocusChanged() {
+        if (isRecording || isPaused) {
+            clearRecording()
+        }
+        if (isPlaying) {
+            stopAudioPlayer()
+        }
+    }
+
+    fun discardAudio() {
+        CompatHelper.compat.vibrate(context, 20)
+        recordButton.apply {
+            iconTint = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
+            strokeColor = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
+            setIconResource(R.drawable.ic_record)
+        }
+        playAudioButton.apply {
+            setIconResource(R.drawable.round_play_arrow_24)
+            iconTint = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
+            strokeColor = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
+        }
+        cancelAudioRecordingButton.isEnabled = false
+        tempAudioPath = generateTempAudioFile(context).also { tempAudioPath = it }
+        audioTimeView.text = DEFAULT_TIME
+        stopAudioPlayer()
+    }
+
+    private fun stopAudioPlayer() {
+        audioWaveform.clear()
+        isPaused = false
+        isCleared = true
+        isRecording = false
+        audioTimer.stop()
+        audioPlayer?.stop()
+        audioPlayer?.release()
+        audioTimer = AudioTimer(this, this)
+        saveButton.isEnabled = false
+        playAudioButtonLayout.visibility = View.GONE
+        recordAudioButtonLayout.visibility = View.VISIBLE
     }
 
     private fun prepareAudioPlayer() {
@@ -392,7 +443,9 @@ class AudioRecordingController :
         recordButton.setIconResource(R.drawable.round_pause_24)
     }
 
-    private fun clearRecording() {
+    fun clearRecording() {
+        CompatHelper.compat.vibrate(context, 20)
+        isCleared = true
         audioTimer.stop()
         recordButton.setIconResource(R.drawable.ic_record)
         cancelAudioRecordingButton.isEnabled = false
@@ -444,6 +497,8 @@ class AudioRecordingController :
     companion object {
         var isRecording = false
         var isSaved = false
+        var isPaused = false
+        var isPlaying = false
         private var inEditField: Boolean = true
         const val DEFAULT_TIME = "00:00.00"
         const val JUMP_VALUE = 500

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -75,6 +75,8 @@ class AudioRecordingController :
     private lateinit var audioProgressBar: LinearProgressIndicator
     lateinit var context: Context
     private var isCleared = false
+    private var isPaused = false
+    private var isPlaying = false
     private lateinit var cancelAudioRecordingButton: MaterialButton
     private lateinit var playAudioButtonLayout: LinearLayout
     private lateinit var recordAudioButtonLayout: LinearLayout
@@ -166,7 +168,7 @@ class AudioRecordingController :
         }
 
         saveButton.setOnClickListener {
-            isSaved = false
+            isAudioRecordingSaved = false
             toggleSave()
         }
 
@@ -232,7 +234,7 @@ class AudioRecordingController :
         }
     }
 
-    private fun onViewFocusChanged() {
+    fun onViewFocusChanged() {
         if (isRecording || isPaused) {
             clearRecording()
         }
@@ -241,7 +243,7 @@ class AudioRecordingController :
         }
     }
 
-    fun discardAudio() {
+    private fun discardAudio() {
         CompatHelper.compat.vibrate(context, 20)
         recordButton.apply {
             iconTint = ContextCompat.getColorStateList(context, R.color.audio_recorder_red)
@@ -428,7 +430,7 @@ class AudioRecordingController :
         cancelAudioRecordingButton.isEnabled = false
         audioTimeView.text = DEFAULT_TIME
         audioWaveform.clear()
-        isSaved = true
+        isAudioRecordingSaved = true
         // save recording only in the edit field not in the reviewer but save it temporarily
         if (inEditField) saveRecording()
     }
@@ -447,7 +449,7 @@ class AudioRecordingController :
         recordButton.setIconResource(R.drawable.round_pause_24)
     }
 
-    fun clearRecording() {
+    private fun clearRecording() {
         CompatHelper.compat.vibrate(context, 20)
         isCleared = true
         audioTimer.stop()
@@ -514,9 +516,7 @@ class AudioRecordingController :
 
     companion object {
         var isRecording = false
-        var isSaved = false
-        var isPaused = false
-        var isPlaying = false
+        var isAudioRecordingSaved = false
         private var inEditField: Boolean = true
         const val DEFAULT_TIME = "00:00.00"
         const val JUMP_VALUE = 500

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -475,6 +475,20 @@ class AudioRecordingController :
         audioRecorder.release()
     }
 
+    // when answer button is clicked in reviewer
+    fun updateUIForNewCard() {
+        try {
+            if (isPlaying) {
+                discardAudio()
+            }
+            if (isRecording || isPaused) {
+                clearRecording()
+            }
+        } catch (e: Exception) {
+            Timber.d("Unable to reset the audio recorder", e)
+        }
+    }
+
     override fun onTimerTick(duration: Duration) {
         if (isPlaying && !isRecording) {
             // This may remain at 0 for a few hundred ms while the audio player starts

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -154,13 +154,7 @@ class AudioRecordingController :
 
         saveButton.setIconResource(if (!inEditField) R.drawable.ic_done_white else R.drawable.ic_save_white)
 
-        if (audioPlayer == null) {
-            Timber.d("Creating media player for playback")
-            audioPlayer = MediaPlayer()
-        } else {
-            Timber.d("Resetting media for playback")
-            audioPlayer!!.reset()
-        }
+        setUpMediaPlayer()
 
         audioTimer = AudioTimer(this, this)
         recordButton.setOnClickListener {
@@ -231,6 +225,20 @@ class AudioRecordingController :
                     // not needed
                 }
             })
+        }
+    }
+
+    private fun setUpMediaPlayer() {
+        try {
+            if (audioPlayer == null) {
+                Timber.d("Creating media player for playback")
+                audioPlayer = MediaPlayer()
+            } else {
+                Timber.d("Resetting media for playback")
+                audioPlayer!!.reset()
+            }
+        } catch (e: IllegalStateException) {
+            Timber.w("Media Player couldn't be reset or already reset", e)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -264,9 +264,13 @@ class AudioRecordingController :
         isPaused = false
         isCleared = true
         isRecording = false
-        audioTimer.stop()
-        audioPlayer?.stop()
-        audioPlayer?.release()
+        try {
+            audioTimer.stop()
+            audioPlayer?.stop()
+            audioPlayer?.release()
+        } catch (e: Exception) {
+            Timber.w(e)
+        }
         audioTimer = AudioTimer(this, this)
         saveButton.isEnabled = false
         playAudioButtonLayout.visibility = View.GONE

--- a/AnkiDroid/src/main/res/layout/activity_audio_recording.xml
+++ b/AnkiDroid/src/main/res/layout/activity_audio_recording.xml
@@ -90,7 +90,6 @@
                 android:clickable="true"
                 android:focusable="true"
                 app:backgroundTint="@color/material_blue_500"
-                app:icon="@drawable/ic_save_white"
                 app:iconPadding="0dp"
                 app:iconSize="22dp" />
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
There were few TODOs I left for myself when I created the previous PRs, so this PR further improves the audio recorder logic and functionality (UX)

- Stop the audio recorder or player in case the user presses back while in multimedia activity or exits the activity. As of now the audio recorder keeps going on and same for the player the audio is played even if the user leaves the screen 
- Same for the reviewer 
- When the user goes to next card the audio recorder UI gets reset to its initial state (was suggested by David)
- When in reviewer the save icon(disk) does not makes sense so replacing it with done icon in case of reviewer 

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15300

## How Has This Been Tested?

Tested on Google emulator 
- Pressed back while playing audio
- Pressed back while recording 
- Pressed back while the recorder was paused 
- changed multiple cards 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
