### PR TITLE
fix: DeckPicker storage error on first run

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1108,7 +1108,7 @@ open class DeckPicker :
         // As `loadDeckCounts` is cancelled in `migrate()`
         val message = dialogHandler.popMessage()
         super.onResume()
-        if (navDrawerIsReady()) {
+        if (navDrawerIsReady() && hasCollectionStoragePermissions()) {
             refreshState()
         }
         message?.let { dialogHandler.sendStoredMessage(it) }


### PR DESCRIPTION
## Purpose / Description
On the DeckPicker, under a 'full' build, on startup with no permissions
* later APIs: a dialog briefly appeared
* earlier APIs: a dialog blocked usage of the screen

## Fixes
* ⚠️ I couldn't find a specific bug

## Approach
* https://github.com/ankidroid/Anki-Android/pull/15258
* Isolate stack trace
* Fix the bug

## How Has This Been Tested?
API 33 emulator

## Learning (optional, can help others)
* https://github.com/ankidroid/Anki-Android/pull/15258

* we can't use `isFinishing`, as showing the permissions screen does not finish the activity

```
* onResume -> refreshState -> updateDeckList
  * -> performBackupInBackground -> withCol
  * -> val deckData = withCol ...
 ```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
