### PR TITLE
fix: crash when leaving previewer if deck is too big

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Previewer.kt
@@ -198,7 +198,6 @@ class Previewer : AbstractFlashcardViewer() {
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putLongArray("cardList", cardList.toLongArray())
         outState.putInt("index", index)
         outState.putBoolean("showingAnswer", showingAnswer)
         outState.putBoolean("reloadRequired", reloadRequired)


### PR DESCRIPTION
## Fixes
* Fixes  #15565

## Approach

the value was never retrieved from the `savedInstanceState`, so it was a no-op

## How Has This Been Tested?

I haven't

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
