### PR TITLE
match IDE and ktlint format line sizes

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -24,6 +24,7 @@
         <package name="" withSubpackages="true" static="true" />
       </value>
     </option>
+    <option name="RIGHT_MARGIN" value="140" />
     <JavaCodeStyleSettings>
       <option name="FIELD_NAME_PREFIX" value="m" />
       <option name="BLANK_LINES_AROUND_INITIALIZER" value="2" />


### PR DESCRIPTION
reference https://pinterest.github.io/ktlint/latest/rules/standard/#max-line-length

<!--- Please fill the necessary details below -->
## Purpose / Description

* Fixes #15143

## Fixes
* Fixes #15143

## Approach

match IDE and ktlint format line sizes

## How Has This Been Tested?

the line length line in Android Studio is longer now

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
