### PR TITLE
chore(debug): fix API 24: 'No Android WebView'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -27,7 +27,6 @@ package com.ichi2.anki
 
 import android.app.Activity
 import android.content.*
-import android.content.pm.PackageManager
 import android.database.SQLException
 import android.graphics.PixelFormat
 import android.graphics.drawable.Drawable
@@ -608,18 +607,17 @@ open class DeckPicker :
      */
     private fun checkWebviewVersion() {
         // Doesn't need to be translated as it's debug only
-        // Specifically check for Android System WebView
-        try {
-            val androidSystemWebViewPackage = "com.google.android.webview"
-            val webviewPackageInfo = packageManager.getPackageInfo(androidSystemWebViewPackage, 0)
-            val versionCode = webviewPackageInfo.versionName.split(".")[0].toInt()
-            if (versionCode < OLDEST_WORKING_WEBVIEW_VERSION) {
-                val snackbarMessage =
-                    "The WebView version $versionCode is outdated (<$OLDEST_WORKING_WEBVIEW_VERSION)."
-                showSnackbar(snackbarMessage, Snackbar.LENGTH_INDEFINITE)
-            }
-        } catch (_: PackageManager.NameNotFoundException) {
+        val webviewPackageInfo = getAndroidSystemWebViewPackageInfo(packageManager)
+        if (webviewPackageInfo == null) {
             val snackbarMessage = "No Android System WebView found"
+            showSnackbar(snackbarMessage, Snackbar.LENGTH_INDEFINITE)
+            return
+        }
+
+        val versionCode = webviewPackageInfo.versionName.split(".")[0].toInt()
+        if (versionCode < OLDEST_WORKING_WEBVIEW_VERSION) {
+            val snackbarMessage =
+                "The WebView version $versionCode is outdated (<$OLDEST_WORKING_WEBVIEW_VERSION)."
             showSnackbar(snackbarMessage, Snackbar.LENGTH_INDEFINITE)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+
+/**
+ * Returns a [PackageInfo] from the current system WebView, or `null` if unavailable
+ */
+fun getAndroidSystemWebViewPackageInfo(packageManager: PackageManager): PackageInfo? {
+    fun getPackage(packageName: String): PackageInfo? {
+        return try {
+            packageManager.getPackageInfo(packageName, 0)
+        } catch (_: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
+
+    // The WebView is called com.android.webview by default.
+    // Partner devices which ship with Google applications ship the Google-specific version
+    // of the WebView called com.google.android.webview.
+    // https://issues.chromium.org/issues/40419837#comment10
+
+    return getPackage("com.google.android.webview")
+        ?: getPackage("com.android.webview") // com.android.webview is used on API 24
+}


### PR DESCRIPTION
## Purpose / Description
"No Android System WebView found" was caused because `com.google.android.webview` was searched for, but `com.android.webview` was used.

## Approach
* also search for `com.android.webview`

## How Has This Been Tested?
API 24 emulator, the actual version of the WebView (52) is now shown
<img width="372" alt="Screenshot 2024-02-17 at 02 08 17" src="https://github.com/ankidroid/Anki-Android/assets/62114487/21c53070-1417-4490-8232-7092bd50cf49">


## Learning (optional, can help others)
See commit, https://issues.chromium.org/issues/40419837#comment10

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
