### PR TITLE
feat: JS API in the new previewer/templatePreviewer

### DIFF
--- a/AnkiDroid/src/main/assets/ankidroid.css
+++ b/AnkiDroid/src/main/assets/ankidroid.css
@@ -1,3 +1,13 @@
 video {
     max-width: 100%;
 }
+
+@font-face {
+    font-family: "Free Mono";
+    src: url("file:///android_asset/fonts/freefont/FreeMono.ttf")
+}
+
+#typeans {
+  width: 100%;
+  font-family: "Free Mono";
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2548,7 +2548,7 @@ abstract class AbstractFlashcardViewer :
         return AnkiDroidJsAPI.CardDataForJsApi()
     }
 
-    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray {
+    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray? {
         return if (uri.startsWith(AnkiServer.ANKIDROID_JS_PREFIX)) {
             jsApi.handleJsApiRequest(
                 uri.substring(AnkiServer.ANKIDROID_JS_PREFIX.length),
@@ -2556,7 +2556,8 @@ abstract class AbstractFlashcardViewer :
                 returnDefaultValues = true
             )
         } else {
-            throw IllegalArgumentException("unhandled request: $uri")
+            Timber.d("unhandled request: %s", uri)
+            return null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -584,6 +584,11 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             templateEditor.finish()
         }
 
+        private fun getNote(col: Collection): Note? {
+            val nid = requireArguments().getLong(EDITOR_NOTE_ID)
+            return if (nid != -1L) col.getNote(nid) else null
+        }
+
         fun performPreview() {
             val col = templateEditor.getColUnsafe
             val tempModel = templateEditor.tempModel
@@ -591,13 +596,12 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             // Create intent for the previewer and add some arguments
             val i = Intent(templateEditor, CardTemplatePreviewer::class.java)
             val ordinal = templateEditor.viewPager.currentItem
-            val noteId = requireArguments().getLong("noteId")
             i.putExtra("ordinal", ordinal)
             i.putExtra("cardListIndex", 0)
 
             // If we have a card for this position, send it, otherwise an empty card list signals to show a blank
-            if (noteId != -1L) {
-                val cids = col.getNote(noteId).cardIds(col)
+            getNote(col)?.let {
+                val cids = it.cardIds(col)
                 if (ordinal < cids.size) {
                     i.putExtra("cardList", longArrayOf(cids[ordinal]))
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -47,6 +47,9 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog.Companion.REQUEST_FIELD_INSERT
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.previewer.TemplatePreviewerArguments
+import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -589,7 +592,30 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             return if (nid != -1L) col.getNote(nid) else null
         }
 
+        private fun openNewPreviewer() {
+            val col = templateEditor.getColUnsafe
+            val notetype = templateEditor.tempModel!!.notetype
+            val notetypeFile = NotetypeFile(requireContext(), notetype)
+            val ord = templateEditor.viewPager.currentItem
+            val note = getNote(col) ?: Note.fromNotetypeId(col, notetype.id)
+            val args = TemplatePreviewerArguments(
+                notetypeFile = notetypeFile,
+                id = note.id,
+                ord = ord,
+                fields = note.fields,
+                tags = note.tags,
+                fillEmpty = true
+            )
+            val intent = TemplatePreviewerFragment.getIntent(requireContext(), args)
+            startActivity(intent)
+            return
+        }
+
         fun performPreview() {
+            if (requireContext().sharedPrefs().getBoolean("new_previewer", false)) {
+                openNewPreviewer()
+                return
+            }
             val col = templateEditor.getColUnsafe
             val tempModel = templateEditor.tempModel
             Timber.i("CardTemplateEditor:: Preview on tab %s", templateEditor.viewPager.currentItem)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -79,6 +79,8 @@ import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.anki.pages.ImageOcclusion
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.previewer.TemplatePreviewerArguments
+import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.anki.servicelayer.NoteService
@@ -1213,8 +1215,27 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // ----------------------------------------------------------------------------
     // CUSTOM METHODS
     // ----------------------------------------------------------------------------
+    private fun openNewPreviewer() {
+        val fields = editFields?.mapTo(mutableListOf()) { it!!.fieldText.toString() } ?: mutableListOf()
+        val tags = selectedTags ?: mutableListOf()
+        val args = TemplatePreviewerArguments(
+            notetypeFile = NotetypeFile(this, editorNote!!.notetype),
+            fields = fields,
+            tags = tags,
+            id = editorNote!!.id,
+            ord = currentEditedCard?.ord ?: 0,
+            fillEmpty = false
+        )
+        val intent = TemplatePreviewerFragment.getIntent(this, args)
+        startActivity(intent)
+    }
+
     @VisibleForTesting
     fun performPreview() {
+        if (sharedPrefs().getBoolean("new_previewer", false)) {
+            openNewPreviewer()
+            return
+        }
         val previewer = Intent(this@NoteEditor, CardTemplatePreviewer::class.java)
         if (currentEditedCard != null) {
             previewer.putExtra("ordinal", currentEditedCard!!.ord)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1406,7 +1406,7 @@ open class Reviewer :
         return activity.window.decorView.systemUiVisibility and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION == 0
     }
 
-    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray {
+    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray? {
         return if (uri.startsWith(ANKI_PREFIX)) {
             when (val methodName = uri.substring(ANKI_PREFIX.length)) {
                 "getSchedulingStatesWithContext" -> getSchedulingStatesWithContext()
@@ -1420,7 +1420,8 @@ open class Reviewer :
                 returnDefaultValues = false
             )
         } else {
-            throw IllegalArgumentException("unhandled request: $uri")
+            Timber.d("unhandled request: %s", uri)
+            null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -37,6 +37,8 @@ open class AnkiServer(
         return "http://$LOCALHOST:$listeningPort/"
     }
 
+    fun domain(): String = "$hostname:$listeningPort"
+
     // it's faster to serve local files without GZip. see 'page render' in logs
     // This also removes 'W/System: A resource failed to call end.'
     override fun useGzipWhenAccepted(r: Response?) = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -59,7 +59,7 @@ open class AnkiServer(
     }
 
     private fun buildResponse(
-        block: suspend CoroutineScope.() -> ByteArray
+        block: suspend CoroutineScope.() -> ByteArray?
     ): Response {
         return try {
             val data = runBlocking {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -82,12 +82,12 @@ abstract class PageFragment : Fragment(R.layout.page_fragment), PostRequestHandl
         }
     }
 
-    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray {
-        val methodName = if (uri.startsWith(AnkiServer.ANKI_PREFIX)) {
-            uri.substring(AnkiServer.ANKI_PREFIX.length)
-        } else {
-            throw IllegalArgumentException("unhandled request: $uri")
+    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray? {
+        if (!uri.startsWith(AnkiServer.ANKI_PREFIX)) {
+            Timber.d("unhandled request: %s", uri)
+            return null
         }
+        val methodName = uri.substring(AnkiServer.ANKI_PREFIX.length)
         return requireActivity().handleUiPostRequest(methodName, bytes)
             ?: handleCollectionPostRequest(methodName, bytes)
             ?: throw IllegalArgumentException("unhandled method: $methodName")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -44,7 +44,7 @@ import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.delay
 
 interface PostRequestHandler {
-    suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray
+    suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray?
 }
 
 suspend fun handleCollectionPostRequest(methodName: String, bytes: ByteArray): ByteArray? {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (c) 2023 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.webkit.CookieManager
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceError
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import android.widget.FrameLayout
+import androidx.annotation.CallSuper
+import androidx.annotation.LayoutRes
+import androidx.appcompat.app.AlertDialog
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
+import com.ichi2.anki.getViewerAssetLoader
+import com.ichi2.anki.localizedErrorMessage
+import com.ichi2.anki.pages.AnkiServer
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.themes.Themes
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
+
+abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
+    protected abstract val viewModel: CardViewerViewModel
+    protected abstract val webView: WebView
+
+    @CallSuper
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        setupWebView(savedInstanceState)
+        setupErrorListeners()
+    }
+
+    override fun onStart() {
+        super.onStart()
+        viewModel.setSoundPlayerEnabled(true)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (!requireActivity().isChangingConfigurations) {
+            viewModel.setSoundPlayerEnabled(false)
+        }
+    }
+
+    private fun setupWebView(savedInstanceState: Bundle?) {
+        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
+        with(webView) {
+            webViewClient = onCreateWebViewClient(savedInstanceState)
+            webChromeClient = onCreateWebChromeClient()
+            scrollBarStyle = View.SCROLLBARS_OUTSIDE_OVERLAY
+            with(settings) {
+                javaScriptEnabled = true
+                loadWithOverviewMode = true
+                builtInZoomControls = true
+                displayZoomControls = false
+                allowFileAccess = true
+                domStorageEnabled = true
+            }
+            loadDataWithBaseURL(
+                "http://${AnkiServer.LOCALHOST}/",
+                stdHtml(requireContext(), Themes.currentTheme.isNightMode),
+                "text/html",
+                null,
+                null
+            )
+        }
+        viewModel.eval
+            .flowWithLifecycle(lifecycle)
+            .onEach { eval ->
+                webView.evaluateJavascript(eval, null)
+            }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun setupErrorListeners() {
+        viewModel.onError
+            .flowWithLifecycle(lifecycle)
+            .onEach { errorMessage ->
+                AlertDialog.Builder(requireContext())
+                    .setTitle(R.string.vague_error)
+                    .setMessage(errorMessage)
+                    .show()
+            }
+            .launchIn(lifecycleScope)
+
+        viewModel.onMediaError
+            .onEach { showMediaErrorSnackbar(it) }
+            .launchIn(lifecycleScope)
+
+        viewModel.onTtsError
+            .onEach { showSnackbar(it.localizedErrorMessage(requireContext())) }
+            .launchIn(lifecycleScope)
+    }
+
+    private fun onCreateWebViewClient(savedInstanceState: Bundle?): WebViewClient {
+        val assetLoader = requireContext().getViewerAssetLoader(AnkiServer.LOCALHOST)
+        return object : WebViewClient() {
+            override fun shouldInterceptRequest(
+                view: WebView?,
+                request: WebResourceRequest
+            ): WebResourceResponse? {
+                return assetLoader.shouldInterceptRequest(request.url)
+            }
+
+            override fun onPageFinished(view: WebView?, url: String?) {
+                viewModel.onPageFinished(isAfterRecreation = savedInstanceState != null)
+            }
+
+            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+                val urlString = request.url.toString()
+                if (urlString.startsWith("playsound:")) {
+                    viewModel.playSoundFromUrl(urlString)
+                    return true
+                }
+                if (urlString.startsWith("tts-voices:")) {
+                    TtsVoicesDialogFragment().show(childFragmentManager, null)
+                    return true
+                }
+                try {
+                    openUrl(request.url)
+                    return true
+                } catch (_: Exception) {
+                    Timber.w("Could not open url")
+                }
+                return false
+            }
+
+            override fun onReceivedError(
+                view: WebView,
+                request: WebResourceRequest,
+                error: WebResourceError
+            ) {
+                viewModel.mediaErrorHandler.processFailure(request) { filename: String ->
+                    showMediaErrorSnackbar(filename)
+                }
+            }
+        }
+    }
+
+    private fun onCreateWebChromeClient(): WebChromeClient {
+        return object : WebChromeClient() {
+            private lateinit var customView: View
+
+            // used for displaying `<video>` in fullscreen.
+            // This implementation requires configChanges="orientation" in the manifest
+            // to avoid destroying the View if the device is rotated
+            override fun onShowCustomView(
+                paramView: View,
+                paramCustomViewCallback: CustomViewCallback?
+            ) {
+                customView = paramView
+                val window = requireActivity().window
+                (window.decorView as FrameLayout).addView(
+                    customView,
+                    FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT
+                    )
+                )
+                // hide system bars
+                with(WindowInsetsControllerCompat(window, window.decorView)) {
+                    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    hide(WindowInsetsCompat.Type.systemBars())
+                }
+            }
+
+            override fun onHideCustomView() {
+                val window = requireActivity().window
+                (window.decorView as FrameLayout).removeView(customView)
+                // show system bars back
+                with(WindowInsetsControllerCompat(window, window.decorView)) {
+                    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+                    show(WindowInsetsCompat.Type.systemBars())
+                }
+            }
+        }
+    }
+
+    private fun showMediaErrorSnackbar(filename: String) {
+        showSnackbar(getString(R.string.card_viewer_could_not_find_image, filename)) {
+            setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
+        }
+    }
+
+    private fun openUrl(uri: Uri) = startActivity(Intent(Intent.ACTION_VIEW, uri))
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -39,7 +39,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.getViewerAssetLoader
 import com.ichi2.anki.localizedErrorMessage
-import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.themes.Themes
 import kotlinx.coroutines.flow.launchIn
@@ -83,7 +82,7 @@ abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
                 domStorageEnabled = true
             }
             loadDataWithBaseURL(
-                "http://${AnkiServer.LOCALHOST}/",
+                viewModel.baseUrl(),
                 stdHtml(requireContext(), Themes.currentTheme.isNightMode),
                 "text/html",
                 null,
@@ -119,13 +118,17 @@ abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
     }
 
     private fun onCreateWebViewClient(savedInstanceState: Bundle?): WebViewClient {
-        val assetLoader = requireContext().getViewerAssetLoader(AnkiServer.LOCALHOST)
+        val assetLoader = requireContext().getViewerAssetLoader(viewModel.assetLoaderDomain())
         return object : WebViewClient() {
             override fun shouldInterceptRequest(
                 view: WebView?,
                 request: WebResourceRequest
             ): WebResourceResponse? {
-                return assetLoader.shouldInterceptRequest(request.url)
+                return if (request.method == "GET") {
+                    assetLoader.shouldInterceptRequest(request.url)
+                } else {
+                    null
+                }
             }
 
             override fun onPageFinished(view: WebView?, url: String?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -159,12 +159,12 @@ abstract class CardViewerViewModel : ViewModel(), OnErrorListener, PostRequestHa
         }
     }
 
-    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray {
+    override suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray? {
         return if (uri.startsWith(AnkiServer.ANKIDROID_JS_PREFIX)) {
             AnkiDroidJsAPI.ApiResult(true, "-1").toString().toByteArray()
         } else {
             Timber.d("Unhandled post request %s", uri)
-            byteArrayOf()
+            null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -1,0 +1,192 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.media.MediaPlayer
+import android.net.Uri
+import androidx.annotation.CallSuper
+import androidx.core.net.toFile
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.OnErrorListener
+import com.ichi2.anki.cardviewer.MediaErrorHandler
+import com.ichi2.anki.cardviewer.SoundErrorBehavior
+import com.ichi2.anki.cardviewer.SoundErrorListener
+import com.ichi2.anki.cardviewer.SoundPlayer
+import com.ichi2.anki.launchCatchingIO
+import com.ichi2.libanki.Card
+import com.ichi2.libanki.Sound
+import com.ichi2.libanki.TtsPlayer
+import com.ichi2.libanki.note
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.jetbrains.annotations.VisibleForTesting
+import org.json.JSONObject
+import timber.log.Timber
+
+abstract class CardViewerViewModel : ViewModel(), OnErrorListener {
+    override val onError = MutableSharedFlow<String>()
+    val onMediaError = MutableSharedFlow<String>()
+    val onTtsError = MutableSharedFlow<TtsPlayer.TtsError>()
+    val mediaErrorHandler = MediaErrorHandler()
+
+    val eval = MutableSharedFlow<String>()
+
+    val showingAnswer = MutableStateFlow(false)
+    protected val soundPlayer = SoundPlayer(createSoundErrorListener())
+    protected lateinit var currentCard: Card
+
+    @CallSuper
+    override fun onCleared() {
+        super.onCleared()
+        soundPlayer.close()
+    }
+
+    /* *********************************************************************************************
+    ************************ Public methods: meant to be used by the View **************************
+    ********************************************************************************************* */
+
+    /**
+     * Call this after the webView has finished loading the page
+     *
+     * @param isAfterRecreation whether this is being called after an `Activity` recreation
+     */
+    abstract fun onPageFinished(isAfterRecreation: Boolean)
+
+    fun setSoundPlayerEnabled(isEnabled: Boolean) {
+        soundPlayer.isEnabled = isEnabled
+    }
+
+    fun playSoundFromUrl(url: String) {
+        launchCatchingIO {
+            Sound.getAvTag(currentCard, url)?.let {
+                soundPlayer.playOneSound(it)
+            }
+        }
+    }
+
+    /* *********************************************************************************************
+    *************************************** Internal methods ***************************************
+    ********************************************************************************************* */
+
+    protected abstract suspend fun typeAnsFilter(text: String): String
+
+    private fun bodyClass(): String = bodyClassForCardOrd(currentCard.ord)
+
+    /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L358) */
+    private suspend fun mungeQA(text: String): String =
+        typeAnsFilter(prepareCardTextForDisplay(text))
+
+    private suspend fun prepareCardTextForDisplay(text: String): String {
+        return Sound.addPlayButtons(withCol { media.escapeMediaFilenames(text) })
+    }
+
+    protected open suspend fun showQuestion() {
+        Timber.v("showQuestion()")
+        showingAnswer.emit(false)
+
+        val questionData = withCol { currentCard.question(this) }
+        val question = mungeQA(questionData)
+        val answer =
+            withCol { media.escapeMediaFilenames(currentCard.answer(this)) }
+
+        eval.emit("_showQuestion(${Json.encodeToString(question)}, ${Json.encodeToString(answer)}, '${bodyClass()}');")
+    }
+
+    protected open suspend fun showAnswer() {
+        Timber.v("showAnswer()")
+        showingAnswer.emit(true)
+        val answerData = withCol { currentCard.answer(this) }
+        val answer = mungeQA(answerData)
+        eval.emit("_showAnswer(${Json.encodeToString(answer)}, '${bodyClass()}');")
+    }
+
+    private fun createSoundErrorListener(): SoundErrorListener {
+        return object : SoundErrorListener {
+            override fun onError(uri: Uri): SoundErrorBehavior {
+                val file = uri.toFile()
+                // There is a multitude of transient issues with the MediaPlayer.
+                // Retrying fixes most of these
+                if (file.exists()) return SoundErrorBehavior.RETRY_AUDIO
+                mediaErrorHandler.processMissingSound(file) { fileName ->
+                    viewModelScope.launch { onMediaError.emit(fileName) }
+                }
+                return SoundErrorBehavior.CONTINUE_AUDIO
+            }
+
+            override fun onMediaPlayerError(
+                mp: MediaPlayer?,
+                which: Int,
+                extra: Int,
+                uri: Uri
+            ): SoundErrorBehavior {
+                Timber.w("Media Error: (%d, %d)", which, extra)
+                return onError(uri)
+            }
+
+            override fun onTtsError(error: TtsPlayer.TtsError, isAutomaticPlayback: Boolean) {
+                mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
+                    viewModelScope.launch { onTtsError.emit(error) }
+                }
+            }
+        }
+    }
+
+    companion object {
+        /* ********************************** Type-in answer ************************************ */
+        /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L669] */
+        @VisibleForTesting
+        val typeAnsRe = Regex("\\[\\[type:(.+?)]]")
+
+        suspend fun getTypeAnswerField(card: Card, text: String): JSONObject? {
+            val match = typeAnsRe.find(text) ?: return null
+
+            val typeAnsFieldName = match.groups[1]!!.value.let {
+                if (it.startsWith("cloze:")) {
+                    it.split(":")[1]
+                } else {
+                    it
+                }
+            }
+
+            val fields = withCol { card.model(this).flds }
+            for (i in 0 until fields.length()) {
+                val field = fields.get(i) as JSONObject
+                if (field.getString("name") == typeAnsFieldName) {
+                    return field
+                }
+            }
+            return null
+        }
+
+        suspend fun getExpectedTypeInAnswer(card: Card, field: JSONObject): String? {
+            val fieldName = field.getString("name")
+            val expected = withCol { card.note().getItem(fieldName) }
+            return if (fieldName.startsWith("cloze:")) {
+                val clozeIdx = card.ord + 1
+                withCol {
+                    extractClozeForTyping(expected, clozeIdx).takeIf { it.isNotBlank() }
+                }
+            } else {
+                expected
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -188,5 +188,7 @@ abstract class CardViewerViewModel : ViewModel(), OnErrorListener {
                 expected
             }
         }
+
+        fun getFontSize(field: JSONObject): String = field.getString("size")
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerActivity.kt
@@ -15,6 +15,21 @@
  */
 package com.ichi2.anki.previewer
 
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
 import com.ichi2.anki.SingleFragmentActivity
+import kotlin.reflect.KClass
+import kotlin.reflect.jvm.jvmName
 
-class PreviewerActivity : SingleFragmentActivity()
+class PreviewerActivity : SingleFragmentActivity() {
+    companion object {
+        fun getIntent(context: Context, fragmentClass: KClass<out Fragment>, arguments: Bundle? = null): Intent {
+            return Intent(context, PreviewerActivity::class.java).apply {
+                putExtra(FRAGMENT_NAME_EXTRA, fragmentClass.jvmName)
+                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -17,28 +17,16 @@ package com.ichi2.anki.previewer
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
-import android.webkit.CookieManager
-import android.webkit.WebChromeClient
-import android.webkit.WebResourceError
-import android.webkit.WebResourceRequest
-import android.webkit.WebResourceResponse
 import android.webkit.WebView
-import android.webkit.WebViewClient
-import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
-import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
-import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
@@ -48,27 +36,27 @@ import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.PreviewerIdsFile
-import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
-import com.ichi2.anki.getViewerAssetLoader
-import com.ichi2.anki.localizedErrorMessage
-import com.ichi2.anki.pages.AnkiServer.Companion.LOCALHOST
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
-import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
-import com.ichi2.themes.Themes
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class PreviewerFragment :
-    Fragment(R.layout.previewer),
+    CardViewerFragment(R.layout.previewer),
     Toolbar.OnMenuItemClickListener,
     BaseSnackbarBuilderProvider {
-    private lateinit var viewModel: PreviewerViewModel
+
+    override val viewModel: PreviewerViewModel by viewModels {
+        val previewerIdsFile = requireNotNull(requireArguments().getSerializableCompat(CARD_IDS_FILE_ARG)) {
+            "$CARD_IDS_FILE_ARG is required"
+        } as PreviewerIdsFile
+        val currentIndex = requireArguments().getInt(CURRENT_INDEX_ARG, 0)
+        PreviewerViewModel.factory(previewerIdsFile, currentIndex)
+    }
+    override val webView: WebView
+        get() = requireView().findViewById(R.id.webview)
 
     override val baseSnackbarBuilder: SnackbarBuilder
         get() = {
@@ -81,54 +69,13 @@ class PreviewerFragment :
         }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        val previewerIdsFile = requireNotNull(requireArguments().getSerializableCompat(CARD_IDS_FILE_ARG)) {
-            "$CARD_IDS_FILE_ARG is required"
-        } as PreviewerIdsFile
-        val currentIndex = requireArguments().getInt(CURRENT_INDEX_ARG, 0)
-
-        viewModel = ViewModelProvider(
-            requireActivity(),
-            PreviewerViewModel.factory(previewerIdsFile, currentIndex)
-        )[PreviewerViewModel::class.java]
-
-        val webView = view.findViewById<WebView>(R.id.webview)
-        CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
-        with(webView) {
-            webViewClient = onCreateWebViewClient(savedInstanceState)
-            webChromeClient = onCreateWebChromeClient()
-            scrollBarStyle = View.SCROLLBARS_OUTSIDE_OVERLAY
-            with(settings) {
-                javaScriptEnabled = true
-                loadWithOverviewMode = true
-                builtInZoomControls = true
-                displayZoomControls = false
-                allowFileAccess = true
-                domStorageEnabled = true
-            }
-            loadDataWithBaseURL(
-                "http://$LOCALHOST/",
-                stdHtml(requireContext(), Themes.currentTheme.isNightMode),
-                "text/html",
-                null,
-                null
-            )
-        }
-
-        setupErrorListeners()
-
+        super.onViewCreated(view, savedInstanceState)
         val slider = view.findViewById<Slider>(R.id.slider)
         val nextButton = view.findViewById<MaterialButton>(R.id.show_next)
         val previousButton = view.findViewById<MaterialButton>(R.id.show_previous)
         val progressIndicator = view.findViewById<MaterialTextView>(R.id.progress_indicator)
-
-        viewModel.eval
-            .flowWithLifecycle(lifecycle)
-            .onEach { eval ->
-                webView.evaluateJavascript(eval, null)
-            }
-            .launchIn(lifecycleScope)
-
         val cardsCount = viewModel.cardsCount()
+
         lifecycleScope.launch {
             viewModel.currentIndex
                 .flowWithLifecycle(lifecycle)
@@ -217,124 +164,6 @@ class PreviewerFragment :
             setOnMenuItemClickListener(this@PreviewerFragment)
             setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
         }
-
-        super.onViewCreated(view, savedInstanceState)
-    }
-
-    private fun setupErrorListeners() {
-        viewModel.onError
-            .flowWithLifecycle(lifecycle)
-            .onEach { errorMessage ->
-                AlertDialog.Builder(requireContext())
-                    .setTitle(R.string.vague_error)
-                    .setMessage(errorMessage)
-                    .show()
-            }
-            .launchIn(lifecycleScope)
-
-        viewModel.onMediaError
-            .onEach { showMediaErrorSnackbar(it) }
-            .launchIn(lifecycleScope)
-
-        viewModel.onTtsError
-            .onEach { showSnackbar(it.localizedErrorMessage(requireContext())) }
-            .launchIn(lifecycleScope)
-    }
-
-    private fun onCreateWebViewClient(savedInstanceState: Bundle?): WebViewClient {
-        val assetLoader = requireContext().getViewerAssetLoader(LOCALHOST)
-        return object : WebViewClient() {
-            override fun shouldInterceptRequest(
-                view: WebView?,
-                request: WebResourceRequest
-            ): WebResourceResponse? {
-                return assetLoader.shouldInterceptRequest(request.url)
-            }
-
-            override fun onPageFinished(view: WebView?, url: String?) {
-                viewModel.onPageFinished(isAfterRecreation = savedInstanceState != null)
-            }
-
-            override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
-                val urlString = request.url.toString()
-                if (urlString.startsWith("playsound:")) {
-                    viewModel.playSoundFromUrl(urlString)
-                    return true
-                }
-                if (urlString.startsWith("tts-voices:")) {
-                    TtsVoicesDialogFragment().show(childFragmentManager, null)
-                    return true
-                }
-                try {
-                    openUrl(request.url)
-                    return true
-                } catch (_: Exception) {
-                    Timber.w("Could not open url")
-                }
-                return false
-            }
-
-            override fun onReceivedError(
-                view: WebView,
-                request: WebResourceRequest,
-                error: WebResourceError
-            ) {
-                viewModel.mediaErrorHandler.processFailure(request) { filename: String ->
-                    showMediaErrorSnackbar(filename)
-                }
-            }
-        }
-    }
-
-    private fun onCreateWebChromeClient(): WebChromeClient {
-        return object : WebChromeClient() {
-            private lateinit var customView: View
-
-            // used for displaying `<video>` in fullscreen.
-            // This implementation requires configChanges="orientation" in the manifest
-            // to avoid destroying the View if the device is rotated
-            override fun onShowCustomView(
-                paramView: View,
-                paramCustomViewCallback: CustomViewCallback?
-            ) {
-                customView = paramView
-                val window = requireActivity().window
-                (window.decorView as FrameLayout).addView(
-                    customView,
-                    FrameLayout.LayoutParams(
-                        FrameLayout.LayoutParams.MATCH_PARENT,
-                        FrameLayout.LayoutParams.MATCH_PARENT
-                    )
-                )
-                // hide system bars
-                with(WindowInsetsControllerCompat(window, window.decorView)) {
-                    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                    hide(WindowInsetsCompat.Type.systemBars())
-                }
-            }
-
-            override fun onHideCustomView() {
-                val window = requireActivity().window
-                (window.decorView as FrameLayout).removeView(customView)
-                // show system bars back
-                with(WindowInsetsControllerCompat(window, window.decorView)) {
-                    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
-                    show(WindowInsetsCompat.Type.systemBars())
-                }
-            }
-        }
-    }
-
-    override fun onStart() {
-        super.onStart()
-        viewModel.setSoundPlayerEnabled(true)
-    }
-
-    override fun onStop() {
-        super.onStop()
-        if (!requireActivity().isChangingConfigurations) {
-            viewModel.setSoundPlayerEnabled(false)
-        }
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
@@ -374,14 +203,6 @@ class PreviewerFragment :
         val intent = viewModel.getNoteEditorDestination().toIntent(requireContext())
         editCardLauncher.launch(intent)
     }
-
-    private fun showMediaErrorSnackbar(filename: String) {
-        showSnackbar(getString(R.string.card_viewer_could_not_find_image, filename)) {
-            setAction(R.string.help) { openUrl(Uri.parse(getString(R.string.link_faq_missing_media))) }
-        }
-    }
-
-    private fun openUrl(uri: Uri) = startActivity(Intent(Intent.ACTION_VIEW, uri))
 
     companion object {
         /** Index of the card to be first displayed among the IDs provided by [CARD_IDS_FILE_ARG] */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -94,7 +94,7 @@ class PreviewerFragment :
         val webView = view.findViewById<WebView>(R.id.webview)
         CookieManager.getInstance().setAcceptThirdPartyCookies(webView, true)
         with(webView) {
-            webViewClient = onCreateWebViewClient()
+            webViewClient = onCreateWebViewClient(savedInstanceState)
             webChromeClient = onCreateWebChromeClient()
             scrollBarStyle = View.SCROLLBARS_OUTSIDE_OVERLAY
             with(settings) {
@@ -241,7 +241,7 @@ class PreviewerFragment :
             .launchIn(lifecycleScope)
     }
 
-    private fun onCreateWebViewClient(): WebViewClient {
+    private fun onCreateWebViewClient(savedInstanceState: Bundle?): WebViewClient {
         val assetLoader = requireContext().getViewerAssetLoader(LOCALHOST)
         return object : WebViewClient() {
             override fun shouldInterceptRequest(
@@ -252,7 +252,7 @@ class PreviewerFragment :
             }
 
             override fun onPageFinished(view: WebView?, url: String?) {
-                viewModel.onPageFinished()
+                viewModel.onPageFinished(isAfterRecreation = savedInstanceState != null)
             }
 
             override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -47,8 +47,6 @@ import com.google.android.material.slider.Slider
 import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
-import com.ichi2.anki.SingleFragmentActivity.Companion.FRAGMENT_ARGS_EXTRA
-import com.ichi2.anki.SingleFragmentActivity.Companion.FRAGMENT_NAME_EXTRA
 import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.getViewerAssetLoader
@@ -65,7 +63,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import kotlin.reflect.jvm.jvmName
 
 class PreviewerFragment :
     Fragment(R.layout.previewer),
@@ -398,10 +395,7 @@ class PreviewerFragment :
                 CURRENT_INDEX_ARG to currentIndex,
                 CARD_IDS_FILE_ARG to previewerIdsFile
             )
-            return Intent(context, PreviewerActivity::class.java).apply {
-                putExtra(FRAGMENT_NAME_EXTRA, PreviewerFragment::class.jvmName)
-                putExtra(FRAGMENT_ARGS_EXTRA, arguments)
-            }
+            return PreviewerActivity.getIntent(context, PreviewerFragment::class, arguments)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
@@ -37,6 +37,7 @@ class NoteEditorDestination(val cardId: Long) {
 /**
  * Not exactly equal to anki's stdHtml. Some differences:
  * * `ankidroid.css` is added
+ * * `js-api.js` is added
  * * `bridgeCommand()` is ignored
  *
  * Aimed to be used only for reviewing/previewing cards
@@ -99,6 +100,7 @@ fun stdHtml(
                     <script src="file:///android_asset/jquery.min.js"></script>
                     <script src="file:///android_asset/mathjax/tex-chtml.js"></script>
                     <script src="file:///android_asset/backend/web/reviewer.js"></script>
+                    <script src="file:///android_asset/scripts/js-api.js"></script>
                     <script>bridgeCommand = function(){};</script>
                 </body>
                 </html>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.launchCatchingIO
+import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
@@ -58,6 +59,8 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
     }
 
     private val showAnswerOnReload get() = showingAnswer.value || backSideOnly.value
+
+    override val server = AnkiServer(this).also { it.start() }
 
     /* *********************************************************************************************
     ************************ Public methods: meant to be used by the View **************************

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -15,13 +15,8 @@
  */
 package com.ichi2.anki.previewer
 
-import android.media.MediaPlayer
-import android.net.Uri
 import androidx.activity.result.ActivityResult
-import androidx.core.net.toFile
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewModelScope
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.ichi2.anki.CollectionManager.withCol
@@ -29,49 +24,30 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.browser.PreviewerIdsFile
-import com.ichi2.anki.cardviewer.MediaErrorHandler
-import com.ichi2.anki.cardviewer.SoundErrorBehavior
-import com.ichi2.anki.cardviewer.SoundErrorListener
-import com.ichi2.anki.cardviewer.SoundPlayer
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.Card
-import com.ichi2.libanki.Sound
-import com.ichi2.libanki.Sound.addPlayButtons
-import com.ichi2.libanki.TtsPlayer
 import com.ichi2.libanki.hasTag
 import com.ichi2.libanki.note
 import com.ichi2.libanki.undoableOp
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.VisibleForTesting
-import org.json.JSONObject
 import timber.log.Timber
 
 class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
-    ViewModel(),
+    CardViewerViewModel(),
     OnErrorListener {
 
-    override val onError = MutableSharedFlow<String>()
-    val onMediaError = MutableSharedFlow<String>()
-    val onTtsError = MutableSharedFlow<TtsPlayer.TtsError>()
-    val mediaErrorHandler = MediaErrorHandler()
-
-    val eval = MutableSharedFlow<String>()
     val currentIndex = MutableStateFlow(firstIndex)
     val backSideOnly = MutableStateFlow(false)
     val isMarked = MutableStateFlow(false)
     val flagCode: MutableStateFlow<Int> = MutableStateFlow(Flag.NONE.code)
-    private val showingAnswer = MutableStateFlow(false)
     private val selectedCardIds: List<Long> = previewerIdsFile.getCardIds()
     val isBackButtonEnabled =
         combine(currentIndex, showingAnswer, backSideOnly) { index, showingAnswer, isBackSideOnly ->
@@ -81,26 +57,15 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
         index != selectedCardIds.lastIndex || !showingAnswer
     }
 
-    private lateinit var currentCard: Card
-
     private val showAnswerOnReload get() = showingAnswer.value || backSideOnly.value
-
-    private val soundPlayer = SoundPlayer(createSoundErrorListener())
-
-    override fun onCleared() {
-        super.onCleared()
-        soundPlayer.close()
-    }
 
     /* *********************************************************************************************
     ************************ Public methods: meant to be used by the View **************************
     ********************************************************************************************* */
 
     /** Call this after the webView has finished loading the page */
-    fun onPageFinished() {
-        /* if currentCard has already been initialized, it means that this method was already called
-        once and the fragment is being recreated, which happens in configuration changes. */
-        if (this::currentCard.isInitialized) {
+    override fun onPageFinished(isAfterRecreation: Boolean) {
+        if (isAfterRecreation) {
             launchCatchingIO { showCard(showAnswerOnReload) }
             return
         }
@@ -188,18 +153,6 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
 
     fun cardsCount() = selectedCardIds.count()
 
-    fun playSoundFromUrl(url: String) {
-        launchCatchingIO {
-            Sound.getAvTag(currentCard, url)?.let {
-                soundPlayer.playOneSound(it)
-            }
-        }
-    }
-
-    fun setSoundPlayerEnabled(isEnabled: Boolean) {
-        soundPlayer.isEnabled = isEnabled
-    }
-
     /* *********************************************************************************************
     *************************************** Internal methods ***************************************
     ********************************************************************************************* */
@@ -207,6 +160,8 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
     private suspend fun showCard(showAnswer: Boolean) {
         currentCard = withCol { getCard(selectedCardIds[currentIndex.value]) }
         if (showAnswer) showAnswer() else showQuestion()
+        updateFlagIcon()
+        updateMarkIcon()
     }
 
     private suspend fun updateFlagIcon() {
@@ -216,30 +171,6 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
     private suspend fun updateMarkIcon() {
         val isMarkedValue = withCol { currentCard.note().hasTag(MARKED_TAG) }
         isMarked.emit(isMarkedValue)
-    }
-
-    private fun bodyClass(): String = bodyClassForCardOrd(currentCard.ord)
-
-    private suspend fun showQuestion() {
-        Timber.v("showQuestion()")
-        showingAnswer.emit(false)
-
-        val questionData = withCol { currentCard.question(this) }
-        val question = mungeQA(questionData)
-        val answer = withCol { media.escapeMediaFilenames(currentCard.answer(this)) }
-
-        eval.emit("_showQuestion(${Json.encodeToString(question)}, ${Json.encodeToString(answer)}, '${bodyClass()}');")
-
-        updateFlagIcon()
-        updateMarkIcon()
-    }
-
-    private suspend fun showAnswer() {
-        Timber.v("showAnswer()")
-        showingAnswer.emit(true)
-        val answerData = withCol { currentCard.answer(this) }
-        val answer = mungeQA(answerData)
-        eval.emit("_showAnswer(${Json.encodeToString(answer)}, '${bodyClass()}');")
     }
 
     private suspend fun loadAndPlaySounds() {
@@ -252,51 +183,12 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
         soundPlayer.playAllSoundsForSide(side)
     }
 
-    /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L358) */
-    private suspend fun mungeQA(text: String): String =
-        typeAnsFilter(prepareCardTextForDisplay(text))
-
-    private suspend fun prepareCardTextForDisplay(text: String): String {
-        return addPlayButtons(withCol { media.escapeMediaFilenames(text) })
-    }
-
     /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L671) */
-    private suspend fun typeAnsFilter(text: String): String {
+    override suspend fun typeAnsFilter(text: String): String {
         return if (showingAnswer.value) {
             typeAnsAnswerFilter(currentCard, text)
         } else {
             typeAnsQuestionFilter(text)
-        }
-    }
-
-    private fun createSoundErrorListener(): SoundErrorListener {
-        return object : SoundErrorListener {
-            override fun onError(uri: Uri): SoundErrorBehavior {
-                val file = uri.toFile()
-                // There is a multitude of transient issues with the MediaPlayer.
-                // Retrying fixes most of these
-                if (file.exists()) return SoundErrorBehavior.RETRY_AUDIO
-                mediaErrorHandler.processMissingSound(file) { fileName ->
-                    viewModelScope.launch { onMediaError.emit(fileName) }
-                }
-                return SoundErrorBehavior.CONTINUE_AUDIO
-            }
-
-            override fun onMediaPlayerError(
-                mp: MediaPlayer?,
-                which: Int,
-                extra: Int,
-                uri: Uri
-            ): SoundErrorBehavior {
-                Timber.w("Media Error: (%d, %d)", which, extra)
-                return onError(uri)
-            }
-
-            override fun onTtsError(error: TtsPlayer.TtsError, isAutomaticPlayback: Boolean) {
-                mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
-                    viewModelScope.launch { onTtsError.emit(error) }
-                }
-            }
         }
     }
 
@@ -309,50 +201,10 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
             }
         }
 
-        /* ********************************** Type-in answer ************************************ */
-
-        /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L669] */
-        @VisibleForTesting
-        val typeAnsRe = Regex("\\[\\[type:(.+?)]]")
-
         /** removes `[[type:]]` blocks in questions */
         @VisibleForTesting
         fun typeAnsQuestionFilter(text: String) =
             typeAnsRe.replace(text, "")
-
-        private suspend fun getTypeAnswerField(card: Card, text: String): JSONObject? {
-            val match = typeAnsRe.find(text) ?: return null
-
-            val typeAnsFieldName = match.groups[1]!!.value.let {
-                if (it.startsWith("cloze:")) {
-                    it.split(":")[1]
-                } else {
-                    it
-                }
-            }
-
-            val fields = withCol { card.model(this).flds }
-            for (i in 0 until fields.length()) {
-                val field = fields.get(i) as JSONObject
-                if (field.getString("name") == typeAnsFieldName) {
-                    return field
-                }
-            }
-            return null
-        }
-
-        private suspend fun getExpectedTypeInAnswer(card: Card, field: JSONObject): String? {
-            val fieldName = field.getString("name")
-            val expected = withCol { card.note().getItem(fieldName) }
-            return if (fieldName.startsWith("cloze:")) {
-                val clozeIdx = card.ord + 1
-                withCol {
-                    extractClozeForTyping(expected, clozeIdx).takeIf { it.isNotBlank() }
-                }
-            } else {
-                expected
-            }
-        }
 
         /** Adapted from the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L720) */
         suspend fun typeAnsAnswerFilter(card: Card, text: String): String {
@@ -363,12 +215,11 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
             val typeFont = typeAnswerField.getString("font")
             val typeSize = typeAnswerField.getString("size")
             val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
-            return typeAnsRe.replace(text) {
-                @Language("HTML")
-                val output =
-                    """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
-                output
-            }
+
+            @Language("HTML")
+            val output =
+                """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
+            return typeAnsRe.replace(text, output)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -213,7 +213,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
             val expectedAnswer = getExpectedTypeInAnswer(card, typeAnswerField)
                 ?: return typeAnsRe.replace(text, "")
             val typeFont = typeAnswerField.getString("font")
-            val typeSize = typeAnswerField.getString("size")
+            val typeSize = getFontSize(typeAnswerField)
             val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
 
             @Language("HTML")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebView
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import com.ichi2.anki.R
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
+import com.ichi2.anki.snackbar.SnackbarBuilder
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
+
+class TemplatePreviewerFragment :
+    CardViewerFragment(R.layout.template_previewer),
+    BaseSnackbarBuilderProvider {
+
+    override val viewModel: TemplatePreviewerViewModel by viewModels {
+        val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
+        TemplatePreviewerViewModel.factory(arguments)
+    }
+    override val webView: WebView
+        get() = requireView().findViewById(R.id.webview)
+
+    override val baseSnackbarBuilder: SnackbarBuilder
+        get() = { anchorView = this@TemplatePreviewerFragment.view?.findViewById(R.id.show_answer) }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
+            requireActivity().onBackPressedDispatcher.onBackPressed()
+        }
+        setupButtons(view)
+    }
+
+    private fun setupButtons(view: View) {
+        val showAnswerButton = view.findViewById<MaterialButton>(R.id.show_answer).apply {
+            setOnClickListener { viewModel.toggleShowAnswer() }
+        }
+        val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)
+
+        viewModel.showingAnswer
+            .onEach { showingAnswer ->
+                showAnswerButton.text = if (showingAnswer) {
+                    getString(R.string.hide_answer)
+                } else {
+                    getString(R.string.show_answer)
+                }
+            }
+            .launchIn(lifecycleScope)
+
+        launchCatchingTask {
+            viewModel.getTemplateNames().forEach {
+                tabLayout.addTab(tabLayout.newTab().setText(it))
+            }
+            tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))
+            tabLayout.addOnTabSelectedListener(object : OnTabSelectedListener {
+                override fun onTabSelected(tab: TabLayout.Tab) {
+                    Timber.v("Selected tab %d", tab.position)
+                    viewModel.onTabSelected(tab.position)
+                }
+
+                override fun onTabUnselected(tab: TabLayout.Tab) {
+                    // do nothing
+                }
+
+                override fun onTabReselected(tab: TabLayout.Tab) {
+                    // do nothing
+                }
+            })
+        }
+    }
+
+    companion object {
+        const val ARGS_KEY = "templatePreviewerArgs"
+
+        fun getIntent(context: Context, arguments: TemplatePreviewerArguments): Intent {
+            return PreviewerActivity.getIntent(
+                context,
+                TemplatePreviewerFragment::class,
+                bundleOf(ARGS_KEY to arguments)
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import android.os.Parcelable
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.NotetypeFile
+import com.ichi2.anki.launchCatchingIO
+import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.anki.utils.ext.ifNullOrEmpty
+import com.ichi2.libanki.Note
+import com.ichi2.libanki.NotetypeJson
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.parcelize.Parcelize
+import org.intellij.lang.annotations.Language
+
+class TemplatePreviewerViewModel(arguments: TemplatePreviewerArguments) : CardViewerViewModel() {
+    private val notetype = arguments.notetype
+    private val fillEmpty = arguments.fillEmpty
+
+    /**
+     * identifies which of the card templates or cloze deletions it corresponds to
+     * * for card templates, values are from 0 to the number of templates minus 1
+     * * for cloze deletions, values are from 0 to max cloze index minus 1
+     */
+    private val ordFlow = MutableStateFlow(arguments.ord)
+
+    private lateinit var note: Note
+    private lateinit var templateNames: List<String>
+    private var initJob: Job? = null
+
+    init {
+        initJob = launchCatchingIO {
+            note = withCol {
+                if (arguments.id != 0L) {
+                    Note(this, arguments.id)
+                } else {
+                    Note.fromNotetypeId(this, arguments.notetype.id)
+                }
+            }.apply {
+                fields = arguments.fields
+                tags = arguments.tags
+            }
+
+            templateNames = if (notetype.isCloze) {
+                val tr = CollectionManager.TR
+                withCol { clozeNumbersInNote(note) }.map { tr.cardTemplatesCloze(it) }
+            } else {
+                notetype.templatesNames
+            }
+        }.also {
+            it.invokeOnCompletion {
+                initJob = null
+            }
+        }
+    }
+
+    /* *********************************************************************************************
+    ************************ Public methods: meant to be used by the View **************************
+    ********************************************************************************************* */
+
+    override fun onPageFinished(isAfterRecreation: Boolean) {
+        if (isAfterRecreation) {
+            launchCatchingIO {
+                if (showingAnswer.value) showAnswer() else showQuestion()
+            }
+            return
+        }
+        launchCatchingIO {
+            initJob?.join()
+            ordFlow.collectLatest {
+                currentCard = withCol {
+                    note.ephemeralCard(
+                        col = this,
+                        ord = ordFlow.value,
+                        customNoteType = notetype,
+                        fillEmpty = fillEmpty
+                    )
+                }
+                showQuestion()
+                loadAndPlaySounds(CardSide.QUESTION)
+            }
+        }
+    }
+
+    fun toggleShowAnswer() {
+        launchCatchingIO {
+            if (showingAnswer.value) {
+                showQuestion()
+                loadAndPlaySounds(CardSide.QUESTION)
+            } else {
+                showAnswer()
+                loadAndPlaySounds(CardSide.ANSWER)
+            }
+        }
+    }
+
+    suspend fun getTemplateNames(): List<String> {
+        initJob?.join()
+        return templateNames
+    }
+
+    fun onTabSelected(ord: Int) {
+        launchCatchingIO { ordFlow.emit(ord) }
+    }
+
+    fun getCurrentTabIndex(): Int = ordFlow.value
+
+    /* *********************************************************************************************
+    *************************************** Internal methods ***************************************
+    ********************************************************************************************* */
+
+    private suspend fun loadAndPlaySounds(side: CardSide) {
+        soundPlayer.loadCardSounds(currentCard)
+        soundPlayer.playAllSoundsForSide(side)
+    }
+
+    // https://github.com/ankitects/anki/blob/df70564079f53e587dc44f015c503fdf6a70924f/qt/aqt/clayout.py#L579
+    override suspend fun typeAnsFilter(text: String): String {
+        val typeAnswerField = getTypeAnswerField(currentCard, text)
+        val expectedAnswer = typeAnswerField?.let {
+            getExpectedTypeInAnswer(currentCard, typeAnswerField)
+        }.ifNullOrEmpty { "example" }
+
+        val repl = if (showingAnswer.value) {
+            withCol { compareAnswer(expectedAnswer, "sample") }
+        } else {
+            "<center><input id='typeans' type=text value='example' readonly='readonly'></center>"
+        }
+        // Anki doesn't set the font size of the type answer field in the template previewer,
+        // but it does in the reviewer. To get a more accurate preview of what people are going
+        // to study, the font size is being set here.
+        val out = if (typeAnswerField != null) {
+            val fontSize = getFontSize(typeAnswerField)
+
+            @Language("HTML")
+            val replWithFontSize = """<div style="font-size: ${fontSize}px">$repl</div>"""
+            typeAnsRe.replaceFirst(text, replWithFontSize)
+        } else {
+            typeAnsRe.replaceFirst(text, repl)
+        }
+
+        val warning = "<center><b>${CollectionManager.TR.cardTemplatesTypeBoxesWarning()}</b></center>"
+        return typeAnsRe.replace(out, warning)
+    }
+
+    companion object {
+        fun factory(arguments: TemplatePreviewerArguments): ViewModelProvider.Factory {
+            return viewModelFactory {
+                initializer {
+                    TemplatePreviewerViewModel(arguments)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * @param id id of the note. Use 0 for non-created notes.
+ *
+ * @param ord identifies which of the card templates or cloze deletions it corresponds to
+ * * for card templates, values are from 0 to the number of templates minus 1
+ * * for cloze deletions, values are from 0 to max cloze index minus 1
+ *
+ * @param fillEmpty if blank fields should be replaced with placeholder content
+ */
+@Parcelize
+data class TemplatePreviewerArguments(
+    private val notetypeFile: NotetypeFile,
+    val fields: MutableList<String>,
+    val tags: MutableList<String>,
+    val id: Long = 0,
+    val ord: Int = 0,
+    val fillEmpty: Boolean = false
+) : Parcelable {
+    val notetype: NotetypeJson get() = notetypeFile.getNotetype()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NotetypeFile
 import com.ichi2.anki.launchCatchingIO
+import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.utils.ext.ifNullOrEmpty
 import com.ichi2.libanki.Note
@@ -47,6 +48,7 @@ class TemplatePreviewerViewModel(arguments: TemplatePreviewerArguments) : CardVi
     private lateinit var note: Note
     private lateinit var templateNames: List<String>
     private var initJob: Job? = null
+    override val server = AnkiServer(this).also { it.start() }
 
     init {
         initJob = launchCatchingIO {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
@@ -1,0 +1,19 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils.ext
+
+fun String?.ifNullOrEmpty(defaultValue: () -> String): String =
+    if (isNullOrEmpty()) defaultValue() else this

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -202,19 +202,19 @@ class Note : Cloneable {
      * Tags
      * ***********************************************************
      */
-    fun hasTag(col: Collection, tag: String?): Boolean {
-        return col.tags.inList(tag!!, tags)
+    fun hasTag(col: Collection, tag: String): Boolean {
+        return col.tags.inList(tag, tags)
     }
 
     fun stringTags(col: Collection): String {
         return col.tags.join(col.tags.canonify(tags))
     }
 
-    fun setTagsFromStr(col: Collection, str: String?) {
-        tags = col.tags.split(str!!)
+    fun setTagsFromStr(col: Collection, str: String) {
+        tags = col.tags.split(str)
     }
 
-    fun removeTag(tag: String?) {
+    fun removeTag(tag: String) {
         val rem: MutableList<String> = ArrayList(
             tags.size
         )
@@ -235,8 +235,8 @@ class Note : Cloneable {
         tags.add(tag)
     }
 
-    fun addTags(tags: AbstractSet<String>?) {
-        tags!!.addAll(tags)
+    fun addTags(tags: AbstractSet<String>) {
+        tags.addAll(tags)
     }
 
     /**
@@ -308,7 +308,7 @@ fun Note.hasTag(tag: String) = this.hasTag(this@Collection, tag)
 
 /** @see Note.setTagsFromStr */
 context (Collection)
-fun Note.setTagsFromStr(str: String?) = this.setTagsFromStr(this@Collection, str)
+fun Note.setTagsFromStr(str: String) = this.setTagsFromStr(this@Collection, str)
 
 /** @see Note.load */
 context (Collection)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -48,9 +48,7 @@ class Note : Cloneable {
     var mid: Long = 0
         private set
     lateinit var tags: MutableList<String>
-        private set
     lateinit var fields: MutableList<String>
-        private set
     private var fMap: Map<String, Pair<Int, JSONObject>>? = null
     var usn = 0
         private set

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".previewer.TemplatePreviewerFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/appbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <com.google.android.material.appbar.MaterialToolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:navigationContentDescription="@string/abc_action_bar_up_description"
+                app:navigationIcon="?attr/homeAsUpIndicator">
+
+                <com.google.android.material.tabs.TabLayout
+                    android:id="@+id/tab_layout"
+                    android:background="@color/transparent"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    app:tabMode="scrollable"
+                    />
+
+            </com.google.android.material.appbar.MaterialToolbar>
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <WebView
+            android:id="@+id/webview"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:background="@color/transparent"
+            app:layout_constraintTop_toBottomOf="@id/appbar"
+            app:layout_constraintBottom_toTopOf="@id/show_answer"
+            />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/show_answer"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            style="@style/Widget.Material3.Button.TextButton"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/webview"
+            android:text="@string/show_answer"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

On top of #15554. Only the last two commits are for this PR

## Approach

Handle the JS API the exact same way the old previewer/templatePreviewer do: sending empty messages

## How Has This Been Tested?

emulator 31

[js api.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/2da51da7-278b-45b9-b17f-f9b3bba9cae7)

[definetely.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/7ca6185c-c43e-4401-85e2-664f0f1aa6ec)


## Learning (optional, can help others)

The JS API is still in 0.0.2, so I believe that I can be more radical when reorganizing it for the reviewer rewrite

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
