### PR TITLE
fix: assets loading with mixed `<script>` tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -340,7 +340,7 @@ fun parseVideos(text: String, mediaDir: String): String {
 @NotInLibAnki
 @VisibleForTesting
 fun parseSourcesToFileScheme(content: String, mediaDir: String): String {
-    val doc = Jsoup.parse(content)
+    val doc = Jsoup.parseBodyFragment(content)
     doc.outputSettings(OutputSettings().prettyPrint(false))
 
     fun replaceWithFileScheme(tag: String, attr: String): Boolean {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
@@ -133,6 +133,33 @@ class TemplateManagerTest {
         assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid@%23$%25/collection.media/magenta.png">""", result)
     }
 
+    @Test
+    fun `parseSourcesToFileScheme - mixed script`() {
+        @Language("HTML")
+        val input = """
+            <!-- VERSION 1.14 -->
+            <script>
+            var scroll = false;
+            </script>
+            <img src="lovely.jpg">
+            <!-- ENHANCED_CLOZE -->
+            hughes and kisses
+        """
+
+        @Language("HTML")
+        val expectedResult = """
+            <!-- VERSION 1.14 -->
+            <script>
+            var scroll = false;
+            </script>
+            <img src="file:///storage/emulated/0/15773/collection.media/lovely.jpg">
+            <!-- ENHANCED_CLOZE -->
+            hughes and kisses
+        """
+        val result = parseSourcesToFileScheme(input, "/storage/emulated/0/15773/collection.media")
+        assertEquals(expectedResult, result)
+    }
+
     /***********************************************************************************************
      * [parseVideos] tests
      **********************************************************************************************/


### PR DESCRIPTION
## Fixes
* Fixes #15773

## How Has This Been Tested?

31:

[Screen_recording_20240305_104701.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/57cbc663-7006-41ac-8b01-a8906909783c)

## Learning (optional, can help others)

https://jsoup.org/cookbook/input/parse-body-fragment

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
