### PR TITLE
NF: Reposition Card Template Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -48,6 +48,7 @@ import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog.Companion.REQUEST_FIELD_INSERT
 import com.ichi2.anki.notetype.RenameCardTemplateDialog
+import com.ichi2.anki.notetype.RepositionCardTemplateDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.TemplatePreviewerArguments
 import com.ichi2.anki.previewer.TemplatePreviewerFragment
@@ -442,6 +443,14 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             }
         }
 
+        private fun showRepositionDialog() {
+            RepositionCardTemplateDialog.showInstance(requireContext(), templateEditor.viewPager.adapter!!.itemCount) { newPosition ->
+                val currentPosition = templateEditor.viewPager.currentItem
+                Timber.w("moving card template %d to %d", currentPosition, newPosition)
+                TODO("CardTemplateNotetype is a complex class and requires significant testing")
+            }
+        }
+
         @Suppress("unused")
         private fun insertField(fieldName: String) {
             val start = max(editorEditText.selectionStart, 0)
@@ -544,6 +553,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                                 confirmAddCards(tempModel.notetype, numAffectedCards)
                                 return true
                             }
+                            R.id.action_reposition -> showRepositionDialog()
                             R.id.action_rename -> showRenameDialog()
                             R.id.action_insert_field -> showInsertFieldDialog()
                             R.id.action_delete -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RepositionCardTemplateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RepositionCardTemplateDialog.kt
@@ -1,0 +1,55 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.notetype
+
+import android.content.Context
+import android.text.InputType
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.R
+import com.ichi2.utils.getInputField
+import com.ichi2.utils.input
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+
+class RepositionCardTemplateDialog {
+
+    companion object {
+        fun showInstance(context: Context, numberOfTemplates: Int, result: (Int) -> Unit) {
+            var displayedDialog: AlertDialog? = null
+
+            displayedDialog = AlertDialog.Builder(context).show {
+                positiveButton(R.string.dialog_ok) { result(displayedDialog!!.getInputField().text.toString().toInt()) }
+                negativeButton(R.string.dialog_cancel)
+                setMessage(CollectionManager.TR.cardTemplatesEnterNewCardPosition1(numberOfTemplates))
+                setView(R.layout.dialog_generic_text_input)
+            }.input(
+                inputType = InputType.TYPE_CLASS_NUMBER,
+                displayKeyboard = true,
+                waitForPositiveButton = false
+            ) { dialog, text: CharSequence ->
+                val number = text.toString().toIntOrNull()
+                if (number == null || number < 1 || number > numberOfTemplates) {
+                    dialog.positiveButton.isEnabled = false
+                    return@input
+                }
+                dialog.positiveButton.isEnabled = true
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -16,6 +16,12 @@
         android:id="@+id/action_add"
         android:title="@string/menu_add"
         ankidroid:showAsAction="never"/>
+    <!-- not implemented -->
+    <item
+        android:id="@+id/action_reposition"
+        android:title="@string/card_template_reposition_template"
+        android:visible="false"
+        ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_rename"
         android:title="@string/rename"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -124,7 +124,7 @@
 
     <string name="fact_adder_intent_title" comment="Label of the 'Add Note' window. This title can't be seen in AnkiDroid directly.">AnkiDroid card</string>
     <string name="note_editor_copy_note">Copy note</string>
-    <string name="card_editor_reposition_card">Reposition</string>
+    <string name="card_editor_reposition_card" comment="reposition a card in the new queue">Reposition</string>
     <string name="card_editor_reset_card">Reset progress</string>
     <string name="card_editor_reschedule_card" comment="Action to reschedule a card">Reschedule</string>
     <string name="card_editor_preview_card" comment="Button offering to preview some card(s)">Preview</string>
@@ -434,4 +434,6 @@ opening the system text to speech settings fails">
     <string name="failed_to_copy">Failed to copy</string>
 
     <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
+
+    <string name="card_template_reposition_template" comment="move a card template to a new position">Reposition</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Just the UI

Not yet implemented due to the logical complexity: the CardTemplateNotetype keeps an in memory log of changes, and a reposition + delete would need to be thoroughly tested to be sure it does not delete incorrect templates

## Issue
* #6017

## How Has This Been Tested?
Non-functional, just adding the dialog class

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
