### PR TITLE
Change milestone target for PRs and issues to 2.18

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -20,7 +20,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: ${{ github.event.pull_request.number }},
-            milestone: 51
+            milestone: 52
           });
 
           // graphql query to get referenced issues to merged pull request
@@ -51,7 +51,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              milestone: 51
+              milestone: 52
             });
           }
                     


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
As 2.17 is released I think we could change the target milestone to 2.18. See the number at the end of the milestones url https://github.com/ankidroid/Anki-Android/milestone/52
