### PR TITLE
Removed the Material Dialog Box and Added Alert Box from DeckPickerAnalyticsOption

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -40,7 +40,7 @@ class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
             }
             cancelable(true)
             setOnCancelListener { (activity as DeckPicker).dismissAllDialogFragments() }
-        }.show()
+        }.create()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -17,28 +17,28 @@
 package com.ichi2.anki.dialogs
 
 import android.os.Bundle
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.checkbox.checkBoxPrompt
-import com.afollestad.materialdialogs.checkbox.isCheckPromptChecked
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.utils.*
 
 class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
-        return MaterialDialog(requireActivity()).show {
+        return AlertDialog.Builder(requireActivity()).apply {
             title(R.string.analytics_dialog_title)
             message(R.string.analytics_summ)
-            checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true, onToggle = null)
+            checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true) { checked ->
+                UsageAnalytics.isEnabled = checked
+            }
             positiveButton(R.string.dialog_continue) {
-                UsageAnalytics.isEnabled = it.isCheckPromptChecked()
                 (activity as DeckPicker).dismissAllDialogFragments()
             }
             cancelable(true)
             setOnCancelListener { (activity as DeckPicker).dismissAllDialogFragments() }
-        }
+        }.show()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -27,20 +27,17 @@ import com.ichi2.utils.*
 class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
-        return AlertDialog.Builder(requireActivity()).apply {
-            var isChecked = true
+        return AlertDialog.Builder(requireActivity()).create {
             title(R.string.analytics_dialog_title)
             message(R.string.analytics_summ)
-            checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true) { checked ->
-                isChecked = checked
-            }
+            checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true) {}
             positiveButton(R.string.dialog_continue) {
-                UsageAnalytics.isEnabled = isChecked
+                UsageAnalytics.isEnabled = (it as AlertDialog).getCheckBoxPrompt().isChecked
                 (activity as DeckPicker).dismissAllDialogFragments()
             }
             cancelable(true)
             setOnCancelListener { (activity as DeckPicker).dismissAllDialogFragments() }
-        }.create()
+        }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerAnalyticsOptInDialog.kt
@@ -28,12 +28,14 @@ class DeckPickerAnalyticsOptInDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
         return AlertDialog.Builder(requireActivity()).apply {
+            var isChecked = true
             title(R.string.analytics_dialog_title)
             message(R.string.analytics_summ)
             checkBoxPrompt(R.string.analytics_title, isCheckedDefault = true) { checked ->
-                UsageAnalytics.isEnabled = checked
+                isChecked = checked
             }
             positiveButton(R.string.dialog_continue) {
+                UsageAnalytics.isEnabled = isChecked
                 (activity as DeckPicker).dismissAllDialogFragments()
             }
             cancelable(true)


### PR DESCRIPTION

## Fixes
* Related #13315  

## Approach
Replaces usages of Deprecated MaterialDialog and adds the Native AlertDialog For Deck Picker Analytics.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
