### PR TITLE
RecursivePictureMenu uses AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/RecursivePictureMenu.kt
@@ -24,17 +24,16 @@ import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import androidx.core.os.BundleCompat
 import androidx.core.os.ParcelCompat
-import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.list.customListAdapter
-import com.afollestad.materialdialogs.list.getRecyclerView
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.utils.customListAdapter
+import com.ichi2.utils.title
 import java.util.*
 
 /** A Dialog displaying The various options for "Help" in a nested structure  */
@@ -61,10 +60,11 @@ class RecursivePictureMenu : DialogFragment() {
                 return items.size
             }
         }
-        return MaterialDialog(requireContext()).show {
-            customListAdapter(adapter, null)
+        val dialog = AlertDialog.Builder(requireContext()).apply {
+            customListAdapter(adapter)
             title(text = title)
-        }.apply { getRecyclerView().updatePadding(bottom = 0) }
+        }.create()
+        return dialog
     }
 
     abstract class Item : Parcelable {


### PR DESCRIPTION
## Fixes
* Related #13315  

## Approach
Replaces usages of Deprecated MaterialDialog and adds the Native AlertDialog For RecursivePictureMenu.

## Images

| Material Dialog | Alert Dialog |
|-----------------|--------------|
| ![Material Dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/bdcfe2e4-e9ec-4ab4-af32-5d990049fd5d) | ![alert dialog](https://github.com/ankidroid/Anki-Android/assets/60827173/00489c6f-c9d2-4525-8ff4-fd83f33b4e99) |


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
