### PR TITLE
Added CopyURL function to openUrl fun.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.AdaptionUtil
+import com.ichi2.utils.copyToClipboard
 
 /**
  * Acquire a wake lock and release it after running [block].
@@ -56,7 +57,11 @@ fun Context.openUrl(uri: Uri) {
     if (!AdaptionUtil.hasWebBrowser(this)) {
         val noBrowserMessage = getString(R.string.no_browser_msg, uri.toString())
         if (this is FragmentActivity) {
-            showSnackbar(noBrowserMessage)
+            showSnackbar(noBrowserMessage) {
+                setAction(android.R.string.copyUrl) {
+                    copyToClipboard(uri.toString(), failureMessageId = R.string.failed_to_copy)
+                }
+            }
         } else {
             UIUtils.showThemedToast(this, noBrowserMessage, shortLength = false)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
@@ -59,7 +59,7 @@ fun Context.openUrl(uri: Uri) {
         if (this is FragmentActivity) {
             showSnackbar(noBrowserMessage) {
                 setAction(android.R.string.copyUrl) {
-                    copyToClipboard(uri.toString(), failureMessageId = R.string.failed_to_copy)
+                    copyToClipboard(uri.toString())
                 }
             }
         } else {


### PR DESCRIPTION
## Purpose / Description
Added Copy to clipboard as a option when openUrl does not have a browser to open a link with.

## Fixes
* Fixes #15671 

## Approach
- Adds a show snackbar which allows you to copy to clipboard 

## How Has This Been Tested?

When through compilation, tested by using a fresh install and running cases the following cases: 
- Clicking on  help icon with a browser available. Result: Opens as normal
- Clicking on help icon with no browser available. Result: Shows snackbar with copy URL option. (Look below for screenshot)
![Screenshot_20240311_011110](https://github.com/ankidroid/Anki-Android/assets/79502699/6f55cf78-bb31-439e-8ab4-414ad3e008ae)



## Checklist
- [-] You have a descriptive commit message with a short title (first line, max 50 chars).
- [-] You have commented your code, particularly in hard-to-understand areas
- [-] You have performed a self-review of your own code
- [-] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [-] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)




