### PR TITLE
chore: replace `@RequiresApi` with `@SdkSuppress`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -18,9 +18,9 @@ package com.ichi2.anki.tests
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.test.annotation.UiThreadTest
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
 import com.ichi2.anki.testutil.GrantStoragePermission
@@ -36,7 +36,7 @@ import timber.log.Timber
 import kotlin.test.junit.JUnitAsserter.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
-@RequiresApi(Build.VERSION_CODES.O) // getNotificationChannels, NotificationChannel.getId
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.O) // getNotificationChannels, NotificationChannel.getId
 
 @KotlinCleanup("Enable JUnit 5 in androidTest and use JUnit5Asserter to match the standard tests")
 class NotificationChannelTest : InstrumentedTest() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -8,10 +8,10 @@ import android.content.Intent
 import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import androidx.annotation.CheckResult
-import androidx.annotation.RequiresApi
 import androidx.core.content.IntentCompat
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SdkSuppress
 import anki.config.ConfigKey
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.WebViewSignalParserUtils.ANSWER_ORDINAL_1
@@ -54,7 +54,7 @@ import java.util.stream.Stream
 import com.ichi2.anim.ActivityTransitionAnimation.Direction as Direction
 
 @Suppress("SameParameterValue")
-@RequiresApi(api = Build.VERSION_CODES.O) // getImeHintLocales, toLanguageTags, onRenderProcessGone, RenderProcessGoneDetail
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.O) // getImeHintLocales, toLanguageTags, onRenderProcessGone, RenderProcessGoneDetail
 @RunWith(AndroidJUnit4::class)
 class AbstractFlashcardViewerTest : RobolectricTest() {
     class NonAbstractFlashcardViewer : AbstractFlashcardViewer() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/OnRenderProcessGoneDelegateTest.kt
@@ -19,8 +19,8 @@ import android.content.res.Resources
 import android.os.Build
 import android.webkit.RenderProcessGoneDetail
 import android.webkit.WebView
-import androidx.annotation.RequiresApi
 import androidx.lifecycle.Lifecycle
+import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
@@ -32,7 +32,7 @@ import org.mockito.Mockito.*
 import org.mockito.kotlin.whenever
 import java.util.concurrent.locks.Lock
 
-@RequiresApi(api = Build.VERSION_CODES.O) // onRenderProcessGone & RenderProcessGoneDetail
+@SdkSuppress(minSdkVersion = Build.VERSION_CODES.O) // onRenderProcessGone & RenderProcessGoneDetail
 class OnRenderProcessGoneDelegateTest {
     @Test
     fun singleCallCausesRefresh() {


### PR DESCRIPTION
This is a lint failure in android_gradle_plugin 8.3.0

* See PR #15733

`minSdkVersion` is inclusive

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
