### PR TITLE
fix(CardBrowser): selecting a deck twice

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -118,11 +118,11 @@ open class CardBrowser :
     TagsDialogListener,
     ChangeManager.Subscriber,
     ExportDialogsFactoryProvider {
+
+    @NeedsTest("15448: double-selecting deck does nothing")
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let {
-            val deckId = deck.deckId
-            deckSpinnerSelection!!.initializeActionBarDeckSpinner(getColUnsafe, this.supportActionBar!!)
-            launchCatchingTask { selectDeckAndSave(deckId) }
+            launchCatchingTask { selectDeckAndSave(deck.deckId) }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -161,7 +161,7 @@ open class CardBrowser :
     private lateinit var mExportingDelegate: ActivityExportingDelegate
 
     // card that was clicked (not marked)
-    private var mCurrentCardId
+    override var currentCardId
         get() = viewModel.currentCardId
         set(value) { viewModel.currentCardId = value }
 
@@ -186,7 +186,7 @@ open class CardBrowser :
             mShouldRestoreScroll = true
             forceRefreshSearch()
             // in use by reviewer?
-            if (reviewerCardId == mCurrentCardId) {
+            if (reviewerCardId == currentCardId) {
                 mReloadRequired = true
             }
         }
@@ -213,7 +213,7 @@ open class CardBrowser :
             (data.getBooleanExtra(NoteEditor.RELOAD_REQUIRED_EXTRA_KEY, false) || data.getBooleanExtra(NoteEditor.NOTE_CHANGED_EXTRA_KEY, false))
         ) {
             forceRefreshSearch()
-            if (reviewerCardId == mCurrentCardId) {
+            if (reviewerCardId == currentCardId) {
                 mReloadRequired = true
             }
         }
@@ -680,8 +680,8 @@ open class CardBrowser :
     /** Opens the note editor for a card.
      * We use the Card ID to specify the preview target  */
     private fun openNoteEditorForCard(cardId: CardId) {
-        mCurrentCardId = cardId
-        cardBrowserCard = getColUnsafe.getCard(mCurrentCardId)
+        currentCardId = cardId
+        cardBrowserCard = getColUnsafe.getCard(currentCardId)
         // start note editor using the card we just loaded
         val editCard = Intent(this, NoteEditor::class.java)
             .putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_CARDBROWSER_EDIT)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1867,8 +1867,6 @@ open class CardBrowser :
     fun onSelectionChanged() {
         Timber.d("onSelectionChanged()")
         try {
-            actionBarTitle.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", viewModel.selectedRowCount())
-
             // If we're not in mutliselect, we can select cards if there are cards to select
             if (!viewModel.isInMultiSelectMode) {
                 actionBarMenu?.findItem(R.id.action_select_all)?.apply {
@@ -1876,6 +1874,9 @@ open class CardBrowser :
                 }
                 return
             }
+
+            // set the number of selected rows (only in multiselect)
+            actionBarTitle.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", viewModel.selectedRowCount())
             updateMultiselectMenu()
         } finally {
             if (colIsOpenUnsafe()) {


### PR DESCRIPTION
## Fixes
* Fixes #15448

## Approach
* cleanup
* diagnose and fix issues - due to `deckId` now being a `MutableStateFlow`

## How Has This Been Tested?
Physically on my S21

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
