### PR TITLE
Enhacement: allow the apkg packages to be shared with AnkiDroid

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -229,13 +229,13 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <action android:name="android.intent.action.SEND"/>
                 <data android:mimeType="application/apkg"/>
                 <data android:mimeType="application/colpkg"/>
                 <data android:mimeType="application/vnd.anki"/>
                 <data android:mimeType="application/x-apkg"/>
                 <data android:mimeType="application/x-colpkg"/>
                 <data android:mimeType="application/octet-stream"/>
-                <data android:mimeType="application/zip"/>
                 <data android:mimeType="text/tab-separated-values"/>
                 <data android:mimeType="text/comma-separated-values"/>
             </intent-filter>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
@@ -94,17 +94,19 @@ class IntentHandlerTest {
 
     @Test
     fun textImportIntentReturnsTextImport() {
-        // TSV import
-        var intent = Intent(Intent.ACTION_VIEW)
-        intent.setDataAndType(Uri.parse("content://valid"), "text/tab-separated-values")
-        var expected = getLaunchType(intent)
-        assertThat(expected, equalTo(LaunchType.TEXT_IMPORT))
+        testIntentType("content://valid", "text/tab-separated-values", LaunchType.TEXT_IMPORT)
+        testIntentType("content://valid", "text/comma-separated-values", LaunchType.TEXT_IMPORT)
 
-        // CSV import
-        intent = Intent(Intent.ACTION_VIEW)
-        intent.setDataAndType(Uri.parse("content://valid"), "text/comma-separated-values")
-        expected = getLaunchType(intent)
-        assertThat(expected, equalTo(LaunchType.TEXT_IMPORT))
+        // Test for ACTION_SEND
+        testIntentType("content://valid", "text/tab-separated-values", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
+        testIntentType("content://valid", "text/comma-separated-values", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
+    }
+
+    private fun testIntentType(data: String, type: String, expected: LaunchType, action: String = Intent.ACTION_VIEW) {
+        val intent = Intent(action)
+        intent.setDataAndType(Uri.parse(data), type)
+        val actual = getLaunchType(intent)
+        assertThat(actual, equalTo(expected))
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Working on  #15264 we enabled the images to be shared with AnkiDroid, similarly enabling the application to register itself for the share intent which is not enabled as of now, I originally included it in the PR I mentioned but since it was not part of that was removed for later

* Fixes #15618

## How Has This Been Tested?
Tested on Google emualtor API 34


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
