### PR TITLE
Adding up Congrats Page back to deck environment.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -99,7 +99,7 @@ import com.ichi2.anki.introduction.hasCollectionStoragePermissions
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.pages.AnkiPackageImporterFragment
 import com.ichi2.anki.pages.CongratsPage
-import com.ichi2.anki.pages.CongratsPage.Companion.onDeckCompleted
+
 import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
@@ -1118,7 +1118,7 @@ open class DeckPicker :
 
     private fun processReviewResults(resultCode: Int) {
         if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
-            CongratsPage.onReviewsCompleted(this, getColUnsafe.sched.totalCount() == 0)
+            startActivity(CongratsPage.getIntent(this))
         } else if (resultCode == AbstractFlashcardViewer.RESULT_ABORT_AND_SYNC) {
             Timber.i("Obtained Abort and Sync result")
             sync()
@@ -1888,16 +1888,16 @@ open class DeckPicker :
             return
         }
 
-        when (val completedDeckStatus = queryCompletedDeckCustomStudyAction(did)) {
+        when (queryCompletedDeckCustomStudyAction(did)) {
             CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED,
             CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY,
             CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED,
             CompletedDeckStatus.DAILY_STUDY_LIMIT_REACHED -> {
-                onDeckCompleted(did, completedDeckStatus, ::updateUi)
+                startActivity(CongratsPage.getIntent(this))
             }
             CompletedDeckStatus.EMPTY_REGULAR_DECK -> {
+                startActivity(CongratsPage.getIntent(this))
                 // If the deck is empty (& has no children) then show a message saying it's empty
-                showEmptyDeckSnackbar()
                 updateUi()
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -237,24 +237,62 @@ class CongratsPage :
 
             when (completedDeckStatus) {
                 CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED -> {
+                    fun display(activity: Activity) {
+                        if (displayNewCongratsScreen(activity)) {
+                            activity.startActivity(getIntent(activity))
+                        } else {
+                            UIUtils.showThemedToast(activity, R.string.studyoptions_congrats_limit_set, false)
+                        }
+                    }
+
                     // If there are cards due that can't be studied yet (due to the learn ahead limit) then go to study options
                     openStudyOptions(withDeckOptions = false)
                 }
                 CompletedDeckStatus.DAILY_STUDY_LIMIT_REACHED -> {
+                    fun display(activity: Activity) {
+                        if (displayNewCongratsScreen(activity)) {
+                            activity.startActivity(getIntent(activity))
+                        } else {
+                            UIUtils.showThemedToast(activity, R.string.studyoptions_congrats_limit_set, false)
+                        }
+                    }
+
                     // If there are no cards to review because of the daily study limit then give "Study more" option
                     showStudyMoreSnackbar(did)
                     updateUi()
                 }
                 CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED -> {
+                    fun display(activity: Activity) {
+                        if (displayNewCongratsScreen(activity)) {
+                            activity.startActivity(getIntent(activity))
+                        } else {
+                            UIUtils.showThemedToast(activity, R.string.studyoptions_no_scheduled, false)
+                        }
+                    }
+
                     // Go to the study options screen if filtered deck with no cards to study
                     openStudyOptions(withDeckOptions = false)
                 }
                 CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY -> {
+                    fun display(activity: Activity) {
+                        if (displayNewCongratsScreen(activity)) {
+                            activity.startActivity(getIntent(activity))
+                        } else {
+                            UIUtils.showThemedToast(activity, R.string.studyoptions_empty_schedule, false)
+                        }
+                    }
+
                     // Otherwise say there are no cards scheduled to study, and give option to do custom study
                     showCustomStudySnackbar(did)
                     updateUi()
                 }
-                CompletedDeckStatus.EMPTY_REGULAR_DECK -> { }
+                CompletedDeckStatus.EMPTY_REGULAR_DECK -> {
+                    fun display(activity: Activity) {
+                        UIUtils.showThemedToast(activity, R.string.empty_deck, false)
+                    }
+                    openStudyOptions(withDeckOptions = false)
+                    updateUi()
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -123,6 +123,9 @@
     <string name="studyoptions_empty_schedule">No cards scheduled to study</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
+    <string name="studyoptions_deck_completed">No more cards to study as of today.</string>
+    <string name="studyoptions_no_scheduled">No cards are scheduled to study.</string>
+    <string name="studyoptions_congrats_limit_set">There are more new cards available, but the daily limit has been reached. You can Increase the limit in the options, but please bear in mind that the more new cards you introduce, the higher your short-term review workload will become.</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>
     <string name="button_sync" comment="Text of the sync button">Sync</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
A large number of users do not like the screen so rolling back to congrats page for a while .#15886

## Fixes
## Approach
Partially reverted  [this ](https://github.com/ankidroid/Anki-Android/pull/15818)PR .

_How does this change address the problem?_
It introduces back the congrats page back to the deck environment
## How Has This Been Tested?
Android-14.0("upsideDownCake") | arm64 , sdk-34 , physical

https://github.com/ankidroid/Anki-Android/assets/139516059/c4e3ef1a-036c-4132-be9d-3e5a7fd2c151


## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
