### PR TITLE
fix NoteEditor deprecation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -345,7 +345,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // ----------------------------------------------------------------------------
     // ANDROID METHODS
     // ----------------------------------------------------------------------------
-    @Suppress("UNCHECKED_CAST", "deprecation") // deprecation: getSerializable
     @KotlinCleanup("fix suppress")
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -364,9 +363,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             selectedTags = savedInstanceState.getStringArrayList("tags")
             reloadRequired = savedInstanceState.getBoolean(RELOAD_REQUIRED_EXTRA_KEY)
             pastedImageCache =
-                savedInstanceState.getSerializable("imageCache") as HashMap<String, String>
+                savedInstanceState.getSerializableCompat<HashMap<String, String>>("imageCache")!!
             toggleStickyText =
-                savedInstanceState.getSerializable("toggleSticky") as HashMap<Int, String?>
+                savedInstanceState.getSerializableCompat<HashMap<Int, String?>>("toggleSticky")!!
             changed = savedInstanceState.getBoolean(NOTE_CHANGED_EXTRA_KEY)
         } else {
             if (intentLaunchedWithImage(intent)) {


### PR DESCRIPTION
## Fixes
* Fixes #12364

## Approach
I used the compat method

## How Has This Been Tested?

I went to the note editor and nothing crashed

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
