### PR TITLE
fix + perf: use file scheme in `<img>` `<audio>`, `<video>` and `<object>`

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
@@ -132,4 +132,35 @@ class TemplateManagerTest {
         val result = parseSourcesToFileScheme("<img src=magenta.png>", "storage/emulated/0/AnkiDroid@#$%/collection.media")
         assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid@%23$%25/collection.media/magenta.png">""", result)
     }
+
+    /***********************************************************************************************
+     * [parseVideos] tests
+     **********************************************************************************************/
+
+    @Test
+    fun `parseVideos - video in anki scheme`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseVideos("[sound:samba.mp4]", mediaDir)
+        assertEquals("""<video src="file:///$mediaDir/samba.mp4" controls controlsList="nodownload"></video>""", result)
+    }
+
+    @Test
+    fun `parseVideos - special characters are encoded`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseVideos("[sound:bregafunk@$%#.mp4]", mediaDir)
+        assertEquals("""<video src="file:///$mediaDir/bregafunk@$%25%23.mp4" controls controlsList="nodownload"></video>""", result)
+    }
+
+    @Test
+    fun `parseVideos - sound extensions aren't parsed`() {
+        val result = parseVideos("[sound:forró.mp3]", "any_directory")
+        assertEquals("[sound:forró.mp3]", result)
+    }
+
+    @Test
+    fun `parseVideos - other content kept`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseVideos("rio [sound:bossa_nova.mkv]", mediaDir)
+        assertEquals("""rio <video src="file:///$mediaDir/bossa_nova.mkv" controls controlsList="nodownload"></video>""", result)
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.libanki
+
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@Suppress("HtmlUnknownTarget", "HtmlRequiredAltAttribute")
+class TemplateManagerTest {
+
+    /***********************************************************************************************
+     * [parseSourcesToFileScheme] tests
+     **********************************************************************************************/
+
+    @Test
+    fun `parseSourcesToFileScheme - img`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseSourcesToFileScheme("<img src=magenta.png>", mediaDir)
+        assertEquals("""<img src="file:///$mediaDir/magenta.png">""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - audio`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseSourcesToFileScheme("<audio controls src=FOO_bar.mp3 style=\"visibility: hidden;\"></audio>", mediaDir)
+        assertEquals("""<audio controls src="file:///$mediaDir/FOO_bar.mp3" style="visibility: hidden;"></audio>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - video`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseSourcesToFileScheme("""<video src="figaro.mp4"></video>""", mediaDir)
+        assertEquals("""<video src="file:///$mediaDir/figaro.mp4"></video>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - object`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+        val result = parseSourcesToFileScheme("<object data=\"ben.avi\"></object>", mediaDir)
+        assertEquals("""<object data="file:///$mediaDir/ben.avi"></object>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - source`() {
+        val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
+
+        @Language("HTML")
+        val content = """<video width="320" height="240" controls><source src="AnkiDroid.mp4" type="video/mp4"></video>"""
+
+        @Language("HTML")
+        val expected = """<video width="320" height="240" controls><source src="file:///$mediaDir/AnkiDroid.mp4" type="video/mp4"></video>"""
+
+        val result = parseSourcesToFileScheme(content, mediaDir)
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - uppercase tag and attribute`() {
+        @Language("HTML")
+        val content = "<IMG SRC=magenta.png>"
+
+        @Language("HTML")
+        val expectedResult = """<img src="file:///storage/emulated/0/AnkiDroid/collection.media/magenta.png">"""
+        val result = parseSourcesToFileScheme(content, "storage/emulated/0/AnkiDroid/collection.media")
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - invalid sources not parsed`() {
+        val result = parseSourcesToFileScheme("<img src=\"m#gent%nki.png\">", "any_directory")
+        assertEquals("""<img src="m#gent%nki.png">""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - strings without img,audio,video and object aren't parsed`() {
+        val result = parseSourcesToFileScheme("<p> foo</p>", "any_directory")
+        assertEquals("<p> foo</p>", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - HTTP scheme isn't parsed`() {
+        val result = parseSourcesToFileScheme("<audio src=\"http://ankidroid.org/secret.mp3\"></audio>", "any_directory")
+        assertEquals("""<audio src="http://ankidroid.org/secret.mp3"></audio>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - File scheme isn't parsed`() {
+        val result = parseSourcesToFileScheme("""<audio src="file:///storage/lies.m4a"></audio>""", "any_directory")
+        assertEquals("""<audio src="file:///storage/lies.m4a"></audio>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - tags without a source aren't parsed`() {
+        val result = parseSourcesToFileScheme("""<audio id="ben"></audio>""", "any_directory")
+        assertEquals("""<audio id="ben"></audio>""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - full directory`() {
+        val result = parseSourcesToFileScheme("<img src=magenta.png>", "storage/emulated/0/AnkiDroid/collection.media")
+        assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid/collection.media/magenta.png">""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - play directory`() {
+        val result = parseSourcesToFileScheme("<img src=magenta.png>", "storage/emulated/0/Android/data/com.ichi2.anki/files/AnkiDroid/collection.media")
+        assertEquals("""<img src="file:///storage/emulated/0/Android/data/com.ichi2.anki/files/AnkiDroid/collection.media/magenta.png">""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - full directory with slash at the beginning and end`() {
+        val result = parseSourcesToFileScheme("<img src=magenta.png>", "/storage/emulated/0/AnkiDroid/collection.media/")
+        assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid/collection.media/magenta.png">""", result)
+    }
+
+    @Test
+    fun `parseSourcesToFileScheme - path with special characters`() {
+        val result = parseSourcesToFileScheme("<img src=magenta.png>", "storage/emulated/0/AnkiDroid@#$%/collection.media")
+        assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid@%23$%25/collection.media/magenta.png">""", result)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

To be able to use a server to intercept POST requests in the reviewer, the base url of the reviewer isn't the media directory anymore, so files aren't automatically using the `file:///` protocol

## Fixes
* Fixes #15631

## Approach

It uses the `file:///` scheme in the tag sources, which allow seeking and has a better performance than using HTTP partial content (I tried https://github.com/ankidroid/Anki-Android/compare/main...BrayanDSO:Anki-Android:fix_audio_seeking)

## How Has This Been Tested?

### Please note that I removed the video audio because it was copyrighted

Emulator 31:

[yeah-boy_3drhy0gn.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/7cb784c8-a3a8-402b-b431-e998d7e182e4)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
