### PR TITLE
build(ci): add `lintVitalFullRelease` to lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,7 +67,8 @@ jobs:
           # "lint" is run under the 'Amazon' flavor, so slow in CI
           # "lintPlayRelease" doesn't test androidTest
           # "lintPlayDebug" doesn't test the API
-          arguments: lintPlayDebug :api:lintDebug ktLintCheck lint-rules:test --daemon
+          # "lintVitalFullRelease": if `main` resources are only used in `androidTest` (#15741)
+          arguments: lintPlayDebug :api:lintDebug ktLintCheck lintVitalFullRelease lint-rules:test --daemon
 
         # Handled under the pre-commit hook: ./gradlew installGitHook
 


### PR DESCRIPTION
## Purpose / Description
`lintVitalFullRelease` is run on publish, and can fail

So it should also be run on a normal lint check

## Fixes
* Issue #15741

## How Has This Been Tested?
Tested locally.

The fix has not been applied yet, so if lint fails, this works

* https://github.com/ankidroid/Anki-Android/pull/15742

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
