### PR TITLE
Make undo icon gray when the icon is unavailable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -754,6 +754,7 @@ open class Reviewer :
                 // so in some languages such as Japanese, which have pre/post-positional particle with the object,
                 // we need to use the string for just "Undo" instead of the string for "Undo %s".
                 undoIcon.title = resources.getString(R.string.undo)
+                undoIcon.iconAlpha = Themes.ALPHA_ICON_DISABLED_LIGHT
             }
             menu.findItem(R.id.action_redo)?.apply {
                 if (getColUnsafe.redoAvailable()) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Make the undo icon "grayed out" appearance when there is no action to undo.

## Fixes
* Fixes #15455

## How Has This Been Tested?
Checked on a physical device (Android 11)

https://github.com/ankidroid/Anki-Android/assets/10436072/e424948d-4e1e-41e3-a23e-cd8056e7a159



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
