### PR TITLE
refactor: use `-night` to deduplicate browser flag colors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -28,13 +28,14 @@ import android.widget.*
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
+import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.ThemeUtils
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
 import com.afollestad.materialdialogs.utils.MDUtil.ifNotZero
-import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anki.CollectionManager.TR
@@ -1784,7 +1785,7 @@ open class CardBrowser :
                     column.text = card.getColumnHeaderText(fromKeys[i]) // set text for column
                 }
             // set card's background color
-            val backgroundColor: Int = MaterialColors.getColor(this@CardBrowser, card.color, 0)
+            val backgroundColor: Int = card.getBackgroundColor(this@CardBrowser)
             v.setBackgroundColor(backgroundColor)
             // setup checkbox to change color in multi-select mode
             val checkBox = v.findViewById<CheckBox>(R.id.card_checkbox)
@@ -1961,27 +1962,21 @@ open class CardBrowser :
          * Get the background color of items in the card list based on the Card
          * @return index into TypedArray specifying the background color
          */
-        val color: Int
-            get() {
-                return when (card.userFlag()) {
-                    1 -> R.attr.flagRed
-                    2 -> R.attr.flagOrange
-                    3 -> R.attr.flagGreen
-                    4 -> R.attr.flagBlue
-                    5 -> R.attr.flagPink
-                    6 -> R.attr.flagTurquoise
-                    7 -> R.attr.flagPurple
-                    else -> {
-                        if (isMarked(col, card.note(col))) {
-                            R.attr.markedColor
-                        } else if (card.queue == Consts.QUEUE_TYPE_SUSPENDED) {
-                            R.attr.suspendedColor
-                        } else {
-                            android.R.attr.colorBackground
-                        }
-                    }
-                }
+        @ColorInt
+        fun getBackgroundColor(context: Context): Int {
+            val flagColor = Flag.fromCode(card.userFlag()).browserColorRes
+            if (flagColor != null) {
+                return context.getColor(flagColor)
             }
+            val colorAttr = if (isMarked(col, card.note(col))) {
+                R.attr.markedColor
+            } else if (card.queue == Consts.QUEUE_TYPE_SUSPENDED) {
+                R.attr.suspendedColor
+            } else {
+                android.R.attr.colorBackground
+            }
+            return ThemeUtils.getThemeAttrColor(context, colorAttr)
+        }
 
         fun getColumnHeaderText(key: CardBrowserColumn?): String? {
             return when (key) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -15,20 +15,21 @@
  */
 package com.ichi2.anki
 
+import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
 
-enum class Flag(val code: Int, @DrawableRes val drawableRes: Int) {
-    NONE(0, R.drawable.ic_flag_transparent),
-    RED(1, R.drawable.ic_flag_red),
-    ORANGE(2, R.drawable.ic_flag_orange),
-    GREEN(3, R.drawable.ic_flag_green),
-    BLUE(4, R.drawable.ic_flag_blue),
-    PINK(5, R.drawable.ic_flag_pink),
-    TURQUOISE(6, R.drawable.ic_flag_turquoise),
-    PURPLE(7, R.drawable.ic_flag_purple);
+enum class Flag(val code: Int, @DrawableRes val drawableRes: Int, @ColorRes val browserColorRes: Int?) {
+    NONE(0, R.drawable.ic_flag_transparent, null),
+    RED(1, R.drawable.ic_flag_red, R.color.flag_red),
+    ORANGE(2, R.drawable.ic_flag_orange, R.color.flag_orange),
+    GREEN(3, R.drawable.ic_flag_green, R.color.flag_green),
+    BLUE(4, R.drawable.ic_flag_blue, R.color.flag_blue),
+    PINK(5, R.drawable.ic_flag_pink, R.color.flag_pink),
+    TURQUOISE(6, R.drawable.ic_flag_turquoise, R.color.flag_turquoise),
+    PURPLE(7, R.drawable.ic_flag_purple, R.color.flag_purple);
 
     companion object {
         fun fromCode(code: Int): Flag {

--- a/AnkiDroid/src/main/res/values-night/colors.xml
+++ b/AnkiDroid/src/main/res/values-night/colors.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
+    <color name="flag_red">#D32525</color>
+    <color name="flag_orange">#BB7A17</color>
+    <color name="flag_green">#057A05</color>
+    <color name="flag_blue">#1A4FC2</color>
+    <color name="flag_pink">#A70D64</color>
+    <color name="flag_turquoise">#138072</color>
+    <color name="flag_purple">#6320A0</color>
+</resources>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -115,13 +115,6 @@
     <attr name="suspendedColor" format="color"/>
     <attr name="selectedColor" format="color"/>
     <attr name="markedColor" format="color"/>
-    <attr name="flagRed" format="color"/>
-    <attr name="flagOrange" format="color"/>
-    <attr name="flagGreen" format="color"/>
-    <attr name="flagBlue" format="color"/>
-    <attr name="flagPink" format="color"/>
-    <attr name="flagTurquoise" format="color"/>
-    <attr name="flagPurple" format="color"/>
     <!-- Note editor colors -->
     <attr name="duplicateColor" format="color"/>
     <attr name="editTextBackgroundColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -104,14 +104,6 @@
     <color name="flag_turquoise">#85FFEF</color>
     <color name="flag_purple">#C398EC</color>
 
-    <color name="flag_red_dark">#D32525</color>
-    <color name="flag_orange_dark">#BB7A17</color>
-    <color name="flag_green_dark">#057A05</color>
-    <color name="flag_blue_dark">#1A4FC2</color>
-    <color name="flag_pink_dark">#A70D64</color>
-    <color name="flag_turquoise_dark">#138072</color>
-    <color name="flag_purple_dark">#6320A0</color>
-
     <!-- For flag icons -->
     <color name="flag_reviewer_red">#ff0000</color>
     <color name="flag_reviewer_orange">#ff9800</color>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -62,13 +62,6 @@
         <item name="suspendedColor">#A8A634</item>
         <item name="selectedColor">#a86634</item>
         <item name="markedColor">#391080</item>
-        <item name="flagRed">@color/flag_red_dark</item>
-        <item name="flagOrange">@color/flag_orange_dark</item>
-        <item name="flagGreen">@color/flag_green_dark</item>
-        <item name="flagBlue">@color/flag_blue_dark</item>
-        <item name="flagPink">@color/flag_pink_dark</item>
-        <item name="flagTurquoise">@color/flag_turquoise_dark</item>
-        <item name="flagPurple">@color/flag_purple_dark</item>
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <!-- Note editor colors -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -84,13 +84,6 @@
         <!-- Browser colors -->
         <item name="suspendedColor">@color/material_grey_700</item>
         <item name="markedColor">@color/material_deep_purple_400</item>
-        <item name="flagRed">@color/flag_red_dark</item>
-        <item name="flagOrange">@color/flag_orange_dark</item>
-        <item name="flagGreen">@color/flag_green_dark</item>
-        <item name="flagBlue">@color/flag_blue_dark</item>
-        <item name="flagPink">@color/flag_pink_dark</item>
-        <item name="flagTurquoise">@color/flag_turquoise_dark</item>
-        <item name="flagPurple">@color/flag_purple_dark</item>
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <item name="editTextBackgroundColor">#EE5C5C5C</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -77,13 +77,6 @@
         <item name="suspendedColor">#FFFFB2</item>
         <item name="selectedColor">#FFFFBB99</item>
         <item name="markedColor">#D9B2E9</item>
-        <item name="flagRed">@color/flag_red</item>
-        <item name="flagOrange">@color/flag_orange</item>
-        <item name="flagGreen">@color/flag_green</item>
-        <item name="flagBlue">@color/flag_blue</item>
-        <item name="flagPink">@color/flag_pink</item>
-        <item name="flagTurquoise">@color/flag_turquoise</item>
-        <item name="flagPurple">@color/flag_purple</item>
         <!-- Note editor colors -->
         <item name="duplicateColor">#fcc</item>
         <item name="editTextBackgroundColor">#EBCCCCCC</item>


### PR DESCRIPTION
## Purpose/Description

organize a little the mess that the themes are

## How Has This Been Tested?

[colors.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/e5d25f72-f16d-45ea-a31d-9f19c2c1145f)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
