### PR TITLE
fix: image name with unescaped chars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -19,8 +19,10 @@
 
 package com.ichi2.anki.multimediacard.fields
 
+import android.net.Uri
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.KotlinCleanup
 import org.jsoup.Jsoup
@@ -74,9 +76,11 @@ class ImageField : FieldBase(), IField {
         private const val serialVersionUID = 4431611060655809687L
 
         @VisibleForTesting
+        @NeedsTest("files with HTML illegal chars can be imported and rendered")
         fun formatImageFileName(file: File): String {
             return if (file.exists()) {
-                """<img src="${file.name}">"""
+                val encodedName = Uri.encode(file.name)
+                """<img src="$encodedName">"""
             } else {
                 ""
             }


### PR DESCRIPTION
## Fixes
* Fixes #15844

## How Has This Been Tested?

Import an image with `%20` in its name

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
