### PR TITLE
fix: Anki Desktop strings: use sentence case

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -29,6 +29,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
 import androidx.annotation.ColorInt
+import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
@@ -86,6 +87,7 @@ import com.ichi2.anki.servicelayer.totalLapsesOfNote
 import com.ichi2.anki.servicelayer.totalReviewsForNote
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.BasicItemSelectedListener
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.anki.utils.roundedTimeSpanUnformatted
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
@@ -847,7 +849,7 @@ open class CardBrowser :
         }
         if (viewModel.hasSelectedAnyRows()) {
             actionBarMenu!!.findItem(R.id.action_suspend_card).apply {
-                title = TR.browsingToggleSuspend()
+                title = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
                 setIcon(R.drawable.ic_suspend)
             }
             actionBarMenu!!.findItem(R.id.action_mark_card).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui.internationalization
+
+import android.app.Activity
+import androidx.annotation.StringRes
+
+// Functions for handling a move from 'Title Case' in Anki Desktop to 'Sentence case' in AnkiDroid
+
+/**
+ * Converts a string to sentence case if it matches the provided resource in `sentence-case.xml`
+ *
+ * ```
+ * "Toggle Suspend".toSentenceCase(R.string.sentence_toggle_suspend) // "Toggle suspend"
+ * ```
+ */
+context (Activity)
+fun String.toSentenceCase(@StringRes resId: Int): String {
+    val resString = getString(resId)
+    // lowercase both for the comparison: sentence case doesn't mean all words are lowercase
+    if (this.lowercase() == resString.lowercase()) return resString
+    return this
+}

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+These strings are from Anki Desktop, but in Title Case, rather than Sentence case.
+As only English uses Title Case [https://en.wikipedia.org/wiki/Letter_case#], we can define
+constant overrides to transform string to sentence case
+
+https://github.com/ankidroid/Anki-Android/issues/15760
+
+TODO:
+col.undoLabel()
+col.redoLabel()
+undoActionUndone()
+-->
+<resources>
+    <string name="sentence_toggle_suspend">Toggle suspend</string>
+</resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui.internationalization
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.IntroductionActivity
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.EmptyApplication
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class SentenceCaseTest : RobolectricTest() {
+    @Test
+    fun `English is converted to sentence case`() {
+        with(super.startRegularActivity<IntroductionActivity>()) {
+            assertThat(TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
+            assertThat("Toggle Suspend".toSentenceCase(R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
+            assertThat("Ook? Ook?".toSentenceCase(R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
+        }
+    }
+}


### PR DESCRIPTION
## Fixes
* Issue #15760

## Approach
Since English is the only language which uses title case
* define strings in English only which use sentence case
* Use these as overrides for strings from `TR`


## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
