### PR TITLE
test(ci): upgrade macOS runner to M1 & macOS 14

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   emulator_test:
     name: Android Emulator Test
+    # macos-14 is blocked on https://github.com/ReactiveCircus/android-emulator-runner/issues/350
     runs-on: macos-latest
     timeout-minutes: 75
     strategy:

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -25,7 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+        # macOS 14 is in beta and runs on Apple Silicon [M1]
+        os: [ubuntu-latest, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This is a beta, we are currently on `macos-12`

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

> The macos-latest workflow label currently uses the macOS 12 runner image.
> `macos-14` [beta]

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

This reduces the available RAM from 14 to 7GB

## How Has This Been Tested?
This is the test 

## Learning (optional, can help others)
https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories


Virtual Machine | Processor (CPU) | Memory (RAM) | Storage (SSD) | OS (YAML workflow label) | Notes
-- | -- | -- | -- | -- | --
macOS | 3 | 14 GB | 14 GB | macos-latest, macos-12, macos-11 | The macos-latest workflow label currently uses the macOS 12 runner image.
macOS | 4 | 14 GB | 14 GB | macos-13 | N/A
macOS | 3 (M1) | 7 GB | 14 GB | macos-14 [Beta] | N/A




## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
