### PR TITLE
Fix bottom padding issues in HelpDialog

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_help_page.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_help_page.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:id="@+id/page_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical" />
+</ScrollView>

--- a/AnkiDroid/src/main/res/layout/item_help_entry.xml
+++ b/AnkiDroid/src/main/res/layout/item_help_entry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.ichi2.ui.FixedTextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:attr/selectableItemBackground"
+    android:gravity="center_vertical"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:textAppearance="?android:attr/textAppearanceListItemSmall" />

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/help/HelpDialogTest.kt
@@ -16,7 +16,7 @@ package com.ichi2.anki.dialogs.help
 import androidx.core.os.bundleOf
 import androidx.fragment.app.testing.launchFragment
 import androidx.lifecycle.Lifecycle
-import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBackUnconditionally
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
@@ -28,11 +28,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.help.HelpItem.Action.Rate
 import io.mockk.mockk
 import io.mockk.verify
-import org.hamcrest.CoreMatchers.allOf
-import org.hamcrest.CoreMatchers.instanceOf
-import org.hamcrest.Description
-import org.hamcrest.Matcher
-import org.hamcrest.TypeSafeMatcher
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -134,47 +129,33 @@ class HelpDialogTest {
             themeResId = R.style.Theme_Light,
             initialState = Lifecycle.State.RESUMED
         ).onFragment {
-            onData(matcherOf(R.string.help_title_community)).inRoot(isDialog()).perform(click())
+            onView(withText(R.string.help_title_community)).inRoot(isDialog()).perform(click())
             // check that the expected six children are shown
-            onData(matcherOf(R.string.help_item_discord)).inRoot(isDialog())
+            onView(withText(R.string.help_item_discord)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_item_reddit)).inRoot(isDialog())
+            onView(withText(R.string.help_item_reddit)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_item_facebook)).inRoot(isDialog())
+            onView(withText(R.string.help_item_facebook)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_item_mailing_list)).inRoot(isDialog())
+            onView(withText(R.string.help_item_mailing_list)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_item_twitter)).inRoot(isDialog())
+            onView(withText(R.string.help_item_twitter)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_item_anki_forums)).inRoot(isDialog())
+            onView(withText(R.string.help_item_anki_forums)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
             // press back
             pressBackUnconditionally()
             // check that the expected initial four menu items are shown
-            onData(matcherOf(R.string.help_title_community)).inRoot(isDialog())
+            onView(withText(R.string.help_title_community)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_title_get_help)).inRoot(isDialog())
+            onView(withText(R.string.help_title_get_help)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_title_privacy)).inRoot(isDialog())
+            onView(withText(R.string.help_title_privacy)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
-            onData(matcherOf(R.string.help_title_using_ankidroid)).inRoot(isDialog())
+            onView(withText(R.string.help_title_using_ankidroid)).inRoot(isDialog())
                 .check(matches(isDisplayed()))
         }
     }
-
-    /**
-     * Matches a [HelpItem] with the requested [HelpItem.titleResId].
-     */
-    private fun matcherOf(titleRes: Int): Matcher<HelpItem> = allOf(
-        instanceOf(HelpItem::class.java),
-        object : TypeSafeMatcher<HelpItem>(HelpItem::class.java) {
-            override fun describeTo(description: Description?) {
-                description?.appendText("match HelpItem with titleRes: $titleRes")
-            }
-
-            override fun matchesSafely(item: HelpItem?): Boolean = item?.titleResId == titleRes
-        }
-    )
 
     @Test
     fun `Help menu item executes expected action on menu item selection`() {
@@ -189,23 +170,23 @@ class HelpDialogTest {
         ).onFragment { fragment ->
             fragment.actionsDispatcher = mockActionDispatcher
             // start the first submenu
-            onData(matcherOf(R.string.help_title_using_ankidroid)).inRoot(isDialog())
+            onView(withText(R.string.help_title_using_ankidroid)).inRoot(isDialog())
                 .perform(click())
             // the manual url is being shown
-            onData(matcherOf(R.string.help_item_ankidroid_manual)).inRoot(isDialog())
+            onView(withText(R.string.help_item_ankidroid_manual)).inRoot(isDialog())
                 .perform(click())
             verify(exactly = 1) { mockActionDispatcher.onOpenUrl(AnkiDroidApp.manualUrl) }
             // an url resource is being shown
-            onData(matcherOf(R.string.help_item_anki_manual)).inRoot(isDialog()).perform(click())
+            onView(withText(R.string.help_item_anki_manual)).inRoot(isDialog()).perform(click())
             verify(exactly = 1) { mockActionDispatcher.onOpenUrlResource(R.string.link_anki_manual) }
             pressBackUnconditionally()
             // start the second submenu
-            onData(matcherOf(R.string.help_title_get_help)).inRoot(isDialog()).perform(click())
+            onView(withText(R.string.help_title_get_help)).inRoot(isDialog()).perform(click())
             // the feedback url is being shown
-            onData(matcherOf(R.string.help_item_report_bug)).inRoot(isDialog()).perform(click())
+            onView(withText(R.string.help_item_report_bug)).inRoot(isDialog()).perform(click())
             verify(exactly = 1) { mockActionDispatcher.onOpenUrl(AnkiDroidApp.feedbackUrl) }
             // a report is sent
-            onData(matcherOf(R.string.help_title_send_exception)).inRoot(isDialog())
+            onView(withText(R.string.help_title_send_exception)).inRoot(isDialog())
                 .perform(click())
             verify(exactly = 1) { mockActionDispatcher.onSendReport() }
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Replaced the original implementation using a ListView with manually adding the "rows" to a layout. This seems to better handle some languages with longer words where the dialog wasn't calculating correctly the row height.

<img src="https://github.com/ankidroid/Anki-Android/assets/52494258/aa9b3466-66f8-466d-8138-5b9140e26656" width="340px" height="670px"/><img src="https://github.com/ankidroid/Anki-Android/assets/52494258/2af57503-74a6-4df5-8c36-ca734d2f8ad2"  width="340px" height="670px"/>


## Fixes
* Fixes #15568

## How Has This Been Tested?

Tried the original scenario which showed the padding issue.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
