### PR TITLE
WIP : Allow Multiple Selected Note to delete

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -127,9 +127,7 @@ class ManageNotetypes : AnkiActivity(), NotetypesAdapter.NotetypeAdapterCallback
                 return true
             }
         })
-        return true
-    }
-
+        // Menu for deleting multiple notes
         menuInflater.inflate(R.menu.menu_manage_notes, menu)
         launchCatchingTask {
             menu.findItem(R.id.action_delete_notes).isVisible =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeUiModel.kt
@@ -25,7 +25,8 @@ import anki.notetypes.NotetypeNameIdUseCount
 internal data class NoteTypeUiModel(
     val id: Long,
     val name: String,
-    val useCount: Int
+    val useCount: Int,
+    var isSelected: Boolean = false
 )
 
 internal fun NotetypeNameIdUseCount.toUiModel(): NoteTypeUiModel =

--- a/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
@@ -14,8 +14,25 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+        <CheckBox
+            android:id="@+id/selected_item_checkbox"
+            android:focusable="false"
+            android:focusableInTouchMode="false"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            android:visibility="gone"
+            tools:visibility="visible"/>
+        </LinearLayout>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:padding="16dp">
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp"
+            android:paddingBottom="16dp">
 
             <TextView
                 android:id="@+id/note_name"

--- a/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
+++ b/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
@@ -6,7 +6,7 @@
     <item
         android:id="@+id/action_delete_notes"
         android:icon="@drawable/ic_delete_white"
-        android:title="@string/title_delete"
+        android:title="@string/dialog_positive_delete"
         android:visible="false"
         ankidroid:showAsAction="always"/>
 </menu>

--- a/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
+++ b/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".DeckPicker">
+    <item
+        android:id="@+id/action_delete_notes"
+        android:icon="@drawable/ic_delete_white"
+        android:title="@string/title_delete"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+</menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -434,4 +434,5 @@ opening the system text to speech settings fails">
     <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
 
     <string name="card_template_reposition_template" comment="move a card template to a new position">Reposition</string>
+    <string name="title_delete">Delete</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -434,5 +434,4 @@ opening the system text to speech settings fails">
     <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
 
     <string name="card_template_reposition_template" comment="move a card template to a new position">Reposition</string>
-    <string name="title_delete" comment="content description (title) of the delete icon in menu">Delete</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -434,5 +434,5 @@ opening the system text to speech settings fails">
     <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
 
     <string name="card_template_reposition_template" comment="move a card template to a new position">Reposition</string>
-    <string name="title_delete">Delete</string>
+    <string name="title_delete" comment="content description (title) of the delete icon in menu">Delete</string>
 </resources>


### PR DESCRIPTION
## Fix
* Fixes #15885

## Todo

- [ ] 1. Deletion seems to work properly, but if a new note is added it doesn't considers old notes it only works on the selection works on newly added note only. Somehow the getSelectedItems() doesn't return old cards selected value.
- [ ] 2. Enhance the ui (remove checkbox & change background color as discussed in discord).
- [ ] 3. Add snackbar to show "x selected cards are deleted" for feedback to user.
- [ ] 4. Refactor unused code for review.

## Video

### Working of Multiple selection and allowing to delete

https://github.com/ankidroid/Anki-Android/assets/60827173/a230fafe-a6c0-4c8a-ae40-3249b84792f2

### Current bug in the code


https://github.com/ankidroid/Anki-Android/assets/60827173/05757290-1dea-4064-a0d7-e8145690053b



 

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
