### PR TITLE
Fix: checkbox color tint issue for dark theme

### DIFF
--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -199,9 +199,15 @@
         <item name="dialogCornerRadius">@dimen/dialog_corner_radius</item>
         <item name="android:background">?attr/dialogBackground</item>
         <item name="android:dialogCornerRadius" tools:targetApi="p">@dimen/dialog_corner_radius</item>
+        <item name="checkboxStyle">@style/AlertDialogCheckBox.Style</item>
     </style>
 
     <style name="CustomButtonBarButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">?attr/progressDialogButtonTextColor</item>
     </style>
+
+    <style name="AlertDialogCheckBox.Style" parent="Widget.MaterialComponents.CompoundButton.CheckBox">
+        <item name="buttonTint">@color/material_blue_500</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Tint for check box in dark theme was poor

## Fixes
* Fixes #15680

## Approach
Override the `checkBoxStyle` in styles 

## How Has This Been Tested?
Dark:
![Screenshot 2024-02-27 010108](https://github.com/ankidroid/Anki-Android/assets/48384865/d52a661d-df87-4285-b416-7fff3394924a) 
Black: 
![Screenshot 2024-02-27 010821](https://github.com/ankidroid/Anki-Android/assets/48384865/70f9a58e-2ee6-4921-a4b3-59534e9a3468)
Plain: 
![Screenshot 2024-02-27 010859](https://github.com/ankidroid/Anki-Android/assets/48384865/4322ec6f-a483-41fb-966c-0432ed52f18b) 
Light: 
![Screenshot 2024-02-27 010920](https://github.com/ankidroid/Anki-Android/assets/48384865/040bc78b-6826-4f84-bf68-65db230f682c)




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
