### PR TITLE
Removed the Material Dialog Box and Added Alert Box from TagsDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -235,6 +235,10 @@ fun AlertDialog.Builder.customListAdapterWithDecoration(adapter: RecyclerView.Ad
 }
 
 /**
+ * Note: using [waitForPositiveButton] = true doesn't automatically close the dialog and it
+ * requires a manual call to [android.app.Dialog.dismiss] inside the callback listening for text
+ * input to replicate the standard dialog behavior.
+ *
  * @param hint The hint text to be displayed to the user
  * @param prefill The text to initially appear in the [EditText]
  * @param allowEmpty If true, [DialogInterface.BUTTON_POSITIVE] is disabled if the [EditText] is empty

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -15,20 +15,18 @@
  */
 package com.ichi2.anki.dialogs.tags
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.EditText
 import android.widget.RadioGroup
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.WhichButton
-import com.afollestad.materialdialogs.actions.getActionButton
-import com.afollestad.materialdialogs.customview.getCustomView
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.CardStateFilter
@@ -65,14 +63,15 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
+
+            val optionsGroup = dialog!!.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)!!
             Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
             val expectedOption = CardStateFilter.NEW
             optionsGroup.getChildAt(1).performClick()
-            dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE).callOnClick()
+            advanceRobolectricLooper()
             Mockito.verify(mockListener, Mockito.times(1)).onSelectedTags(ArrayList(), ArrayList(), expectedOption)
         }
     }
@@ -87,7 +86,7 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
             val returnedList = AtomicReference<List<String>?>()
             val returnedOption = AtomicReference<CardStateFilter>()
@@ -98,12 +97,13 @@ class TagsDialogTest : RobolectricTest() {
                 returnedList.set(bundle.getStringArrayList(TagsDialogListener.ON_SELECTED_TAGS__SELECTED_TAGS))
                 returnedOption.set(bundle.getSerializableCompat<CardStateFilter>(TagsDialogListener.ON_SELECTED_TAGS__OPTION))
             }
-            val body = dialog!!.getCustomView()
-            val optionsGroup = body.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
+
+            val optionsGroup = dialog!!.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)!!
             Assert.assertEquals(optionsGroup.visibility.toLong(), View.VISIBLE.toLong())
             val expectedOption = CardStateFilter.DUE
             optionsGroup.getChildAt(2).performClick()
-            dialog.getActionButton(WhichButton.POSITIVE).callOnClick()
+            dialog.getButton(DialogInterface.BUTTON_POSITIVE).callOnClick()
+            advanceRobolectricLooper()
             ListUtil.assertListEquals(ArrayList(), returnedList.get())
             Assert.assertEquals(expectedOption, returnedOption.get())
         }
@@ -124,10 +124,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
             val tag = "zzzz"
             f.addTag(tag)
 
@@ -159,10 +159,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
             val tag = "e"
             f.addTag(tag)
 
@@ -197,10 +197,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
 
             // workaround robolectric recyclerView issue
             // update recycler
@@ -252,10 +252,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
 
             fun getItem(index: Int): TagsArrayAdapter.ViewHolder {
                 return RecyclerViewUtils.viewHolderAt(recycler, index)
@@ -299,10 +299,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
             val tag = "common::sport::football::small"
             f.addTag(tag)
 
@@ -353,10 +353,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
             val tag = "common::::careless"
             f.addTag(tag)
 
@@ -401,10 +401,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
             val adapter = recycler.adapter!! as TagsArrayAdapter
             adapter.filter.filter("tennis")
 
@@ -442,10 +442,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
 
             fun updateLayout() {
                 recycler.measure(0, 0)
@@ -489,10 +489,10 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            val body = dialog!!.getCustomView()
-            val recycler: RecyclerView = body.findViewById(R.id.tags_dialog_tags_list)
+
+            val recycler: RecyclerView = dialog!!.findViewById(R.id.tags_dialog_tags_list)!!
 
             fun getItem(index: Int): TagsArrayAdapter.ViewHolder {
                 return RecyclerViewUtils.viewHolderAt(recycler, index)
@@ -608,7 +608,7 @@ class TagsDialogTest : RobolectricTest() {
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
         scenario.moveToState(Lifecycle.State.STARTED)
         scenario.onFragment { f: TagsDialog ->
-            val dialog = f.dialog as MaterialDialog?
+            val dialog = f.dialog as AlertDialog?
             MatcherAssert.assertThat(dialog, IsNull.notNullValue())
             val editText = f.getSearchView()!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)!!
 


### PR DESCRIPTION
## Fixes
* Related #13315  

## Approach
Replaces usages of Deprecated MaterialDialog and adds the Native AlertDialog For TagsDialog.

## Working Video (Alert Dialog)

https://github.com/ankidroid/Anki-Android/assets/60827173/a4c14e6e-5cd2-4740-a6fa-ef25207eb4d9

https://github.com/ankidroid/Anki-Android/assets/60827173/e17afcf3-0f1e-427c-9587-7be35fbd6810

## Previously (Material Dialog)

https://github.com/ankidroid/Anki-Android/assets/60827173/4539bf8b-7739-420f-9435-ea5277561a0f

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
