### PR TITLE
fix: non-transparent dialog background

### DIFF
--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -197,7 +197,6 @@
         <item name="colorPrimary">?attr/progressDialogButtonTextColor</item>
         <item name="buttonTint">?attr/colorOnPrimary</item>
         <item name="dialogCornerRadius">@dimen/dialog_corner_radius</item>
-        <item name="android:background">?attr/dialogBackground</item>
         <item name="android:dialogCornerRadius" tools:targetApi="p">@dimen/dialog_corner_radius</item>
         <item name="checkboxStyle">@style/AlertDialogCheckBox.Style</item>
     </style>


### PR DESCRIPTION
## Purpose / Description
This caused context menus to be large, opaque and cover the screen


## Fixes
* Fixes #15717

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/a111699a-0e07-43fd-a8cf-e5ca6281cae5)


![image](https://github.com/ankidroid/Anki-Android/assets/62114487/8a7c0709-2b74-4f56-a108-11e3c2b10f02)

Haven't seen any reason for this line to exist

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
