### PR TITLE
feat: inform users collection is no longer accessible [Android13+ & WRITE_EXTERNAL_STORAGE]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -375,7 +375,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     }
 
     /** List items for [DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL] */
-    private enum class UninstallListItem(@StringRes val stringRes: Int, val dismissesDialog: Boolean, val onClick: (DeckPicker) -> Unit) {
+    enum class UninstallListItem(@StringRes val stringRes: Int, val dismissesDialog: Boolean, val onClick: (AnkiActivity) -> Unit) {
 
         RESTORE_FROM_ANKIWEB(
             R.string.restore_data_from_ankiweb,
@@ -403,7 +403,8 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         RESTORE_FROM_BACKUP(
             R.string.restore_data_from_backup,
             dismissesDialog = false,
-            { deckPicker ->
+            { activity ->
+                val deckPicker = activity as DeckPicker
                 Timber.i("Restoring from colpkg")
                 val newAnkiDroidDirectory = CollectionHelper.getDefaultAnkiDroidDirectory(deckPicker)
                 deckPicker.importColpkgListener = DatabaseRestorationListener(deckPicker, newAnkiDroidDirectory)
@@ -440,7 +441,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
 
         companion object {
             /** A dialog which creates a new collection in an unsafe location */
-            fun displayResetToNewDirectoryDialog(context: DeckPicker) {
+            fun displayResetToNewDirectoryDialog(context: AnkiActivity) {
                 AlertDialog.Builder(context).show {
                     title(R.string.backup_new_collection)
                     setIcon(R.drawable.ic_warning)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui.windows.permissions
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.DialogInterface
+import androidx.annotation.StringRes
+import com.afollestad.materialdialogs.MaterialDialog
+import com.afollestad.materialdialogs.list.listItems
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.UninstallListItem
+import timber.log.Timber
+
+/**
+ * Inform the user that Android 13+ has permanently revoked access to `WRITE_EXTERNAL_STORAGE`.
+ * Typically due to app permissions being revoked from unused apps
+ *
+ * Their collection is safe, but inaccessible
+ *
+ * Provide recovery options
+ *
+ * Issue 14423
+ *
+ * @see DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL
+ */
+object AndroidPermanentlyRevokedPermissionsDialog {
+    @SuppressLint("CheckResult")
+    fun show(context: AnkiActivity) {
+        val listItemData = StoragePermanentlyRevokedOptions.createList()
+
+        val message = context.getString(
+            R.string.directory_revoked_after_inactivity,
+            "WRITE_EXTERNAL_STORAGE",
+            getCurrentAnkiDroidDirectory(context)
+        )
+        MaterialDialog(context).show {
+            // AlertDialog does not allow message and listItems
+            message(text = message)
+            listItems(items = listItemData.map { context.getString(it.stringRes) }) { dialog: DialogInterface, index: Int, _: CharSequence ->
+                val listItem = listItemData[index]
+                listItem.onClick(context)
+                if (listItem.dismissesDialog) {
+                    dialog.dismiss()
+                }
+            }
+            cancelable(false)
+        }
+    }
+
+    private fun getCurrentAnkiDroidDirectory(context: Context): String = try {
+        CollectionHelper.getCurrentAnkiDroidDirectory(context)
+    } catch (e: Exception) {
+        Timber.w(e)
+        context.getString(R.string.card_browser_unknown_deck_name)
+    }
+
+    /**
+     * List items, copied from [UninstallListItem]
+     * Aside from 'Restore from AnkiWeb': we're unable to access the Deck Picker to sync
+     * and would also have no folder to restore to
+     */
+    private class StoragePermanentlyRevokedOptions(@StringRes val stringRes: Int, val dismissesDialog: Boolean, val onClick: (AnkiActivity) -> Unit) {
+        companion object {
+            fun createList(): List<StoragePermanentlyRevokedOptions> {
+                return UninstallListItem.createList()
+                    .filter { it != UninstallListItem.RESTORE_FROM_ANKIWEB }
+                    .map { listItem ->
+                        StoragePermanentlyRevokedOptions(
+                            stringRes = listItem.stringRes,
+                            dismissesDialog = listItem.dismissesDialog,
+                            onClick = listItem.onClick
+                        )
+                    }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsUntil29Fragment.kt
@@ -15,9 +15,11 @@
  */
 package com.ichi2.anki.ui.windows.permissions
 
+import android.os.Build
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.hasAnyOfPermissionsBeenDenied
@@ -38,6 +40,10 @@ class PermissionsUntil29Fragment : PermissionsFragment(R.layout.permissions_unti
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         val storagePermission = view.findViewById<PermissionItem>(R.id.storage_permission)
         storagePermission.setOnSwitchClickListener {
+            if (!userCanGrantWriteExternalStorage()) {
+                AndroidPermanentlyRevokedPermissionsDialog.show(requireActivity() as AnkiActivity)
+                return@setOnSwitchClickListener
+            }
             if (!hasAnyOfPermissionsBeenDenied(storagePermission.permissions)) {
                 storageLauncher.launch(storagePermission.permissions.toTypedArray())
             } else {
@@ -45,4 +51,8 @@ class PermissionsUntil29Fragment : PermissionsFragment(R.layout.permissions_unti
             }
         }
     }
+
+    // On SDK 33 (TIRAMISU), `WRITE_EXTERNAL_STORAGE` cannot be set [after AnkiDroid 2.15]
+    // https://github.com/ankidroid/Anki-Android/issues/14423#issuecomment-1777504376
+    private fun userCanGrantWriteExternalStorage() = Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -318,6 +318,8 @@ val AlertDialog.positiveButton: Button
 
 /**
  * Extension function for AlertDialog.Builder to set a list of items.
+ * Items are not displayed if [AlertDialog.Builder.setMessage] has been called
+ *
  * @param items The items to display in the list.
  * @param onClick A lambda function that is invoked when an item is clicked.
  */

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -273,6 +273,7 @@
 
     <string name="directory_inaccessible_after_uninstall" comment="Dialog title if AnkiDroid can't access the collection once the app is installed">Inaccessible collection</string>
     <string name="directory_inaccessible_after_uninstall_summary" comment="the parameter is the path to the AnkiDroid folder. Typically /storage/emulated/0/AnkiDroid">We are unable to access your collection after AnkiDroid is uninstalled due to a change in Play Store Policy\n\nYour data is safe and can be restored. It is located at\n%s\n\nSelect an option below to restore:</string>
+    <string name="directory_revoked_after_inactivity" comment="the first parameter is WRITE_EXTERNAL_STORAGE the second parameter is the path to the AnkiDroid folder. Typically /storage/emulated/0/AnkiDroid">Android has removed AnkiDroid\'s %1$s permission due to app inactivity.\n\nYour data is safe and can be restored. It is located at\n%2$s\n\nSelect an option below to restore:</string>
     <string name="restore_data_from_ankiweb">Restore from AnkiWeb (recommended)</string>
     <string name="install_non_play_store_ankidroid_recommended">Restore folder access (recommended)</string>
     <string name="install_non_play_store_ankidroid">Restore folder access (advanced)</string>


### PR DESCRIPTION
## Purpose / Description
After a period of time with an inactive app, Android 13+ will remove `WRITE_EXTERNAL_STORAGE` if AnkiDroid is unused.

This causes `PermissionsUntil29Fragment` to be shown.

Android does not allow `WRITE_EXTERNAL_STORAGE` to be re-granted (excluding via `adb`)

So we link a user to the same options as we did in `DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL`

## Fixes
* Fixes #14423

## Approach
* rewrite https://github.com/ankidroid/Anki-Android/wiki/Full%20Storage%20Access
* Show a dialog providing options

## How Has This Been Tested?

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt	(revision a89b9795590a93689d00fedec5a2145605621877)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt	(date 1710006949762)
@@ -112,6 +112,7 @@
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.dialogs.storageMigrationFailedDialogIsShownOrPending
+import com.ichi2.anki.ui.windows.permissions.AndroidPermanentlyRevokedPermissionsDialog
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.annotations.NeedsTest
@@ -404,6 +405,7 @@
         // Then set theme and content view
         super.onCreate(savedInstanceState)
 
+        AndroidPermanentlyRevokedPermissionsDialog.show(this)
         // handle the first load: display the app introduction
         if (!hasShownAppIntro()) {
             Timber.i("Displaying app intro")
```

<img width="346" alt="Screenshot 2024-03-09 at 18 01 29" src="https://github.com/ankidroid/Anki-Android/assets/62114487/d87359ee-28b6-432b-bcd6-25c51f79a863">


## Learning (optional, can help others)
* `listItems` is not compatible with `message()`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
