### PR TITLE
fix: error on POST request if app is backgrounded

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -65,6 +65,7 @@ open class AnkiServer(
             }
             newChunkedResponse(data)
         } catch (exc: Exception) {
+            Timber.w(exc, "buildResponse failure")
             newChunkedResponse(exc.localizedMessage?.encodeToByteArray(), status = Response.Status.INTERNAL_ERROR)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -88,7 +88,7 @@ abstract class PageFragment : Fragment(R.layout.page_fragment), PostRequestHandl
         } else {
             throw IllegalArgumentException("unhandled request: $uri")
         }
-        return requireActivity().handleUiPostRequest(methodName, bytes)
+        return activity.handleUiPostRequest(methodName, bytes)
             ?: handleCollectionPostRequest(methodName, bytes)
             ?: throw IllegalArgumentException("unhandled method: $methodName")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -42,6 +42,7 @@ import com.ichi2.libanki.stats.graphsRaw
 import com.ichi2.libanki.stats.setGraphPreferencesRaw
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.delay
+import timber.log.Timber
 
 interface PostRequestHandler {
     suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray
@@ -78,7 +79,11 @@ suspend fun handleCollectionPostRequest(methodName: String, bytes: ByteArray): B
     }
 }
 
-suspend fun FragmentActivity.handleUiPostRequest(methodName: String, bytes: ByteArray): ByteArray? {
+suspend fun FragmentActivity?.handleUiPostRequest(methodName: String, bytes: ByteArray): ByteArray? {
+    if (this == null) {
+        Timber.w("ignored UI request '%s' due to screen/app being backgrounded", methodName)
+        return null
+    }
     return when (methodName) {
         "searchInBrowser" -> searchInBrowser(bytes)
         "updateDeckConfigs" -> updateDeckConfigsRaw(bytes)


### PR DESCRIPTION
## Purpose / Description
If a screen is backgrounded, `requireActivity()` throws `IllegalStateException("Fragment " + this + " not attached to an activity.")`

The request which caused this was `/_anki/congratsInfo` which occurred every minute

This was returned to the screen and caused a messagebox to appear

And one messagebox per minute eventually exceeded the system window limit

Causing
* #15659

## Fixes
* Fixes #15679
* Fixes #15659

## Approach
Allow a `null` activity

## How Has This Been Tested?
⚠️ I can no loner reproduce this, but feel the reasoning is locally sonud

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
