### PR TITLE
chore: improve 'Unavailable in ‘Notes Only’ mode'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -920,7 +920,9 @@ open class CardBrowser :
      */
     private fun warnUserIfInNotesOnlyMode(): Boolean {
         if (viewModel.cardsOrNotes != NOTES) return false
-        showSnackbar(R.string.card_browser_unavailable_when_notes_mode)
+        showSnackbar(R.string.card_browser_unavailable_when_notes_mode) {
+            setAction(R.string.error_handling_options) { showOptionsDialog() }
+        }
         return true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -920,7 +920,7 @@ open class CardBrowser :
      */
     private fun warnUserIfInNotesOnlyMode(): Boolean {
         if (viewModel.cardsOrNotes != NOTES) return false
-        showSnackbar(R.string.card_browser_unavailable_when_notes_only)
+        showSnackbar(R.string.card_browser_unavailable_when_notes_mode)
         return true
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -428,5 +428,5 @@ opening the system text to speech settings fails">
 
     <string name="failed_to_copy">Failed to copy</string>
 
-    <string name="card_browser_unavailable_when_notes_only">Unavailable in ‘Notes Only’ mode</string>
+    <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
 </resources>


### PR DESCRIPTION
```diff
- Unavailable in ‘Notes Only’ mode
+ Unavailable in ‘Notes’ mode
```

```diff
- card_browser_unavailable_when_notes_only
+ card_browser_unavailable_when_notes_mode
```

And add an 'options' action

review comment on PR #15509

Follow up to #15444

<img width="326" alt="Screenshot 2024-02-16 at 02 59 08" src="https://github.com/ankidroid/Anki-Android/assets/62114487/218bf5fd-72e5-4d07-b442-1e67aacd42c9">


Thank you @snowtimeglass!