### PR TITLE
build(ci): remove `IN_PROCESS` compiler execution strategy

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,13 +140,6 @@ ext {
         // Which is 1:1 https://docs.microsoft.com/en-gb/azure/virtual-machines/acu : DS1_v2 - DS15_v2 | 1:1
         gradleTestMaxParallelForks = 2
 
-        // separate gradle compile process is a major speed improvement, but consumes 2x RAM
-        // the CI machines don't have enough RAM to do that without going in to swap quite a bit
-        // so for CI machines only - to improve reliability despite compilation speed hit, compile kotlin in process
-        println "CI build detected: setting compiler execution strategy to IN_PROCESS"
-        tasks.withType(KotlinCompile).configureEach {
-            compilerExecutionStrategy.set(KotlinCompilerExecutionStrategy.IN_PROCESS)
-        }
     } else {
         // Use 50% of cores to account for SMT which doesn't help this workload
         gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1


### PR DESCRIPTION
## Purpose / Description

Added in f5ecb05efc3117238cbd42935542176d4436ee5f
Related: 655516582cbee7dffb70a3be6318103731f9b9a0

but CI runners now have 16GB RAM, so this is not necessary any more

## Fixes
* Part of #15368
* Reverts change added in https://github.com/ankidroid/Anki-Android/pull/11341
    *  https://github.com/ankidroid/Anki-Android/commit/f5ecb05efc3117238cbd42935542176d4436ee5f 

## Learning (optional, can help others)

https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

> discovered you can eliminate the standalone (multi-gigabyte, persists after compile) kotlin compiler daemon by having it run in process, and just ensuring main process is sufficient (it is, determined by GC logging). I think this might be the final set, allowing for a build/lint run that's about 
> 
> - 2.5GB total for the JVM and a compile/lint
> - about 1.5GB*workers max, or 
> - total 5.5GB max in CI
> 
> https://github.com/ankidroid/Anki-Android/pull/11341/commits/97ac61197a3ab703ba110225665a582bc6f99a4e
> 
> Previous config was 
> - 7GB for compile/lint
> - about 1.5GB*workers
> - total 10GB maxin CI
> 
> No wonder windows blew up with 7.5GB ram + 1.5GB swap default, and adding swap made it work but in suffer mode.
> 
> This should be noticeable as less memory pressure on development machines as well, I had begun to notice it using up too much RAM on my machine even

* https://github.com/ankidroid/Anki-Android/pull/11341#issuecomment-1129119319

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
