### PR TITLE
remove noCodeFormatting preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -555,7 +555,6 @@ object UsageAnalytics {
         "useInputTag", // Type answer into the card
         "disableExtendedTextUi", // Disable Single-Field Edit Mode
         "noteEditorNewlineReplace", // Replace newlines with HTML
-        "noCodeFormatting", // Simple typed answer formatting
         "autoFocusTypeInAnswer", // Focus ‘type in answer’
         "mediaImportAllowAllFiles", // Allow all files in media imports
         "providerEnabled", // Enable AnkiDroid API

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TypeAnswer.kt
@@ -38,7 +38,6 @@ import java.util.regex.Pattern
  */
 class TypeAnswer(
     val useInputTag: Boolean,
-    val doNotUseCodeFormatting: Boolean,
     val autoFocus: Boolean
 ) {
 
@@ -198,10 +197,7 @@ class TypeAnswer(
         val sb = StringBuilder()
         fun append(@Language("HTML") html: String) = sb.append(html)
 
-        var comparisonText = CollectionManager.compareAnswer(correctAnswer, userAnswer)
-        if (doNotUseCodeFormatting) {
-            comparisonText = "$comparisonText<style>code.typeans { font-family: sans-serif; }</style>"
-        }
+        val comparisonText = CollectionManager.compareAnswer(correctAnswer, userAnswer)
         append(Matcher.quoteReplacement(comparisonText))
         return m.replaceAll(sb.toString())
     }
@@ -213,7 +209,6 @@ class TypeAnswer(
         fun createInstance(preferences: SharedPreferences): TypeAnswer {
             return TypeAnswer(
                 useInputTag = preferences.getBoolean("useInputTag", false),
-                doNotUseCodeFormatting = preferences.getBoolean("noCodeFormatting", false),
                 autoFocus = preferences.getBoolean("autoFocusTypeInAnswer", true)
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -98,6 +98,7 @@ object PreferenceUpgradeService {
                 yield(RemoveReviewerETA())
                 yield(SetShowDeckTitle())
                 yield(ResetAnalyticsOptIn())
+                yield(RemoveNoCodeFormatting())
             }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -493,6 +494,11 @@ object PreferenceUpgradeService {
         internal class ResetAnalyticsOptIn : PreferenceUpgrade(17) {
             override fun upgrade(preferences: SharedPreferences) =
                 preferences.edit { remove("analyticsOptIn") }
+        }
+
+        internal class RemoveNoCodeFormatting : PreferenceUpgrade(18) {
+            override fun upgrade(preferences: SharedPreferences) =
+                preferences.edit { remove("noCodeFormatting") }
         }
     }
 }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -241,9 +241,6 @@
 
     <string name="note_editor_replace_newlines" maxLength="41">Replace newlines with HTML</string>
     <string name="note_editor_replace_newlines_summ">In the Note Editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
-
-    <string name="no_code_formatting" maxLength="41">Simple typed answer formatting</string>
-    <string name="no_code_formatting_summ">Fixes ‘􏿾’ appearing in typed answer results</string>
     
     <string name="type_in_answer_focus" maxLength="41">Focus ‘type in answer’</string>
     <string name="type_in_answer_focus_summ">Automatically focus the ‘type in answer’ field in the reviewer</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -143,7 +143,6 @@
     <string name="use_input_tag_key">useInputTag</string>
     <string name="disable_single_field_edit_key">disableExtendedTextUi</string>
     <string name="note_editor_newline_replace_key">noteEditorNewlineReplace</string>
-    <string name="no_code_formatting_key">noCodeFormatting</string>
     <string name="type_in_answer_focus_key">autoFocusTypeInAnswer</string>
     <string name="exit_via_double_tap_back_key">exitViaDoubleTapBack</string>
     <string name="media_import_allow_all_files_key">mediaImportAllowAllFiles</string>

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -70,13 +70,6 @@
                 android:summary="@string/note_editor_replace_newlines_summ"
                 android:title="@string/note_editor_replace_newlines"
                 />
-            <!-- #7896 - Workaround for old webviews which could not render some characters in a <code> block
-            due to problems with the default monospace font handling -->
-            <SwitchPreferenceCompat
-                android:defaultValue="false"
-                android:key="@string/no_code_formatting_key"
-                android:summary="@string/no_code_formatting_summ"
-                android:title="@string/no_code_formatting" />
             <!-- #8424 - allow users to decide if they want to focus the EditText
                 Note: this functionality is already disabled if useInputTag is enabled
                 UseInputTag: has had `disableDependentsState` set, so this is disabled

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/TypeAnswerTest.kt
@@ -251,7 +251,6 @@ $!"""
 
     private fun typeAnsAnswerFilter(answer: String, correctAnswer: String, userAnswer: String): String =
         TypeAnswer(
-            doNotUseCodeFormatting = false,
             useInputTag = false,
             autoFocus = false
         ).filterAnswer(answer, correctAnswer, userAnswer)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Remove noCodeFormatting preference

## Fixes
* Fixes #15556 

## Approach
I removed it

## How Has This Been Tested?

I opened the settings and it was gone

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
