### PR TITLE
return opChanges in setUserFlagForCards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -263,7 +263,7 @@ open class Reviewer :
         }
         launchCatchingTask {
             card.setUserFlag(flag.code)
-            withCol {
+            undoableOp(this@Reviewer) {
                 setUserFlagForCards(listOf(card.id), flag.code)
             }
             refreshActionBar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -43,6 +43,7 @@ import com.ichi2.libanki.Sound.addPlayButtons
 import com.ichi2.libanki.TtsPlayer
 import com.ichi2.libanki.hasTag
 import com.ichi2.libanki.note
+import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -135,7 +136,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int) :
 
     fun setFlag(flag: Flag) {
         launchCatchingIO {
-            withCol {
+            undoableOp {
                 setUserFlagForCards(listOf(currentCard.id), flag.code)
             }
             flagCode.emit(flag.code)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -679,8 +679,9 @@ open class Collection(
     }
 
     /** Change the flag color of the specified cards. flag=0 removes flag. */
-    fun setUserFlagForCards(cids: Iterable<Long>, flag: Int) {
-        backend.setFlag(cardIds = cids, flag = flag)
+    @CheckResult
+    fun setUserFlagForCards(cids: Iterable<Long>, flag: Int): OpChangesWithCount {
+        return backend.setFlag(cardIds = cids, flag = flag)
     }
 
     fun getEmptyCards(): EmptyCardsReport {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

~~Gonna need it to fix a bug~~ Actually, it already fixes the bug of the card browser not being updated after card changes in the new previewer

## Approach

match the desktop code and return opChanges in setUserFlagForCards

## How Has This Been Tested?

[el fuego.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/83f105e5-322f-4d18-8e9b-0b36ddccdd27)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
