### PR TITLE
chore: Failure string as default in `copyToClipboard` method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -653,8 +653,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
             context?.let { ctx ->
                 ctx.copyToClipboard(
-                    template.toMarkdown(ctx),
-                    failureMessageId = R.string.failed_to_copy
+                    template.toMarkdown(ctx)
                 )
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
@@ -21,7 +21,6 @@ import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AndroidTtsVoice
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.R
 import com.ichi2.anki.TtsVoices
 import com.ichi2.anki.dialogs.tryDisplayLocalizedName
 import com.ichi2.libanki.TTSTag
@@ -180,8 +179,7 @@ class TtsVoicesViewModel : ViewModel() {
         // At least in API 33, we do not need to display a snackbar, as the Android OS already
         // displays the copied text
         AnkiDroidApp.instance.copyToClipboard(
-            text = voice.toString(),
-            failureMessageId = R.string.failed_to_copy
+            text = voice.toString()
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -81,7 +81,7 @@ object ClipboardUtil {
 fun Context.copyToClipboard(
     text: String,
     @StringRes successMessageId: Int = R.string.about_ankidroid_successfully_copied_debug_info,
-    @StringRes failureMessageId: Int
+    @StringRes failureMessageId: Int = R.string.failed_to_copy
 ) {
     val copied = copyTextToClipboard(text)
     // in Android S_V2 and above, the system is guaranteed to show a message on a successful copy


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The success string was default param but failure. Hence making `R.string.failed_to_copy` as default 

I did comment on a PR regarding this but was not resolved 



## How Has This Been Tested?
Google emulator API 34 build successfully 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
