### PR TITLE
chore: Remove `col` from class Card

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1177,7 +1177,7 @@ class ContentProviderTest : InstrumentedTest() {
         // get the first card due
         // ----------------------
         val card = getFirstCardFromScheduler(col)
-        val note = card!!.note()
+        val note = card!!.note(col)
         val noteId = note.id
 
         // make sure the tag is what we expect initially
@@ -1312,7 +1312,7 @@ class ContentProviderTest : InstrumentedTest() {
             )
             for (c in newNote.cards()) {
                 c.did = did
-                c.col.updateCard(c, skipUndoEntry = true)
+                col.updateCard(c, skipUndoEntry = true)
             }
             return Uri.withAppendedPath(
                 FlashCardsContract.Note.CONTENT_URI,

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -149,7 +149,7 @@ abstract class InstrumentedTest {
         this.queue = Consts.QUEUE_TYPE_REV
         this.type = Consts.CARD_TYPE_REV
         this.due = 0
-        this.col.updateCard(this, true)
+        col.updateCard(this, true)
     }
 
     @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -40,6 +40,7 @@ import com.ichi2.anki.servicelayer.resetCards
 import com.ichi2.anki.snackbar.setMaxLines
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.SortOrder
 import com.ichi2.utils.NetworkUtils
@@ -52,6 +53,9 @@ import timber.log.Timber
 open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     private val currentCard: Card
         get() = activity.currentCard!!
+
+    private val getColUnsafe: Collection
+        get() = activity.getColUnsafe
 
     /**
      Javascript Interface class for calling Java function from AnkiDroid WebView
@@ -226,7 +230,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                 activity.launchCatchingTask { activity.resetCards(cardIds) }
                 convertToByteArray(apiContract, true)
             }
-            "cardMark" -> convertToByteArray(apiContract, currentCard.note().hasTag("marked"))
+            "cardMark" -> convertToByteArray(apiContract, currentCard.note(getColUnsafe).hasTag("marked"))
             "cardFlag" -> convertToByteArray(apiContract, currentCard.userFlag())
             "cardReps" -> convertToByteArray(apiContract, currentCard.reps)
             "cardInterval" -> convertToByteArray(apiContract, currentCard.ivl)
@@ -355,8 +359,8 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
         val searchResult: MutableList<String> = ArrayList()
         for (s in cards) {
             val jsonObject = JSONObject()
-            val fieldsData = s.card.note().fields
-            val fieldsName = s.card.model().fieldsNames
+            val fieldsData = s.card.note(getColUnsafe).fields
+            val fieldsName = s.card.model(getColUnsafe).fieldsNames
 
             val noteId = s.card.nid
             val cardId = s.card.id

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1300,7 +1300,7 @@ open class CardBrowser :
         }
         val allTags = getColUnsafe.tags.all()
         val selectedNotes = selectedCardIds
-            .map { cardId: CardId? -> getColUnsafe.getCard(cardId!!).note() }
+            .map { cardId: CardId? -> getColUnsafe.getCard(cardId!!).note(getColUnsafe) }
             .distinct()
         val checkedTags = selectedNotes
             .flatMap { note: Note -> note.tags }
@@ -1514,7 +1514,7 @@ open class CardBrowser :
     private suspend fun editSelectedCardsTags(selectedTags: List<String>, indeterminateTags: List<String>) = withProgress {
         undoableOp {
             val selectedNotes = selectedCardIds
-                .map { cardId -> getCard(cardId).note() }
+                .map { cardId -> getCard(cardId).note(this) }
                 .distinct()
                 .onEach { note ->
                     val previousTags: List<String> = note.tags
@@ -1554,7 +1554,7 @@ open class CardBrowser :
         val card = cardBrowserCard!!
         withProgress {
             undoableOp {
-                updateNote(card.note())
+                updateNote(card.note(this))
             }
         }
         updateCardInList(card)
@@ -1965,7 +1965,7 @@ open class CardBrowser :
                     6 -> R.attr.flagTurquoise
                     7 -> R.attr.flagPurple
                     else -> {
-                        if (isMarked(card.note())) {
+                        if (isMarked(card.note(col))) {
                             R.attr.markedColor
                         } else if (card.queue == Consts.QUEUE_TYPE_SUSPENDED) {
                             R.attr.suspendedColor
@@ -1980,20 +1980,20 @@ open class CardBrowser :
             return when (key) {
                 CardBrowserColumn.FLAGS -> Integer.valueOf(card.userFlag()).toString()
                 CardBrowserColumn.SUSPENDED -> if (card.queue == Consts.QUEUE_TYPE_SUSPENDED) "True" else "False"
-                CardBrowserColumn.MARKED -> if (isMarked(card.note())) "marked" else null
-                CardBrowserColumn.SFLD -> card.note().sFld()
+                CardBrowserColumn.MARKED -> if (isMarked(card.note(col))) "marked" else null
+                CardBrowserColumn.SFLD -> card.note(col).sFld()
                 CardBrowserColumn.DECK -> col.decks.name(card.did)
-                CardBrowserColumn.TAGS -> card.note().stringTags()
-                CardBrowserColumn.CARD -> if (inCardMode) card.template().optString("name") else "${card.note().numberOfCards()}"
-                CardBrowserColumn.DUE -> card.dueString()
+                CardBrowserColumn.TAGS -> card.note(col).stringTags()
+                CardBrowserColumn.CARD -> if (inCardMode) card.template(col).optString("name") else "${card.note(col).numberOfCards()}"
+                CardBrowserColumn.DUE -> card.dueString(col)
                 CardBrowserColumn.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
-                CardBrowserColumn.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note().mod.toLong())
+                CardBrowserColumn.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note(col).mod.toLong())
                 CardBrowserColumn.CREATED -> LanguageUtil.getShortDateFormatFromMs(card.nid)
-                CardBrowserColumn.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note().mod)
+                CardBrowserColumn.EDITED -> LanguageUtil.getShortDateFormatFromS(card.note(col).mod)
                 CardBrowserColumn.INTERVAL -> if (inCardMode) queryIntervalForCards() else queryAvgIntervalForNotes()
-                CardBrowserColumn.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote()).toString()
-                CardBrowserColumn.NOTE_TYPE -> card.model().optString("name")
-                CardBrowserColumn.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote().toString()
+                CardBrowserColumn.LAPSES -> (if (inCardMode) card.lapses else card.totalLapsesOfNote(col)).toString()
+                CardBrowserColumn.NOTE_TYPE -> card.model(col).optString("name")
+                CardBrowserColumn.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote(col).toString()
                 CardBrowserColumn.QUESTION -> {
                     updateSearchItemQA()
                     mQa!!.first
@@ -2015,7 +2015,7 @@ open class CardBrowser :
         }
 
         private fun getAvgEaseForNotes(): String {
-            val avgEase = card.avgEaseOfNote()
+            val avgEase = card.avgEaseOfNote(col)
 
             return if (avgEase == null) {
                 AnkiDroidApp.instance.getString(R.string.card_browser_interval_new_card)
@@ -2033,7 +2033,7 @@ open class CardBrowser :
         }
 
         private fun queryAvgIntervalForNotes(): String {
-            val avgInterval = card.avgIntervalOfNote()
+            val avgInterval = card.avgIntervalOfNote(col)
 
             return if (avgInterval == null) {
                 "" // upstream does not display interval for notes with new or learning cards
@@ -2048,7 +2048,7 @@ open class CardBrowser :
             if (reload) {
                 reload()
             }
-            card.note()
+            card.note(col)
             // First column can not be the answer. If it were to change, this code should also be changed.
             if (COLUMN1_KEYS[column1Index] == CardBrowserColumn.QUESTION || arrayOf(CardBrowserColumn.QUESTION, CardBrowserColumn.ANSWER).contains(COLUMN2_KEYS[column2Index])) {
                 updateSearchItemQA()
@@ -2066,10 +2066,11 @@ open class CardBrowser :
                 return
             }
             // render question and answer
-            val qa = card.renderOutput(reload = true, browser = true)
+            val qa = card.renderOutput(col, reload = true, browser = true)
             // Render full question / answer if the bafmt (i.e. "browser appearance") setting forced blank result
             if (qa.questionText.isEmpty() || qa.answerText.isEmpty()) {
                 val (questionText, answerText) = card.renderOutput(
+                    col,
                     reload = true,
                     browser = false
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -239,7 +239,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             // loading from the note editor
             val toPreview = setCurrentCardFromNoteEditorBundle(col)
             if (toPreview != null) {
-                cardCount = toPreview.note().numberOfCardsEphemeral()
+                cardCount = toPreview.note(getColUnsafe).numberOfCardsEphemeral()
                 if (cardCount >= 2) {
                     previewLayout!!.showNavigationButtons()
                 }
@@ -287,7 +287,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             currentCard!!.oDid = currentCard!!.did
         }
         currentCard!!.did = newDid
-        val currentNote = currentCard!!.note()
+        val currentNote = currentCard!!.note(col)
         val tagsList = noteEditorBundle!!.getStringArrayList("tags")
         setTags(currentNote, tagsList)
         return currentCard
@@ -397,14 +397,15 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
 
         /* if we have an unsaved note saved, use it instead of a collection lookup */
         override fun note(
+            col: Collection,
             reload: Boolean
         ): Note {
-            return _note ?: super.note(reload)
+            return _note ?: super.note(col, reload)
         }
 
         /** if we have an unsaved note saved, use it instead of a collection lookup  */
-        override fun note(): Note {
-            return _note ?: super.note()
+        override fun note(col: Collection): Note {
+            return _note ?: super.note(col)
         }
 
         /** if we have an unsaved note, never return empty  */
@@ -412,22 +413,22 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
             get() = _note != null
 
         /** Override the method that fetches the model so we can render unsaved models  */
-        override fun model(): NotetypeJson {
-            return editedNotetype ?: super.model()
+        override fun model(col: Collection): NotetypeJson {
+            return editedNotetype ?: super.model(col)
         }
 
-        override fun renderOutput(reload: Boolean, browser: Boolean): TemplateRenderOutput {
+        override fun renderOutput(col: Collection, reload: Boolean, browser: Boolean): TemplateRenderOutput {
             if (renderOutput == null || reload) {
-                val index = if (model().isCloze) {
+                val index = if (model(col).isCloze) {
                     0
                 } else {
                     ord
                 }
                 val context = TemplateManager.TemplateRenderContext.fromCardLayout(
-                    note(),
+                    note(col),
                     this,
-                    model(),
-                    model().getJSONArray("tmpls")[index] as JSONObject,
+                    model(col),
+                    model(col).getJSONArray("tmpls")[index] as JSONObject,
                     fillEmpty = false
                 )
                 renderOutput =
@@ -439,7 +440,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
 }
 
 private class EphemeralCard(col: Collection, id: Long?) : Card(col, id) {
-    override fun renderOutput(reload: Boolean, browser: Boolean): TemplateRenderOutput {
+    override fun renderOutput(col: Collection, reload: Boolean, browser: Boolean): TemplateRenderOutput {
         return this.renderOutput!!
     }
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardUtils.kt
@@ -2,6 +2,7 @@
 package com.ichi2.anki
 
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Note
 import com.ichi2.utils.HashUtil.hashSetInit
 
@@ -12,10 +13,10 @@ object CardUtils {
     /**
      * @return List of corresponding notes without duplicates, even if the input list has multiple cards of the same note.
      */
-    fun getNotes(cards: Collection<Card>): Set<Note> {
+    fun getNotes(col: Collection, cards: kotlin.collections.Collection<Card>): Set<Note> {
         val notes: MutableSet<Note> = hashSetInit(cards.size)
         for (card in cards) {
-            notes.add(card.note())
+            notes.add(card.note(col))
         }
         return notes
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -463,14 +463,14 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     finish()
                     return
                 }
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(col)
                 addNote = false
             }
             CALLER_PREVIEWER_EDIT -> {
                 val id = intent.extras?.getLong(EXTRA_EDIT_FROM_CARD_ID)
                     ?: throw IllegalArgumentException("null EXTRA_EDIT_FROM_CARD_ID")
                 mCurrentEditedCard = col.getCard(id)
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(getColUnsafe)
             }
             CALLER_STUDYOPTIONS, CALLER_DECKPICKER, CALLER_REVIEWER_ADD, CALLER_CARDBROWSER_ADD, CALLER_NOTEEDITOR ->
                 addNote =
@@ -481,7 +481,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     finish()
                     return
                 }
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(col)
                 addNote = false
             }
             CALLER_NOTEEDITOR_INTENT_ADD -> {
@@ -797,7 +797,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed note type?
         if (!addNote && mCurrentEditedCard != null) {
             val newModel: JSONObject? = currentlySelectedNotetype
-            val oldModel: JSONObject = mCurrentEditedCard!!.model()
+            val oldModel: JSONObject = mCurrentEditedCard!!.model(getColUnsafe)
             if (newModel != oldModel) {
                 return true
             }
@@ -905,7 +905,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         } else {
             // Check whether note type has been changed
             val newModel = currentlySelectedNotetype
-            val oldModel = if (mCurrentEditedCard == null) null else mCurrentEditedCard!!.model()
+            val oldModel = if (mCurrentEditedCard == null) null else mCurrentEditedCard!!.model(getColUnsafe)
             if (newModel != oldModel) {
                 mReloadRequired = true
                 if (mModelChangeCardMap!!.size < mEditorNote!!.numberOfCards() || mModelChangeCardMap!!.containsValue(
@@ -934,9 +934,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 mReloadRequired = true
                 getColUnsafe.setDeck(listOf(mCurrentEditedCard!!.id), deckId)
                 // refresh the card object to reflect the database changes from above
-                mCurrentEditedCard!!.load()
+                mCurrentEditedCard!!.load(getColUnsafe)
                 // also reload the note object
-                mEditorNote = mCurrentEditedCard!!.note()
+                mEditorNote = mCurrentEditedCard!!.note(getColUnsafe)
                 // then set the card ID to the new deck
                 mCurrentEditedCard!!.did = deckId
                 modified = true
@@ -971,7 +971,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
             withProgress {
                 undoableOp {
-                    updateNote(mCurrentEditedCard!!.note())
+                    updateNote(mCurrentEditedCard!!.note(getColUnsafe))
                 }
                 closeNoteEditor()
             }
@@ -1974,7 +1974,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         for (i in 0 until tmpls.length()) {
             var name = tmpls.getJSONObject(i).optString("name")
             // If more than one card, and we have an existing card, underline existing card
-            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.notetype && mCurrentEditedCard != null && mCurrentEditedCard!!.template()
+            if (!addNote && tmpls.length() > 1 && model === mEditorNote!!.notetype && mCurrentEditedCard != null && mCurrentEditedCard!!.template(getColUnsafe)
                 .optString("name") == name
             ) {
                 name = "<u>$name</u>"
@@ -2100,7 +2100,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private inner class EditNoteTypeListener : OnItemSelectedListener {
         override fun onItemSelected(parent: AdapterView<*>?, view: View?, pos: Int, id: Long) {
             // Get the current model
-            val noteModelId = mCurrentEditedCard!!.model().getLong("id")
+            val noteModelId = mCurrentEditedCard!!.model(getColUnsafe).getLong("id")
             // Get new model
             val newModel = getColUnsafe.notetypes.get(mAllModelIds!![pos])
             if (newModel == null) {
@@ -2144,7 +2144,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 updateFieldsFromStickyText()
             } else {
                 populateEditFields(FieldChangeType.refresh(shouldReplaceNewlines()), false)
-                updateCards(mCurrentEditedCard!!.model())
+                updateCards(mCurrentEditedCard!!.model(getColUnsafe))
                 findViewById<View>(R.id.CardEditorTagButton).isEnabled = true
                 // ((LinearLayout) findViewById(R.id.CardEditorCardsButton)).setEnabled(false);
                 mDeckSpinnerSelection!!.setEnabledActionBarSpinner(true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -202,7 +202,7 @@ open class Reviewer :
     override fun onResume() {
         when {
             stopTimerOnAnswer && isDisplayingAnswer -> {}
-            else -> answerTimer.resume()
+            else -> launchCatchingTask { withCol { answerTimer.resume(this) } }
         }
         super.onResume()
         if (typeAnswer?.autoFocusEditText() == true) {
@@ -248,7 +248,7 @@ open class Reviewer :
             return
         }
         launchCatchingTask {
-            toggleMark(card.note(), handler = this@Reviewer)
+            toggleMark(card.note(getColUnsafe), handler = this@Reviewer)
             refreshActionBar()
             onMarkChanged()
         }
@@ -701,7 +701,7 @@ open class Reviewer :
         actionButtons.setCustomButtonsStatus(menu)
         val alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
         val markCardIcon = menu.findItem(R.id.action_mark_card)
-        if (currentCard != null && isMarked(currentCard!!.note())) {
+        if (currentCard != null && isMarked(currentCard!!.note(getColUnsafe))) {
             markCardIcon.setTitle(R.string.menu_unmark_note).setIcon(R.drawable.ic_star_white)
         } else {
             markCardIcon.setTitle(R.string.menu_mark_note).setIcon(R.drawable.ic_star_border_white)
@@ -1015,7 +1015,7 @@ open class Reviewer :
     override suspend fun updateCurrentCard() {
         val state = withCol {
             sched.currentQueueState()?.apply {
-                topCard.renderOutput(true)
+                topCard.renderOutput(this@withCol, true)
             }
         }
         state?.timeboxReached?.let { dealWithTimeBox(it) }
@@ -1033,7 +1033,7 @@ open class Reviewer :
             }
         }.also {
             if (ease == Consts.BUTTON_ONE && wasLeech) {
-                state.topCard.load()
+                state.topCard.load(getColUnsafe)
                 val leechMessage: String = if (state.topCard.queue < 0) {
                     resources.getString(R.string.leech_suspend_notification)
                 } else {
@@ -1064,7 +1064,7 @@ open class Reviewer :
     override fun displayCardQuestion() {
         statesMutated = false
         // show timer, if activated in the deck's preferences
-        answerTimer.setupForCard(currentCard!!)
+        answerTimer.setupForCard(getColUnsafe, currentCard!!)
         delayedHide(100)
         super.displayCardQuestion()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardHtml.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.cardviewer.SingleSoundSide.ANSWER
 import com.ichi2.anki.cardviewer.SingleSoundSide.QUESTION
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.*
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.template.MathJax
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
@@ -80,8 +81,8 @@ class CardHtml(
     }
 
     companion object {
-        fun createInstance(card: Card, side: Side, context: HtmlGenerator): CardHtml {
-            val content = displayString(card, side, context)
+        fun createInstance(col: Collection, card: Card, side: Side, context: HtmlGenerator): CardHtml {
+            val content = displayString(col, card, side, context)
             return CardHtml(
                 content,
                 card.ord,
@@ -95,9 +96,9 @@ class CardHtml(
          * Or warning if required
          * TODO: This is no longer entirely true as more post-processing occurs
          */
-        private fun displayString(card: Card, side: Side, context: HtmlGenerator): String {
-            var content: String = if (side == Side.FRONT) card.question() else card.answer()
-            content = card.col.media.escapeMediaFilenames(content)
+        private fun displayString(col: Collection, card: Card, side: Side, context: HtmlGenerator): String {
+            var content: String = if (side == Side.FRONT) card.question(col) else card.answer(col)
+            content = col.media.escapeMediaFilenames(content)
             content = context.filterTypeAnswer(content, side)
             Timber.v("question: '%s'", content)
             return enrichWithQADiv(content)
@@ -117,10 +118,10 @@ class CardHtml(
             return sb.toString()
         }
 
-        fun legacyGetTtsTags(card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
+        fun legacyGetTtsTags(col: Collection, card: Card, cardSide: SingleSoundSide, context: Context): List<TTSTag> {
             val cardSideContent: String = when (cardSide) {
-                QUESTION -> card.question(true)
-                ANSWER -> card.pureAnswer()
+                QUESTION -> card.question(col, true)
+                ANSWER -> card.pureAnswer(col)
             }
             return TtsParser.getTextsToRead(cardSideContent, context.getString(R.string.reviewer_tts_cloze_spoken_replacement))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/HtmlGenerator.kt
@@ -41,8 +41,8 @@ class HtmlGenerator(
 ) {
 
     @CheckResult
-    fun generateHtml(card: Card, side: Side): CardHtml {
-        return CardHtml.createInstance(card, side, this)
+    fun generateHtml(col: Collection, card: Card, side: Side): CardHtml {
+        return CardHtml.createInstance(col, card, side, this)
     }
 
     fun filterTypeAnswer(content: String, side: Side): String {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.cardviewer.SoundSide.QUESTION_AND_ANSWER
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.AvTag
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.TtsPlayer
@@ -113,11 +114,11 @@ class SoundPlayer(
         close()
     }
 
-    suspend fun loadCardSounds(card: Card, side: Side) {
+    suspend fun loadCardSounds(col: Collection, card: Card, side: Side) {
         Timber.i("loading sounds for card %s (%s)", card.id, side)
         stopSounds()
-        this.questions = card.renderOutput().questionAvTags
-        this.answers = card.renderOutput().answerAvTags
+        this.questions = card.renderOutput(col).questionAvTags
+        this.answers = card.renderOutput(col).answerAvTags
         this.side = side
 
         if (!this::config.isInitialized || !config.appliesTo(card)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.CardUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.ReadText
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.template.TemplateFilters
@@ -41,8 +42,8 @@ class TTS {
      * @param card The card to check the type of before determining the ordinal.
      * @return The card ordinal. If it's a Cloze card, returns 0.
      */
-    private fun getOrdUsingCardType(card: Card): Int {
-        return if (card.model().isCloze) {
+    private fun getOrdUsingCardType(card: Card, col: Collection): Int {
+        return if (card.model(col).isCloze) {
             0
         } else {
             card.ord
@@ -55,8 +56,8 @@ class TTS {
      * @param card     The card to play TTS for
      * @param cardSide The side of the current card to play TTS for
      */
-    fun readCardText(ttsTags: List<TTSTag>, card: Card, cardSide: SoundSide) {
-        ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card))
+    fun readCardText(col: Collection, ttsTags: List<TTSTag>, card: Card, cardSide: SoundSide) {
+        ReadText.readCardSide(ttsTags, cardSide, CardUtils.getDeckIdForCard(card), getOrdUsingCardType(card, col))
     }
 
     /**
@@ -65,13 +66,13 @@ class TTS {
      * @param card The card to read text from
      * @param qa   The card question or card answer
      */
-    fun selectTts(context: Context, card: Card, qa: SoundSide) {
-        val textToRead = if (qa == SoundSide.QUESTION) card.question(true) else card.pureAnswer()
+    fun selectTts(col: Collection, context: Context, card: Card, qa: SoundSide) {
+        val textToRead = if (qa == SoundSide.QUESTION) card.question(col, true) else card.pureAnswer(col)
         // get the text from the card
         ReadText.selectTts(
             getTextForTts(context, textToRead),
             CardUtils.getDeckIdForCard(card),
-            getOrdUsingCardType(card),
+            getOrdUsingCardType(card, col),
             qa
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.servicelayer.LanguageHint
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.utils.jsonObjectIterable
 import org.intellij.lang.annotations.Language
 import org.json.JSONArray
@@ -84,9 +85,9 @@ class TypeAnswer(
      * Extract type answer/cloze text and font/size
      * @param card The next card to display
      */
-    fun updateInfo(card: Card, res: Resources) {
+    fun updateInfo(col: Collection, card: Card, res: Resources) {
         correct = null
-        val q = card.question()
+        val q = card.question(col)
         val m = PATTERN.matcher(q)
         var clozeIdx = 0
         if (!m.find()) {
@@ -100,11 +101,11 @@ class TypeAnswer(
             fldTag = fldTag.split(":").toTypedArray()[1]
         }
         // loop through fields for a match
-        val flds: JSONArray = card.model().getJSONArray("flds")
+        val flds: JSONArray = card.model(col).getJSONArray("flds")
         for (fld in flds.jsonObjectIterable()) {
             val name = fld.getString("name")
             if (name == fldTag) {
-                correct = card.note().getItem(name)
+                correct = card.note(col).getItem(name)
                 if (clozeIdx != 0) {
                     // narrow to cloze
                     correct = contentForCloze(correct!!, clozeIdx)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -88,7 +88,8 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
 
     fun toggleMark() {
         launchCatching {
-            val note = currentCard.note()
+            // TODO: Consider a context receiver
+            val note = withCol { currentCard.note(this) }
             NoteService.toggleMark(note)
             isMarked.emit(NoteService.isMarked(note))
         }
@@ -129,15 +130,17 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     }
 
     private suspend fun updateMarkIcon() {
-        isMarked.emit(currentCard.note().hasTag(MARKED_TAG))
+        val note = withCol { currentCard.note(this) }
+        isMarked.emit(note.hasTag(MARKED_TAG))
     }
 
     private suspend fun showQuestion() {
         Timber.v("showQuestion()")
         showingAnswer.emit(false)
 
-        val question = prepareCardTextForDisplay(currentCard.question())
-        val answer = withCol { media.escapeMediaFilenames(currentCard.answer()) }
+        val questionData = withCol { currentCard.question(this) }
+        val question = prepareCardTextForDisplay(questionData)
+        val answer = withCol { media.escapeMediaFilenames(currentCard.answer(this)) }
         val bodyClass = bodyClassForCardOrd(currentCard.ord)
 
         eval.emit("_showQuestion(${Json.encodeToString(question)}, ${Json.encodeToString(answer)}, '$bodyClass');")
@@ -151,7 +154,8 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     private suspend fun showAnswer() {
         Timber.v("showAnswer()")
         showingAnswer.emit(true)
-        val answer = prepareCardTextForDisplay(currentCard.answer())
+        val answerData = withCol { currentCard.answer(this) }
+        val answer = prepareCardTextForDisplay(answerData)
         eval.emit("_showAnswer(${Json.encodeToString(answer)});")
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1038,14 +1038,14 @@ class CardContentProvider : ContentProvider() {
         }
     }
 
-    private fun addCardToCursor(currentCard: Card, rv: MatrixCursor, @Suppress("UNUSED_PARAMETER") col: Collection, columns: Array<String>) {
+    private fun addCardToCursor(currentCard: Card, rv: MatrixCursor, col: Collection, columns: Array<String>) {
         val cardName: String = try {
-            currentCard.template().getString("name")
+            currentCard.template(col).getString("name")
         } catch (je: JSONException) {
             throw IllegalArgumentException("Card is using an invalid template", je)
         }
-        val question = currentCard.renderOutput().questionWithFixedSoundTags()
-        val answer = currentCard.renderOutput().answerWithFixedSoundTags()
+        val question = currentCard.renderOutput(col).questionWithFixedSoundTags()
+        val answer = currentCard.renderOutput(col).answerWithFixedSoundTags()
         val rb = rv.newRow()
         for (column in columns) {
             when (column) {
@@ -1055,9 +1055,9 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.DECK_ID -> rb.add(currentCard.did)
                 FlashCardsContract.Card.QUESTION -> rb.add(question)
                 FlashCardsContract.Card.ANSWER -> rb.add(answer)
-                FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple())
-                FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.renderOutput(false).answerText)
-                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer())
+                FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.qSimple(col))
+                FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.renderOutput(col, false).answerText)
+                FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer(col))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }
@@ -1071,7 +1071,7 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.ReviewInfo.CARD_ORD -> rb.add(currentCard.ord)
                 FlashCardsContract.ReviewInfo.BUTTON_COUNT -> rb.add(buttonCount)
                 FlashCardsContract.ReviewInfo.NEXT_REVIEW_TIMES -> rb.add(nextReviewTimesJson.toString())
-                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.question() + currentCard.answer())))
+                FlashCardsContract.ReviewInfo.MEDIA_FILES -> rb.add(JSONArray(col.media.filesInStr(currentCard.question(col) + currentCard.answer(col))))
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -24,6 +24,7 @@ import androidx.annotation.VisibleForTesting
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 
 /**
  * Responsible for pause/resume of the card timer and the UI element displaying the amount of time to answer a card
@@ -56,9 +57,9 @@ class AnswerTimer(private val cardTimer: Chronometer) {
      *
      * This may also change the limit, based on [Card.timeLimit]
      */
-    fun setupForCard(newCard: Card) {
+    fun setupForCard(col: Collection, newCard: Card) {
         currentCard = newCard
-        showTimer = newCard.showTimer()
+        showTimer = newCard.showTimer(col)
         if (showTimer && cardTimer.visibility == View.INVISIBLE) {
             cardTimer.visibility = View.VISIBLE
         } else if (!showTimer && cardTimer.visibility != View.INVISIBLE) {
@@ -69,11 +70,11 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         if (!showTimer) {
             cardTimer.stop()
         } else {
-            resetTimerUI(newCard)
+            resetTimerUI(col, newCard)
         }
     }
 
-    private fun resetTimerUI(newCard: Card) {
+    private fun resetTimerUI(col: Collection, newCard: Card) {
         // Set normal timer color
         cardTimer.setTextColor(MaterialColors.getColor(context, android.R.attr.textColor, 0))
 
@@ -81,7 +82,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         cardTimer.start()
 
         // Stop and highlight the timer if it reaches the time limit.
-        limit = newCard.timeLimit()
+        limit = newCard.timeLimit(col)
         cardTimer.setOnChronometerTickListener { chronometer: Chronometer ->
             val elapsed: Long = elapsedRealTime - chronometer.base
             if (elapsed >= limit) {
@@ -102,7 +103,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         currentCard.stopTimer()
     }
 
-    fun resume() {
+    fun resume(col: Collection) {
         if (!this::currentCard.isInitialized) {
             return
         }
@@ -114,10 +115,10 @@ class AnswerTimer(private val cardTimer: Chronometer) {
             return
         }
         // Then update and resume the UI timer. Set the base time as if the timer had started
-        // timeTaken() seconds ago.
-        cardTimer.base = elapsedRealTime - currentCard.timeTaken()
+        // timeTaken(col) seconds ago.
+        cardTimer.base = elapsedRealTime - currentCard.timeTaken(col)
         // Don't start the timer if we have already reached the time limit or it will tick over
-        if (elapsedRealTime - cardTimer.base < currentCard.timeLimit()) {
+        if (elapsedRealTime - cardTimer.base < currentCard.timeLimit(col)) {
             cardTimer.start()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/CardService.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.servicelayer
 
 import com.ichi2.anki.CardUtils
+import com.ichi2.libanki.Collection
 
 object CardService {
     /**
@@ -25,8 +26,9 @@ object CardService {
      * can do better with performance here
      * TODO: blocks the UI, should be fixed
      */
-    fun selectedNoteIds(selectedCardIds: List<Long>, col: com.ichi2.libanki.Collection) =
+    fun selectedNoteIds(selectedCardIds: List<Long>, col: Collection) =
         CardUtils.getNotes(
+            col,
             selectedCardIds.map { col.getCard(it) }
         ).map { it.id }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteTypeId
@@ -156,7 +157,7 @@ object NoteService {
      */
     @VisibleForTesting
     @CheckResult
-    fun getFieldsAsBundleForPreview(editFields: Collection<NoteField?>?, replaceNewlines: Boolean): Bundle {
+    fun getFieldsAsBundleForPreview(editFields: List<NoteField?>?, replaceNewlines: Boolean): Bundle {
         val fields = Bundle()
         // Save the content of all the note fields. We use the field's ord as the key to
         // easily map the fields correctly later.
@@ -233,8 +234,8 @@ object NoteService {
 
 const val MARKED_TAG = "marked"
 
-fun Card.totalLapsesOfNote() = NoteService.totalLapses(note())
+fun Card.totalLapsesOfNote(col: Collection) = NoteService.totalLapses(note(col))
 
-fun Card.totalReviewsForNote() = NoteService.totalReviews(note())
+fun Card.totalReviewsForNote(col: Collection) = NoteService.totalReviews(note(col))
 
-fun Card.avgIntervalOfNote() = NoteService.avgInterval(note())
+fun Card.avgIntervalOfNote(col: Collection) = NoteService.avgInterval(note(col))

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -17,7 +17,6 @@
 package com.ichi2.async
 
 import com.ichi2.anki.*
-import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.Dispatchers
@@ -120,23 +119,6 @@ suspend fun renderBrowserQA(
         withContext(Dispatchers.Main) { onProgressUpdate(progress.toInt()) }
     }
     Pair(cards, invalidCardIds)
-}
-
-/**
- * Goes through selected cards and checks selected and marked attribute
- * @return If there are unselected cards, if there are unmarked cards
- */
-suspend fun checkCardSelection(checkedCards: Set<CardBrowser.CardCache>): Pair<Boolean, Boolean> = withContext(Dispatchers.IO) {
-    var hasUnsuspended = false
-    var hasUnmarked = false
-    for (c in checkedCards) {
-        ensureActive() // check if job is not cancelled
-        val card = c.card
-        hasUnsuspended = hasUnsuspended || card.queue != Consts.QUEUE_TYPE_SUSPENDED
-        hasUnmarked = hasUnmarked || !NoteService.isMarked(card.note())
-        if (hasUnsuspended && hasUnmarked) break
-    }
-    Pair(hasUnsuspended, hasUnmarked)
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -130,16 +130,16 @@ object Sound {
     }
 
     /** Extract av tag from playsound:q:x link */
-    suspend fun getAvTag(card: Card, url: String): AvTag? {
+    suspend fun getAvTag(col: Collection, card: Card, url: String): AvTag? {
         return AV_PLAYLINK_RE.matchEntire(url)?.let {
             val values = it.groupValues
             val questionSide = values[1] == "q"
             val index = values[2].toInt()
             val tags = CollectionManager.withCol {
                 if (questionSide) {
-                    card.questionAvTags()
+                    card.questionAvTags(col)
                 } else {
-                    card.answerAvTags()
+                    card.answerAvTags(col)
                 }
             }
             if (index < tags.size) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -130,8 +130,8 @@ class TemplateManager {
         private var noteType: NotetypeJson = notetype ?: note.notetype
 
         companion object {
-            fun fromExistingCard(card: Card, browser: Boolean): TemplateRenderContext {
-                return TemplateRenderContext(card.col, card, card.note(), browser)
+            fun fromExistingCard(col: Collection, card: Card, browser: Boolean): TemplateRenderContext {
+                return TemplateRenderContext(col, card, card.note(col), browser)
             }
 
             fun fromCardLayout(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -64,14 +64,14 @@ open class Scheduler(val col: Collection) {
     /** Legacy API */
     open val card: Card?
         get() = queuedCards.cardsList.firstOrNull()?.card?.let {
-            Card(col, it).apply { startTimer() }
+            Card(it).apply { startTimer() }
         }
 
     fun currentQueueState(): CurrentQueueState? {
         val queue = queuedCards
         return queue.cardsList.firstOrNull()?.let {
             CurrentQueueState(
-                topCard = Card(col, it.card).apply { startTimer() },
+                topCard = Card(it.card).apply { startTimer() },
                 countsIndex = when (it.queue) {
                     QueuedCards.Queue.NEW -> Counts.Queue.NEW
                     QueuedCards.Queue.LEARNING -> Counts.Queue.LRN
@@ -109,7 +109,7 @@ open class Scheduler(val col: Collection) {
         col.backend.answerCard(answer)
         reps += 1
         // tests assume the card was mutated
-        card.load()
+        card.load(col)
     }
 
     fun againIsLeech(info: CurrentQueueState): Boolean {
@@ -123,7 +123,7 @@ open class Scheduler(val col: Collection) {
             newState = stateFromEase(states, ease)
             rating = ratingFromEase(ease)
             answeredAtMillis = time.intTimeMS()
-            millisecondsTaken = card.timeTaken()
+            millisecondsTaken = card.timeTaken(col)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
@@ -224,7 +224,7 @@ class SoundPlayerTest : RobolectricTest() {
         val card = addNoteUsingBasicModel().firstCard()
         mockkObject(card)
 
-        every { card.renderOutput() } answers {
+        every { card.renderOutput(any()) } answers {
             TemplateManager.TemplateRenderContext.TemplateRenderOutput(
                 questionText = "",
                 answerText = "",
@@ -245,7 +245,7 @@ class SoundPlayerTest : RobolectricTest() {
             }
         }
 
-        this.loadCardSounds(card, side)
+        this.loadCardSounds(col, card, side)
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -176,7 +176,7 @@ class FinderTest : JvmTest() {
             type = CARD_TYPE_REV
         }
         assertEquals(0, col.findCards("is:review").size)
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:review"))
         assertEquals(0, col.findCards("is:due").size)
         c.update {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -309,7 +309,7 @@ open class SchedulerTest : JvmTest() {
             queue = QUEUE_TYPE_REV
             type = CARD_TYPE_REV
         }
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
 
         // fail the card
         c = col.sched.card!!
@@ -338,7 +338,7 @@ open class SchedulerTest : JvmTest() {
             queue = QUEUE_TYPE_REV
             type = CARD_TYPE_REV
         }
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         val conf = col.decks.confForDid(1)
         conf.getJSONObject("lapse").put("delays", JSONArray(doubleArrayOf()))
         col.decks.save(conf)
@@ -453,13 +453,13 @@ open class SchedulerTest : JvmTest() {
             ivl = 100
         }
         c.startTimer()
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         // save it for later use as well
         val cardcopy = c.clone()
         // try with an ease of 2
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         col.sched.answerCard(c, BUTTON_TWO)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         // the new interval should be (100) * 1.2 = 120
@@ -473,7 +473,7 @@ open class SchedulerTest : JvmTest() {
         // ease 3
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         col.sched.answerCard(c, BUTTON_THREE)
         // the new interval should be (100 + 8/2) * 2.5 = 260
         Assert.assertTrue(AnkiAssert.checkRevIvl(c, 260))
@@ -483,7 +483,7 @@ open class SchedulerTest : JvmTest() {
         // ease 4
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c = cardcopy.clone()
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         col.sched.answerCard(c, BUTTON_FOUR)
         // the new interval should be (100 + 8) * 2.5 * 1.3 = 351
         Assert.assertTrue(AnkiAssert.checkRevIvl(c, 351))
@@ -774,7 +774,7 @@ open class SchedulerTest : JvmTest() {
         }
 
         c.startTimer()
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         Assert.assertEquals(Counts(0, 0, 0), col.sched.counts())
         // create a dynamic deck and refresh it
         val did = addDynamicDeck("Cram")
@@ -1227,7 +1227,7 @@ open class SchedulerTest : JvmTest() {
             ivl = 100
             due = 0
         }
-        c.col.updateCard(c, skipUndoEntry = true)
+        col.updateCard(c, skipUndoEntry = true)
         Assert.assertEquals(Counts(0, 0, 1), col.sched.counts())
         col.sched.forgetCards(listOf(c.id))
         Assert.assertEquals(Counts(1, 0, 0), col.sched.counts())

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -170,6 +170,18 @@ interface TestClass {
         return this
     }
 
+    fun Card.note() = this.note(col)
+    fun Card.note(reload: Boolean) = this.note(col, reload)
+    fun Card.model() = this.model(col)
+    fun Card.template() = this.template(col)
+    fun Card.question() = this.question(col)
+    fun Card.question(reload: Boolean = false, browser: Boolean = false) = this.question(col, reload, browser)
+    fun Card.answer() = this.answer(col)
+    fun Card.load() = this.load(col)
+    fun Card.nextDue() = this.nextDue(col)
+    fun Card.dueString() = this.dueString(col)
+    fun Card.pureAnswer() = this.pureAnswer(col)
+
     /** * A wrapper around the standard [kotlinx.coroutines.test.runTest] that
      * takes care of updating the dispatcher used by CollectionManager as well.
      * * An argument could be made for using [StandardTestDispatcher] and

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -727,7 +727,7 @@ public object FlashCardsContract {
      *      ContentResolver cr = getContentResolver();
      *      Uri reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI;
      *      ContentValues values = new ContentValues();
-     *      long noteId = card.note().getId();
+     *      long noteId = card.note(col).getId();
      *      int cardOrd = card.getOrd();
      *
      *      values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);

--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -17,12 +17,9 @@
 package com.ichi2.anki.api
 
 import android.text.Html
-import java.lang.Exception
-import java.lang.IllegalStateException
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.util.regex.Pattern
-
 /**
  * Utilities class for the API
  */


### PR DESCRIPTION
This commit was revived from and is the penultimate refactoring which will come from the following PR

* https://github.com/ankidroid/Anki-Android/pull/13936
  * https://github.com/ankidroid/Anki-Android/pull/13936/commits/5f01180be25f13eae46aad1fc78caf122a620f8a

The final commit in the series will be to apply the same change to `Note`

I applied the patch, fixed a large number of conflicts, then added a number of extension methods to `TestClass` to reduce code churn in tests

There was one deadlock in `reviewer`, which I fixed. 

I briefly tested reviewing, `CardBrowser` and `NoteEditor`

I modified `getNotes` to accept a `List<T>` rather than a `Collection<T>` 

## Learning

I feel that the syntax inside `withCol` could be further improved with [Kotlin Context Receivers](https://github.com/Kotlin/KEEP/blob/master/proposals/context-receivers.md), but I didn't feel this was appropriate to introduce in a large refactoring PR


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


----
## Original Commit Message

This requires adding `col` to any function using it, recursively, until finding another function with `col` in its context.

`Reviewer.onResume` has moved to `launchWithCol`, as otherwise tests crash with the following trace:

```
java.lang.NullPointerException
	at com.ichi2.anki.AnkiActivity.getCol(AnkiActivity.kt:151)
	at com.ichi2.anki.Reviewer.onResume(Reviewer.kt:191)
	at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1476)
	at org.robolectric.android.internal.RoboMonitoringInstrumentation.callActivityOnResume(RoboMonitoringInstrumentation.java:321)
	at android.app.Activity.performResume(Activity.java:8191)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.robolectric.shadows._Activity_$$Reflector19.performResume(Unknown Source)
	at org.robolectric.android.controller.ActivityController.lambda$resume$5(ActivityController.java:197)
	at org.robolectric.shadows.ShadowPausedLooper.runPaused(ShadowPausedLooper.java:204)
	at org.robolectric.android.controller.ComponentController.invokeWhilePaused(ComponentController.java:64)
	at org.robolectric.android.controller.ActivityController.resume(ActivityController.java:192)
	at org.robolectric.android.internal.RoboMonitoringInstrumentation.startActivitySyncInternal(RoboMonitoringInstrumentation.java:121)
	at org.robolectric.android.internal.LocalActivityInvoker.startActivity(LocalActivityInvoker.java:35)
	at org.robolectric.android.internal.LocalActivityInvoker.startActivity(LocalActivityInvoker.java:40)
	at androidx.test.core.app.ActivityScenario.launchInternal(ActivityScenario.java:362)
	at androidx.test.core.app.ActivityScenario.launch(ActivityScenario.java:202)
	at com.ichi2.anki.ReviewerTest.verifyStartupNoCollection(ReviewerTest.kt:67)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:589)
	at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$2(SandboxTestRunner.java:290)
	at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:99)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
	Suppressed:
        org.robolectric.android.internal.AndroidTestEnvironment$UnExecutedRunnablesException:
        Main looper has queued unexecuted runnables. This might be the cause of
        the test failure. You might need a
        shadowOf(Looper.getMainLooper()).idle() call.
```

In the worst case, this slightly delays when the time starts again, which is acceptable.
