### PR TITLE
Removed the Material Dialog Box and Added Alert Box from CardBrowserMySearchesDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -18,6 +18,7 @@
 
 package com.ichi2.utils
 
+import android.content.Context
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
 import android.text.InputFilter
@@ -31,6 +32,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doOnTextChanged
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textfield.TextInputLayout
@@ -199,6 +201,20 @@ fun AlertDialog.Builder.customListAdapter(adapter: RecyclerView.Adapter<*>) {
     val recyclerView = LayoutInflater.from(context).inflate(R.layout.dialog_generic_recycler_view, null, false) as RecyclerView
     recyclerView.adapter = adapter
     recyclerView.layoutManager = LinearLayoutManager(context)
+    this.setView(recyclerView)
+}
+
+/**
+ * Adds a RecyclerView with a custom adapter and decoration to the AlertDialog.
+ * @param adapter The adapter for the RecyclerView.
+ * @param context The context used to access resources and LayoutInflater.
+ */
+fun AlertDialog.Builder.customListAdapterWithDecoration(adapter: RecyclerView.Adapter<*>, context: Context) {
+    val recyclerView = LayoutInflater.from(context).inflate(R.layout.dialog_generic_recycler_view, null, false) as RecyclerView
+    recyclerView.adapter = adapter
+    recyclerView.layoutManager = LinearLayoutManager(context)
+    val dividerItemDecoration = DividerItemDecoration(recyclerView.context, LinearLayoutManager.VERTICAL)
+    recyclerView.addItemDecoration(dividerItemDecoration)
     this.setView(recyclerView)
 }
 

--- a/AnkiDroid/src/main/res/layout/card_browser_item_my_searches_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser_item_my_searches_dialog.xml
@@ -1,30 +1,35 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:descendantFocusability="blocksDescendants"
-    android:paddingTop="5dp"
+    android:paddingTop="8dp"
     android:paddingLeft="32dp"
     android:paddingRight="32dp"
-    android:paddingBottom="5dp">
+    android:paddingBottom="8dp">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical"
-        android:gravity="start|center_vertical"
-        android:layout_toStartOf="@+id/card_browser_my_search_remove_button">
-        <com.ichi2.ui.FixedTextView android:id="@+id/card_browser_my_search_name_textview"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textSize="16sp"/>
-    </LinearLayout>
-    <ImageButton android:id="@+id/card_browser_my_search_remove_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+    <ImageButton
+        android:id="@+id/card_browser_my_search_remove_button"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
         android:layout_alignParentEnd="true"
         android:layout_centerVertical="true"
+        android:background="@color/transparent"
         android:src="@drawable/ic_remove_circle_grey"
-        android:background="@color/transparent"/>
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-</RelativeLayout>
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/card_browser_my_search_name_textview"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:textSize="16sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/card_browser_my_search_remove_button"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Fixes
* Related #13315  

## Approach
Replaces usages of Deprecated MaterialDialog and adds the Native AlertDialog For CardBrowserMySearchesDialog.

## Video

https://github.com/ankidroid/Anki-Android/assets/60827173/e94a9360-9d12-462e-9b32-d75a9dcbeed5


## Few questions :
~~1. Are we okay with removing the divider lines in My searches which were there in Material Dialog? As in our extension method of Alert Dialog we don't have it. 
2. Padding seems uneven for `(-)`in my searches compared to Material dialog not sure its it good to go or we need to set padding for `(-)` explicitly .~~
1. On closer look when we open save search the keyboard doesn't seems to work it needs a tap at the input and the input opens agains and works fine. I am not able to fix this issue. Need help in this.
2. Can we add prefill for save search? As the user who search a particular thing is probably gonna save that new thing. Correct me if I am wrong. I didn't added it yet as it was not there previously.
```
input(hint = getString(R.string.card_browser_list_my_searches_new_name), **prefill = currentSearchTerms**, allowEmpty = false, displayKeyboard = true, waitForPositiveButton = true)
```

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
