### PR TITLE
Fix browser displayed deck when selected from DeckPicker's context menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -36,6 +36,7 @@ import androidx.lifecycle.MutableLiveData
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
 import com.ichi2.anki.exception.StorageAccessException
@@ -73,6 +74,7 @@ open class AnkiDroidApp : Application() {
     private val notifications = MutableLiveData<Void?>()
 
     lateinit var activityAgnosticDialogs: ActivityAgnosticDialogs
+    val sharedPrefsLastDeckIdRepository = SharedPreferencesLastDeckIdRepository()
 
     /** Used to avoid showing extra progress dialogs when one already shown. */
     var progressDialogShown = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1891,7 +1891,7 @@ open class CardBrowser :
      */
     private fun createViewModel() = ViewModelProvider(
         viewModelStore,
-        CardBrowserViewModel.factory(SharedPreferencesLastDeckIdRepository()),
+        CardBrowserViewModel.factory(AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository),
         defaultViewModelCreationExtras
     )[CardBrowserViewModel::class.java]
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -567,6 +567,7 @@ open class DeckPicker :
             DeckPickerContextMenuOption.BROWSE_CARDS -> {
                 Timber.i("ContextMenu: Browse cards")
                 getColUnsafe.decks.select(deckId)
+                AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository.lastDeckId = deckId
                 val intent = Intent(this, CardBrowser::class.java)
                 startActivity(intent)
                 dismissAllDialogFragments()


### PR DESCRIPTION
## Purpose / Description
A quick fix for the linked bug. The refactored CardBrowser uses LastDeckIdRepository to get the last selected deck id but this wasn't updated when selecting the browse option in the context menu in DeckPicker. I extracted the SharedPreferencesLastDeckIdRepository to the application class so it is available to both components CardBrowser and DeckPicker. Should be safe as the class just reads a preference and handles a missing id.

Edit: I'm not sure we need the LastDeckIdRepository abstraction, SharedPreferencesLastDeckIdRepository could be an object.

## Fixes
* Fixes #15386 

## How Has This Been Tested?
Ran the tests, manually checked the bug steps.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
