### PR TITLE
Add AnkiDroid API LGPL License to Readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,4 @@ License
 -------
 * [GPL-3.0 License](https://github.com/ankidroid/Anki-Android/blob/main/COPYING)
 * [AGPL-3.0 Licence](https://github.com/ankitects/anki/blob/main/LICENSE) for some part of the back-end
+* [LGPL-3.0 License](https://github.com/ankidroid/Anki-Android/blob/main/api/COPYING.LESSER) for the AnkiDroid API


### PR DESCRIPTION
I've added a link to the LGPL (Lesser General Public License) file in the README of the repository. This helps users and developers easily access the license terms and understand the permissions and obligations associated with the AnkiDroid API.

* Fixes #15337 