### PR TITLE
chore: early return in `filterUrl`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2289,6 +2289,7 @@ abstract class AbstractFlashcardViewer :
             }
             if (url.startsWith("state-mutation-error:")) {
                 onStateMutationError()
+                return true
             }
             if (url.startsWith("tts-voices:")) {
                 showDialogFragment(TtsVoicesDialogFragment())


### PR DESCRIPTION
Non-functional, caught after code was merged

* PR #15061