### PR TITLE
feat: port Anki template previewer

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1297,7 +1297,7 @@ class ContentProviderTest : InstrumentedTest() {
             fields: Array<String>,
             tag: String
         ): Uri {
-            val newNote = Note.fromNotetypeId(col, mid)
+            val newNote = col.run { Note.fromNotetypeId(mid) }
             for (idx in fields.indices) {
                 newNote.setField(idx, fields[idx])
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -625,6 +625,11 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             templateEditor.finish()
         }
 
+        private fun getNote(col: Collection): Note? {
+            val nid = requireArguments().getLong(EDITOR_NOTE_ID)
+            return if (nid != -1L) col.getNote(nid) else null
+        }
+
         fun performPreview() {
             val col = templateEditor.getColUnsafe
             val tempModel = templateEditor.tempModel
@@ -632,13 +637,12 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             // Create intent for the previewer and add some arguments
             val i = Intent(templateEditor, CardTemplatePreviewer::class.java)
             val ordinal = templateEditor.viewPager.currentItem
-            val noteId = requireArguments().getLong("noteId")
             i.putExtra("ordinal", ordinal)
             i.putExtra("cardListIndex", 0)
 
             // If we have a card for this position, send it, otherwise an empty card list signals to show a blank
-            if (noteId != -1L) {
-                val cids = col.getNote(noteId).cardIds(col)
+            getNote(col)?.let {
+                val cids = it.cardIds(col)
                 if (ordinal < cids.size) {
                     i.putExtra("cardList", longArrayOf(cids[ordinal]))
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -637,7 +637,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             val notetype = templateEditor.tempModel!!.notetype
             val notetypeFile = NotetypeFile(requireContext(), notetype)
             val ord = templateEditor.viewPager.currentItem
-            val note = withCol { getNote(this) ?: Note.fromNotetypeId(this, notetype.id) }
+            val note = withCol { getNote(this) ?: Note.fromNotetypeId(notetype.id) }
             val args = TemplatePreviewerArguments(
                 notetypeFile = notetypeFile,
                 id = note.id,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import com.ichi2.async.saveModel
@@ -440,6 +441,48 @@ class CardTemplateNotetype(val notetype: NotetypeJson) {
                 changesIndex
             )
             return -1
+        }
+    }
+}
+
+/**
+ * Temporary file containing a [NotetypeJson]
+ *
+ * Useful for adding a [NotetypeJson] into a [Bundle], like when using [Intent.putExtra]
+ * for sending an object to another activity.
+ *
+ * The notetype is written into a file because there is a
+ * [limit of 1MB](https://developer.android.com/reference/android/os/TransactionTooLargeException.html)
+ * for [Bundle] transactions, and notetypes can be bigger than that (#5600).
+ *
+ * @param directory parent directory of the file. Generally it should be the cache directory
+ * @param notetype to be stored
+ */
+class NotetypeFile(directory: File, notetype: NotetypeJson) :
+    File(createTempFile("notetype", ".tmp", directory).absolutePath) {
+
+    /** @param context for getting the cache directory */
+    constructor(context: Context, notetype: NotetypeJson) : this(context.cacheDir, notetype)
+
+    init {
+        try {
+            ByteArrayInputStream(notetype.toString().toByteArray()).use { source ->
+                compat.copyFile(source, this.absolutePath)
+            }
+        } catch (ioe: IOException) {
+            Timber.w(ioe, "Unable to create+write temp file for model")
+        }
+    }
+
+    fun getNotetype(): NotetypeJson {
+        return try {
+            ByteArrayOutputStream().use { target ->
+                compat.copyFile(absolutePath, target)
+                NotetypeJson(target.toString())
+            }
+        } catch (e: IOException) {
+            Timber.e(e, "Unable to read+parse tempModel from file %s", absolutePath)
+            throw e
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1819,9 +1819,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     /** Handles setting the current note (non-null afterwards) and rebuilding the UI based on this note  */
     private fun setNote(note: Note?, changeType: FieldChangeType) {
         editorNote = if (note == null || addNote) {
-            getColUnsafe.let { col ->
-                val notetype = col.notetypes.current()
-                Note.fromNotetypeId(col, notetype.id)
+            getColUnsafe.run {
+                val notetype = notetypes.current()
+                Note.fromNotetypeId(notetype.id)
             }
         } else {
             note

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -79,6 +79,8 @@ import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.anki.pages.ImageOcclusion
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.previewer.TemplatePreviewerArguments
+import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.anki.servicelayer.NoteService
@@ -1213,8 +1215,31 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // ----------------------------------------------------------------------------
     // CUSTOM METHODS
     // ----------------------------------------------------------------------------
+    private fun openNewPreviewer() {
+        val fields = if (currentNotetypeIsImageOcclusion()) {
+            fieldsFromSelectedNote.mapTo(mutableListOf()) { it[1] }
+        } else {
+            editFields?.mapTo(mutableListOf()) { it!!.fieldText.toString() } ?: mutableListOf()
+        }
+        val tags = selectedTags ?: mutableListOf()
+        val args = TemplatePreviewerArguments(
+            notetypeFile = NotetypeFile(this, editorNote!!.notetype),
+            fields = fields,
+            tags = tags,
+            id = editorNote!!.id,
+            ord = currentEditedCard?.ord ?: 0,
+            fillEmpty = false
+        )
+        val intent = TemplatePreviewerFragment.getIntent(this, args)
+        startActivity(intent)
+    }
+
     @VisibleForTesting
     fun performPreview() {
+        if (sharedPrefs().getBoolean("new_previewer", false)) {
+            openNewPreviewer()
+            return
+        }
         val previewer = Intent(this@NoteEditor, CardTemplatePreviewer::class.java)
         if (currentEditedCard != null) {
             previewer.putExtra("ordinal", currentEditedCard!!.ord)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -188,5 +188,7 @@ abstract class CardViewerViewModel : ViewModel(), OnErrorListener {
                 expected
             }
         }
+
+        fun getFontSize(field: JSONObject): String = field.getString("size")
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -213,7 +213,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
             val expectedAnswer = getExpectedTypeInAnswer(card, typeAnswerField)
                 ?: return typeAnsRe.replace(text, "")
             val typeFont = typeAnswerField.getString("font")
-            val typeSize = typeAnswerField.getString("size")
+            val typeSize = getFontSize(typeAnswerField)
             val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
 
             @Language("HTML")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -1,0 +1,107 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebView
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import com.ichi2.anki.R
+import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
+import com.ichi2.anki.snackbar.SnackbarBuilder
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class TemplatePreviewerFragment :
+    CardViewerFragment(R.layout.template_previewer),
+    BaseSnackbarBuilderProvider {
+
+    override val viewModel: TemplatePreviewerViewModel by viewModels {
+        val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
+        TemplatePreviewerViewModel.factory(arguments)
+    }
+    override val webView: WebView
+        get() = requireView().findViewById(R.id.webview)
+
+    override val baseSnackbarBuilder: SnackbarBuilder
+        get() = { anchorView = this@TemplatePreviewerFragment.view?.findViewById(R.id.show_answer) }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+
+        val showAnswerButton = view.findViewById<MaterialButton>(R.id.show_answer).apply {
+            setOnClickListener { viewModel.toggleShowAnswer() }
+        }
+        viewModel.showingAnswer
+            .onEach { showingAnswer ->
+                showAnswerButton.text = if (showingAnswer) {
+                    getString(R.string.hide_answer)
+                } else {
+                    getString(R.string.show_answer)
+                }
+            }
+            .launchIn(lifecycleScope)
+
+        val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)
+        lifecycleScope.launch {
+            for (templateName in viewModel.getTemplateNames()) {
+                tabLayout.addTab(tabLayout.newTab().setText(templateName))
+            }
+            tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))
+            tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
+                override fun onTabSelected(tab: TabLayout.Tab) {
+                    Timber.v("Selected tab %d", tab.position)
+                    viewModel.onTabSelected(tab.position)
+                }
+
+                override fun onTabUnselected(tab: TabLayout.Tab) {
+                    // do nothing
+                }
+
+                override fun onTabReselected(tab: TabLayout.Tab) {
+                    // do nothing
+                }
+            })
+        }
+    }
+
+    companion object {
+        const val ARGS_KEY = "templatePreviewerArgs"
+
+        fun getIntent(context: Context, arguments: TemplatePreviewerArguments): Intent {
+            return PreviewerActivity.getIntent(
+                context,
+                TemplatePreviewerFragment::class,
+                bundleOf(ARGS_KEY to arguments)
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -54,7 +54,7 @@ class TemplatePreviewerViewModel(arguments: TemplatePreviewerArguments) : CardVi
                 if (arguments.id != 0L) {
                     Note(this, arguments.id)
                 } else {
-                    Note.fromNotetypeId(this, arguments.notetype.id)
+                    Note.fromNotetypeId(arguments.notetype.id)
                 }
             }.apply {
                 fields = arguments.fields

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.os.Parcelable
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.NotetypeFile
+import com.ichi2.anki.launchCatchingIO
+import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.anki.utils.ext.ifNullOrEmpty
+import com.ichi2.libanki.Note
+import com.ichi2.libanki.NotetypeJson
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.parcelize.Parcelize
+import org.intellij.lang.annotations.Language
+
+class TemplatePreviewerViewModel(arguments: TemplatePreviewerArguments) : CardViewerViewModel() {
+    private val notetype = arguments.notetype
+    private val fillEmpty = arguments.fillEmpty
+
+    /**
+     * identifies which of the card templates or cloze deletions it corresponds to
+     * * for card templates, values are from 0 to the number of templates minus 1
+     * * for cloze deletions, values are from 0 to max cloze index minus 1
+     */
+    private val ordFlow = MutableStateFlow(arguments.ord)
+
+    private lateinit var note: Note
+    private lateinit var templateNames: List<String>
+    private var initJob: Job? = null
+
+    init {
+        initJob = launchCatchingIO {
+            note = withCol {
+                if (arguments.id != 0L) {
+                    Note(this, arguments.id)
+                } else {
+                    Note.fromNotetypeId(this, arguments.notetype.id)
+                }
+            }.apply {
+                fields = arguments.fields
+                tags = arguments.tags
+            }
+
+            templateNames = if (notetype.isCloze) {
+                val tr = CollectionManager.TR
+                withCol { clozeNumbersInNote(note) }.map { tr.cardTemplatesCloze(it) }
+            } else {
+                notetype.templatesNames
+            }
+        }.also {
+            it.invokeOnCompletion {
+                initJob = null
+            }
+        }
+    }
+
+    /* *********************************************************************************************
+    ************************ Public methods: meant to be used by the View **************************
+    ********************************************************************************************* */
+
+    override fun onPageFinished(isAfterRecreation: Boolean) {
+        if (isAfterRecreation) {
+            launchCatchingIO {
+                if (showingAnswer.value) showAnswer() else showQuestion()
+            }
+            return
+        }
+        launchCatchingIO {
+            initJob?.join()
+            ordFlow.collectLatest {
+                currentCard = withCol {
+                    note.ephemeralCard(
+                        col = this,
+                        ord = ordFlow.value,
+                        customNoteType = notetype,
+                        fillEmpty = fillEmpty
+                    )
+                }
+                showQuestion()
+                loadAndPlaySounds(CardSide.QUESTION)
+            }
+        }
+    }
+
+    fun toggleShowAnswer() {
+        launchCatchingIO {
+            if (showingAnswer.value) {
+                showQuestion()
+                loadAndPlaySounds(CardSide.QUESTION)
+            } else {
+                showAnswer()
+                loadAndPlaySounds(CardSide.ANSWER)
+            }
+        }
+    }
+
+    suspend fun getTemplateNames(): List<String> {
+        initJob?.join()
+        return templateNames
+    }
+
+    fun onTabSelected(ord: Int) {
+        launchCatchingIO { ordFlow.emit(ord) }
+    }
+
+    fun getCurrentTabIndex(): Int = ordFlow.value
+
+    /* *********************************************************************************************
+    *************************************** Internal methods ***************************************
+    ********************************************************************************************* */
+
+    private suspend fun loadAndPlaySounds(side: CardSide) {
+        soundPlayer.loadCardSounds(currentCard)
+        soundPlayer.playAllSoundsForSide(side)
+    }
+
+    // https://github.com/ankitects/anki/blob/df70564079f53e587dc44f015c503fdf6a70924f/qt/aqt/clayout.py#L579
+    override suspend fun typeAnsFilter(text: String): String {
+        val typeAnswerField = getTypeAnswerField(currentCard, text)
+        val expectedAnswer = typeAnswerField?.let {
+            getExpectedTypeInAnswer(currentCard, typeAnswerField)
+        }.ifNullOrEmpty { "sample" }
+
+        val repl = if (showingAnswer.value) {
+            withCol { compareAnswer(expectedAnswer, "example") }
+        } else {
+            "<center><input id='typeans' type=text value='example' readonly='readonly'></center>"
+        }
+        // Anki doesn't set the font size of the type answer field in the template previewer,
+        // but it does in the reviewer. To get a more accurate preview of what people are going
+        // to study, the font size is being set here.
+        val out = if (typeAnswerField != null) {
+            val fontSize = getFontSize(typeAnswerField)
+
+            @Language("HTML")
+            val replWithFontSize = """<div style="font-size: ${fontSize}px">$repl</div>"""
+            typeAnsRe.replaceFirst(text, replWithFontSize)
+        } else {
+            typeAnsRe.replaceFirst(text, repl)
+        }
+
+        val warning = "<center><b>${CollectionManager.TR.cardTemplatesTypeBoxesWarning()}</b></center>"
+        return typeAnsRe.replace(out, warning)
+    }
+
+    companion object {
+        fun factory(arguments: TemplatePreviewerArguments): ViewModelProvider.Factory {
+            return viewModelFactory {
+                initializer {
+                    TemplatePreviewerViewModel(arguments)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @param id id of the note. Use 0 for non-created notes.
+ *
+ * @param ord identifies which of the card templates or cloze deletions it corresponds to
+ * * for card templates, values are from 0 to the number of templates minus 1
+ * * for cloze deletions, values are from 0 to max cloze index minus 1
+ *
+ * @param fillEmpty if blank fields should be replaced with placeholder content
+ */
+@Parcelize
+data class TemplatePreviewerArguments(
+    private val notetypeFile: NotetypeFile,
+    val fields: MutableList<String>,
+    val tags: MutableList<String>,
+    val id: Long = 0,
+    val ord: Int = 0,
+    val fillEmpty: Boolean = false
+) : Parcelable {
+    val notetype: NotetypeJson get() = notetypeFile.getNotetype()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -710,7 +710,7 @@ class CardContentProvider : ContentProvider() {
             }
             val fldsArray = Utils.splitFields(flds)
             // Create empty note
-            val newNote = Note.fromNotetypeId(col, thisModelId)
+            val newNote = col.run { Note.fromNotetypeId(thisModelId) }
             // Set fields
             // Check that correct number of flds specified
             if (fldsArray.size != newNote.fields.size) {
@@ -754,7 +754,7 @@ class CardContentProvider : ContentProvider() {
                 val tags = values.getAsString(FlashCardsContract.Note.TAGS)
 //                val allowEmpty = AllowEmpty.fromBoolean(values.getAsBoolean(FlashCardsContract.Note.ALLOW_EMPTY))
                 // Create empty note
-                val newNote = Note.fromNotetypeId(col, modelId) // ué
+                val newNote = col.run { Note.fromNotetypeId(modelId) }
                 // Set fields
                 val fldsArray = Utils.splitFields(flds)
                 // Check that correct number of flds specified

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils.ext
+
+fun String?.ifNullOrEmpty(defaultValue: () -> String): String =
+    if (isNullOrEmpty()) defaultValue() else this

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -302,7 +302,7 @@ open class Collection(
      * @return The new note
      */
     fun newNote(m: NotetypeJson): Note {
-        return Note.fromNotetypeId(this, m.id)
+        return Note.fromNotetypeId(m.id)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -48,9 +48,7 @@ class Note : Cloneable {
     var mid: Long = 0
         private set
     lateinit var tags: MutableList<String>
-        private set
     lateinit var fields: MutableList<String>
-        private set
     private var fMap: Map<String, Pair<Int, JSONObject>>? = null
     var usn = 0
         private set

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -65,9 +65,10 @@ class Note : Cloneable {
     }
 
     companion object {
-        fun fromNotetypeId(col: Collection, ntid: NoteTypeId): Note {
-            val backendNote = col.backend.newNote(ntid)
-            return Note(col, backendNote)
+        context (Collection)
+        fun fromNotetypeId(ntid: NoteTypeId): Note {
+            val backendNote = backend.newNote(ntid)
+            return Note(this@Collection, backendNote)
         }
     }
 

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".previewer.TemplatePreviewerFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:navigationContentDescription="@string/abc_action_bar_up_description"
+                app:navigationIcon="?attr/homeAsUpIndicator">
+
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tab_layout"
+                    android:background="@color/transparent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabMode="scrollable"
+                    />
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <WebView
+            android:id="@+id/webview"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/transparent"
+            app:layout_constraintTop_toBottomOf="@id/appbar"
+            app:layout_constraintBottom_toTopOf="@id/show_answer"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/show_answer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            style="@style/Widget.Material3.Button.TextButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/webview"
+            android:text="@string/show_answer"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -58,7 +58,7 @@ class NoteServiceTest : RobolectricTest() {
         multiMediaNote!!.getField(0)!!.text = "foo"
         multiMediaNote.getField(1)!!.text = "bar"
 
-        val basicNote = Note.fromNotetypeId(col, testModel.id).apply {
+        val basicNote = col.run { Note.fromNotetypeId(testModel.id) }.apply {
             setField(0, "this should be changed to foo")
             setField(1, "this should be changed to bar")
         }
@@ -79,7 +79,7 @@ class NoteServiceTest : RobolectricTest() {
         testNotetype = col.notetypes.newBasicNotetype()
         testNotetype.id = 45
         col.notetypes.add(testNotetype)
-        val noteWithID45 = Note.fromNotetypeId(col, testNotetype.id)
+        val noteWithID45 = col.run { Note.fromNotetypeId(testNotetype.id) }
         val expectedException: Throwable = assertThrows(RuntimeException::class.java) { NoteService.updateJsonNoteFromMultimediaNote(multiMediaNoteWithID42, noteWithID45) }
         assertEquals(expectedException.message, "Source and Destination Note ID do not match.")
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I wasn't that motivated to port the template previewer, but did it because 1. it was easy after porting the previewer; 2. serves as a proof of concept of generifying the "card viewing" functionality, so it can be reused in the Reviewer port; 3. it is necessary for being able to replace `AbstractFlashcardViewer` completely (and I like diff red lines)

* On top of #15546

## Approach

In the commits. It is under the new previewer dev option, since I didn't see the need to create a new one for this

## How Has This Been Tested?

Emulator 31:

I changed the `previous/next` button approach to a TabLayout with the templates (which was not only better looking, but simpler to implement), so the three last videos are a bit outdated, but still serve to show the rendering functionality in different scenarios

[pretty.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/3201516c-b2b7-4093-a0da-51ec41421f5b)

[1.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/37a5733f-65c9-41aa-ae8b-38f57c14af51)

[2.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/bd186a3e-0d4b-4c3d-a386-7e69d18095a8)

[audio.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/6893c5af-0ff7-4da7-9a26-26d25b91a94c)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
