### PR TITLE
fix: change context to match application theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -803,7 +803,7 @@ open class Reviewer :
             if (!actionButtons.status.whiteboardPenColorIsDisabled()) {
                 changePenColorIcon.isVisible = true
             }
-            val whiteboardIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_white)!!.mutate()
+            val whiteboardIcon = ContextCompat.getDrawable(applicationContext, R.drawable.ic_gesture_white)!!.mutate()
             val stylusIcon = ContextCompat.getDrawable(this, R.drawable.ic_gesture_stylus)!!.mutate()
             val whiteboardColorPaletteIcon = VectorDrawableCompat.create(resources, R.drawable.ic_color_lens_white_24dp, this.theme)!!.mutate()
             if (showWhiteboard) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -122,7 +122,7 @@ class SharedDecksActivity : AnkiActivity() {
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
         supportActionBar?.setDisplayShowHomeEnabled(true)
 
-        webviewToolbar.navigationIcon = ContextCompat.getDrawable(this, R.drawable.close_icon)
+        webviewToolbar.navigationIcon = ContextCompat.getDrawable(applicationContext, R.drawable.close_icon)
 
         webView = findViewById(R.id.web_view)
 


### PR DESCRIPTION
## Purpose / Description
fix: change context to match application theme of close icon and white board icon.

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15457
* Closes #15858

## Approach
Replace `this` with `applicationContext` to match application theme, since `ContextCompat()` requires a suitable context.

## How Has This Been Tested?

Before (Light)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/566d96ed-6900-4b1f-968c-88ca31652110)

After (Light)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/24601ecf-262f-4b8e-8d17-f159b9b47e93)


Before (Plain)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/fa5bfe37-c51a-42a4-9001-1aa9e13715af)


After (Plain)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/c571c06a-abea-437c-9b5a-ac979cf0b146)

Before(Black)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/d632c2c7-a786-46a5-bfd6-50efc2dbb0cb)


After(Black)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/48b0d4a8-78d7-4890-947c-71a1b0aa1769)

Before(Dark)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/0df0966b-6239-452a-901b-89948d338acd)

After(Dark)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/583a50ec-f35d-4dea-8da0-6d0b2583c647)




Before (Light)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/e06b8b02-785f-4cdf-9e54-13e113b15192)



After (Light)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/12181dc0-4144-4d1a-8104-9319f0143c15)


Before (Plain)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/3fbeef96-ba48-4eb5-9f37-162b21aa8802)




After (Plain)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/dea1b6ed-a410-4c68-a8bf-4f361f88e2bc)


Before(Black)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/efe137fb-66c6-443e-86a1-045baa91925e)



After(Black)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/521acc24-25b5-42f9-aa9b-a7e412e36660)


Before(Dark)
![image](https://github.com/ankidroid/Anki-Android/assets/76740999/9bcdcd7b-dcb9-4608-97f0-6e5406fda6fa)


After(Dark)

![image](https://github.com/ankidroid/Anki-Android/assets/76740999/5cb3997c-d270-454b-8db9-4a33602394ef)








## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
