### PR TITLE
Fix: Widget intent not updated if added before storage permission

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -518,6 +518,13 @@
                 />
         </receiver>
 
+        <receiver android:name="com.ichi2.widget.WidgetPermissionReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.ichi2.widget.UPDATE_WIDGET" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name="com.ichi2.anki.receiver.SdCardReceiver"
             android:enabled="true"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -176,6 +176,8 @@ abstract class NavigationDrawerActivity :
         drawerLayout.addDrawerListener(drawerToggle)
 
         enablePostShortcut(this)
+        val intent = Intent("com.ichi2.widget.UPDATE_WIDGET")
+        this.sendBroadcast(intent)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
@@ -44,11 +44,30 @@ class AddNoteWidget : AppWidgetProvider() {
             return
         }
         Timber.d("onUpdate")
-        val remoteViews = RemoteViews(context.packageName, R.layout.widget_add_note)
-        val intent = Intent(context, NoteEditor::class.java)
-        intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
-        val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, false)
-        remoteViews.setOnClickPendingIntent(R.id.widget_add_note_button, pendingIntent)
-        appWidgetManager.updateAppWidget(appWidgetIds, remoteViews)
+        updateWidgets(context, appWidgetManager, appWidgetIds)
+    }
+
+    companion object {
+
+        /**
+         * Updates the widgets displayed in the provided context using the given AppWidgetManager
+         * and widget IDs, setting up an intent to open the NoteEditor with the caller as the deck picker.
+         *
+         * @param context The context in which the widgets are updated.
+         * @param appWidgetManager The AppWidgetManager instance used to update widgets.
+         * @param appWidgetIds The array of widget IDs to be updated.
+         */
+        fun updateWidgets(
+            context: Context,
+            appWidgetManager: AppWidgetManager,
+            appWidgetIds: IntArray
+        ) {
+            val remoteViews = RemoteViews(context.packageName, R.layout.widget_add_note)
+            val intent = Intent(context, NoteEditor::class.java)
+            intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_DECKPICKER)
+            val pendingIntent = PendingIntentCompat.getActivity(context, 0, intent, 0, false)
+            remoteViews.setOnClickPendingIntent(R.id.widget_add_note_button, pendingIntent)
+            appWidgetManager.updateAppWidget(appWidgetIds, remoteViews)
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.BroadcastReceiver
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.IntentHandler
+
+/**
+ * BroadcastReceiver to handle the scenario where storage permissions are granted,
+ * triggering an update for widgets using the AddNoteWidget class.
+ */
+class WidgetPermissionReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (IntentHandler.grantedStoragePermissions(context, showToast = false)) {
+            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val widgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, AddNoteWidget::class.java))
+            AddNoteWidget.updateWidgets(context, appWidgetManager, widgetIds)
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* #15765 Aimed to fix the widget NPE issue in case of no storage permission but when the widget is added before allowing file access the widget intent is not updated or set due to returning early, the PR aims to resolve that by using a broadcast receiver and updating the intent as soon as permission are granted, it is usually preferred to use broadcast receivers in case of widget rather than directly accessing the methods. 

## How Has This Been Tested?
Google emulator API 34

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
