### PR TITLE
feat(whiteboard): S Pen eraser on OneUI 6

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -118,11 +118,19 @@ class Whiteboard(activity: AnkiActivity, private val handleMultiTouch: Boolean, 
         }
         return when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                drawStart(x, y)
-                invalidate()
+                if (event.buttonState == MotionEvent.BUTTON_STYLUS_PRIMARY) {
+                    stylusErase(event)
+                } else {
+                    drawStart(x, y)
+                    invalidate()
+                }
                 true
             }
             MotionEvent.ACTION_MOVE -> {
+                if (event.buttonState == MotionEvent.BUTTON_STYLUS_PRIMARY) {
+                    stylusErase(event)
+                    return true
+                }
                 if (isCurrentlyDrawing) {
                     for (i in 0 until event.historySize) {
                         drawAlong(event.getHistoricalX(i), event.getHistoricalY(i))


### PR DESCRIPTION
## Purpose / Description
OneUI 6 changed how the S Pen sent MotionEvents, which broke 'erase'

## Fixes
* Fixes #14767

## Approach
Handle `BUTTON_STYLUS_PRIMARY`

## How Has This Been Tested?

Tested-by: @mmarlo-hassio on a physical device with an S Pen

## Learning (optional, can help others)
`buttonState == BUTTON_STYLUS_PRIMARY` is how the events are now sent

I reverse engineered the S Pen Remote SDK, nothing relevant here

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
