### PR TITLE
fix Crash on opening Previewer in a large deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -48,6 +48,7 @@ import com.ichi2.anki.browser.CardBrowserColumn.Companion.COLUMN2_KEYS
 import com.ichi2.anki.browser.CardBrowserLaunchOptions
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModel.*
+import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
@@ -1224,14 +1225,14 @@ open class CardBrowser :
 
     private fun onPreview() {
         val intentData = viewModel.previewIntentData
-        onPreviewCardsActivityResult.launch(getPreviewIntent(intentData.index, intentData.cardList))
+        onPreviewCardsActivityResult.launch(getPreviewIntent(intentData.index, intentData.previewerIdsFile))
     }
 
-    private fun getPreviewIntent(index: Int, selectedCardIds: LongArray): Intent {
+    private fun getPreviewIntent(index: Int, previewerIdsFile: PreviewerIdsFile): Intent {
         return if (sharedPrefs().getBoolean("new_previewer", false)) {
-            Previewer2Destination(index, selectedCardIds).toIntent(this)
+            Previewer2Destination(index, previewerIdsFile).toIntent(this)
         } else {
-            PreviewDestination(index, selectedCardIds).toIntent(this)
+            PreviewDestination(index, previewerIdsFile).toIntent(this)
         }
     }
 
@@ -1891,7 +1892,7 @@ open class CardBrowser :
      */
     private fun createViewModel() = ViewModelProvider(
         viewModelStore,
-        CardBrowserViewModel.factory(AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository),
+        CardBrowserViewModel.factory(AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository, cacheDir),
         defaultViewModelCreationExtras
     )[CardBrowserViewModel::class.java]
 
@@ -2282,8 +2283,8 @@ private fun Sequence<CardId>.toCardCache(isInCardMode: CardsOrNotes): Sequence<C
     return this.mapIndexed { idx, cid -> CardBrowser.CardCache(cid, this@Collection, idx, isInCardMode) }
 }
 
-class Previewer2Destination(val currentIndex: Int, val selectedCardIds: LongArray)
+class Previewer2Destination(val currentIndex: Int, val previewerIdsFile: PreviewerIdsFile)
 
 @CheckResult
 fun Previewer2Destination.toIntent(context: Context) =
-    PreviewerFragment.getIntent(context, selectedCardIds, currentIndex)
+    PreviewerFragment.getIntent(context, previewerIdsFile, currentIndex)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -30,10 +30,12 @@ import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.PreviewLayout
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper.Companion.getSerializableExtraCompat
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.performClickIfEnabled
 import timber.log.Timber
@@ -45,7 +47,7 @@ import timber.log.Timber
  */
 
 class Previewer : AbstractFlashcardViewer() {
-    private lateinit var cardList: LongArray
+    private lateinit var cardList: List<Long>
     private var index = 0
     private var showingAnswer = false
     private lateinit var progressSeekBar: SeekBar
@@ -60,7 +62,8 @@ class Previewer : AbstractFlashcardViewer() {
             return
         }
         super.onCreate(savedInstanceState)
-        cardList = requireNotNull(intent.getLongArrayExtra("cardList")) { "'cardList' required" }
+        val previewerIdsFile = requireNotNull(intent.getSerializableExtraCompat("idsFile")) { "'idsFile' required" } as PreviewerIdsFile
+        cardList = previewerIdsFile.getCardIds()
         index = intent.getIntExtra("index", -1)
         if (savedInstanceState != null) {
             index = savedInstanceState.getInt("index", index)
@@ -193,7 +196,7 @@ class Previewer : AbstractFlashcardViewer() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putLongArray("cardList", cardList)
+        outState.putLongArray("cardList", cardList.toLongArray())
         outState.putInt("index", index)
         outState.putBoolean("showingAnswer", showingAnswer)
         outState.putBoolean("reloadRequired", reloadRequired)
@@ -231,13 +234,13 @@ class Previewer : AbstractFlashcardViewer() {
     override fun performReload() {
         reloadRequired = true
         setOkResult()
-        val newCardList = getColUnsafe.filterToValidCards(cardList)
+        val newCardList = getColUnsafe.filterToValidCards(cardList.toLongArray())
         if (newCardList.isEmpty()) {
             finish()
             return
         }
         index = getNextIndex(newCardList)
-        cardList = newCardList.toLongArray()
+        cardList = newCardList
         currentCard = getColUnsafe.getCard(cardList[index])
         displayCardQuestion()
     }
@@ -300,9 +303,9 @@ class Previewer : AbstractFlashcardViewer() {
         fun PreviewDestination.toIntent(context: Context) =
             Intent(context, Previewer::class.java).apply {
                 putExtra("index", index)
-                putExtra("cardList", cardList)
+                putExtra("idsFile", previewerIdsFile)
             }
     }
 }
 
-class PreviewDestination(val index: Int, val cardList: LongArray)
+class PreviewDestination(val index: Int, val previewerIdsFile: PreviewerIdsFile)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.LanguageUtils
 import com.ichi2.anki.OnErrorListener
+import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.launchCatching
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
@@ -47,7 +48,7 @@ import org.jetbrains.annotations.VisibleForTesting
 import org.json.JSONObject
 import timber.log.Timber
 
-class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int) :
+class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
     ViewModel(),
     OnErrorListener {
 
@@ -58,6 +59,7 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     val isMarked = MutableStateFlow(false)
     val flagCode: MutableStateFlow<Int> = MutableStateFlow(Flag.NONE.code)
     private val showingAnswer = MutableStateFlow(false)
+    private val selectedCardIds: List<Long> = previewerIdsFile.getCardIds()
     val isBackButtonEnabled =
         combine(currentIndex, showingAnswer, backsideOnly) { index, showingAnswer, isBackSideOnly ->
             index != 0 || (showingAnswer && !isBackSideOnly)
@@ -108,6 +110,8 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     }
 
     fun cardId() = currentCard.id
+
+    fun cardsCount() = selectedCardIds.count()
 
     /**
      * MUST be called once before accessing [currentCard] for the first time
@@ -208,10 +212,10 @@ class PreviewerViewModel(private val selectedCardIds: LongArray, firstIndex: Int
     }
 
     companion object {
-        fun factory(selectedCardIds: LongArray, currentIndex: Int): ViewModelProvider.Factory {
+        fun factory(previewerIdsFile: PreviewerIdsFile, currentIndex: Int): ViewModelProvider.Factory {
             return viewModelFactory {
                 initializer {
-                    PreviewerViewModel(selectedCardIds, currentIndex)
+                    PreviewerViewModel(previewerIdsFile, currentIndex)
                 }
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -440,8 +440,8 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("before: index", previewIntent.index, equalTo(0))
         assertThat(
             "before: cards",
-            previewIntent.cardList,
-            equalTo(longArrayOf(cid1, cid2))
+            previewIntent.previewerIdsFile.getCardIds(),
+            equalTo(listOf(cid1, cid2))
         )
 
         // reverse
@@ -455,8 +455,8 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("after: index", intentAfterReverse.index, equalTo(0))
         assertThat(
             "after: cards",
-            intentAfterReverse.cardList,
-            equalTo(longArrayOf(cid2, cid1))
+            intentAfterReverse.previewerIdsFile.getCardIds(),
+            equalTo(listOf(cid2, cid1))
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/PreviewerTest.kt
@@ -19,6 +19,7 @@ import android.widget.SeekBar
 import android.widget.TextView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Previewer.Companion.toIntent
+import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.libanki.Card
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.not
@@ -160,15 +161,13 @@ class PreviewerTest : RobolectricTest() {
         val front = arrayOf("1", "2", "3", "4", "5", "6")
         val back = arrayOf("7", "8", "9", "10", "11", "12")
         val c = arrayOfNulls<Card>(front.size)
-        val arrayList = LongArray(front.size)
-        for (i in front.indices) {
-            val cardToPreview = addNoteUsingBasicModel(front[i], back[i]).firstCard()
+        val longList = front.indices.map {
+            val cardToPreview = addNoteUsingBasicModel(front[it], back[it]).firstCard()
             setDeck("Deck", cardToPreview)
-            val h = cardToPreview.id
-            arrayList[i] = h
-            c[i] = cardToPreview
+            c[it] = cardToPreview
+            cardToPreview.id
         }
-        return getPreviewerPreviewingList(arrayList, c)
+        return getPreviewerPreviewingList(longList, c)
     }
 
     @KotlinCleanup("extension function")
@@ -176,8 +175,8 @@ class PreviewerTest : RobolectricTest() {
         card.update { did = addDeck(name) }
     }
 
-    private fun getPreviewerPreviewingList(cardIds: LongArray, c: Array<Card?>): Previewer {
-        val previewIntent = PreviewDestination(index = 0, cardIds).toIntent(targetContext)
+    private fun getPreviewerPreviewingList(cardIds: List<Long>, c: Array<Card?>): Previewer {
+        val previewIntent = PreviewDestination(index = 0, PreviewerIdsFile(targetContext.cacheDir, cardIds)).toIntent(targetContext)
         val previewer = super.startActivityNormallyOpenCollectionWithIntent(
             Previewer::class.java,
             previewIntent
@@ -189,7 +188,7 @@ class PreviewerTest : RobolectricTest() {
     }
 
     private fun getPreviewerPreviewing(usableCard: Card): Previewer {
-        val previewIntent = PreviewDestination(index = 0, longArrayOf(usableCard.id)).toIntent(targetContext)
+        val previewIntent = PreviewDestination(index = 0, PreviewerIdsFile(targetContext.cacheDir, listOf(usableCard.id))).toIntent(targetContext)
         val previewer = super.startActivityNormallyOpenCollectionWithIntent(
             Previewer::class.java,
             previewIntent

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.browser
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.testutils.JvmTest
+import com.ichi2.testutils.createTransientDirectory
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
@@ -40,6 +41,7 @@ class CardBrowserViewModelTest : JvmTest() {
     private fun runViewModelTest(testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
         val viewModel = CardBrowserViewModel(
             lastDeckIdRepository = SharedPreferencesLastDeckIdRepository(),
+            cacheDir = createTransientDirectory(),
             preferences = AnkiDroidApp.sharedPreferencesProvider
         )
         testBody(viewModel)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes #15380 

## Fixes
* Fixes #15380 

## Approach
I wrote the ids in a file like suggested by Mike Hardy

## How Has This Been Tested?

I don't have a deck that big, but in a small one the previewer still works

## Learning (optional, can help others)

File.createTempFile can be used to create a temporary file

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
