### PR TITLE
chore(deps): keep npm dependency updates to one PR if non-breaking

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,10 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   target-branch: dependency-updates
+  groups:
+    non-breaking:
+      update-types:
+        - "minor"
+        - "patch"
   labels:
   - "dependencies"


### PR DESCRIPTION
the npm package ecosystem releases all the time and it clutters up the PR queue for mostly meaningless dependency updates

dependabot has a new "groups" feature to group dependency update PRs together in to one PR based on either name globs, update types, or dependency type

this should allow us to get all non-breaking changes through in single PRs, while breaking (semver-major) changes will get individual PRs for more detailed consideration

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes _Link to the issues._

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
