### PR TITLE
refactor: convert IntegerDialog to AlertDialog 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -81,7 +81,7 @@ class CreateDeckDialog(
             positiveButton(R.string.dialog_ok) { onPositiveButtonClicked() }
             negativeButton(R.string.dialog_cancel)
             setView(R.layout.dialog_generic_text_input)
-        }.input(prefill = initialDeckName, displayKeyboard = true) { dialog, text ->
+        }.input(prefill = initialDeckName, displayKeyboard = true, waitForPositiveButton = false) { dialog, text ->
             // we need the fully-qualified name for subdecks
             val maybeDeckName = fullyQualifyDeckName(dialogText = text)
             // if the name is empty, it seems distracting to show an error

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -55,7 +55,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     @Suppress("Deprecation") // Material dialog neutral button deprecation
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
-        super.onCreate(savedInstanceState)
+        super.onCreateDialog(savedInstanceState)
         val res = res()
         val dialog = MaterialDialog(requireActivity())
         val isLoggedIn = isLoggedIn()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -27,7 +27,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 
 class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
-        super.onCreate(savedInstanceState)
+        super.onCreateDialog(savedInstanceState)
         return MaterialDialog(requireActivity()).show {
             title(R.string.analytics_dialog_title)
             message(R.string.analytics_summ)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -46,7 +46,7 @@ open class IntegerDialog : AnalyticsDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
-        super.onCreate(savedInstanceState)
+        super.onCreateDialog(savedInstanceState)
         @SuppressLint("CheckResult")
         val show = MaterialDialog(requireActivity()).show {
             title(text = requireArguments().getString("title")!!)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/IntegerDialog.kt
@@ -16,17 +16,16 @@
 
 package com.ichi2.anki.dialogs
 
-import android.annotation.SuppressLint
 import android.os.Bundle
 import android.text.InputType
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.callbacks.onShow
-import com.afollestad.materialdialogs.input.getInputField
-import com.afollestad.materialdialogs.input.input
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
-import com.ichi2.utils.contentNullable
-import com.ichi2.utils.displayKeyboard
+import com.ichi2.utils.input
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+import com.ichi2.utils.title
 import java.util.function.Consumer
 
 open class IntegerDialog : AnalyticsDialogFragment() {
@@ -45,24 +44,22 @@ open class IntegerDialog : AnalyticsDialogFragment() {
         arguments = args
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
-        @SuppressLint("CheckResult")
-        val show = MaterialDialog(requireActivity()).show {
+        return AlertDialog.Builder(requireActivity()).show {
             title(text = requireArguments().getString("title")!!)
             positiveButton(R.string.dialog_ok)
             negativeButton(R.string.dialog_cancel)
-            input(
-                hint = requireArguments().getString("prompt"),
-                inputType = InputType.TYPE_CLASS_NUMBER,
-                maxLength = requireArguments().getInt("digits")
-            ) { _: MaterialDialog?, text: CharSequence -> consumer!!.accept(text.toString().toInt()) }
-            contentNullable(requireArguments().getString("content"))
-            onShow {
-                displayKeyboard(getInputField())
-            }
+            setMessage(requireArguments().getString("content"))
+            setView(R.layout.dialog_generic_text_input)
+        }.input(
+            hint = requireArguments().getString("prompt"),
+            inputType = InputType.TYPE_CLASS_NUMBER,
+            maxLength = requireArguments().getInt("digits"),
+            displayKeyboard = true
+        ) { _, text: CharSequence ->
+            consumer!!.accept(text.toString().toInt())
+            dismiss()
         }
-
-        return show
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -16,7 +16,6 @@
 package com.ichi2.preferences
 
 import android.content.Context
-import android.text.InputFilter
 import android.text.InputFilter.LengthFilter
 import android.text.InputType
 import android.util.AttributeSet
@@ -142,13 +141,7 @@ open class NumberRangePreference : android.preference.EditTextPreference, AutoFo
         editText.inputType = InputType.TYPE_CLASS_NUMBER
 
         // Set max number of digits
-        val maxLength = max.toString().length
-        // Clone the existing filters so we don't override them, then append our one at the end.
-        val filters = editText.filters
-        val newFilters = arrayOfNulls<InputFilter>(filters.size + 1)
-        System.arraycopy(filters, 0, newFilters, 0, filters.size)
-        newFilters[newFilters.size - 1] = LengthFilter(maxLength)
-        editText.filters = newFilters
+        editText.filters += LengthFilter(max.toString().length)
     }
     var value: Int
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MaterialBuilderUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MaterialBuilderUtil.kt
@@ -16,10 +16,7 @@
 
 package com.ichi2.utils
 
-import android.widget.EditText
-import androidx.annotation.DrawableRes
 import com.afollestad.materialdialogs.MaterialDialog
-import com.ichi2.themes.Themes
 
 // Extension methods for MaterialDialog workarounds in Kotlin
 // Previously the methods accepted null into a non-null parameter,
@@ -28,22 +25,4 @@ import com.ichi2.themes.Themes
 fun MaterialDialog.contentNullable(message: CharSequence?): MaterialDialog {
     message?.let { this.message(text = it) }
     return this
-}
-
-/**
- * Method to display keyboard when dialog is shown.
- *
- * @param editText EditText present in the dialog.
- */
-fun MaterialDialog.displayKeyboard(editText: EditText) {
-    AndroidUiUtils.setFocusAndOpenKeyboard(editText, window!!)
-}
-
-/**
- * Shows an icon to the left of the dialog title.
- */
-fun MaterialDialog.iconAttr(
-    @DrawableRes res: Int
-): MaterialDialog = apply {
-    this.icon(Themes.getResFromAttr(this.context, res))
 }


### PR DESCRIPTION
## Fixes
* Part of #13315

## How Has This Been Tested?
API 33 emulator: Reposition Dialog dialog

<img width="356" alt="Screenshot 2024-01-21 at 17 56 14" src="https://github.com/ankidroid/Anki-Android/assets/62114487/243b0fd9-f12e-4391-9b86-62b0e86df73f">

<img width="336" alt="Screenshot 2024-01-21 at 17 55 56" src="https://github.com/ankidroid/Anki-Android/assets/62114487/d67a85c9-9e30-4fec-99dd-a422546133fb">

## Learning

* waitForPositiveButton matches the material dialog UI, but is questionable
* `.show()` is required for `.input()`
* `allowEmpty` potentially has a bug if called alongside `waitForPositiveButton`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
