### PR TITLE
fix: eternal load when editing a note from the new previewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -971,7 +971,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
             withProgress {
                 undoableOp {
-                    updateNote(mCurrentEditedCard!!.note(getColUnsafe))
+                    updateNote(mCurrentEditedCard!!.note(this))
                 }
                 closeNoteEditor()
             }


### PR DESCRIPTION
cause: https://github.com/ankidroid/Anki-Android/commit/65c9f9197ef31e223e5ced4950c366883c94205b#diff-6d9f7ea7bba9cc72513b5078633cee9bdbbd1ea7646114869679f302ad607459R974

## How Has This Been Tested?

Android 31: Enable the new previewer in dev options -> Tap edit note -> Edit the note -> Confirm

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
