### PR TITLE
fix: gesture display in dark mode

### DIFF
--- a/AnkiDroid/src/main/res/layout/gesture_display.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_display.xml
@@ -101,6 +101,7 @@
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:background="@color/transparent"
         app:srcCompat="@drawable/ic_gesture_swipe" />
 
 </merge>


### PR DESCRIPTION
This one was a nightmare to diagnose

Introduced in 15333 (a20284e)

<img width="344" alt="Screenshot 2024-02-20 at 00 27 23" src="https://github.com/ankidroid/Anki-Android/assets/62114487/50c9c31a-4952-4e81-9cdf-72c9627078b8">

## Fixes
* Fixes #15588

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
