### PR TITLE
fix: editing card deck shows wrong card 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -59,7 +59,10 @@ object ActivityTransitionAnimation {
 
     @Parcelize
     enum class Direction : Parcelable {
-        START, END, FADE, UP, DOWN, RIGHT, LEFT, DEFAULT, NONE
+        START, END, FADE, UP, DOWN, RIGHT, LEFT, DEFAULT, NONE;
+
+        /** @see getInverseTransition */
+        fun invert(): Direction = getInverseTransition(this)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -54,7 +54,6 @@ import anki.collection.OpChanges
 import com.drakeet.drawer.FullDraggableContainer
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
-import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -67,6 +66,8 @@ import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.model.CardStateFilter
+import com.ichi2.anki.noteeditor.EditCardDestination
+import com.ichi2.anki.noteeditor.toIntent
 import com.ichi2.anki.pages.AnkiServer.Companion.LOCALHOST
 import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.preferences.sharedPrefs
@@ -802,12 +803,9 @@ abstract class AbstractFlashcardViewer :
             // This should never occurs. It means the review button was pressed while there is no more card in the reviewer.
             return
         }
-        val editCard = Intent(this@AbstractFlashcardViewer, NoteEditor::class.java)
-        val animation = getAnimationTransitionFromGesture(fromGesture)
-        editCard.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_EDIT)
-        editCard.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
-        editorCard = currentCard
-        editCurrentCardLauncher.launch(editCard)
+        val animation = fromGesture.toAnimationTransition().invert()
+        val editCardIntent = EditCardDestination(currentCard!!).toIntent(this, animation)
+        editCurrentCardLauncher.launch(editCardIntent)
     }
 
     protected fun showDeleteNoteDialog() {
@@ -2635,6 +2633,8 @@ abstract class AbstractFlashcardViewer :
                 else -> ActivityTransitionAnimation.Direction.FADE
             }
         }
+
+        fun Gesture?.toAnimationTransition() = getAnimationTransitionFromGesture(this)
 
         /**
          * @param mediaDir media directory path on SD card

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -462,11 +462,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 return
             }
             CALLER_REVIEWER_EDIT -> {
-                mCurrentEditedCard = AbstractFlashcardViewer.editorCard
-                if (mCurrentEditedCard == null) {
-                    finish()
-                    return
-                }
+                val cardId = requireNotNull(intent.extras?.getLong(EXTRA_CARD_ID)) { "EXTRA_CARD_ID" }
+                mCurrentEditedCard = col.getCard(cardId)
                 mEditorNote = mCurrentEditedCard!!.note(col)
                 addNote = false
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -935,7 +935,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             // changed did? this has to be done first as remFromDyn() involves a direct write to the database
             if (mCurrentEditedCard != null && mCurrentEditedCard!!.did != deckId) {
                 mReloadRequired = true
-                getColUnsafe.setDeck(listOf(mCurrentEditedCard!!.id), deckId)
+                undoableOp { setDeck(listOf(mCurrentEditedCard!!.id), deckId) }
                 // refresh the card object to reflect the database changes from above
                 mCurrentEditedCard!!.load(getColUnsafe)
                 // also reload the note object

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -30,6 +30,7 @@ import android.widget.SeekBar.OnSeekBarChangeListener
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.PreviewLayout
@@ -225,6 +226,10 @@ class Previewer : AbstractFlashcardViewer() {
 
     override fun displayAnswerBottomBar() {
         /* do nothing */
+    }
+
+    override suspend fun updateCurrentCard() {
+        currentCard = withCol { getCard(currentCardId!!) }
     }
 
     override fun executeCommand(which: ViewerCommand, fromGesture: Gesture?): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -51,6 +51,7 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
+import timber.log.Timber
 import java.util.*
 import kotlin.collections.ArrayList
 
@@ -220,6 +221,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
      * Same action as pressing on the deck in the list. I.e. send the deck to listener and close the dialog.
      */
     protected fun selectDeckAndClose(deck: SelectableDeck) {
+        Timber.d("selected deck '%s'", deck.name)
         onDeckSelected(deck)
         dismiss()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/EditCardDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/EditCardDestination.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.noteeditor
+
+import android.content.Context
+import android.content.Intent
+import android.os.Parcelable
+import androidx.annotation.CheckResult
+import com.ichi2.anim.ActivityTransitionAnimation
+import com.ichi2.anki.AbstractFlashcardViewer
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.NoteEditor
+import com.ichi2.libanki.Card
+
+/**
+ * Opens the [Note Editor][NoteEditor] to the note of a selected card
+ *
+ * As the card of the note is known, additional context is provided to the UI
+ */
+data class EditCardDestination(val card: Card)
+
+@CheckResult
+fun EditCardDestination.toIntent(context: Context, animation: ActivityTransitionAnimation.Direction): Intent {
+    AbstractFlashcardViewer.editorCard = card
+    return Intent(context, NoteEditor::class.java).apply {
+        putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_EDIT)
+        putExtra(AnkiActivity.FINISH_ANIMATION_EXTRA, animation as Parcelable)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/EditCardDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/EditCardDestination.kt
@@ -21,23 +21,22 @@ import android.content.Intent
 import android.os.Parcelable
 import androidx.annotation.CheckResult
 import com.ichi2.anim.ActivityTransitionAnimation
-import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.NoteEditor
-import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardId
 
 /**
  * Opens the [Note Editor][NoteEditor] to the note of a selected card
  *
  * As the card of the note is known, additional context is provided to the UI
  */
-data class EditCardDestination(val card: Card)
+data class EditCardDestination(val cardId: CardId)
 
 @CheckResult
 fun EditCardDestination.toIntent(context: Context, animation: ActivityTransitionAnimation.Direction): Intent {
-    AbstractFlashcardViewer.editorCard = card
     return Intent(context, NoteEditor::class.java).apply {
         putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_EDIT)
+        putExtra(NoteEditor.EXTRA_CARD_ID, cardId)
         putExtra(AnkiActivity.FINISH_ANIMATION_EXTRA, animation as Parcelable)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.AutomaticAnswerSettings
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.libanki.StdModels
+import com.ichi2.libanki.undoableOp
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.Flaky
 import com.ichi2.testutils.OS
@@ -152,12 +153,9 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         waitForAsyncTasksToComplete()
 
-        AbstractFlashcardViewer.editorCard = viewer.currentCard
-
         val note = viewer.currentCard!!.note()
         note.setField(1, "David")
-
-        viewer.saveEditedCard()
+        undoableOp { updateNote(note) }
 
         waitForAsyncTasksToComplete()
 
@@ -179,12 +177,9 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
 
         waitForAsyncTasksToComplete()
 
-        AbstractFlashcardViewer.editorCard = viewer.currentCard
-
         val note = viewer.currentCard!!.note()
         note.setField(1, "David")
-
-        viewer.saveEditedCard()
+        undoableOp { updateNote(note) }
 
         waitForAsyncTasksToComplete()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -24,11 +24,13 @@ import android.widget.EditText
 import android.widget.TextView
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.AbstractFlashcardViewer.Companion.editorCard
+import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
 import com.ichi2.anki.NoteEditorTest.FromScreen.REVIEWER
 import com.ichi2.anki.api.AddContentApi.Companion.DEFAULT_DECK_ID
 import com.ichi2.anki.multimediacard.activity.MultimediaEditFieldActivity
+import com.ichi2.anki.noteeditor.EditCardDestination
+import com.ichi2.anki.noteeditor.toIntent
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.libanki.Note
@@ -407,11 +409,10 @@ class NoteEditorTest : RobolectricTest() {
     }
 
     private fun <T : NoteEditor?> getNoteEditorEditingExistingBasicNote(n: Note, from: FromScreen, clazz: Class<T>): T {
-        val i = Intent()
+        var i = Intent()
         when (from) {
             REVIEWER -> {
-                i.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_REVIEWER_EDIT)
-                editorCard = n.firstCard()
+                i = EditCardDestination(n.firstCard().id).toIntent(targetContext, ActivityTransitionAnimation.Direction.DEFAULT)
             }
             DECK_LIST -> i.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
         }


### PR DESCRIPTION
## Purpose / Description
If a card deck is edited, the previous card was shown but new scheduling was displayed

This was because we used `editorCard`, and `editorCard` was no longer in the correct deck

## Fixes
* Fixes #15402

## Approach
`undoableOp` handles this all, so trust `updateCardAndRedraw` to do its job

and a few cleanups / logging

## How Has This Been Tested?
API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
