### PR TITLE
fix: undo delete deck action in snackbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2113,7 +2113,9 @@ open class DeckPicker :
                     decks.removeDecks(listOf(did))
                 }
             }
-            showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT)
+            showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {
+                setAction(R.string.undo) { undo() }
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Undo Delete deck action in snackbar

## Fixes
* Fixes #15273 

## Approach
setAction in snackbar

## How Has This Been Tested?

Physical Device ( Realme 9 )

https://github.com/ankidroid/Anki-Android/assets/65113071/735b4e24-7eb3-463b-8f01-d00021f50c75

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
