### PR TITLE
fix: legacy TTS should stop on card flip

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper.Companion.getMediaDirectory
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.ReadText
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.CONTINUE_AUDIO
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.RETRY_AUDIO
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.STOP_AUDIO
@@ -186,6 +187,7 @@ class SoundPlayer : Closeable {
     suspend fun stopSounds() {
         if (playSoundsJob != null) Timber.i("stopping sounds")
         cancelPlaySoundsJob(playSoundsJob)
+        ReadText.stopTts() // TODO: Reconsider design
     }
 
     override fun close() {


### PR DESCRIPTION
## Purpose / Description
Issue introduced in: ee5e267

Cause: mis-abstraction, and didn't stop the legacy TTS in the new TTS Player

https://github.com/ankidroid/Anki-Android/commit/ee5e26702ff55cd83a8dad5bbdab3550c27b26de#diff-7cd4e14b716b1bcd35f3cb3318da36eb706289a8e79658266d1f37d4ff8df796L178

## Fixes
* Fixes #15423

## Approach
Re-add the missing line

## How Has This Been Tested?
https://github.com/ankidroid/Anki-Android/issues/15423#issuecomment-1942817771

Then testing on API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
