### PR TITLE
Test: instrumented test for NoteEditor when text is sent

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import android.content.ComponentName
+import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.NoteEditor.Companion.intentLaunchedWithImage
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.GrantStoragePermission
+import junit.framework.TestCase.assertFalse
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestRule
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicReference
+
+@RunWith(AndroidJUnit4::class)
+class NoteEditorIntentTest : InstrumentedTest() {
+    @get:Rule
+    var runtimePermissionRule: TestRule? = GrantStoragePermission.instance
+
+    @get:Rule
+    var activityRuleIntent: ActivityScenarioRule<NoteEditor>? = ActivityScenarioRule(
+        noteEditorTextIntent
+    )
+
+    @Test
+    fun launchActivityWithIntent() {
+        col
+        val scenario = activityRuleIntent!!.scenario
+        scenario.moveToState(Lifecycle.State.RESUMED)
+
+        onActivity(scenario) { editor ->
+            val currentFieldStrings = editor.currentFieldStrings
+            MatcherAssert.assertThat(currentFieldStrings[0], Matchers.equalTo("sample text"))
+        }
+    }
+
+    @Test
+    fun intentLaunchedWithNonImageIntent() {
+        val intent = Intent().apply {
+            action = Intent.ACTION_SEND
+            type = "text/plain"
+        }
+        assertFalse(intentLaunchedWithImage(intent))
+    }
+
+    private val noteEditorTextIntent: Intent
+        get() {
+            return Intent(testContext, NoteEditor::class.java).apply {
+                component = ComponentName(testContext, NoteEditor::class.java)
+                action = Intent.ACTION_SEND
+                putExtra(Intent.EXTRA_TEXT, "sample text")
+            }
+        }
+
+    @Throws(Throwable::class)
+    private fun onActivity(
+        scenario: ActivityScenario<NoteEditor>,
+        noteEditorActivityAction: ActivityScenario.ActivityAction<NoteEditor>
+    ) {
+        val wrapped = AtomicReference<Throwable?>(null)
+        scenario.onActivity { a: NoteEditor ->
+            try {
+                noteEditorActivityAction.perform(a)
+            } catch (t: Throwable) {
+                wrapped.set(t)
+            }
+        }
+        wrapped.get()?.let { throw it }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -409,13 +409,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         setNavigationBarColor(R.attr.toolbarBackgroundColor)
     }
 
-    @NeedsTest("15566: sharing text should be processed as text")
-    private fun intentLaunchedWithImage(intent: Intent): Boolean {
-        if (intent.action != Intent.ACTION_SEND && intent.action != Intent.ACTION_VIEW) return false
-        if (ImportUtils.isInvalidViewIntent(intent)) return false
-        return intent.resolveMimeType()?.startsWith("image/") == true
-    }
-
     @NeedsTest("Test when the user directly passes image to the edit note field")
     private fun handleImageIntent(data: Intent) {
         val imageUri = if (data.action == Intent.ACTION_SEND) {
@@ -2391,6 +2384,14 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         private fun shouldReplaceNewlines(): Boolean {
             return AnkiDroidApp.instance.sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_NEWLINE_REPLACE, true)
+        }
+
+        @VisibleForTesting
+        @CheckResult
+        fun intentLaunchedWithImage(intent: Intent): Boolean {
+            if (intent.action != Intent.ACTION_SEND && intent.action != Intent.ACTION_VIEW) return false
+            if (ImportUtils.isInvalidViewIntent(intent)) return false
+            return intent.resolveMimeType()?.startsWith("image/") == true
         }
 
         private fun shouldHideToolbar(): Boolean {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
it would be greatly appreciated if you could follow up with a regression test in `androidTest`

_Originally posted by @david-allison in https://github.com/ankidroid/Anki-Android/issues/15566#issuecomment-1950966979_

* https://github.com/ankidroid/Anki-Android/issues/15566#issuecomment-1950966979_

## How Has This Been Tested?
Google emualtor and ran test locally 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
