### PR TITLE
fix: strip special fields from deletion previews

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -792,7 +792,7 @@ abstract class AbstractFlashcardViewer :
             message(
                 text = resources.getString(
                     R.string.delete_note_message,
-                    Utils.stripHTML(currentCard!!.question(getColUnsafe, true))
+                    Utils.stripHTMLAndSpecialFields(currentCard!!.question(getColUnsafe, true)).trim()
                 )
             )
             positiveButton(R.string.dialog_positive_delete) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -41,6 +41,8 @@ object Utils {
     private val scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>")
     private val tagPattern = Pattern.compile("(?s)<.*?>")
     private val imgPattern = Pattern.compile("(?i)<img[^>]+src=[\"']?([^\"'>]+)[\"']?[^>]*>")
+    private val typePattern = Pattern.compile("(?s)\\[\\[type:.+?]]")
+    private val avRefPattern = Pattern.compile("(?s)\\[anki:play:.:\\d+?]")
     private val htmlEntitiesPattern = Pattern.compile("&#?\\w+;")
     private const val ALL_CHARACTERS =
         "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
@@ -109,6 +111,26 @@ object Utils {
         }
         htmlEntities.appendTail(sb)
         return sb.toString()
+    }
+
+    /**
+     * Strip special fields like `[[type:...]]` and `[anki:play...]` from a string.
+     * @param input The text to be cleaned.
+     * @return The text without special fields.
+     */
+    fun stripSpecialFields(input: String): String {
+        val s = typePattern.matcher(input).replaceAll("")
+        return avRefPattern.matcher(s).replaceAll("")
+    }
+
+    /**
+     * Strip HTML and special fields from a string.
+     * @param input The text to be cleaned.
+     * @return The text without HTML and special fields.
+     */
+    fun stripHTMLAndSpecialFields(input: String): String {
+        val s = stripHTML(input)
+        return stripSpecialFields(s)
     }
 
     /*

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
@@ -68,4 +68,26 @@ class UtilsTest {
             )
         }
     }
+
+    @Test
+    fun test_stripSpecialFields_will_remove_type() {
+        val input = "test\n\n[[type:Back]]"
+        val output = Utils.stripSpecialFields(input)
+        assertEquals(
+            "type field should be removed",
+            "test\n\n",
+            output
+        )
+    }
+
+    @Test
+    fun test_stripSpecialFields_will_remove_avRef() {
+        val input = "test\n\n[anki:play:q:0]"
+        val output = Utils.stripSpecialFields(input)
+        assertEquals(
+            "avRef field should be removed",
+            "test\n\n",
+            output
+        )
+    }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

When previewing notes for deletion, some special fields (like `[[type:...]]` and `[anki:play...]`) still exist in the dialog. This will create some confusion for users.

## Fixes
* Fixes #15443

## Approach

To solve the problem, we should remove these special fields from the delete note dialog.

## How Has This Been Tested?

Unit tests have been added to test the functionality of `stripSpecialFields`.

Manual test:

1. Make a "type the answer" note
2. Open the review panel, delete the note

Result:

![image](https://github.com/ankidroid/Anki-Android/assets/27683756/247cec7e-8cd7-401e-b580-779b86258288)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
