### PR TITLE
chore: cleanups to allow List-based input of collection path 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -230,7 +230,7 @@ object CollectionHelper {
      * @see android.content.Context.getExternalFilesDirs
      */
     fun getAppSpecificExternalDirectories(context: Context): List<File> {
-        return context.getExternalFilesDirs(null).filterNotNull()
+        return context.getExternalFilesDirs(null)?.filterNotNull() ?: listOf()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -29,6 +29,7 @@ import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceManager.OnPreferenceTreeClickListener
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.preferences.DialogFragmentProvider
+import timber.log.Timber
 import java.lang.NumberFormatException
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
@@ -91,14 +92,12 @@ abstract class SettingsFragment :
     // `getTargetFragment()`, which throws if `setTargetFragment()` isn't used before.
     // While this isn't fixed on upstream, suppress the deprecation warning
     override fun onDisplayPreferenceDialog(preference: Preference) {
-        if (preference is DialogFragmentProvider) {
-            val dialogFragment = preference.makeDialogFragment()
-            dialogFragment.arguments = bundleOf("key" to preference.key)
-            dialogFragment.setTargetFragment(this, 0)
-            dialogFragment.show(parentFragmentManager, "androidx.preference.PreferenceFragment.DIALOG")
-        } else {
-            super.onDisplayPreferenceDialog(preference)
-        }
+        val dialogFragment = (preference as? DialogFragmentProvider)?.makeDialogFragment()
+            ?: return super.onDisplayPreferenceDialog(preference)
+        Timber.d("displaying custom preference: ${dialogFragment::class.simpleName}")
+        dialogFragment.arguments = bundleOf("key" to preference.key)
+        dialogFragment.setTargetFragment(this, 0)
+        dialogFragment.show(parentFragmentManager, "androidx.preference.PreferenceFragment.DIALOG")
     }
 
     override fun onStart() {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ListPreferenceTrait.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ListPreferenceTrait.kt
@@ -1,0 +1,154 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates code under the following license
+ *
+ *     Copyright 2018 The Android Open Source Project
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ * Source: androidx.preference.ListPreferenceDialogFragmentCompat
+ *
+ * Changes:
+ * * Convert to Kotlin
+ * * Remove Hungarian Notation
+ * * Rely on `ListPreferenceTrait` rather than `ListPreference`
+ * * `bundleOf` + `.apply` usage
+ * * `if (preference.callChangeListener(value)) {` - depend on `preference` and `listPreference`
+ */
+
+package com.ichi2.preferences
+
+import android.content.DialogInterface
+import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.preference.ListPreferenceDialogFragmentCompat
+import androidx.preference.Preference
+import androidx.preference.PreferenceDialogFragmentCompat
+import androidx.preference.R
+
+/**
+ * A [Preference] may inherit from [ListPreferenceTrait] if it wishes to
+ * optionally display a List-based dialog.
+ * To do so, return a [ListPreferenceDialogFragment] via [DialogFragmentProvider.makeDialogFragment]
+ */
+// This exists as we want a dialog to show either a List or an EditText, and both the framework
+// classes require inheritance
+interface ListPreferenceTrait : DialogFragmentProvider {
+    var listEntries: List<Entry>
+    val entryKeys get() = listEntries.map { it.key }
+    val entryValues get() = listEntries.map { it.value }
+
+    fun indexOf(value: String) = listEntries.indexOfFirst { it.value == value }
+
+    var listValue: String
+
+    data class Entry(val key: String, val value: String)
+
+    companion object {
+        /** to be passed into defStyleAttr in the [Preference] constructor */
+        val STYLE_ATTR = R.attr.dialogPreferenceStyle
+    }
+}
+
+/**
+ * A fragment which may be launched from a [Preference] implementing a [ListPreferenceTrait]
+ *
+ * Adapted from: [ListPreferenceDialogFragmentCompat]
+ * @see ListPreferenceDialogFragmentCompat
+ */
+class ListPreferenceDialogFragment : PreferenceDialogFragmentCompat() {
+
+    /* synthetic access */
+    private var clickedDialogEntryIndex = 0
+    private lateinit var entries: Array<CharSequence>
+    private lateinit var entryValues: Array<CharSequence>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState == null) {
+            val preference = listPreference
+            clickedDialogEntryIndex = preference.indexOf(preference.listValue)
+            entries = preference.entryKeys.toTypedArray()
+            entryValues = preference.entryValues.toTypedArray()
+        } else {
+            clickedDialogEntryIndex = savedInstanceState.getInt(SAVE_STATE_INDEX, 0)
+            entries = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRIES)!!
+            entryValues = savedInstanceState.getCharSequenceArray(SAVE_STATE_ENTRY_VALUES)!!
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putInt(SAVE_STATE_INDEX, clickedDialogEntryIndex)
+        outState.putCharSequenceArray(SAVE_STATE_ENTRIES, entries)
+        outState.putCharSequenceArray(SAVE_STATE_ENTRY_VALUES, entryValues)
+    }
+
+    private val listPreference get() = preference as ListPreferenceTrait
+
+    override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
+        super.onPrepareDialogBuilder(builder)
+        builder.setSingleChoiceItems(
+            entries,
+            clickedDialogEntryIndex
+        ) { dialog, which ->
+            clickedDialogEntryIndex = which
+
+            // Clicking on an item simulates the positive button click, and dismisses
+            // the dialog.
+            this.onClick(
+                dialog,
+                DialogInterface.BUTTON_POSITIVE
+            )
+            dialog.dismiss()
+        }
+
+        // The typical interaction for list-based dialogs is to have click-on-an-item dismiss the
+        // dialog instead of the user having to press 'Ok'.
+        builder.setPositiveButton(null, null)
+    }
+
+    override fun onDialogClosed(positiveResult: Boolean) {
+        if (positiveResult && clickedDialogEntryIndex >= 0) {
+            val value = entryValues[clickedDialogEntryIndex].toString()
+            if (preference.callChangeListener(value)) {
+                listPreference.listValue = value
+            }
+        }
+    }
+
+    companion object {
+        private const val SAVE_STATE_INDEX = "ListPreferenceDialogFragment.index"
+        private const val SAVE_STATE_ENTRIES = "ListPreferenceDialogFragment.entries"
+        private const val SAVE_STATE_ENTRY_VALUES = "ListPreferenceDialogFragment.entryValues"
+
+        fun newInstance(key: String?): ListPreferenceDialogFragment =
+            ListPreferenceDialogFragment().apply {
+                arguments = bundleOf(ARG_KEY to key)
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/PreferenceUtil.kt
@@ -35,11 +35,11 @@ import kotlin.contracts.contract
 interface DialogFragmentProvider {
 
     /**
-     * @return A DialogFragment to show.
+     * @return A DialogFragment to show or `null` to use the parent fragment
      *   The dialog must have a zero-parameter constructor.
      *   Any arguments set via [Fragment.setArguments] may get overridden.
      */
-    fun makeDialogFragment(): DialogFragment
+    fun makeDialogFragment(): DialogFragment?
 }
 
 /**


### PR DESCRIPTION
`onDisplayPreferenceDialog`: If a call to super is requested, `null` may be returned In this case, `super` would be called

This is useful if you would optionally want to inherit from a class (say `EditTextPreference`), but also allow conditionally return a different fragment

* Prep for #3114 : 
   * We'll want a `ListPreference` if the user is on `play`
   * An `EditTextPreference` if the user is on `full`
   * Preferences screens don't expect two preferences for the same key
     * So we need one preference which will change implementations  

----

One refactoring to `CollectonManager`

----

A new trait which allows a list preference to **optionally** be displayed when a preference is clicked