### PR TITLE
fix: navbar color if answer buttons aren't in the bottom

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -180,7 +180,9 @@ open class Reviewer :
         textBarReview = findViewById(R.id.review_number)
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
-        setNavigationBarColor(R.attr.showAnswerColor)
+        if (sharedPrefs().getString("answerButtonPosition", "bottom") == "bottom") {
+            setNavigationBarColor(R.attr.showAnswerColor)
+        }
         if (!sharedPrefs().getBoolean("showDeckTitle", false)) {
             // avoid showing "AnkiDroid"
             supportActionBar?.title = ""


### PR DESCRIPTION
the goal of changing the navbar color was to match the answer buttons color that are above it.

If the buttons aren't in the bottom, the color change is dissonant

## How Has This Been Tested?

Emulator 31:

[foo.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/28f291a4-2614-4337-97ad-f43a22874e21)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
