### PR TITLE
fix: unable to edit note in the Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1006,17 +1006,18 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             mEditorNote!!.setTagsFromStr(getColUnsafe, tagsAsString(mSelectedTags!!))
             changed = true
 
-            if (caller != CALLER_PREVIEWER_EDIT) {
-                closeNoteEditor()
-                return
-            }
-
-            withProgress {
-                undoableOp {
-                    updateNote(mCurrentEditedCard!!.note())
+            // these activities are updated to handle `opChanges`
+            // and no longer using the legacy ActivityResultCallback/onActivityResult to
+            // accept & update the note in the activity
+            if (caller == CALLER_PREVIEWER_EDIT || caller == CALLER_REVIEWER_EDIT) {
+                withProgress {
+                    undoableOp {
+                        updateNote(mCurrentEditedCard!!.note())
+                    }
                 }
-                closeNoteEditor()
             }
+            closeNoteEditor()
+            return
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Allow a user to edit notes again

## Fixes
* Fixes #15526

## Approach
* make the condition on which we call `undoableOp {` more clear
* accept `CALLER_REVIEWER_EDIT`

## How Has This Been Tested?
API 33 & S21
* editing a note from the reviewer edits the note

## Learning (optional, can help others)
`undoableOp` was used in REVIEWER, but not sent

Cause: 74487d39f3900e3448d8e8ad1220bacd51fa0a83
* https://github.com/ankidroid/Anki-Android/pull/15496 -> https://github.com/ankidroid/Anki-Android/issues/15402

`updateNote` was removed from the CardViewer and the tests were updated to assume that NoteEditor did this.

I did not realise that `undoableOp` was ONLY sent if the receiver was the Previewer

and falsely presumed testing in the Previewer was testing AbstractFlashcardViewer

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
