### PR TITLE
make possible to use `-night` resources

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -24,6 +24,7 @@ import android.content.res.Configuration
 import android.graphics.Color
 import androidx.annotation.AttrRes
 import androidx.annotation.ColorInt
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
@@ -51,6 +52,7 @@ object Themes {
     fun setTheme(context: Context) {
         updateCurrentTheme(context)
         Timber.i("Setting theme to %s", currentTheme.name)
+        AppCompatDelegate.setDefaultNightMode(getDefaultNightModeFromTheme(context))
         context.setTheme(currentTheme.resId)
     }
 
@@ -136,6 +138,23 @@ object Themes {
     fun systemIsInNightMode(context: Context): Boolean {
         return context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
             Configuration.UI_MODE_NIGHT_YES
+    }
+
+    private fun getDefaultNightModeFromTheme(context: Context): Int {
+        // TODO (#5019): always use the context as the parameter for sharedPrefs()
+        val prefs = if (context is AppCompatPreferenceActivity<*>) {
+            AnkiDroidApp.instance.sharedPrefs()
+        } else {
+            context.sharedPrefs()
+        }
+        if (themeFollowsSystem(prefs)) {
+            return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+        }
+        return if (currentTheme.isNightMode) {
+            AppCompatDelegate.MODE_NIGHT_YES
+        } else {
+            AppCompatDelegate.MODE_NIGHT_NO
+        }
     }
 }
 


### PR DESCRIPTION
the system needs to now the default night mode of the app to get `-night` resources

## How Has This Been Tested?

Emulator 31:
1. create a colors.xml file in `values-night/`
2. override some `@color` resource
3. check out the result in night mode

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
