### PR TITLE
fix: 'playsound:' on API 23

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2238,6 +2238,12 @@ abstract class AbstractFlashcardViewer :
         private var pageFinishedFired = true
         private val pageRenderStopwatch = Stopwatch.init("page render")
 
+        @Deprecated("Deprecated in Java") // still needed for API 23
+        override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+            Timber.d("Obtained URL from card: '%s'", url)
+            return filterUrl(url)
+        }
+
         override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
             val url = request.url.toString()
             Timber.d("Obtained URL from card: '%s'", url)


### PR DESCRIPTION
## Fixes
* Fixes #15834

## Approach
partial revert of 2a08b0a066d9b0adf5b35d6722d2fc2de0ff635c


## How Has This Been Tested?
API 23 emulator.

I can't hear emulator output, but it looks much better now

It used to look like:

![Screenshot 2024-03-13 at 01 19 45](https://github.com/ankidroid/Anki-Android/assets/62114487/4dd80165-2b9d-41c5-a6b0-93485e42648b)

## Learning (optional, can help others)
Google deprecate methods which are still needed

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
