### PR TITLE
Deck Options: add unconditional 'back' confirmation and duplicate save icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.OnPageFinishedCallback
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.undoableOp
 import com.ichi2.libanki.updateDeckConfigsRaw
@@ -48,10 +49,23 @@ class DeckOptions : PageFragment() {
         }
     }
 
+    // HACK: this is enabled unconditionally as we currently cannot get the 'changed' status
+    private val onBackSaveCallback = object : OnBackPressedCallback(true) {
+        override fun handleOnBackPressed() {
+            Timber.v("DeckOptions: showing 'discard changes'")
+            DiscardChangesDialog.showDialog(requireContext()) {
+                Timber.i("OK button pressed to confirm discard changes")
+                this.isEnabled = false
+                requireActivity().onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
+
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
         val deckId = arguments?.getLong(ARG_DECK_ID)
             ?: throw Exception("missing deck ID")
 
+        requireActivity().onBackPressedDispatcher.addCallback(this, onBackSaveCallback)
         requireActivity().onBackPressedDispatcher.addCallback(this, onBackCallback)
         return DeckOptionsWebClient(deckId).apply {
             onPageFinishedCallback = OnPageFinishedCallback { view ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.pages
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.KeyEvent
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.FragmentActivity
@@ -36,6 +37,7 @@ import timber.log.Timber
 
 @NeedsTest("pressing back: icon + button should go to the previous screen")
 @NeedsTest("15130: pressing back: icon + button should return to options if the manual is open")
+@NeedsTest("saveAndExit closes screen")
 class DeckOptions : PageFragment() {
     override val title: String
         get() = resources.getString(R.string.menu__deck_options)
@@ -73,6 +75,15 @@ class DeckOptions : PageFragment() {
                 onBackCallback.isEnabled = view.canGoBack()
             }
         }
+    }
+
+    @Suppress("unused")
+    fun saveAndExit() {
+        // dispatch Ctrl+Enter
+        val downEvent = KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER, 0, KeyEvent.META_CTRL_ON)
+        val upEvent = KeyEvent(0, 0, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER, 0, KeyEvent.META_CTRL_ON)
+        webView.dispatchKeyEvent(downEvent)
+        webView.dispatchKeyEvent(upEvent)
     }
 
     class DeckOptionsWebClient(val deckId: Long) : PageWebViewClient() {


### PR DESCRIPTION
## Fixes
* Fixes #14438 

## Approach
* ⚠️ Add unconditional back confirmation, as we can't know if changes are made
* Add functionality to save, to be implemented later

## How Has This Been Tested?

<img width="337" alt="Screenshot 2024-02-15 at 03 51 44" src="https://github.com/ankidroid/Anki-Android/assets/62114487/89bc0ee5-01ba-4188-85e5-a7469218ab07">

<img width="347" alt="Screenshot 2024-02-15 at 03 51 55" src="https://github.com/ankidroid/Anki-Android/assets/62114487/986ed00f-5b59-469a-9536-a20480cbe5aa">

<img width="329" alt="Screenshot 2024-02-15 at 03 30 16" src="https://github.com/ankidroid/Anki-Android/assets/62114487/e6e7f487-9016-4295-91e2-e235a66a3974">

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
