### PR TITLE
Crop tool for image occlusion

### DIFF
--- a/.idea/dictionaries/usernames.xml
+++ b/.idea/dictionaries/usernames.xml
@@ -4,6 +4,7 @@
       <w>Abdalla</w>
       <w>Akshit</w>
       <w>Almas</w>
+      <w>Avanish</w>
       <w>Azevedo</w>
       <w>Bhatt</w>
       <w>Bibek</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -256,7 +256,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
     )
 
-    private val ioEditorLauncher = registerForActivityResult(
+    private var ioEditorLauncher = registerForActivityResult(
         ActivityResultContracts.GetContent()
     ) { uri ->
         if (uri != null) {
@@ -555,6 +555,21 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             editOcclusionsButton?.text = resources.getString(R.string.edit_occlusions)
             editOcclusionsButton?.setOnClickListener {
                 setupImageOcclusionEditor()
+            }
+        }
+        fun startCrop(imageUri: Uri) {
+            ImageUtils.cropImage(activityResultRegistry, imageUri) { result ->
+                if (result != null && result.isSuccessful) {
+                    val uriFilePath = result.getUriFilePath(this)
+                    uriFilePath?.let { setupImageOcclusionEditor(it) }
+                } else {
+                    Timber.v("Failed to crop the image")
+                }
+            }
+        }
+        ioEditorLauncher = registerForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
+            uri?.let { imageUri ->
+                startCrop(imageUri)
             }
         }
 
@@ -1189,7 +1204,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             return sp.roundToInt().toString()
         }
 
-    fun addNewNote() {
+    private fun addNewNote() {
         openNewNoteEditor { }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicImageFieldController.kt
@@ -227,6 +227,7 @@ class BasicImageFieldController : FieldControllerBase(), IFieldController {
 
     override fun setEditingActivity(activity: MultimediaEditFieldActivity) {
         super.setEditingActivity(activity)
+        val registryToUse = if (this::registryToUse.isInitialized) registryToUse else _activity.activityResultRegistry
 
         takePictureLauncher = registryToUse.register(
             TAKE_PICTURE_LAUNCHER_KEY,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImageUtils.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024 Avanish Yadav <mailto:awanishyadav967@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import android.net.Uri
+import androidx.activity.result.ActivityResultRegistry
+import com.canhub.cropper.CropImageContract
+import com.canhub.cropper.CropImageContractOptions
+import com.canhub.cropper.CropImageOptions
+import com.canhub.cropper.CropImageView
+import timber.log.Timber
+
+object ImageUtils {
+    private const val CROP_IMAGE_KEY = "crop_image_launcher"
+
+    /**
+     * Initiates the image cropping process using the specified ActivityResultRegistry, URI of the image to crop,
+     * and a callback function to handle the result.
+     *
+     * @param registry The ActivityResultRegistry instance used for registering the activity result.
+     * @param uri The URI of the image to be cropped.
+     * @param callback The callback function that receives the crop result (CropImageView.CropResult) or null if the cropping operation fails.
+     */
+    fun cropImage(
+        registry: ActivityResultRegistry,
+        uri: Uri,
+        callback: (CropImageView.CropResult?) -> Unit
+    ) {
+        val cropImage = registry.register(CROP_IMAGE_KEY, CropImageContract()) { result ->
+            if (result.isSuccessful) {
+                callback(result)
+            } else {
+                Timber.v(result.error)
+                callback(null)
+            }
+        }
+        cropImage.launch(
+            CropImageContractOptions(
+                uri,
+                CropImageOptions()
+            )
+        )
+    }
+}


### PR DESCRIPTION

##  Description
Here I Implement a crop tool for the image occlusion feature. When a user select an image from the gallery, the crop tool option will open before proceeding to the image occlusion editor.

## Fixes
* Fixes #15864 

## Video Demo

https://github.com/ankidroid/Anki-Android/assets/91160609/fcec0e90-dbf9-4333-b918-d890642d6fe9




## How Has This Been Tested?
 Realme 6 (Android Level 30)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
