### PR TITLE
fix: theme for PermissionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.themes.Themes
 import com.ichi2.themes.setTransparentStatusBar
 
 /**
@@ -47,6 +48,7 @@ class PermissionsActivity : AnkiActivity() {
             return
         }
         super.onCreate(savedInstanceState)
+        Themes.setTheme(this)
         setContentView(R.layout.permissions_activity)
         setTransparentStatusBar()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
@@ -29,6 +29,8 @@ import com.ichi2.anki.UIUtils
 
 /**
  * Base class for constructing a permissions screen
+ *
+ * @see PermissionsActivity
  */
 abstract class PermissionsFragment(@LayoutRes contentLayoutId: Int) : Fragment(contentLayoutId) {
     /**

--- a/AnkiDroid/src/main/res/drawable/ic_save_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_save_white.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M17,3L5,3c-1.11,0 -2,0.9 -2,2v14c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2L21,7l-4,-4zM12,19c-1.66,0 -3,-1.34 -3,-3s1.34,-3 3,-3 3,1.34 3,3 -1.34,3 -3,3zM15,9L5,9L5,5h10v4z"/>


### PR DESCRIPTION
**Before**

<img width="337" alt="Screenshot 2024-02-15 at 03 49 31" src="https://github.com/ankidroid/Anki-Android/assets/62114487/c8143dba-281a-4cb8-ad29-1b8f804e83cd">


In dark mode, the 'save' icon didn't appear

**After**
<img width="330" alt="Screenshot 2024-02-15 at 03 47 40" src="https://github.com/ankidroid/Anki-Android/assets/62114487/f764be3d-0108-4740-9563-034247ffbe38">

<img width="328" alt="Screenshot 2024-02-15 at 03 47 50" src="https://github.com/ankidroid/Anki-Android/assets/62114487/cd5157c1-9545-41db-8e20-27fdecc4d72b">
