### PR TITLE
chore(deps): switch i18n workflow to use node 20

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       
       - name: Install dependencies and build
         run: |


### PR DESCRIPTION
this appears to work fine in local testing, and it is the current active release, node 18 is maintenance only

not sure how to handle this PR-merge-workflow wise other than to just merge it and pay attention 🤷 