### PR TITLE
Improve the extension methods available in AlertDialogFacade

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -23,7 +23,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
-import com.ichi2.utils.create
+import com.ichi2.utils.createAndApply
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
@@ -39,7 +39,7 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finish()
             }
-        }.create {
+        }.createAndApply {
             setCanceledOnTouchOutside(false)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -43,7 +43,7 @@ import com.ichi2.anki.dialogs.help.HelpItem.Action.OpenUrl
 import com.ichi2.anki.dialogs.help.HelpItem.Action.OpenUrlResource
 import com.ichi2.anki.dialogs.help.HelpItem.Action.Rate
 import com.ichi2.anki.dialogs.help.HelpItem.Action.SendReport
-import com.ichi2.utils.create
+import com.ichi2.utils.createAndApply
 import com.ichi2.utils.customView
 import com.ichi2.utils.title
 
@@ -67,7 +67,7 @@ class HelpDialog : DialogFragment() {
         return AlertDialog.Builder(requireContext())
             .title(requireArguments().getInt(ARG_MENU_TITLE))
             .customView(customView)
-            .create {
+            .createAndApply {
                 // the dialog captures the BACK call so we manually pop the inner FragmentManager
                 // if there's a second page
                 onBackPressedDispatcher.addCallback(this@HelpDialog, true) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -182,6 +182,11 @@ fun AlertDialog.Builder.checkBoxPrompt(
     return this.setView(checkBoxView)
 }
 
+fun AlertDialog.getCheckBoxPrompt(): CheckBox =
+    requireNotNull(findViewById(R.id.checkbox)) {
+        "CheckBox prompt is not available. Forgot to call AlertDialog.Builder.checkBoxPrompt()?"
+    }
+
 fun AlertDialog.Builder.customView(
     view: View,
     paddingTop: Int = 0,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -138,9 +138,9 @@ inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): Aler
 }
 
 /**
- * Creates an [AlertDialog], then executes [block] with it
+ * Creates an [AlertDialog] from the [AlertDialog.Builder] instance, then executes [block] with it.
  */
-fun AlertDialog.Builder.create(block: AlertDialog.() -> Unit): AlertDialog = create().apply {
+fun AlertDialog.Builder.createAndApply(block: AlertDialog.() -> Unit): AlertDialog = create().apply {
     block()
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -145,6 +145,14 @@ fun AlertDialog.Builder.createAndApply(block: AlertDialog.() -> Unit): AlertDial
 }
 
 /**
+ * Executes [block] on the [AlertDialog.Builder] instance and returns the initialized [AlertDialog].
+ */
+fun AlertDialog.Builder.create(block: AlertDialog.Builder.() -> Unit): AlertDialog {
+    block()
+    return create()
+}
+
+/**
  * Adds a checkbox to the dialog, whilst continuing to display the value of [message]
  * @param stringRes The string resource to display for the checkbox label.
  * @param text The literal string to display for the checkbox label.


### PR DESCRIPTION
## Purpose / Description
I've renamed the current _create{}_ extension method to _createAndApply{}_ to avoid confusion with a basic _create{}_ extension that works on the _AlertDialog.Builder_ instance. Feel free to comment on the naming.
Also added a getter for the prompt CheckBox that can be used in  #15376


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
