### PR TITLE
Added FSRS info to getDebugInfo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -136,12 +136,7 @@ open class AnkiDroidApp : Application() {
         }
 
         applicationScope.launch {
-            try {
-                val debugInfo = DebugInfoService.getDebugInfo(this@AnkiDroidApp)
-                Timber.i(debugInfo)
-            } catch (e: Exception) {
-                Timber.w(e, "Error getting debug info")
-            }
+            Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
         }
 
         // Stop after analytics and logging are initialised.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -60,6 +60,7 @@ import com.ichi2.utils.Permissions
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import timber.log.Timber.DebugTree
 import java.util.Locale
@@ -134,7 +135,14 @@ open class AnkiDroidApp : Application() {
             UsageAnalytics.setDryRun(true)
         }
 
-        Timber.i(DebugInfoService.getDebugInfo(this))
+        applicationScope.launch {
+            try {
+                val debugInfo = DebugInfoService.getDebugInfo(this@AnkiDroidApp)
+                Timber.i(debugInfo)
+            } catch (e: Exception) {
+                Timber.e(e, "Error getting debug info")
+            }
+        }
 
         // Stop after analytics and logging are initialised.
         if (CrashReportService.isProperServiceProcess()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -134,13 +134,13 @@ open class AnkiDroidApp : Application() {
         if (BuildConfig.DEBUG) {
             UsageAnalytics.setDryRun(true)
         }
-        // Use applicationScope as a coroutine scope to use getDebugInfo() since it is a suspend fun
+
         applicationScope.launch {
             try {
                 val debugInfo = DebugInfoService.getDebugInfo(this@AnkiDroidApp)
                 Timber.i(debugInfo)
             } catch (e: Exception) {
-                Timber.e(e, "Error getting debug info")
+                Timber.w(e, "Error getting debug info")
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -134,7 +134,7 @@ open class AnkiDroidApp : Application() {
         if (BuildConfig.DEBUG) {
             UsageAnalytics.setDryRun(true)
         }
-
+        // Use applicationScope as a coroutine scope to use getDebugInfo() since it is a suspend fun
         applicationScope.launch {
             try {
                 val debugInfo = DebugInfoService.getDebugInfo(this@AnkiDroidApp)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -27,7 +27,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.*
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.snackbar.showSnackbar
@@ -36,7 +35,6 @@ import com.ichi2.utils.VersionUtils.pkgVersionName
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.show
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.text.SimpleDateFormat
@@ -116,8 +114,7 @@ class AboutFragment : Fragment(R.layout.about_layout) {
      * Copies debug info (from [DebugInfoService.getDebugInfo]) to the clipboard
      */
     private fun copyDebugInfo() {
-        // Use lifecycleScope as a coroutine scope to use getDebugInfo() since it is a suspend fun
-        viewLifecycleOwner.lifecycleScope.launch {
+        launchCatchingTask {
             try {
                 val debugInfo = withContext(Dispatchers.IO) {
                     DebugInfoService.getDebugInfo(requireContext())
@@ -127,7 +124,7 @@ class AboutFragment : Fragment(R.layout.about_layout) {
                     failureMessageId = R.string.about_ankidroid_error_copy_debug_info
                 )
             } catch (e: Exception) {
-                Timber.e(e, "Error copying debug info")
+                Timber.w(e, "Error copying debug info")
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -116,6 +116,7 @@ class AboutFragment : Fragment(R.layout.about_layout) {
      * Copies debug info (from [DebugInfoService.getDebugInfo]) to the clipboard
      */
     private fun copyDebugInfo() {
+        // Use lifecycleScope as a coroutine scope to use getDebugInfo() since it is a suspend fun
         viewLifecycleOwner.lifecycleScope.launch {
             try {
                 val debugInfo = withContext(Dispatchers.IO) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -36,7 +36,6 @@ import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.show
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -115,17 +114,13 @@ class AboutFragment : Fragment(R.layout.about_layout) {
      */
     private fun copyDebugInfo() {
         launchCatchingTask {
-            try {
-                val debugInfo = withContext(Dispatchers.IO) {
-                    DebugInfoService.getDebugInfo(requireContext())
-                }
-                requireContext().copyToClipboard(
-                    debugInfo,
-                    failureMessageId = R.string.about_ankidroid_error_copy_debug_info
-                )
-            } catch (e: Exception) {
-                Timber.w(e, "Error copying debug info")
+            val debugInfo = withContext(Dispatchers.IO) {
+                DebugInfoService.getDebugInfo(requireContext())
             }
+            requireContext().copyToClipboard(
+                debugInfo,
+                failureMessageId = R.string.about_ankidroid_error_copy_debug_info
+            )
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -29,7 +29,11 @@ import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
 object DebugInfoService {
 
-    // This is run on the startup path, we need to protect against a null/corrupt collection
+    /**
+     * Retrieves the debug info based in different parameters of the app.
+     *
+     * Note that the `FSRS` parameter can be null if the collection doesn't exist or the config is not set.
+     */
     suspend fun getDebugInfo(info: Context): String {
         val webviewUserAgent = getWebviewUserAgent(info)
         val isFSRSEnabled = getFSRSStatus()
@@ -52,7 +56,7 @@ object DebugInfoService {
                
                ACRA UUID = ${Installation.id(info)}
                
-               FSRS  = $isFSRSEnabled
+               FSRS Enabled = $isFSRSEnabled
                
                Crash Reports Enabled = ${isSendingCrashReports(info)}
         """.trimIndent()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -36,6 +36,7 @@ object DebugInfoService {
      */
     suspend fun getDebugInfo(info: Context): String {
         val webviewUserAgent = getWebviewUserAgent(info)
+        // isFSRSEnabled is null on startup
         val isFSRSEnabled = getFSRSStatus()
         return """
                AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
@@ -77,7 +78,7 @@ object DebugInfoService {
 
     // Uses config.get() to get the FSRS status from the collection using withOpenColOrNull
     private suspend fun getFSRSStatus(): Boolean? = try {
-        CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs") }
+        CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs", false) }
     } catch (e: Error) {
         Timber.w(e)
         null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -76,7 +76,6 @@ object DebugInfoService {
         return CrashReportService.isAcraEnabled(context, false)
     }
 
-    // Uses config.get() to get the FSRS status from the collection using withOpenColOrNull
     private suspend fun getFSRSStatus(): Boolean? = try {
         CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs", false) }
     } catch (e: Error) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -23,10 +23,6 @@ import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.utils.VersionUtils.pkgVersionName
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import org.acra.util.Installation
 import timber.log.Timber
 import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
@@ -36,12 +32,7 @@ object DebugInfoService {
     // This is run on the startup path, we need to protect against a null/corrupt collection
     suspend fun getDebugInfo(info: Context): String {
         val webviewUserAgent = getWebviewUserAgent(info)
-        // Launch a coroutine to get the FSRS status
-        val deferred: Deferred<Boolean?> = CoroutineScope(Dispatchers.Main).async {
-            getFSRSStatus()
-        }
-        // Await the result of the coroutine
-        val isFSRSEnabled = deferred.await()
+        val isFSRSEnabled = getFSRSStatus()
         return """
                AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
                

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -79,6 +79,8 @@ object DebugInfoService {
     private fun isSendingCrashReports(context: Context): Boolean {
         return CrashReportService.isAcraEnabled(context, false)
     }
+
+    // Uses config.get() to get the FSRS status from the collection using withOpenColOrNull
     private suspend fun getFSRSStatus(): Boolean? = try {
         CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs") }
     } catch (e: Error) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
@@ -18,6 +18,7 @@ package com.ichi2.libanki
 
 import anki.config.ConfigKey
 import com.google.protobuf.kotlin.toByteStringUtf8
+import com.ichi2.libanki.utils.NotInLibAnki
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -56,5 +57,16 @@ class Config(val backend: Backend) {
 
     fun setBool(key: ConfigKey.Bool, value: Boolean) {
         backend.setConfigBool(key, value, false)
+    }
+
+    @NotInLibAnki
+    inline fun<reified T> get(key: String, default: T): T? {
+        return try {
+            Json.decodeFromString<T>(backend.getConfigJson(key).toStringUtf8())
+        } catch (ex: BackendNotFoundException) {
+            default
+        } catch (ex: SerializationException) {
+            null
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Added FSRS status to getDebugInfo as a coroutine and converted getDebugInfo into a suspend function and converted it's callers to applicationScopeLaunch.

## Fixes
* Fixes #15447

## Approach
- Adds info to the debug about weather the user is using FSRS or not, by creating a suspend fun getFSRSStatus(), which uses config.get() to get the FSRS status. 
- Converted getDebugInfo() to a suspend function.
- Wrapped all the relevant getDebugInfo() with a coroutine. 
## How Has This Been Tested?

When through compilation, tested by using a fresh install and running cases the following cases: 
- With no decks (Fresh Install). (FSRS = null)
- One deck with no cards. (FSRS = null)
- One deck with Cards but FSRS has never been enabled. (FSRS = null)
- One deck with Cards and FSRS has been enabled. (FSRS = True)
- One deck with Card and FSRS has been disabled but was enabled some time in the past. (FSRS = False)
- With no decks but FSRS has been enabled before. (FSRS = null)
- New empty deck created with FSRS never enabled. (FSRS = False)

## Checklist
- [-] You have a descriptive commit message with a short title (first line, max 50 chars).
- [-] You have commented your code, particularly in hard-to-understand areas
- [-] You have performed a self-review of your own code
- [-] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [-] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

Here is a video with some TestCases
https://github.com/ankidroid/Anki-Android/assets/79502699/8184ce57-9c9a-4580-bd45-510690537073


