### PR TITLE
fix: wrong text color of snackbar action button

### DIFF
--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -156,10 +156,10 @@
     </style>
 
     <!-- Snackbars -->
-    <style name="SnackbarStyle" parent="Widget.MaterialComponents.Snackbar">
+    <style name="SnackbarStyle" parent="Widget.Material3.Snackbar">
         <item name="android:backgroundTint">?attr/snackbarBackgroundTintColor</item>
     </style>
-    <style name="SnackbarButtonStyle" parent="Widget.MaterialComponents.Button.TextButton.Snackbar">
+    <style name="SnackbarButtonStyle" parent="Widget.Material3.Button.TextButton.Snackbar">
         <item name="android:textColor">?attr/snackbarButtonTextColor</item>
     </style>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After the upgrade to Material 3, action buttons of snackbars have the wrong color displayed.

See #15892 for examples of incorrect colors.

## Fixes
* Fixes #15892

## Approach

Change Material 2's styles to Material 3's.

## How Has This Been Tested?

This fix has been tested on a physical device. In all themes, snackbars and action buttons are displayed correctly.

Specifically, in Black theme, the action button is displayed the same as version 2.16.5 (before the upgrade to Material 3). 

Screenshot follows:

![image](https://github.com/ankidroid/Anki-Android/assets/27683756/1fc7081e-390a-4b14-b6b2-d3024816d270)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
