### PR TITLE
fix: "Invalid input: card was modified"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -81,6 +81,8 @@ import com.ichi2.anki.services.migrationServiceWhileStartedOrNull
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.OnlyOnce.Method.ANSWER_CARD
+import com.ichi2.anki.utils.OnlyOnce.preventSimultaneousExecutions
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat
 import com.ichi2.compat.ResolveInfoFlagsCompat
@@ -859,7 +861,7 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
-    open fun answerCard(@BUTTON_TYPE ease: Int) {
+    open fun answerCard(@BUTTON_TYPE ease: Int) = preventSimultaneousExecutions(ANSWER_CARD) {
         launchCatchingTask {
             if (inAnswer) {
                 return@launchCatchingTask

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/OnlyOnce.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/OnlyOnce.kt
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import kotlinx.coroutines.Job
+import timber.log.Timber
+
+/**
+ * Prevent multiple instances of a method being executed simultaneously
+ */
+object OnlyOnce {
+    private val blockedFunctions = mutableSetOf<Any>()
+
+    enum class Method {
+        ANSWER_CARD,
+        UNIT_TEST
+    }
+
+    /**
+     * Prevents multiple instances of a method being executed simultaneously
+     *
+     * If the provided method is not running, run it
+     * If the provided method is running, do nothing more
+     */
+    fun preventSimultaneousExecutions(name: Method, function: () -> Job) {
+        if (!blockedFunctions.add(name)) {
+            Timber.w("simultaneously executions of $name blocked")
+            return
+        }
+        Timber.v("executing $name")
+        function().invokeOnCompletion {
+            Timber.v("completed $name")
+            blockedFunctions.remove(name)
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/OnlyOnceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/OnlyOnceTest.kt
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.utils.OnlyOnce.Method.*
+import com.ichi2.anki.utils.OnlyOnce.preventSimultaneousExecutions
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OnlyOnceTest : RobolectricTest() {
+    @Test
+    fun `single run works`() = runTest {
+        var i = 0
+        preventMultipleExecutions(wait = true) { i++ }
+        assertThat(i, equalTo(1))
+    }
+
+    @Test
+    fun `simultaneous run is blocked`() = runTest {
+        var i = 0
+        preventMultipleExecutions(wait = false) { i++ }
+        preventMultipleExecutions(wait = false) { i++ }
+        advanceUntilIdle()
+        assertThat(i, equalTo(1))
+    }
+
+    @Test
+    fun `exceptional run does not block`() = runTest {
+        var i = 0
+        preventMultipleExecutions(wait = true, shouldCatchException = true) { throw IllegalStateException() }
+        preventMultipleExecutions(wait = true) { i++ }
+        assertThat(i, equalTo(1))
+    }
+
+    @Test
+    fun `second run is not blocked`() = runTest {
+        var i = 0
+        preventMultipleExecutions(wait = true) { i++ }
+        preventMultipleExecutions(wait = true) { i++ }
+        assertThat(i, equalTo(2))
+    }
+
+    // catch the exception here otherwise the test scope will catch it and throw it, safe as we expect the exception
+    context(TestScope)
+    private fun preventMultipleExecutions(
+        shouldCatchException: Boolean = false,
+        wait: Boolean,
+        function: () -> Unit
+    ) {
+        preventSimultaneousExecutions(UNIT_TEST) {
+            launch {
+                if (shouldCatchException) {
+                    runCatching { function() }
+                } else {
+                    function()
+                }
+            }
+        }
+        if (wait) this@TestScope.advanceUntilIdle()
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Cause: answering the card too quickly, which caused two executions of `answerCard()`

## Fixes
* Fixes #12946

## Approach
Define and use `preventSimultaneousExecutions`

## How Has This Been Tested?
* calling `answerCard(EASE_4)` twice and ensuring no error
* throwing an exception inside the method and ensuring it's unlocked
   * technically not perfect due to `launchCatchingTask`
* adding a log statement afterwards and ensuring the call is not blocking
* Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
