### PR TITLE
fix(note-editor): Switch Image Occlusion types 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -52,7 +52,6 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
 import anki.config.ConfigKey
 import anki.notes.NoteFieldsCheckResponse
-import anki.notetypes.StockNotetype
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
@@ -87,6 +86,7 @@ import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
+import com.ichi2.anki.utils.ext.isImageOcclusion
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -99,7 +99,6 @@ import com.ichi2.utils.*
 import com.ichi2.utils.IntentUtil.resolveMimeType
 import com.ichi2.widget.WidgetStatus
 import org.json.JSONArray
-import org.json.JSONException
 import org.json.JSONObject
 import timber.log.Timber
 import java.util.*
@@ -138,7 +137,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     private var mTagsDialogFactory: TagsDialogFactory? = null
     private var mTagsButton: AppCompatButton? = null
     private var mCardsButton: AppCompatButton? = null
-    private var mNoteTypeSpinner: Spinner? = null
+
+    @VisibleForTesting
+    internal var mNoteTypeSpinner: Spinner? = null
     private var mDeckSpinnerSelection: DeckSpinnerSelection? = null
     private var imageOcclusionButtonsContainer: LinearLayout? = null
     private var selectImageForOcclusionButton: Button? = null
@@ -2079,13 +2080,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     val fieldsFromSelectedNote: Array<Array<String>>
         get() = mEditorNote!!.items()
 
-    private fun currentNotetypeIsImageOcclusion(): Boolean {
-        try {
-            return currentlySelectedNotetype?.getInt("originalStockKind") == StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION_VALUE
-        } catch (j: JSONException) {
-            return false
-        }
-    }
+    private fun currentNotetypeIsImageOcclusion() =
+        currentlySelectedNotetype?.isImageOcclusion == true
 
     private fun setImageOcclusionButton() {
         imageOcclusionButtonsContainer?.visibility = View.VISIBLE

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1720,6 +1720,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     }
 
     private fun setDuplicateFieldStyles() {
+        // #15579 can be null if switching between two image occlusion types
+        if (mEditFields == null) return
         val field = mEditFields!![0]
         // Keep copy of current internal value for this field.
         val oldValue = mEditorNote!!.fields[0]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/NoteType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/NoteType.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION_VALUE
+import com.ichi2.libanki.NotetypeJson
+import org.json.JSONException
+
+/**
+ * @throws JSONException if the mapping doesn't exist or cannot be coerced to an int.
+ */
+val NotetypeJson.isImageOcclusion: Boolean
+    get() = try {
+        getInt("originalStockKind") == ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION_VALUE
+    } catch (e: JSONException) {
+        false
+    }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -358,7 +358,6 @@ class NoteEditorTest : RobolectricTest() {
         }
     }
 
-    @Ignore("15579")
     @Test
     fun `can switch two image occlusion note types 15579`() {
         val otherOcclusion = getSecondImageOcclusionNoteType()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -26,6 +26,7 @@ import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.libanki.utils.set
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -169,6 +170,20 @@ interface TestClass {
         this@TestClass.col.updateCard(this, skipUndoEntry = true)
         return this
     }
+
+    fun NotetypeJson.createClone(): NotetypeJson {
+        val targetNotetype = requireNotNull(col.notetypes.byName(name)) { "could not find note type '$name'" }
+        val newNotetype = targetNotetype.deepClone().apply {
+            id = 0
+            set("name", "$name+")
+        }
+        col.notetypes.add(newNotetype)
+        return col.notetypes.byName("$name+")!!
+    }
+
+    /** Returns the note types matching [predicate] */
+    fun Notetypes.filter(predicate: (NotetypeJson) -> Boolean): List<NotetypeJson> =
+        all().filter { predicate(it) }
 
     fun Card.note() = this.note(col)
     fun Card.note(reload: Boolean) = this.note(col, reload)


### PR DESCRIPTION
## Fixes
* Fixes #15579

## Approach
check for null

## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
![image](https://github.com/ankidroid/Anki-Android/assets/62114487/25e6ae08-f3e3-4c7c-bfdf-5003af4ce142)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
