### PR TITLE
Some Dialogs of DatabaseErrorDialog Converted to AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -202,8 +202,8 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 val path = CollectionHelper.getCollectionPath(requireContext())
                 backups = BackupManager.getBackups(File(path))
                 if (backups.isEmpty()) {
-                    dialog.title(R.string.backup_restore)
-                        .contentNullable(message)
+                    alertDialog.title(R.string.backup_restore)
+                        .title(text = message)
                         .positiveButton(R.string.dialog_ok) {
                             (activity as DeckPicker?)
                                 ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
@@ -298,8 +298,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_FULL_SYNC_FROM_SERVER -> {
                 // Allow user to do a full-sync from the server
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.show {
+                    title(R.string.backup_full_sync_from_server)
+                    message(text = message)
                     positiveButton(R.string.dialog_positive_overwrite) {
                         (activity as DeckPicker).sync(ConflictResolution.FULL_DOWNLOAD)
                         dismissAllDialogFragments()
@@ -309,8 +310,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_DB_LOCKED -> {
                 // If the database is locked, all we can do is ask the user to exit.
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.show {
+                    title(R.string.database_locked_title)
+                    message(text = message)
                     positiveButton(R.string.close) {
                         closeCollectionAndFinish()
                     }
@@ -346,8 +348,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
             DIALOG_DISK_FULL -> {
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.show {
+                    title(R.string.storage_full_title)
+                    message(text = message)
                     positiveButton(R.string.close) {
                         closeCollectionAndFinish()
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -149,10 +149,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     repairValues[i] = values[i]
                     i++
                 }
-                dialog.show {
-                    icon(R.drawable.ic_warning)
+                alertDialog.show {
+                    title(R.string.error_handling_title)
+                    setIcon(R.drawable.ic_warning)
                     negativeButton(R.string.dialog_cancel)
-                    listItems(items = titles.toList().map { it as CharSequence }) { _: MaterialDialog, index: Int, _: CharSequence ->
+                    listItems(items = titles.toList().map { it as CharSequence }) { _, index ->
                         when (repairValues[index]) {
                             0 -> {
                                 ActivityCompat.recreate(activity as DeckPicker)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -76,10 +76,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             DIALOG_LOAD_FAILED -> {
                 // Collection failed to load; give user the option of either choosing from repair options, or closing
                 // the activity
-                dialog.show {
+                alertDialog.show {
+                    title(R.string.open_collection_failed_title)
                     cancelable(false)
-                    contentNullable(message)
-                    icon(R.drawable.ic_warning)
+                    message(text = message)
+                    setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
                         (activity as DeckPicker?)
                             ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
@@ -184,9 +185,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_REPAIR_COLLECTION -> {
                 // Allow user to run BackupManager.repairCollection()
-                dialog.show {
-                    contentNullable(message)
-                    icon(R.drawable.ic_warning)
+                alertDialog.show {
+                    title(R.string.dialog_positive_repair)
+                    message(text = message)
+                    setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.dialog_positive_repair) {
                         (activity as DeckPicker).repairCollection()
                         dismissAllDialogFragments()
@@ -252,8 +254,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_NEW_COLLECTION -> {
                 // Allow user to create a new empty collection
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.show {
+                    title(R.string.backup_new_collection)
+                    message(text = message)
                     positiveButton(R.string.dialog_positive_create) {
                         val ch = CollectionHelper.instance
                         val time = TimeManager.time

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.dialogs
 
 import android.annotation.SuppressLint
+import android.app.Dialog
 import android.content.DialogInterface
 import android.net.Uri
 import android.os.Bundle
@@ -54,9 +55,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
 
     @Suppress("Deprecation") // Material dialog neutral button deprecation
     @SuppressLint("CheckResult")
-    override fun onCreateDialog(savedInstanceState: Bundle?): MaterialDialog {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreateDialog(savedInstanceState)
         val res = res()
+        val alertDialog = AlertDialog.Builder(requireActivity())
         val dialog = MaterialDialog(requireActivity())
         val isLoggedIn = isLoggedIn()
         dialog.cancelable(true)
@@ -279,14 +281,15 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_CONFIRM_RESTORE_BACKUP -> {
                 // Confirmation dialog for backup restore
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.apply {
+                    title(R.string.restore_backup_title)
+                    message(text = message)
                     positiveButton(R.string.dialog_continue) {
                         (activity as DeckPicker?)
                             ?.showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
                     }
                     negativeButton(R.string.dialog_cancel)
-                }
+                }.show()
             }
             DIALOG_FULL_SYNC_FROM_SERVER -> {
                 // Allow user to do a full-sync from the server

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -270,8 +270,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_CONFIRM_DATABASE_CHECK -> {
                 // Confirmation dialog for database check
-                dialog.show {
-                    contentNullable(message)
+                alertDialog.show {
+                    title(R.string.check_db_title)
+                    message(text = message)
                     positiveButton(R.string.dialog_ok) {
                         (activity as DeckPicker).integrityCheck()
                         dismissAllDialogFragments()
@@ -281,7 +282,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_CONFIRM_RESTORE_BACKUP -> {
                 // Confirmation dialog for backup restore
-                alertDialog.apply {
+                alertDialog.show {
                     title(R.string.restore_backup_title)
                     message(text = message)
                     positiveButton(R.string.dialog_continue) {
@@ -289,7 +290,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             ?.showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
                     }
                     negativeButton(R.string.dialog_cancel)
-                }.show()
+                }
             }
             DIALOG_FULL_SYNC_FROM_SERVER -> {
                 // Allow user to do a full-sync from the server


### PR DESCRIPTION
## Fixes
* Related #13315  

## Approach
Replaces usages of Deprecated MaterialDialog and adds the Native AlertDialog For DatabaseErrorDialog

## Images

**Restore Backup**

| Material Dialog | Alert Dialog |
|-----------------|--------------|
| ![Material Dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/4182ed26-32f8-4d0c-9a67-393898d7d4ee) | ![Alert Dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/d553ee91-fa43-4795-aa60-22293b6a55b5) |

<img src="https://github.com/ankidroid/Anki-Android/assets/60827173/13e77965-6731-4b80-ba0c-3dc31f5ee9f0" width="30%" height="30%">

<img src="https://github.com/ankidroid/Anki-Android/assets/60827173/c43f8617-2708-4aad-b2f3-8b8813480118" width="30%" height="30%">

<img src="https://github.com/ankidroid/Anki-Android/assets/60827173/96c0b030-33e3-4ef6-bcc1-d705d62cf57d" width="30%" height="30%">
<img src ="https://github.com/ankidroid/Anki-Android/assets/60827173/1a831a59-053c-4b15-a8b5-129b7a136130" width = "30%" height = "30%">

| Material Dialog | Alert Dialog |
|-----------------|--------------|
| ![Material Dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/7e790e23-9042-4ee7-8dda-5f355e5fbfc8) | ![Alert Dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/787d025e-56d2-4560-baf0-cf1286af05d1) |


## Checklist
_Please, go through these checks before submitting the PR._
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
