### PR TITLE
hack: fix deck import crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -20,6 +20,7 @@ import android.app.Activity
 import android.content.Intent
 import androidx.core.app.TaskStackBuilder
 import androidx.core.content.edit
+import androidx.lifecycle.Lifecycle
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.ImportDialog
@@ -29,6 +30,7 @@ import com.ichi2.anki.pages.CsvImporter
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
 
@@ -46,11 +48,17 @@ fun interface ImportColpkgListener {
     fun onImportColpkg(colpkgPath: String?)
 }
 
+@NeedsTest("successful import from the app menu")
 fun DeckPicker.onSelectedPackageToImport(data: Intent) {
     val importResult = ImportUtils.handleFileImport(this, data)
     if (!importResult.isSuccess) {
         runOnUiThread {
             ImportUtils.showImportUnsuccessfulDialog(this, importResult.humanReadableMessage, false)
+        }
+    } else {
+        // a Message was posted, don't wait for onResume to process it
+        if (this.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+            dialogHandler.popMessage()?.let { dialogHandler.sendStoredMessage(it) }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
`onResume` was expected to be called, but wasn't

This meant the `Message` was stored, but not executed.

When a user went to import again, there were two `Messages` to import

Both of these were executed, as finishing the import called `onResume` One executed successfully, showing the dialog
the second executed after the `Import` screen was opened and crashed due to issue 5075


## Fixes
* Fixes #15635
* Closes https://github.com/ankidroid/Anki-Android/pull/15636

## Approach
Execute the message after it's posted

## How Has This Been Tested?
API 33 emulator

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
