### PR TITLE
Fix: Save & Preview options available in image occlusion edit note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1008,11 +1008,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.note_editor, menu)
+        val iconVisible = allowSaveAndPreview()
+        menu.findItem(R.id.action_preview).isVisible = iconVisible
+        menu.findItem(R.id.action_save).isVisible = iconVisible
         if (addNote) {
             menu.findItem(R.id.action_copy_note).isVisible = false
-            val iconVisible = allowSaveAndPreview()
-            menu.findItem(R.id.action_save).isVisible = iconVisible
-            menu.findItem(R.id.action_preview).isVisible = iconVisible
         } else {
             menu.findItem(R.id.action_add_note_from_note_editor).isVisible = true
         }
@@ -1042,7 +1042,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
      * when the card is saved successfully
      */
     private fun allowSaveAndPreview(): Boolean = when {
-        addNote && currentNotetypeIsImageOcclusion() -> false
+        currentNotetypeIsImageOcclusion() -> false
         else -> true
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Don't allow  preview in case of Image occlusion, we don't want the Save and preview options to be visible in case of IO as Save option is there in IO, which was fixed in https://github.com/ankidroid/Anki-Android/pull/15030 but allowed preview and save option to be enabled in edit note mode, IO already have an update card option that updates the card in case of IO mode so we want to diable them both in edit/add note

## Fixes
* Fixes #15359

## How Has This Been Tested?
Tested on Google emulator API33

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
