### PR TITLE
chore: convert `CreateDeckDialog` to `AlertDialog`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -16,14 +16,9 @@
 
 package com.ichi2.anki.dialogs
 
-import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.WhichButton
-import com.afollestad.materialdialogs.actions.setActionButtonEnabled
-import com.afollestad.materialdialogs.input.getInputField
-import com.afollestad.materialdialogs.input.input
+import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager.withCol
@@ -34,7 +29,12 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.getOrCreateFilteredDeck
-import com.ichi2.utils.displayKeyboard
+import com.ichi2.utils.getInputField
+import com.ichi2.utils.input
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+import com.ichi2.utils.title
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import timber.log.Timber
 import java.util.function.Consumer
@@ -50,7 +50,7 @@ class CreateDeckDialog(
     private var previousDeckName: String? = null
     private var onNewDeckCreated: Consumer<Long>? = null
     private var initialDeckName = ""
-    private var shownDialog: MaterialDialog? = null
+    private var shownDialog: AlertDialog? = null
 
     enum class DeckDialogType {
         FILTERED_DECK, DECK, SUB_DECK, RENAME_DECK
@@ -75,25 +75,21 @@ class CreateDeckDialog(
             initialDeckName = deckName
         }
 
-    fun showDialog(): MaterialDialog {
-        @SuppressLint("CheckResult")
-        val dialog = MaterialDialog(context).show {
+    fun showDialog(): AlertDialog {
+        val dialog = AlertDialog.Builder(context).show {
             title(title)
-            positiveButton(R.string.dialog_ok) {
-                onPositiveButtonClicked()
-            }
+            positiveButton(R.string.dialog_ok) { onPositiveButtonClicked() }
             negativeButton(R.string.dialog_cancel)
-            input(prefill = initialDeckName, waitForPositiveButton = false) { dialog, text ->
-                // we need the fully-qualified name for subdecks
-                val maybeDeckName = fullyQualifyDeckName(dialogText = text)
-                // if the name is empty, it seems distracting to show an error
-                if (maybeDeckName == null || !Decks.isValidDeckName(maybeDeckName)) {
-                    dialog.setActionButtonEnabled(WhichButton.POSITIVE, false)
-                    return@input
-                }
-                dialog.setActionButtonEnabled(WhichButton.POSITIVE, true)
+            setView(R.layout.dialog_generic_text_input)
+        }.input(prefill = initialDeckName, displayKeyboard = true) { dialog, text ->
+            // we need the fully-qualified name for subdecks
+            val maybeDeckName = fullyQualifyDeckName(dialogText = text)
+            // if the name is empty, it seems distracting to show an error
+            if (maybeDeckName == null || !Decks.isValidDeckName(maybeDeckName)) {
+                dialog.positiveButton.isEnabled = false
+                return@input
             }
-            displayKeyboard(getInputField())
+            dialog.positiveButton.isEnabled = true
         }
         shownDialog = dialog
         return dialog

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -127,9 +127,9 @@ fun AlertDialog.Builder.cancelable(cancelable: Boolean): AlertDialog.Builder {
  * Executes the provided block, then creates an [AlertDialog] with the arguments supplied
  * and immediately displays the dialog
  */
-inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog.Builder = apply {
-    this.block()
-    this.show()
+inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog {
+    this.apply { block() }
+    return this.show()
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/EditTextUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/EditTextUtils.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -14,11 +14,9 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.anki.dialogs.utils
+package com.ichi2.utils
 
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.input.getInputField
+import android.widget.EditText
 
-var MaterialDialog.input
-    get() = this.getInputField().text.toString()
-    set(value) = this.getInputField().setText(value)
+/** Moves the cursor to the end of the [EditText] */
+fun EditText.moveCursorToEnd() = setSelection(text?.length ?: 0)

--- a/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+
+<com.google.android.material.textfield.TextInputLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_text_input_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="@dimen/content_vertical_padding"
+    android:paddingLeft="32dp"
+    android:paddingRight="32dp"
+    android:paddingBottom="4dp"
+    android:paddingTop="16dp" >
+
+    <com.google.android.material.textfield.TextInputEditText
+        android:id="@+id/dialog_text_input"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:drawablePadding="8dp"
+        />
+</com.google.android.material.textfield.TextInputLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -1,7 +1,6 @@
 // noinspection MissingCopyrightHeader #8659
 package com.ichi2.anki
 
-import android.annotation.SuppressLint
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -20,6 +19,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_4
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerContextMenu
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
+import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.exception.UnknownDatabaseVersionException
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.annotations.NeedsTest
@@ -50,7 +50,6 @@ import java.io.File
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 @KotlinCleanup("SPMockBuilder")
 @RunWith(ParameterizedRobolectricTestRunner::class)
@@ -403,26 +402,14 @@ class DeckPickerTest : RobolectricTest() {
 
     // TODO delete test or at least use espresso, this is a poor implementation that can break at any time
     private fun assertDialogTitleEquals(expectedTitle: String) {
-        val actualTitle =
-            (ShadowDialog.getLatestDialog() as MaterialDialog)
-                .view
-                .findViewById<RtlTextView>(com.afollestad.materialdialogs.R.id.md_text_title)
-                ?.text
-        Timber.d("titles = \"$actualTitle\", \"$expectedTitle\"")
-        assertEquals(expectedTitle, "$actualTitle")
-    }
-
-    // TODO delete test or at least use espresso, this is a poor implementation that can break at any time
-    @SuppressLint("DiscouragedApi")
-    private fun assertAlertDialogTitleEquals(expectedTitle: String) {
-        val dialog = (ShadowDialog.getLatestDialog() as AlertDialog)
-        val titleId = dialog.context.resources.getIdentifier(
-            "alertTitle",
-            "id",
-            dialog.context.packageName
-        )
-        if (titleId <= 0) fail("Unable to find dialog title for matching")
-        val actualTitle = dialog.findViewById<TextView>(titleId)?.text
+        val actualTitle = when (val dialog = ShadowDialog.getLatestDialog()) {
+            is MaterialDialog ->
+                dialog.view
+                    .findViewById<RtlTextView>(com.afollestad.materialdialogs.R.id.md_text_title)
+                    ?.text
+            is AlertDialog -> dialog.title
+            else -> TODO()
+        }
         Timber.d("titles = \"$actualTitle\", \"$expectedTitle\"")
         assertEquals(expectedTitle, "$actualTitle")
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.dialogs
 
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
@@ -27,9 +28,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.CreateDeckDialog.DeckDialogType
 import com.ichi2.anki.dialogs.utils.input
-import com.ichi2.anki.dialogs.utils.positiveButton
 import com.ichi2.libanki.DeckId
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import com.ichi2.utils.positiveButton
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.junit.Test
@@ -42,7 +42,6 @@ import kotlin.coroutines.suspendCoroutine
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 
-@OptIn(ExperimentalCoroutinesApi::class)
 @RunWith(RobolectricTestRunner::class)
 class CreateDeckDialogTest : RobolectricTest() {
     private lateinit var activityScenario: ActivityScenario<DeckPicker>
@@ -189,14 +188,10 @@ class CreateDeckDialogTest : RobolectricTest() {
         assertEquals(deckPicker.optionsMenuState!!.searchIcon, true)
     }
 
-    private fun createDeck(deckName: String) {
-        col.decks.id(deckName)
-    }
-
     /**
      * Executes [callback] on the [MaterialDialog] created from [CreateDeckDialog]
      */
-    private fun testDialog(deckDialogType: DeckDialogType, parentId: DeckId? = null, callback: (MaterialDialog.() -> Unit)) {
+    private fun testDialog(deckDialogType: DeckDialogType, parentId: DeckId? = null, callback: (AlertDialog.() -> Unit)) {
         activityScenario.onActivity { activity: DeckPicker ->
             val dialog = CreateDeckDialog(activity, R.string.new_deck, deckDialogType, parentId).showDialog()
             callback(dialog)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -16,9 +16,15 @@
 
 package com.ichi2.anki.dialogs.utils
 
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.input.getInputField
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.utils.getInputField
 
-var MaterialDialog.input
-    get() = this.getInputField().text.toString()
-    set(value) = this.getInputField().setText(value)
+var AlertDialog.input
+    get() = getInputField().text.toString()
+    set(value) { getInputField().setText(value) }
+
+val AlertDialog.title
+    get() = requireNotNull(this.findViewById<TextView>(androidx.appcompat.R.id.alertTitle)) {
+        "androidx.appcompat.R.id.alertTitle not found"
+    }.text.toString()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
First one I saw, was "not fun", especially unit test changes

## Fixes
* Issue #13315

## Approach
This involved handling `input()`, this was done via

* `setView(R.id.dialog_generic_text_input.xml)`
* and `AlertDialog.input()`


## How Has This Been Tested?

⚠️ padding is a little different, I feel it's better, but encourage a hard comparison between both images.

The text selection is at the end of the input, as it is in 2.16.5

<details>
<summary>before (2.16.5)</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/2c9828cb-d42b-45f3-89ad-bf7b73f1e9d2)

</details>

<details>

<summary>after</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/3882167d-1747-40db-a690-58c36e200ccf)


</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
