### PR TITLE
revert: disable widget if no storage access

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -496,11 +496,11 @@
             android:foregroundServiceType="dataSync"
             />
 
+        <!-- Don't disable/enable the widgets here until min API>=31, see issue #15747 & https://issuetracker.google.com/issues/36914010 -->
         <!-- small widget -->
         <receiver
             android:name="com.ichi2.widget.AnkiDroidWidgetSmall"
             android:label="@string/widget_small"
-            android:enabled="false"
             android:exported="true"
             >
             <intent-filter>
@@ -517,7 +517,6 @@
         <receiver
             android:name="com.ichi2.widget.AddNoteWidget"
             android:label="@string/menu_add_note"
-            android:enabled="false"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -17,10 +17,8 @@
 package com.ichi2.anki
 
 import android.app.Activity
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.os.Message
@@ -48,8 +46,6 @@ import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.hasStorageAccessPermission
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.trimToLength
-import com.ichi2.widget.AddNoteWidget
-import com.ichi2.widget.AnkiDroidWidgetSmall
 import timber.log.Timber
 import java.io.File
 import kotlin.math.max
@@ -76,12 +72,6 @@ class IntentHandler : Activity() {
         // #6157 - We want to block actions that need permissions we don't have, but not the default case
         // as this requires nothing
         val runIfStoragePermissions = { runnable: () -> Unit -> performActionIfStorageAccessible(reloadIntent, action) { runnable() } }
-
-        runIfStoragePermissions {
-            enableWidgets(this)
-            NavigationDrawerActivity.enablePostShortcut(this)
-        }
-
         when (getLaunchType(intent)) {
             LaunchType.FILE_IMPORT -> runIfStoragePermissions {
                 handleFileImport(fileIntent, reloadIntent, action)
@@ -276,26 +266,6 @@ class IntentHandler : Activity() {
             // Negating a negative because we want to call specific attention to the fact that it's invalid
             // #6312 - Smart Launcher provided an empty ACTION_VIEW, no point in importing here.
             return !isInvalidViewIntent(intent)
-        }
-
-        /**
-         * Enables the widgets if the storage permission is granted. It enables both the small widget
-         * and the "Add Note" widget by setting their component enabled state to ENABLED.
-         **/
-        fun enableWidgets(context: Context) {
-            val smallWidgetComponentName = ComponentName(context, AnkiDroidWidgetSmall::class.java)
-            context.packageManager.setComponentEnabledSetting(
-                smallWidgetComponentName,
-                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                PackageManager.DONT_KILL_APP
-            )
-
-            val addNoteWidgetComponentName = ComponentName(context, AddNoteWidget::class.java)
-            context.packageManager.setComponentEnabledSetting(
-                addNoteWidgetComponentName,
-                PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                PackageManager.DONT_KILL_APP
-            )
         }
 
         @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -174,6 +174,8 @@ abstract class NavigationDrawerActivity :
         }
         drawerToggle.isDrawerSlideAnimationEnabled = animationEnabled()
         drawerLayout.addDrawerListener(drawerToggle)
+
+        enablePostShortcut(this)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -24,8 +24,6 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.IntentCompat
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.IntentHandler
-import com.ichi2.anki.NavigationDrawerActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.annotations.NeedsTest
@@ -70,11 +68,6 @@ class PermissionsActivity : AnkiActivity() {
 
     fun setContinueButtonEnabled(isEnabled: Boolean) {
         findViewById<AppCompatButton>(R.id.continue_button).isEnabled = isEnabled
-        // in case it's not play build
-        if (isEnabled) {
-            IntentHandler.enableWidgets(this)
-            NavigationDrawerActivity.enablePostShortcut(this)
-        }
     }
 
     companion object {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* AnkiDroid introduces this bug in #15698 as a fix for #13518 and permanently disabled widgets for users on Android 10 and lower

This Pull Request reverts the above PR, re-enables widgets, and re-introduces a bug with widgets if storage permission is not granted.

As a follow-up, an alternate fix will be applied: widgets will be modified to handle the collection being inaccessible without crashing 

## Fixes
* Fixes #15745

## How Has This Been Tested?

API29 after reverting 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/65e32623-3b7a-4e52-9d50-01728f1e1d4d)


## Learning (optional, can help others)

Google issue https://issuetracker.google.com/issues/36914010

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
