### PR TITLE
fix: IO - use absolute path for cached copy

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.*
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.dialogs.ImportDialog
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import org.jetbrains.annotations.Contract
 import timber.log.Timber
@@ -126,11 +127,12 @@ object ImportUtils {
             }
         }
 
+        @NeedsTest("Check file name is absolute")
         fun getFileCachedCopy(context: Context, uri: Uri): String? {
             val filename = ensureValidLength(getFileNameFromContentProvider(context, uri) ?: return null)
-            val tempPath = Uri.fromFile(File(context.cacheDir, filename)).encodedPath!!
-            return if (copyFileToCache(context, uri, tempPath)) {
-                tempPath
+            val tempFile = File(context.cacheDir, filename)
+            return if (copyFileToCache(context, uri, tempFile.absolutePath)) {
+                tempFile.absolutePath
             } else {
                 null
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
We are getting encoded path when we get the cached copy of the IO image file which caused issue with image rendering 

## Fixes
* Fixes #15908

## Approach
Use absolute path 

## How Has This Been Tested?
![Screenshot 2024-03-15 221643](https://github.com/ankidroid/Anki-Android/assets/48384865/0ed70be4-2bf5-4ee4-91a8-84f9144033fc)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
