### PR TITLE
non-functional: sync `Decks` with libAnki

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
@@ -39,7 +39,7 @@ class FilteredDeckOptionsTest : InstrumentedTest() {
     @Test
     fun canOpenDeckOptions() {
         ActivityScenario.launch(DeckPicker::class.java).onActivity { deckPicker ->
-            val deckId = col.decks.newDyn("Filtered Testing")
+            val deckId = col.decks.newFiltered("Filtered Testing")
             deckPicker.showContextMenuDeckOptions(deckId)
         }.close()
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -133,7 +133,7 @@ class ContentProviderTest : InstrumentedTest() {
             )
         }
         // delete test decks
-        col.decks.removeDecks(testDeckIds)
+        col.decks.remove(testDeckIds)
         assertEquals(
             "Check that all created decks have been deleted",
             numDecksBeforeTest,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1263,7 +1263,7 @@ abstract class AbstractFlashcardViewer :
 
     private suspend fun automaticAnswerShouldWaitForAudio(): Boolean {
         return withCol {
-            decks.confForDid(currentCard!!.did).optBoolean("waitForAudio", true)
+            decks.configDictForDeckId(currentCard!!.did).optBoolean("waitForAudio", true)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -224,7 +224,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         val template = tempModel!!.getTemplate(ordinal)
         val templateName = template.getString("name")
 
-        if (deck != null && getColUnsafe.decks.isDyn(deck.deckId)) {
+        if (deck != null && getColUnsafe.decks.isFiltered(deck.deckId)) {
             Timber.w("Attempted to set default deck of %s to dynamic deck %s", templateName, deck.name)
             showSnackbar(getString(R.string.multimedia_editor_something_wrong), Snackbar.LENGTH_SHORT)
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2128,7 +2128,7 @@ open class DeckPicker :
         return launchCatchingTask {
             val changes = withProgress(resources.getString(R.string.delete_deck)) {
                 undoableOp {
-                    decks.removeDecks(listOf(did))
+                    decks.remove(listOf(did))
                 }
             }
             showSnackbar(TR.browsingCardsDeleted(changes.count), Snackbar.LENGTH_SHORT) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -373,7 +373,7 @@ open class DeckPicker :
                 decks.select(deckId)
                 Triple(
                     decks.name(deckId),
-                    decks.isDyn(deckId),
+                    decks.isFiltered(deckId),
                     sched.haveBuriedInCurrentDeck()
                 )
             }
@@ -2046,7 +2046,7 @@ open class DeckPicker :
     // Callback to show study options for currently selected deck
     fun showContextMenuDeckOptions(did: DeckId) {
         // open deck options
-        if (getColUnsafe.decks.isDyn(did)) {
+        if (getColUnsafe.decks.isFiltered(did)) {
             // open cram options if filtered deck
             val i = Intent(this@DeckPicker, FilteredDeckOptions::class.java)
             i.putExtra("did", did)
@@ -2546,7 +2546,7 @@ open class DeckPicker :
         when {
             sched.hasCardsTodayAfterStudyAheadLimit() -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
             sched.newDue() || sched.revDue() -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
-            decks.isDyn(did) -> CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED
+            decks.isFiltered(did) -> CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED
             deckListAdapter.getNodeByDid(did).children.isEmpty() && isEmptyDeck(did) -> CompletedDeckStatus.EMPTY_REGULAR_DECK
             else -> CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1793,7 +1793,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
 
             val currentDeckId = getColUnsafe.config.get(CURRENT_DECK) ?: 1L
-            return if (getColUnsafe.decks.isDyn(currentDeckId)) {
+            return if (getColUnsafe.decks.isFiltered(currentDeckId)) {
                 /*
                  * If the deck in mCurrentDid is a filtered (dynamic) deck, then we can't create cards in it,
                  * and we set mCurrentDid to the Default deck. Otherwise, we keep the number that had been

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -832,7 +832,7 @@ open class Reviewer :
         } else {
             toggleWhiteboardIcon.setTitle(R.string.enable_whiteboard)
         }
-        if (colIsOpenUnsafe() && getColUnsafe.decks.isDyn(parentDid)) {
+        if (colIsOpenUnsafe() && getColUnsafe.decks.isFiltered(parentDid)) {
             menu.findItem(R.id.action_open_deck_options).isVisible = false
         }
         if (tts.enabled && !actionButtons.status.selectTtsIsDisabled()) {
@@ -1289,7 +1289,7 @@ open class Reviewer :
     override fun restoreCollectionPreferences(col: Collection) {
         super.restoreCollectionPreferences(col)
         showRemainingCardCount = col.config.get("dueCounts") ?: true
-        stopTimerOnAnswer = col.decks.confForDid(col.decks.current().id).getBoolean("stopTimerOnAnswer")
+        stopTimerOnAnswer = col.decks.configDictForDeckId(col.decks.current().id).getBoolean("stopTimerOnAnswer")
     }
 
     override fun onSingleTap(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -230,7 +230,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             }
             R.id.action_deck_or_study_options -> {
                 Timber.i("StudyOptionsFragment:: Deck or study options button pressed")
-                if (col!!.decks.isDyn(col!!.decks.selected())) {
+                if (col!!.decks.isFiltered(col!!.decks.selected())) {
                     openFilteredDeckOptions()
                 } else {
                     val i = com.ichi2.anki.pages.DeckOptions.getIntent(requireContext(), col!!.decks.current().id)
@@ -315,7 +315,7 @@ class StudyOptionsFragment : Fragment(), Toolbar.OnMenuItemClickListener {
             toolbar!!.setOnMenuItemClickListener(this)
             val menu = toolbar!!.menu
             // Switch on or off rebuild/empty/custom study depending on whether or not filtered deck
-            if (col != null && col!!.decks.isDyn(col!!.decks.selected())) {
+            if (col != null && col!!.decks.isFiltered(col!!.decks.selected())) {
                 menu.findItem(R.id.action_rebuild).isVisible = true
                 menu.findItem(R.id.action_empty).isVisible = true
                 menu.findItem(R.id.action_custom_study).isVisible = false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardSoundConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardSoundConfig.kt
@@ -41,7 +41,7 @@ class CardSoundConfig(val replayQuestion: Boolean, val autoplay: Boolean, val de
         @CheckResult
         fun create(card: Card): CardSoundConfig {
             Timber.v("start loading SoundConfig")
-            val deckConfig = this@Collection.decks.confForDid(CardUtils.getDeckIdForCard(card))
+            val deckConfig = this@Collection.decks.configDictForDeckId(CardUtils.getDeckIdForCard(card))
 
             val autoPlay = deckConfig.optBoolean("autoplay", false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -132,7 +132,7 @@ class CreateDeckDialog(
         try {
             // create filtered deck
             Timber.i("CreateDeckDialog::createFilteredDeck...")
-            val newDeckId = getColUnsafe.decks.newDyn(deckName)
+            val newDeckId = getColUnsafe.decks.newFiltered(deckName)
             Timber.d("Created filtered deck '%s'; id: %d", deckName, newDeckId)
             onNewDeckCreated(newDeckId)
         } catch (ex: BackendDeckIsFilteredException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -451,7 +451,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         } else {
             Timber.i("Creating Dynamic Deck '%s' for custom study", customStudyDeck)
             dyn = try {
-                decks.get(decks.newDyn(customStudyDeck))!!
+                decks.get(decks.newFiltered(customStudyDeck))!!
             } catch (ex: BackendDeckIsFilteredException) {
                 showThemedToast(requireActivity(), ex.localizedMessage ?: ex.message ?: "", true)
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -194,7 +194,7 @@ class CongratsViewModel : ViewModel(), OnErrorListener {
     fun onDeckOptions() {
         launchCatchingIO {
             val deckId = withCol { decks.getCurrentId() }
-            val isFiltered = withCol { decks.isDyn(deckId) }
+            val isFiltered = withCol { decks.isFiltered(deckId) }
             deckOptionsDestination.emit(DeckOptionsDestination(deckId, isFiltered))
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -454,7 +454,7 @@ class CardContentProvider : ContentProvider() {
                     isDeckUpdate = key == FlashCardsContract.Card.DECK_ID
                     did = values.getAsLong(key)
                 }
-                require(!col.decks.isDyn(did)) { "Cards cannot be moved to a filtered deck" }
+                require(!col.decks.isFiltered(did)) { "Cards cannot be moved to a filtered deck" }
                 /* now update the card
                  */if (isDeckUpdate && did >= 0) {
                     Timber.d("CardContentProvider: Moving card to other deck...")
@@ -495,7 +495,7 @@ class CardContentProvider : ContentProvider() {
                         updated++
                     }
                     if (newDid != null) {
-                        if (col.decks.isDyn(newDid.toLong())) {
+                        if (col.decks.isFiltered(newDid.toLong())) {
                             throw IllegalArgumentException("Cannot set a filtered deck as default deck for a model")
                         }
                         model!!.put("did", newDid)
@@ -693,7 +693,7 @@ class CardContentProvider : ContentProvider() {
         }
         val col = CollectionHelper.instance.getColUnsafe(context!!)
             ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
-        if (col.decks.isDyn(deckId)) {
+        if (col.decks.isFiltered(deckId)) {
             throw IllegalArgumentException("A filtered deck cannot be specified as the deck in bulkInsertNotes")
         }
         col.log(String.format(Locale.US, "bulkInsertNotes: %d items.\n%s", valuesArr.size, getLogMessage("bulkInsert", null)))
@@ -792,7 +792,7 @@ class CardContentProvider : ContentProvider() {
                 if (modelName == null || fieldNames == null || numCards == null) {
                     throw IllegalArgumentException("Model name, field_names, and num_cards can't be empty")
                 }
-                if (did != null && col.decks.isDyn(did)) {
+                if (did != null && col.decks.isFiltered(did)) {
                     throw IllegalArgumentException("Cannot set a filtered deck as default deck for a model")
                 }
                 // Create a new model
@@ -1132,10 +1132,10 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Deck.DECK_ID -> rb.add(id)
                 FlashCardsContract.Deck.DECK_COUNTS -> rb.add(deckCounts)
                 FlashCardsContract.Deck.OPTIONS -> {
-                    val config = col.decks.confForDid(id).toString()
+                    val config = col.decks.configDictForDeckId(id).toString()
                     rb.add(config)
                 }
-                FlashCardsContract.Deck.DECK_DYN -> rb.add(col.decks.isDyn(id))
+                FlashCardsContract.Deck.DECK_DYN -> rb.add(col.decks.isFiltered(id))
                 FlashCardsContract.Deck.DECK_DESC -> {
                     val desc = col.decks.current().description
                     rb.add(desc)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -273,7 +273,7 @@ class AutomaticAnswerSettings(
             col: Collection,
             selectedDid: DeckId
         ): AutomaticAnswerSettings {
-            val conf = col.decks.confForDid(selectedDid)
+            val conf = col.decks.configDictForDeckId(selectedDid)
             val action = getAction(conf)
             val useTimer = preferences.getBoolean("timeoutAnswer", false)
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -258,7 +258,7 @@ open class Card : Cloneable {
      * Time limit for answering in milliseconds.
      */
     fun timeLimit(col: Collection): Int {
-        val conf = col.decks.confForDid(if (!isInDynamicDeck) did else oDid)
+        val conf = col.decks.configDictForDeckId(if (!isInDynamicDeck) did else oDid)
         return conf.getInt("maxTaken") * 1000
     }
 
@@ -322,7 +322,7 @@ open class Card : Cloneable {
     }
 
     fun showTimer(col: Collection): Boolean {
-        val options = col.decks.confForDid(if (!isInDynamicDeck) did else oDid)
+        val options = col.decks.configDictForDeckId(if (!isInDynamicDeck) did else oDid)
         return DeckConfig.parseTimerOpt(options, true)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -159,7 +159,7 @@ class Decks(private val col: Collection) {
     }
 
     /** Falls back on default config if deck or config missing */
-    fun confForDid(did: DeckId): DeckConfig {
+    fun configDictForDeckId(did: DeckId): DeckConfig {
         val conf = get(did)?.conf ?: 1
         return DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(conf)))
     }
@@ -181,16 +181,16 @@ class Decks(private val col: Collection) {
         return DeckConfig(BackendUtils.from_json_bytes(col.backend.newDeckConfigLegacy()))
     }
 
-    fun setConf(grp: Deck, id: DeckConfigId) {
+    fun setConfigIdForDeckDict(grp: Deck, id: DeckConfigId) {
         grp.conf = id
         this.save(grp)
     }
 
     /* Reverts to default if provided id missing */
-    fun getConf(confId: DeckConfigId): DeckConfig =
+    fun getConfig(confId: DeckConfigId): DeckConfig =
         DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(confId)))
 
-    fun confId(name: String): Long {
+    fun addConfigReturningId(name: String): Long {
         return addConfig(name).id
     }
 
@@ -231,7 +231,7 @@ class Decks(private val col: Collection) {
      */
 
     /** Return a new dynamic deck and set it as the current deck. */
-    fun newDyn(name: String): DeckId {
+    fun newFiltered(name: String): DeckId {
         val deck = this.newDeckLegacy(true)
         deck.name = name
         addDeckLegacy(deck)
@@ -239,7 +239,7 @@ class Decks(private val col: Collection) {
         return deck.id
     }
 
-    fun isDyn(did: DeckId): Boolean {
+    fun isFiltered(did: DeckId): Boolean {
         return this.get(did)?.isFiltered == true
     }
 
@@ -252,6 +252,7 @@ class Decks(private val col: Collection) {
      */
 
     /** @return the fully qualified name of the subdeck, or null if unavailable */
+    @NotInLibAnki
     fun getSubdeckName(did: DeckId, subdeckName: String?): String? {
         if (subdeckName.isNullOrEmpty()) {
             return null

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -55,6 +55,7 @@ class Decks(private val col: Collection) {
         return deck.id
     }
 
+    @LibAnkiAlias("add_deck_legacy")
     private fun addDeckLegacy(deck: Deck): OpChangesWithId {
         val changes = col.backend.addDeckLegacy(
             json = BackendUtils.to_json_bytes(deck)
@@ -68,6 +69,7 @@ class Decks(private val col: Collection) {
     }
 
     /** A sorted sequence of deck names and IDs. */
+    @LibAnkiAlias("all_names_and_ids")
     fun allNamesAndIds(
         skipEmptyDefault: Boolean = false,
         includeFiltered: Boolean = true
@@ -77,6 +79,7 @@ class Decks(private val col: Collection) {
         }
     }
 
+    @LibAnkiAlias("id_for_name")
     fun idForName(name: String): DeckId? {
         return try {
             col.backend.getDeckIdByName(name)
@@ -93,6 +96,7 @@ class Decks(private val col: Collection) {
         }
     }
 
+    @LibAnkiAlias("new_deck_legacy")
     private fun newDeckLegacy(filtered: Boolean): Deck {
         val deck = BackendUtils.from_json_bytes(col.backend.newDeckLegacy(filtered))
         return Deck(
@@ -123,6 +127,7 @@ class Decks(private val col: Collection) {
     }
 
     /** Get deck with NAME, ignoring case. */
+    @LibAnkiAlias("by_name")
     fun byName(name: String): Deck? {
         val id = this.idForName(name)
         if (id != null) {
@@ -151,6 +156,7 @@ class Decks(private val col: Collection) {
     /* Deck configurations */
 
     /** A list of all deck config. */
+    @LibAnkiAlias("all_config")
     fun allConfig(): List<DeckConfig> {
         return BackendUtils.jsonToArray(col.backend.allDeckConfigLegacy())
             .jsonObjectIterable()
@@ -159,6 +165,7 @@ class Decks(private val col: Collection) {
     }
 
     /** Falls back on default config if deck or config missing */
+    @LibAnkiAlias("config_dict_for_deck_id")
     fun configDictForDeckId(did: DeckId): DeckConfig {
         val conf = get(did)?.conf ?: 1
         return DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(conf)))
@@ -168,6 +175,7 @@ class Decks(private val col: Collection) {
         g.id = col.backend.addOrUpdateDeckConfigLegacy(g.toString().toByteStringUtf8())
     }
 
+    @LibAnkiAlias("add_config")
     private fun addConfig(
         name: String
     ): DeckConfig {
@@ -181,15 +189,18 @@ class Decks(private val col: Collection) {
         return DeckConfig(BackendUtils.from_json_bytes(col.backend.newDeckConfigLegacy()))
     }
 
+    @LibAnkiAlias("set_config_id_for_deck_dict")
     fun setConfigIdForDeckDict(grp: Deck, id: DeckConfigId) {
         grp.conf = id
         this.save(grp)
     }
 
     /* Reverts to default if provided id missing */
+    @LibAnkiAlias("get_config")
     fun getConfig(confId: DeckConfigId): DeckConfig =
         DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(confId)))
 
+    @LibAnkiAlias("add_config_returning_id")
     fun addConfigReturningId(name: String): Long {
         return addConfig(name).id
     }
@@ -206,6 +217,7 @@ class Decks(private val col: Collection) {
     }
 
     /** @return The currently selected deck ID. */
+    @LibAnkiAlias("get_current_id")
     fun getCurrentId(): DeckId = col.backend.getCurrentDeck().id
 
     /** @return The currently selected deck ID. */
@@ -231,6 +243,7 @@ class Decks(private val col: Collection) {
      */
 
     /** Return a new dynamic deck and set it as the current deck. */
+    @LibAnkiAlias("new_filtered")
     fun newFiltered(name: String): DeckId {
         val deck = this.newDeckLegacy(true)
         deck.name = name
@@ -239,6 +252,7 @@ class Decks(private val col: Collection) {
         return deck.id
     }
 
+    @LibAnkiAlias("is_filtered")
     fun isFiltered(did: DeckId): Boolean {
         return this.get(did)?.isFiltered == true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -25,9 +25,14 @@
 
 package com.ichi2.libanki
 
+import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
 import anki.collection.OpChangesWithId
+import anki.deck_config.DeckConfigsForUpdate
+import anki.deck_config.UpdateDeckConfigsRequest
+import anki.decks.DeckTreeNode
 import anki.decks.FilteredDeckForUpdate
+import anki.decks.SetDeckCollapsedRequest
 import com.google.protobuf.kotlin.toByteStringUtf8
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.utils.*
@@ -38,21 +43,43 @@ import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.json.JSONArray
 import java.util.*
 
+typealias UpdateDeckConfigs = UpdateDeckConfigsRequest
 data class DeckNameId(val name: String, val id: DeckId)
 
 // TODO: col was a weakref
 
 class Decks(private val col: Collection) {
-    /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
-    fun id(name: String): DeckId {
-        val id = this.idForName(name)
-        if (id != null) {
-            return id
-        }
-        val deck = this.newDeckLegacy(false)
-        deck.name = name
-        addDeckLegacy(deck)
-        return deck.id
+
+    /*
+     * Registry save/load
+     *************************************************************
+     */
+
+    /**
+     * Add or update an existing deck. Used for syncing and merging.
+     * @throws BackendDeckIsFilteredException
+     */
+    fun save(g: Deck) {
+        g.id = col.backend.addOrUpdateDeckLegacy(
+            BackendUtils.toByteString(g),
+            preserveUsnAndMtime = false
+        )
+    }
+
+    fun save(g: DeckConfig) {
+        g.id = col.backend.addOrUpdateDeckConfigLegacy(g.toString().toByteStringUtf8())
+    }
+
+    /*
+     * Deck save/load
+     *************************************************************
+     */
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("add_normal_deck_with_name")
+    @Suppress("unused", "unused_parameter")
+    private fun addNormalDeckWithName(name: String): OpChangesWithId {
+        TODO()
     }
 
     @LibAnkiAlias("add_deck_legacy")
@@ -62,6 +89,19 @@ class Decks(private val col: Collection) {
         )
         deck.id = changes.id
         return changes
+    }
+
+    /** "Add a deck with NAME. Reuse deck if already exists. Return id as int." */
+    @RustCleanup("add 'create' parameter + change return type")
+    fun id(name: String): DeckId {
+        val id = this.idForName(name)
+        if (id != null) {
+            return id
+        }
+        val deck = this.newDeckLegacy(false)
+        deck.name = name
+        addDeckLegacy(deck)
+        return deck.id
     }
 
     fun remove(deckIds: Iterable<Long>): OpChangesWithCount {
@@ -88,12 +128,42 @@ class Decks(private val col: Collection) {
         }
     }
 
+    @LibAnkiAlias("get_legacy")
+    @RustCleanup("rename once we've removed this")
     fun get(did: DeckId): Deck? {
         return try {
             Deck(BackendUtils.from_json_bytes(col.backend.getDeckLegacy(did)))
         } catch (ex: BackendNotFoundException) {
             null
         }
+    }
+
+    @RustCleanup("implement and make public")
+    @Suppress("unused", "unused_parameter")
+    private fun have(id: DeckId): Boolean {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("get_all_legacy")
+    @Suppress("unused")
+    private fun getAllLegacy(): List<Deck> {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("new_deck")
+    @Suppress("unused")
+    /** "Return a new normal deck. It must be added with [addDeck] after a name assigned. */
+    private fun newDeck(): Deck {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("add_deck")
+    @Suppress("unused", "unused_parameter")
+    private fun addDeck(deck: Deck): OpChangesWithId {
+        TODO()
     }
 
     @LibAnkiAlias("new_deck_legacy")
@@ -116,14 +186,60 @@ class Decks(private val col: Collection) {
         )
     }
 
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("deck_tree")
+    @Suppress("unused")
+    private fun deckTree(): DeckTreeNode {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @Suppress("unused")
+    /** "All decks. Expensive; prefer [allNamesAndIds] */
+    private fun all(): List<Deck> {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("set_collapsed")
+    @Suppress("unused", "unused_parameter")
+    private fun setCollapsed(deckId: DeckId, collapsed: Boolean, scope: SetDeckCollapsedRequest.Scope): OpChanges {
+        TODO()
+    }
+
     fun collapse(did: DeckId) {
         val deck = this.get(did) ?: return
         deck.collapsed = !deck.collapsed
         this.save(deck)
     }
 
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("collapse_browser")
+    @Suppress("unused", "unused_parameter")
+    private fun collapseBrowser(deckId: DeckId) {
+        TODO()
+    }
+
     fun count(): Int {
         return len(this.allNamesAndIds())
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("card_count")
+    @Suppress("unused", "unused_parameter")
+    private fun cardCount(vararg decks: DeckId, includeSubdecks: Boolean): Int {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("get")
+    @Suppress("unused", "unused_parameter")
+    private fun get(did: DeckId, default: Boolean = true): Deck? {
+        return try {
+            Deck(BackendUtils.from_json_bytes(col.backend.getDeckLegacy(did)))
+        } catch (ex: BackendNotFoundException) {
+            null
+        }
     }
 
     /** Get deck with NAME, ignoring case. */
@@ -136,24 +252,61 @@ class Decks(private val col: Collection) {
         return null
     }
 
-    /**
-     * Add or update an existing deck. Used for syncing and merging.
-     * @throws BackendDeckIsFilteredException
-     */
-    fun save(g: Deck) {
-        g.id = col.backend.addOrUpdateDeckLegacy(
-            BackendUtils.toByteString(g),
-            preserveUsnAndMtime = false
-        )
+    @RustCleanup("implement and make public")
+    @Suppress("unused", "unused_parameter")
+    /** Add or update an existing deck. Used for syncing and merging. */
+    private fun update(deck: Deck, preserveUsn: Boolean) {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("update_dict")
+    @Suppress("unused", "unused_parameter")
+    private fun updateDict(deck: Deck): OpChanges {
+        TODO()
     }
 
     /** Rename deck prefix to NAME if not exists. Updates children. */
-    fun rename(g: Deck, newName: String) {
-        g.name = newName
-        this.save(g)
+    @RustCleanup("return OpChanges")
+    fun rename(deck: Deck, newName: String) {
+        deck.name = newName
+        this.save(deck)
     }
 
-    /* Deck configurations */
+    /*
+     * Drag/drop
+     *************************************************************
+     */
+
+    @RustCleanup("implement and make public")
+    @Suppress("unused", "unused_parameter")
+    /**
+     * Rename one or more source decks that were dropped on [newParent].
+     *
+     * If [newParent] is `0`, decks will be placed at the top level.
+     */
+    private fun reparent(deckIds: List<DeckId>, newParent: DeckId): OpChangesWithCount {
+        TODO()
+    }
+
+    /*
+     * Deck configurations
+     *************************************************************
+     */
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("get_deck_configs_for_update")
+    @Suppress("unused", "unused_parameter")
+    private fun getDeckConfigsForUpdate(deckId: DeckId): DeckConfigsForUpdate {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("update_deck_configs")
+    @Suppress("unused", "unused_parameter")
+    private fun updateDeckConfigs(input: UpdateDeckConfigs): DeckConfigsForUpdate {
+        TODO()
+    }
 
     /** A list of all deck config. */
     @LibAnkiAlias("all_config")
@@ -171,8 +324,16 @@ class Decks(private val col: Collection) {
         return DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(conf)))
     }
 
-    fun save(g: DeckConfig) {
-        g.id = col.backend.addOrUpdateDeckConfigLegacy(g.toString().toByteStringUtf8())
+    /* Reverts to default if provided id missing */
+    @LibAnkiAlias("get_config")
+    fun getConfig(confId: DeckConfigId): DeckConfig =
+        DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(confId)))
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("update_config")
+    @Suppress("unused", "unused_parameter")
+    private fun updateConfig(config: DeckConfig, preserveUsn: Boolean = false) {
+        TODO()
     }
 
     @LibAnkiAlias("add_config")
@@ -185,8 +346,16 @@ class Decks(private val col: Collection) {
         return conf
     }
 
-    private fun newDeckConfigLegacy(): DeckConfig {
-        return DeckConfig(BackendUtils.from_json_bytes(col.backend.newDeckConfigLegacy()))
+    @LibAnkiAlias("add_config_returning_id")
+    fun addConfigReturningId(name: String): Long {
+        return addConfig(name).id
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("remove_config")
+    @Suppress("unused", "unused_parameter")
+    private fun removeConfig(id: DeckConfigId) {
+        TODO()
     }
 
     @LibAnkiAlias("set_config_id_for_deck_dict")
@@ -195,36 +364,82 @@ class Decks(private val col: Collection) {
         this.save(grp)
     }
 
-    /* Reverts to default if provided id missing */
-    @LibAnkiAlias("get_config")
-    fun getConfig(confId: DeckConfigId): DeckConfig =
-        DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(confId)))
-
-    @LibAnkiAlias("add_config_returning_id")
-    fun addConfigReturningId(name: String): Long {
-        return addConfig(name).id
+    @NotInLibAnki
+    @RustCleanup("inline")
+    private fun newDeckConfigLegacy(): DeckConfig {
+        return DeckConfig(BackendUtils.from_json_bytes(col.backend.newDeckConfigLegacy()))
     }
 
-    /* Deck selection */
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("decks_using_config")
+    @Suppress("unused", "unused_parameter")
+    private fun decksUsingConfig(config: DeckConfig): List<DeckId> {
+        TODO()
+    }
 
-    /** The currently active dids. */
-    @RustCleanup("Probably better as a queue")
-    fun active(): LinkedList<DeckId> {
-        val activeDecks = col.config.get<List<DeckId>>(ACTIVE_DECKS) ?: listOf()
-        val result = LinkedList<Long>()
-        result.addAll(activeDecks.asIterable())
-        return result
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("restore_to_default")
+    @Suppress("unused", "unused_parameter")
+    private fun restoreToDefault(config: DeckConfig) {
+        TODO()
+    }
+
+    /*
+     * Deck utils
+     *************************************************************
+     */
+
+    @RustCleanup("use TR")
+    fun name(did: DeckId): String = get(did)?.name ?: "[no deck]"
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("name_if_exists")
+    @Suppress("unused", "unused_parameter")
+    private fun nameIfExists(did: DeckId): String? {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @Suppress("unused", "unused_parameter")
+    private fun cids(did: DeckId, children: Boolean): List<CardId> {
+        TODO()
+    }
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("for_card_ids")
+    @Suppress("unused", "unused_parameter")
+    private fun forCardIds(cids: List<CardId>): List<DeckId> {
+        TODO()
+    }
+
+    /*
+     * Deck selection
+     *************************************************************
+     */
+
+    @RustCleanup("implement and make public")
+    @LibAnkiAlias("set_current")
+    @Suppress("unused", "unused_parameter")
+    private fun setCurrent(deck: DeckId): OpChanges {
+        TODO()
     }
 
     /** @return The currently selected deck ID. */
     @LibAnkiAlias("get_current_id")
     fun getCurrentId(): DeckId = col.backend.getCurrentDeck().id
 
-    /** @return The currently selected deck ID. */
-    fun selected(): DeckId = getCurrentId()
-
     fun current(): Deck {
         return this.get(this.selected()) ?: this.get(1)!!
+    }
+
+    /** The currently active dids. */
+    @RustCleanup("Probably better as a queue")
+    @RustCleanup("should not return an empty list")
+    fun active(): LinkedList<DeckId> {
+        val activeDecks = col.config.get<List<DeckId>>(ACTIVE_DECKS) ?: listOf()
+        val result = LinkedList<Long>()
+        result.addAll(activeDecks.asIterable())
+        return result
     }
 
     /** Select a new branch. */
@@ -238,8 +453,19 @@ class Decks(private val col: Collection) {
         col.config.set(ACTIVE_DECKS, listOf(did) + childrenDids)
     }
 
+    /** @return The currently selected deck ID. */
+    fun selected(): DeckId = getCurrentId()
+
     /*
-     Dynamic decks
+     * Parents/children
+     *************************************************************
+     */
+
+    // TODO
+
+    /*
+     * Filtered decks
+     *************************************************************
      */
 
     /** Return a new dynamic deck and set it as the current deck. */
@@ -257,12 +483,9 @@ class Decks(private val col: Collection) {
         return this.get(did)?.isFiltered == true
     }
 
-    fun name(did: DeckId): String = get(did)?.name ?: "[no deck]"
-
     /*
-     * ***********************************************************
-     * The methods below are not in LibAnki.
-     * ***********************************************************
+     * Not in libAnki
+     *************************************************************
      */
 
     /** @return the fully qualified name of the subdeck, or null if unavailable */
@@ -278,10 +501,6 @@ class Decks(private val col: Collection) {
         val deck = get(did) ?: return null
         return deck.getString("name") + DECK_SEPARATOR + subdeckName
     }
-
-    /*
-     * Not in libAnki
-     */
 
     companion object {
         /* Parents/children */
@@ -306,11 +525,7 @@ class Decks(private val col: Collection) {
         // not in libAnki
         const val DECK_SEPARATOR = "::"
 
-    /*
-    * ***********************************************************
-    * The methods below are not in LibAnki.
-    * ***********************************************************
-    */
+        @NotInLibAnki
         fun isValidDeckName(deckName: String): Boolean = deckName.trim { it <= ' ' }.isNotEmpty()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -64,7 +64,7 @@ class Decks(private val col: Collection) {
         return changes
     }
 
-    fun removeDecks(deckIds: Iterable<Long>): OpChangesWithCount {
+    fun remove(deckIds: Iterable<Long>): OpChangesWithCount {
         return col.backend.removeDecks(dids = deckIds)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -616,7 +616,7 @@ open class Scheduler(val col: Collection) {
      * @return The conf of the deck of the card.
      */
     fun cardConf(card: Card): DeckConfig {
-        return col.decks.confForDid(card.did)
+        return col.decks.configDictForDeckId(card.did)
     }
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/LibAnkiAlias.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/LibAnkiAlias.kt
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki.utils
+
+/**
+ * Specifies the name of the method in anki's pylib
+ *
+ * https://github.com/ankitects/anki/tree/main/pylib/anki
+ */
+@Retention(AnnotationRetention.SOURCE)
+annotation class LibAnkiAlias(val alias: String)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -167,7 +167,7 @@ class DeckPickerTest : RobolectricTest() {
     @Test
     fun limitAppliedAfterReview() {
         val sched = col.sched
-        val dconf = col.decks.getConf(1)
+        val dconf = col.decks.getConfig(1)
         assertNotNull(dconf)
         dconf.getJSONObject("new").put("perDay", 10)
         col.decks.save(dconf)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -124,7 +124,7 @@ class ReviewerTest : RobolectricTest() {
     @Flaky(OS.ALL, "java.lang.AssertionError: Unexpected card ord Expected: <2> but: was <1>")
     fun testMultipleCards() = runTest {
         addNoteWithThreeCards()
-        val nw = col.decks.confForDid(1).getJSONObject("new")
+        val nw = col.decks.configDictForDeckId(1).getJSONObject("new")
         val time = collectionTime
         nw.put("delays", JSONArray(intArrayOf(1, 10, 60, 120)))
 
@@ -153,7 +153,7 @@ class ReviewerTest : RobolectricTest() {
     @Test
     @Flaky(OS.ALL, "java.lang.AssertionError: Expected: \"2\" but: was \"1\"")
     fun testLrnQueueAfterUndo() = runTest {
-        val nw = col.decks.confForDid(1).getJSONObject("new")
+        val nw = col.decks.configDictForDeckId(1).getJSONObject("new")
         val time = TimeManager.time as MockTime
         nw.put("delays", JSONArray(intArrayOf(1, 10, 60, 120)))
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.reviewer
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -44,13 +43,13 @@ class AutomaticAnswerAndroidTest : RobolectricTest() {
     }
 
     private fun resetPrefs() {
-        val conf = col.decks.confForDid(col.decks.selected())
+        val conf = col.decks.configDictForDeckId(col.decks.selected())
         conf.remove(AutomaticAnswerAction.CONFIG_KEY)
         col.decks.save(conf)
     }
 
     private fun setPreference(value: Int) {
-        val conf = col.decks.confForDid(col.decks.selected())
+        val conf = col.decks.configDictForDeckId(col.decks.selected())
         conf.put(AutomaticAnswerAction.CONFIG_KEY, value)
         col.decks.save(conf)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
@@ -36,7 +36,7 @@ class AbstractSchedTest : JvmTest() {
     @Test
     fun ensureUndoCorrectCounts() {
         val sched = col.sched
-        val dconf = col.decks.getConf(1)
+        val dconf = col.decks.getConfig(1)
         assertThat(dconf, notNullValue())
         dconf.getJSONObject("new").put("perDay", 10)
         col.decks.save(dconf)
@@ -58,7 +58,7 @@ class AbstractSchedTest : JvmTest() {
 
     @Test
     fun undoAndRedo() {
-        val conf = col.decks.confForDid(1)
+        val conf = col.decks.configDictForDeckId(1)
         conf.getJSONObject("new").put("delays", JSONArray(doubleArrayOf(1.0, 3.0, 5.0, 10.0)))
         col.decks.save(conf)
         col.config.set("collapseTime", 20 * 60)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -317,7 +317,7 @@ class CardTest : JvmTest() {
         assertEquals("", c.dueString())
 
         // Dynamic deck
-        val dyn = decks.newDyn("dyn")
+        val dyn = decks.newFiltered("dyn")
         c.oDid = c.did
         c.did = dyn
         assertEquals("(filtered)", c.nextDue())

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -43,7 +43,7 @@ class DecksTest : JvmTest() {
         val c = note.cards()[0]
         assertEquals(deck1, c.did)
         assertEquals(1, col.cardCount().toLong())
-        col.decks.removeDecks(listOf(deck1))
+        col.decks.remove(listOf(deck1))
         assertEquals(0, col.cardCount().toLong())
         // if we try to get it, we get the default
         assertEquals("[no deck]", col.decks.name(c.did))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -178,20 +178,20 @@ open class SchedulerTest : JvmTest() {
             col.addNote(note)
         }
         // give the child deck a different configuration
-        val c2 = col.decks.confId("new conf")
-        col.decks.setConf(col.decks.get(deck2)!!, c2)
+        val c2 = col.decks.addConfigReturningId("new conf")
+        col.decks.setConfigIdForDeckDict(col.decks.get(deck2)!!, c2)
         // both confs have defaulted to a limit of 20
         Assert.assertEquals(20, col.sched.newCount().toLong())
         // first card we get comes from parent
         val c = col.sched.card!!
         Assert.assertEquals(1, c.did)
         // limit the parent to 10 cards, meaning we get 10 in total
-        val conf1 = col.decks.confForDid(1)
+        val conf1 = col.decks.configDictForDeckId(1)
         conf1.getJSONObject("new").put("perDay", 10)
         col.decks.save(conf1)
         Assert.assertEquals(10, col.sched.newCount().toLong())
         // if we limit child to 4, we should get 9
-        val conf2 = col.decks.confForDid(deck2)
+        val conf2 = col.decks.configDictForDeckId(deck2)
         conf2.getJSONObject("new").put("perDay", 4)
         col.decks.save(conf2)
         Assert.assertEquals(9, col.sched.newCount().toLong())
@@ -339,7 +339,7 @@ open class SchedulerTest : JvmTest() {
             type = CARD_TYPE_REV
         }
         col.updateCard(c, skipUndoEntry = true)
-        val conf = col.decks.confForDid(1)
+        val conf = col.decks.configDictForDeckId(1)
         conf.getJSONObject("lapse").put("delays", JSONArray(doubleArrayOf()))
         col.decks.save(conf)
 
@@ -492,7 +492,7 @@ open class SchedulerTest : JvmTest() {
         Assert.assertEquals(2650, c.factor)
         // leech handling
         // //////////////////////////////////////////////////////////////////////////////////////////////////
-        val conf = col.decks.getConf(1)
+        val conf = col.decks.getConfig(1)
         conf.getJSONObject("lapse").put("leechAction", LEECH_SUSPEND)
         col.decks.save(conf)
         cardcopy.clone().update { lapses = 7 }
@@ -552,7 +552,7 @@ open class SchedulerTest : JvmTest() {
         )
 
         // if hard factor is <= 1, then hard may not increase
-        val conf = col.decks.confForDid(1)
+        val conf = col.decks.configDictForDeckId(1)
         conf.getJSONObject("rev").put("hardFactor", 1)
         col.decks.save(conf)
         Assert.assertEquals(
@@ -606,7 +606,7 @@ open class SchedulerTest : JvmTest() {
         note.setItem("Front", "one")
         note.setItem("Back", "two")
         col.addNote(note)
-        val conf = col.decks.confForDid(1)
+        val conf = col.decks.configDictForDeckId(1)
         conf.getJSONObject("new").put("delays", JSONArray(doubleArrayOf(0.5, 3.0, 10.0)))
         conf.getJSONObject("lapse").put("delays", JSONArray(doubleArrayOf(1.0, 5.0, 9.0)))
         col.decks.save(conf)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -131,7 +131,7 @@ interface TestClass {
 
     fun addDynamicDeck(name: String?): DeckId {
         return try {
-            col.decks.newDyn(name!!)
+            col.decks.newFiltered(name!!)
         } catch (filteredAncestor: BackendDeckIsFilteredException) {
             throw RuntimeException(filteredAncestor)
         }
@@ -153,7 +153,7 @@ interface TestClass {
 
     /** helper method to update deck config */
     fun updateDeckConfig(deckId: DeckId, function: DeckConfig.() -> Unit) {
-        val deckConfig = col.decks.confForDid(deckId)
+        val deckConfig = col.decks.configDictForDeckId(deckId)
         function(deckConfig)
         col.decks.save(deckConfig)
     }


### PR DESCRIPTION
## Purpose / Description

`Decks` was pretty badly out of sync with `decks.py`

https://github.com/ankitects/anki/blob/main/pylib/anki/decks.py

I want to get back in sync, as https://github.com/ankidroid/Anki-Android/issues/15611 has shown that we still have issues.

* https://github.com/ankidroid/Anki-Android/issues/15611#issuecomment-1985742924

This will also allow us to more easily deprecate the `legacy` methods, rather than using a combination of new and legacy methods

```python
DeckManager.register_deprecated_aliases(
    confForDid=DeckManager.config_dict_for_deck_id,
    setConf=DeckManager.set_config_id_for_deck_dict,
    allConf=DeckManager.all_config,
    getConf=DeckManager.get_config,
    confId=DeckManager.add_config_returning_id,
    newDyn=DeckManager.new_filtered,
    isDyn=DeckManager.is_filtered,
)
```

As a long-term stretch goal, this brings us closer to automation to map from `libanki` to `pylib`

## Approach
* rename + reorder methods
* Introduce `LibAnkiAlias`: I suspect we'll eventually want all methods in `libAnki` to be annotated by this OR `NotinLibAnki`. This makes it easier to map from `libanki` to `pylib`
* Brief look through and add cleanup annotations where necessary


## How Has This Been Tested?
Ran unit tests, then rebased onto `main`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
