### PR TITLE
fix: Error dialog: due to "show timer" on resume 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -207,7 +207,7 @@ open class Reviewer :
     override fun onResume() {
         when {
             stopTimerOnAnswer && isDisplayingAnswer -> {}
-            else -> launchCatchingTask { withCol { answerTimer.resume() } }
+            else -> launchCatchingTask { answerTimer.resume() }
         }
         super.onResume()
         if (typeAnswer?.autoFocusEditText() == true) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -25,6 +25,7 @@ import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
+import timber.log.Timber
 
 /**
  * Responsible for pause/resume of the card timer and the UI element displaying the amount of time to answer a card
@@ -119,7 +120,10 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         cardTimer.base = elapsedRealTime - currentCard.timeTaken(col)
         // Don't start the timer if we have already reached the time limit or it will tick over
         if (elapsedRealTime - cardTimer.base < currentCard.timeLimit(col)) {
+            Timber.v("restarting timer")
             cardTimer.start()
+        } else {
+            Timber.v("not restarting timer - at time limit")
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AnswerTimer.kt
@@ -20,12 +20,17 @@ import android.content.Context
 import android.os.SystemClock
 import android.view.View
 import android.widget.Chronometer
+import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import com.google.android.material.color.MaterialColors
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
-import timber.log.Timber
+import com.ichi2.libanki.timeLimit
+import com.ichi2.libanki.timeTaken
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /**
  * Responsible for pause/resume of the card timer and the UI element displaying the amount of time to answer a card
@@ -58,6 +63,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
      *
      * This may also change the limit, based on [Card.timeLimit]
      */
+    @MainThread // resetTimerUI
     fun setupForCard(col: Collection, newCard: Card) {
         currentCard = newCard
         showTimer = newCard.showTimer(col)
@@ -75,6 +81,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         }
     }
 
+    @MainThread // cardTimer.base
     private fun resetTimerUI(col: Collection, newCard: Card) {
         // Set normal timer color
         cardTimer.setTextColor(MaterialColors.getColor(context, android.R.attr.textColor, 0))
@@ -104,7 +111,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
         currentCard.stopTimer()
     }
 
-    fun resume(col: Collection) {
+    suspend fun resume() {
         if (!this::currentCard.isInitialized) {
             return
         }
@@ -116,14 +123,12 @@ class AnswerTimer(private val cardTimer: Chronometer) {
             return
         }
         // Then update and resume the UI timer. Set the base time as if the timer had started
-        // timeTaken(col) seconds ago.
-        cardTimer.base = elapsedRealTime - currentCard.timeTaken(col)
+        // timeTaken() seconds ago.
+        setBase(elapsedRealTime - withCol { currentCard.timeTaken() })
+
         // Don't start the timer if we have already reached the time limit or it will tick over
-        if (elapsedRealTime - cardTimer.base < currentCard.timeLimit(col)) {
-            Timber.v("restarting timer")
+        if (elapsedRealTime - cardTimer.base < withCol { currentCard.timeLimit() }) {
             cardTimer.start()
-        } else {
-            Timber.v("not restarting timer - at time limit")
         }
     }
 
@@ -138,10 +143,7 @@ class AnswerTimer(private val cardTimer: Chronometer) {
     /** Milliseconds since boot */
     private val elapsedRealTime
         get() = SystemClock.elapsedRealtime()
-}
 
-/** @see AnswerTimer.resume */
-context (Collection)
-fun AnswerTimer.resume() {
-    this@AnswerTimer.resume(this@Collection)
+    /** @see Chronometer.setBase */
+    private suspend fun setBase(base: Long) = withContext(Dispatchers.Main) { cardTimer.base = base }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -541,3 +541,13 @@ fun Card.renderOutput(reload: Boolean = false, browser: Boolean = false) =
 context (Collection)
 fun Card.note() =
     this@Card.note(this@Collection)
+
+/** @see Card.timeTaken */
+context (Collection)
+fun Card.timeTaken() =
+    this@Card.timeTaken(this@Collection)
+
+/** @see Card.timeLimit */
+context (Collection)
+fun Card.timeLimit() =
+    this@Card.timeLimit(this@Collection)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -24,26 +24,28 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.JvmTest
+import com.ichi2.testutils.rules.MockitoCollectionRule
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.*
 import org.robolectric.annotation.Config
+import timber.log.Timber
 
 // This is difficult to test as Chronometer.mStarted isn't visible
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
-class AnswerTimerTest {
-    lateinit var chronometer: Chronometer
-    val mockCol = Mockito.mock(Collection::class.java)
+class AnswerTimerTest : JvmTest() {
+    private val chronometer = spy(Chronometer(ApplicationProvider.getApplicationContext()))
 
-    @Before
-    fun init() {
-        chronometer = spy(Chronometer(ApplicationProvider.getApplicationContext()))
-    }
+    @get:Rule
+    val mockColRule = MockitoCollectionRule()
+    override val col: Collection
+        get() = mockColRule.col
 
     @Test
     fun disabledTimer() {
@@ -53,7 +55,7 @@ class AnswerTimerTest {
             on { showTimer(any()) } doReturn false
         }
 
-        timer.setupForCard(mockCol, card)
+        timer.setupForCard(col, card)
 
         assertThat("timer should not be enabled", timer.showTimer, equalTo(false))
 
@@ -76,7 +78,7 @@ class AnswerTimerTest {
         Mockito.mockStatic(SystemClock::class.java).use { mocked ->
             mocked.`when`<Long> { SystemClock.elapsedRealtime() }.doReturn(13)
 
-            timer.setupForCard(mockCol, card)
+            timer.setupForCard(col, card)
         }
 
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
@@ -102,48 +104,49 @@ class AnswerTimerTest {
             on { showTimer(any()) } doReturn false
         }
 
-        timer.setupForCard(mockCol, timerCard)
+        timer.setupForCard(col, timerCard)
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
         assertThat("chronometer should be visible", chronometer.visibility, equalTo(View.VISIBLE))
 
-        timer.setupForCard(mockCol, nonTimerCard)
+        timer.setupForCard(col, nonTimerCard)
 
         assertThat("timer should not be enabled", timer.showTimer, equalTo(false))
         assertThat("chronometer should not be visible", chronometer.visibility, equalTo(View.INVISIBLE))
 
-        timer.setupForCard(mockCol, timerCard)
+        timer.setupForCard(col, timerCard)
         assertThat("timer should be enabled", timer.showTimer, equalTo(true))
         assertThat("chronometer should be visible", chronometer.visibility, equalTo(View.VISIBLE))
     }
 
     @Test
-    fun testNoCrashOnEarlyPauseResume() {
+    fun testNoCrashOnEarlyPauseResume() = runTest {
         val timer = getTimer()
         // before we call setupForCard
         timer.pause()
-        timer.resume(mockCol)
+        timer.resume(col)
     }
 
     @Test
-    fun pauseResumeIfEnabled() {
+    fun pauseResumeIfEnabled() = runTest {
+        Timber.v("aaa")
         val timer = getTimer()
 
         val timerCard: Card = mock {
-            on { showTimer(mockCol) } doReturn true
-            on { timeLimit(mockCol) } doReturn 1000
+            on { showTimer(col) } doReturn true
+            on { timeLimit(col) } doReturn 1000
         }
 
-        timer.setupForCard(mockCol, timerCard)
+        timer.setupForCard(col, timerCard)
 
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume(mockCol)
+        timer.resume(col)
         verify(chronometer).start()
     }
 
     @Test
-    fun pauseResumeDoesNotCallStartIfTimeElapsed() {
+    fun pauseResumeDoesNotCallStartIfTimeElapsed() = runTest {
         val timer = getTimer()
 
         val timerCard: Card = mock {
@@ -152,17 +155,17 @@ class AnswerTimerTest {
             on { timeTaken(any()) } doReturn 1001
         }
 
-        timer.setupForCard(mockCol, timerCard)
+        timer.setupForCard(col, timerCard)
 
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume(mockCol)
+        timer.resume(col)
         verify(chronometer, never()).start()
     }
 
     @Test
-    fun cardTimerIsRestartedEvenIfDisabled() {
+    fun cardTimerIsRestartedEvenIfDisabled() = runTest {
         // The class is responsible for the pause/resume handling of the card, not just the UI element
         // This may be a candidate for later refactoring
 
@@ -172,12 +175,12 @@ class AnswerTimerTest {
             on { showTimer(any()) } doReturn false
         }
 
-        timer.setupForCard(mockCol, nonTimerCard)
+        timer.setupForCard(col, nonTimerCard)
 
         timer.pause()
         verify(nonTimerCard).stopTimer()
         verify(nonTimerCard, never()).resumeTimer()
-        timer.resume(mockCol)
+        timer.resume(col)
         verify(nonTimerCard).resumeTimer()
 
         verify(chronometer, never()).start()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -123,7 +123,7 @@ class AnswerTimerTest : JvmTest() {
         val timer = getTimer()
         // before we call setupForCard
         timer.pause()
-        timer.resume(col)
+        timer.resume()
     }
 
     @Test
@@ -141,7 +141,7 @@ class AnswerTimerTest : JvmTest() {
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume(col)
+        timer.resume()
         verify(chronometer).start()
     }
 
@@ -160,7 +160,7 @@ class AnswerTimerTest : JvmTest() {
         reset(chronometer)
         timer.pause()
         verify(chronometer).stop()
-        timer.resume(col)
+        timer.resume()
         verify(chronometer, never()).start()
     }
 
@@ -180,7 +180,7 @@ class AnswerTimerTest : JvmTest() {
         timer.pause()
         verify(nonTimerCard).stopTimer()
         verify(nonTimerCard, never()).resumeTimer()
-        timer.resume(col)
+        timer.resume()
         verify(nonTimerCard).resumeTimer()
 
         verify(chronometer, never()).start()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.rules
+
+import android.content.Context
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
+import com.ichi2.libanki.Collection
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.mockito.Mockito
+import timber.log.Timber
+
+/**
+ * Mocks [Collection] using [Mockito.mock]
+ *
+ * usage:
+ *
+ * ```
+ *      @get:Rule
+ *      val mockColRule = MockitoCollectionRule()
+ *      override val col: Collection get() = mockColRule.col
+ * ```
+ */
+class MockitoCollectionRule : TestRule {
+    val col: Collection = Mockito.mock(Collection::class.java)
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                try {
+                    mockCollection()
+                    base.evaluate()
+                } finally {
+                    removeCollectionMock()
+                }
+            }
+        }
+    }
+
+    private fun removeCollectionMock() {
+        Timber.v("removing collection mock")
+        CollectionManager.setColForTests(null)
+        CollectionHelper.setInstanceForTesting(CollectionHelper())
+    }
+
+    private fun mockCollection() {
+        Timber.v("mocking collection")
+        CollectionManager.setColForTests(col)
+        CollectionHelper.setInstanceForTesting(object : CollectionHelper() {
+            override fun getColUnsafe(context: Context?) = col
+        })
+    }
+}


### PR DESCRIPTION
## Purpose / Description
"Show Answer Timer" must be enabled

* background + foreground AnkiDroid
* Error dialog appears

## Fixes
* Fixes #15317 

## Approach
* make `resume() ` a suspend function

## How Has This Been Tested?
Manually + Added `@MainThread`

## Learning (optional, can help others)
`Chronometer.base` must be called on main thread

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
