### PR TITLE
Show toast when importing without the app being started at least once

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -599,10 +599,6 @@ open class DeckPicker :
         }
     }
 
-    private fun hasShownAppIntro(): Boolean {
-        return this.sharedPrefs().getBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, false)
-    }
-
     /**
      * Check if the current WebView version is older than the last supported version and if it is,
      * inform the developer with a snackbar.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -156,6 +156,11 @@ class IntentHandler : Activity() {
 
     private fun handleFileImport(intent: Intent, reloadIntent: Intent, action: String?) {
         Timber.i("Handling file import")
+        if (!hasShownAppIntro()) {
+            Timber.i("Trying to import a file when the app was not started at all")
+            showThemedToast(this, R.string.app_not_initialized, false)
+            return
+        }
         val importResult = handleFileImport(this, intent)
         // attempt to delete the downloaded deck if it is a shared deck download import
         if (intent.hasExtra(SharedDecksDownloadFragment.EXTRA_IS_SHARED_DOWNLOAD)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.anki
 
+import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.ActivityResult
@@ -89,4 +90,8 @@ class IntroductionActivity : AnkiActivity() {
 
         const val INTRODUCTION_SLIDES_SHOWN = "IntroductionSlidesShown"
     }
+}
+
+internal fun Context.hasShownAppIntro(): Boolean {
+    return sharedPrefs().getBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, false)
 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -351,6 +351,9 @@
     <string name="intro_get_started" comment="Action to start AnkiDroid for the first time without syncing from AnkiWeb">Get Started</string>
     <string name="intro_sync_from_ankiweb">Sync from AnkiWeb</string>
 
+    <!-- IntentHandler -->
+    <string name="app_not_initialized">AnkiDroid is not initialized yet. Please open AnkiDroid once, then try again</string>
+
     <string name="already_logged_in">Already logged in</string>
 
     <!-- Deck Creation -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Fixes the linked issues by notifying the user through a toast(suggestions for the notice message of course welcome) and aborting the import that he must start the app at least once before he can import. At first I tried to be more precise in DeckPicker to try to remove the import dialog message from the handler and then show the toast, this didn't worked at all so I moved the check in IntentHandler.

## Fixes
* Fixes #15672

## How Has This Been Tested?

Ran the tests(but hit some OutOfMemoryErrors) and manually installed debug apks(play and full) to first reproduce and then check the patch.

## Learning (optional, can help others)

I dislike the handler system used for async dialogs. 

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
