### PR TITLE
Fix: Audio save icon not set properly after being used in reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,7 +74,7 @@ import com.ichi2.audio.AudioRecordingController
 import com.ichi2.audio.AudioRecordingController.Companion.generateTempAudioFile
 import com.ichi2.audio.AudioRecordingController.Companion.isAudioRecordingSaved
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
-import com.ichi2.audio.AudioRecordingController.Companion.setReviewerStatus
+import com.ichi2.audio.AudioRecordingController.Companion.setEditorStatus
 import com.ichi2.audio.AudioRecordingController.Companion.tempAudioPath
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
@@ -615,7 +615,7 @@ open class Reviewer :
         if (isMicToolBarVisible) {
             micToolBarLayer.visibility = View.GONE
         } else {
-            setReviewerStatus(false)
+            setEditorStatus(false)
             if (!isAudioUIInitialized) {
                 try {
                     audioRecordingController = AudioRecordingController()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivity.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.multimediacard.fields.*
 import com.ichi2.audio.AudioRecordingController
 import com.ichi2.audio.AudioRecordingController.Companion.isAudioRecordingSaved
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
+import com.ichi2.audio.AudioRecordingController.Companion.setEditorStatus
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
@@ -469,6 +470,7 @@ class MultimediaEditFieldActivity :
             EFieldType.IMAGE -> BasicImageFieldController()
             EFieldType.AUDIO_RECORDING -> {
                 isAudioUIInitialized = true
+                setEditorStatus(true)
                 audioRecordingController
             }
             EFieldType.MEDIA_CLIP -> BasicMediaClipFieldController()

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -539,7 +539,7 @@ class AudioRecordingController :
             return tempAudioPath
         }
 
-        fun setReviewerStatus(isReviewer: Boolean) {
+        fun setEditorStatus(isReviewer: Boolean) {
             this.inEditField = isReviewer
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Audio save icon not set properly after recorder being used in reviewer 

## Fixes
* Fixes #15601


## How Has This Been Tested?
Google Emulator API 34

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
