### PR TITLE
fix: mixing %% in strings with substitutions fails lint even with escapes

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -26,7 +26,7 @@
         <item quantity="other">%d mins</item>
     </plurals>
     <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"
-        name="pref_summary_percentage">%s\%%</string>
+        formatted="false" name="pref_summary_percentage">%s\%%</string>
     <!-- TODO: move to 20-search-preference so we can contribute upstream (searchpreference_no_results)-->
     <string name="pref_search_no_results">No results</string>
 


### PR DESCRIPTION
## Purpose / Description

The new Turkish translation here was valid, but failing lint: https://crowdin.com/editor/ankidroid/7291/en-tr?view=comfortable&filter=basic&value=0#6535593

Here is what I discovered through testing each combination:

- if a string has a substitution and you need a % (so you need \%%),
- then you can do the \%% after the substitution but,
- if you put the \%% before the substition it works on device but fails lint

However,
- if a string has a substitution and you need a %,
- and you have the \%% before or after the %2,
- and you have formatted="false" then it works on device and passes lint

## Fixes
* Related #15726 

## Approach

I *believe* if we change comments or formatting attributes in a string, that will affect strings that have already been translated?

I am not sure about that, but the hope is we merge this, and do a strings sync and the formatted="false" attribute is pushed out to all values-NN files, which will unblock #15726

## How Has This Been Tested?

I tested lint with `./gradlew :AnkiDroid:lintPlayDebug`
I tested functionality with `./gradlew installPlayDebug` then Settings -> Accessibility (it loads up sliders with %s from this string)

- I tested main with the string set to `%s\%%` as it is now (works, lint passes)
- I tested main with the string set to `\%%%s` like Turkish legitimately should be (works, but lint fails)
- I tested main with the string with the unicode % as `&#x0025;%s` (app crash)
- I tested main with a more complete specifier as `\%%%1$s` (fails lint)
- I tested main with string set to `\%%%s` like Turkish wants, and `formatted="false"` (works, lint passes)

So here we are

## Learning (optional, can help others)

I think AAPT has a lint-related bug. This is just a way to get it to pass.

I'm open to other ideas