### PR TITLE
fix: Play store already has 2.18alpha4, bump version

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -74,8 +74,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode=21800103
-        versionName="2.18alpha3"
+        versionCode=21800104
+        versionName="2.18alpha4"
         minSdk 23 // also in testlib/build.gradle.kts
         // After #13695: change .tests_emulator.yml
         targetSdk 33 // also in [api|testlib]/build.gradle.kts and ../robolectricDownloader.gradle


### PR DESCRIPTION
## Purpose / Description

as part of the release pipeline failure previously, the build version commit did not land on main, so our version in source on main is stale vs the version already out in alpha channel, causing all releases to fail as the version has been used

## Approach

Read through the failed release workflow logs and realize the `AnkIDroid/build.gradle` file was still showing alpha3 but alpha4 was rolled out to alpha channel and that explains why the release workflow log failure indicates the build code is too low or already in use...

