### PR TITLE
chore: log debug info on startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -46,6 +46,7 @@ import com.ichi2.anki.logging.ProductionCrashReportingTree
 import com.ichi2.anki.logging.RobolectricDebugTree
 import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.services.BootService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
@@ -132,6 +133,8 @@ open class AnkiDroidApp : Application() {
         if (BuildConfig.DEBUG) {
             UsageAnalytics.setDryRun(true)
         }
+
+        Timber.i(DebugInfoService.getDebugInfo(this))
 
         // Stop after analytics and logging are initialised.
         if (CrashReportService.isProperServiceProcess()) {


### PR DESCRIPTION
If a user can't get to the `About` screen, we want this in logcat

```
AnkiDroid Version = 2.18alpha1-debug (f145def4c4ee9b944bcb1df6cd04a636a5cc8bd3)
                                                     
                                                     Backend Version = 0.1.34-anki23.12.1 (23.12.1 1a1d4d5419c6b57ef3baf99c9d2d9cf85d36ae0a)
                                                     
                                                     Android Version = 13 (SDK 33)
                                                     
                                                     ProductFlavor = amazon
                                                     
                                                     Manufacturer = Google
                                                     
                                                     Model = sdk_gphone64_arm64
                                                     
                                                     Hardware = ranchu
                                                     
                                                     Webview User Agent = Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64 Build/TE1A.220922.034; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/103.0.5060.71 Mobile Safari/537.36
                                                     
                                                     ACRA UUID = 43e6af5c-4182-4226-8933-c5cdda5b2203
                                                     
                                                     Crash Reports Enabled = false
```