### PR TITLE
Support customizing preview delays for Again, Hard, and Good buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -76,6 +76,9 @@ class FilteredDeckOptions :
                 values["stepsOn"] = java.lang.Boolean.toString(false)
             }
             values["resched"] = java.lang.Boolean.toString(deck.getBoolean("resched"))
+            values["previewAgainSecs"] = deck.getString("previewAgainSecs")
+            values["previewHardSecs"] = deck.getString("previewHardSecs")
+            values["previewGoodSecs"] = deck.getString("previewGoodSecs")
         }
 
         inner class Editor : AppCompatPreferenceActivity<FilteredDeckOptions.DeckPreferenceHack>.AbstractPreferenceHack.Editor() {
@@ -110,6 +113,15 @@ class FilteredDeckOptions :
                         }
                         "resched" -> {
                             deck.put("resched", value)
+                        }
+                        "previewAgainSecs" -> {
+                            deck.put("previewAgainSecs", value)
+                        }
+                        "previewHardSecs" -> {
+                            deck.put("previewHardSecs", value)
+                        }
+                        "previewGoodSecs" -> {
+                            deck.put("previewGoodSecs", value)
                         }
                         "stepsOn" -> {
                             val on = value as Boolean
@@ -233,6 +245,7 @@ class FilteredDeckOptions :
             Timber.d("sched v2: removing filtered deck custom study steps")
             // getPreferenceScreen.removePreference didn't return true, so remove from the category
             setupSecondFilterListener()
+            setupPreviewDelaysListener()
             val category = findPreference("studyOptions") as PreferenceCategory
             removePreference(category, "stepsOn")
             removePreference(category, "steps")
@@ -339,6 +352,20 @@ class FilteredDeckOptions :
                 val newOrderPrefSecond = findPreference("order_2") as ListPreference
                 newOrderPrefSecond.value = "5"
             }
+            true
+        }
+    }
+
+    @Suppress("deprecation")
+    private fun setupPreviewDelaysListener() {
+        val reschedPref = findPreference(getString(R.string.filtered_deck_resched_key)) as CheckBoxPreference
+        val delaysPrefCategory = findPreference(getString(R.string.filtered_deck_previewDelays_key)) as PreferenceCategory
+        delaysPrefCategory.isEnabled = !reschedPref.isChecked
+        reschedPref.onPreferenceChangeListener = Preference.OnPreferenceChangeListener { _: Preference?, newValue: Any? ->
+            if (newValue !is Boolean) {
+                return@OnPreferenceChangeListener true
+            }
+            delaysPrefCategory.isEnabled = !newValue
             true
         }
     }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -227,7 +227,6 @@
     <string name="deck_conf_cram_reschedule"  maxLength="41" comment="Title of the box labelled by deck_conf_cram_reschedule_summ">Reschedule</string>
     <string name="deck_conf_cram_reschedule_summ">Reschedule cards based on my answers in this deck</string>
     <string name="deck_conf_cram_filter_2_check">Enable second filter</string>
-    <string name="deck_conf_cram_steps" maxLength="41">Custom steps (in minutes)</string>
     <string name="deck_conf_cram_steps_summ" maxLength="41">Define custom steps</string>
     <string name="deck_conf_cram_preview_delays" maxLength="41">Preview delays</string>
     <string name="deck_conf_cram_preview_delays_summ">Delays are in seconds. 0 returns card to original deck.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -229,6 +229,8 @@
     <string name="deck_conf_cram_filter_2_check">Enable second filter</string>
     <string name="deck_conf_cram_steps" maxLength="41">Custom steps (in minutes)</string>
     <string name="deck_conf_cram_steps_summ" maxLength="41">Define custom steps</string>
+    <string name="deck_conf_cram_preview_delays" maxLength="41">Preview delays</string>
+    <string name="deck_conf_cram_preview_delays_summ">Delays are in seconds. 0 returns card to original deck.</string>
 
     <!-- analytics options -->
     <string name="analytics_dialog_title">Help make AnkiDroid better!</string>

--- a/AnkiDroid/src/main/res/values/filtered_deck_options.xml
+++ b/AnkiDroid/src/main/res/values/filtered_deck_options.xml
@@ -27,4 +27,8 @@
     <string name="filtered_deck_stepsOn_key">stepsOn</string>
     <string name="filtered_deck_steps_key">steps</string>
     <string name="filtered_deck_filterSecond_key">filterSecond</string>
+    <string name="filtered_deck_previewDelays_key">previewDelays</string>
+    <string name="filtered_deck_preview_again">previewAgainSecs</string>
+    <string name="filtered_deck_preview_hard">previewHardSecs</string>
+    <string name="filtered_deck_preview_good">previewGoodSecs</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/filtered_deck_options.xml
+++ b/AnkiDroid/src/main/res/values/filtered_deck_options.xml
@@ -25,7 +25,6 @@
     <string name="filtered_deck_studyOptions_key">studyOptions</string>
     <string name="filtered_deck_resched_key">resched</string>
     <string name="filtered_deck_stepsOn_key">stepsOn</string>
-    <string name="filtered_deck_steps_key">steps</string>
     <string name="filtered_deck_filterSecond_key">filterSecond</string>
     <string name="filtered_deck_previewDelays_key">previewDelays</string>
     <string name="filtered_deck_preview_again">previewAgainSecs</string>

--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -50,6 +50,27 @@
             android:key="@string/filtered_deck_order_2_key"
             android:title="@string/deck_conf_cram_order" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/deck_conf_cram_preview_delays" android:key="@string/filtered_deck_previewDelays_key">
+        <Preference android:summary="@string/deck_conf_cram_preview_delays_summ" android:selectable="false"></Preference>
+        <com.ichi2.preferences.IncrementerNumberRangePreference
+            android:key="@string/filtered_deck_preview_again"
+            android:numeric="integer"
+            android:title="@string/ease_button_again"
+            app:max="99999"
+            app:min="1" />
+        <com.ichi2.preferences.IncrementerNumberRangePreference
+            android:key="@string/filtered_deck_preview_hard"
+            android:numeric="integer"
+            android:title="@string/ease_button_hard"
+            app:max="99999"
+            app:min="0" />
+        <com.ichi2.preferences.IncrementerNumberRangePreference
+            android:key="@string/filtered_deck_preview_good"
+            android:numeric="integer"
+            android:title="@string/ease_button_good"
+            app:max="99999"
+            app:min="0" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/study_options" android:key="@string/filtered_deck_studyOptions_key" >
         <CheckBoxPreference
             android:defaultValue="true"
@@ -61,12 +82,6 @@
             android:disableDependentsState="false"
             android:key="@string/filtered_deck_stepsOn_key"
             android:title="@string/deck_conf_cram_steps_summ" />
-
-        <com.ichi2.preferences.StepsPreference
-            android:dependency="@string/filtered_deck_stepsOn_key"
-            android:key="@string/filtered_deck_steps_key"
-            android:title="@string/deck_conf_cram_steps"
-            app:allowEmpty="false" />
 
         <CheckBoxPreference
             android:key="@string/filtered_deck_filterSecond_key"


### PR DESCRIPTION
## Purpose / Description

This makes it possible to customize the preview delays of the Again, Hard, Good buttons in filtered decks. Supported in Anki 23.12+.

## Fixes

Fixes the last task and closes #15167

## Approach

When the rescheduling option is disabled, the new Preview delays section is enabled. 

![image](https://github.com/ankidroid/Anki-Android/assets/41397710/323051e4-1014-4219-b1c8-8f9f26f86c03)

## How Has This Been Tested?

Manually tested in the emulator.

## Learning (optional, can help others)

See https://github.com/ankitects/anki/issues/2858

The old `previewDelay` deck config key used for the single delay doesn't appear to be handled in AnkiDroid, so it wasn't possible to customize any delay anyway?


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
