### PR TITLE
fix(browser): update title on deck creation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1097,7 +1097,7 @@ open class DeckPicker :
 
     fun createFilteredDialog() {
         val createFilteredDeckDialog = CreateDeckDialog(this@DeckPicker, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null)
-        createFilteredDeckDialog.setOnNewDeckCreated {
+        createFilteredDeckDialog.onNewDeckCreated = {
             // a filtered deck was created
             openFilteredDeckOptions()
         }
@@ -2110,7 +2110,7 @@ open class DeckPicker :
         val currentName = getColUnsafe.decks.name(did)
         val createDeckDialog = CreateDeckDialog(this@DeckPicker, R.string.rename_deck, CreateDeckDialog.DeckDialogType.RENAME_DECK, null)
         createDeckDialog.deckName = currentName
-        createDeckDialog.setOnNewDeckCreated {
+        createDeckDialog.onNewDeckCreated = {
             dismissAllDialogFragments()
             deckListAdapter.notifyDataSetChanged()
             updateDeckList()
@@ -2234,7 +2234,7 @@ open class DeckPicker :
 
     fun createSubDeckDialog(did: DeckId) {
         val createDeckDialog = CreateDeckDialog(this@DeckPicker, R.string.create_subdeck, CreateDeckDialog.DeckDialogType.SUB_DECK, did)
-        createDeckDialog.setOnNewDeckCreated {
+        createDeckDialog.onNewDeckCreated = {
             // a deck was created
             dismissAllDialogFragments()
             deckListAdapter.notifyDataSetChanged()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -345,7 +345,7 @@ class DeckPickerFloatingActionMenu(
                     CreateDeckDialog.DeckDialogType.DECK,
                     null
                 )
-                createDeckDialog.setOnNewDeckCreated { deckPicker.updateDeckList() }
+                createDeckDialog.onNewDeckCreated = { deckPicker.updateDeckList() }
                 createDeckDialog.showDialog()
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -26,6 +26,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.DeckSelectionDialog
+import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckCreationListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck.Companion.fromCollection
 import com.ichi2.anki.widgets.DeckDropDownAdapter
@@ -205,7 +206,15 @@ class DeckSpinnerSelection(
             decks.add(SelectableDeck(ALL_DECKS_ID, context.resources.getString(R.string.card_browser_all_decks)))
         }
         val dialog = DeckSelectionDialog.newInstance(context.getString(R.string.search_deck), null, false, decks)
+        // TODO: retain state after onDestroy
+        dialog.deckCreationListener = DeckCreationListener { onDeckAdded(it) }
         AnkiActivity.showDialogFragment(fragmentManagerSupplier.getFragmentManager(), dialog)
+    }
+
+    private fun onDeckAdded(deck: DeckNameId) {
+        Timber.d("added deck %s to spinner", deck)
+        deckDropDownAdapter?.addDeck(deck)
+        dropDownDecks.add(deck)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -290,6 +290,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             return
         }
         deckId = deck.deckId
+        // this is called because DeckSpinnerSelection.onDeckAdded doesn't update the list
         mDeckSpinnerSelection!!.initializeNoteEditorDeckSpinner(getColUnsafe)
         launchCatchingTask {
             mDeckSpinnerSelection!!.selectDeckById(deckId, false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -171,6 +171,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         launchCatchingTask {
             val name = withCol { decks.name(id) }
             val deck = SelectableDeck(id, name)
+            deckCreationListener?.onDeckCreated(DeckNameId(name, id))
             selectDeckAndClose(deck)
         }
     }
@@ -198,6 +199,8 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             }
             throw IllegalStateException("Neither activity or parent fragment were a selection listener")
         }
+
+    var deckCreationListener: DeckCreationListener? = null
 
     /**
      * Same action as pressing on the deck in the list. I.e. send the deck to listener and close the dialog.
@@ -346,6 +349,9 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
     fun interface DeckSelectionListener {
         fun onDeckSelected(deck: SelectableDeck?)
+    }
+    fun interface DeckCreationListener {
+        fun onDeckCreated(deck: DeckNameId)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -154,12 +154,10 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         launchCatchingTask {
             val parentId = withCol { decks.id(parentDeckPath) }
             val createDeckDialog = CreateDeckDialog(requireActivity(), R.string.create_subdeck, CreateDeckDialog.DeckDialogType.SUB_DECK, parentId)
-            createDeckDialog.setOnNewDeckCreated { id: Long? ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a sub deck was created
                 launchCatchingTask {
-                    val name = withCol {
-                        decks.name(id!!)
-                    }
+                    val name = withCol { decks.name(id) }
                     selectDeckWithDeckName(name)
                 }
             }
@@ -169,12 +167,10 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
     private fun showDeckDialog() {
         val createDeckDialog = CreateDeckDialog(requireActivity(), R.string.new_deck, CreateDeckDialog.DeckDialogType.DECK, null)
-        // todo
-        // setOnNewDeckCreated parameter to be made non null
-        createDeckDialog.setOnNewDeckCreated { id: Long? ->
+        createDeckDialog.onNewDeckCreated = { id: DeckId ->
             // a deck was created
             launchCatchingTask {
-                val name = withCol { decks.name(id!!) }
+                val name = withCol { decks.name(id) }
                 selectDeckWithDeckName(name)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.kt
@@ -25,7 +25,11 @@ import android.widget.TextView
 import com.ichi2.anki.R
 import com.ichi2.libanki.DeckNameId
 
-class DeckDropDownAdapter(private val context: Context, private val decks: List<DeckNameId>) : BaseAdapter() {
+class DeckDropDownAdapter(private val context: Context, decks: List<DeckNameId>) : BaseAdapter() {
+    private val deckList = decks.toMutableList()
+    val decks: List<DeckNameId>
+        get() = deckList.toList()
+
     interface SubtitleListener {
         val subtitleText: String?
     }
@@ -35,15 +39,20 @@ class DeckDropDownAdapter(private val context: Context, private val decks: List<
         var deckCountsView: TextView? = null
     }
 
+    fun addDeck(deck: DeckNameId) {
+        deckList.add(deck)
+        notifyDataSetChanged()
+    }
+
     override fun getCount(): Int {
-        return decks.size + 1
+        return deckList.size + 1
     }
 
     override fun getItem(position: Int): Any? {
         return if (position == 0) {
             null
         } else {
-            decks[position + 1]
+            deckList[position + 1]
         }
     }
 
@@ -72,7 +81,7 @@ class DeckDropDownAdapter(private val context: Context, private val decks: List<
         if (position == 0) {
             deckNameView!!.text = context.resources.getString(R.string.card_browser_all_decks)
         } else {
-            val deck = decks[position - 1]
+            val deck = deckList[position - 1]
             val deckName = deck.name
             deckNameView!!.text = deckName
         }
@@ -93,7 +102,7 @@ class DeckDropDownAdapter(private val context: Context, private val decks: List<
         if (position == 0) {
             deckNameView.text = context.resources.getString(R.string.card_browser_all_decks)
         } else {
-            val deck = decks[position - 1]
+            val deck = deckList[position - 1]
             val deckName = deck.name
             deckNameView.text = deckName
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -64,7 +64,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     fun testCreateFilteredDeckFunction() {
         val deckName = "filteredDeck"
         ensureExecutionOfScenario(DeckDialogType.FILTERED_DECK) { createDeckDialog, assertionCalled ->
-            createDeckDialog.setOnNewDeckCreated { id: Long ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a deck was created
                 assertThat(id, equalTo(col.decks.id(deckName)))
                 assertionCalled()
@@ -78,7 +78,7 @@ class CreateDeckDialogTest : RobolectricTest() {
         val deckParentId = col.decks.id("Deck Name")
         val deckName = "filteredDeck"
         ensureExecutionOfScenario(DeckDialogType.SUB_DECK, deckParentId) { createDeckDialog, assertionCalled ->
-            createDeckDialog.setOnNewDeckCreated { id: Long ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 val deckNameWithParentName = col.decks.getSubdeckName(deckParentId, deckName)
                 assertThat(id, equalTo(col.decks.id(deckNameWithParentName!!)))
                 assertionCalled()
@@ -91,7 +91,7 @@ class CreateDeckDialogTest : RobolectricTest() {
     fun testCreateDeckFunction() {
         val deckName = "Deck Name"
         ensureExecutionOfScenario(DeckDialogType.DECK) { createDeckDialog, assertionCalled ->
-            createDeckDialog.setOnNewDeckCreated { id: Long ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a deck was created
                 assertThat(id, equalTo(col.decks.byName(deckName)!!.getLong("id")))
                 assertionCalled()
@@ -106,9 +106,9 @@ class CreateDeckDialogTest : RobolectricTest() {
         val deckNewName = "New Deck Name"
         ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { createDeckDialog, assertionCalled ->
             createDeckDialog.deckName = deckName
-            createDeckDialog.setOnNewDeckCreated { id: Long? ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a deck name was renamed
-                assertThat(deckNewName, equalTo(col.decks.name(id!!)))
+                assertThat(deckNewName, equalTo(col.decks.name(id)))
                 assertionCalled()
             }
             createDeckDialog.renameDeck(deckNewName)
@@ -146,7 +146,7 @@ class CreateDeckDialogTest : RobolectricTest() {
                 null
             )
             val did = suspendCoroutine { coro ->
-                createDeckDialog.setOnNewDeckCreated { did ->
+                createDeckDialog.onNewDeckCreated = { did: DeckId ->
                     coro.resume(did)
                 }
                 createDeckDialog.createDeck("Deck$i")


### PR DESCRIPTION
## Fixes
* Fixes #15577

## Approach
Define `DeckSelectionDialog.deckCreationListener` and handle the change internally so the adapter doesn't need an external rebuild


## How Has This Been Tested?
Selected a deck, double selected a deck, selected a different deck
created a deck

## Learning
Everything about this is eww

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
