### PR TITLE
fix(ci): disable cache on all runners

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -67,8 +67,9 @@ jobs:
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-home-cache-cleanup: true
-          # Windows runner currently having cache pollution issues, disable cache for the platform
-          cache-disabled: ${{ contains(matrix.os, 'windows') }}
+          # All runners have cache pollution issues, disable all caches
+          # https://github.com/gradle/actions/issues/47
+          cache-disabled: true
 
       - name: Clear Caches Optionally
         if: "${{ github.event.inputs.clearCaches != '' }}"


### PR DESCRIPTION
cache is corrupt on both macOS and Ubuntu. Disable it so CI works again

follow-on from 6768519cbbfab9be604ccf1f5393ed529364fd22

issue:

```
* What went wrong:
Execution failed for task ':AnkiDroid:testPlayDebugUnitTest'.
> A build operation failed.
      Immutable workspace contents have been modified: /home/runner/.gradle/caches/transforms-4/f46cf63d0a549c8bc814e25133f449eb. These workspace directories are not supposed to be modified once they are created. Deleting the directory in question can allow the content to be recreated.
   > Immutable workspace contents have been modified: /home/runner/.gradle/caches/transforms-4/f46cf63d0a549c8bc814e25133f449eb. These workspace directories are not supposed to be modified once they are created. Deleting the directory in question can allow the content to be recreated.
```