### PR TITLE
feat: day rollover handling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -190,6 +190,9 @@ open class AnkiDroidApp : Application() {
         // Register for notifications
         notifications.observeForever { NotificationService.triggerNotificationFor(this) }
 
+        // listen for day rollover: time + timezone changes
+        DayRolloverHandler.listenForRolloverEvents(this)
+
         registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
             override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
                 Timber.i("${activity::class.simpleName}::onCreate")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ *  This file incorporates code under the following license
+ *  https://github.com/ankitects/anki/blob/edd38ca06730d7fc16804f52ce10f6bc54c3d145/qt/aqt/main.py#L508-L528
+ *
+ *    Copyright: Ankitects Pty Ltd and contributors
+ *    License: GNU AGPL, version 3 or later; http://www.gnu.org/licenses/agpl.html
+ */
+
+package com.ichi2.anki
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.*
+import android.content.IntentFilter
+import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
+import anki.collection.OpChanges
+import anki.collection.opChanges
+import com.ichi2.anki.CollectionManager.withOpenColOrNull
+import com.ichi2.libanki.ChangeManager
+import com.ichi2.libanki.EpochSeconds
+import com.ichi2.libanki.sched.Scheduler
+import kotlinx.coroutines.Dispatchers
+import timber.log.Timber
+
+/**
+ * Checks on time change events for 'day rollover'
+ *
+ * If so, notifies [ChangeManager] that [studyQueues][OpChanges.getStudyQueues] have changed
+ *
+ * HACK: This exists due to Android's complexities of scheduling an event at a given time.
+ * It would be preferred to receive an event at the instant of rollover
+ */
+object DayRolloverHandler : BroadcastReceiver() {
+    /** @see Scheduler.dayCutoff */
+    private var lastCutoff: EpochSeconds? = null
+
+    /** Receive an event each minute AND for time/timezone changes */
+    fun listenForRolloverEvents(context: Context) {
+        fun register(filter: IntentFilter) =
+            ContextCompat.registerReceiver(context, DayRolloverHandler, filter, RECEIVER_EXPORTED)
+
+        Timber.d("listening for rollover events")
+        // ACTION_TIME_TICK occurs every time the displayed time changes (once per minute)
+        // this relies on the assumption that the day rollover's granularity is per-minute
+        register(IntentFilter(ACTION_TIME_TICK))
+        register(IntentFilter(ACTION_TIME_CHANGED))
+        register(IntentFilter(ACTION_TIMEZONE_CHANGED))
+    }
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        // potential race condition if a timezone/tick change occur simultaneously
+        // the outcome would be two calls to notifySubscribers, which is acceptable
+        Timber.v("received ${intent?.action}")
+        // launch coroutine as we need access to `col.sched`
+        AnkiDroidApp.applicationScope.launchCatching(Dispatchers.IO, errorMessageHandler = { Timber.w(it) }) {
+            handleTimeChange()
+        }
+    }
+
+    private suspend fun handleTimeChange() {
+        val currentCutoff = withOpenColOrNull { sched.dayCutoff }
+        if (currentCutoff == null) {
+            // assumption: if the collection is not open, queue status will be updated
+            // by the act of opening the collection, missing an event is acceptable
+            Timber.w("could not check/update day rollover: collection not open")
+            return
+        }
+
+        // Anki Desktop: instead of comparing the current time to the cutoff,
+        // it detects if a change to the cutoff has occurred
+        // https://github.com/ankitects/anki/blob/edd38ca06730d7fc16804f52ce10f6bc54c3d145/qt/aqt/main.py#L508-L528
+        if (lastCutoff == currentCutoff) return
+
+        Timber.i("day cutoff changed %d -> %d", lastCutoff, currentCutoff)
+        // we do not want to send a "study queues changes" message initially
+        if (lastCutoff != null) {
+            Timber.i("updating study queues")
+            ChangeManager.notifySubscribers(opChanges { studyQueues = true }, initiator = null)
+        }
+        this.lastCutoff = currentCutoff
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -26,6 +26,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import anki.collection.OpChanges
 import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
@@ -37,6 +38,7 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.StudyOptionsActivity
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.launchCatchingIO
+import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -44,11 +46,26 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import timber.log.Timber
 
-class CongratsPage : PageFragment(), CustomStudyDialog.CustomStudyListener {
+class CongratsPage :
+    PageFragment(),
+    CustomStudyDialog.CustomStudyListener,
+    ChangeManager.Subscriber {
     override val title: String = ""
     override val pageName = "congrats"
 
     private val viewModel by viewModels<CongratsViewModel>()
+
+    init {
+        ChangeManager.subscribe(this)
+    }
+
+    override fun opExecuted(changes: OpChanges, handler: Any?) {
+        // typically due to 'day rollover'
+        if (changes.studyQueues) {
+            Timber.i("refreshing: study queues updated")
+            webView.reload()
+        }
+    }
 
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
         return super.onCreateWebViewClient(savedInstanceState).also { client ->

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -26,3 +26,13 @@ internal typealias CardId = Long
 internal typealias DeckConfigId = Long
 internal typealias NoteId = Long
 internal typealias NoteTypeId = Long
+
+/**
+ * The number of non-leap seconds which have elapsed since the
+ * [Unix Epoch](https://en.wikipedia.org/wiki/Unix_time) (00:00:00 UTC on 1 January 1970)
+ *
+ * See: [https://www.epochconverter.com/](https://www.epochconverter.com/)
+ *
+ * example: 6 February 2024 19:15:49 -> `1707246949`
+ */
+typealias EpochSeconds = Long

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -36,6 +36,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckConfig
 import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.EpochSeconds
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.utils.TimeManager.time
@@ -417,7 +418,7 @@ open class Scheduler(val col: Collection) {
     /**
      * @return Timestamp of when the day ends. Takes into account hour at which day change for anki and timezone
      */
-    open val dayCutoff: Long
+    open val dayCutoff: EpochSeconds
         get() = timingToday().nextDayAt
 
     /* internal */

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
@@ -41,6 +41,28 @@ fun <T> measureTime(functionName: String? = "", function: () -> T): T {
 }
 
 /**
+ * Measures the time to execute a `suspend` function
+ *
+ * Usage:
+ *
+ * ```kotlin
+ * val result = coMeasureTime("operation") { operation() }
+ * ```
+ * -> `D/TimeUtilKt executed mHtmlGenerator in 23ms`
+ */
+suspend fun <T> coMeasureTime(functionName: String? = "", function: suspend () -> T): T {
+    val startTime = TimeManager.time.intTimeMS()
+    val result = function()
+    val endTime = TimeManager.time.intTimeMS()
+    Timber.d(
+        "executed %sin %dms",
+        if (functionName.isNullOrEmpty()) "" else "$functionName ",
+        endTime - startTime
+    )
+    return result
+}
+
+/**
  * Used to time an operation across two function calls
  *
  * ```kotlin


### PR DESCRIPTION
## Reviewer Note

See: https://github.com/ankitects/anki/blob/edd38ca06730d7fc16804f52ce10f6bc54c3d145/qt/aqt/main.py#L508-L528

## Purpose / Description
AnkiDroid needs to perform certain operations after a day rollover, otherwise the backend throws InvalidInputException when reviewing



## Fixes
* Fixes #14090

## Approach
* ⚠️ This is a hack, please suggest a better method, happy to rewrite


Due to complexities of Android scheduling a timer at a given time, we use a hack:

* Every time change, or every minute (when the clock changes), run a function

We care about:

* Reviewer - a new card may be seen
* DeckPicker - counts will be updated
* CongratsScreen - bury status will change


## How Has This Been Tested?
I changed code to perform a 'day rollover' every second, and ensured that the change was fired

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
