### PR TITLE
fix: theme follow system configuration

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -52,7 +52,6 @@ object Themes {
     fun setTheme(context: Context) {
         updateCurrentTheme(context)
         Timber.i("Setting theme to %s", currentTheme.name)
-        AppCompatDelegate.setDefaultNightMode(getDefaultNightModeFromTheme(context))
         context.setTheme(currentTheme.resId)
     }
 
@@ -77,13 +76,17 @@ object Themes {
         }
 
         currentTheme = if (themeFollowsSystem(prefs)) {
+            AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
             if (systemIsInNightMode(context)) {
                 Theme.ofId(prefs.getString(NIGHT_THEME_KEY, Theme.BLACK.id)!!)
             } else {
                 Theme.ofId(prefs.getString(DAY_THEME_KEY, Theme.LIGHT.id)!!)
             }
         } else {
-            Theme.ofId(prefs.getString(APP_THEME_KEY, Theme.fallback.id)!!)
+            Theme.ofId(prefs.getString(APP_THEME_KEY, Theme.fallback.id)!!).also {
+                val mode = if (it.isNightMode) AppCompatDelegate.MODE_NIGHT_YES else AppCompatDelegate.MODE_NIGHT_NO
+                AppCompatDelegate.setDefaultNightMode(mode)
+            }
         }
     }
 
@@ -138,23 +141,6 @@ object Themes {
     fun systemIsInNightMode(context: Context): Boolean {
         return context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK ==
             Configuration.UI_MODE_NIGHT_YES
-    }
-
-    private fun getDefaultNightModeFromTheme(context: Context): Int {
-        // TODO (#5019): always use the context as the parameter for sharedPrefs()
-        val prefs = if (context is AppCompatPreferenceActivity<*>) {
-            AnkiDroidApp.instance.sharedPrefs()
-        } else {
-            context.sharedPrefs()
-        }
-        if (themeFollowsSystem(prefs)) {
-            return AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
-        }
-        return if (currentTheme.isNightMode) {
-            AppCompatDelegate.MODE_NIGHT_YES
-        } else {
-            AppCompatDelegate.MODE_NIGHT_NO
-        }
     }
 }
 


### PR DESCRIPTION
cause f145def4c4ee9b944bcb1df6cd04a636a5cc8bd3

reproduction steps:
1. Disable system dark mode
2. Set theme to `Follow system`
3. Set theme to `Dark` or `Black`
4. Set theme back to `Follow system`

expected result: theme should be light
actual result: theme is dark

## How Has This Been Tested?

API 31, same reproduction steps

## Learning (optional, can help others)

AppCompatDelegate.setDefaultNightMode interferes with checking the current night mode

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
