### PR TITLE
fix: can't create first deck if named 'default'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.getOrCreateFilteredDeck
@@ -96,16 +97,23 @@ class CreateDeckDialog(
                 return@input
             }
             // if deck name already exists, show an error
-            else if (Decks.deckExists(getColUnsafe, maybeDeckName)){
+            if (deckExists(getColUnsafe, maybeDeckName)){
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
                 dialog.positiveButton.isEnabled = false
                 return@input
-            } else dialog.getInputTextLayout().error = null
+            }
+            dialog.getInputTextLayout().error = null
             dialog.positiveButton.isEnabled = true
         }
         shownDialog = dialog
         return dialog
     }
+
+    /**
+     * @return true if the collection contains a deck with the given name
+     */
+    private fun deckExists(col: Collection, name: String) =
+        col.decks.byName(name) != null
 
     /**
      * Returns the fully qualified deck name for the provided input

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -96,7 +96,6 @@ class CreateDeckDialog(
                 dialog.positiveButton.isEnabled = false
                 return@input
             }
-            // if deck name already exists, show an error
             if (deckExists(getColUnsafe, maybeDeckName)) {
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_already_exists)
                 dialog.positiveButton.isEnabled = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -26,10 +26,12 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.getOrCreateFilteredDeck
 import com.ichi2.utils.getInputField
+import com.ichi2.utils.getInputTextLayout
 import com.ichi2.utils.input
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -94,11 +96,22 @@ class CreateDeckDialog(
                 dialog.positiveButton.isEnabled = false
                 return@input
             }
+            else if (deckExists(getColUnsafe, maybeDeckName)){
+                dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
+                dialog.positiveButton.isEnabled = false
+                return@input
+            } else dialog.getInputTextLayout().error = null
             dialog.positiveButton.isEnabled = true
         }
         shownDialog = dialog
         return dialog
     }
+
+    /**
+     * @return true if the collection contains a deck with the given name
+     */
+    private fun deckExists(col: Collection, name: String) =
+        col.decks.byName(name) != null
 
     /**
      * Returns the fully qualified deck name for the provided input

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -97,7 +97,7 @@ class CreateDeckDialog(
                 return@input
             }
             // if deck name already exists, show an error
-            if (deckExists(getColUnsafe, maybeDeckName)){
+            if (deckExists(getColUnsafe, maybeDeckName)) {
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
                 dialog.positiveButton.isEnabled = false
                 return@input

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -26,7 +26,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.getOrCreateFilteredDeck
@@ -96,7 +95,8 @@ class CreateDeckDialog(
                 dialog.positiveButton.isEnabled = false
                 return@input
             }
-            if (deckExists(getColUnsafe, maybeDeckName)){
+            // if deck name already exists, show an error
+            else if (Decks.deckExists(getColUnsafe, maybeDeckName)){
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
                 dialog.positiveButton.isEnabled = false
                 return@input
@@ -106,12 +106,6 @@ class CreateDeckDialog(
         shownDialog = dialog
         return dialog
     }
-
-    /**
-     * @return true if the collection contains a deck with the given name
-     */
-    fun deckExists(col: Collection, name: String) =
-        col.decks.byName(name) != null
 
     /**
      * Returns the fully qualified deck name for the provided input

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -96,7 +96,7 @@ class CreateDeckDialog(
                 dialog.positiveButton.isEnabled = false
                 return@input
             }
-            else if (deckExists(getColUnsafe, maybeDeckName)){
+            if (deckExists(getColUnsafe, maybeDeckName)){
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
                 dialog.positiveButton.isEnabled = false
                 return@input
@@ -110,7 +110,7 @@ class CreateDeckDialog(
     /**
      * @return true if the collection contains a deck with the given name
      */
-    private fun deckExists(col: Collection, name: String) =
+    fun deckExists(col: Collection, name: String) =
         col.decks.byName(name) != null
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -98,7 +98,7 @@ class CreateDeckDialog(
             }
             // if deck name already exists, show an error
             if (deckExists(getColUnsafe, maybeDeckName)) {
-                dialog.getInputTextLayout().error = context.getString(R.string.deck_name_exist)
+                dialog.getInputTextLayout().error = context.getString(R.string.deck_already_exists)
                 dialog.positiveButton.isEnabled = false
                 return@input
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -112,8 +112,7 @@ class CreateDeckDialog(
     /**
      * @return true if the collection contains a deck with the given name
      */
-    private fun deckExists(col: Collection, name: String) =
-        col.decks.byName(name) != null
+    private fun deckExists(col: Collection, name: String): Boolean = col.decks.byName(name) != null
 
     /**
      * Returns the fully qualified deck name for the provided input

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -297,10 +297,6 @@ class Decks(private val col: Collection) {
     * ***********************************************************
     */
         fun isValidDeckName(deckName: String): Boolean = deckName.trim { it <= ' ' }.isNotEmpty()
-        /**
-         * @return true if the collection contains a deck with the given name
-         */
-        fun deckExists(col: Collection, name: String): Boolean = col.decks.byName(name) != null
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -297,6 +297,10 @@ class Decks(private val col: Collection) {
     * ***********************************************************
     */
         fun isValidDeckName(deckName: String): Boolean = deckName.trim { it <= ' ' }.isNotEmpty()
+        /**
+         * @return true if the collection contains a deck with the given name
+         */
+        fun deckExists(col: Collection, name: String): Boolean = col.decks.byName(name) != null
     }
 }
 

--- a/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
@@ -15,8 +15,8 @@
   -->
 
 
-<com.google.android.material.textfield.TextInputLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dialog_text_input_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -24,7 +24,8 @@
     android:paddingLeft="32dp"
     android:paddingRight="32dp"
     android:paddingBottom="4dp"
-    android:paddingTop="16dp" >
+    app:errorEnabled="true"
+    android:paddingTop="16dp">
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/dialog_text_input"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -260,4 +260,6 @@
         Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled
     </string>
 
+    <string name="deck_name_exist">Deck name already exist</string>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -260,6 +260,6 @@
         Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled
     </string>
 
-    <string name="deck_name_exist">Deck name already exist</string>
+    <string name="deck_already_exists">Deck already exists</string>
 
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this change is to check if the deck name already exists before creating a new deck. This ensures that no deck with the same name exists.

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15678
* Fixes https://github.com/ankidroid/Anki-Android/issues/15759

## Approach
Created a function which takes the input deck name as parameter and checks whether it is present in the Collection or not.
If it is present, user is not allowed to add the deck.

## How Has This Been Tested?
The changes have been tested thoroughly to ensure functionality and compatibility across different devices and screen sizes. The following steps were taken to verify the changes:

1. Opened the "Create deck" section
2. Entered "Default" as the first deck. It didn't create since "Default" deck already exists.
3. Created "test" deck.
4. Tried to create "test" deck again. But an error is shown that the deck name already exists.
5. Reviewed the code changes for any potential issues or regressions.

## Learning (optional, can help others)
During the implementation of this feature, I learned about creating an object that is accessible from all files.

No additional external resources were used in the implementation of this feature.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
