### PR TITLE
fix: checkbox style in black theme

### DIFF
--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -195,6 +195,7 @@
 
     <style name="AlertDialogStyle" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorPrimary">?attr/progressDialogButtonTextColor</item>
+        <item name="buttonTint">?attr/colorOnPrimary</item>
         <item name="dialogCornerRadius">@dimen/dialog_corner_radius</item>
         <item name="android:background">?attr/dialogBackground</item>
         <item name="android:dialogCornerRadius" tools:targetApi="p">@dimen/dialog_corner_radius</item>


### PR DESCRIPTION
## Purpose / Description
In the black theme, the checkbox had a black tint

## Fixes
* Fixes #15638

## Approach
This had no contrast with the background, so change it to white

## How Has This Been Tested?
<img width="352" alt="Screenshot 2024-02-24 at 13 48 19" src="https://github.com/ankidroid/Anki-Android/assets/62114487/5af5ee48-658d-4ec6-a87f-c942cf7139fd">

<img width="348" alt="Screenshot 2024-02-24 at 13 48 08" src="https://github.com/ankidroid/Anki-Android/assets/62114487/c8d7dc71-0f8b-4505-8a0a-972c0a65541e">

<img width="361" alt="Screenshot 2024-02-24 at 13 47 56" src="https://github.com/ankidroid/Anki-Android/assets/62114487/a0be596c-62e6-4b95-bf70-eb6a609577f1">

<img width="358" alt="Screenshot 2024-02-24 at 13 47 32" src="https://github.com/ankidroid/Anki-Android/assets/62114487/c59080b7-8b11-4416-91eb-3a8cd755fdc0">

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
