### PR TITLE
WIP : ANR when checking large amount of media.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1633,8 +1633,12 @@ open class DeckPicker :
      */
     override fun mediaCheck() {
         launchCatchingTask {
-            val mediaCheckResult = checkMedia() ?: return@launchCatchingTask
-            showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, mediaCheckResult)
+            this@DeckPicker.withProgress(R.string.check_media_message) {
+                val mediaCheckResult = checkMedia()
+                if (mediaCheckResult != null) {
+                    showMediaCheckDialog(MediaCheckDialog.DIALOG_MEDIA_CHECK_RESULTS, mediaCheckResult)
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
@@ -21,19 +21,26 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.withProgress
 import com.ichi2.libanki.MediaCheckResult
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 suspend fun AnkiActivity.checkMedia(): MediaCheckResult? {
-    if (ScopedStorageService.mediaMigrationIsInProgress(this)) {
-        showSnackbar(
-            R.string.functionality_disabled_during_storage_migration,
-            Snackbar.LENGTH_SHORT
-        )
-        return null
-    }
-
-    return withProgress(R.string.check_media_message) {
-        CollectionManager.withCol { media.check() }
+    return try {
+        withContext(Dispatchers.IO) {
+            if (ScopedStorageService.mediaMigrationIsInProgress(this@checkMedia)) {
+                withContext(Dispatchers.Main) {
+                    showSnackbar(
+                        R.string.functionality_disabled_during_storage_migration,
+                        Snackbar.LENGTH_SHORT
+                    )
+                }
+                null
+            } else {
+                CollectionManager.withCol { media.check() }
+            }
+        }
+    } finally {
+        this@checkMedia.hideProgressBar()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/MediaService.kt
@@ -26,21 +26,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 suspend fun AnkiActivity.checkMedia(): MediaCheckResult? {
-    return try {
-        withContext(Dispatchers.IO) {
-            if (ScopedStorageService.mediaMigrationIsInProgress(this@checkMedia)) {
-                withContext(Dispatchers.Main) {
-                    showSnackbar(
-                        R.string.functionality_disabled_during_storage_migration,
-                        Snackbar.LENGTH_SHORT
-                    )
-                }
-                null
-            } else {
-                CollectionManager.withCol { media.check() }
+    return withContext(Dispatchers.IO) {
+        if (ScopedStorageService.mediaMigrationIsInProgress(this@checkMedia)) {
+            withContext(Dispatchers.Main) {
+                showSnackbar(
+                    R.string.functionality_disabled_during_storage_migration,
+                    Snackbar.LENGTH_SHORT
+                )
             }
+            null
+        } else {
+            CollectionManager.withCol { media.check() }
         }
-    } finally {
-        this@checkMedia.hideProgressBar()
     }
 }


### PR DESCRIPTION
## Fixes
* Fixes #15626

## Steps to reproduce/test
1. Create a lot of fake media from the developer options (<10.000+)
2. Check media

## Approach

We wrapped the long-running checkMedia operation in withContext(Dispatchers.IO) to execute it on a background thread, 

## Screenshots/Video

https://github.com/ankidroid/Anki-Android/assets/60827173/06a7b000-af6e-41fc-a90d-43fc56aa9ac9


## Learning (optional, can help others)

[Dispatcher.IO](https://developer.android.com/kotlin/coroutines/coroutines-adv)

## TODO

The ANR is fixed, but if you notice the user can still click on rest of the screen (which doesn't open anything results in app hang till the result dialog is shown). The loader get hidden after few seconds not sure why.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
