### PR TITLE
refactor: move onCreateView content to onViewCreated on some fragments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -20,9 +20,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.print.PrintAttributes
 import android.print.PrintManager
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.core.content.ContextCompat.getSystemService
 import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.CollectionManager
@@ -39,14 +37,8 @@ class Statistics : PageFragment() {
     override var webViewClient = PageWebViewClient()
     override var webChromeClient = PageChromeClient()
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        val view = super.onCreateView(inflater, container, savedInstanceState)
-
-        view?.findViewById<MaterialToolbar>(R.id.toolbar)?.apply {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        view.findViewById<MaterialToolbar>(R.id.toolbar)?.apply {
             inflateMenu(R.menu.statistics)
             menu.findItem(R.id.action_export_stats).title = CollectionManager.TR.statisticsSavePdf()
             setOnMenuItemClickListener { item ->
@@ -56,8 +48,6 @@ class Statistics : PageFragment() {
                 true
             }
         }
-
-        return view
     }
 
     /**Prepares and initiates a printing task for the content(stats) displayed in the WebView.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -20,9 +20,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.text.format.DateFormat
 import android.text.method.LinkMovementMethod
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
@@ -42,35 +40,30 @@ import java.util.Date
 import java.util.Locale
 import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
-class AboutFragment : Fragment() {
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        val layoutView = inflater.inflate(R.layout.about_layout, container, false)
+class AboutFragment : Fragment(R.layout.about_layout) {
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         // Version date
         val apkBuildDate = SimpleDateFormat(DateFormat.getBestDateTimePattern(Locale.getDefault(), "d MMM yyyy"))
             .format(Date(BuildConfig.BUILD_TIME))
-        layoutView.findViewById<TextView>(R.id.about_build_date).text = apkBuildDate
+        view.findViewById<TextView>(R.id.about_build_date).text = apkBuildDate
 
         // Version text
-        layoutView.findViewById<TextView>(R.id.about_version).text =
+        view.findViewById<TextView>(R.id.about_version).text =
             pkgVersionName
 
         // Backend version text
-        layoutView.findViewById<TextView>(R.id.about_backend).text =
+        view.findViewById<TextView>(R.id.about_backend).text =
             "(anki " + BackendBuildConfig.ANKI_DESKTOP_VERSION + " / " + BackendBuildConfig.ANKI_COMMIT_HASH.subSequence(0, 8) + ")"
 
         // Logo secret
-        layoutView.findViewById<ImageView>(R.id.about_app_logo)
+        view.findViewById<ImageView>(R.id.about_app_logo)
             .setOnClickListener(DevOptionsSecretClickListener(requireActivity() as Preferences))
 
         // Contributors text
         val contributorsLink = getString(R.string.link_contributors)
         val contributingGuideLink = getString(R.string.link_contribution)
-        layoutView.findViewById<TextView>(R.id.about_contributors_description).apply {
+        view.findViewById<TextView>(R.id.about_contributors_description).apply {
             text = getString(R.string.about_contributors_description, contributorsLink, contributingGuideLink).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
@@ -79,25 +72,25 @@ class AboutFragment : Fragment() {
         val gplLicenseLink = getString(R.string.licence_wiki)
         val agplLicenseLink = getString(R.string.link_agpl_wiki)
         val sourceCodeLink = getString(R.string.link_source)
-        layoutView.findViewById<TextView>(R.id.about_license_description).apply {
+        view.findViewById<TextView>(R.id.about_license_description).apply {
             text = getString(R.string.license_description, gplLicenseLink, agplLicenseLink, sourceCodeLink).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
 
         // Donate text
         val donateLink = getString(R.string.link_opencollective_donate)
-        layoutView.findViewById<TextView>(R.id.about_donate_description).apply {
+        view.findViewById<TextView>(R.id.about_donate_description).apply {
             text = getString(R.string.donate_description, donateLink).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
 
         // Rate Ankidroid button
-        layoutView.findViewById<Button>(R.id.about_rate).setOnClickListener {
+        view.findViewById<Button>(R.id.about_rate).setOnClickListener {
             IntentUtil.tryOpenIntent((requireActivity() as AnkiActivity), AnkiDroidApp.getMarketIntent(requireContext()))
         }
 
         // Open changelog button
-        layoutView.findViewById<Button>(R.id.about_open_changelog).setOnClickListener {
+        view.findViewById<Button>(R.id.about_open_changelog).setOnClickListener {
             val openChangelogIntent = Intent(requireContext(), Info::class.java).apply {
                 putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
             }
@@ -105,11 +98,9 @@ class AboutFragment : Fragment() {
         }
 
         // Copy debug info button
-        layoutView.findViewById<Button>(R.id.about_copy_debug).setOnClickListener {
+        view.findViewById<Button>(R.id.about_copy_debug).setOnClickListener {
             copyDebugInfo()
         }
-
-        return layoutView
     }
 
     override fun onStart() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
@@ -17,9 +17,7 @@ package com.ichi2.anki.ui.windows.permissions
 
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.R
@@ -36,24 +34,15 @@ import com.ichi2.utils.Permissions.canManageExternalStorage
  *   which isn't deleted when the app is uninstalled
  */
 @RequiresApi(Build.VERSION_CODES.R)
-class Full30and31PermissionsFragment : PermissionsFragment() {
+class Full30and31PermissionsFragment : PermissionsFragment(R.layout.permissions_full_30_and_31) {
 
     private val accessAllFilesLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
     ) {}
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val view = inflater.inflate(R.layout.permissions_full_30_and_31, container, false)
-
-        val allFilesPermission = view.findViewById<PermissionItem>(R.id.all_files_permission)
-        allFilesPermission.setOnSwitchClickListener {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {
             accessAllFilesLauncher.showManageAllFilesScreen()
         }
-
-        return view
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
@@ -20,6 +20,7 @@ import android.net.Uri
 import android.os.Build
 import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.LayoutRes
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.core.view.allViews
@@ -29,7 +30,7 @@ import com.ichi2.anki.UIUtils
 /**
  * Base class for constructing a permissions screen
  */
-abstract class PermissionsFragment : Fragment() {
+abstract class PermissionsFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayoutId) {
     /**
      * All the [PermissionItem]s in the fragment.
      * Must be called ONLY AFTER [onCreateView]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
@@ -16,9 +16,7 @@
 package com.ichi2.anki.ui.windows.permissions
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import com.ichi2.anki.R
 import com.ichi2.utils.Permissions
@@ -32,18 +30,12 @@ import com.ichi2.utils.hasAnyOfPermissionsBeenDenied
  *   Used for saving the collection in a public directory
  *   which isn't deleted when the app is uninstalled
  */
-class PermissionsUntil29Fragment : PermissionsFragment() {
+class PermissionsUntil29Fragment : PermissionsFragment(R.layout.permissions_until_29) {
     private val storageLauncher = registerForActivityResult(
         ActivityResultContracts.RequestMultiplePermissions()
     ) {}
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val view = inflater.inflate(R.layout.permissions_until_29, container, false)
-
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val storagePermission = view.findViewById<PermissionItem>(R.id.storage_permission)
         storagePermission.setOnSwitchClickListener {
             if (!hasAnyOfPermissionsBeenDenied(storagePermission.permissions)) {
@@ -52,7 +44,5 @@ class PermissionsUntil29Fragment : PermissionsFragment() {
                 showToastAndOpenAppSettingsScreen(R.string.startup_no_storage_permission)
             }
         }
-
-        return view
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
@@ -17,9 +17,7 @@ package com.ichi2.anki.ui.windows.permissions
 
 import android.os.Build
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.R
@@ -37,21 +35,12 @@ import com.ichi2.utils.Permissions.canManageExternalStorage
  * 2. TODO notifications permission
  */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-class TiramisuPermissionsFragment : PermissionsFragment() {
+class TiramisuPermissionsFragment : PermissionsFragment(R.layout.permissions_tiramisu) {
     private val accessAllFilesLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
 
-    override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View {
-        val view = inflater.inflate(R.layout.permissions_tiramisu, container, false)
-
-        val allFilesPermission = view.findViewById<PermissionItem>(R.id.all_files_permission)
-        allFilesPermission.setOnSwitchClickListener {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {
             accessAllFilesLauncher.showManageAllFilesScreen()
         }
-
-        return view
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
As the docs of [onCreateView](https://developer.android.com/reference/androidx/fragment/app/Fragment.html#onCreateView(android.view.LayoutInflater,android.view.ViewGroup,android.os.Bundle)) says:
> It is recommended to only inflate the layout in this method and move logic that operates on the returned View to [onViewCreated](https://developer.android.com/reference/androidx/fragment/app/Fragment#onViewCreated(android.view.View,android.os.Bundle)).

Most of the other fragments are handled in #15218 

so I did some cleaning

## How Has This Been Tested?

34 emulator:
check if statistics, about and permissions screen still appear

## Learning (optional, can help others)

Fragment has a constructor which accepts a layout resource to automatically inflate it (thanks to lukstbit for pointing it out) [source](https://developer.android.com/reference/androidx/fragment/app/Fragment.html#Fragment(int))

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
