### PR TITLE
test(ci, unit): configure windows pagefile correctly

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -41,12 +41,12 @@ jobs:
     #  CODACY_TOKEN: ${{ secrets.CODACY_TOKEN }}
     steps:
       - name: Configure Windows Pagefile
-        uses: al-cheb/configure-pagefile-action@v1.3
+        uses: al-cheb/configure-pagefile-action@v1.4
         if: matrix.os == 'windows-latest'
         with:
           minimum-size: 8GB
           maximum-size: 12GB
-          disk-root: "D:"
+          disk-root: "C:"
 
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
- use new v1.4 tag that updates action to node 20 to quiet warning
- use C: drive since D: has issues (#15372)

proof it works will be examination of CI log to make sure the step has sane output on the windows runner

- Fixes #15372 