### PR TITLE
lint: "JavaScript" capitalization

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
 import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage
+import com.ichi2.anki.lint.rules.TranslationTypo
 import com.ichi2.anki.lint.rules.VariableNamingDetector
 
 class IssueRegistry : IssueRegistry() {
@@ -57,6 +58,7 @@ class IssueRegistry : IssueRegistry() {
                 JUnitNullAssertionDetector.ISSUE,
                 PrintStackTraceUsage.ISSUE,
                 NonPositionalFormatSubstitutions.ISSUE,
+                TranslationTypo.ISSUE,
                 FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
                 FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
                 VariableNamingDetector.ISSUE,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+@file:Suppress("UnstableApiUsage")
+
+package com.ichi2.anki.lint.rules
+
+import com.android.resources.ResourceFolderType
+import com.android.tools.lint.detector.api.*
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import org.w3c.dom.Element
+
+/**
+ * Ensures that strings are cased correctly
+ *
+ * `JavaScript`, not `Javascript`
+ */
+class TranslationTypo : ResourceXmlDetector(), XmlScanner {
+    companion object {
+        @VisibleForTesting
+        val ID_TITLE_LENGTH = "TranslationTypo"
+
+        @VisibleForTesting
+        val EXPLANATION_TITLE_LENGTH = "Typo in translation"
+
+        private val implementation = Implementation(TranslationTypo::class.java, Scope.RESOURCE_FILE_SCOPE)
+        val ISSUE: Issue = Issue.create(
+            ID_TITLE_LENGTH,
+            EXPLANATION_TITLE_LENGTH,
+            EXPLANATION_TITLE_LENGTH,
+            Constants.ANKI_XML_CATEGORY,
+            Constants.ANKI_XML_PRIORITY,
+            Constants.ANKI_XML_SEVERITY,
+            implementation
+        )
+    }
+
+    override fun getApplicableElements(): Collection<String>? = ALL
+
+    override fun appliesTo(folderType: ResourceFolderType): Boolean =
+        folderType == ResourceFolderType.XML || folderType == ResourceFolderType.VALUES
+
+    override fun visitElement(context: XmlContext, element: Element) {
+        if ("preferences.xml" == context.file.name) {
+            return
+        }
+        if ("resources" == element.tagName) {
+            return
+        }
+
+        if (element.textContent.lowercase().contains("javascript") && !element.textContent.contains("JavaScript")) {
+            context.report(ISSUE, context.getElementLocation(element), "should be 'JavaScript'")
+        }
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.ichi2.anki.lint.testutils.assertXmlStringsHasError
+import com.ichi2.anki.lint.testutils.assertXmlStringsNoIssues
+import org.junit.Test
+
+/**
+ * Test of [TranslationTypo]
+ */
+class TranslationTypoTest {
+
+    @Test
+    fun `JavaScript is valid casing`() {
+        val validCasing = """<resources>
+           <string name="hello">JavaScript</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsNoIssues(validCasing)
+    }
+
+    @Test
+    fun `title case fails`() {
+        val invalidTitleCase = """<resources>
+           <string name="hello">Javascript</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(invalidTitleCase, "should be 'JavaScript'")
+    }
+
+    @Test
+    fun `lowercase fails`() {
+        val invalidLowerCase = """<resources>
+           <string name="hello">javascript</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(invalidLowerCase, "should be 'JavaScript'")
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.testutils
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.detector.api.Issue
+import org.intellij.lang.annotations.Language
+import org.junit.Assert.assertTrue
+
+fun Issue.assertXmlStringsNoIssues(@Language("XML") xmlFile: String) {
+    TestLintTask.lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(TestFiles.xml("res/values/string.xml", xmlFile))
+        .issues(this)
+        .run()
+        .expectClean()
+}
+
+fun Issue.assertXmlStringsHasErrorCount(@Language("XML") xmlFile: String, expectedErrorCount: Int) {
+    assert(expectedErrorCount > 0) { "Use assertXmlStringsNoIssues" }
+    TestLintTask.lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(TestFiles.xml("res/values/string.xml", xmlFile))
+        .issues(this)
+        .run()
+        .expectErrorCount(expectedErrorCount)
+}
+
+fun Issue.assertXmlStringsHasError(@Language("XML") xmlFile: String, expectedError: String) {
+    TestLintTask.lint()
+        .allowMissingSdk()
+        .allowCompilationErrors()
+        .files(TestFiles.xml("res/values/string.xml", xmlFile))
+        .issues(this)
+        .run()
+        .expectErrorCount(1)
+        .check({ output: String ->
+            assertTrue(
+                "check should fail wth '$expectedError', but was '$output'",
+                output.contains(expectedError)
+            )
+        })
+}


### PR DESCRIPTION
## Purpose / Description
not "javascript" or "Javascript"

## Fixes
* Fixes #15755

## Approach
Lint

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
