### PR TITLE
fix: play tags shown in card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -27,6 +27,7 @@ package com.ichi2.libanki
 
 import anki.config.ConfigKey
 import com.ichi2.anki.CollectionManager
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import java.util.regex.Pattern
 
 /**
@@ -57,7 +58,7 @@ open class AvTag
  */
 val SOUND_RE = Pattern.compile("\\[sound:([^\\[\\]]*)]").toRegex()
 
-fun stripAvRefs(text: String) = Sound.AV_REF_RE.replace(text, "")
+fun stripAvRefs(text: String, replacement: String = "") = Sound.AV_REF_RE.replace(text, replacement)
 
 // not in libAnki
 object Sound {
@@ -109,7 +110,21 @@ object Sound {
      */
     fun replaceWithSoundTags(
         content: String,
-        renderOutput: TemplateManager.TemplateRenderContext.TemplateRenderOutput
+        renderOutput: TemplateRenderOutput
+    ): String = replaceAvRefsWith(content, renderOutput) { tag -> "[sound:${tag.filename}]" }
+
+    /**
+     * Replaces [anki:play:q:0] with ` example.mp3 `
+     */
+    fun replaceWithFileNames(
+        content: String,
+        renderOutput: TemplateRenderOutput
+    ): String = replaceAvRefsWith(content, renderOutput) { tag -> " ${tag.filename} " }
+
+    private fun replaceAvRefsWith(
+        content: String,
+        renderOutput: TemplateRenderOutput,
+        processTag: (SoundOrVideoTag) -> String
     ): String {
         return AV_REF_RE.replace(content) { match ->
             val groups = match.groupValues
@@ -124,7 +139,7 @@ object Sound {
             if (tag !is SoundOrVideoTag) {
                 return@replace match.value
             } else {
-                return@replace "[sound:${tag.filename}]"
+                return@replace processTag(tag)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -41,7 +41,6 @@ object Utils {
     private val scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>")
     private val tagPattern = Pattern.compile("(?s)<.*?>")
     private val imgPattern = Pattern.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>")
-    private val soundPattern = Pattern.compile("(?i)\\[sound:([^]]+)]")
     private val htmlEntitiesPattern = Pattern.compile("&#?\\w+;")
     private const val ALL_CHARACTERS =
         "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -85,14 +84,6 @@ object Utils {
     fun stripHTMLMedia(s: String, replacement: String = " $1 "): String {
         val imgMatcher = imgPattern.matcher(s)
         return stripHTML(imgMatcher.replaceAll(replacement))
-    }
-
-    /**
-     * Strip sound but keep media filenames
-     */
-    fun stripSoundMedia(s: String, replacement: String = " $1 "): String {
-        val soundMatcher = soundPattern.matcher(s)
-        return soundMatcher.replaceAll(replacement)
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserNonAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserNonAndroidTest.kt
@@ -16,6 +16,8 @@
 package com.ichi2.anki
 
 import androidx.annotation.CheckResult
+import com.ichi2.libanki.SoundOrVideoTag
+import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -23,13 +25,13 @@ import org.junit.Test
 class CardBrowserNonAndroidTest {
     @Test
     fun soundIsStrippedCorrectly() {
-        val output = formatWithFilenamesStripped("aou[sound:foo.mp3]aou")
+        val output = formatWithFilenamesStripped("aou[anki:play:a:0]aou")
         assertThat(output, equalTo("aou aou"))
     }
 
     @Test
     fun soundIsRetainedWithoutTag() {
-        val output = formatWithFilenamesRetained("aou[sound:foo.mp3]aou")
+        val output = formatWithFilenamesRetained("aou[anki:play:a:0]aou")
         assertThat(output, equalTo("aou foo.mp3 aou"))
     }
 
@@ -47,11 +49,33 @@ class CardBrowserNonAndroidTest {
 
     @CheckResult
     private fun formatWithFilenamesRetained(input: String): String {
-        return CardBrowser.formatQAInternal(input, true)
+        return CardBrowser.formatQAInternal(
+            input,
+            TemplateRenderOutput(
+                questionText = input,
+                answerText = input,
+                questionAvTags = listOf(SoundOrVideoTag("foo.mp3")),
+                answerAvTags = listOf(SoundOrVideoTag("foo.mp3")),
+                css = ""
+
+            ),
+            true
+        )
     }
 
     @CheckResult
     private fun formatWithFilenamesStripped(input: String): String {
-        return CardBrowser.formatQAInternal(input, false)
+        return CardBrowser.formatQAInternal(
+            input,
+            TemplateRenderOutput(
+                questionText = input,
+                answerText = input,
+                questionAvTags = listOf(SoundOrVideoTag("foo.mp3")),
+                answerAvTags = listOf(SoundOrVideoTag("foo.mp3")),
+                css = ""
+
+            ),
+            false
+        )
     }
 }


### PR DESCRIPTION
## Purpose / Description
`[sound:foo.mp3]` is now `[anki:play:a:0]`, CardBrowser needed further handling of this

## Fixes
* Fixes #14353

## Approach
* Define `replaceAvRefsWith` to enable replacements
* pass in TemplateRenderContext so we have a reference to the AvTag
* allow `stripAvRefs` to accept a formatter override

## How Has This Been Tested?
Unit tests changed and tested on my S21

<details>

<summary>hide names</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/ba01ee50-aa85-42a6-86af-f6f464566bd0)

</details>

<details>

<summary>show names</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/28e95a32-2a80-443e-a77c-a9818f4d8255)

</details>

## Learning (optional, can help others)
I'll be glad when we kill this code in the CardBrowser, it'll be the last to go though

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
