### PR TITLE
fix: no need to hide the "show answer" button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2303,8 +2303,6 @@ abstract class AbstractFlashcardViewer :
             if (url.startsWith("typeblurtext:")) {
                 // Store the text the javascript has send us…
                 typeAnswer!!.input = decodeUrl(url.replaceFirst("typeblurtext:".toRegex(), ""))
-                // … and show the “SHOW ANSWER” button again.
-                flipCardLayout!!.visibility = View.VISIBLE
                 return true
             }
             if (url.startsWith("typeentertext:")) {
@@ -2324,12 +2322,7 @@ abstract class AbstractFlashcardViewer :
             when (val signalOrdinal = WebViewSignalParserUtils.getSignalFromUrl(url)) {
                 WebViewSignalParserUtils.SIGNAL_UNHANDLED -> {}
                 WebViewSignalParserUtils.SIGNAL_NOOP -> return true
-                WebViewSignalParserUtils.TYPE_FOCUS -> {
-                    // Hide the “SHOW ANSWER” button when the input has focus. The soft keyboard takes up enough
-                    // space by itself.
-                    flipCardLayout!!.visibility = View.GONE
-                    return true
-                }
+                WebViewSignalParserUtils.TYPE_FOCUS -> return true
 
                 WebViewSignalParserUtils.RELINQUISH_FOCUS -> {
                     // #5811 - The WebView could be focused via mouse. Allow components to return focus to Android.


### PR DESCRIPTION
## Purpose / Description
Looks like there is no need to hide the "Show answer" button

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15487

## Approach
Lets just dont hide button when soft keyboard shows up

## How Has This Been Tested?

manually

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
