### PR TITLE
UI: add divider above show answer in card previewer

### DIFF
--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -46,6 +46,14 @@
             app:layout_constraintBottom_toTopOf="@id/show_answer"
             />
 
+        <com.google.android.material.divider.MaterialDivider
+            app:layout_constraintBottom_toTopOf="@id/show_answer"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:dividerThickness="1dp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/show_answer"
             android:layout_width="0dp"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
There is no way to well where is the webview ending and the button starts so this PR is a minor change to handle that

## How Has This Been Tested?
![Screenshot 2024-03-11 234325](https://github.com/ankidroid/Anki-Android/assets/48384865/983ebd2a-1492-4b44-b02b-a68459d9ce6d)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
