### PR TITLE
fix: handle unencoded `#` in file paths

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -125,6 +125,7 @@
       <w>uncatchable</w>
       <w>undeletable</w>
       <w>underlaid</w>
+      <w>unencoded</w>
       <w>unflag</w>
       <w>unmark</w>
       <w>unopenable</w>

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -364,8 +364,17 @@ fun parseSourcesToFileScheme(content: String, mediaDir: String): String {
             }
             if (attrUri.scheme != null) continue
 
-            val path = Paths.get(mediaDir, attrUri.path).toString()
-            val newUri = getFileUri(path)
+            // For "legacy reasons" (https://forums.ankiweb.net/t/ankiweb-and-ankidroid-do-not-display-images-containing-pound-hashtag-sharp-symbol/42444/5)
+            // anki accepts unencoded `#` in paths.
+            val path = buildString {
+                append(attrUri.path)
+                attrUri.fragment?.let {
+                    append("#")
+                    append(it)
+                }
+            }
+            val filePath = Paths.get(mediaDir, path).toString()
+            val newUri = getFileUri(filePath)
 
             elem.attr(attr, newUri.toString())
             madeChanges = true

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/TemplateManagerTest.kt
@@ -135,6 +135,12 @@ class TemplateManagerTest {
     }
 
     @Test
+    fun `parseSourcesToFileScheme - path with unencoded #`() {
+        val result = parseSourcesToFileScheme("<img src='C#4.png'>", "storage/emulated/0/AnkiDroid/collection.media")
+        assertEquals("""<img src="file:///storage/emulated/0/AnkiDroid/collection.media/C%234.png">""", result)
+    }
+
+    @Test
     fun `parseSourcesToFileScheme - mixed script`() {
         @Language("HTML")
         val input = """


### PR DESCRIPTION
For "legacy reasons" (https://forums.ankiweb.net/t/ankiweb-and-ankidroid-do-not-display-images-containing-pound-hashtag-sharp-symbol/42444/5), anki accepts unencoded `#` in file paths, although that is an URL syntax breakage.

## Fixes
* Fixes #15963

## Approach

I broke the URL syntax by adding the URL fragment as well while parsing the file source

## How Has This Been Tested?

Emulator 34: opened this deck https://ankiweb.net/shared/info/789434294

## Learning (optional, can help others)

Anki sometimes complicates its life more than it should.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
