### PR TITLE
Revert "remove reviewer ETA"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -534,9 +534,6 @@ abstract class AbstractFlashcardViewer :
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
         gestureDetectorImpl = LinkDetectingGestureDetector()
         TtsVoicesFieldFilter.ensureApplied()
-        if (!sharedPrefs().getBoolean("showDeckTitle", false)) {
-            supportActionBar?.setDisplayShowTitleEnabled(false)
-        }
     }
 
     protected open fun getContentViewAttr(fullscreenMode: FullScreenMode): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -193,7 +193,10 @@ open class Reviewer :
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
         setNavigationBarColor(R.attr.showAnswerColor)
-
+        if (!sharedPrefs().getBoolean("showDeckTitle", false)) {
+            // avoid showing "AnkiDroid"
+            supportActionBar?.title = ""
+        }
         startLoadingCollection()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -948,7 +948,7 @@ open class Reviewer :
     override fun restorePreferences(): SharedPreferences {
         val preferences = super.restorePreferences()
         prefHideDueCount = preferences.getBoolean("hideDueCount", false)
-        prefShowETA = preferences.getBoolean("showETA", true)
+        prefShowETA = preferences.getBoolean("showETA", false)
         processor.setup()
         prefFullscreenReview = isFullScreenReview(preferences)
         actionButtons.setup(preferences)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -483,6 +483,7 @@ object UsageAnalytics {
         "answerButtonPosition", // Answer buttons position
         "showTopbar", // Show top bar
         "showProgress", // Show remaining
+        "showETA", // Show ETA
         "showAudioPlayButtons", // Show play buttons on cards with audio (reversed in collection: HIDE_AUDIO_PLAY_BUTTONS)
         "card_browser_show_media_filenames", // Display filenames in card browser
         "showDeckTitle", // Show deck title

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
@@ -23,6 +23,8 @@ import com.ichi2.libanki.utils.Time
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -40,6 +42,52 @@ private const val TIME_HOUR = 60.0 * TIME_MINUTE
 private const val TIME_DAY = 24.0 * TIME_HOUR
 private const val TIME_MONTH = 30.0 * TIME_DAY
 private const val TIME_YEAR = 12.0 * TIME_MONTH
+
+/**
+ * Return a string representing how much time remains
+ *
+ * @param context The application's environment.
+ * @param time_s The time to format, in seconds
+ * @return The time quantity string. Something like "3 minutes left" or "2 hours left".
+ */
+fun remainingTime(context: Context, time_s: Long): String {
+    val time_x: Int // Time in unit x
+    val remaining_seconds: Int // Time not counted in the number in unit x
+    val remaining: Int // Time in the unit smaller than x
+    val res = context.resources
+    return if (time_s < TIME_HOUR_LONG) {
+        // get time remaining, but never less than 1
+        time_x = max(
+            (time_s / TIME_MINUTE).roundToInt(),
+            1
+        )
+        res.getQuantityString(R.plurals.reviewer_window_title, time_x, time_x)
+        // It used to be minutes only. So the word "minutes" is not
+        // explicitly written in the ressource name.
+    } else if (time_s < TIME_DAY_LONG) {
+        time_x = (time_s / TIME_HOUR_LONG).toInt()
+        remaining_seconds = (time_s % TIME_HOUR_LONG).toInt()
+        remaining =
+            (remaining_seconds.toFloat() / TIME_MINUTE).roundToInt()
+        res.getQuantityString(
+            R.plurals.reviewer_window_title_hours_new,
+            time_x,
+            time_x,
+            remaining
+        )
+    } else {
+        time_x = (time_s / TIME_DAY_LONG).toInt()
+        remaining_seconds = (time_s.toFloat() % TIME_DAY_LONG).toInt()
+        remaining =
+            (remaining_seconds / TIME_HOUR).roundToInt()
+        res.getQuantityString(
+            R.plurals.reviewer_window_title_days_new,
+            time_x,
+            time_x,
+            remaining
+        )
+    }
+}
 
 /**
  * Return a proper string for a time value in seconds

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -36,6 +36,18 @@
     <!-- DeckPicker.kt -->
     <string name="expand">Expand</string>
     <string name="collapse">Collapse</string>
+    <plurals name="reviewer_window_title">
+        <item quantity="one">%d minute left</item>
+        <item quantity="other">%d minutes left</item>
+    </plurals>
+    <plurals name="reviewer_window_title_hours_new">
+        <item quantity="one">%1$d hour %2$d left</item>
+        <item quantity="other">%1$d hours %2$d left</item>
+    </plurals>
+    <plurals name="reviewer_window_title_days_new">
+        <item quantity="one">%1$d day %2$d left</item>
+        <item quantity="other">%1$d days %2$d left</item>
+    </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>
     <string name="no_cards_placeholder_description">Start adding cards\nusing the + icon.</string>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -152,6 +152,8 @@
     <string name="show_top_bar_summ">Show card counts, flag and mark in top bar</string>
     <string name="show_progress" maxLength="41">Show remaining</string>
     <string name="show_progress_summ">Show remaining card count</string>
+    <string name="show_eta" maxLength="41">Show ETA</string>
+    <string name="show_eta_summ">Show remaining time</string>
     <string name="use_current" maxLength="41">Deck for new cards</string>
     <string name="learn_cutoff" maxLength="41">Learn ahead limit</string>
     <string name="time_limit" maxLength="41">Timebox time limit</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -41,6 +41,7 @@
     <string name="pref_display_filenames_in_browser_key">card_browser_show_media_filenames</string>
     <string name="show_topbar_preference">showTopbar</string>
     <string name="show_progress_preference">showProgress</string>
+    <string name="show_eta_preference">showETA</string>
     <string name="show_audio_play_buttons_key">showAudioPlayButtons</string>
     <string name="pref_card_browser_font_scale_key">relativeCardBrowserFontSize</string>
     <string name="show_deck_title_key">showDeckTitle</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -106,6 +106,11 @@
             android:summary="@string/show_progress_summ"
             android:title="@string/show_progress" />
         <SwitchPreferenceCompat
+            android:key="@string/show_eta_preference"
+            android:defaultValue="true"
+            android:summary="@string/show_eta_summ"
+            android:title="@string/show_eta" />
+        <SwitchPreferenceCompat
             android:key="@string/show_audio_play_buttons_key"
             android:defaultValue="true"
             tools:title="Show play buttons on cards with audio"

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -107,7 +107,7 @@
             android:title="@string/show_progress" />
         <SwitchPreferenceCompat
             android:key="@string/show_eta_preference"
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:summary="@string/show_eta_summ"
             android:title="@string/show_eta" />
         <SwitchPreferenceCompat


### PR DESCRIPTION
## Purpose / Description
A number of users have asked for the functionality to be restored. We restore the functionality, but default the preference to "false"


## Fixes
* Issue #15405
* Needs a follow-on to revert the string removal

## Approach
* Revert & fix conflicts (commit revert)
* Fix an issue which meant the bar didn't appear
* Set default to false

## How Has This Been Tested?

<details>
![image](https://github.com/ankidroid/Anki-Android/assets/62114487/2372812a-d8e3-441f-ba6e-eec9ad330d84)

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/499cfacf-49e5-4aa6-9b41-4fcdf0d59838)

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/1c57fe77-d39f-457c-83ee-833be369db6b)
</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
