### PR TITLE
previewers: improve nav bar color

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplatePreviewer.kt
@@ -98,6 +98,7 @@ open class CardTemplatePreviewer : AbstractFlashcardViewer() {
                 closeCardTemplatePreviewer()
             }
         }
+        setNavigationBarColor(R.attr.showAnswerColor)
         showBackIcon()
         // Ensure navigation drawer can't be opened. Various actions in the drawer cause crashes.
         disableDrawerSwipe()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -76,6 +76,7 @@ class Previewer : AbstractFlashcardViewer() {
             finish()
             return
         }
+        setNavigationBarColor(R.attr.showAnswerColor)
         showBackIcon()
         // Ensure navigation drawer can't be opened. Various actions in the drawer cause crashes.
         disableDrawerSwipe()


### PR DESCRIPTION
matches the navigation bar color with 'show answer'

* uses `setNavigationBarColor`

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/976e15e7-ef9d-455e-8980-f8caa841b040)

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/8082e608-6ee2-4399-b971-9f46c94e7d81)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
