### PR TITLE
#13282: Fixes Android Studio Warnings under Kotlin Header

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2043,7 +2043,7 @@ abstract class AbstractFlashcardViewer :
 
     /** #6141 - blocks clicking links from executing "touch" gestures.
      * COULD_BE_BETTER: Make base class static and move this out of the CardViewer  */
-    internal inner class LinkDetectingGestureDetector() :
+    internal inner class LinkDetectingGestureDetector :
         MyGestureDetector(), ShakeDetector.Listener {
         private var shakeDetector: ShakeDetector? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -13,7 +13,11 @@ import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.view.*
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import android.view.animation.Animation
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResultLauncher
@@ -27,8 +31,10 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.browser.customtabs.CustomTabColorSchemeParams
-import androidx.browser.customtabs.CustomTabsIntent
-import androidx.browser.customtabs.CustomTabsIntent.*
+import androidx.browser.customtabs.CustomTabsIntent.Builder
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_LIGHT
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_SYSTEM
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.fragment.app.DialogFragment
@@ -36,7 +42,8 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
-import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
+import com.ichi2.anim.ActivityTransitionAnimation.Direction.DEFAULT
+import com.ichi2.anim.ActivityTransitionAnimation.Direction.NONE
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.AsyncDialogFragment
@@ -339,7 +346,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
             .setToolbarColor(toolbarColor)
             .setNavigationBarColor(navBarColor)
             .build()
-        val builder = CustomTabsIntent.Builder(customTabActivityHelper.session)
+        val builder = Builder(customTabActivityHelper.session)
             .setShowTitle(true)
             .setStartAnimations(this, R.anim.slide_right_in, R.anim.slide_left_out)
             .setExitAnimations(this, R.anim.slide_left_in, R.anim.slide_right_out)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1490,7 +1490,7 @@ open class CardBrowser :
 
     // convenience method for updateCardsInList(...)
     private fun updateCardInList(card: Card) {
-        val cards: MutableList<Card> = java.util.ArrayList(1)
+        val cards: MutableList<Card> = ArrayList(1)
         cards.add(card)
         updateCardsInList(cards)
     }
@@ -1773,7 +1773,6 @@ open class CardBrowser :
             return v
         }
 
-        @Suppress("UNCHECKED_CAST")
         @KotlinCleanup("Unchecked cast")
         private fun bindView(position: Int, v: View) {
             // Draw the content in the columns

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -136,7 +136,6 @@ import timber.log.Timber
 import java.io.File
 import java.lang.Runnable
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 
 const val MIGRATION_WAS_LAST_POSTPONED_AT_SECONDS = "secondWhenMigrationWasPostponedLast"
@@ -1225,7 +1224,7 @@ open class DeckPicker :
         }
     }
 
-    @Suppress("DEPRECATION") // onBackPressed
+    // onBackPressed
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         val preferences = baseContext.sharedPrefs()
@@ -1852,7 +1851,6 @@ open class DeckPicker :
             }
             negativeButton(R.string.dialog_cancel)
             if (AdaptionUtil.hasWebBrowser(this@DeckPicker)) {
-                @Suppress("DEPRECATION")
                 neutralButton(text = getColUnsafe.tr.schedulingUpdateMoreInfoButton()) {
                     this@DeckPicker.openUrl(Uri.parse("https://faqs.ankiweb.net/the-anki-2.1-scheduler.html#updating"))
                 }
@@ -2348,7 +2346,6 @@ open class DeckPicker :
         MigrationService.start(baseContext)
     }
 
-    @OptIn(ExperimentalTime::class)
     private fun launchShowingHidingEssentialFileMigrationProgressDialog() = lifecycleScope.launch {
         while (true) {
             MigrationService.flowOfProgress

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -432,7 +432,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
 
     private suspend fun changeSortField(notetype: NotetypeJson, idx: Int) {
         withProgress(resources.getString(R.string.model_field_editor_changing)) {
-            CollectionManager.withCol {
+            withCol {
                 Timber.d("doInBackgroundChangeSortField")
                 notetypes.set_sort_index(notetype, idx)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -274,7 +274,7 @@ abstract class NavigationDrawerActivity :
      * Called, when navigation button of the action bar is pressed.
      * Design pattern: template method. Subclasses can override this to define their own behaviour.
      */
-    public open fun onNavigationPressed() {
+    open fun onNavigationPressed() {
         if (navButtonGoesBack) {
             finish()
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -71,7 +71,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         isCancelable = true
     }
 
-    @Suppress("Deprecation") // Material dialog neutral button deprecation
+    // Material dialog neutral button deprecation
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialogView = LayoutInflater.from(activity)
             .inflate(R.layout.deck_picker_dialog, null, false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -222,7 +222,7 @@ class TtsVoicesDialogFragment : DialogFragment() {
     }
 
     // inner allows access to viewModel/openTtsSettings
-    inner class TtsVoiceAdapter() : ListAdapter<AndroidTtsVoice, TtsVoiceAdapter.TtsViewHolder>(TtsVoiceDiffCallback()) {
+    inner class TtsVoiceAdapter : ListAdapter<AndroidTtsVoice, TtsVoiceAdapter.TtsViewHolder>(TtsVoiceDiffCallback()) {
         inner class TtsViewHolder(private val voiceView: View) : RecyclerView.ViewHolder(voiceView) {
             private val textViewTop = voiceView.findViewById<TextView>(R.id.mtrl_list_item_secondary_text)
             private val textViewBottom = voiceView.findViewById<TextView>(R.id.mtrl_list_item_text)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -182,7 +182,6 @@ class DB(val database: SupportSQLiteDatabase) {
      */
     @KotlinCleanup("""Use Kotlin string. Change split so that there is no empty string after last ";".""")
     fun executeScript(@Language("SQL") sql: String) {
-        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
         val queries = java.lang.String(sql).split(";")
         for (query in queries) {
             database.execSQL(query)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -388,8 +388,8 @@ class Notetypes(val col: Collection) {
      * [ConfirmModSchemaException]
      */
     @RustCleanup("Since Kotlin doesn't have throws, this may not be needed")
-    fun addFieldInNewModel(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
-        Assert.that(Notetypes.isModelNew(m), "Model was assumed to be new, but is not")
+    fun addFieldInNewModel(m: NotetypeJson, field: JSONObject) {
+        Assert.that(isModelNew(m), "Model was assumed to be new, but is not")
         try {
             _addField(m, field)
         } catch (e: ConfirmModSchemaException) {
@@ -399,10 +399,10 @@ class Notetypes(val col: Collection) {
         }
     }
 
-    fun addTemplateInNewModel(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun addTemplateInNewModel(m: NotetypeJson, template: JSONObject) {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
-        Assert.that(Notetypes.isModelNew(m), "Model was assumed to be new, but is not")
+        Assert.that(isModelNew(m), "Model was assumed to be new, but is not")
 
         try {
             _addTemplate(m, template)
@@ -413,7 +413,7 @@ class Notetypes(val col: Collection) {
         }
     }
 
-    fun addFieldModChanged(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
+    fun addFieldModChanged(m: NotetypeJson, field: JSONObject) {
         // similar to Anki's addField; but thanks to assumption that
         // mod is already changed, it never has to throw
         // ConfirmModSchemaException.
@@ -421,7 +421,7 @@ class Notetypes(val col: Collection) {
         _addField(m, field)
     }
 
-    fun addTemplateModChanged(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun addTemplateModChanged(m: NotetypeJson, template: JSONObject) {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
         Assert.that(col.schemaChanged(), "Mod was assumed to be already changed, but is not")
@@ -573,11 +573,11 @@ class Notetypes(val col: Collection) {
         return all_names_and_ids().count()
     }
 
-    fun _addTemplate(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun _addTemplate(m: NotetypeJson, template: JSONObject) {
         addTemplate(m, template)
     }
 
-    fun _addField(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
+    fun _addField(m: NotetypeJson, field: JSONObject) {
         addField(m, field)
     }
 
@@ -629,7 +629,7 @@ class Notetypes(val col: Collection) {
                 )
 
         /** "Mapping of field name -> (ord, field).  */
-        fun fieldMap(m: com.ichi2.libanki.NotetypeJson): Map<String, Pair<Int, JSONObject>> {
+        fun fieldMap(m: NotetypeJson): Map<String, Pair<Int, JSONObject>> {
             val flds = m.getJSONArray("flds")
             // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
             val result: MutableMap<String, Pair<Int, JSONObject>> = HashUtil.hashMapInit(flds.length())
@@ -640,11 +640,11 @@ class Notetypes(val col: Collection) {
         }
 
         // not in anki
-        fun isModelNew(m: com.ichi2.libanki.NotetypeJson): Boolean {
+        fun isModelNew(m: NotetypeJson): Boolean {
             return m.getLong("id") == 0L
         }
 
-        fun _updateTemplOrds(m: com.ichi2.libanki.NotetypeJson) {
+        fun _updateTemplOrds(m: NotetypeJson) {
             val tmpls = m.getJSONArray("tmpls")
             for (i in 0 until tmpls.length()) {
                 val f = tmpls.getJSONObject(i)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/NoteUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/NoteUtil.kt
@@ -25,7 +25,7 @@ fun Note.toBackendNote(): anki.notes.Note {
         id = note.id
         guid = note.guId!!
         notetypeId = note.mid
-        mtimeSecs = note.mod.toInt() // this is worrying, 2038 problem
+        mtimeSecs = note.mod // this is worrying, 2038 problem
         usn = note.usn
         tags.addAll(note.tags.asIterable())
         fields.addAll(note.fields.asIterable())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.reviewer
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.createTransientFile
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
@@ -24,8 +24,7 @@ import org.mockito.Mockito
 /** Test helper:
  * causes getCol to emulate an exception caused by having another AnkiDroid instance open on the same collection
  */
-class BackendEmulatingOpenConflict() : Backend() {
-    @Suppress("UNUSED_PARAMETER")
+class BackendEmulatingOpenConflict : Backend() {
     override fun openCollection(
         collectionPath: String,
         mediaFolderPath: String,

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
@@ -17,7 +17,6 @@ package com.ichi2.utils
 
 import java.io.File
 import java.io.RandomAccessFile
-import java.util.*
 
 class FileOperation {
     companion object {

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -85,15 +85,15 @@ import com.ichi2.anki.api.BuildConfig
  * --------------------------------------------------------------------------------------------------------------------
  * ```
  */
-public object FlashCardsContract {
-    public const val AUTHORITY: String = BuildConfig.AUTHORITY
-    public const val READ_WRITE_PERMISSION: String = BuildConfig.READ_WRITE_PERMISSION
+object FlashCardsContract {
+    const val AUTHORITY: String = BuildConfig.AUTHORITY
+    const val READ_WRITE_PERMISSION: String = BuildConfig.READ_WRITE_PERMISSION
 
     /**
      * A content:// style uri to the authority for the flash card provider
      */
     @JvmField // required for Java API
-    public val AUTHORITY_URI: Uri = Uri.parse("content://$AUTHORITY")
+    val AUTHORITY_URI: Uri = Uri.parse("content://$AUTHORITY")
 
     /**
      * The Notes can be accessed by
@@ -189,7 +189,7 @@ public object FlashCardsContract {
      * --------------------------------------------------------------------------------------------------------------------
      * ```
      */
-    public object Note {
+    object Note {
         /**
          * The content:// style URI for notes. If the it is appended by the note's ID, this
          * note can be directly accessed, e.g.
@@ -211,14 +211,14 @@ public object FlashCardsContract {
          * For examples on how to use the URI for queries see class description.
          */
         @JvmField // required for Java API
-        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes")
+        val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes")
 
         /**
          * The content:// style URI for notes, but with a direct SQL query to the notes table instead of accepting
          * a query in the libanki browser search syntax like the main URI #CONTENT_URI does.
          */
         @JvmField // required for Java API
-        public val CONTENT_URI_V2: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes_v2")
+        val CONTENT_URI_V2: Uri = Uri.withAppendedPath(AUTHORITY_URI, "notes_v2")
 
         /**
          * This is the ID of the note. It is the same as the note ID in Anki. This ID can be
@@ -226,32 +226,32 @@ public object FlashCardsContract {
          * "content://com.ichi2.anki.flashcards/notes/<ID>/data
          */
         @Suppress("ObjectPropertyName")
-        public const val _ID: String = "_id"
+        const val _ID: String = "_id"
 
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
-        public const val GUID: String = "guid"
-        public const val MID: String = "mid"
+        const val GUID: String = "guid"
+        const val MID: String = "mid"
 
         @Suppress("unused")
-        public const val ALLOW_EMPTY: String = "allow_empty"
-        public const val MOD: String = "mod"
+        const val ALLOW_EMPTY: String = "allow_empty"
+        const val MOD: String = "mod"
 
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
-        public const val USN: String = "usn"
-        public const val TAGS: String = "tags"
-        public const val FLDS: String = "flds"
+        const val USN: String = "usn"
+        const val TAGS: String = "tags"
+        const val FLDS: String = "flds"
 
         // field is part of the default projection available to the clients
         @Suppress("MemberVisibilityCanBePrivate")
-        public const val SFLD: String = "sfld"
-        public const val CSUM: String = "csum"
-        public const val FLAGS: String = "flags"
-        public const val DATA: String = "data"
+        const val SFLD: String = "sfld"
+        const val CSUM: String = "csum"
+        const val FLAGS: String = "flags"
+        const val DATA: String = "data"
 
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             GUID,
             MID,
@@ -268,17 +268,17 @@ public object FlashCardsContract {
         /**
          * MIME type used for a note.
          */
-        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.note"
+        const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.note"
 
         /**
          * MIME type used for notes.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.note"
 
         /**
          * Used only by bulkInsert() to specify which deck the notes should be placed in
          */
-        public const val DECK_ID_QUERY_PARAM: String = "deckId"
+        const val DECK_ID_QUERY_PARAM: String = "deckId"
     }
 
     /**
@@ -346,14 +346,14 @@ public object FlashCardsContract {
      *      Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, FlashCardsContract.Model.CURRENT_MODEL_ID);
      * ```
      */
-    public object Model {
+    object Model {
         /**
          * The content:// style URI for model. If the it is appended by the model's ID, this
          * note can be directly accessed. See class description above for further details.
          */
         @JvmField // required for Java API
-        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "models")
-        public const val CURRENT_MODEL_ID: String = "current"
+        val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "models")
+        const val CURRENT_MODEL_ID: String = "current"
 
         /**
          * This is the ID of the model. It is the same as the note ID in Anki. This ID can be
@@ -361,26 +361,26 @@ public object FlashCardsContract {
          * `content://com.ichi2.anki.flashcards/models/<ID>`
          */
         @Suppress("ObjectPropertyName")
-        public const val _ID: String = "_id"
-        public const val NAME: String = "name"
-        public const val FIELD_NAME: String = "field_name"
-        public const val FIELD_NAMES: String = "field_names"
-        public const val NUM_CARDS: String = "num_cards"
-        public const val CSS: String = "css"
-        public const val SORT_FIELD_INDEX: String = "sort_field_index"
-        public const val TYPE: String = "type"
-        public const val LATEX_POST: String = "latex_post"
-        public const val LATEX_PRE: String = "latex_pre"
-        public const val NOTE_COUNT: String = "note_count"
+        const val _ID: String = "_id"
+        const val NAME: String = "name"
+        const val FIELD_NAME: String = "field_name"
+        const val FIELD_NAMES: String = "field_names"
+        const val NUM_CARDS: String = "num_cards"
+        const val CSS: String = "css"
+        const val SORT_FIELD_INDEX: String = "sort_field_index"
+        const val TYPE: String = "type"
+        const val LATEX_POST: String = "latex_post"
+        const val LATEX_PRE: String = "latex_pre"
+        const val NOTE_COUNT: String = "note_count"
 
         /**
          * The deck ID that is selected by default when adding new notes with this model.
          * This is only used when the "Deck for new cards" preference is set to "Decide by note type"
          */
-        public const val DECK_ID: String = "deck_id"
+        const val DECK_ID: String = "deck_id"
 
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             NAME,
             FIELD_NAMES,
@@ -396,12 +396,12 @@ public object FlashCardsContract {
         /**
          * MIME type used for a model.
          */
-        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model"
+        const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model"
 
         /**
          * MIME type used for model.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model"
     }
 
     /**
@@ -411,12 +411,12 @@ public object FlashCardsContract {
      * reverse card allowing review in the "reverse" direction (e.g dog -> 犬). When a Note is inserted, a Card will
      * be generated for each active CardTemplate which is defined.
      */
-    public object CardTemplate {
+    object CardTemplate {
         /**
          * MIME type used for data.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model.template"
-        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model.template"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.model.template"
+        const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.model.template"
 
         /**
          * Row ID. This is a virtual ID which actually does not exist in AnkiDroid's data base.
@@ -426,49 +426,49 @@ public object FlashCardsContract {
          * the _ID will change too.
          */
         @Suppress("ObjectPropertyName")
-        public const val _ID: String = "_id"
+        const val _ID: String = "_id"
 
         /**
          * This is the ID of the model that this row belongs to (i.e. [Model._ID]).
          */
-        public const val MODEL_ID: String = "model_id"
+        const val MODEL_ID: String = "model_id"
 
         /**
          * This is the ordinal / index of the card template (from 0 to number of cards - 1).
          */
-        public const val ORD: String = "ord"
+        const val ORD: String = "ord"
 
         /**
          * The template name e.g. "Card 1".
          */
-        public const val NAME: String = "card_template_name"
+        const val NAME: String = "card_template_name"
 
         /**
          * The definition of the template for the question
          */
-        public const val QUESTION_FORMAT: String = "question_format"
+        const val QUESTION_FORMAT: String = "question_format"
 
         /**
          * The definition of the template for the answer
          */
-        public const val ANSWER_FORMAT: String = "answer_format"
+        const val ANSWER_FORMAT: String = "answer_format"
 
         /**
          * Optional alternative definition of the template for the question when rendered with the browser
          */
-        public const val BROWSER_QUESTION_FORMAT: String = "browser_question_format"
+        const val BROWSER_QUESTION_FORMAT: String = "browser_question_format"
 
         /**
          * Optional alternative definition of the template for the answer when rendered with the browser
          */
-        public const val BROWSER_ANSWER_FORMAT: String = "browser_answer_format"
-        public const val CARD_COUNT: String = "card_count"
+        const val BROWSER_ANSWER_FORMAT: String = "browser_answer_format"
+        const val CARD_COUNT: String = "card_count"
 
         /**
          * Default columns that are returned when querying the ...models/#/templates URI.
          */
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             _ID,
             MODEL_ID,
             ORD,
@@ -566,56 +566,56 @@ public object FlashCardsContract {
      *      } while (cur.moveToNext());
      * ```
      */
-    public object Card {
+    object Card {
         /**
          * This is the ID of the note that this card belongs to (i.e. [Note._ID]).
          */
-        public const val NOTE_ID: String = "note_id"
+        const val NOTE_ID: String = "note_id"
 
         /**
          * This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
          * to directly access a card as describe in the class description.
          */
-        public const val CARD_ORD: String = "ord"
+        const val CARD_ORD: String = "ord"
 
         /**
          * The card's name.
          */
-        public const val CARD_NAME: String = "card_name"
+        const val CARD_NAME: String = "card_name"
 
         /**
          * The name of the deck that this card is part of.
          */
-        public const val DECK_ID: String = "deck_id"
+        const val DECK_ID: String = "deck_id"
 
         /**
          * The question for this card.
          */
-        public const val QUESTION: String = "question"
+        const val QUESTION: String = "question"
 
         /**
          * The answer for this card.
          */
-        public const val ANSWER: String = "answer"
+        const val ANSWER: String = "answer"
 
         /**
          * Simplified version of the question, without card styling (CSS).
          */
-        public const val QUESTION_SIMPLE: String = "question_simple"
+        const val QUESTION_SIMPLE: String = "question_simple"
 
         /**
          * Simplified version of the answer, without card styling (CSS).
          */
-        public const val ANSWER_SIMPLE: String = "answer_simple"
+        const val ANSWER_SIMPLE: String = "answer_simple"
 
         /**
          * Purified version of the answer. In case the ANSWER contains any additional elements
          * (like a duplicate of the question) this is removed for ANSWER_PURE
          */
-        public const val ANSWER_PURE: String = "answer_pure"
+        const val ANSWER_PURE: String = "answer_pure"
 
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
             CARD_ORD,
             CARD_NAME,
@@ -627,12 +627,12 @@ public object FlashCardsContract {
         /**
          * MIME type used for a card.
          */
-        public const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.card"
+        const val CONTENT_ITEM_TYPE: String = "vnd.android.cursor.item/vnd.com.ichi2.anki.card"
 
         /**
          * MIME type used for cards.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.card"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.card"
     }
 
     /**
@@ -742,59 +742,59 @@ public object FlashCardsContract {
      *      int updateCount = cr.update(reviewInfoUri, values, null, null);
      * ```
      */
-    public object ReviewInfo {
+    object ReviewInfo {
         @JvmField // required for Java API
-        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "schedule")
+        val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "schedule")
 
         /**
          * This is the ID of the note that this card belongs to (i.e. [Note._ID]).
          */
-        public const val NOTE_ID: String = "note_id"
+        const val NOTE_ID: String = "note_id"
 
         /**
          * This is the ordinal of the card. A note has 1..n cards. The ordinal can also be used
          * to directly access a card as describe in the class description.
          */
-        public const val CARD_ORD: String = "ord"
+        const val CARD_ORD: String = "ord"
 
         /**
          * This is the number of ease modes. It can take a value between 2 and 4.
          */
-        public const val BUTTON_COUNT: String = "button_count"
+        const val BUTTON_COUNT: String = "button_count"
 
         /**
          * This is a JSONArray containing the next review times for all buttons.
          */
-        public const val NEXT_REVIEW_TIMES: String = "next_review_times"
+        const val NEXT_REVIEW_TIMES: String = "next_review_times"
 
         /**
          * The names of the media files in the question and answer
          */
-        public const val MEDIA_FILES: String = "media_files"
+        const val MEDIA_FILES: String = "media_files"
 
         /*
          * Ease of an answer. Is not set when requesting the scheduled cards.
          * Can take values of AbstractFlashcardViewer e.g. EASE_1
          */
-        public const val EASE: String = "answer_ease"
+        const val EASE: String = "answer_ease"
 
         /*
          * Time it took to answer the card (in ms)
          */
-        public const val TIME_TAKEN: String = "time_taken"
+        const val TIME_TAKEN: String = "time_taken"
 
         /**
          * Write-only field, allows burying of a card when set to 1
          */
-        public const val BURY: String = "buried"
+        const val BURY: String = "buried"
 
         /**
          * Write-only field, allows suspending of a card when set to 1
          */
-        public const val SUSPEND: String = "suspended"
+        const val SUSPEND: String = "suspended"
 
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             NOTE_ID,
             CARD_ORD,
             BUTTON_COUNT,
@@ -805,7 +805,7 @@ public object FlashCardsContract {
         /**
          * MIME type used for ReviewInfo.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.review_info"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.review_info"
     }
 
     /**
@@ -900,45 +900,45 @@ public object FlashCardsContract {
      *      cr.update(selectDeckUri, values, null, null);
      * ```
      */
-    public object Deck {
+    object Deck {
         @JvmField // required for Java API
-        public val CONTENT_ALL_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "decks")
+        val CONTENT_ALL_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "decks")
 
         @JvmField // required for Java API
-        public val CONTENT_SELECTED_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
+        val CONTENT_SELECTED_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "selected_deck")
 
         /**
          * The name of the Deck
          */
-        public const val DECK_NAME: String = "deck_name"
+        const val DECK_NAME: String = "deck_name"
 
         /**
          * The unique identifier of the Deck
          */
-        public const val DECK_ID: String = "deck_id"
+        const val DECK_ID: String = "deck_id"
 
         /**
          * The number of cards in the Deck
          */
-        public const val DECK_COUNTS: String = "deck_count"
+        const val DECK_COUNTS: String = "deck_count"
 
         /**
          * The options of the Deck
          */
-        public const val OPTIONS: String = "options"
+        const val OPTIONS: String = "options"
 
         /**
          * 1 if dynamic (AKA filtered) deck
          */
-        public const val DECK_DYN: String = "deck_dyn"
+        const val DECK_DYN: String = "deck_dyn"
 
         /**
          * Deck description
          */
-        public const val DECK_DESC: String = "deck_desc"
+        const val DECK_DESC: String = "deck_desc"
 
         @JvmField // required for Java API
-        public val DEFAULT_PROJECTION: Array<String> = arrayOf(
+        val DEFAULT_PROJECTION: Array<String> = arrayOf(
             DECK_NAME,
             DECK_ID,
             DECK_COUNTS,
@@ -950,7 +950,7 @@ public object FlashCardsContract {
         /**
          * MIME type used for Deck.
          */
-        public const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.deck"
+        const val CONTENT_TYPE: String = "vnd.android.cursor.dir/vnd.com.ichi2.anki.deck"
     }
 
     /**
@@ -969,21 +969,21 @@ public object FlashCardsContract {
      *      Uri insertedFile = cr.insert(AnkiMedia.CONTENT_URI, cv);
      * ```
      */
-    public object AnkiMedia {
+    object AnkiMedia {
         /**
          * Content Uri for the MEDIA row of the CardContentProvider
          */
         @JvmField // required for Java API
-        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "media")
+        val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "media")
 
         /**
          * Uri.toString() which points to the media file that is to be inserted.
          */
-        public const val FILE_URI: String = "file_uri"
+        const val FILE_URI: String = "file_uri"
 
         /**
          * The preferred name for the file that will be inserted/copied into collection.media
          */
-        public const val PREFERRED_NAME: String = "preferred_name"
+        const val PREFERRED_NAME: String = "preferred_name"
     }
 }

--- a/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
+++ b/api/src/main/java/com/ichi2/anki/api/AddContentApi.kt
@@ -45,7 +45,7 @@ import java.util.*
  * this may be extended to all operations at a later date.
  */
 @Suppress("unused")
-public class AddContentApi(context: Context) {
+class AddContentApi(context: Context) {
     private val context: Context = context.applicationContext
     private val resolver: ContentResolver = this.context.contentResolver
 
@@ -58,7 +58,7 @@ public class AddContentApi(context: Context) {
      * @param tags tags to include in the new note
      * @return note id or null if the note could not be added
      */
-    public fun addNote(modelId: Long, deckId: Long, fields: Array<String>, tags: Set<String>?): Long? {
+    fun addNote(modelId: Long, deckId: Long, fields: Array<String>, tags: Set<String>?): Long? {
         val noteUri = addNoteInternal(modelId, deckId, fields, tags) ?: return null
         return noteUri.lastPathSegment!!.toLong()
     }
@@ -102,7 +102,7 @@ public class AddContentApi(context: Context) {
      * @param tagsList List of tags (one per note) (may be null)
      * @return The number of notes added (< 0 means there was a problem)
      */
-    public fun addNotes(
+    fun addNotes(
         modelId: Long,
         deckId: Long,
         fieldsList: List<Array<String>>,
@@ -157,7 +157,7 @@ public class AddContentApi(context: Context) {
      * @return the correctly formatted String for the media file to be placed in the desired field of a Card, or null
      * if unsuccessful.
      */
-    public fun addMediaFromUri(
+    fun addMediaFromUri(
         fileUri: Uri,
         preferredName: String,
         mimeType: String
@@ -188,7 +188,7 @@ public class AddContentApi(context: Context) {
      * @param key the first field of a note
      * @return a list of duplicate notes
      */
-    public fun findDuplicateNotes(mid: Long, key: String): List<NoteInfo?> {
+    fun findDuplicateNotes(mid: Long, key: String): List<NoteInfo?> {
         val notes = compat.findDuplicateNotes(mid, listOf(key))
         return if (notes!!.size() == 0) {
             emptyList<NoteInfo>()
@@ -204,7 +204,7 @@ public class AddContentApi(context: Context) {
      * @param keys list of keys
      * @return a SparseArray with a list of duplicate notes for each key
      */
-    public fun findDuplicateNotes(mid: Long, keys: List<String>): SparseArray<MutableList<NoteInfo?>>? {
+    fun findDuplicateNotes(mid: Long, keys: List<String>): SparseArray<MutableList<NoteInfo?>>? {
         return compat.findDuplicateNotes(mid, keys)
     }
 
@@ -213,7 +213,7 @@ public class AddContentApi(context: Context) {
      * @param mid id of the model to be used
      * @return number of notes that exist with that model ID or -1 if there was a problem
      */
-    public fun getNoteCount(mid: Long): Int = compat.queryNotes(mid)?.use { cursor -> cursor.count } ?: 0
+    fun getNoteCount(mid: Long): Int = compat.queryNotes(mid)?.use { cursor -> cursor.count } ?: 0
 
     /**
      * Set the tags for a given note
@@ -222,7 +222,7 @@ public class AddContentApi(context: Context) {
      * @return true if noteId was found, otherwise false
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    public fun updateNoteTags(noteId: Long, tags: Set<String>): Boolean {
+    fun updateNoteTags(noteId: Long, tags: Set<String>): Boolean {
         return updateNote(noteId, null, tags)
     }
 
@@ -233,7 +233,7 @@ public class AddContentApi(context: Context) {
      * @return true if noteId was found, otherwise false
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    public fun updateNoteFields(noteId: Long, fields: Array<String>): Boolean {
+    fun updateNoteFields(noteId: Long, fields: Array<String>): Boolean {
         return updateNote(noteId, fields, null)
     }
 
@@ -242,7 +242,7 @@ public class AddContentApi(context: Context) {
      * @param noteId the ID of the note to find
      * @return object containing the contents of note with noteID or null if there was a problem
      */
-    public fun getNote(noteId: Long): NoteInfo? {
+    fun getNote(noteId: Long): NoteInfo? {
         val noteUri = Uri.withAppendedPath(Note.CONTENT_URI, noteId.toString())
         val query = resolver.query(noteUri, PROJECTION, null, null, null) ?: return null
         return query.use { cursor ->
@@ -272,7 +272,7 @@ public class AddContentApi(context: Context) {
      * @return list of front &amp; back pairs for each card which contain the card HTML, or null if there was a problem
      * @throws SecurityException if READ_WRITE_PERMISSION not granted (e.g. due to install order bug)
      */
-    public fun previewNewNote(mid: Long, flds: Array<String>): Map<String, Map<String, String>>? {
+    fun previewNewNote(mid: Long, flds: Array<String>): Map<String, Map<String, String>>? {
         if (!hasReadWritePermission()) {
             // avoid situation where addNote will pass, but deleteNote will fail
             throw SecurityException("previewNewNote requires full read-write-permission")
@@ -304,7 +304,7 @@ public class AddContentApi(context: Context) {
      * @param name name of the model
      * @return the mid of the model which was created, or null if it could not be created
      */
-    public fun addNewBasicModel(name: String): Long? {
+    fun addNewBasicModel(name: String): Long? {
         return addNewCustomModel(
             name,
             BasicModel.FIELDS,
@@ -323,7 +323,7 @@ public class AddContentApi(context: Context) {
      * @param name name of the model
      * @return the mid of the model which was created, or null if it could not be created
      */
-    public fun addNewBasic2Model(name: String): Long? {
+    fun addNewBasic2Model(name: String): Long? {
         return addNewCustomModel(
             name,
             Basic2Model.FIELDS,
@@ -350,7 +350,7 @@ public class AddContentApi(context: Context) {
      * @return the mid of the model which was created, or null if it could not be created
      */
     @Suppress("MemberVisibilityCanBePrivate") // silence IDE
-    public fun addNewCustomModel(
+    fun addNewCustomModel(
         name: String,
         fields: Array<String>,
         cards: Array<String>,
@@ -391,7 +391,7 @@ public class AddContentApi(context: Context) {
      * Get the ID for the note type / model which is currently in use
      * @return id for current model, or < 0 if there was a problem
      */
-    public val currentModelId: Long
+    val currentModelId: Long
         get() {
             // Get the current model
             val uri = Uri.withAppendedPath(Model.CONTENT_URI, Model.CURRENT_MODEL_ID)
@@ -407,7 +407,7 @@ public class AddContentApi(context: Context) {
      * @param modelId the ID of the model to use
      * @return the names of all the fields, or null if the model doesn't exist or there was some other problem
      */
-    public fun getFieldList(modelId: Long): Array<String>? {
+    fun getFieldList(modelId: Long): Array<String>? {
         // Get the current model
         val uri = Uri.withAppendedPath(Model.CONTENT_URI, modelId.toString())
         val modelQuery = resolver.query(uri, null, null, null, null) ?: return null
@@ -426,7 +426,7 @@ public class AddContentApi(context: Context) {
      * Get a map of all model ids and names
      * @return map of (id, name) pairs
      */
-    public val modelList: Map<Long, String>?
+    val modelList: Map<Long, String>?
         get() = getModelList(1)
 
     /**
@@ -434,7 +434,7 @@ public class AddContentApi(context: Context) {
      * @param minNumFields minimum number of fields to consider the model for inclusion
      * @return map of (id, name) pairs or null if there was a problem
      */
-    public fun getModelList(minNumFields: Int): Map<Long, String>? {
+    fun getModelList(minNumFields: Int): Map<Long, String>? {
         // Get the current model
         val allModelsQuery =
             resolver.query(Model.CONTENT_URI, null, null, null, null)
@@ -460,14 +460,14 @@ public class AddContentApi(context: Context) {
      * @param mid id of model
      * @return the name of the model, or null if no model was found
      */
-    public fun getModelName(mid: Long): String? = modelList!![mid]
+    fun getModelName(mid: Long): String? = modelList!![mid]
 
     /**
      * Create a new deck with specified name and save the reference to SharedPreferences for later
      * @param deckName name of the deck to add
      * @return id of the added deck, or null if the deck was not added
      */
-    public fun addNewDeck(deckName: String): Long? {
+    fun addNewDeck(deckName: String): Long? {
         // Create a new note
         val values = ContentValues().apply { put(Deck.DECK_NAME, deckName) }
         val newDeckUri = resolver.insert(Deck.CONTENT_ALL_URI, values)
@@ -482,7 +482,7 @@ public class AddContentApi(context: Context) {
      * Get the name of the selected deck
      * @return deck name or null if there was a problem
      */
-    public val selectedDeckName: String?
+    val selectedDeckName: String?
         get() {
             val selectedDeckQuery = resolver.query(
                 Deck.CONTENT_SELECTED_URI,
@@ -504,7 +504,7 @@ public class AddContentApi(context: Context) {
      * Get a list of all the deck id / name pairs
      * @return Map of (id, name) pairs, or null if there was a problem
      */
-    public val deckList: Map<Long, String>?
+    val deckList: Map<Long, String>?
         get() {
             // Get the current model
             val allDecksQuery =
@@ -526,7 +526,7 @@ public class AddContentApi(context: Context) {
      * @param did ID of deck
      * @return the name of the deck, or null if no deck was found
      */
-    public fun getDeckName(did: Long): String? = deckList!![did]
+    fun getDeckName(did: Long): String? = deckList!![did]
 
     /**
      * The API spec version of the installed AnkiDroid app. This is not the same as the AnkiDroid app version code.
@@ -541,7 +541,7 @@ public class AddContentApi(context: Context) {
      *
      * @return the spec version number or -1 if AnkiDroid is not installed.
      */
-    public val apiHostSpecVersion: Int
+    val apiHostSpecVersion: Int
         get() {
             // PackageManager#resolveContentProvider docs suggest flags should be 0 (but that gives null metadata)
             // GET_META_DATA seems to work anyway
@@ -747,9 +747,9 @@ public class AddContentApi(context: Context) {
         }
     }
 
-    public companion object {
-        public const val READ_WRITE_PERMISSION: String = FlashCardsContract.READ_WRITE_PERMISSION
-        public const val DEFAULT_DECK_ID: Long = 1L
+    companion object {
+        const val READ_WRITE_PERMISSION: String = FlashCardsContract.READ_WRITE_PERMISSION
+        const val DEFAULT_DECK_ID: Long = 1L
         private const val TEST_TAG = "PREVIEW_NOTE"
         private const val PROVIDER_SPEC_META_DATA_KEY = "com.ichi2.anki.provider.spec"
         private const val DEFAULT_PROVIDER_SPEC_VALUE = 1 // for when meta-data key does not exist
@@ -767,7 +767,7 @@ public class AddContentApi(context: Context) {
          * @return packageId of AnkiDroid if a supported version is not installed, otherwise null
          */
         @JvmStatic // required for API
-        public fun getAnkiDroidPackageName(context: Context): String? {
+        fun getAnkiDroidPackageName(context: Context): String? {
             val manager = context.packageManager
             return if (Build.VERSION.SDK_INT >= 33) {
                 manager.resolveContentProvider(

--- a/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
+++ b/api/src/main/java/com/ichi2/anki/api/NoteInfo.kt
@@ -24,7 +24,7 @@ import java.util.*
  * Representation of the contents of a note in AnkiDroid.
  */
 @Suppress("unused")
-public class NoteInfo {
+class NoteInfo {
     private val id: Long
     private val fields: Array<String>
     private val tags: Set<String>
@@ -61,29 +61,29 @@ public class NoteInfo {
      * Clone a NoteInfo object
      * @param parent the object to clone
      */
-    public constructor(parent: NoteInfo) {
+    constructor(parent: NoteInfo) {
         id = parent.id
         fields = parent.fields.clone()
         tags = HashSet(parent.tags)
     }
 
     /** Note ID  */
-    public fun getId(): Long {
+    fun getId(): Long {
         return id
     }
 
     /** The array of fields  */
-    public fun getFields(): Array<String> {
+    fun getFields(): Array<String> {
         return fields
     }
 
     /** The set of tags  */
-    public fun getTags(): Set<String> {
+    fun getTags(): Set<String> {
         return tags
     }
 
     /** The first field  */
-    public fun getKey(): String {
+    fun getKey(): String {
         return getFields()[0]
     }
 }


### PR DESCRIPTION

##  Description
I addressed the issue #13282 by fixing Android Studio warnings under Kotlin ->redundant constructs header (The list of warnings can be obtained via: Code -> Inspect Code). The changes include removing redundant constructs such as unused imports and redundant quantifier names.

## Fixes
* Fixes #13282

## Approach
I reviewed the code and identified areas with Android Studio warnings. I removed unnecessary constructs to improve code readability and maintainability.

## How Has This Been Tested?
I tested these changes on Level 30 (Android 11).

### Before

![Screenshot1](https://github.com/ankidroid/Anki-Android/assets/91160609/a93b2c17-a59f-402d-852c-a735673b9c24)

### After

![Screenshot2](https://github.com/ankidroid/Anki-Android/assets/91160609/36fb699a-ad08-4027-8cb3-42bc50134dfc)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
