### PR TITLE
Fix: Keep the widgets & shortcuts disabled until storage permission is granted 

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -500,6 +500,7 @@
         <receiver
             android:name="com.ichi2.widget.AnkiDroidWidgetSmall"
             android:label="@string/widget_small"
+            android:enabled="false"
             android:exported="true"
             >
             <intent-filter>
@@ -516,6 +517,7 @@
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"
             android:label="@string/menu_add_note"
+            android:enabled="false"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -174,8 +174,6 @@ abstract class NavigationDrawerActivity :
         }
         drawerToggle.isDrawerSlideAnimationEnabled = animationEnabled()
         drawerLayout.addDrawerListener(drawerToggle)
-
-        enablePostShortcut(this)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -24,6 +24,8 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.IntentCompat
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.NavigationDrawerActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.annotations.NeedsTest
@@ -68,6 +70,11 @@ class PermissionsActivity : AnkiActivity() {
 
     fun setContinueButtonEnabled(isEnabled: Boolean) {
         findViewById<AppCompatButton>(R.id.continue_button).isEnabled = isEnabled
+        // in case it's not play build
+        if (isEnabled) {
+            IntentHandler.enableWidgets(this)
+            NavigationDrawerActivity.enablePostShortcut(this)
+        }
     }
 
     companion object {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* Don't enable the shortcuts unless file access is given
* Keep the widgets disabled until the application has storage access

## Fixes
* Fixes #15686
* Fixes #13518

## Approach
Keeping the widgets and shortcuts disabled at install and as soon as file access is granted we can enable them, if storage is cleared the shortcuts will be disabled again but widgets, as they won't through NPE in this case

## How Has This Been Tested?

Tested on Google emulator API 34

Fresh install:
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/6fc5e152-790e-4894-a799-7c72b25b171f)

After giving out required permissions:
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/4b4a9e67-2d54-4d8e-86d3-e85019a39800)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
