### PR TITLE
hack(tts): treat 'speed = 1' as 'use system'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -104,8 +104,10 @@ class AndroidTtsPlayer(private val context: Context, private val voices: List<Tt
         suspendCancellableCoroutine { continuation ->
             val tts = tts?.also {
                 it.voice = voice.voice
-                if (it.setSpeechRate(tag.speed) == ERROR) {
-                    return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.failure(TtsErrorCode.APP_SPEECH_RATE_FAILED))
+                tag.speed?.let { speed ->
+                    if (it.setSpeechRate(speed) == ERROR) {
+                        return@suspendCancellableCoroutine continuation.resume(AndroidTtsError.failure(TtsErrorCode.APP_SPEECH_RATE_FAILED))
+                    }
                 }
                 // if it's already playing: stop it
                 it.stopPlaying()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -32,6 +32,8 @@ import java.util.regex.Pattern
 
 /**
  * Records information about a text to speech tag.
+ *
+ * @param speed speed of speech, where `1.0f` is normal speed. `null`: use system
  */
 data class TTSTag(
     val fieldText: String,
@@ -40,7 +42,7 @@ data class TTSTag(
      */
     val lang: String,
     val voices: List<String>,
-    val speed: Float,
+    val speed: Float?,
     /** each arg should be in the form 'foo=bar' */
     val otherArgs: List<String>
 ) : AvTag()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -93,7 +93,10 @@ class TemplateManager {
                         lang = tag.tts.lang,
                         voices = tag.tts.voicesList,
                         otherArgs = tag.tts.otherArgsList,
-                        speed = tag.tts.speed
+                        // The backend currently sends speed = 1, even when undefined.
+                        // We agreed that '1' should be classed as 'use system' and ignored
+                        // https://github.com/ankidroid/Anki-Android/issues/15598#issuecomment-1953653639
+                        speed = tag.tts.speed.let { if (it == 1f) null else it }
                     )
                 }
             }


### PR DESCRIPTION
## Purpose / Description
The Anki backend sends `speed` as a non-nullable float The default is '1'

But, using `setSpeechRate(1)` overrides the android system speech rate

## Fixes
* Fixes #15598

## Approach
So we ignore all values of '1' coming from the backend and treat them as 'use system'

## How Has This Been Tested?
API 33 emulator: 
* No parameter: use system
* `1`: use system
* `0.5`: half speed
* `-1`: error `SPEECH_RATE_FAILED`

## Learning
* https://github.com/ankidroid/Anki-Android/issues/15598#issuecomment-1953653639
* https://github.com/ankitects/anki/blob/9642a69b88a4cf631af23d49e08df9b918deee8b/proto/anki/card_rendering.proto#L60-L66


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
