### PR TITLE
test: fix OutOfMemoryError: Java heap space

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.dialogs.CreateDeckDialog.DeckDialogType
 import com.ichi2.anki.dialogs.utils.input
 import com.ichi2.libanki.DeckId
 import com.ichi2.utils.positiveButton
+import okhttp3.internal.closeQuietly
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.junit.Test
@@ -52,6 +53,11 @@ class CreateDeckDialogTest : RobolectricTest() {
         activityScenario = ActivityScenario.launch(DeckPicker::class.java).apply {
             moveToState(Lifecycle.State.STARTED)
         }
+    }
+
+    override fun tearDown() {
+        super.tearDown()
+        activityScenario.closeQuietly()
     }
 
     @Test


### PR DESCRIPTION
on macos:

```
at com.ichi2.anki.dialogs.CreateDeckDialogTest.setUp(CreateDeckDialogTest.kt:52)

Caused by:
java.lang.OutOfMemoryError: Java heap space
    at java.desktop/java.awt.image.DataBufferInt.<init>(DataBufferInt.java:77)
    at java.desktop/java.awt.image.Raster.createPackedRaster(Raster.java:538)
    at java.desktop/java.awt.image.DirectColorModel.createCompatibleWritableRaster(DirectColorModel.java:1032)
    at java.desktop/java.awt.image.BufferedImage.<init>(BufferedImage.java:333)
    at org.robolectric.shadows.ShadowBitmapFactory.create(ShadowBitmapFactory.java:287)
    at org.robolectric.shadows.ShadowBitmapFactory.decodeStream(ShadowBitmapFactory.java:189)
    at org.robolectric.shadows.ShadowBitmapFactory.decodeStream(ShadowBitmapFactory.java:153)
```

* https://github.com/ankidroid/Anki-Android/pull/15520#issuecomment-1948416566