### PR TITLE
Fix ExportReadyDialog restore from Bundle

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -20,7 +20,6 @@ import android.annotation.SuppressLint
 import android.os.Bundle
 import android.os.Message
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
@@ -77,7 +76,7 @@ class ExportReadyDialog(private val listener: ExportReadyDialogListener) : Async
 
         companion object {
             fun fromMessage(message: Message): ExportReadyDialogMessage {
-                val exportPath = BundleCompat.getParcelable(message.data, "exportPath", String::class.java)!!
+                val exportPath = message.data.getString("exportPath")!!
                 return ExportReadyDialogMessage(exportPath)
             }
         }


### PR DESCRIPTION
## Purpose / Description

Small PR to fix one issue with restoring an async set ExportReadyDialog. In order to restore the dialog it needs a path as a String, but the code was trying to retrieve the path as a Parcelable which produced a null path.

## How Has This Been Tested?

I've tested the restore scenario.
