### PR TITLE
fix: emulator tests (🎉)

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -33,6 +33,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.testutils.IgnoreFlakyTestsInCIRule
 import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendException
 import org.junit.After
@@ -54,6 +55,10 @@ abstract class InstrumentedTest {
 
     @get:Rule
     val ensureAllFilesAccessRule = EnsureAllFilesAccessRule()
+
+    /** Allows [com.ichi2.testutils.Flaky] to annotate tests in subclasses */
+    @get:Rule
+    val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
 
     /**
      * @return A File object pointing to a directory in which temporary test files can be placed. The directory is

--- a/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.testutils
 
+import com.ichi2.anki.BuildConfig
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -52,7 +53,7 @@ class IgnoreFlakyTestsInCIRule : TestRule {
     }
 
     companion object {
-        val isRunningUnderCI = System.getenv("CI") == "true"
+        val isRunningUnderCI: Boolean = BuildConfig.CI
     }
 }
 
@@ -83,6 +84,6 @@ class IgnoreFlakyTestsTest {
     @Test
     @Flaky(os = OS.ALL)
     fun ensureFlakyTestsAreOnlyRunLocally() {
-        assertThat("Not running under CI", System.getenv("CI"), not(equalTo("true")))
+        assertThat("Not running under CI", BuildConfig.CI, not(equalTo("true")))
     }
 }

--- a/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
@@ -30,6 +30,16 @@ import java.util.*
 
 /**
  * An annotation which marks a test as flaky so it will be skipped if run under CI
+ *
+ * The test class or a subclass must contain the code:
+ *
+ * ```kotlin
+ *     @get:Rule
+ *     val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
+ * ```
+ *
+ * @see IgnoreFlakyTestsInCIRule
+ *
  * @param os The OS The test fails under (required)
  * @param message The message to display when the test is skipped
  */


### PR DESCRIPTION
0c238ed9bbf783708fdcf7eb5125c1a9cc8a8d64 broke with

```
com.ichi2.anki.ReviewerTest > testCustomSchedulerWithRuntimeError[test(AVD) - 11] FAILED
	java.lang.AssertionError: View assertion was not true within 30000 milliseconds
	at org.junit.Assert.fail(Assert.java:89)
E0201 20:37:37.824023 bcf7000 FrameBuffer.cpp:3765] Failed to find ColorBuffer:314

com.ichi2.anki.ReviewerTest > testCustomSchedulerWithCustomData[test(AVD) - 11] FAILED
	java.lang.AssertionError: View assertion was not true within 30000 milliseconds
	at org.junit.Assert.fail(Assert.java:89)
```

But only when run on `main`, not on the pull request

The "CI" parameter appeared to not passed to the emulator

So we should use BuildConfig, rather than getenv

* ref: https://github.com/ankidroid/Anki-Android/pull/15381#issuecomment-1922257990

----

EDIT: we were also missing

```kotlin
    @get:Rule
    val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
```

## How Has This Been Tested?
This is the test. Check CI to confirm that the test is skipped

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
