### PR TITLE
chore: remove hungarian notation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -73,7 +73,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
     private val talker = JavaScriptTTS()
 
     // Speech to Text
-    private val mSpeechRecognizer = JavaScriptSTT(context)
+    private val speechRecognizer = JavaScriptSTT(context)
 
     open fun convertToByteArray(apiContract: ApiContract, boolean: Boolean): ByteArray {
         return ApiResult(apiContract.isValid, boolean.toString()).toString().toByteArray()
@@ -333,7 +333,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                 activity.flipOrAnswerCard(AbstractFlashcardViewer.EASE_4)
                 convertToByteArray(apiContract, true)
             }
-            "sttSetLanguage" -> convertToByteArray(apiContract, mSpeechRecognizer.setLanguage(apiParams))
+            "sttSetLanguage" -> convertToByteArray(apiContract, speechRecognizer.setLanguage(apiParams))
             "sttStart" -> {
                 val callback = object : JavaScriptSTT.SpeechRecognitionCallback {
                     override fun onResult(results: List<String>) {
@@ -351,10 +351,10 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                         }
                     }
                 }
-                mSpeechRecognizer.setRecognitionCallback(callback)
-                convertToByteArray(apiContract, mSpeechRecognizer.start())
+                speechRecognizer.setRecognitionCallback(callback)
+                convertToByteArray(apiContract, speechRecognizer.start())
             }
-            "sttStop" -> convertToByteArray(apiContract, mSpeechRecognizer.stop())
+            "sttStop" -> convertToByteArray(apiContract, speechRecognizer.stop())
             else -> {
                 showDeveloperContact(ankiJsErrorCodeError, apiContract.cardSuppliedDeveloperContact)
                 throw Exception("unhandled request: $methodName")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1753,13 +1753,13 @@ open class CardBrowser :
         private val toIds: IntArray,
         private val fontSizeScalePcent: Int
     ) : BaseAdapter() {
-        private var mOriginalTextSize = -1.0f
-        private val mInflater: LayoutInflater
+        private var originalTextSize = -1.0f
+        private val inflater: LayoutInflater
         override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             // Get the main container view if it doesn't already exist, and call bindView
             val v: View
             if (convertView == null) {
-                v = mInflater.inflate(resource, parent, false)
+                v = inflater.inflate(resource, parent, false)
                 val count = toIds.size
                 val columns = arrayOfNulls<View>(count)
                 for (i in 0 until count) {
@@ -1818,13 +1818,13 @@ open class CardBrowser :
         private fun setFont(v: TextView) {
             // Set the font and font size for a TextView v
             val currentSize = v.textSize
-            if (mOriginalTextSize < 0) {
-                mOriginalTextSize = v.textSize
+            if (originalTextSize < 0) {
+                originalTextSize = v.textSize
             }
             // do nothing when pref is 100% and apply scaling only once
-            if (fontSizeScalePcent != 100 && abs(mOriginalTextSize - currentSize) < 0.1) {
+            if (fontSizeScalePcent != 100 && abs(originalTextSize - currentSize) < 0.1) {
                 // getTextSize returns value in absolute PX so use that in the setter
-                v.setTextSize(TypedValue.COMPLEX_UNIT_PX, mOriginalTextSize * (fontSizeScalePcent / 100.0f))
+                v.setTextSize(TypedValue.COMPLEX_UNIT_PX, originalTextSize * (fontSizeScalePcent / 100.0f))
             }
         }
 
@@ -1853,7 +1853,7 @@ open class CardBrowser :
         }
 
         init {
-            mInflater = LayoutInflater.from(context)
+            inflater = LayoutInflater.from(context)
         }
     }
 
@@ -1934,7 +1934,7 @@ open class CardBrowser :
     class CardCache : Card.Cache, PositionAware {
         var isLoaded = false
             private set
-        private var mQa: Pair<String, String>? = null
+        private var qa: Pair<String, String>? = null
         override var position: Int
 
         private val inCardMode: Boolean
@@ -1945,7 +1945,7 @@ open class CardBrowser :
 
         constructor(cache: CardCache, position: Int) : super(cache) {
             isLoaded = cache.isLoaded
-            mQa = cache.mQa
+            qa = cache.qa
             this.position = position
             this.inCardMode = cache.inCardMode
         }
@@ -1954,7 +1954,7 @@ open class CardBrowser :
         override fun reload() {
             super.reload()
             isLoaded = false
-            mQa = null
+            qa = null
         }
 
         /**
@@ -2003,11 +2003,11 @@ open class CardBrowser :
                 CardBrowserColumn.REVIEWS -> if (inCardMode) card.reps.toString() else card.totalReviewsForNote(col).toString()
                 CardBrowserColumn.QUESTION -> {
                     updateSearchItemQA()
-                    mQa!!.first
+                    qa!!.first
                 }
                 CardBrowserColumn.ANSWER -> {
                     updateSearchItemQA()
-                    mQa!!.second
+                    qa!!.second
                 }
                 else -> null
             }
@@ -2069,7 +2069,7 @@ open class CardBrowser :
          * question.
          */
         private fun updateSearchItemQA() {
-            if (mQa != null) {
+            if (qa != null) {
                 return
             }
             // render question and answer
@@ -2097,7 +2097,7 @@ open class CardBrowser :
             }
             a = formatQA(a, qa, AnkiDroidApp.instance)
             q = formatQA(q, qa, AnkiDroidApp.instance)
-            mQa = Pair(q, a)
+            this.qa = Pair(q, a)
         }
 
         override fun equals(other: Any?): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -60,18 +60,18 @@ abstract class NavigationDrawerActivity :
      */
     var fragmented = false
         protected set
-    private var mNavButtonGoesBack = false
+    private var navButtonGoesBack = false
 
     // Navigation drawer list item entries
-    private lateinit var mDrawerLayout: DrawerLayout
-    private var mNavigationView: NavigationView? = null
+    private lateinit var drawerLayout: DrawerLayout
+    private var navigationView: NavigationView? = null
     lateinit var drawerToggle: ActionBarDrawerToggle
         private set
 
     /**
      * runnable that will be executed after the drawer has been closed.
      */
-    private var mPendingRunnable: Runnable? = null
+    private var pendingRunnable: Runnable? = null
 
     override fun setContentView(@LayoutRes layoutResID: Int) {
         val preferences = baseContext.sharedPrefs()
@@ -108,18 +108,18 @@ abstract class NavigationDrawerActivity :
     }
 
     fun navDrawerIsReady(): Boolean {
-        return mNavigationView != null
+        return navigationView != null
     }
 
     // Navigation drawer initialisation
     protected fun initNavigationDrawer(mainView: View) {
         // Create inherited navigation drawer layout here so that it can be used by parent class
-        mDrawerLayout = mainView.findViewById(R.id.drawer_layout)
+        drawerLayout = mainView.findViewById(R.id.drawer_layout)
         // set a custom shadow that overlays the main content when the drawer opens
-        mDrawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START)
+        drawerLayout.setDrawerShadow(R.drawable.drawer_shadow, GravityCompat.START)
         // Force transparent status bar with primary dark color underlaid so that the drawer displays under status bar
         window.statusBarColor = getColor(R.color.transparent)
-        mDrawerLayout.setStatusBarBackgroundColor(
+        drawerLayout.setStatusBarBackgroundColor(
             MaterialColors.getColor(
                 this,
                 R.attr.appBarColor,
@@ -127,8 +127,8 @@ abstract class NavigationDrawerActivity :
             )
         )
         // Setup toolbar and hamburger
-        mNavigationView = mDrawerLayout.findViewById(R.id.navdrawer_items_container)
-        mNavigationView!!.setNavigationItemSelectedListener(this)
+        navigationView = drawerLayout.findViewById(R.id.navdrawer_items_container)
+        navigationView!!.setNavigationItemSelectedListener(this)
         val toolbar: Toolbar? = mainView.findViewById(R.id.toolbar)
         if (toolbar != null) {
             setSupportActionBar(toolbar)
@@ -143,7 +143,7 @@ abstract class NavigationDrawerActivity :
         // between the sliding drawer and the action bar app icon
         drawerToggle = object : ActionBarDrawerToggle(
             this,
-            mDrawerLayout,
+            drawerLayout,
             R.string.drawer_open,
             R.string.drawer_close
         ) {
@@ -155,9 +155,9 @@ abstract class NavigationDrawerActivity :
                 // If animations are disabled, this is executed before onNavigationItemSelected is called
                 // PERF: May be able to reduce this delay
                 HandlerUtils.postDelayedOnNewHandler({
-                    if (mPendingRunnable != null) {
-                        HandlerUtils.postOnNewHandler(mPendingRunnable!!) // TODO: See if we can use the same handler here
-                        mPendingRunnable = null
+                    if (pendingRunnable != null) {
+                        HandlerUtils.postOnNewHandler(pendingRunnable!!) // TODO: See if we can use the same handler here
+                        pendingRunnable = null
                     }
                 }, 100)
             }
@@ -167,13 +167,13 @@ abstract class NavigationDrawerActivity :
                 invalidateOptionsMenu()
             }
         }
-        if (mDrawerLayout is ClosableDrawerLayout) {
-            (mDrawerLayout as ClosableDrawerLayout).setAnimationEnabled(animationEnabled())
+        if (drawerLayout is ClosableDrawerLayout) {
+            (drawerLayout as ClosableDrawerLayout).setAnimationEnabled(animationEnabled())
         } else {
             Timber.w("Unexpected Drawer layout - could not modify navigation animation")
         }
         drawerToggle.isDrawerSlideAnimationEnabled = animationEnabled()
-        mDrawerLayout.addDrawerListener(drawerToggle)
+        drawerLayout.addDrawerListener(drawerToggle)
 
         enablePostShortcut(this)
     }
@@ -182,7 +182,7 @@ abstract class NavigationDrawerActivity :
      * Sets selected navigation drawer item
      */
     protected fun selectNavigationItem(itemId: Int) {
-        val menu = mNavigationView!!.menu
+        val menu = navigationView!!.menu
         if (itemId == -1) {
             for (i in 0 until menu.size()) {
                 menu.getItem(i).isChecked = false
@@ -229,7 +229,7 @@ abstract class NavigationDrawerActivity :
      * function in a noop if the drawer hasn't been initialized.
      */
     protected fun disableDrawerSwipe() {
-        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
+        drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_LOCKED_CLOSED)
     }
 
     /**
@@ -237,10 +237,10 @@ abstract class NavigationDrawerActivity :
      * function in a noop if the drawer hasn't been initialized.
      */
     protected fun enableDrawerSwipe() {
-        mDrawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
+        drawerLayout.setDrawerLockMode(DrawerLayout.LOCK_MODE_UNLOCKED)
     }
 
-    private val mPreferencesLauncher =
+    private val preferencesLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             val preferences = preferences
             Timber.i(
@@ -275,7 +275,7 @@ abstract class NavigationDrawerActivity :
      * Design pattern: template method. Subclasses can override this to define their own behaviour.
      */
     public open fun onNavigationPressed() {
-        if (mNavButtonGoesBack) {
+        if (navButtonGoesBack) {
             finish()
         } else {
             openDrawer()
@@ -293,7 +293,7 @@ abstract class NavigationDrawerActivity :
          * This runnable will be executed in onDrawerClosed(...)
          * to make the animation more fluid on older devices.
          */
-        mPendingRunnable = Runnable {
+        pendingRunnable = Runnable {
             // Take action if a different item selected
             when (item.itemId) {
                 R.id.nav_decks -> {
@@ -318,7 +318,7 @@ abstract class NavigationDrawerActivity :
                 R.id.nav_settings -> {
                     Timber.i("Navigating to settings")
                     val intent = Intent(this, Preferences::class.java)
-                    mPreferencesLauncher.launch(intent)
+                    preferencesLauncher.launch(intent)
                 }
 
                 R.id.nav_help -> {
@@ -354,17 +354,17 @@ abstract class NavigationDrawerActivity :
         if (supportActionBar != null) {
             supportActionBar!!.setDisplayHomeAsUpEnabled(true)
         }
-        mNavButtonGoesBack = true
+        navButtonGoesBack = true
     }
 
     protected fun restoreDrawerIcon() {
         drawerToggle.isDrawerIndicatorEnabled = true
-        mNavButtonGoesBack = false
+        navButtonGoesBack = false
     }
 
     @VisibleForTesting
     open val isDrawerOpen: Boolean
-        get() = mDrawerLayout.isDrawerOpen(GravityCompat.START)
+        get() = drawerLayout.isDrawerOpen(GravityCompat.START)
 
     /**
      * Restart the activity and discard old backstack, creating it new from the hierarchy in the manifest
@@ -388,17 +388,17 @@ abstract class NavigationDrawerActivity :
     }
 
     private fun openDrawer() {
-        mDrawerLayout.openDrawer(GravityCompat.START, animationEnabled())
+        drawerLayout.openDrawer(GravityCompat.START, animationEnabled())
     }
 
     private fun closeDrawer() {
-        mDrawerLayout.closeDrawer(GravityCompat.START, animationEnabled())
+        drawerLayout.closeDrawer(GravityCompat.START, animationEnabled())
     }
 
     fun focusNavigation() {
         // mNavigationView.getMenu().getItem(0).setChecked(true);
         selectNavigationItem(R.id.nav_decks)
-        mNavigationView!!.requestFocus()
+        navigationView!!.requestFocus()
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -362,8 +362,8 @@ class NoteEditorTest : RobolectricTest() {
     fun `can switch two image occlusion note types 15579`() {
         val otherOcclusion = getSecondImageOcclusionNoteType()
         getNoteEditorAdding(NoteType.IMAGE_OCCLUSION).build().apply {
-            val position = requireNotNull(mNoteTypeSpinner!!.getItemIndex(otherOcclusion.name)) { "could not find ${otherOcclusion.name}" }
-            mNoteTypeSpinner!!.setSelection(position)
+            val position = requireNotNull(noteTypeSpinner!!.getItemIndex(otherOcclusion.name)) { "could not find ${otherOcclusion.name}" }
+            noteTypeSpinner!!.setSelection(position)
         }
     }
 


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
This completes the Hungarian Notation removal

* Note Editor
* NavigationDrawerActivity
* AnkiDroidJsAPI
* CardBrowser


## How Has This Been Tested?

<details>

<summary>patch</summary>



```patch
Subject: [PATCH] chore: remove hungarian notation

* Note Editor
* NavigationDrawerActivity
* AnkiDroidJsAPI
* CardBrowser

This completes the removal

tested via `NonPublicNonStaticFieldDetector`
---
Index: lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.kt b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.kt
new file mode 100644
--- /dev/null	(date 1708660608915)
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FieldNamingPatternDetector.kt	(date 1708660608915)
@@ -0,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.JavaContext
+import org.jetbrains.uast.UField
+import org.jetbrains.uast.UVariable
+
+abstract class FieldNamingPatternDetector : Detector(), Detector.UastScanner {
+    override fun createUastHandler(context: JavaContext): UElementHandler? {
+        return VariableNamingHandler(context)
+    }
+
+    override fun getApplicableUastTypes() = listOf(UVariable::class.java)
+
+    private inner class VariableNamingHandler(private val mContext: JavaContext) :
+        UElementHandler() {
+        override fun visitVariable(node: UVariable) {
+            // HACK: Using visitField didn't return any results
+            if (node !is UField) {
+                return
+            }
+            if (!isApplicable(node)) {
+                return
+            }
+            val variableName = node.name
+            if (meetsNamingStandards(variableName)) {
+                return
+            }
+            reportVariable(mContext, node, variableName)
+        }
+    }
+
+    /** If the lint check is applicable to the given variable  */
+    protected abstract fun isApplicable(variable: UVariable): Boolean
+    protected abstract fun meetsNamingStandards(variableName: String): Boolean
+
+    /** Report the problematic variable to the lint checker  */
+    protected abstract fun reportVariable(
+        context: JavaContext,
+        node: UVariable,
+        variableName: String
+    )
+}
Index: lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.kt b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.kt
new file mode 100644
--- /dev/null	(date 1708660608918)
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/NonPublicNonStaticFieldDetector.kt	(date 1708660608918)
@@ -0,0 +1,80 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.ichi2.anki.lint.utils.Constants
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UVariable
+import org.jetbrains.uast.UastVisibility
+import java.util.EnumSet
+
+/**
+ * https://github.com/ankidroid/Anki-Android/wiki/Code-style#non-public-non-static-field-names-should-start-with-m
+ */
+class NonPublicNonStaticFieldDetector : FieldNamingPatternDetector() {
+
+    companion object {
+        private val implementation = Implementation(NonPublicNonStaticFieldDetector::class.java, EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES))
+
+        @JvmField
+        var ISSUE: Issue = Issue.create(
+            "NonPublicNonStaticFieldName",
+            "non-public non-static naming",
+            "Non-public, non-static field names should start with m: https://github.com/ankidroid/Anki-Android/wiki/Code-style#non-public-non-static-field-names-should-start-with-m",
+            Constants.ANKI_CODE_STYLE_CATEGORY,
+            Constants.ANKI_CODE_STYLE_PRIORITY,
+            Constants.ANKI_CODE_STYLE_SEVERITY,
+            implementation
+        )
+    }
+    override fun isApplicable(variable: UVariable): Boolean {
+        if (variable.isStatic) {
+            return false
+        }
+        return variable.visibility != UastVisibility.PUBLIC
+    }
+
+    override fun meetsNamingStandards(variableName: String): Boolean {
+        if (variableName.length <= 2) return true
+        if (!variableName.startsWith("m")) return true
+        return !Character.isUpperCase(variableName[1])
+    }
+
+    override fun reportVariable(context: JavaContext, node: UVariable, variableName: String) {
+        if (variableName.length < 2) {
+            // cast the node as it's ambiguous between two interfaces
+            val uNode: UElement = node
+            context.report(ISSUE, uNode, context.getNameLocation(uNode), "Variable name is too short")
+            return
+        }
+
+        // trim the 'm' and make the next character lowercase
+        val replacement = variableName[1].lowercaseChar() + variableName.substring(2)
+
+        // TODO: A fix should be possible, but it requires a rename operation
+
+        // cast the node as it's ambiguous between two interfaces
+        val uNode: UElement = node
+        context.report(ISSUE, uNode, context.getNameLocation(uNode), "Field should be named: '$replacement'")
+    }
+}
Index: lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt	(revision 0a8c8c75ee66f26abfc9ba914d930fff28da74dd)
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt	(date 1708660608920)
@@ -35,6 +35,7 @@
 import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
 import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions
+import com.ichi2.anki.lint.rules.NonPublicNonStaticFieldDetector
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage
 import com.ichi2.anki.lint.rules.VariableNamingDetector
 
@@ -60,7 +61,8 @@
                 FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
                 FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
                 VariableNamingDetector.ISSUE,
-                InvalidStringFormatDetector.ISSUE
+                InvalidStringFormatDetector.ISSUE,
+                NonPublicNonStaticFieldDetector.ISSUE
             )
         }
     override val api: Int
```

</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
