### PR TITLE
enhancement: show copied to clipboard toast for API ≤ 32

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -100,13 +100,11 @@ class IntentHandler : Activity() {
 
     private fun copyDebugInfoToClipboard(intent: Intent) {
         Timber.i("Copying debug info to clipboard")
-        if (!this.copyToClipboard(intent.getStringExtra(CLIPBOARD_INTENT_EXTRA_DATA)!!)) {
-            Timber.w("Failed to obtain ClipboardManager")
-            showThemedToast(this, R.string.something_wrong, true)
-            return
-        }
-
-        showThemedToast(this, R.string.about_ankidroid_successfully_copied_debug_info, true)
+        // null string is handled by copyToClipboard in try-catch
+        this.copyToClipboard(
+            text = (intent.getStringExtra(CLIPBOARD_INTENT_EXTRA_DATA)!!),
+            failureMessageId = R.string.about_ankidroid_error_copy_debug_info
+        )
     }
 
     private val fileIntent: Intent

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
@@ -21,6 +21,7 @@ import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AndroidTtsVoice
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import com.ichi2.anki.TtsVoices
 import com.ichi2.anki.dialogs.tryDisplayLocalizedName
 import com.ichi2.libanki.TTSTag
@@ -178,7 +179,10 @@ class TtsVoicesViewModel : ViewModel() {
     fun copyToClipboard(voice: TtsVoice) {
         // At least in API 33, we do not need to display a snackbar, as the Android OS already
         // displays the copied text
-        AnkiDroidApp.instance.copyToClipboard(voice.toString())
+        AnkiDroidApp.instance.copyToClipboard(
+            text = voice.toString(),
+            failureMessageId = R.string.failed_to_copy
+        )
     }
 
     private suspend fun playTts(textToSpeak: String, voice: TtsVoice) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
-import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.*
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.snackbar.showSnackbar
@@ -113,17 +112,10 @@ class AboutFragment : Fragment(R.layout.about_layout) {
      */
     private fun copyDebugInfo() {
         val debugInfo = DebugInfoService.getDebugInfo(requireContext())
-        if (requireContext().copyToClipboard(debugInfo)) {
-            showSnackbar(
-                R.string.about_ankidroid_successfully_copied_debug_info,
-                Snackbar.LENGTH_SHORT
-            )
-        } else {
-            showSnackbar(
-                R.string.about_ankidroid_error_copy_debug_info,
-                Snackbar.LENGTH_SHORT
-            )
-        }
+        requireContext().copyToClipboard(
+            debugInfo,
+            failureMessageId = R.string.about_ankidroid_error_copy_debug_info
+        )
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/ActivityAgnosticDialogs.kt
@@ -32,7 +32,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs.Companion.MIGRATION_FAILED_DIALOG_ERROR_TEXT_KEY
 import com.ichi2.anki.utils.getUserFriendlyErrorText
-import com.ichi2.utils.copyToClipboardAndShowConfirmation
+import com.ichi2.utils.copyToClipboard
 import makeLinksClickable
 
 // TODO BEFORE-RELEASE Dismiss the related notification, if any, when the dialog is dismissed.
@@ -81,9 +81,8 @@ class MigrationFailedDialogFragment : DialogFragment() {
             .setMessage(message)
             .setPositiveButton(R.string.dialog_ok) { _, _ -> dismiss() }
             .setNegativeButton(R.string.feedback_copy_debug) { _, _ ->
-                requireContext().copyToClipboardAndShowConfirmation(
+                requireContext().copyToClipboard(
                     text = stacktrace,
-                    successMessageId = R.string.about_ankidroid_successfully_copied_debug_info,
                     failureMessageId = R.string.about_ankidroid_error_copy_debug_info
                 )
             }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -425,4 +425,6 @@ opening the system text to speech settings fails">
     <string name="shared_decks_login_required">Please log in to download more decks</string>
 
     <string name="deck_description_field_hint">Description</string>
+
+    <string name="failed_to_copy">Failed to copy</string>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In Android 12L (API level 32) and lower, users might be unsure whether they successfully copied content or what they copied. 

## Fixes
* Fixes  #14992

## How Has This Been Tested?
Tested on Google emulator for API 12 and lower and API 33

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
