### PR TITLE
Fix: IllegalArgumentException on with progress dialog dimiss

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import android.app.Activity
+import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
 import android.view.WindowManager
@@ -352,11 +353,21 @@ suspend fun <T> withProgressDialog(
         op(dialog)
     } finally {
         dialogJob.cancel()
-        dialog.dismiss()
+        dismissDialogIfShowing(dialog)
         context.window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
         if (dialogIsOurs) {
             AnkiDroidApp.instance.progressDialogShown = false
         }
+    }
+}
+
+private fun dismissDialogIfShowing(dialog: Dialog) {
+    try {
+        if (dialog.isShowing) {
+            dialog.dismiss()
+        }
+    } catch (e: Exception) {
+        Timber.w(e)
     }
 }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`withProgress` dialog might throw IllegalArgumentException if the dialog is not shown and dismiss is called.
Stracktrace pointed at DeckPicker which was calling with progress having context from DeckPicker,
```View=DecorView@1caa981[DeckPicker] not attached to window manager: ```
This message indicates that the DecorView with the identifier 1caa981 (associated with a DeckPicker) is not currently attached to the window manager.

## Fixes
* Fixes #15445 

## How Has This Been Tested?

Adding a condition to check whether the dialog is showing before dismissing it  fixes the issue.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
