### PR TITLE
allow access to webViewClient on API 23

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -177,6 +177,10 @@ abstract class AbstractFlashcardViewer :
      */
     var webView: WebView? = null
         private set
+
+    /** Accessor for [WebView.getWebViewClient] before API 26 */
+    private var webViewClient: CardViewerWebClient? = null
+
     private var cardFrame: FrameLayout? = null
     private var touchLayer: FrameLayout? = null
     protected var answerField: FixedEditText? = null
@@ -1010,7 +1014,10 @@ abstract class AbstractFlashcardViewer :
             isScrollbarFadingEnabled = true
             // Set transparent color to prevent flashing white when night mode enabled
             setBackgroundColor(Color.argb(1, 0, 0, 0))
-            webViewClient = CardViewerWebClient(assetLoader, this@AbstractFlashcardViewer)
+            CardViewerWebClient(assetLoader, this@AbstractFlashcardViewer).apply {
+                webViewClient = this
+                this@AbstractFlashcardViewer.webViewClient = this
+            }
         }
         Timber.d(
             "Focusable = %s, Focusable in touch mode = %s",
@@ -2504,14 +2511,7 @@ abstract class AbstractFlashcardViewer :
     @SuppressLint("WebViewApiAvailability")
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun handleUrlFromJavascript(url: String) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            // WebViewCompat recommended here, but I'll avoid the dependency as it's test code
-            val c = webView?.webViewClient as? CardViewerWebClient?
-                ?: throw IllegalStateException("Couldn't obtain WebView - maybe it wasn't created yet")
-            c.filterUrl(url)
-        } else {
-            throw IllegalStateException("Can't get WebViewClient due to Android API")
-        }
+        webViewClient?.filterUrl(url) ?: throw IllegalStateException("Couldn't obtain WebView - maybe it wasn't created yet")
     }
 
     val isDisplayingAnswer


### PR DESCRIPTION
## Purpose / Description
Split from #15840

* we want to run javascript to play a video 
* we needed to access the `WebViewClient` for this
* But the `webView.webViewClient` accessor is API 26+

## How Has This Been Tested?
API 33 emulator for #15840

## Learning (optional, can help others)
`onPageStarted` may be called after `evaluateJavascript` is called, therefore `evaluateJavascript` would be executing with the `WebViewClient` state of the previous page

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
