### PR TITLE
#13282: Replace Java methods with Kotlin analogs and perform code cleanup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2043,7 +2043,7 @@ abstract class AbstractFlashcardViewer :
 
     /** #6141 - blocks clicking links from executing "touch" gestures.
      * COULD_BE_BETTER: Make base class static and move this out of the CardViewer  */
-    internal inner class LinkDetectingGestureDetector() :
+    internal inner class LinkDetectingGestureDetector :
         MyGestureDetector(), ShakeDetector.Listener {
         private var shakeDetector: ShakeDetector? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -809,7 +809,7 @@ abstract class AbstractFlashcardViewer :
     private fun deleteNoteWithoutConfirmation() {
         val cardId = currentCard!!.id
         launchCatchingTask {
-            val noteCount = withProgress() {
+            val noteCount = withProgress {
                 undoableOp {
                     removeNotes(cids = listOf(cardId))
                 }.count

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -27,7 +27,6 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.browser.customtabs.CustomTabColorSchemeParams
-import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.*
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
@@ -339,7 +338,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
             .setToolbarColor(toolbarColor)
             .setNavigationBarColor(navBarColor)
             .build()
-        val builder = CustomTabsIntent.Builder(customTabActivityHelper.session)
+        val builder = Builder(customTabActivityHelper.session)
             .setShowTitle(true)
             .setStartAnimations(this, R.anim.slide_right_in, R.anim.slide_left_out)
             .setExitAnimations(this, R.anim.slide_left_in, R.anim.slide_right_out)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1406,7 +1406,7 @@ open class CardBrowser :
             val cards = withProgress { searchForCards(query, order, viewModel.cardsOrNotes) }
             Timber.d("Search returned %d cards", cards.size)
             // Render the first few items
-            for (i in 0 until Math.min(numCardsToRender(), cards.size)) {
+            for (i in 0 until numCardsToRender().coerceAtMost(cards.size)) {
                 cards[i].load(false, viewModel.column1Index, viewModel.column2Index)
             }
             redrawAfterSearch(cards)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1490,7 +1490,7 @@ open class CardBrowser :
 
     // convenience method for updateCardsInList(...)
     private fun updateCardInList(card: Card) {
-        val cards: MutableList<Card> = java.util.ArrayList(1)
+        val cards: MutableList<Card> = ArrayList(1)
         cards.add(card)
         updateCardsInList(cards)
     }
@@ -1773,7 +1773,6 @@ open class CardBrowser :
             return v
         }
 
-        @Suppress("UNCHECKED_CAST")
         @KotlinCleanup("Unchecked cast")
         private fun bindView(position: Int, v: View) {
             // Draw the content in the columns

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2428,7 +2428,7 @@ open class DeckPicker :
         }
 
         var userCheckedDoNotShowAgain = false
-        var dialog = AlertDialog.Builder(this)
+        val dialog = AlertDialog.Builder(this)
             .setTitle(R.string.scoped_storage_title)
             .setMessage(message)
             .setPositiveButton(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -136,7 +136,6 @@ import timber.log.Timber
 import java.io.File
 import java.lang.Runnable
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.ExperimentalTime
 import kotlin.time.measureTimedValue
 
 const val MIGRATION_WAS_LAST_POSTPONED_AT_SECONDS = "secondWhenMigrationWasPostponedLast"
@@ -1225,7 +1224,6 @@ open class DeckPicker :
         }
     }
 
-    @Suppress("DEPRECATION") // onBackPressed
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         val preferences = baseContext.sharedPrefs()
@@ -1852,7 +1850,6 @@ open class DeckPicker :
             }
             negativeButton(R.string.dialog_cancel)
             if (AdaptionUtil.hasWebBrowser(this@DeckPicker)) {
-                @Suppress("DEPRECATION")
                 neutralButton(text = getColUnsafe.tr.schedulingUpdateMoreInfoButton()) {
                     this@DeckPicker.openUrl(Uri.parse("https://faqs.ankiweb.net/the-anki-2.1-scheduler.html#updating"))
                 }
@@ -2348,7 +2345,6 @@ open class DeckPicker :
         MigrationService.start(baseContext)
     }
 
-    @OptIn(ExperimentalTime::class)
     private fun launchShowingHidingEssentialFileMigrationProgressDialog() = lifecycleScope.launch {
         while (true) {
             MigrationService.flowOfProgress

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -249,9 +249,9 @@ object MetaDB {
             mMetaDb!!.rawQuery(
                 query,
                 arrayOf(
-                    java.lang.Long.toString(did),
-                    Integer.toString(ord),
-                    Integer.toString(qa.int)
+                    did.toString(),
+                    ord.toString(),
+                    qa.int.toString()
                 )
             ).use { cur ->
                 Timber.v("getLanguage: %s", query)
@@ -275,7 +275,7 @@ object MetaDB {
         try {
             mMetaDb!!.rawQuery(
                 "SELECT state FROM whiteboardState  WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur -> return DatabaseUtil.getScalarBoolean(cur) }
         } catch (e: Exception) {
             Timber.e(e, "Error retrieving whiteboard state from MetaDB ")
@@ -296,7 +296,7 @@ object MetaDB {
             val metaDb = mMetaDb!!
             metaDb.rawQuery(
                 "SELECT _id FROM whiteboardState WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur ->
                 if (cur.moveToNext()) {
                     metaDb.execSQL(
@@ -327,7 +327,7 @@ object MetaDB {
         try {
             mMetaDb!!.rawQuery(
                 "SELECT stylus FROM whiteboardState WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur -> return DatabaseUtil.getScalarBoolean(cur) }
         } catch (e: Exception) {
             Timber.e(e, "Error retrieving whiteboard stylus mode state from MetaDB ")
@@ -348,7 +348,7 @@ object MetaDB {
             val metaDb = mMetaDb!!
             metaDb.rawQuery(
                 "SELECT _id FROM whiteboardState WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur ->
                 if (cur.moveToNext()) {
                     metaDb.execSQL(
@@ -379,7 +379,7 @@ object MetaDB {
         try {
             mMetaDb!!.rawQuery(
                 "SELECT visible FROM whiteboardState WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur -> return DatabaseUtil.getScalarBoolean(cur) }
         } catch (e: Exception) {
             Timber.e(e, "Error retrieving whiteboard state from MetaDB ")
@@ -400,7 +400,7 @@ object MetaDB {
             val metaDb = mMetaDb!!
             metaDb.rawQuery(
                 "SELECT _id FROM whiteboardState WHERE did  = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur ->
                 if (cur.moveToNext()) {
                     metaDb.execSQL(
@@ -429,7 +429,7 @@ object MetaDB {
         try {
             mMetaDb!!.rawQuery(
                 "SELECT lightpencolor, darkpencolor FROM whiteboardState WHERE did = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur ->
                 cur.moveToFirst()
                 val light = DatabaseUtil.getInteger(cur, 0)
@@ -456,7 +456,7 @@ object MetaDB {
             val metaDb = mMetaDb!!
             metaDb.rawQuery(
                 "SELECT _id FROM whiteboardState WHERE did  = ?",
-                arrayOf(java.lang.Long.toString(did))
+                arrayOf(did.toString())
             ).use { cur ->
                 if (cur.moveToNext()) {
                     metaDb.execSQL(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -432,7 +432,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
 
     private suspend fun changeSortField(notetype: NotetypeJson, idx: Int) {
         withProgress(resources.getString(R.string.model_field_editor_changing)) {
-            CollectionManager.withCol {
+            withCol {
                 Timber.d("doInBackgroundChangeSortField")
                 notetypes.set_sort_index(notetype, idx)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -196,7 +196,7 @@ object ReadText {
         Timber.d("ReadText.textToSpeech() method started for string '%s', locale '%s'", tag.fieldText, tag.lang)
         var localeCode = tag.lang
         val originalLocaleCode = localeCode
-        if (!localeCode.isEmpty()) {
+        if (localeCode.isNotEmpty()) {
             if (!isLanguageAvailable(localeCode)) {
                 localeCode = ""
             }
@@ -210,13 +210,13 @@ object ReadText {
             // user has chosen not to read the text
             return false
         }
-        if (!localeCode.isEmpty() && isLanguageAvailable(localeCode)) {
+        if (localeCode.isNotEmpty() && isLanguageAvailable(localeCode)) {
             speak(textToSpeak, localeCode, queueMode)
             return true
         }
 
         // Otherwise ask the user what language they want to use
-        if (!originalLocaleCode.isEmpty()) {
+        if (originalLocaleCode.isNotEmpty()) {
             // (after notifying them first that no TTS voice was found for the locale
             // they originally requested)
             showThemedToast(
@@ -252,9 +252,7 @@ object ReadText {
                     Timber.d("TTS initialized and available languages found")
                     (context as AbstractFlashcardViewer).ttsInitialized()
                 } else {
-                    if (ankiActivityContext != null) {
-                        ankiActivityContext.showSnackbar(R.string.no_tts_available_message)
-                    }
+                    ankiActivityContext?.showSnackbar(R.string.no_tts_available_message)
                     Timber.w("TTS initialized but no available languages found")
                 }
                 textToSpeech!!.setOnUtteranceProgressListener(object : UtteranceProgressListener() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -876,10 +876,7 @@ open class Reviewer :
         if (answerFieldIsFocused()) {
             return super.onKeyDown(keyCode, event)
         }
-        if (processor.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)) {
-            return true
-        }
-        return false
+        return processor.onKeyDown(keyCode, event) || super.onKeyDown(keyCode, event)
     }
 
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -71,7 +71,6 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         isCancelable = true
     }
 
-    @Suppress("Deprecation") // Material dialog neutral button deprecation
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val dialogView = LayoutInflater.from(activity)
             .inflate(R.layout.deck_picker_dialog, null, false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -222,7 +222,7 @@ class TtsVoicesDialogFragment : DialogFragment() {
     }
 
     // inner allows access to viewModel/openTtsSettings
-    inner class TtsVoiceAdapter() : ListAdapter<AndroidTtsVoice, TtsVoiceAdapter.TtsViewHolder>(TtsVoiceDiffCallback()) {
+    inner class TtsVoiceAdapter : ListAdapter<AndroidTtsVoice, TtsVoiceAdapter.TtsViewHolder>(TtsVoiceDiffCallback()) {
         inner class TtsViewHolder(private val voiceView: View) : RecyclerView.ViewHolder(voiceView) {
             private val textViewTop = voiceView.findViewById<TextView>(R.id.mtrl_list_item_secondary_text)
             private val textViewBottom = voiceView.findViewById<TextView>(R.id.mtrl_list_item_text)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -519,7 +519,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         EMPTY_SCHEDULE(3);
 
         companion object {
-            fun fromInt(value: Int): ContextMenuConfiguration = values().first { it.value == value }
+            fun fromInt(value: Int): ContextMenuConfiguration = entries.first { it.value == value }
         }
     }
 
@@ -541,8 +541,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         MORE_OPTIONS(108, R.string.more_options);
 
         companion object {
-            fun fromInt(value: Int): ContextMenuOption = values().first { it.value == value }
-            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = values().first { resources.getString(it.stringResource as Int) == stringValue }
+            fun fromInt(value: Int): ContextMenuOption = entries.first { it.value == value }
+            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = entries.first { resources.getString(it.stringResource as Int) == stringValue }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -58,7 +58,7 @@ class FieldState private constructor(private val editor: NoteEditor) {
         }
         if (type.type == Type.CHANGE_FIELD_COUNT) {
             val currentFieldStrings = editor.currentFieldStrings
-            for (i in 0 until Math.min(currentFieldStrings.size, fieldEditLines.size)) {
+            for (i in 0 until currentFieldStrings.size.coerceAtMost(fieldEditLines.size)) {
                 fieldEditLines[i].setContent(currentFieldStrings[i], type.replaceNewlines)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -268,7 +268,7 @@ open class Card : Cloneable {
     fun timeTaken(col: Collection): Int {
         // Indeed an int. Difference between two big numbers is still small.
         val total = (TimeManager.time.intTimeMS() - timerStarted).toInt()
-        return Math.min(total, timeLimit(col))
+        return total.coerceAtMost(timeLimit(col))
     }
 
     /*

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -93,7 +93,7 @@ object Consts {
     // The labels defined in consts.py are in AnkiDroid's resources files.
     const val DEFAULT_DECK_ID: Long = 1
 
-    val FIELD_SEPARATOR = Character.toString('\u001f')
+    val FIELD_SEPARATOR = '\u001f'.toString()
 
     /** Time duration for toast **/
     const val SHORT_TOAST_DURATION: Long = 2000

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -182,7 +182,6 @@ class DB(val database: SupportSQLiteDatabase) {
      */
     @KotlinCleanup("""Use Kotlin string. Change split so that there is no empty string after last ";".""")
     fun executeScript(@Language("SQL") sql: String) {
-        @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
         val queries = java.lang.String(sql).split(";")
         for (query in queries) {
             database.execSQL(query)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -388,8 +388,8 @@ class Notetypes(val col: Collection) {
      * [ConfirmModSchemaException]
      */
     @RustCleanup("Since Kotlin doesn't have throws, this may not be needed")
-    fun addFieldInNewModel(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
-        Assert.that(Notetypes.isModelNew(m), "Model was assumed to be new, but is not")
+    fun addFieldInNewModel(m: NotetypeJson, field: JSONObject) {
+        Assert.that(isModelNew(m), "Model was assumed to be new, but is not")
         try {
             _addField(m, field)
         } catch (e: ConfirmModSchemaException) {
@@ -399,10 +399,10 @@ class Notetypes(val col: Collection) {
         }
     }
 
-    fun addTemplateInNewModel(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun addTemplateInNewModel(m: NotetypeJson, template: JSONObject) {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
-        Assert.that(Notetypes.isModelNew(m), "Model was assumed to be new, but is not")
+        Assert.that(isModelNew(m), "Model was assumed to be new, but is not")
 
         try {
             _addTemplate(m, template)
@@ -413,7 +413,7 @@ class Notetypes(val col: Collection) {
         }
     }
 
-    fun addFieldModChanged(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
+    fun addFieldModChanged(m: NotetypeJson, field: JSONObject) {
         // similar to Anki's addField; but thanks to assumption that
         // mod is already changed, it never has to throw
         // ConfirmModSchemaException.
@@ -421,7 +421,7 @@ class Notetypes(val col: Collection) {
         _addField(m, field)
     }
 
-    fun addTemplateModChanged(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun addTemplateModChanged(m: NotetypeJson, template: JSONObject) {
         // similar to addTemplate, but doesn't throw exception;
         // asserting the model is new.
         Assert.that(col.schemaChanged(), "Mod was assumed to be already changed, but is not")
@@ -573,11 +573,11 @@ class Notetypes(val col: Collection) {
         return all_names_and_ids().count()
     }
 
-    fun _addTemplate(m: com.ichi2.libanki.NotetypeJson, template: JSONObject) {
+    fun _addTemplate(m: NotetypeJson, template: JSONObject) {
         addTemplate(m, template)
     }
 
-    fun _addField(m: com.ichi2.libanki.NotetypeJson, field: JSONObject) {
+    fun _addField(m: NotetypeJson, field: JSONObject) {
         addField(m, field)
     }
 
@@ -629,7 +629,7 @@ class Notetypes(val col: Collection) {
                 )
 
         /** "Mapping of field name -> (ord, field).  */
-        fun fieldMap(m: com.ichi2.libanki.NotetypeJson): Map<String, Pair<Int, JSONObject>> {
+        fun fieldMap(m: NotetypeJson): Map<String, Pair<Int, JSONObject>> {
             val flds = m.getJSONArray("flds")
             // TreeMap<Integer, String> map = new TreeMap<Integer, String>();
             val result: MutableMap<String, Pair<Int, JSONObject>> = HashUtil.hashMapInit(flds.length())
@@ -640,11 +640,11 @@ class Notetypes(val col: Collection) {
         }
 
         // not in anki
-        fun isModelNew(m: com.ichi2.libanki.NotetypeJson): Boolean {
+        fun isModelNew(m: NotetypeJson): Boolean {
             return m.getLong("id") == 0L
         }
 
-        fun _updateTemplOrds(m: com.ichi2.libanki.NotetypeJson) {
+        fun _updateTemplOrds(m: NotetypeJson) {
             val tmpls = m.getJSONArray("tmpls")
             for (i in 0 until tmpls.length()) {
                 val f = tmpls.getJSONObject(i)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -539,7 +539,7 @@ class Notetypes(val col: Collection) {
 
     /** Convert old->new map to list of old indexes/nulls */
     private fun convertLegacyMap(map: Map<Int, Int?>, newSize: Int): Iterable<Int> {
-        val newToOld = map.entries.filter({ it.value != null }).associate { (k, v) -> v to k }
+        val newToOld = map.entries.filter { it.value != null }.associate { (k, v) -> v to k }
         val output = mutableListOf<Int>()
         for (idx in 0 until newSize) {
             output.append(newToOld[idx] ?: -1)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/NoteUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/model/NoteUtil.kt
@@ -25,7 +25,7 @@ fun Note.toBackendNote(): anki.notes.Note {
         id = note.id
         guid = note.guId!!
         notetypeId = note.mid
-        mtimeSecs = note.mod.toInt() // this is worrying, 2038 problem
+        mtimeSecs = note.mod
         usn = note.usn
         tags.addAll(note.tags.asIterable())
         fields.addAll(note.fields.asIterable())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.reviewer
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MockMigrationContext.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.servicelayer.scopedstorage
 
-import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.*
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.MigrationContext
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.MigrateUserData.Operation
 import com.ichi2.anki.servicelayer.scopedstorage.migrateuserdata.NumberOfBytes

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.createTransientFile
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflict.kt
@@ -24,8 +24,7 @@ import org.mockito.Mockito
 /** Test helper:
  * causes getCol to emulate an exception caused by having another AnkiDroid instance open on the same collection
  */
-class BackendEmulatingOpenConflict() : Backend() {
-    @Suppress("UNUSED_PARAMETER")
+class BackendEmulatingOpenConflict : Backend() {
     override fun openCollection(
         collectionPath: String,
         mediaFolderPath: String,

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileOperation.kt
@@ -17,7 +17,6 @@ package com.ichi2.utils
 
 import java.io.File
 import java.io.RandomAccessFile
-import java.util.*
 
 class FileOperation {
     companion object {


### PR DESCRIPTION

## Description
- In this commit:
- Replaced Java methods with their Kotlin equivalents for improved readability and idiomatic usage.
- Removed redundant code and unnecessary constructs to simplify and clean up the codebase.

## Fixes
* Fixes #13282 

## How Has This Been Tested?

- I tested these changes on Level 30 (Android 11).
