### PR TITLE
hack: [API28] fix crash on 'Filtered Deck Options'

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.core.content.edit
+import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.GrantStoragePermission
+import com.ichi2.anki.testutil.grantPermissions
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+class FilteredDeckOptionsTest : InstrumentedTest() {
+    @get:Rule
+    val runtimePermissionRule = grantPermissions(GrantStoragePermission.storagePermission)
+
+    @Before
+    fun before() {
+        AnkiDroidApp.sharedPrefs().edit {
+            putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, true)
+        }
+    }
+
+    @Test
+    fun canOpenDeckOptions() {
+        ActivityScenario.launch(DeckPicker::class.java).onActivity { deckPicker ->
+            val deckId = col.decks.newDyn("Filtered Testing")
+            deckPicker.showContextMenuDeckOptions(deckId)
+        }.close()
+    }
+}

--- a/AnkiDroid/src/main/res/values-v29/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values-v29/theme_dark.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
+    <style name="Base.V29.Dark" parent="@style/Base.Theme.Dark">
+        <item name="colorSurfaceContainer">@color/faded_primary</item>
+    </style>
+
+    <style name="Theme_Dark" parent="Base.V29.Dark"/>
+</resources>

--- a/AnkiDroid/src/main/res/values-v29/theme_light.xml
+++ b/AnkiDroid/src/main/res/values-v29/theme_light.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
+    <style name="Base.V29.Light" parent="@style/Base.Theme.Light">
+        <item name="colorSurfaceContainer">@color/faded_primary</item>
+    </style>
+
+    <style name="Theme_Light" parent="Base.V29.Light"/>
+</resources>

--- a/AnkiDroid/src/main/res/values-v29/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values-v29/theme_plain.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
+    <style name="Base.V29.Light.Plain" parent="@style/Base.Theme.Light.Plain">
+        <item name="colorSurfaceContainer">@color/faded_primary</item>
+    </style>
+
+    <style name="Theme_Light.Plain" parent="Base.V29.Light.Plain"/>
+</resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -9,7 +9,7 @@
     <color name="theme_dark_drawer_row_current">#33999999</color>
     <color name="theme_dark_drawer_item">#DEFFFFFF</color>
 
-    <style name="Theme_Dark" parent="@style/Theme.Material3.Dark.NoActionBar">
+    <style name="Base.Theme.Dark" parent="@style/Theme.Material3.Dark.NoActionBar">
         <!-- Android colors -->
         <item name="colorPrimary">@color/material_blue_400</item>
         <item name="colorOnPrimary">@color/white</item>
@@ -27,7 +27,7 @@
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
         <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
-        <item name="colorSurfaceContainer">@color/faded_primary</item>
+        <item name="colorSurfaceContainer">#0F42A5F5</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
         <!-- Widget colors -->
         <item name="widgetColorActivated">?attr/colorAccent</item>
@@ -155,4 +155,6 @@
         <item name="alertDialogTheme">@style/AlertDialogStyle</item>
 
     </style>
+
+    <style name="Theme_Dark" parent="Base.Theme.Dark"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="Theme_Light" parent="@style/Theme.Material3.Light.NoActionBar">
+    <style name="Base.Theme.Light" parent="@style/Theme.Material3.Light.NoActionBar">
         <!-- Android colors -->
         <item name="colorPrimary">@color/material_light_blue_500</item>
         <item name="colorPrimaryDark">@color/material_light_blue_700</item>
@@ -13,7 +13,7 @@
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
         <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
-        <item name="colorSurfaceContainer">@color/faded_primary</item>
+        <item name="colorSurfaceContainer">#0F03A9F4</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
 
         <item name="android:textColor">@color/text_color_light</item>
@@ -143,4 +143,6 @@
         <item name="progressDialogButtonTextColor">@color/material_light_blue_500</item>
 
     </style>
+
+    <style name="Theme_Light" parent="Base.Theme.Light"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -6,11 +6,12 @@
     <color name="theme_plain_accent">#607D8B</color>
     <color name="theme_plain_primary_text">#212121</color>
 
-    <style name="Theme_Light.Plain">
+    <style name="Base.Theme.Light.Plain">
         <!-- Android colors -->
         <item name="colorPrimary">@color/theme_plain_primary</item>
         <item name="colorPrimaryDark">@color/theme_plain_primary_dark</item>
         <item name="colorAccent">@color/theme_plain_accent</item>
+        <item name="colorSurfaceContainer">#0F9E9E9E</item>
         <item name="android:textColor">@color/text_color_light</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_light</item>
         <item name="preferenceCategoryTitleTextColor">?attr/colorAccent</item>
@@ -72,4 +73,6 @@
         <item name="progressDialogButtonTextColor">@color/theme_plain_primary</item>
 
     </style>
+
+    <style name="Theme_Light.Plain" parent="Base.Theme.Light.Plain"/>
 </resources>


### PR DESCRIPTION
## Purpose / Description
`android.content.res.Resources$NotFoundException: File res/color/faded_primary.xml from drawable resource ID #0x7f06007d`

`Binary XML file line https://github.com/ankidroid/Anki-Android/pull/17: <item> tag requires a 'drawable' attribute or child tag defining a drawable`

## Fixes
* Fixes #15536

## Approach
We fix the XML issue by hardcoding the colors

0.06 * 256 = 15.36, so use an alpha of 15/256 (#0FXXXXXX)

## How Has This Been Tested?
API 24 emulator

Samsung S21 (API 34)
<details>

<summary>Before</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/14b3d856-74f1-4df4-81b2-455c6d9f34e2)

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/e8ac1b4e-5ff7-4213-afbc-1289150026d3)

</details>

<details>

<summary>After</summary>

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/7e63a190-261c-44b1-a818-294c09868602)

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/135daa63-7598-4b99-ab08-5f8b3a4fd20a)



</details>


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
