### PR TITLE
feat: copy card template to clipboard as Markdown

### DIFF
--- a/AnkiDroid/src/main/res/menu/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/menu/card_template_editor.xml
@@ -38,4 +38,8 @@
         android:id="@+id/action_insert_field"
         android:title="@string/card_template_editor_insert_field"
         ankidroid:showAsAction="never"/>
+    <item
+        android:id="@+id/action_copy_as_markdown"
+        android:title="@string/copy_as_markdown"
+        ankidroid:showAsAction="never" />
 </menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -128,6 +128,7 @@
     <string name="card_editor_reset_card">Reset progress</string>
     <string name="card_editor_reschedule_card" comment="Action to reschedule a card">Reschedule</string>
     <string name="card_editor_preview_card" comment="Button offering to preview some card(s)">Preview</string>
+    <string name="copy_as_markdown" comment="Copies text to the clipboard as Markdown">Copy as Markdown</string>
     <string name="preview_progress_bar_text" comment="What card we are on out of how many in card previewer progress bar">%1$d of %2$d</string>
     <string name="rename" comment="Confirm that the renaming action should be processed.">Rename</string>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -22,6 +22,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CardTemplateEditor.CardTemplateFragment.CardTemplate
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.assertFalse
@@ -602,6 +603,41 @@ class CardTemplateEditorTest : RobolectricTest() {
             getAlertDialogText(true)
         )
         clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+    }
+
+    @Test
+    fun `template to markdown`() {
+        val template = CardTemplate(
+            front = "Hello World{{Front}}\n{{Extra}}",
+            back = "{{FrontSide}}\n",
+            style = ".card { }"
+        )
+
+        assertEquals(
+            "markdown formatted template",
+"""
+**Front template**
+
+```html
+Hello World{{Front}}
+{{Extra}}
+```
+
+**Back template**
+
+```html
+{{FrontSide}}
+
+```
+
+**Styling**
+
+```css
+.card { }
+```
+""".trim(),
+            template.toMarkdown(targetContext)
+        )
     }
 
     private fun getModelCardCount(notetype: NotetypeJson): Int {


### PR DESCRIPTION
## Purpose / Description
A number of users post their templates on Anki Forums/Reddit/Discord/GitHub and these are often badly formatted

Providing a Markdown-friendly option seems sensible

## Fixes
* Fixes #15748

## Approach
* Provide a Markdown formatted template


## How Has This Been Tested?

<img width="214" alt="Screenshot 2024-03-02 at 22 04 34" src="https://github.com/ankidroid/Anki-Android/assets/62114487/fa7c191d-565f-4dd0-b54d-8225e4e535fc">

* updates to the text field are included

**Front template**

```html
{{Front}}

<div id="result"></div>

<div class="result">
</div>

<script>
    var jsApi = { "version": "0.0.2", "developer":  "" };

   var api = AnkiDroidJS.init(jsApi)
   api.ankiGetETA().then(response => console.log(response));

    (async function() {
       let eta = await api.ankiGetETA();
       console.log("2aa" + eta.value);
})();
    
        
</script>
```

**Back template**

```html
{{FrontSide}}

<hr id=answer>

{{Back}}
```

**Styling**

```css
.card {
    font-family: arial;
    font-size: 20px;
    text-align: center;
    color: black;
    background-color: white;
}

```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
