### PR TITLE
test: ignore NoteEditorIntentTest in CI

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -24,6 +24,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.NoteEditor.Companion.intentLaunchedWithImage
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.GrantStoragePermission
+import com.ichi2.testutils.Flaky
+import com.ichi2.testutils.OS
 import junit.framework.TestCase.assertFalse
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
@@ -44,6 +46,7 @@ class NoteEditorIntentTest : InstrumentedTest() {
     )
 
     @Test
+    @Flaky(OS.ALL, "Issue 15707 - java.lang.ArrayIndexOutOfBoundsException: length=0; index=0")
     fun launchActivityWithIntent() {
         col
         val scenario = activityRuleIntent!!.scenario


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

We've got a new flake in CI, caused 2 PRs to eject from merge queue

## Fixes
* Related but not fixing #15707
* seen on #15692 

## Approach

Mark as flaky, this works in androidTest now, and worked locally

## How Has This Been Tested?

`./gradlew jacocoAndroidTestReport` locally, CI should pass

## Learning (optional, can help others)

ENTROPY
