### PR TITLE
fix: edit Comments field in Image Occlusion note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -50,6 +50,7 @@ import androidx.core.content.IntentCompat
 import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.view.isVisible
 import anki.config.ConfigKey
 import anki.notes.NoteFieldsCheckResponse
 import com.google.android.material.color.MaterialColors
@@ -988,10 +989,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 currentEditedCard!!.did = deckId
                 modified = true
             }
-            if (currentNotetypeIsImageOcclusion()) {
-                closeNoteEditor()
-                return
-            }
             // now load any changes to the fields from the form
             for (f in editFields!!) {
                 modified = modified or updateField(f)
@@ -1216,11 +1213,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     // CUSTOM METHODS
     // ----------------------------------------------------------------------------
     private fun openNewPreviewer() {
-        val fields = if (currentNotetypeIsImageOcclusion()) {
-            fieldsFromSelectedNote.mapTo(mutableListOf()) { it[1] }
-        } else {
-            editFields?.mapTo(mutableListOf()) { it!!.fieldText.toString() } ?: mutableListOf()
-        }
+        val fields = editFields?.mapTo(mutableListOf()) { it!!.fieldText.toString() } ?: mutableListOf()
         val tags = selectedTags ?: mutableListOf()
         val args = TemplatePreviewerArguments(
             notetypeFile = NotetypeFile(this, editorNote!!.notetype),
@@ -1252,24 +1245,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         // Send the previewer all our current editing information
         val noteEditorBundle = Bundle()
         addInstanceStateToBundle(noteEditorBundle)
-        addFieldsToBundle(noteEditorBundle)
+        noteEditorBundle.putBundle("editFields", fieldsAsBundleForPreview)
         previewer.putExtra("noteEditorBundle", noteEditorBundle)
         startActivity(previewer)
-    }
-
-    @NeedsTest("IO fields are passed to the template previewer and the card can be previewed")
-    private fun addFieldsToBundle(bundle: Bundle) {
-        val fieldsBundle = if (currentNotetypeIsImageOcclusion()) {
-            val ioFieldsBundle = Bundle()
-            fieldsFromSelectedNote.forEachIndexed { index, field ->
-                val fieldValue = NoteService.convertToHtmlNewline(field[1], shouldReplaceNewlines())
-                ioFieldsBundle.putString(index.toString(), fieldValue)
-            }
-            ioFieldsBundle
-        } else {
-            fieldsAsBundleForPreview
-        }
-        bundle.putBundle("editFields", fieldsBundle)
     }
 
     /**
@@ -1438,12 +1416,19 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         val editLines = fieldState.loadFieldEditLines(type)
         fieldsLayoutContainer!!.removeAllViews()
         customViewIds.clear()
+        imageOcclusionButtonsContainer?.isVisible = currentNotetypeIsImageOcclusion()
+
+        val indicesToHide = mutableListOf<Int>()
         if (currentNotetypeIsImageOcclusion()) {
-            setImageOcclusionButton()
-            return
-        } else {
-            imageOcclusionButtonsContainer?.visibility = View.GONE
-            fieldsLayoutContainer?.visibility = View.VISIBLE
+            val occlusionTag = "0"
+            val imageTag = "1"
+            val fields = currentlySelectedNotetype!!.getJSONArray("flds")
+            for (i in 0 until fields.length()) {
+                val tag = fields.getJSONObject(i).getString("tag")
+                if (tag == occlusionTag || tag == imageTag) {
+                    indicesToHide.add(i)
+                }
+            }
         }
 
         editFields = LinkedList()
@@ -1511,6 +1496,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 getString(R.string.multimedia_editor_attach_mm_content, editLineView.name)
             toggleStickyButton.contentDescription =
                 getString(R.string.note_editor_toggle_sticky, editLineView.name)
+
+            editLineView.isVisible = i !in indicesToHide
             fieldsLayoutContainer!!.addView(editLineView)
         }
     }
@@ -2127,11 +2114,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
     private fun currentNotetypeIsImageOcclusion() =
         currentlySelectedNotetype?.isImageOcclusion == true
-
-    private fun setImageOcclusionButton() {
-        imageOcclusionButtonsContainer?.visibility = View.VISIBLE
-        fieldsLayoutContainer?.visibility = View.GONE
-    }
 
     private fun setupImageOcclusionEditor(imagePath: String = "") {
         val kind: String


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Edit image occlusion fields in the note editor

## Fixes
* Fixes #15610 
* Fixes #15702

## Approach

The fields aren't hidden anymore and the previews were fixed

Repositioning the fields work too

## How Has This Been Tested?

![image](https://github.com/ankidroid/Anki-Android/assets/154519856/656d98e1-9784-432d-b8cc-a2dea6f71ff3)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
