### PR TITLE
build(ci): use stable job names

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   unit:
-    name: JUnit Tests (${{ matrix.os}})
+    name: JUnit Tests (${{ matrix.name }})
     timeout-minutes: 40
     strategy:
       fail-fast: false
@@ -28,6 +28,14 @@ jobs:
         # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
         # macOS 14 is in beta and runs on Apple Silicon [M1]
         os: [ubuntu-latest, macos-14, windows-latest]
+        # define 'name' so we don't need to update branch protection rules if the os changes
+        include:
+          - os: ubuntu-latest
+            name: ubuntu
+          - os: macos-14
+            name: macos
+          - os: windows-latest
+            name: windows
     runs-on: ${{ matrix.os }}
     #env:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}


### PR DESCRIPTION
We don't want the name of the job to be changed when changing the OS of runners

## Fixes
* Fixes #15371

## Approach
use `include` to expand the `os` matrix to include the name
then use the variable as a job name

https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations


## How Has This Been Tested?
<img  alt="Screenshot 2024-01-31 at 14 50 54" src="https://github.com/ankidroid/Anki-Android/assets/62114487/e0bf35ec-7f02-4ea9-9adb-0209efbb5515">


## Learning (optional, can help others)
https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-expanding-configurations


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
