### PR TITLE
fix: image occlusion cards couldn't be previewed in the note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1227,9 +1227,24 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // Send the previewer all our current editing information
         val noteEditorBundle = Bundle()
         addInstanceStateToBundle(noteEditorBundle)
-        noteEditorBundle.putBundle("editFields", fieldsAsBundleForPreview)
+        addFieldsToBundle(noteEditorBundle)
         previewer.putExtra("noteEditorBundle", noteEditorBundle)
         startActivity(previewer)
+    }
+
+    @NeedsTest("IO fields are passed to the template previewer and the card can be previewed")
+    private fun addFieldsToBundle(bundle: Bundle) {
+        val fieldsBundle = if (currentNotetypeIsImageOcclusion()) {
+            val ioFieldsBundle = Bundle()
+            fieldsFromSelectedNote.forEachIndexed { index, field ->
+                val fieldValue = NoteService.convertToHtmlNewline(field[1], shouldReplaceNewlines())
+                ioFieldsBundle.putString(index.toString(), fieldValue)
+            }
+            ioFieldsBundle
+        } else {
+            fieldsAsBundleForPreview
+        }
+        bundle.putBundle("editFields", fieldsBundle)
     }
 
     /**


### PR DESCRIPTION
the fields need to be passed for the card to be previewed, but they weren't built in IO so they couldn't have their values taken

Fixes:
- #15359

## Approach
The new template previewer showed that there were missing fields in the IO preview, so the rest was easy (good, ain't it? review at #15554)

## How Has This Been Tested?

[oi tudo bem.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/46c7f333-1ebc-497c-a35c-120bb7c5e637)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
