### PR TITLE
Fix: API30 tts `availableVoices` to return empty set to avoid crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -149,6 +149,7 @@ object TtsVoices {
         val tts = createTts()
         if (tts == null) {
             Timber.e("Unable to build list of TTS Voices")
+            availableVoices = emptySet()
             availableLocaleData = emptyList()
             return
         }
@@ -162,6 +163,7 @@ object TtsVoices {
             availableVoices = tts.voices.map { it.toTtsVoice(ttsEngine) }.toSet()
             availableLocaleData = tts.availableLanguages.map { CompatHelper.compat.normalize(it) }
         } catch (e: Exception) {
+            availableVoices = emptySet()
             availableLocaleData = emptyList()
         } finally {
             tts.shutdown()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
As I mentioned this in the issue it happens only for API30 and no other API, I have tested it for other API i.e. 24 and 33 and its works fine. It might be related to emulator only as it was reported under emulator category but still fixing it so that it doesn't break in API30 emualtor.

## Fixes
* Fixes #15364

## How Has This Been Tested?
Tested on API30 (emulator) / API24 / API 33(physical and emulator both)

## Learning (optional, can help others)
https://issuetracker.google.com/issues/199606758

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
