### PR TITLE
Fix: Widget - Missing storage permission causing NPE and crashing app

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -544,6 +544,23 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         finish()
     }
 
+    /**
+     * If storage permissions are not granted, shows a toast message and finishes the activity.
+     *
+     * This should be called AFTER a call to `super.`[onCreate]
+     *
+     * @return `true`: activity may continue to start, `false`: [onCreate] should stop executing
+     * as storage permissions are mot granted
+     */
+    fun ensureStoragePermissions(): Boolean {
+        if (IntentHandler.grantedStoragePermissions(this, showToast = true)) {
+            return true
+        }
+        Timber.w("finishing activity. No storage permission")
+        finish()
+        return false
+    }
+
     companion object {
         const val DIALOG_FRAGMENT_TAG = "dialog"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -29,7 +29,6 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
 import androidx.annotation.ColorInt
-import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
@@ -41,7 +40,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.anki.browser.CardBrowserColumn.Companion.COLUMN1_KEYS
 import com.ichi2.anki.browser.CardBrowserColumn.Companion.COLUMN2_KEYS
@@ -67,7 +65,6 @@ import com.ichi2.anki.export.ActivityExportingDelegate
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.export.ExportDialogsFactory
 import com.ichi2.anki.export.ExportDialogsFactoryProvider
-import com.ichi2.anki.introduction.hasCollectionStoragePermissions
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.*
@@ -349,23 +346,15 @@ open class CardBrowser :
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
-        // must be called after showedActivityFailedScreen
-        viewModel = createViewModel()
-
         tagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         exportingDelegate = ActivityExportingDelegate(this) { getColUnsafe }
         super.onCreate(savedInstanceState)
-        if (wasLoadedFromExternalTextActionItem() && !hasCollectionStoragePermissions()) {
-            // we need to do this as DeckPicker still contains app init logic/upgrade logic
-            Timber.w("'Card Browser' Action item pressed before storage permissions granted.")
-            showThemedToast(
-                this,
-                getString(R.string.intent_handler_failed_no_storage_permission),
-                false
-            )
-            displayDeckPickerForPermissionsDialog()
+        if (!ensureStoragePermissions()) {
             return
         }
+        // must be called once we have an accessible collection
+        viewModel = createViewModel()
+
         launchOptions = intent?.toCardBrowserLaunchOptions() // must be called after super.onCreate()
         setContentView(R.layout.card_browser)
         initNavigationDrawer(findViewById(android.R.id.content))
@@ -818,23 +807,6 @@ open class CardBrowser :
         } else {
             super.onNavigationPressed()
         }
-    }
-
-    private fun displayDeckPickerForPermissionsDialog() {
-        // TODO: Combine this with class: IntentHandler after both are well-tested
-        val deckPicker = Intent(this, DeckPicker::class.java)
-        deckPicker.action = Intent.ACTION_MAIN
-        deckPicker.addCategory(Intent.CATEGORY_LAUNCHER)
-        deckPicker.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-        startActivity(deckPicker)
-        finish()
-        this.setResult(RESULT_CANCELED)
-    }
-
-    private fun wasLoadedFromExternalTextActionItem(): Boolean {
-        val intent = this.intent ?: return false
-        // API 23: Replace with Intent.ACTION_PROCESS_TEXT
-        return "android.intent.action.PROCESS_TEXT".equals(intent.action, ignoreCase = true)
     }
 
     private fun updatePreviewMenuItem() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -126,12 +126,11 @@ class IntentHandler : Activity() {
      */
     @NeedsTest("clicking a file in 'Files' to import")
     private fun performActionIfStorageAccessible(reloadIntent: Intent, action: String?, block: () -> Unit) {
-        if (!ScopedStorageService.isLegacyStorage(this) || hasStorageAccessPermission(this) || Permissions.isExternalStorageManagerCompat()) {
+        if (grantedStoragePermissions(this, showToast = true)) {
             Timber.i("User has storage permissions. Running intent: %s", action)
             block()
         } else {
             Timber.i("No Storage Permission, cancelling intent '%s'", action)
-            showThemedToast(this, getString(R.string.intent_handler_failed_no_storage_permission), false)
             launchDeckPickerIfNoOtherTasks(reloadIntent)
         }
     }
@@ -266,6 +265,20 @@ class IntentHandler : Activity() {
             // Negating a negative because we want to call specific attention to the fact that it's invalid
             // #6312 - Smart Launcher provided an empty ACTION_VIEW, no point in importing here.
             return !isInvalidViewIntent(intent)
+        }
+
+        /** Checks whether storage permissions are granted on the device. If the device is not using legacy storage,
+         *  it verifies if the app has been granted the necessary storage access permission.
+         *  @return `true`: if granted, otherwise `false` and shows a missing permission toast
+         */
+        fun grantedStoragePermissions(context: Context, showToast: Boolean): Boolean {
+            val granted = !ScopedStorageService.isLegacyStorage(context) || hasStorageAccessPermission(context) || Permissions.isExternalStorageManagerCompat()
+
+            if (!granted && showToast) {
+                showThemedToast(context, context.getString(R.string.intent_handler_failed_no_storage_permission), false)
+            }
+
+            return granted
         }
 
         @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -420,6 +420,10 @@ abstract class NavigationDrawerActivity :
         const val EXTRA_STARTED_WITH_SHORTCUT = "com.ichi2.anki.StartedWithShortcut"
 
         fun enablePostShortcut(context: Context) {
+            if (!IntentHandler.grantedStoragePermissions(context, showToast = false)) {
+                Timber.w("No storage access, not enabling shortcuts")
+                return
+            }
             // Review Cards Shortcut
             val intentReviewCards = Intent(context, Reviewer::class.java)
             intentReviewCards.action = Intent.ACTION_VIEW

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -354,6 +354,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         tagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         mediaRegistration = MediaRegistration(this)
         super.onCreate(savedInstanceState)
+        if (!ensureStoragePermissions()) {
+            return
+        }
         fieldState.setInstanceState(savedInstanceState)
         setContentView(R.layout.note_editor)
         val intent = intent

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -173,6 +173,9 @@ open class Reviewer :
             return
         }
         super.onCreate(savedInstanceState)
+        if (!ensureStoragePermissions()) {
+            return
+        }
         colorPalette = findViewById(R.id.whiteboard_editor)
         answerTimer = AnswerTimer(findViewById(R.id.card_time))
         textBarNew = findViewById(R.id.new_number)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
+import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -38,6 +39,10 @@ class AddNoteWidget : AppWidgetProvider() {
 
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         super.onUpdate(context, appWidgetManager, appWidgetIds)
+        if (!IntentHandler.grantedStoragePermissions(context, showToast = false)) {
+            Timber.w("Opening AddNote widget without storage access")
+            return
+        }
         Timber.d("onUpdate")
         val remoteViews = RemoteViews(context.packageName, R.layout.widget_add_note)
         val intent = Intent(context, NoteEditor::class.java)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -28,6 +28,7 @@ import androidx.core.app.PendingIntentCompat
 import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.preferences.sharedPrefs
@@ -38,6 +39,10 @@ import kotlin.math.sqrt
 class AnkiDroidWidgetSmall : AppWidgetProvider() {
     override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
         Timber.d("SmallWidget: onUpdate")
+        if (!grantedStoragePermissions(context, showToast = false)) {
+            Timber.w("Opening AnkiDroid Small widget without storage access")
+            return
+        }
         WidgetStatus.updateInBackground(context)
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* #15698 PR tried to fix the widget issue but it introduced a bug in lower API (Android<=10) which I revert in   #15747
Here in this PR instead of disabling the widgets from manifest file, I updated the flow which is
* The shortcuts are not enabled until the storage access is granted using a return statement in the same function
* Widgets are enabled by default but if user tries to access the widget i.e. open it without storage permission then they are taken to storage permission screen. For existing user having the widgets(we can't update the existing widget that are already added) placing a check in the respective activities to handle the cases and showing a relevant toast that storage permission is missing 
* No existing widget is deleted 
* Not bound to any API level 


## Fixes
* Fixes #13518
* Fixes #15686

## How Has This Been Tested?
[widget_new_device.webm](https://github.com/ankidroid/Anki-Android/assets/48384865/a1c20b3d-33ff-42fd-a38f-0ba044c93e29)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
