### PR TITLE
fix: wrong input to "type answer into the card" 

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -99,11 +99,11 @@ function reloadPage() {
     window.location.href = "signal:reload_card_html";
 }
 
-/* Tell the app the text in the input box when it loses focus */
-function taBlur(itag) {
+/* Inform the app of the current 'type in the answer' value */
+function taChange(itag) {
     //#5944 - percent wasn't encoded, but Mandarin was.
     var encodedVal = encodeURI(itag.value);
-    window.location.href = "typeblurtext:" + encodedVal;
+    window.location.href = "typechangetext:" + encodedVal;
 }
 
 /* Look at the text entered into the input box and send the text on a return */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2291,6 +2291,7 @@ abstract class AbstractFlashcardViewer :
 
         // Filter any links using the custom "playsound" protocol defined in Sound.java.
         // We play sounds through these links when a user taps the sound icon.
+        @NeedsTest("integration test with typechangetext")
         fun filterUrl(url: String): Boolean {
             if (url.startsWith("playsound:")) {
                 launchCatchingTask {
@@ -2309,9 +2310,9 @@ abstract class AbstractFlashcardViewer :
             if (url.startsWith("file") || url.startsWith("data:")) {
                 return false // Let the webview load files, i.e. local images.
             }
-            if (url.startsWith("typeblurtext:")) {
-                // Store the text the javascript has send us…
-                typeAnswer!!.input = decodeUrl(url.replaceFirst("typeblurtext:".toRegex(), ""))
+            if (url.startsWith("typechangetext:")) {
+                // Store the text the javascript has sent us…
+                typeAnswer!!.input = decodeUrl(url.replaceFirst("typechangetext:".toRegex(), ""))
                 return true
             }
             if (url.startsWith("typeentertext:")) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -32,17 +32,17 @@ import timber.log.Timber
 import java.util.regex.Matcher
 import java.util.regex.Pattern
 
-// TODO: investigate whether it's feasible to drop the useInputTag option introduced back
-// in 2015. https://github.com/ankidroid/Anki-Android/pull/3921
-
+/**
+ * @param useInputTag use an `<input>` tag to allow for HTML styling
+ * @param autoFocus Whether the user wants to focus "type in answer"
+ */
 class TypeAnswer(
-    @get:JvmName("useInputTag") val useInputTag: Boolean,
-    @get:JvmName("doNotUseCodeFormatting") val doNotUseCodeFormatting: Boolean,
-    /** Preference: Whether the user wants to focus "type in answer" */
+    val useInputTag: Boolean,
+    val doNotUseCodeFormatting: Boolean,
     val autoFocus: Boolean
 ) {
 
-    /** The correct answer in the compare to field if answer should be given by learner. Null if no answer is expected. */
+    /** The correct answer in the compare to field if answer should be given by learner. `null` if no answer is expected. */
     var correct: String? = null
         private set
 
@@ -71,7 +71,7 @@ class TypeAnswer(
 
     /**
      * @return true If entering input via EditText
-     * and if the current card has a {{type:field}} on the card template
+     * and if the current card has a `{{type:field}}` on the card template
      */
     fun validForEditText(): Boolean {
         return !useInputTag && correct != null
@@ -155,7 +155,7 @@ class TypeAnswer(
 <input type="text" name="typed" id="typeans" onfocus="taFocus();" onblur="taBlur(this);" onKeyPress="return taKey(this, event)" autocomplete="off" """
             )
             // We have to watch out. For the preview we don’t know the font or font size. Skip those there. (Anki
-            // desktop just doesn’t show the input tag there. Do it with standard values here instead.)
+            // desktop just doesn't show the input tag there. Do it with standard values here instead.)
             if (font.isNotEmpty() && size > 0) {
                 append("style=\"font-family: '").append(font).append("'; font-size: ")
                     .append(size).append("px;\" ")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -152,7 +152,7 @@ class TypeAnswer(
             // shouldOverrideUrlLoading() in createWebView() in this file.
             append(
                 """<center>
-<input type="text" name="typed" id="typeans" onfocus="taFocus();" onblur="taBlur(this);" onKeyPress="return taKey(this, event)" autocomplete="off" """
+<input type="text" name="typed" id="typeans" onfocus="taFocus();" oninput='taChange(this);' onKeyPress="return taKey(this, event)" autocomplete="off" """
             )
             // We have to watch out. For the preview we don’t know the font or font size. Skip those there. (Anki
             // desktop just doesn't show the input tag there. Do it with standard values here instead.)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -134,7 +134,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     @Test
     fun validEncodingSetsAnswerCorrectly() {
         // 你好%
-        val url = "typeblurtext:%E4%BD%A0%E5%A5%BD%25"
+        val url = "typechangetext:%E4%BD%A0%E5%A5%BD%25"
         val viewer: NonAbstractFlashcardViewer = getViewer(true)
 
         viewer.handleUrlFromJavascript(url)


### PR DESCRIPTION
## Purpose / Description
We handled onBlur and pressing enter, but, typing into the field, then pressing 'show answer' did not have the latest value, so `input` was null and a comparison wasn't made

## Fixes
* Fixes #15552

## Approach
To fix this, we update the typed input on each text change, rather than onBlur

## How Has This Been Tested?
API 24 emulator

## Learning (optional, can help others)
* `oninput` rather than `onchange`: `onchange` is similar to `onblur`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
