### PR TITLE
fix: flaky NoteEditorIntentTest

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.testutil.GrantStoragePermission
 import junit.framework.TestCase.assertFalse
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
-import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TestRule
@@ -48,22 +47,7 @@ class NoteEditorIntentTest : InstrumentedTest() {
     fun launchActivityWithIntent() {
         col
         val scenario = activityRuleIntent!!.scenario
-        scenario.moveToState(Lifecycle.State.RESUMED)
-
-        val maxRetryCount = 5
-        var retryCount = 0
-        var collectionLoaded = false
-
-        while (!collectionLoaded && retryCount < maxRetryCount) {
-            onActivity(scenario) { editor ->
-                collectionLoaded = editor.collectionHasLoaded()
-            }
-            if (!collectionLoaded) {
-                Thread.sleep(1000)
-                retryCount++
-            }
-        }
-        Assert.assertTrue(collectionLoaded)
+        scenario.moveToState(Lifecycle.State.CREATED)
 
         onActivity(scenario) { editor ->
             val currentFieldStrings = editor.currentFieldStrings

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -865,7 +865,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed tags?
     }
 
-    private fun collectionHasLoaded(): Boolean {
+    @VisibleForTesting
+    fun collectionHasLoaded(): Boolean {
         return allModelIds != null
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -865,7 +865,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed tags?
     }
 
-    @VisibleForTesting
     fun collectionHasLoaded(): Boolean {
         return allModelIds != null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -865,7 +865,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // changed tags?
     }
 
-    fun collectionHasLoaded(): Boolean {
+    private fun collectionHasLoaded(): Boolean {
         return allModelIds != null
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Flaky test if trying to access edit field before it has loaded

## Fixes
* Fixes  #15707

## Approach
Place a check

## How Has This Been Tested?
Locally tested on PC need CI testing passing though

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
