### PR TITLE
refactor: Locale selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -82,38 +82,36 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
     }
 
     private fun setupRecyclerView(activity: Activity, tagsDialogView: View, adapter: LocaleListAdapter) {
-        val recyclerView: RecyclerView = tagsDialogView.findViewById(R.id.locale_dialog_selection_list)
-        recyclerView.requestFocus()
-        val layoutManager: RecyclerView.LayoutManager = LinearLayoutManager(activity)
-        recyclerView.layoutManager = layoutManager
-        recyclerView.adapter = adapter
-        recyclerView.addOnItemTouchListener(
-            RecyclerSingleTouchAdapter(
-                activity
-            ) { _, position ->
-                val l = adapter.getLocaleAtPosition(position)
-                dialogHandler!!.onSelectedLocale(l)
-            }
-        )
+        tagsDialogView.findViewById<RecyclerView>(R.id.locale_dialog_selection_list).apply {
+            requestFocus()
+            this.adapter = adapter
+            layoutManager = LinearLayoutManager(activity)
+            addOnItemTouchListener(
+                RecyclerSingleTouchAdapter(activity) { _, position ->
+                    dialogHandler!!.onSelectedLocale(adapter.getLocaleAtPosition(position))
+                }
+            )
+        }
     }
 
     private fun inflateMenu(tagsDialogView: View, adapter: LocaleListAdapter) {
-        val toolbar: Toolbar = tagsDialogView.findViewById(R.id.locale_dialog_selection_toolbar)
-        toolbar.inflateMenu(R.menu.locale_dialog_search_bar)
-        toolbar.setNavigationOnClickListener { dialogHandler!!.onLocaleSelectionCancelled() }
-        val searchItem = toolbar.menu.findItem(R.id.locale_dialog_action_search)
-        val searchView = searchItem.actionView as SearchView
-        searchView.imeOptions = EditorInfo.IME_ACTION_DONE
-        searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
-            override fun onQueryTextSubmit(query: String): Boolean {
-                return false
-            }
+        tagsDialogView.findViewById<Toolbar>(R.id.locale_dialog_selection_toolbar).apply {
+            inflateMenu(R.menu.locale_dialog_search_bar)
+            setNavigationOnClickListener { dialogHandler!!.onLocaleSelectionCancelled() }
+            (menu.findItem(R.id.locale_dialog_action_search).actionView as SearchView).apply {
+                imeOptions = EditorInfo.IME_ACTION_DONE
+                setOnQueryTextListener(object : SearchView.OnQueryTextListener {
+                    override fun onQueryTextSubmit(query: String): Boolean {
+                        return false
+                    }
 
-            override fun onQueryTextChange(newText: String): Boolean {
-                adapter.filter.filter(newText)
-                return false
+                    override fun onQueryTextChange(newText: String): Boolean {
+                        adapter.filter.filter(newText)
+                        return false
+                    }
+                })
             }
-        })
+        }
     }
 
     class LocaleListAdapter(locales: Array<Locale>) : RecyclerView.Adapter<TextViewHolder>(), Filterable {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -99,7 +99,6 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
 
     private fun inflateMenu(tagsDialogView: View, adapter: LocaleListAdapter) {
         val toolbar: Toolbar = tagsDialogView.findViewById(R.id.locale_dialog_selection_toolbar)
-        toolbar.setTitle(R.string.locale_selection_dialog_title)
         toolbar.inflateMenu(R.menu.locale_dialog_search_bar)
         toolbar.setNavigationOnClickListener { dialogHandler!!.onLocaleSelectionCancelled() }
         val searchItem = toolbar.menu.findItem(R.id.locale_dialog_action_search)

--- a/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
@@ -19,7 +19,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:orientation="vertical"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:paddingBottom="8dp">
 
     <androidx.appcompat.widget.Toolbar xmlns:app="http://schemas.android.com/apk/res-auto"
         android:id="@+id/locale_dialog_selection_toolbar"
@@ -31,6 +32,8 @@
         android:layout_alignParentTop="true"
         app:title="@string/locale_selection_dialog_title"
         app:popupTheme="@style/ActionBar.Popup"
+        app:navigationContentDescription="@string/abc_action_bar_up_description"
+        app:navigationIcon="@drawable/close_icon"
         />
 
 
@@ -42,6 +45,7 @@
         android:layout_below="@+id/locale_dialog_selection_toolbar"
         android:layout_above="@+id/locale_dialog_summary"
         android:fadeScrollbars="false"
+        android:paddingStart="8dp"
         />
 
     <com.ichi2.ui.FixedTextView
@@ -52,6 +56,8 @@
         android:text="@string/locale_selection_dialog_summary"
         android:padding="@dimen/content_vertical_padding"
         android:layout_alignParentBottom="true"
+        android:paddingStart="8dp"
+        android:paddingEnd="8dp"
         />
 
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
@@ -30,7 +30,7 @@
         android:theme="@style/ActionBarStyle"
         android:background="?attr/colorPrimary"
         android:layout_alignParentTop="true"
-        app:title="@string/locale_selection_dialog_title"
+        app:title="@string/locale_selection_dialog_title_new"
         app:popupTheme="@style/ActionBar.Popup"
         app:navigationContentDescription="@string/abc_action_bar_up_description"
         app:navigationIcon="@drawable/close_icon"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -186,7 +186,7 @@
     <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
 
     <!-- Locale Selection Dialog -->
-    <string name="locale_selection_dialog_title">Keyboard Language Selection</string>
+    <string name="locale_selection_dialog_title_new">Set Language</string>
     <string name="locale_selection_dialog_summary">Some multilingual keyboards, such as GBoard support changing language when editing text\n\nPlease request the “setImeHintLocales” feature from your keyboard manufacturer if your keyboard does not change language.</string>
 
     <!-- Help Dialog -->


### PR DESCRIPTION
## Purpose / Description
MaterialDialog refactor, followed by a few more to make the screen nicer. Compare screenshots

## Fixes
* Issue #13315

## Approach
* Convert to `DialogFragment:onCreateView`

## How Has This Been Tested?

<details>

<summary>
Old
</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/5f85b47e-a813-4273-a788-37439cffb45c)

</details>

<details>

<summary>new</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/84e0d437-23a2-464e-9f48-512b9f3df0a8)

</details>


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
