### PR TITLE
feat: make 'CongratsPage' developer-only

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -70,6 +70,7 @@ import com.ichi2.anki.noteeditor.EditCardDestination
 import com.ichi2.anki.noteeditor.toIntent
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.pages.AnkiServer.Companion.LOCALHOST
+import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.pages.PostRequestHandler
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
@@ -468,7 +469,7 @@ abstract class AbstractFlashcardViewer :
             closeReviewer(RESULT_NO_MORE_CARDS)
             // When launched with a shortcut, we want to display a message when finishing
             if (intent.getBooleanExtra(EXTRA_STARTED_WITH_SHORTCUT, false)) {
-                showThemedToast(baseContext, R.string.studyoptions_congrats_finished, false)
+                CongratsPage.display(this)
             }
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -70,7 +70,6 @@ import com.ichi2.anki.noteeditor.EditCardDestination
 import com.ichi2.anki.noteeditor.toIntent
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.pages.AnkiServer.Companion.LOCALHOST
-import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.pages.PostRequestHandler
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
@@ -469,7 +468,7 @@ abstract class AbstractFlashcardViewer :
             closeReviewer(RESULT_NO_MORE_CARDS)
             // When launched with a shortcut, we want to display a message when finishing
             if (intent.getBooleanExtra(EXTRA_STARTED_WITH_SHORTCUT, false)) {
-                startActivity(CongratsPage.getIntent(this))
+                showThemedToast(baseContext, R.string.studyoptions_congrats_finished, false)
             }
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -98,7 +98,6 @@ import com.ichi2.anki.introduction.CollectionPermissionScreenLauncher
 import com.ichi2.anki.introduction.hasCollectionStoragePermissions
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.pages.AnkiPackageImporterFragment
-import com.ichi2.anki.pages.CongratsPage
 import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
@@ -1118,7 +1117,12 @@ open class DeckPicker :
 
     private fun processReviewResults(resultCode: Int) {
         if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
-            startActivity(CongratsPage.getIntent(this))
+            // Show a message when reviewing has finished
+            if (getColUnsafe.sched.totalCount() == 0) {
+                showSnackbar(R.string.studyoptions_congrats_finished)
+            } else {
+                showSnackbar(R.string.studyoptions_no_cards_due)
+            }
         } else if (resultCode == AbstractFlashcardViewer.RESULT_ABORT_AND_SYNC) {
             Timber.i("Obtained Abort and Sync result")
             sync()
@@ -1858,8 +1862,31 @@ open class DeckPicker :
 
     @NeedsTest("14608: Ensure that the deck options refer to the selected deck")
     private suspend fun handleDeckSelection(did: DeckId, selectionType: DeckSelectionType) {
+        fun showStudyMoreSnackbar(did: DeckId) =
+            showSnackbar(R.string.studyoptions_limit_reached) {
+                setAction(R.string.study_more) {
+                    val d = customStudyDialogFactory.newCustomStudyDialog().withArguments(
+                        CustomStudyDialog.ContextMenuConfiguration.LIMITS,
+                        did,
+                        true
+                    )
+                    showDialogFragment(d)
+                }
+            }
+
         fun showEmptyDeckSnackbar() = showSnackbar(R.string.empty_deck) {
             setAction(R.string.menu_add) { addNote() }
+        }
+
+        fun showCustomStudySnackbar() = showSnackbar(R.string.studyoptions_empty_schedule) {
+            setAction(R.string.custom_study) {
+                val d = customStudyDialogFactory.newCustomStudyDialog().withArguments(
+                    CustomStudyDialog.ContextMenuConfiguration.EMPTY_SCHEDULE,
+                    did,
+                    true
+                )
+                showDialogFragment(d)
+            }
         }
 
         /** Check if we need to update the fragment or update the deck list */
@@ -1891,15 +1918,27 @@ open class DeckPicker :
         }
 
         when (queryCompletedDeckCustomStudyAction(did)) {
-            CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED,
-            CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY,
-            CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED,
+            CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED -> {
+                // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
+                openStudyOptions(withDeckOptions = false)
+            }
             CompletedDeckStatus.DAILY_STUDY_LIMIT_REACHED -> {
-                startActivity(CongratsPage.getIntent(this))
+                // If there are no cards to review because of the daily study limit then give "Study more" option
+                showStudyMoreSnackbar(did)
+                updateUi()
+            }
+            CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED -> {
+                // Go to the study options screen if filtered deck with no cards to study
+                openStudyOptions(withDeckOptions = false)
             }
             CompletedDeckStatus.EMPTY_REGULAR_DECK -> {
                 // If the deck is empty (& has no children) then show a message saying it's empty
                 showEmptyDeckSnackbar()
+                updateUi()
+            }
+            CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY -> {
+                // Otherwise say there are no cards scheduled to study, and give option to do custom study
+                showCustomStudySnackbar()
                 updateUi()
             }
         }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -36,6 +36,7 @@
     <!-- DeckPicker.kt -->
     <string name="expand">Expand</string>
     <string name="collapse">Collapse</string>
+    <string name="study_more">Study more</string>
     <plurals name="reviewer_window_title">
         <item quantity="one">%d minute left</item>
         <item quantity="other">%d minutes left</item>
@@ -118,6 +119,9 @@
     <string name="search_deck" comment="Deck search for selecting it">Deck Search</string>
     <string name="search_for_download_deck" comment="Deck search value for downloading deck">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
+    <string name="studyoptions_limit_reached">Daily study limit reached</string>
+    <string name="studyoptions_empty_schedule">No cards scheduled to study</string>
+    <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -174,6 +174,7 @@
     <string name="pref_trigger_crash_key">trigger_crash_preference</string>
     <string name="pref_analytics_debug_key">analytics_debug_preference</string>
     <string name="pref_lock_database_key">debug_lock_database</string>
+    <string name="new_congrats_screen_pref_key">new_congrats_screen</string>
     <string name="pref_show_onboarding_key">showOnboarding</string>
     <string name="pref_reset_onboarding_key">resetOnboarding</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -45,6 +45,10 @@
         android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
         android:key="@string/pref_lock_database_key"/>
     <SwitchPreferenceCompat
+        android:title="New congrats screen"
+        android:key="@string/new_congrats_screen_pref_key"
+        android:defaultValue="false"/>
+    <SwitchPreferenceCompat
         android:title="@string/show_onboarding"
         android:summary="@string/show_onboarding_desc"
         android:key="@string/pref_show_onboarding_key"


### PR DESCRIPTION
## Purpose / Description

* A large number of users do not like the screen
* I personally feel that it currently has negative utility, but it can be improved
* But users have spoken: hide the page for now and revert to the snackbars we used to use
* Later, we'll improve the screen so it's useful

## Fixes
* Fixes #15349

## Approach
* Partial revert of 3193cc2174ff443fbb3eccf91da390781c11fb4c
* move the reverted code to `CongratsPage` so we can remove it in future
* Add a development-only preference and gate the new congrats page on it


## How Has This Been Tested?
API 33: snackbars appear. Defaults to 'false' for showing the screen, and the development-only preference works

## Learning (optional, can help others)
One more thing for users to look forward to in 2.18

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
