### PR TITLE
fix(CardBrowser): Wrong deck selected on open

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -589,14 +589,9 @@ open class CardBrowser :
             showAllDecks = true,
             alwaysShowDefault = false,
             showFilteredDecks = true
-        )
-        deckSpinnerSelection!!.initializeActionBarDeckSpinner(this.supportActionBar!!)
-
-        launchCatchingTask {
-            when (val deckId = viewModel.getInitialDeck()) {
-                ALL_DECKS_ID -> selectAllDecks()
-                else -> deckSpinnerSelection!!.selectDeckById(deckId, false)
-            }
+        ).apply {
+            initializeActionBarDeckSpinner(supportActionBar!!)
+            selectDeckById(viewModel.deckId ?: ALL_DECKS_ID, false)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -503,6 +503,11 @@ open class CardBrowser :
                 invalidateOptionsMenu()
             }
             .launchIn(lifecycleScope)
+
+        viewModel.initCompletedFlow
+            .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
+            .onEach { completed -> if (completed) searchCards() }
+            .launchIn(lifecycleScope)
     }
 
     fun searchWithFilterQuery(filterQuery: String) = launchCatchingTask {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -64,6 +64,7 @@ import kotlin.math.min
 
 @NeedsTest("reverseDirectionFlow/sortTypeFlow are not updated on .launch { }")
 @NeedsTest("13442: selected deck is not changed, as this affects the reviewer")
+@NeedsTest("search is called after launch()")
 class CardBrowserViewModel(
     private val lastDeckIdRepository: LastDeckIdRepository,
     preferences: SharedPreferencesProvider
@@ -176,7 +177,7 @@ class CardBrowserViewModel(
         }
     }
 
-    private val initCompletedFlow = MutableStateFlow(false)
+    val initCompletedFlow = MutableStateFlow(false)
 
     /**
      * Whether the task launched from CardBrowserViewModel.init has completed.


### PR DESCRIPTION
We weren't calling searchCards() after viewModel.launch

* Fixes #15072

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
