### PR TITLE
fix: dont reset scroll state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2037,7 +2037,7 @@ open class DeckPicker :
             Timber.e(e, "RuntimeException setting time remaining")
         }
         val current = withCol { decks.current().optLong("id") }
-        if (focusedDeck != current && focusedDeck != 0L) {
+        if (focusedDeck != current) {
             scrollDecklistToDeck(current)
             focusedDeck = current
         }
@@ -2131,6 +2131,7 @@ open class DeckPicker :
                     decks.removeDecks(listOf(did))
                 }
             }
+            focusedDeck = 1
             showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2131,7 +2131,9 @@ open class DeckPicker :
                     decks.removeDecks(listOf(did))
                 }
             }
-            focusedDeck = 1
+            // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
+            // to match and avoid unnecessary scrolls in `renderPage()`.
+            focusedDeck = Consts.DEFAULT_DECK_ID
             showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2037,7 +2037,7 @@ open class DeckPicker :
             Timber.e(e, "RuntimeException setting time remaining")
         }
         val current = withCol { decks.current().optLong("id") }
-        if (focusedDeck != current) {
+        if (focusedDeck != current && focusedDeck != 0L) {
             scrollDecklistToDeck(current)
             focusedDeck = current
         }
@@ -2131,7 +2131,6 @@ open class DeckPicker :
                     decks.removeDecks(listOf(did))
                 }
             }
-            focusedDeck = 1
             showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2131,6 +2131,7 @@ open class DeckPicker :
                     decks.removeDecks(listOf(did))
                 }
             }
+            focusedDeck = 1
             showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Dont reset scroll state after deletion

## Fixes
* Fixes #15442 

## Approach
When user deletes a deck, state of the currently selected deck is reset to 1, while `focusedDeck` variable still holds
deck id of deleted deck, consequently when `renderPage()` is called it executes 
`if (focusedDeck != current) {
            scrollDecklistToDeck(current)
            focusedDeck = current
        }`
resetting the scroll state.
If we change `focusedDeck` to 1, then above if statement is skipped
## How Has This Been Tested?
manually

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
