### PR TITLE
chore: use AlertDialog.Builder.create()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.ImportUtils
+import com.ichi2.utils.create
 import timber.log.Timber
 import java.io.File
 import java.net.URLConnection
@@ -458,7 +459,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
 
     @Suppress("deprecation") // onBackPressed
     fun showCancelConfirmationDialog() {
-        downloadCancelConfirmationDialog = AlertDialog.Builder(requireContext()).apply {
+        downloadCancelConfirmationDialog = AlertDialog.Builder(requireContext()).create {
             setTitle(R.string.cancel_download_question_title)
             setPositiveButton(R.string.dialog_yes) { _, _ ->
                 downloadManager.remove(downloadId)
@@ -469,7 +470,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
             setNegativeButton(R.string.dialog_no) { _, _ ->
                 downloadCancelConfirmationDialog?.dismiss()
             }
-        }.create()
+        }
         downloadCancelConfirmationDialog?.show()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -109,7 +109,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
     }
 
     private fun build(isLoggedIn: Boolean, performBackup: () -> Unit) {
-        this.alertDialog = AlertDialog.Builder(windowContext).apply {
+        this.alertDialog = AlertDialog.Builder(windowContext).create {
             setIcon(if (isLoggedIn) R.drawable.ic_baseline_backup_24 else R.drawable.ic_backup_restore)
             title(R.string.backup_your_collection)
             message(R.string.backup_collection_message)
@@ -127,7 +127,7 @@ class BackupPromptDialog private constructor(private val windowContext: Context)
             }
             negativeButton(R.string.button_backup_later) { onDismiss() }
             cancelable(false)
-        }.create()
+        }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ConfirmationDialog.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.ichi2.anki.R
+import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -55,7 +56,7 @@ class ConfirmationDialog : DialogFragment() {
         super.onCreate(savedInstanceState)
         val res = requireActivity().resources
         val title = requireArguments().getString("title")
-        return AlertDialog.Builder(requireContext()).apply {
+        return AlertDialog.Builder(requireContext()).create {
             title(text = (if ("" == title) res.getString(R.string.app_name) else title)!!)
             message(text = requireArguments().getString("message")!!)
             positiveButton(R.string.dialog_ok) {
@@ -64,6 +65,6 @@ class ConfirmationDialog : DialogFragment() {
             negativeButton(R.string.dialog_cancel) {
                 cancel.run()
             }
-        }.create()
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerBackupNoSpaceLeftDialog.kt
@@ -23,7 +23,7 @@ import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
-import com.ichi2.utils.createAndApply
+import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
@@ -33,13 +33,13 @@ class DeckPickerBackupNoSpaceLeftDialog : AnalyticsDialogFragment() {
         super.onCreate(savedInstanceState)
         val res = resources
         val space = BackupManager.getFreeDiscSpace(CollectionHelper.getCollectionPath(requireActivity()))
-        return AlertDialog.Builder(requireContext()).apply {
+        return AlertDialog.Builder(requireContext()).create {
             title(R.string.storage_almost_full_title)
             message(text = res.getString(R.string.storage_warning, space / 1024 / 1024))
             positiveButton(R.string.dialog_ok) {
                 (activity as DeckPicker).finish()
             }
-        }.createAndApply {
+        }.apply {
             setCanceledOnTouchOutside(false)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerNoSpaceLeftDialog.kt
@@ -22,6 +22,7 @@ import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.utils.cancelable
+import com.ichi2.utils.create
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
@@ -29,13 +30,13 @@ import com.ichi2.utils.title
 class DeckPickerNoSpaceLeftDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
-        return AlertDialog.Builder(requireActivity()).apply {
+        return AlertDialog.Builder(requireActivity()).create {
             title(R.string.storage_full_title)
             message(R.string.backup_deck_no_storage_left)
             cancelable(true)
             positiveButton(R.string.dialog_ok) {}
             setOnCancelListener {}
-        }.create()
+        }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CardTemplateEditor
 import com.ichi2.anki.R
+import com.ichi2.utils.create
 import com.ichi2.utils.customListAdapter
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.title
@@ -60,11 +61,11 @@ class InsertFieldDialog : DialogFragment() {
                 return fieldList.size
             }
         }
-        return AlertDialog.Builder(requireContext()).apply {
+        return AlertDialog.Builder(requireContext()).create {
             title(R.string.card_template_editor_select_field)
             negativeButton(R.string.dialog_cancel)
             customListAdapter(adapter)
-        }.create()
+        }
     }
 
     private fun selectFieldAndClose(textView: TextView) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ModelEditorContextMenu.kt
@@ -14,6 +14,7 @@ import com.ichi2.anki.ModelFieldEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.ModelEditorContextMenu.ModelEditorContextMenuAction.AddLanguageHint
+import com.ichi2.utils.create
 import timber.log.Timber
 
 /**
@@ -32,13 +33,13 @@ open class ModelEditorContextMenu : AnalyticsDialogFragment() {
         }
         availableItems = availableItems.sortedBy { it.order }
 
-        return AlertDialog.Builder(requireActivity()).apply {
+        return AlertDialog.Builder(requireActivity()).create {
             setTitle(requireArguments().getString(KEY_LABEL))
             setItems(availableItems.map { resources.getString(it.actionTextId) }.toTypedArray()) { _, index ->
                 (activity as? ModelFieldEditor)?.run { handleAction(availableItems[index]) }
                     ?: Timber.e("ContextMenu used from outside of its target activity!")
             }
-        }.create()
+        }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SimpleMessageDialog.kt
@@ -20,6 +20,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.utils.create
 
 class SimpleMessageDialog : AsyncDialogFragment() {
     interface SimpleMessageDialogListener {
@@ -28,7 +29,7 @@ class SimpleMessageDialog : AsyncDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreateDialog(savedInstanceState)
-        return AlertDialog.Builder(requireContext()).apply {
+        return AlertDialog.Builder(requireContext()).create {
             setTitle(notificationTitle)
             setMessage(notificationMessage)
             setPositiveButton(R.string.dialog_ok) { _, _ ->
@@ -39,7 +40,7 @@ class SimpleMessageDialog : AsyncDialogFragment() {
                         )
                     )
             }
-        }.create()
+        }
     }
 
     override val notificationTitle: String


### PR DESCRIPTION
## Purpose / Description

Related: 1fd0147afd954d802932efa710b7b0730322cc97 (added `.create` with the wrong receiver: `AlertDialog` instead of `AlertDialog.Builder`)
Fixed in bcc4df072eccdb12887a7626ad2770a95989148e

This left a large number of dialogs using `.apply { }.create()`

A large number of dialogs could be transitioned to this pattern. For now we replace all instances of `.apply { }.create()` to ensure this is a refactor-only commit

## Fixes
* Related: #13315

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
