### PR TITLE
refactor: remove lifecycle dependency from SoundPlayer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2457,7 +2457,7 @@ abstract class AbstractFlashcardViewer :
         @NeedsTest("14221: 'playsound' should play the sound from the start")
         @BlocksSchemaUpgrade("handle TTS tags")
         private suspend fun controlSound(url: String) {
-            val avTag = when (val tag = currentCard?.let { getAvTag(getColUnsafe, it, url) }) {
+            val avTag = when (val tag = currentCard?.let { getAvTag(it, url) }) {
                 is SoundOrVideoTag -> tag
                 is TTSTag -> tag
                 // not currently supported

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -587,6 +587,9 @@ abstract class AbstractFlashcardViewer :
         super.onPause()
         automaticAnswer.disable()
         gestureDetectorImpl.stopShakeDetector()
+        if (this::soundPlayer.isInitialized) {
+            soundPlayer.isEnabled = false
+        }
         longClickHandler.removeCallbacks(startLongClickAction)
         // Prevent loss of data in Cookies
         CookieManager.getInstance().flush()
@@ -596,6 +599,9 @@ abstract class AbstractFlashcardViewer :
         super.onResume()
         automaticAnswer.enable()
         gestureDetectorImpl.startShakeDetector()
+        if (this::soundPlayer.isInitialized) {
+            soundPlayer.isEnabled = true
+        }
         // Reset the activity title
         updateActionBar()
         selectNavigationItem(-1)
@@ -637,6 +643,9 @@ abstract class AbstractFlashcardViewer :
             cardFrame!!.removeAllViews()
         }
         destroyWebView(webView) // OK to do without a lock
+        if (this::soundPlayer.isInitialized) {
+            soundPlayer.close()
+        }
     }
 
     override fun onBackPressed() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1429,7 +1429,7 @@ abstract class AbstractFlashcardViewer :
         Timber.d("updateCard()")
         // TODO: This doesn't need to be blocking
         runBlocking {
-            soundPlayer.loadCardSounds(getColUnsafe, currentCard!!, if (displayAnswer) Side.BACK else Side.FRONT)
+            soundPlayer.loadCardSounds(currentCard!!, if (displayAnswer) Side.BACK else Side.FRONT)
         }
         cardContent = content.getTemplateHtml()
         fillFlashcard()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AndroidTtsError
 import com.ichi2.anki.AndroidTtsError.TtsErrorCode
 import com.ichi2.anki.AndroidTtsPlayer
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.CONTINUE_AUDIO
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.RETRY_AUDIO
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.STOP_AUDIO
@@ -39,7 +40,6 @@ import com.ichi2.anki.cardviewer.SoundSide.QUESTION_AND_ANSWER
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.AvTag
 import com.ichi2.libanki.Card
-import com.ichi2.libanki.Collection
 import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.TtsPlayer
@@ -114,11 +114,11 @@ class SoundPlayer(
         close()
     }
 
-    suspend fun loadCardSounds(col: Collection, card: Card, side: Side) {
+    suspend fun loadCardSounds(card: Card, side: Side) {
         Timber.i("loading sounds for card %s (%s)", card.id, side)
         stopSounds()
-        this.questions = card.renderOutput(col).questionAvTags
-        this.answers = card.renderOutput(col).answerAvTags
+        this.questions = withCol { card.renderOutput(this).questionAvTags }
+        this.answers = withCol { card.renderOutput(this).answerAvTags }
         this.side = side
 
         if (!this::config.isInitialized || !config.appliesTo(card)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -19,12 +19,7 @@ package com.ichi2.anki.cardviewer
 import android.media.MediaPlayer
 import android.net.Uri
 import androidx.annotation.CheckResult
-import androidx.annotation.VisibleForTesting
 import androidx.core.net.toFile
-import androidx.lifecycle.DefaultLifecycleObserver
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.coroutineScope
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AndroidTtsError
@@ -48,7 +43,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
@@ -89,30 +86,26 @@ import java.io.File
 class SoundPlayer(
     private val soundTagPlayer: SoundTagPlayer,
     private val ttsPlayer: Deferred<TtsPlayer>,
-    private val lifecycle: Lifecycle,
     private val onSoundGroupCompleted: () -> Unit,
     private val soundErrorListener: SoundErrorListener
-) : DefaultLifecycleObserver, Closeable {
+) : Closeable {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     private lateinit var questions: List<AvTag>
     private lateinit var answers: List<AvTag>
     private lateinit var side: Side
 
     lateinit var config: CardSoundConfig
+    var isEnabled = true
+        set(value) {
+            if (!value) {
+                scope.launch { stopSounds() }
+            }
+            field = value
+        }
 
     private var playSoundsJob: Job? = null
-
-    val scope get() = lifecycle.coroutineScope
-
-    override fun onPause(owner: LifecycleOwner) {
-        super.onPause(owner)
-        scope.launch { stopSounds() }
-    }
-
-    override fun onDestroy(owner: LifecycleOwner) {
-        super.onDestroy(owner)
-        close()
-    }
 
     suspend fun loadCardSounds(card: Card, side: Side) {
         Timber.i("loading sounds for card %s (%s)", card.id, side)
@@ -127,9 +120,7 @@ class SoundPlayer(
     }
 
     private suspend fun playAllSoundsForSide(soundSide: SoundSide): Job? {
-        if (!canPlaySounds()) {
-            return null
-        }
+        if (!isEnabled) return null
         playSoundsJob {
             Timber.i("playing sounds for %s", soundSide)
             playAllSoundsInternal(soundSide, isAutomaticPlayback = true)
@@ -138,9 +129,7 @@ class SoundPlayer(
     }
 
     suspend fun playOneSound(tag: AvTag): Job? {
-        if (!canPlaySounds()) {
-            return null
-        }
+        if (!isEnabled) return null
         cancelPlaySoundsJob()
         Timber.i("playing one sound")
 
@@ -156,7 +145,7 @@ class SoundPlayer(
             }
         }
 
-        playSoundsJob = scope.launch(Dispatchers.IO) {
+        playSoundsJob = scope.launch {
             try {
                 play(tag)
             } catch (e: SoundException) {
@@ -187,6 +176,7 @@ class SoundPlayer(
         } catch (e: Exception) {
             Timber.i(e, "ttsPlayer close()")
         }
+        scope.cancel()
     }
 
     private suspend fun cancelPlaySoundsJob(job: Job? = playSoundsJob) {
@@ -205,9 +195,7 @@ class SoundPlayer(
      * Obtains all the sounds for the [soundSide] and plays them sequentially
      */
     private suspend fun playAllSoundsInternal(soundSide: SoundSide, isAutomaticPlayback: Boolean) {
-        if (!canPlaySounds()) {
-            return
-        }
+        if (!isEnabled) return
         val soundList = when (soundSide) {
             QUESTION -> questions
             ANSWER -> answers
@@ -307,21 +295,13 @@ class SoundPlayer(
     /** Ensures that only one [playSoundsJob] is running at once */
     private suspend fun playSoundsJob(block: suspend CoroutineScope.() -> Unit) {
         val oldJob = playSoundsJob
-        this.playSoundsJob = scope.launch(Dispatchers.IO) {
+        this.playSoundsJob = scope.launch {
             cancelPlaySoundsJob(oldJob)
             block()
             playSoundsJob = null
         }
     }
 
-    @VisibleForTesting
-    internal fun canPlaySounds(): Boolean {
-        if (!lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
-            Timber.w("sounds are not played as the activity is inactive")
-            return false
-        }
-        return true
-    }
     companion object {
         const val TTS_PLAYER_TIMEOUT_MS = 2_500L
 
@@ -340,12 +320,9 @@ class SoundPlayer(
             return SoundPlayer(
                 soundTagPlayer = soundPlayer,
                 ttsPlayer = tts,
-                lifecycle = viewer.lifecycle,
                 onSoundGroupCompleted = viewer::onSoundGroupCompleted,
                 soundErrorListener = soundErrorListener
-            ).apply {
-                viewer.lifecycle.addObserver(this)
-            }
+            )
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -130,16 +130,16 @@ object Sound {
     }
 
     /** Extract av tag from playsound:q:x link */
-    suspend fun getAvTag(col: Collection, card: Card, url: String): AvTag? {
+    suspend fun getAvTag(card: Card, url: String): AvTag? {
         return AV_PLAYLINK_RE.matchEntire(url)?.let {
             val values = it.groupValues
             val questionSide = values[1] == "q"
             val index = values[2].toInt()
             val tags = CollectionManager.withCol {
                 if (questionSide) {
-                    card.questionAvTags(col)
+                    card.questionAvTags(this)
                 } else {
-                    card.answerAvTags(col)
+                    card.answerAvTags(this)
                 }
             }
             if (index < tags.size) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
@@ -245,7 +245,7 @@ class SoundPlayerTest : RobolectricTest() {
             }
         }
 
-        this.loadCardSounds(col, card, side)
+        this.loadCardSounds(card, side)
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/SoundPlayerTest.kt
@@ -18,14 +18,13 @@ package com.ichi2.anki.cardviewer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CardUtils
-import com.ichi2.anki.IntroductionActivity
-import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.cardviewer.Side.BACK
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.*
 import com.ichi2.libanki.AvTag
 import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.TemplateManager
 import com.ichi2.libanki.TtsPlayer
+import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.TestException
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,7 +40,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class SoundPlayerTest : RobolectricTest() {
+class SoundPlayerTest : JvmTest() {
     internal val tagPlayer: SoundTagPlayer = mockk<SoundTagPlayer>()
     internal val ttsPlayer: TtsPlayer = mockk<TtsPlayer>()
     internal val onSoundGroupCompleted: () -> Unit = mockk<() -> Unit>().also {
@@ -263,19 +262,13 @@ fun SoundPlayerTest.runSoundPlayerTest(
     testBody: suspend SoundPlayer.() -> Unit
 ) =
     runTest {
-        // PERF: See if we can make this faster
-        val lifecycle = startRegularActivity<IntroductionActivity>().lifecycle
-        // val lifecycle = mockk<Lifecycle>()
-        // every { lifecycle.currentState } answers { Lifecycle.State.RESUMED }
-
         val soundPlayer = SoundPlayer(
             soundTagPlayer = tagPlayer,
             ttsPlayer = CompletableDeferred(ttsPlayer),
-            lifecycle = lifecycle,
             onSoundGroupCompleted = onSoundGroupCompleted,
             soundErrorListener = mockk()
         )
-        assertThat("can play sounds", soundPlayer.canPlaySounds())
+        assertThat("can play sounds", soundPlayer.isEnabled)
         soundPlayer.setup(questions, answers, side, replayQuestion, autoplay)
         testBody(soundPlayer)
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Different activities may have different lifecycle behaviors depending on how well they deal with configuration changes or if they have a ViewModel or not

So now the SoundPlayer will get its own scope, which means that callers need to remember to close() it, and it can be enabled/disabled with a property

this also makes removes the Robolectric dependency from SoundPlayerTest, which should make things faster

Additionally, it prepares for handling audios in the new previewer

## Approach
In the commits

## How Has This Been Tested?

Unit tests (should be non functional) + opened some cards with audio in 31 emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
