### PR TITLE
show warning inside control dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GestureSelectionDialogUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GestureSelectionDialogUtils.kt
@@ -16,7 +16,9 @@
 package com.ichi2.anki.dialogs
 
 import android.content.Context
+import androidx.core.view.isVisible
 import com.ichi2.anki.cardviewer.GestureListener
+import com.ichi2.ui.FixedTextView
 import com.ichi2.ui.GesturePicker
 
 /** Helper functions for a Dialog which wraps a [com.ichi2.ui.GesturePicker]  */
@@ -30,5 +32,19 @@ object GestureSelectionDialogUtils {
      * This is **not** when the gesture is submitted */
     fun GesturePicker.onGestureChanged(listener: GestureListener) {
         setGestureChangedListener(listener)
+    }
+}
+
+interface WarningDisplay {
+    val warningTextView: FixedTextView
+
+    fun setWarning(text: CharSequence) {
+        warningTextView.isVisible = true
+        warningTextView.text = text
+    }
+
+    fun clearWarning() {
+        warningTextView.isVisible = false
+        warningTextView.text = ""
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils.onGestureChanged
 import com.ichi2.anki.dialogs.KeySelectionDialogUtils
+import com.ichi2.anki.dialogs.WarningDisplay
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding
@@ -127,12 +128,7 @@ class ControlPreference : ListPreference {
                     customView(view = gesturePicker)
 
                     gesturePicker.onGestureChanged { gesture ->
-                        showToastIfBindingIsUsed(
-                            fromGesture(
-                                gesture,
-                                screenBuilder
-                            )
-                        )
+                        warnIfBindingIsUsed(fromGesture(gesture, screenBuilder), gesturePicker)
                     }
                 }
             }
@@ -145,12 +141,11 @@ class ControlPreference : ListPreference {
 
                     // When the user presses a key
                     keyPicker.setBindingChangedListener { binding ->
-                        showToastIfBindingIsUsed(
-                            MappableBinding(
-                                binding,
-                                screenBuilder(CardSide.BOTH)
-                            )
+                        val mappableBinding = MappableBinding(
+                            binding,
+                            screenBuilder(CardSide.BOTH)
                         )
+                        warnIfBindingIsUsed(mappableBinding, keyPicker)
                     }
 
                     positiveButton(R.string.dialog_ok) {
@@ -214,6 +209,14 @@ class ControlPreference : ListPreference {
      */
     private fun bindingIsUsedOnAnotherCommand(binding: MappableBinding): Boolean {
         return getCommandWithBindingExceptThis(binding) != null
+    }
+
+    private fun warnIfBindingIsUsed(binding: MappableBinding, warningDisplay: WarningDisplay) {
+        getCommandWithBindingExceptThis(binding)?.let {
+            val name = context.getString(it.resourceId)
+            val warning = context.getString(R.string.bindings_already_bound, name)
+            warningDisplay.setWarning(warning)
+        } ?: warningDisplay.clearWarning()
     }
 
     /** Displays a warning to the user if the provided binding couldn't be used */

--- a/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
@@ -27,6 +27,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.GestureListener
+import com.ichi2.anki.dialogs.WarningDisplay
 import com.ichi2.utils.UiUtil.setSelectedValue
 import timber.log.Timber
 
@@ -38,10 +39,12 @@ import timber.log.Timber
  */
 // This class exists as elements resized when adding in the spinner to GestureDisplay.kt
 class GesturePicker(ctx: Context, attributeSet: AttributeSet? = null, defStyleAttr: Int = 0) :
-    ConstraintLayout(ctx, attributeSet, defStyleAttr) {
+    ConstraintLayout(ctx, attributeSet, defStyleAttr),
+    WarningDisplay {
 
     private val gestureSpinner: Spinner
     private val gestureDisplay: GestureDisplay
+    override val warningTextView: FixedTextView
 
     private var onGestureListener: GestureListener? = null
 
@@ -50,6 +53,7 @@ class GesturePicker(ctx: Context, attributeSet: AttributeSet? = null, defStyleAt
         inflater.inflate(R.layout.gesture_picker, this)
         gestureDisplay = findViewById(R.id.gestureDisplay)
         gestureSpinner = findViewById(R.id.spinner_gesture)
+        warningTextView = findViewById(R.id.warning)
         gestureDisplay.setGestureChangedListener(this::onGesture)
         gestureSpinner.adapter = ArrayAdapter(context, android.R.layout.simple_spinner_dropdown_item, allGestures())
         gestureSpinner.onItemSelectedListener = InnerSpinner()
@@ -79,7 +83,7 @@ class GesturePicker(ctx: Context, attributeSet: AttributeSet? = null, defStyleAt
         onGestureListener = listener
     }
 
-    fun allGestures(): List<GestureWrapper> {
+    private fun allGestures(): List<GestureWrapper> {
         return (listOf(null) + availableGestures()).map(this::GestureWrapper).toList()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/KeyPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/KeyPicker.kt
@@ -22,6 +22,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.TextView
 import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.WarningDisplay
 import com.ichi2.anki.reviewer.Binding
 import timber.log.Timber
 
@@ -31,8 +32,10 @@ typealias KeyCode = Int
  * Square dialog which allows a user to select a [Binding] for a key press
  * This does not yet support bluetooth headsets.
  */
-class KeyPicker(val rootLayout: View) {
+class KeyPicker(val rootLayout: View) : WarningDisplay {
     private val textView: TextView = rootLayout.findViewById(R.id.key_picker_selected_key)
+
+    override val warningTextView: FixedTextView = rootLayout.findViewById(R.id.warning)
 
     private val context: Context get() = rootLayout.context
 

--- a/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
@@ -17,7 +17,8 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/key_picker_selected_key"
@@ -30,9 +31,26 @@
         android:text="@string/key_picker_default_press_key"
         android:focusable="true"
         android:focusableInTouchMode="true"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/warning"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/warning"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/colorError"
+        tools:text="Already used in X"
+        android:layout_margin="6dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/key_picker_selected_key"
+        android:drawableStart="@drawable/ic_warning"
+        android:drawableTint="?attr/colorError"
+        android:drawablePadding="4dp"
+        tools:visibility="visible"
+        />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/gesture_picker.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_picker.xml
@@ -43,6 +43,24 @@
         android:spinnerMode="dropdown"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"/>
+        app:layout_constraintBottom_toTopOf="@id/warning"/>
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/warning"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textColor="?attr/colorError"
+        tools:text="Already used in X"
+        android:layout_margin="6dp"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/spinner_gesture"
+        android:drawableStart="@drawable/ic_warning"
+        android:drawableTint="?attr/colorError"
+        android:drawablePadding="4dp"
+        tools:visibility="visible"
+        />
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/ui/KeyPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/ui/KeyPickerTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.KeySelectionDialogUtils
 import com.ichi2.testutils.KeyEventUtils
+import com.ichi2.themes.Theme
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -28,7 +29,10 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class KeyPickerTest : RobolectricTest() {
 
-    private var keyPicker: KeyPicker = KeyPicker.inflate(targetContext)
+    private var keyPicker: KeyPicker = run {
+        targetContext.setTheme(Theme.LIGHT.resId)
+        KeyPicker.inflate(targetContext)
+    }
 
     @Test
     fun test_normal_binding() {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

* Fixes #15724

## Fixes
* Fixes #15724

## Approach

I added the warning inside the dialog like asked but I wasn't able to do it in the joystick dialog

## How Has This Been Tested?

![image](https://github.com/ankidroid/Anki-Android/assets/65715921/a5d691fe-3850-4c10-93b4-6add08f3e66b)

![image](https://github.com/ankidroid/Anki-Android/assets/65715921/a6e3a462-3917-4af1-b8dd-890ce55b0dd4)

![image](https://github.com/ankidroid/Anki-Android/assets/65715921/2d4e6619-5b99-4afc-921c-152b495a6dfe)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
