### PR TITLE
chore: convert InsertFieldDialog to AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -19,14 +19,15 @@ package com.ichi2.anki.dialogs
 import android.os.Bundle
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.list.customListAdapter
 import com.ichi2.anki.CardTemplateEditor
 import com.ichi2.anki.R
-import java.util.*
+import com.ichi2.utils.customListAdapter
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.title
 
 /**
  * Dialog fragment used to show the fields that the user can insert in the card editor. This
@@ -35,13 +36,12 @@ import java.util.*
  * @see [CardTemplateEditor.CardTemplateFragment]
  */
 class InsertFieldDialog : DialogFragment() {
-    private lateinit var dialog: MaterialDialog
     private lateinit var fieldList: List<String>
 
     /**
      * A dialog for inserting field in card template editor
      */
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
         fieldList = requireArguments().getStringArrayList(KEY_FIELD_ITEMS)!!
         val adapter: RecyclerView.Adapter<*> = object : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -60,11 +60,11 @@ class InsertFieldDialog : DialogFragment() {
                 return fieldList.size
             }
         }
-        dialog = MaterialDialog(requireContext())
-            .title(R.string.card_template_editor_select_field)
-            .negativeButton(R.string.dialog_cancel)
-            .customListAdapter(adapter)
-        return dialog
+        return AlertDialog.Builder(requireContext()).apply {
+            title(R.string.card_template_editor_select_field)
+            negativeButton(R.string.dialog_cancel)
+            customListAdapter(adapter)
+        }.create()
     }
 
     private fun selectFieldAndClose(textView: TextView) {
@@ -72,7 +72,7 @@ class InsertFieldDialog : DialogFragment() {
             REQUEST_FIELD_INSERT,
             bundleOf(KEY_INSERTED_FIELD to textView.text.toString())
         )
-        dialog.dismiss()
+        dismiss()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -20,12 +20,15 @@ package com.ichi2.utils
 
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 
@@ -185,4 +188,11 @@ fun AlertDialog.Builder.customView(
     setView(container)
 
     return this
+}
+
+fun AlertDialog.Builder.customListAdapter(adapter: RecyclerView.Adapter<*>) {
+    val recyclerView = LayoutInflater.from(context).inflate(R.layout.dialog_generic_recycler_view, null, false) as RecyclerView
+    recyclerView.adapter = adapter
+    recyclerView.layoutManager = LinearLayoutManager(context)
+    this.setView(recyclerView)
 }

--- a/AnkiDroid/src/main/res/layout/dialog_generic_recycler_view.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_recycler_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/dialog_recycler_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:clipToPadding="false"
+    android:paddingTop="8dp"
+    android:scrollbars="vertical"
+/>


### PR DESCRIPTION

## Fixes
* Issue #13315

## Approach
This involved handling `customListAdapter()`, this was done via

* setView + R.id.dialog_generic_recycler_view
* and AlertDialogFacade.customListAdapter()


## How Has This Been Tested?

<details>

<summary>before</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/4db406b5-b193-45e4-81db-153c785d3b72)


</details>


<details>

<summary>after</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/3f13db65-3e1f-42ba-8019-ced2df399f2a)


</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
