### PR TITLE
fix: sliderPreference width making it independent of value number

### DIFF
--- a/AnkiDroid/src/main/res/layout/preference_slider.xml
+++ b/AnkiDroid/src/main/res/layout/preference_slider.xml
@@ -74,7 +74,7 @@
 
             <TextView
                 android:id="@+id/valueDisplay"
-                android:minWidth="40sp"
+                android:minWidth="64sp"
                 android:paddingStart="0dp"
                 android:paddingEnd="0dp"
                 android:layout_width="wrap_content"


### PR DESCRIPTION
## Purpose / Description
fix: sliderPreference width making it independent of value number

## Fixes
* Fixes #15738 

## Approach
Determine the width of text view (using `.width` and `metrics`) with the maximum value i.e `2000 ms` which comes out to be `63.636364 sp` so made it to `64 sp`.

## How Has This Been Tested?

## Before



https://github.com/ankidroid/Anki-Android/assets/76740999/834f4755-22ab-420e-b65b-4c8192bfd56e


## After


https://github.com/ankidroid/Anki-Android/assets/76740999/44191b22-e985-4c12-863b-42b36c2a426d




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
