### PR TITLE
Ask to check if a bug exists in Anki desktop on the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -14,6 +14,15 @@ body:
         - label: This issue is not a duplicate
           required: true
 
+  - type: checkboxes
+    id: desktop-check
+    attributes:
+      label: Does it happen in the desktop version?
+      description: If not, please report it in the [forums](https://github.com/ankidroid/Anki-Android/issues) instead
+      options:
+        - label: I confirmed that the bug does not occur in the desktop version of Anki
+          required: false
+
   - type: textarea
     id: steps
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -20,7 +20,7 @@ body:
       label: Does it also happen in the desktop version?
       description: If so, please report it in [Anki Forums](https://forums.ankiweb.net) instead
       options:
-        - label: This bug does not occur in the latest version of Anki Desktop
+        - label: This bug does not occur in the latest version of Anki
           required: false
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -20,7 +20,7 @@ body:
       label: Does it happen in the desktop version?
       description: If not, please report it in the [forums](https://github.com/ankidroid/Anki-Android/issues) instead
       options:
-        - label: I confirmed that the bug does not occur in the desktop version of Anki
+        - label: This bug does not occur in the latest version of Anki Desktop
           required: false
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -17,8 +17,8 @@ body:
   - type: checkboxes
     id: desktop-check
     attributes:
-      label: Does it happen in the desktop version?
-      description: If not, please report it in the [forums](https://github.com/ankidroid/Anki-Android/issues) instead
+      label: Does it also happen in the desktop version?
+      description: If so, please report it in [Anki Forums](https://forums.ankiweb.net) instead
       options:
         - label: This bug does not occur in the latest version of Anki Desktop
           required: false


### PR DESCRIPTION
Tested in my branch. I haven't made it `required` because some people don't have a desktop or don't use Anki in their PCs.

I know that the `Anki forums` option exist when selecting a template, but I want to reinforce that the user should check it

![image](https://github.com/ankidroid/Anki-Android/assets/69634269/463cda59-dbe4-4d9f-9348-2662512e1544)

I'm very open to the words' choice. 