### PR TITLE
fix: 'auto focus type in answer' default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -214,7 +214,7 @@ class TypeAnswer(
             return TypeAnswer(
                 useInputTag = preferences.getBoolean("useInputTag", false),
                 doNotUseCodeFormatting = preferences.getBoolean("noCodeFormatting", false),
-                autoFocus = preferences.getBoolean("autoFocusTypeInAnswer", false)
+                autoFocus = preferences.getBoolean("autoFocusTypeInAnswer", true)
             )
         }
 


### PR DESCRIPTION
In the preference it was true

https://github.com/ankidroid/Anki-Android/blob/4711b4c89a9a45da10781c93e7480d541860ad02/AnkiDroid/src/main/res/xml/preferences_advanced.xml#L92-L93

In the code it was false

Make it `true`

## How Has This Been Tested?

Untested

## Learning

At some point we need to look again at making preference defaults consistent. I had a try a long time ago in Java, and it would be much cleaner in Kotlin

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
