### PR TITLE
fix: crash on Async dialog not being attached to a context

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -408,7 +408,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         try {
             showDialogFragment(newFragment)
         } catch (e: IllegalStateException) {
-            Timber.w(e)
+            Timber.w("failed to show fragment, activity is likely paused. Sending notification")
             // Store a persistent message to SharedPreferences instructing AnkiDroid to show dialog
             DialogHandler.storeMessage(newFragment.dialogHandlerMessage?.toMessage())
             // Show a basic notification to the user in the notification bar in the meantime

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -31,10 +31,16 @@ abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
 
     protected fun res(): Resources {
         return try {
+            resources
+        } catch (e: IllegalStateException) {
+            // Fragment SyncErrorDialog not attached to a context.
+            // this will occur when obtaining `notificationTitle`/`notificationMessage` and
+            // the app is in the background
+            Timber.i("resources failure. Likely due to app backgrounded")
             AnkiDroidApp.appResources
         } catch (e: Exception) {
-            Timber.w(e, "AnkiDroidApp.getAppResources failure. Returning Fragment resources as fallback.")
-            resources
+            Timber.w(e, "resources failure. Returning AnkiDroidApp resources as fallback.")
+            AnkiDroidApp.appResources
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import android.os.Message
 import android.os.Parcelable
 import android.view.KeyEvent
+import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
@@ -560,6 +561,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
          *
          * @param dialogType the sub-dialog to show
          */
+        @CheckResult
         fun newInstance(dialogType: DatabaseErrorDialogType): DatabaseErrorDialog {
             val f = DatabaseErrorDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -494,7 +494,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     databaseVersion
                 )
             }
-            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> res().getString(R.string.directory_inaccessible_after_uninstall_summary, CollectionHelper.getCurrentAnkiDroidDirectory(requireContext()))
+            DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL -> {
+                val directory = context?.let { CollectionHelper.getCurrentAnkiDroidDirectory(it) }
+                    ?: res().getString(R.string.card_browser_unknown_deck_name)
+                res().getString(R.string.directory_inaccessible_after_uninstall_summary, directory)
+            }
             else -> requireArguments().getString("dialogMessage")
         }
     private val title: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportDialog.kt
@@ -17,6 +17,8 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
+import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
 import com.ichi2.utils.negativeButton
@@ -93,12 +95,19 @@ class ImportDialog : AsyncDialogFragment() {
         const val DIALOG_IMPORT_ADD_CONFIRM = 2
         const val DIALOG_IMPORT_REPLACE_CONFIRM = 3
 
+        @VisibleForTesting
+        val dialogTypes = arrayOf(
+            DIALOG_IMPORT_ADD_CONFIRM,
+            DIALOG_IMPORT_REPLACE_CONFIRM
+        )
+
         /**
          * A set of dialogs which deal with importing a file
          *
          * @param dialogType An integer which specifies which of the sub-dialogs to show
          * @param packagePath the path of the package to import
          */
+        @CheckResult
         fun newInstance(dialogType: Int, packagePath: String): ImportDialog {
             val f = ImportDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -9,6 +9,8 @@ import android.text.method.ScrollingMovementMethod
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import com.ichi2.anki.DeckPicker
@@ -137,6 +139,11 @@ class MediaCheckDialog : AsyncDialogFragment() {
     companion object {
         const val DIALOG_CONFIRM_MEDIA_CHECK = 0
         const val DIALOG_MEDIA_CHECK_RESULTS = 1
+
+        @VisibleForTesting
+        val dialogTypes = arrayOf(DIALOG_CONFIRM_MEDIA_CHECK, DIALOG_MEDIA_CHECK_RESULTS)
+
+        @CheckResult
         fun newInstance(dialogType: Int): MediaCheckDialog {
             val f = MediaCheckDialog()
             val args = Bundle()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -167,10 +167,10 @@ class SyncErrorDialog : AsyncDialogFragment() {
 
     private val title: String
         get() = when (requireArguments().getInt("dialogType")) {
-            DIALOG_USER_NOT_LOGGED_IN_SYNC -> resources.getString(R.string.not_logged_in_title)
-            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL, DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE -> resources.getString(R.string.sync_conflict_replace_title)
-            DIALOG_SYNC_CONFLICT_RESOLUTION -> resources.getString(R.string.sync_conflict_title_new)
-            else -> resources.getString(R.string.sync_error)
+            DIALOG_USER_NOT_LOGGED_IN_SYNC -> res().getString(R.string.not_logged_in_title)
+            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL, DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE -> res().getString(R.string.sync_conflict_replace_title)
+            DIALOG_SYNC_CONFLICT_RESOLUTION -> res().getString(R.string.sync_conflict_title_new)
+            else -> res().getString(R.string.sync_error)
         }
 
     /**
@@ -181,7 +181,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
     override val notificationTitle: String
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_USER_NOT_LOGGED_IN_SYNC) {
-                resources.getString(R.string.sync_error)
+                res().getString(R.string.sync_error)
             } else {
                 title
             }
@@ -189,15 +189,15 @@ class SyncErrorDialog : AsyncDialogFragment() {
 
     private val message: String?
         get() = when (requireArguments().getInt("dialogType")) {
-            DIALOG_USER_NOT_LOGGED_IN_SYNC -> resources.getString(R.string.login_create_account_message)
-            DIALOG_CONNECTION_ERROR -> resources.getString(R.string.connection_error_message)
-            DIALOG_SYNC_CONFLICT_RESOLUTION -> resources.getString(R.string.sync_conflict_message_new)
-            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL, DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL -> resources.getString(R.string.sync_conflict_local_confirm_new)
-            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE, DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE -> resources.getString(R.string.sync_conflict_remote_confirm_new)
+            DIALOG_USER_NOT_LOGGED_IN_SYNC -> res().getString(R.string.login_create_account_message)
+            DIALOG_CONNECTION_ERROR -> res().getString(R.string.connection_error_message)
+            DIALOG_SYNC_CONFLICT_RESOLUTION -> res().getString(R.string.sync_conflict_message_new)
+            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL, DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL -> res().getString(R.string.sync_conflict_local_confirm_new)
+            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE, DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE -> res().getString(R.string.sync_conflict_remote_confirm_new)
             DIALOG_SYNC_CORRUPT_COLLECTION -> {
                 val syncMessage = requireArguments().getString("dialogMessage")
-                val repairUrl = getString(R.string.repair_deck)
-                val dialogMessage = getString(R.string.sync_corrupt_database, repairUrl)
+                val repairUrl = res().getString(R.string.repair_deck)
+                val dialogMessage = res().getString(R.string.sync_corrupt_database, repairUrl)
                 joinSyncMessages(dialogMessage, syncMessage)
             }
             else -> requireArguments().getString("dialogMessage")
@@ -211,7 +211,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
     override val notificationMessage: String?
         get() {
             return if (requireArguments().getInt("dialogType") == DIALOG_USER_NOT_LOGGED_IN_SYNC) {
-                resources.getString(R.string.not_logged_in_title)
+                res().getString(R.string.not_logged_in_title)
             } else {
                 message
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -20,6 +20,8 @@ import android.app.Dialog
 import android.net.Uri
 import android.os.Bundle
 import android.os.Message
+import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import com.ichi2.anki.AnkiActivity
@@ -239,12 +241,28 @@ class SyncErrorDialog : AsyncDialogFragment() {
         const val DIALOG_SYNC_CORRUPT_COLLECTION = 10
         const val DIALOG_SYNC_BASIC_CHECK_ERROR = 11
 
+        @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+        val dialogTypes = arrayOf(
+            DIALOG_USER_NOT_LOGGED_IN_SYNC,
+            DIALOG_CONNECTION_ERROR,
+            DIALOG_SYNC_CONFLICT_RESOLUTION,
+            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL,
+            DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE,
+            DIALOG_SYNC_SANITY_ERROR,
+            DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_LOCAL,
+            DIALOG_SYNC_SANITY_ERROR_CONFIRM_KEEP_REMOTE,
+            DIALOG_MEDIA_SYNC_ERROR,
+            DIALOG_SYNC_CORRUPT_COLLECTION,
+            DIALOG_SYNC_BASIC_CHECK_ERROR
+        )
+
         /**
          * A set of dialogs belonging to AnkiActivity which deal with sync problems
          *
          * @param dialogType An integer which specifies which of the sub-dialogs to show
          * @param dialogMessage A string which can be optionally used to set the dialog message
          */
+        @CheckResult
         fun newInstance(dialogType: Int, dialogMessage: String?): SyncErrorDialog {
             val f = SyncErrorDialog()
             val args = Bundle()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.dialogs
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
@@ -26,7 +25,6 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class AsyncDialogFragmentsTest {
     @Test
-    @Ignore("failing")
     fun `SyncErrorDialog does not require context`() {
         for (dialogType in SyncErrorDialog.dialogTypes) {
             val instance = SyncErrorDialog.newInstance(dialogType, dialogMessage = null)
@@ -37,7 +35,6 @@ class AsyncDialogFragmentsTest {
     }
 
     @Test
-    @Ignore("failing")
     fun `DatabaseErrorDialog does not require context`() {
         for (dialogType in DatabaseErrorDialog.DatabaseErrorDialogType.entries) {
             val instance = DatabaseErrorDialog.newInstance(dialogType)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AsyncDialogFragmentsTest.kt
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.runner.RunWith
+
+/** Test for any [AsyncDialogFragment] instances */
+@RunWith(AndroidJUnit4::class)
+class AsyncDialogFragmentsTest {
+    @Test
+    @Ignore("failing")
+    fun `SyncErrorDialog does not require context`() {
+        for (dialogType in SyncErrorDialog.dialogTypes) {
+            val instance = SyncErrorDialog.newInstance(dialogType, dialogMessage = null)
+
+            assertDoesNotThrow("$dialogType message required a context") { instance.notificationMessage }
+            assertDoesNotThrow("$dialogType title required a context") { instance.notificationTitle }
+        }
+    }
+
+    @Test
+    @Ignore("failing")
+    fun `DatabaseErrorDialog does not require context`() {
+        for (dialogType in DatabaseErrorDialog.DatabaseErrorDialogType.entries) {
+            val instance = DatabaseErrorDialog.newInstance(dialogType)
+            assertDoesNotThrow("$dialogType message required a context") { instance.notificationMessage }
+            assertDoesNotThrow("$dialogType title required a context") { instance.notificationTitle }
+        }
+    }
+
+    @Test
+    fun `ExportReadyDialog does not require context`() {
+        val instance = ExportReadyDialog(emptyExportListener())
+        assertDoesNotThrow("message required a context") { instance.notificationMessage }
+        assertDoesNotThrow("title required a context") { instance.notificationTitle }
+    }
+
+    @Test
+    fun `MediaCheckDialog does not require context`() {
+        for (dialogType in MediaCheckDialog.dialogTypes) {
+            val instance = MediaCheckDialog.newInstance(dialogType)
+            assertDoesNotThrow("$dialogType message required a context") { instance.notificationMessage }
+            assertDoesNotThrow("$dialogType title required a context") { instance.notificationTitle }
+        }
+    }
+
+    @Test
+    fun `ImportDialog does not require context`() {
+        for (dialogType in ImportDialog.dialogTypes) {
+            val instance = ImportDialog.newInstance(dialogType, "path")
+            assertDoesNotThrow("$dialogType message required a context") { instance.notificationMessage }
+            assertDoesNotThrow("$dialogType title required a context") { instance.notificationTitle }
+        }
+    }
+
+    private fun emptyExportListener(): ExportReadyDialog.ExportReadyDialogListener {
+        return object : ExportReadyDialog.ExportReadyDialogListener {
+            override fun dismissAllDialogFragments() { }
+
+            override fun shareFile(path: String) { }
+
+            override fun saveExportFile(exportPath: String) { }
+        }
+    }
+}


### PR DESCRIPTION
## Fixes
* Fixes #13795

## Approach
Determine that we have two problems:

1. We're using `AnkiDroidApp` resources as default from `res()`, this does not handle language changes well
2. We sometimes use `context.resources` inside `notificationMessage` or `notificationTitle`, this crashes when called in

https://github.com/ankidroid/Anki-Android/blob/08b6a0feeb634a70e99d3ec0887c003cbd81e238/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt#L413-L417

To fix (2), use `res()` throughout
To fix (1), prefer `resources` over `AnkiDroidApp.resources`


## How Has This Been Tested?
Unit tests

modify `sync` to always show the error dialog after a delay, and see the crashes

I haven't tested this thoroughly, I trusted the unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
