### PR TITLE
fix: auto-advance handles milliseconds

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -252,12 +252,12 @@ class AutomaticAnswer(
 class AutomaticAnswerSettings(
     val answerAction: AutomaticAnswerAction = AutomaticAnswerAction.BURY_CARD,
     @get:JvmName("useTimer") val useTimer: Boolean = false,
-    private val secondsToShowQuestionFor: Int = 60,
-    private val secondsToShowAnswerFor: Int = 20
+    private val secondsToShowQuestionFor: Double = 60.0,
+    private val secondsToShowAnswerFor: Double = 20.0
 ) {
 
-    val millisecondsToShowQuestionFor = secondsToShowQuestionFor * 1000L
-    val millisecondsToShowAnswerFor = secondsToShowAnswerFor * 1000L
+    val millisecondsToShowQuestionFor = (secondsToShowQuestionFor * 1000L).toLong()
+    val millisecondsToShowAnswerFor = (secondsToShowAnswerFor * 1000L).toLong()
 
     // a wait of zero means auto-advance is disabled
     val autoAdvanceIfShowingAnswer; get() = secondsToShowAnswerFor > 0

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/DeckConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/DeckConfig.kt
@@ -19,10 +19,10 @@ package com.ichi2.anki.utils.ext
 import com.ichi2.libanki.DeckConfig
 import com.ichi2.libanki.utils.set
 
-var DeckConfig.secondsToShowQuestion: Int
-    get() = optInt("secondsToShowQuestion", 0)
+var DeckConfig.secondsToShowQuestion: Double
+    get() = optDouble("secondsToShowQuestion", 0.0)
     set(value) { set("secondsToShowQuestion", value) }
 
-var DeckConfig.secondsToShowAnswer: Int
-    get() = optInt("secondsToShowAnswer", 0)
+var DeckConfig.secondsToShowAnswer: Double
+    get() = optDouble("secondsToShowAnswer", 0.0)
     set(value) { set("secondsToShowAnswer", value) }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -101,6 +101,10 @@ operator fun JSONObject.set(s: String, value: Int) {
     this.put(s, value)
 }
 
+operator fun JSONObject.set(s: String, value: Double) {
+    this.put(s, value)
+}
+
 fun JSONArray.append(jsonObject: JSONObject) {
     this.put(jsonObject)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -270,7 +270,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     fun noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632() = runTest {
         val controller = getViewerController(addCard = true, startedWithShortcut = false)
         val viewer = controller.get()
-        viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5, 5))
+        viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5.0, 5.0))
         viewer.executeCommand(ViewerCommand.SHOW_ANSWER)
         assertThat("messages after flipping card", viewer.hasAutomaticAnswerQueued(), equalTo(true))
         controller.pause()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -20,6 +20,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -35,11 +36,18 @@ class AutomaticAnswerAndroidTest : RobolectricTest() {
 
     @Test
     fun preference_sets_action() {
-        setPreference(1)
+        setActionType(1)
         assertThat(createInstance().settings.answerAction, equalTo(AutomaticAnswerAction.ANSWER_AGAIN))
         // reset the value
         resetPrefs()
         assertThat("default", createInstance().settings.answerAction, equalTo(AutomaticAnswerAction.BURY_CARD))
+    }
+
+    @Ignore("15928")
+    @Test
+    fun `milliseconds are handled`() {
+        setShowQuestionDuration(1.5)
+        assertThat(createInstance().settings.millisecondsToShowQuestionFor, equalTo(1500))
     }
 
     private fun resetPrefs() {
@@ -48,9 +56,17 @@ class AutomaticAnswerAndroidTest : RobolectricTest() {
         col.decks.save(conf)
     }
 
-    private fun setPreference(value: Int) {
+    @Suppress("SameParameterValue")
+    private fun setActionType(value: Int) {
         val conf = col.decks.configDictForDeckId(col.decks.selected())
         conf.put(AutomaticAnswerAction.CONFIG_KEY, value)
+        col.decks.save(conf)
+    }
+
+    @Suppress("SameParameterValue")
+    private fun setShowQuestionDuration(value: Double) {
+        val conf = col.decks.configDictForDeckId(col.decks.selected())
+        conf.put("secondsToShowQuestion", value)
         col.decks.save(conf)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -20,7 +20,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
@@ -43,7 +42,6 @@ class AutomaticAnswerAndroidTest : RobolectricTest() {
         assertThat("default", createInstance().settings.answerAction, equalTo(AutomaticAnswerAction.BURY_CARD))
     }
 
-    @Ignore("15928")
     @Test
     fun `milliseconds are handled`() {
         setShowQuestionDuration(1.5)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
@@ -54,8 +54,8 @@ class AutomaticAnswerTest : JvmTest() {
             target = automaticallyAnsweredMock(),
             settings = AutomaticAnswerSettings(
                 useTimer = true,
-                secondsToShowQuestionFor = 0,
-                secondsToShowAnswerFor = 0
+                secondsToShowQuestionFor = 0.0,
+                secondsToShowAnswerFor = 0.0
             )
         )
 
@@ -137,8 +137,8 @@ class AutomaticAnswerTest : JvmTest() {
             target = automaticAnswerHandler,
             settings = AutomaticAnswerSettings(
                 useTimer = true,
-                secondsToShowQuestionFor = 10,
-                secondsToShowAnswerFor = 10
+                secondsToShowQuestionFor = 10.0,
+                secondsToShowAnswerFor = 10.0
             )
         ).apply {
             automaticAnswerHandle = this


### PR DESCRIPTION
## Fixes
* Fixes #15928

## Approach
The underlying key is a double. Use that

## How Has This Been Tested?
Unit test only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
