### PR TITLE
[Feature] Pause & Resume Audio

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -130,7 +130,7 @@ class SoundPlayer : Closeable {
         onSoundGroupCompleted = listener
     }
 
-    private fun isSameTag(tag: AvTag) : Boolean {
+    private fun isSameTag(tag: AvTag): Boolean {
         if ((tag as SoundOrVideoTag).filename == currentTagFileName) {
             Timber.i("Toggling sound")
             soundTagPlayer.toggleSounds()
@@ -162,8 +162,9 @@ class SoundPlayer : Closeable {
 
     suspend fun playOneSound(tag: AvTag): Job? {
         if (!isEnabled) return null
-        if (isSameTag(tag))
+        if (isSameTag(tag)) {
             return playSoundsJob
+        }
         cancelPlaySoundsJob()
         Timber.i("playing one sound")
 
@@ -270,8 +271,9 @@ class SoundPlayer : Closeable {
                 }
                 else -> Timber.w("unknown audio: ${tag.javaClass}")
             }
-            if (tag !is SoundOrVideoTag)
+            if (tag !is SoundOrVideoTag) {
                 currentTagFileName = ""
+            }
             ensureActive()
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -129,8 +129,7 @@ class SoundTagPlayer(private val soundUriBase: String) {
                 if (player.isPlaying) {
                     mediaPlayer!!.pause()
                     abandonAudioFocus()
-                }
-                else {
+                } else {
                     mediaPlayer!!.start()
                     requestAudioFocus()
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -119,6 +119,27 @@ class SoundTagPlayer(private val soundUriBase: String) {
         abandonAudioFocus()
     }
 
+    /**
+     * Pauses the sound if playing
+     * Resumes the sound if paused
+     */
+    fun toggleSounds() {
+        try {
+            mediaPlayer?.let { player ->
+                if (player.isPlaying) {
+                    mediaPlayer!!.pause()
+                    abandonAudioFocus()
+                }
+                else {
+                    mediaPlayer!!.start()
+                    requestAudioFocus()
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "toggleSounds()")
+        }
+    }
+
     fun stopSounds() {
         try {
             mediaPlayer?.stop()


### PR DESCRIPTION
## Purpose / Description
Feature: Audio files can be pause and resumed.

## Fixes
* Fixes #15923

## Approach
Clicking on the play button pauses and resumes the current audio file being played.

## How Has This Been Tested?
The feature has been tested both on emulator (Pixel 4 API 30) and physical device (Samsung M515F).

## Checklist

- [✅] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✅] You have commented your code, particularly in hard-to-understand areas
- [✅] You have performed a self-review of your own code
- [✅] No UI changes
