### PR TITLE
fix: Can't exit previewer through Android back button 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -64,7 +64,7 @@ open class SingleFragmentActivity : AnkiActivity() {
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)!!
         return if (fragment is DispatchKeyEventListener) {
-            fragment.dispatchKeyEvent(event)
+            fragment.dispatchKeyEvent(event) || super.dispatchKeyEvent(event)
         } else {
             super.dispatchKeyEvent(event)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerActivity.kt
@@ -23,6 +23,10 @@ import com.ichi2.anki.SingleFragmentActivity
 import kotlin.reflect.KClass
 import kotlin.reflect.jvm.jvmName
 
+/**
+ * @see PreviewerFragment
+ * @see TemplatePreviewerFragment
+ */
 class PreviewerActivity : SingleFragmentActivity() {
     companion object {
         fun getIntent(context: Context, fragmentClass: KClass<out Fragment>, arguments: Bundle? = null): Intent {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerFragmentTest.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.previewer
+
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.PreviewerIdsFile
+import com.ichi2.testutils.createTransientDirectory
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PreviewerFragmentTest : RobolectricTest() {
+
+    @Test
+    fun `previewer - back button`() {
+        val note = addNoteUsingBasicAndReversedModel()
+
+        val intent = PreviewerFragment.getIntent(
+            targetContext,
+            previewerIdsFile = PreviewerIdsFile(createTransientDirectory(), note.cardIds(col)),
+            currentIndex = 0
+        )
+
+        ActivityScenario.launch<PreviewerActivity>(intent).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { previewer ->
+                assertThat("Activity is not finishing", !previewer.isFinishing)
+                // this needs to test the keypress, not the dispatcher
+                Espresso.pressBack()
+                assertThat("Activity is finishing after back press", previewer.isFinishing)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Fixes
* Fixes #15884

## Approach
handle the key event

## How Has This Been Tested?
Unit tested

## Learning (optional, can help others)
Our testers are awesome

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
