### PR TITLE
chore: allow translation of SearchPreference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -72,7 +72,6 @@ class HeaderFragment : PreferenceFragmentCompat() {
                 setBreadcrumbsEnabled(true)
                 setFuzzySearchEnabled(false)
                 setHistoryEnabled(true)
-                textNoResults = activity.getString(R.string.pref_search_no_results)
 
                 index(R.xml.preferences_general)
                 index(R.xml.preferences_reviewing)

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -27,6 +27,7 @@
     </plurals>
     <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"
         name="pref_summary_percentage">%s\%%</string>
+    <!-- TODO: move to 20-search-preference so we can contribute upstream (searchpreference_no_results)-->
     <string name="pref_search_no_results">No results</string>
 
     <!-- preferences.xml categories-->

--- a/AnkiDroid/src/main/res/values/20-search-preference.xml
+++ b/AnkiDroid/src/main/res/values/20-search-preference.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~
+  ~ Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~ This file incorporates code under the following license
+  ~ https://github.com/ByteHamster/SearchPreference/blob/932bac41a4d0d34dc34958129849f20899a63ec1/lib/src/main/res/values/strings.xml
+  ~
+  ~     Copyright (c) 2018 ByteHamster
+  ~
+  ~     Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~     of this software and associated documentation files (the "Software"), to deal
+  ~     in the Software without restriction, including without limitation the rights
+  ~     to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~     copies of the Software, and to permit persons to whom the Software is
+  ~     furnished to do so, subject to the following conditions:
+  ~
+  ~     The above copyright notice and this permission notice shall be included in all
+  ~     copies or substantial portions of the Software.
+  ~
+  ~     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~     IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~     FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~     AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  ~     SOFTWARE.
+  ~
+  -->
+
+<!--
+    from https://github.com/ByteHamster/SearchPreference.
+    Explicitly licensed as MIT so we can contribute upstream
+
+    UnusedResources: these are overrides for SearchPreference
+    the key names MUST NOT be changed due to this
+-->
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <string tools:ignore="UnusedResources" name="searchpreference_search" comment="By submitting this string, you license it under the MIT License">Search…</string>
+    <string tools:ignore="UnusedResources" name="searchpreference_clear_history" comment="By submitting this string, you license it under the MIT License">Clear history</string>
+</resources>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -21,7 +21,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.bytehamster.lib.preferencesearch.SearchPreference
-        android:key="@string/search_preference_key"/>
+        android:key="@string/search_preference_key"
+        app:textNoResults="@string/pref_search_no_results"/>
 
     <!--  General Preferences -->
     <com.ichi2.preferences.HeaderPreference

--- a/tools/localization/src/constants.ts
+++ b/tools/localization/src/constants.ts
@@ -67,6 +67,7 @@ export const I18N_FILES = [
     "16-multimedia-editor",
     "17-model-manager",
     "18-standard-models",
+    "20-search-preference",
 ];
 
 // Below is the list of official AnkiDroid localizations.


### PR DESCRIPTION
## Fixes
* FIxes #15453

## Approach
extract & use strings from `com.github.ByteHamster:SearchPreference` which our translators wish to translate

The repo states:

> If you want to translate the texts shown by the library together
> with your app's other strings, you can just override the strings
> defined in lib/src/main/res/values/strings.xml in your own application
> by copying those lines to your app's strings.xml.

https://github.com/ByteHamster/SearchPreference?tab=readme-ov-file#translations

We license the strings as MIT in a separate file so we may contribute them upstream (20-search-preference.xml)

Add this file to the list of translatable resources

~~I renamed the strings from `searchpreference` to `search_preference` to allow for testing in English: upstream defines '_en' which overrides our override~~


## How Has This Been Tested?

There is a bug in using `search_preference_clear_history`: 
* https://github.com/ByteHamster/SearchPreference/issues/33
 
I submitted a patch:
* https://github.com/ByteHamster/SearchPreference/issues/34

This now doesn't matter as we use the same preference keys as upstream

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
