### PR TITLE
fix(CardBrowser): retain selection when toggling 'mark'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -661,6 +661,7 @@ open class CardBrowser :
     @VisibleForTesting
     fun toggleMark() = launchCatchingTask {
         withProgress { viewModel.toggleMark(selectedCardIds) }
+        cardsAdapter.notifyDataSetChanged()
     }
 
     @VisibleForTesting
@@ -2178,12 +2179,16 @@ open class CardBrowser :
     }
 
     override fun opExecuted(changes: OpChanges, handler: Any?) {
+        if (handler === this || handler === viewModel) {
+            return
+        }
+
         if ((
             changes.browserSidebar ||
                 changes.browserTable ||
                 changes.noteText ||
                 changes.card
-            ) && handler !== this
+            )
         ) {
             refreshAfterUndo()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -658,8 +658,9 @@ open class CardBrowser :
      * If one or more card is unmarked, all will be marked,
      * otherwise, they will be unmarked  */
     @NeedsTest("Test that the mark get toggled as expected for a list of selected cards")
-    private fun toggleMark() {
-        launchCatchingTask { withProgress { viewModel.toggleMark(selectedCardIds) } }
+    @VisibleForTesting
+    fun toggleMark() = launchCatchingTask {
+        withProgress { viewModel.toggleMark(selectedCardIds) }
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -233,7 +233,7 @@ class CardBrowserViewModel(
             Timber.i("Not marking cards - nothing selected")
             return
         }
-        undoableOp {
+        undoableOp(this) {
             val noteIds = notesOfCards(cardIds)
             // if all notes are marked, remove the mark
             // if no notes are marked, add the mark
@@ -246,6 +246,7 @@ class CardBrowserViewModel(
                 tags.bulkRemove(noteIds, "marked")
             }
         }
+        selectedRows.forEach { it.reload() }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_2_KE
 import com.ichi2.anki.introduction.hasCollectionStoragePermissions
 import com.ichi2.anki.model.CardsOrNotes.*
 import com.ichi2.anki.model.SortType
+import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
@@ -1039,6 +1040,31 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("deckId is searched", viewModel.rowCount, equalTo(1))
         }
     }
+
+    @Test
+    @Ignore("14950")
+    fun `selection is maintained after toggle mark 14950`() = withBrowser(noteCount = 5) {
+        // TODO: Once refactoring is completed, move this to the ViewModel Test
+        selectRowsWithPositions(0, 1, 2)
+
+        assertThat("3 rows are selected", viewModel.selectedRows.size, equalTo(3))
+        assertThat("selection is not marked", viewModel.selectedRows.all { !it.isMarked })
+
+        toggleMark().join()
+
+        assertThat("3 rows are still selected", viewModel.selectedRows.size, equalTo(3))
+        assertThat("selection is now marked", viewModel.selectedRows.all { it.isMarked })
+    }
+
+    @Suppress("SameParameterValue")
+    private fun withBrowser(noteCount: Int = 0, block: suspend CardBrowser.() -> Unit) = runTest {
+        getBrowserWithNotes(noteCount).apply {
+            block(this)
+        }
+    }
+
+    private val CardCache.isMarked
+        get() = NoteService.isMarked(card.note(col))
 }
 
 fun CardBrowser.hasSelectedCardAtPosition(i: Int): Boolean =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1042,7 +1042,6 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    @Ignore("14950")
     fun `selection is maintained after toggle mark 14950`() = withBrowser(noteCount = 5) {
         // TODO: Once refactoring is completed, move this to the ViewModel Test
         selectRowsWithPositions(0, 1, 2)


### PR DESCRIPTION
## Fixes
* Fixes #14950


## Approach
* allow ViewModel operations to be handled in CardBrowser
* reload the individual cards so `forceRefreshSearch` is not required
* then just a call to `cardsAdapter.notifyDataSetChanged()`

## How Has This Been Tested?
Unit Tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
