### PR TITLE
Align search view close icon align to end

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -749,6 +749,7 @@ open class CardBrowser :
                 }
             })
             searchView = searchItem!!.actionView as CardBrowserSearchView
+            searchView!!.setMaxWidth(Integer.MAX_VALUE)
             searchView!!.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextChange(newText: String): Boolean {
                     if (searchView!!.shouldIgnoreValueChange()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -191,6 +191,7 @@ class SharedDecksActivity : AnkiActivity() {
 
         val searchView = menu.findItem(R.id.search)?.actionView as SearchView
         searchView.queryHint = getString(R.string.search_using_deck_name)
+        searchView.setMaxWidth(Integer.MAX_VALUE)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
                 webView.loadUrl(resources.getString(R.string.shared_decks_url) + query)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
SharedDecks's SearchView cancel icon is misaligned in landscape mode

## Fixes
* Fixes #15950

## Approach
By setting searchView width to max, close icon moves to end

## How Has This Been Tested?

Physical Device ( Realme 9 )
![WhatsApp Image 2024-03-22 at 2 45 40 AM](https://github.com/ankidroid/Anki-Android/assets/65113071/bda85f64-f21c-4544-9bea-5b3a298e2e95)
![WhatsApp Image 2024-03-22 at 2 45 40 AM (1)](https://github.com/ankidroid/Anki-Android/assets/65113071/09a04f8d-ee80-4f4a-a4b2-f95af95f8330)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
