### PR TITLE
temp: remove TTS Nag in Reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -24,7 +24,6 @@ import android.speech.tts.UtteranceProgressListener
 import android.view.WindowManager.BadTokenException
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
-import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.snackbar.showSnackbar
@@ -287,12 +286,6 @@ object ReadText {
             } else {
                 showThemedToast(context, context.getString(R.string.no_tts_available_message), false)
                 Timber.w("TTS not successfully initialized")
-            }
-        }
-        // Remember the user to upgrade to the new TTS system #15475
-        ankiActivityContext?.showSnackbar(R.string.readtext_reviewer_warn, LENGTH_INDEFINITE) {
-            setAction(R.string.scoped_storage_learn_more) {
-                ankiActivityContext.openUrl(R.string.link_tts)
             }
         }
     }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -293,7 +293,7 @@ this formatter is used if the bind only applies to both the question and the ans
     <!-- Advanced -->
     <string name="pref_cat_experimental" maxLength="41" tools:ignore="UnusedResources">Experimental</string>
     <string name="readtext_deprecation_warn">AnkiDroid has introduced a better TTS mechanism which is compatible with other Anki clients and includes more voices and improvements to language playback!\n\nPlease upgrade as soon as possible, as this setting will be removed soon</string>
-    <string name="readtext_reviewer_warn">Please upgrade to the new text to speech format</string>
+    <string name="readtext_reviewer_warn" tools:ignore="UnusedResources">Please upgrade to the new text to speech format</string>
 
     <!-- Developer options -->
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>


### PR DESCRIPTION
We want to remove legacy TTS, but the migration process is not sufficiently documented.

While we get 2.17 out, remove the nag so we don't get review-bombed more than necessary

This will be reverted once we have a better process

## Fixes
* Fixes #15475 (technically, deferred to 2.18)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
