### PR TITLE
S Pen Button investigation

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -317,6 +317,14 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
+            </intent-filter>
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/samsung_remote_actions" />
+
         </activity>
         <activity
             android:name="com.ichi2.anki.MyAccount"
@@ -332,6 +340,13 @@
             <intent-filter>
                 <category android:name="android.intent.category.MONKEY" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="com.samsung.android.support.REMOTE_ACTION" />
+            </intent-filter>
+            <meta-data
+                android:name="com.samsung.android.support.REMOTE_ACTION"
+                android:resource="@xml/samsung_remote_actions" />
         </activity>
         <activity
             android:name=".FilteredDeckOptions"

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -423,4 +423,6 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="pref__etc__snackbar__no_collection"
         comment="Generic snackbar message to be shown when user taps on a preference
         that is not usable because the collection does not exist">Collection does not exist</string>
+
+    <string name="s_pen_button_click">Customizable in Controls</string>
 </resources>

--- a/AnkiDroid/src/main/res/xml/samsung_remote_actions.xml
+++ b/AnkiDroid/src/main/res/xml/samsung_remote_actions.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+Typically Samsung expects the buttons to NOT be remapped, therefore we need to provide a
+generic label
+
+KEYCODE_STYLUS_BUTTON_PRIMARY would be great here, but is only added in API 34
+ -->
+<remote-actions version="1.2">
+    <action
+        id="pause_or_resume"
+        label="@string/s_pen_button_click"
+        priority="1"
+        trigger_key="MACRO_1">
+        <preference name="gesture" value="click"/>
+        <preference name="button_only" value="true"/>
+    </action>
+</remote-actions>


### PR DESCRIPTION
## For Reviewers

I have not tested this, please test on an S Pen enabled device:

* If this works, the `MACRO_1` key event should be fired in `Reviewer` AND should be mappable in `Preferences -> Controls`

## Purpose / Description

After viewing the S Pen SDK, it appears that the XML following is NOT handled by the SDK, likely by the OS

Due to this, we can map the button on the Reviewer & Preferences.

`MACRO_1` was chosen arbitrarily for the button

I will use `BUTTON_1` ... `N` for the air actions if this works since there are only 4 MACRO keys

## Fixes
* Related: #14767
  *  This allows us to handle the button press inside `Reviewer`, but will not modify anything in the following

https://github.com/ankidroid/Anki-Android/blob/240d9d8f5587e685f6a9f61607aed180a639a68d/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt#L109-L158

## Approach
Map a 'click' to a `KEY_MACRO_1` event

## How Has This Been Tested?
⚠️ I don't have an S Pen so don't know if this works. This PR is drafted so we can determine if the functionality works

## Learning (optional, can help others)

https://developer.android.com/reference/android/view/KeyEvent https://developer.samsung.com/galaxy-spen-remote/air-actions.html

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
