### PR TITLE
fix(card-browser): retain state in 'onStart'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -419,17 +419,17 @@ open class CardBrowser :
         }
         onboarding.onCreate()
 
-        viewModel.isTruncatedFlow
+        viewModel.flowOfIsTruncated
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { cardsAdapter.notifyDataSetChanged() }
             .launchIn(lifecycleScope)
 
-        viewModel.cardsOrNotesFlow
+        viewModel.flowOfCardsOrNotes
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { runOnUiThread { searchCards() } }
             .launchIn(lifecycleScope)
 
-        viewModel.searchQueryExpandedFlow
+        viewModel.flowOfSearchQueryExpanded
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { searchQueryExpanded ->
                 Timber.d("query expansion changed: %b", searchQueryExpanded)
@@ -443,22 +443,22 @@ open class CardBrowser :
             }
             .launchIn(lifecycleScope)
 
-        viewModel.selectedRowsFlow
+        viewModel.flowOfSelectedRows
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { runOnUiThread { onSelectionChanged() } }
             .launchIn(lifecycleScope)
 
-        viewModel.column1IndexFlow
+        viewModel.flowOfColumnIndex1
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { index -> cardsAdapter.updateMapping { it[0] = COLUMN1_KEYS[index] } }
             .launchIn(lifecycleScope)
 
-        viewModel.column2IndexFlow
+        viewModel.flowOfColumnIndex2
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { index -> cardsAdapter.updateMapping { it[1] = COLUMN2_KEYS[index] } }
             .launchIn(lifecycleScope)
 
-        viewModel.filterQueryFlow
+        viewModel.flowOfFilterQuery
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { filterQuery ->
                 searchView!!.setQuery("", false)
@@ -468,7 +468,7 @@ open class CardBrowser :
             }
             .launchIn(lifecycleScope)
 
-        viewModel.deckIdFlow
+        viewModel.flowOfDeckId
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .filterNotNull()
             .onEach { deckId ->
@@ -478,11 +478,11 @@ open class CardBrowser :
             }
             .launchIn(lifecycleScope)
 
-        viewModel.canSaveSearchFlow
+        viewModel.flowOfCanSearch
             .onEach { canSave -> runOnUiThread { saveSearchItem?.isVisible = canSave } }
             .launchIn(lifecycleScope)
 
-        viewModel.isInMultiSelectModeFlow
+        viewModel.flowOfIsInMultiSelectMode
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { inMultiSelect ->
                 if (inMultiSelect) {
@@ -506,7 +506,7 @@ open class CardBrowser :
             }
             .launchIn(lifecycleScope)
 
-        viewModel.initCompletedFlow
+        viewModel.flowOfInitCompleted
             .flowWithLifecycle(lifecycle, Lifecycle.State.STARTED)
             .onEach { completed -> if (completed) searchCards() }
             .launchIn(lifecycleScope)


### PR DESCRIPTION
## Purpose / Description
The flows were refreshed, causing a search if a user backgrounded the app and restored it

Also with editing notes in different activities

## Fixes
* Fixes #14220

## Approach

~~We add `flowWhenActive` to handle this~~

From review comments: remove `flowWithLifecycle` instead

## How Has This Been Tested?
On my S21: editing notes and backgrounding the app:

* editing removes selection (as previously)
* backgrounding now maintains scroll position

## Learning (optional, can help others)
I did not know this issue that a `StateFlow` would refresh when backgrounded. This won't be a problem when we move searching into the `ViewModel`, but is for now

https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/distinct-until-changed.html

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
