### PR TITLE
fix: remove pref_summary_percentage

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -25,8 +25,6 @@
         <item quantity="one">%d min</item>
         <item quantity="other">%d mins</item>
     </plurals>
-    <string comment="Percentage value of a preference. %s represents the number to be replaced. Use \%% to represent a single percent sign (%)"
-        name="pref_summary_percentage">%s\%%</string>
     <!-- TODO: move to 20-search-preference so we can contribute upstream (searchpreference_no_results)-->
     <string name="pref_search_no_results">No results</string>
 

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -25,7 +25,7 @@
         android:valueFrom="10"
         android:valueTo="300"
         android:stepSize="10"
-        app:displayFormat="@string/pref_summary_percentage"/>
+        app:displayFormat="@string/percentage"/>
     <com.ichi2.preferences.SliderPreference
         android:key="@string/image_zoom_preference"
         android:title="@string/image_zoom"
@@ -33,7 +33,7 @@
         android:valueFrom="50"
         android:valueTo="300"
         android:stepSize="10"
-        app:displayFormat="@string/pref_summary_percentage"/>
+        app:displayFormat="@string/percentage"/>
     <com.ichi2.preferences.SliderPreference
         android:title="@string/button_size"
         android:key="@string/answer_button_size_preference"
@@ -41,7 +41,7 @@
         android:valueFrom="10"
         android:valueTo="200"
         android:stepSize="10"
-        app:displayFormat="@string/pref_summary_percentage"/>
+        app:displayFormat="@string/percentage"/>
     <SwitchPreferenceCompat
         android:key="@string/show_large_answer_buttons_preference"
         android:defaultValue="false"
@@ -54,7 +54,7 @@
         android:valueFrom="10"
         android:valueTo="200"
         android:stepSize="10"
-        app:displayFormat="@string/pref_summary_percentage"/>
+        app:displayFormat="@string/percentage"/>
     <com.ichi2.preferences.NumberRangePreferenceCompat
         android:defaultValue="0"
         android:key="@string/pref_card_minimal_click_time"


### PR DESCRIPTION
## Purpose / Description
The advice was incorrect (we should use `%%`, not `\%%`), and the string was duplicated

We had a problem with the Turkish string `\%%%s`

`%%%s` worked

But:
`%%%s` is detected as having 1 format string
`\%%%s` is detected as having 0

and this broke lint

## Fixes
* Fixes #15727
* Unblocks #15726


## Approach
Remove the bad string, encourage our translator to fix `percentage`

## How Has This Been Tested?

`%s%%`
<img width="307" alt="Screenshot 2024-03-01 at 09 58 32" src="https://github.com/ankidroid/Anki-Android/assets/62114487/0fdb2949-c3f6-463e-b948-d1b7893b5b28">

`%%%s`
<img width="344" alt="Screenshot 2024-03-01 at 10 00 13" src="https://github.com/ankidroid/Anki-Android/assets/62114487/992a22b4-c764-4100-bbb1-c0fe9ab2d9d9">

and lint passes

```
➜  Anki-Android git:(remove-percentage-summary) ✗ ./gradlew lint
warn: removing resource com.ichi2.anki.debug:string/pref_summary_percentage without required default value.

warn: removing resource com.ichi2.anki.debug:string/pref_summary_percentage without required default value.

warn: removing resource com.ichi2.anki.debug:string/pref_summary_percentage without required default value.

warn: removing resource com.ichi2.anki.debug:string/pref_summary_percentage without required default value.


> Task :AnkiDroid:compileAmazonDebugJavaWithJavac
Note: /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/build/generated/aidl_source_output_dir/amazonDebug/out/android/content/pm/IPackageStatsObserver.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

BUILD SUCCESSFUL in 1m 7s
101 actionable tasks: 21 executed, 5 from cache, 75 up-to-date
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
