### PR TITLE
fix: auto-advance options inverted

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -24,6 +24,8 @@ import com.ichi2.anki.Reviewer
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.AnswerButtons.*
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.secondsToShowAnswer
+import com.ichi2.anki.utils.ext.secondsToShowQuestion
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckConfig
@@ -274,14 +276,12 @@ class AutomaticAnswerSettings(
             val conf = col.decks.confForDid(selectedDid)
             val action = getAction(conf)
             val useTimer = preferences.getBoolean("timeoutAnswer", false)
-            val waitQuestionSecond = conf.optInt("secondsToShowQuestion", 0)
-            val waitAnswerSecond = conf.optInt("secondsToShowAnswer", 0)
 
             return AutomaticAnswerSettings(
                 answerAction = action,
                 useTimer = useTimer,
-                secondsToShowQuestionFor = waitQuestionSecond,
-                secondsToShowAnswerFor = waitAnswerSecond
+                secondsToShowQuestionFor = conf.secondsToShowQuestion,
+                secondsToShowAnswerFor = conf.secondsToShowAnswer
             )
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/DeckConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/DeckConfig.kt
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import com.ichi2.libanki.DeckConfig
+import com.ichi2.libanki.utils.set
+
+var DeckConfig.secondsToShowQuestion: Int
+    get() = optInt("secondsToShowQuestion", 0)
+    set(value) { set("secondsToShowQuestion", value) }
+
+var DeckConfig.secondsToShowAnswer: Int
+    get() = optInt("secondsToShowAnswer", 0)
+    set(value) { set("secondsToShowAnswer", value) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
@@ -54,8 +54,8 @@ class AutomaticAnswerTest : JvmTest() {
             target = automaticallyAnsweredMock(),
             settings = AutomaticAnswerSettings(
                 useTimer = true,
-                questionDelaySeconds = 0,
-                answerDelaySeconds = 0
+                secondsToShowQuestionFor = 0,
+                secondsToShowAnswerFor = 0
             )
         )
 
@@ -137,8 +137,8 @@ class AutomaticAnswerTest : JvmTest() {
             target = automaticAnswerHandler,
             settings = AutomaticAnswerSettings(
                 useTimer = true,
-                questionDelaySeconds = 10,
-                answerDelaySeconds = 10
+                secondsToShowQuestionFor = 10,
+                secondsToShowAnswerFor = 10
             )
         ).apply {
             automaticAnswerHandle = this


### PR DESCRIPTION
## Purpose / Description
Options were inverted

## Fixes
* Fixes #15514

## Approach
Fixed by changing names to match the new variables in the deck options

## How Has This Been Tested?
API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
