### PR TITLE
fix: Android share menu no longer works for text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -366,6 +366,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             changed = savedInstanceState.getBoolean(NOTE_CHANGED_EXTRA_KEY)
         } else {
             if (intentLaunchedWithImage(intent)) {
+                Timber.i("Intent contained an image")
                 intent.putExtra(EXTRA_CALLER, CALLER_ADD_IMAGE)
             }
             caller = intent.getIntExtra(EXTRA_CALLER, CALLER_NO_CALLER)
@@ -408,13 +409,11 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         setNavigationBarColor(R.attr.toolbarBackgroundColor)
     }
 
+    @NeedsTest("15566: sharing text should be processed as text")
     private fun intentLaunchedWithImage(intent: Intent): Boolean {
-        val action = intent.action
-        return action == Intent.ACTION_SEND || (
-            Intent.ACTION_VIEW == action &&
-                !ImportUtils.isInvalidViewIntent(intent) &&
-                intent.resolveMimeType()?.startsWith("image/") == true
-            )
+        if (intent.action != Intent.ACTION_SEND && intent.action != Intent.ACTION_VIEW) return false
+        if (ImportUtils.isInvalidViewIntent(intent)) return false
+        return intent.resolveMimeType()?.startsWith("image/") == true
     }
 
     @NeedsTest("Test when the user directly passes image to the edit note field")


### PR DESCRIPTION
## Purpose / Description
Intent.ACTION_SEND was always processed as an image
## Fixes

* Fixes #15566

## How Has This Been Tested?
Tested both sharing text and sharing an image on my S21

## Learning (optional, can help others)
Need more tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
