### PR TITLE
Remove `.avi` from supported video extensions, and add `.webm`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -64,7 +64,7 @@ fun stripAvRefs(text: String, replacement: String = "") = Sound.AV_REF_RE.replac
 
 // not in libAnki
 object Sound {
-    val VIDEO_EXTENSIONS = setOf("mp4", "mov", "mpg", "mpeg", "mkv", "avi")
+    val VIDEO_EXTENSIONS = setOf("mp4", "mov", "mpg", "mpeg", "mkv")
 
     /**
      * expandSounds takes content with embedded sound file placeholders and expands them to reference the actual media

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -64,7 +64,7 @@ fun stripAvRefs(text: String, replacement: String = "") = Sound.AV_REF_RE.replac
 
 // not in libAnki
 object Sound {
-    val VIDEO_EXTENSIONS = setOf("mp4", "mov", "mpg", "mpeg", "mkv")
+    val VIDEO_EXTENSIONS = setOf("mp4", "mov", "mpg", "mpeg", "mkv", "webm")
 
     /**
      * expandSounds takes content with embedded sound file placeholders and expands them to reference the actual media

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
@@ -50,8 +50,8 @@ class TemplateManagerTest {
     @Test
     fun `parseSourcesToFileScheme - object`() {
         val mediaDir = "storage/emulated/0/AnkiDroid/collection.media"
-        val result = parseSourcesToFileScheme("<object data=\"ben.avi\"></object>", mediaDir)
-        assertEquals("""<object data="file:///$mediaDir/ben.avi"></object>""", result)
+        val result = parseSourcesToFileScheme("<object data=\"ben.mov\"></object>", mediaDir)
+        assertEquals("""<object data="file:///$mediaDir/ben.mov"></object>""", result)
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
AVI isn't supported by default in Android's WebView (nor in general [Android](https://developer.android.com/media/platform/supported-formats)), while `.webm` is

## Fixes
* Fixes #15772

## Approach
In the commits

## How Has This Been Tested?

Emulator 31
1. Add videos [from this site](https://filesamples.com/categories/video) with `webm` and `avi` files
Result: webm videos are played and nothing happens with avi files

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
