### PR TITLE
test(ci): take advantage of new public repo action runner capabilities

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -21,8 +21,7 @@ concurrency:
 jobs:
   emulator_test:
     name: Android Emulator Test
-    # macos-14 is blocked on https://github.com/ReactiveCircus/android-emulator-runner/issues/350
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -40,6 +39,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
+
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: Configure JDK
         uses: actions/setup-java@v4

--- a/build.gradle
+++ b/build.gradle
@@ -134,12 +134,13 @@ ext {
         // macOS reports hardware cores. This is accurate for CI, Intel (halved due to SMT) and Apple Silicon
         gradleTestMaxParallelForks = "sysctl -n hw.physicalcpu".execute().text.toInteger()
     } else if (ciBuild) {
-        // GitHub Actions run on Standard_DS2_v2 Azure Compute Units. They are 1:1 vCPU to CPU on Linux/Windows with two vCPU cores
+        // GitHub Actions run on Standard_D4ads_v5 Azure Compute Units with 4 vCPUs
+        // They appear to be 2:1 vCPU to CPU on Linux/Windows with two vCPU cores but with performance 1:1-similar
         // Sources to determine the correct Azure Compute Unit (and get CPU count) to tune this:
-        // Standard_DS2_v2 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
-        // Which is 1:1 https://docs.microsoft.com/en-gb/azure/virtual-machines/acu : DS1_v2 - DS15_v2 | 1:1
-        gradleTestMaxParallelForks = 2
-
+        // Which Azure compute unit in use? https://github.com/github/docs/blob/a25a33bb6cbf86a629d0a0c7bef624743991f97e/content/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners.md?plain=1#L176
+        // What is that compute unit? https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series#dadsv5-series
+        // How does it perform? https://learn.microsoft.com/en-gb/azure/virtual-machines/linux/compute-benchmark-scores#dadsv5 (vs previous Standard_DS2_v2 https://learn.microsoft.com/en-gb/azure/virtual-machines/linux/compute-benchmark-scores#dv2---general-compute)
+        gradleTestMaxParallelForks = 4
     } else {
         // Use 50% of cores to account for SMT which doesn't help this workload
         gradleTestMaxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The new github actions runners have about 2x the vCPU and they have nested virt enabled

## Fixes
* Fixes #15368 

## Approach
- one commit doubles the max test forks, based on the throughput benchmarks Azure posts that seems right
- one commit switches to ubuntu, and fiddles with permissions a little bit so it works

## How Has This Been Tested?

The PR is made of tests

## Learning (optional, can help others)
- https://github.com/actions/runner-images/issues/183#issuecomment-1442154492 (which now applies to public repos too)
- https://stackoverflow.com/questions/37300811/android-studio-dev-kvm-device-permission-denied/61984745#61984745
- https://github.com/reactivecircus/android-emulator-runner?tab=readme-ov-file#running-hardware-accelerated-emulators-on-linux-runners

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
