### PR TITLE
chore: reset analytics opt-in

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -39,7 +39,7 @@ import timber.log.Timber
 
 @KotlinCleanup("see if we can make variables lazy, or properties without the `s` prefix")
 object UsageAnalytics {
-    const val ANALYTICS_OPTIN_KEY = "analyticsOptIn"
+    const val ANALYTICS_OPTIN_KEY = "analytics_opt_in"
 
     @KotlinCleanup("lateinit")
     private var sAnalytics: GoogleAnalytics? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -22,6 +22,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
+import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.noteeditor.CustomToolbarButton
@@ -96,6 +97,7 @@ object PreferenceUpgradeService {
                 yield(RemoveInCardsMode())
                 yield(RemoveReviewerETA())
                 yield(SetShowDeckTitle())
+                yield(ResetAnalyticsOptIn())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -471,6 +473,24 @@ object PreferenceUpgradeService {
                     preferences.edit { putBoolean("showDeckTitle", true) }
                 }
             }
+        }
+
+        /**
+         * Issue 14386: Opening preferences opted users in to analytics in 2.16 due to an oversight
+         *
+         * Despite the fact that analytics were broken at the time due to Google's migration from
+         * Universal Analytics to Google Analytics 4, we want analytics to STRICTLY be opt-in
+         *
+         * As we likely have inadvertent opt-ins, we stated that we would opt everyone out:
+         * https://ankidroid.org/docs/changelog.html#_version_2_16_5_20230906
+         *
+         * We now use "analytics_opt_in"
+         *
+         * @see [UsageAnalytics.ANALYTICS_OPTIN_KEY]
+         */
+        internal class ResetAnalyticsOptIn : PreferenceUpgrade(17) {
+            override fun upgrade(preferences: SharedPreferences) =
+                preferences.edit { remove("analyticsOptIn") }
         }
     }
 }

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -5,7 +5,7 @@
     <string name="pref_general_screen_key">generalScreen</string>
     <string name="deck_for_new_cards_key">useCurrent</string>
     <string name="pref_language_key">language</string>
-    <string name="analytics_opt_in_key">analyticsOptIn</string>
+    <string name="analytics_opt_in_key">analytics_opt_in</string>
     <string name="paste_png_key">pastePNG</string>
     <string name="error_reporting_mode_key">reportErrorMode</string>
     <!-- Reviewing -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -38,7 +38,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
 
     /** Keys of preferences that shouldn't be reported */
     private val excludedPrefs = setOf(
-        "analyticsOptIn", // Share feature usage: analytics are only reported if this is enabled :)
+        "analytics_opt_in", // Share feature usage: analytics are only reported if this is enabled :)
         // Screens: don't have a value
         "generalScreen",
         "reviewingScreen",


### PR DESCRIPTION
## Purpose / Description
Opening preferences opted users in to analytics in 2.16 due to an oversight

Despite the fact that analytics were broken at the time due to Google's migration from Universal Analytics to Google Analytics 4, we want analytics to STRICTLY be opt-in

So we stated that we would opt everyone out: https://ankidroid.org/docs/changelog.html#_version_2_16_5_20230906

## Fixes

* Related 
    * #14569 
        * This issue now no longer blocks 2.17 
    * #14386

## Approach
* removing the old preference key ("analyticsOptIn")
  * ensures the default (false) is used
  * removes a deprecated key from preferences
* renaming the preference key ("analytics_opt_in")
  * ensures that the legacy value is never used going forwards

## How Has This Been Tested?
Only CI

## Learning

* Discussion on how we handle this https://github.com/ankidroid/ankidroiddocs/pull/115

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
