### PR TITLE
feat: enable fullscreen in <video> tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -44,6 +44,8 @@ import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle.State.RESUMED
@@ -59,8 +61,6 @@ import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.cardviewer.*
 import com.ichi2.anki.cardviewer.CardHtml.Companion.legacyGetTtsTags
 import com.ichi2.anki.cardviewer.HtmlGenerator.Companion.createInstance
-import com.ichi2.anki.cardviewer.SingleSoundSide
-import com.ichi2.anki.cardviewer.SoundSide
 import com.ichi2.anki.cardviewer.TypeAnswer.Companion.createInstance
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.dialogs.tags.TagsDialog
@@ -1810,7 +1810,7 @@ abstract class AbstractFlashcardViewer :
     /**
      * Provides a hook for calling "alert" from javascript. Useful for debugging your javascript.
      */
-    class AnkiDroidWebChromeClient : WebChromeClient() {
+    inner class AnkiDroidWebChromeClient : WebChromeClient() {
         override fun onJsAlert(
             view: WebView,
             url: String,
@@ -1820,6 +1820,39 @@ abstract class AbstractFlashcardViewer :
             Timber.i("AbstractFlashcardViewer:: onJsAlert: %s", message)
             result.confirm()
             return true
+        }
+
+        private lateinit var customView: View
+
+        // used for displaying `<video>` in fullscreen.
+        // This implementation requires configChanges="orientation" in the manifest
+        // to avoid destroying the View if the device is rotated
+        override fun onShowCustomView(
+            paramView: View,
+            paramCustomViewCallback: CustomViewCallback?
+        ) {
+            customView = paramView
+            (window.decorView as FrameLayout).addView(
+                customView,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.MATCH_PARENT
+                )
+            )
+            // hide system bars
+            with(WindowInsetsControllerCompat(window, window.decorView)) {
+                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                hide(WindowInsetsCompat.Type.systemBars())
+            }
+        }
+
+        override fun onHideCustomView() {
+            (window.decorView as FrameLayout).removeView(customView)
+            // show system bars back
+            with(WindowInsetsControllerCompat(window, window.decorView)) {
+                systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+                show(WindowInsetsCompat.Type.systemBars())
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Add fullscreen to `<video>` tags in Android

Not adding it to the new previewer yet because I want to think if there is a way of doing it without using `configChanges="orientation"` and all of my ideas are complex and I'm not sure if any of them is going to work. 

Also, it's not gonna be in 2.17 anyway, so better hurry this one

## Fixes
* Fixes #14568 

## Approach
Use [onShowCustomView](https://developer.android.com/reference/android/webkit/WebChromeClient#onShowCustomView(android.view.View,%20android.webkit.WebChromeClient.CustomViewCallback))

note: leaving fullscreen after rotating back to portrait mode is Android's default behavior and since apps like YouTube do that, I didn't want to fight Android

## How Has This Been Tested?

[fs.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/e63b709c-4ba4-4f5c-bc1e-770291d7fe1d)

[fs2.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/696bcaf5-9b84-4bb4-8570-e710fe9a0ae0)

## Learning (optional, can help others)

window.decorView can be used to show something in the whole screen

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
