### PR TITLE
[Clean Up] : Replacing enum.values() by enum.entries

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -519,7 +519,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         EMPTY_SCHEDULE(3);
 
         companion object {
-            fun fromInt(value: Int): ContextMenuConfiguration = values().first { it.value == value }
+            fun fromInt(value: Int): ContextMenuConfiguration = entries.first { it.value == value }
         }
     }
 
@@ -541,8 +541,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         MORE_OPTIONS(108, R.string.more_options);
 
         companion object {
-            fun fromInt(value: Int): ContextMenuOption = values().first { it.value == value }
-            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = values().first { resources.getString(it.stringResource as Int) == stringValue }
+            fun fromInt(value: Int): ContextMenuOption = entries.first { it.value == value }
+            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = entries.first { resources.getString(it.stringResource as Int) == stringValue }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Theme.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Theme.kt
@@ -31,7 +31,7 @@ enum class Theme(val id: String, @StyleRes val resId: Int, val isNightMode: Bool
             get() = LIGHT
 
         fun ofId(id: String): Theme {
-            return values().find { it.id == id } ?: fallback
+            return entries.find { it.id == id } ?: fallback
         }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In this PR, I tried to update the code using enum.values() instead of the recommended enum.entries 

## Fixes
* Issue #13282 

## Approach
Using the Android Studio's Inspect Code Option , I found out the files still using the older method and changed them to the recommended method of enum.entries.

## How Has This Been Tested?
I ran `./gradlew jacocoTestReport` to test these changes 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
