### PR TITLE
Exit confirmation in IO Editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.addCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
@@ -38,16 +39,16 @@ class ImageOcclusionActivity : SingleFragmentActivity() {
     }
 
     private fun showExitConfirmationDialog() {
-        val alertDialogBuilder = android.app.AlertDialog.Builder(this)
-        alertDialogBuilder.setMessage("Discard current input?")
-        alertDialogBuilder.setPositiveButton("Discard") { dialog, _ ->
+        val alertDialogBuilder = AlertDialog.Builder(this)
+        alertDialogBuilder.setMessage(CollectionManager.TR.addingDiscardCurrentInput())
+        alertDialogBuilder.setPositiveButton(getString(R.string.discard)) { dialog, _ ->
             dialog.dismiss()
             finish()
         }
-        alertDialogBuilder.setNegativeButton("Keep Editing") { dialog, _ ->
+        alertDialogBuilder.setNegativeButton(CollectionManager.TR.addingKeepEditing()) { dialog, _ ->
             dialog.dismiss()
         }
-        val alertDialog: android.app.AlertDialog = alertDialogBuilder.create()
+        val alertDialog: AlertDialog = alertDialogBuilder.create()
         alertDialog.show()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
@@ -19,8 +19,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.addCallback
-import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.dialogs.DiscardChangesDialog
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
@@ -31,25 +31,18 @@ import kotlin.reflect.jvm.jvmName
  * to avoid unwanted activity recreations
  */
 class ImageOcclusionActivity : SingleFragmentActivity() {
+
     override fun onStart() {
         super.onStart()
         onBackPressedDispatcher.addCallback(this) {
-            showExitConfirmationDialog()
+            DiscardChangesDialog.showDialog(this@ImageOcclusionActivity) {
+                closeIOEditor()
+            }
         }
     }
 
-    private fun showExitConfirmationDialog() {
-        val alertDialogBuilder = AlertDialog.Builder(this)
-        alertDialogBuilder.setMessage(CollectionManager.TR.addingDiscardCurrentInput())
-        alertDialogBuilder.setPositiveButton(getString(R.string.discard)) { dialog, _ ->
-            dialog.dismiss()
-            finish()
-        }
-        alertDialogBuilder.setNegativeButton(CollectionManager.TR.addingKeepEditing()) { dialog, _ ->
-            dialog.dismiss()
-        }
-        val alertDialog: AlertDialog = alertDialogBuilder.create()
-        alertDialog.show()
+    private fun closeIOEditor() {
+        finish()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
@@ -32,17 +32,13 @@ import kotlin.reflect.jvm.jvmName
  */
 class ImageOcclusionActivity : SingleFragmentActivity() {
 
-    override fun onStart() {
-        super.onStart()
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
         onBackPressedDispatcher.addCallback(this) {
             DiscardChangesDialog.showDialog(this@ImageOcclusionActivity) {
-                closeIOEditor()
+                finish()
             }
         }
-    }
-
-    private fun closeIOEditor() {
-        finish()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ImageOcclusionActivity.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
@@ -29,6 +30,26 @@ import kotlin.reflect.jvm.jvmName
  * to avoid unwanted activity recreations
  */
 class ImageOcclusionActivity : SingleFragmentActivity() {
+    override fun onStart() {
+        super.onStart()
+        onBackPressedDispatcher.addCallback(this) {
+            showExitConfirmationDialog()
+        }
+    }
+
+    private fun showExitConfirmationDialog() {
+        val alertDialogBuilder = android.app.AlertDialog.Builder(this)
+        alertDialogBuilder.setMessage("Discard current input?")
+        alertDialogBuilder.setPositiveButton("Discard") { dialog, _ ->
+            dialog.dismiss()
+            finish()
+        }
+        alertDialogBuilder.setNegativeButton("Keep Editing") { dialog, _ ->
+            dialog.dismiss()
+        }
+        val alertDialog: android.app.AlertDialog = alertDialogBuilder.create()
+        alertDialog.show()
+    }
 
     companion object {
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this change is to implement an exit confirmation dialog that appears when the back button is pressed accidentally. This feature aims to prevent users from losing their work accidentally.

## Fixes
* Fixes #15753

## Approach
The approach taken to address this issue was to add an on `onBackPressedDispatcher` in `ImageOcclusionActivity.kt` and call the method named `showExitConfirmationDialog()` when back button was pressed

## How Has This Been Tested?
Tested the app on Realme Narzo 50 Pro Device

## Screenshots
<img height=700 src=https://github.com/ankidroid/Anki-Android/assets/77337791/413c5aa4-8bfd-43d6-824e-15f2636ad428.jpeg>

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
