### PR TITLE
chore: remove `processInefficientImage`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2258,18 +2258,9 @@ abstract class AbstractFlashcardViewer :
                 loader!!.shouldInterceptRequest(url)?.let { return it }
             }
             if (url.toString().startsWith("file://")) {
-                if (isLoadedFromProtocolRelativeUrl(request.url.toString())) {
-                    mMissingImageHandler.processInefficientImage { displayMediaUpgradeRequiredSnackbar() }
-                }
                 url.path?.let { path -> migrationService?.migrateFileImmediately(File(path)) }
             }
             return null
-        }
-
-        private fun isLoadedFromProtocolRelativeUrl(url: String): Boolean {
-            // a URL provided as "//wikipedia.org" is currently transformed to file://wikipedia.org, we can catch this
-            // because <img src="x.png"> maps to file:///.../x.png
-            return url.startsWith("file://") && !url.startsWith("file:///")
         }
 
         override fun onReceivedError(
@@ -2508,12 +2499,6 @@ abstract class AbstractFlashcardViewer :
     internal fun displayCouldNotFindMediaSnackbar(filename: String?) {
         showSnackbar(getString(R.string.card_viewer_could_not_find_image, filename)) {
             setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
-        }
-    }
-
-    private fun displayMediaUpgradeRequiredSnackbar() {
-        showSnackbar(R.string.card_viewer_media_relative_protocol) {
-            setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_invalid_protocol_relative))) }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/MissingImageHandler.kt
@@ -34,7 +34,6 @@ class MissingImageHandler {
     }
 
     private var missingMediaCount = 0
-    private var hasShownInefficientImage = false
     private var hasExecuted = false
 
     private var automaticTtsFailureCount = 0
@@ -85,13 +84,6 @@ class MissingImageHandler {
 
     fun onCardSideChange() {
         hasExecuted = false
-    }
-
-    fun processInefficientImage(onFailure: Runnable) {
-        if (hasShownInefficientImage) return
-
-        hasShownInefficientImage = true
-        onFailure.run()
     }
 
     fun processTtsFailure(activity: AnkiActivity, error: TtsPlayer.TtsError, playingAutomatically: Boolean) {

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -231,7 +231,6 @@
 
     <!-- Card Viewer -->
     <string name="card_viewer_could_not_find_image">Card Content Error: Failed to load ‘%s’</string>
-    <string name="card_viewer_media_relative_protocol">Card Content Error: Media update required</string>
 
     <!-- Deck Picker -->
     <string name="search_decks">Search decks</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -126,7 +126,6 @@
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
     <string name="link_third_party_api_apps">https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps</string>
-    <string name="link_faq_invalid_protocol_relative">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-do-my-images-need-a-protocol</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
     <string name="shared_decks_login_url">https://ankiweb.net/account/login</string>
     <string name="shared_decks_sign_up_url">https://ankiweb.net/account/signup</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MissingImageHandlerTest.kt
@@ -104,10 +104,6 @@ class MissingImageHandlerTest {
         sut.processMissingSound(file, onFailure)
     }
 
-    private fun processInefficientImage(onFailure: Runnable) {
-        sut.processInefficientImage(onFailure)
-    }
-
     @Test
     fun uiFailureDoesNotCrash() {
         processFailure(getValidRequest("example.jpg")) { throw RuntimeException("expected") }
@@ -136,24 +132,6 @@ class MissingImageHandlerTest {
     @Test
     fun testMissingSound_ExceptionCaught() {
         assertDoesNotThrow { processMissingSound(File("example.wav")) { throw RuntimeException("expected") } }
-    }
-
-    @Test
-    fun testInefficientImage() {
-        // Tests that the runnable passed to processInefficientImage only runs once
-        class RunTest : Runnable {
-            var nTimesRun = 0
-                private set
-
-            override fun run() {
-                nTimesRun++
-            }
-        }
-
-        val runnableTest = RunTest()
-        processInefficientImage(runnableTest)
-        processInefficientImage(runnableTest)
-        assertThat(runnableTest.nTimesRun, equalTo(1))
     }
 
     private fun getValidRequest(fileName: String): WebResourceRequest {


### PR DESCRIPTION
since we stopped using the media directory as base URL of the reviewer in 7a65160e0e23e20080091a30abdd4c05fc610e06, urls without a explicit protocol default back to http

## Approach
Remove the URL protocol handling

## How Has This Been Tested?

Android 31:

[rem inefficient.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/c21c4c88-686c-40a5-98e9-f5b8bc629eb8)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
