### PR TITLE
Extension function for listItem in AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -299,3 +299,14 @@ fun AlertDialog.getInputField() = getInputTextLayout().editText!!
 /** @see AlertDialog.getButton */
 val AlertDialog.positiveButton: Button
     get() = getButton(DialogInterface.BUTTON_POSITIVE)
+
+/**
+ * Extension function for AlertDialog.Builder to set a list of items.
+ * @param items The items to display in the list.
+ * @param onClick A lambda function that is invoked when an item is clicked.
+ */
+fun AlertDialog.Builder.listItems(items: List<CharSequence>, onClick: (dialog: DialogInterface, index: Int) -> Unit): AlertDialog.Builder {
+    return this.setItems(items.toTypedArray()) { dialog, which ->
+        onClick(dialog, which)
+    }
+}


### PR DESCRIPTION
## Purpose / Description

There is no extension function for listItem in AlertDialogFacade for displaying list in AlertDialog. Currently there are two places ( [Database Error Dialog](https://github.com/ankidroid/Anki-Android/blob/579eb0f0a28be1e095243d753d282af56c489aea/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt#L152)  & [CustomStudyDialog](https://github.com/ankidroid/Anki-Android/blob/579eb0f0a28be1e095243d753d282af56c489aea/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt#L110))its used.

## Fixes
* Related #13315  

## Tested
Tested this extension on CustomStudyDialog (#15459). 

[customstudy.webm](https://github.com/ankidroid/Anki-Android/assets/60827173/e78f0065-b857-4842-ae01-450a7a14eac9)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
