### PR TITLE
fix: crash changing note type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -984,15 +984,16 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     /**
      * Change the note type from oldModel to newModel, handling the case where a full sync will be required
      */
+    @NeedsTest("test changing note type")
     private fun changeNoteType(oldNotetype: NotetypeJson, newNotetype: NotetypeJson) = launchCatchingTask {
         if (!userAcceptsSchemaChange()) return@launchCatchingTask
 
         val noteId = mEditorNote!!.id
         undoableOp {
             notetypes.change(oldNotetype, noteId, newNotetype, mModelChangeFieldMap!!, mModelChangeCardMap!!)
-            // refresh the note object to reflect the database changes
-            mEditorNote!!.load()
         }
+        // refresh the note object to reflect the database changes
+        withCol { mEditorNote!!.load() }
         // close note editor
         closeNoteEditor()
     }


### PR DESCRIPTION
`opChanges` needs to return changes

## Fixes
* Fixes #15400

## How Has This Been Tested?
API 33 emulator


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
