### PR TITLE
Fix: Block error space for TextInputLayout

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -140,12 +140,9 @@ open class MyAccount : AnkiActivity() {
         username.setOnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 val email = username.text.toString().trim()
-                userNameLayout.apply {
-                    isErrorEnabled = email.isNotEmpty()
-                    error = if (email.isEmpty()) getString(R.string.invalid_email) else null
-                }
+                userNameLayout.error = if (email.isEmpty()) getString(R.string.invalid_email) else null
             } else {
-                userNameLayout.isErrorEnabled = false
+                userNameLayout.error = null
             }
         }
 
@@ -153,11 +150,10 @@ open class MyAccount : AnkiActivity() {
             if (!hasFocus) {
                 val password = password.text.toString()
                 if (password.isEmpty()) {
-                    passwordLayout.isErrorEnabled = true
                     passwordLayout.error = getString(R.string.password_empty)
                 }
             } else {
-                passwordLayout.isErrorEnabled = false
+                passwordLayout.error = null
             }
         }
 

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -54,6 +54,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/username"
                     app:endIconMode="clear_text"
+                    app:errorEnabled="true"
                     android:layout_margin="@dimen/content_vertical_padding">
 
                     <com.google.android.material.textfield.TextInputEditText
@@ -73,6 +74,7 @@
                     android:layout_height="wrap_content"
                     android:hint="@string/password"
                     app:endIconMode="password_toggle"
+                    app:errorEnabled="true"
                     android:layout_margin="@dimen/content_vertical_padding">
 
                     <com.ichi2.ui.TextInputEditField


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The error space was not blocked resulting in misalignement of edit fields

## Fixes
* Fixes  #15620

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Oneplus nord ce
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/c0a2d3bb-c497-4708-924b-b22fe1a4d2b8) 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/ca3aad26-195e-4adc-ae04-1daf8acb9963)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
