### PR TITLE
fix: NPE when adding note via intent

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -107,6 +107,7 @@
     <string name="select">Select</string>
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
+    <string name="missing_note_type">No note type found</string>
 
     <!-- Timebox -->
     <string name="timebox_reached_title">Timebox reached</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Can't share to AnkiDroid if an image occlusion note type is selected 

## Fixes
* Fixes #15584

## Approach
Change the note type to basic when adding an image or text via share intent  

## How Has This Been Tested?
Google emulator - API 34

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
