### PR TITLE
fix: Image Occlusion webView being recreated in orientation changes

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -398,6 +398,11 @@
             android:exported="false"
             />
         <activity
+            android:name="com.ichi2.anki.ImageOcclusionActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize"
+            />
+        <activity
             android:name="com.ichi2.anki.CardTemplatePreviewer"
             android:label="@string/preview_title"
             android:exported="false"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
+
+/**
+ * Handles adding and editing Image Occlusion cards.
+ *
+ * Based in [SingleFragmentActivity], but with `configChanges="orientation|screenSize"`
+ * to avoid unwanted activity recreations
+ */
+class ImageOcclusionActivity : SingleFragmentActivity() {
+
+    companion object {
+
+        fun getIntent(context: Context, fragmentClass: KClass<out Fragment>, arguments: Bundle? = null): Intent {
+            return Intent(context, ImageOcclusionActivity::class.java).apply {
+                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
+                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -35,7 +35,7 @@ import kotlin.reflect.jvm.jvmName
  *
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
-class SingleFragmentActivity : AnkiActivity() {
+open class SingleFragmentActivity : AnkiActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -60,8 +60,8 @@ class SingleFragmentActivity : AnkiActivity() {
         }
     }
     companion object {
-        private const val FRAGMENT_NAME_EXTRA = "fragmentName"
-        private const val FRAGMENT_ARGS_EXTRA = "fragmentArgs"
+        const val FRAGMENT_NAME_EXTRA = "fragmentName"
+        const val FRAGMENT_ARGS_EXTRA = "fragmentArgs"
 
         fun getIntent(context: Context, fragmentClass: KClass<out Fragment>, arguments: Bundle? = null): Intent {
             return Intent(context, SingleFragmentActivity::class.java).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -21,7 +21,7 @@ import android.os.Bundle
 import android.webkit.WebView
 import androidx.core.os.bundleOf
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.ImageOcclusionActivity
 import org.json.JSONObject
 
 class ImageOcclusion : PageFragment() {
@@ -60,7 +60,7 @@ class ImageOcclusion : PageFragment() {
 
         fun getIntent(context: Context, kind: String, noteOrNotetypeId: Long, imagePath: String?): Intent {
             val arguments = bundleOf(ARG_KEY_KIND to kind, ARG_KEY_ID to noteOrNotetypeId, ARG_KEY_PATH to imagePath)
-            return SingleFragmentActivity.getIntent(context, ImageOcclusion::class, arguments)
+            return ImageOcclusionActivity.getIntent(context, ImageOcclusion::class, arguments)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ActivityList.kt
@@ -73,7 +73,8 @@ object ActivityList {
             get(ManageNotetypes::class.java),
             get(ManageSpaceActivity::class.java),
             get(PermissionsActivity::class.java),
-            get(SingleFragmentActivity::class.java)
+            get(SingleFragmentActivity::class.java),
+            get(ImageOcclusionActivity::class.java)
         )
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Allow `SingleFragmentActivity` to survive config changes

## Fixes
* Fixes #15392

## How Has This Been Tested?
Google Pixel 8 emualtor 
Posting emulator ss itself
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/17eae43c-113a-44a6-b7fc-efe7b9a12d27)
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/20237182-6ff1-48fa-a732-9fdbbc17139f)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
