### PR TITLE
Renaming deck must not show error initially

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -96,7 +96,7 @@ class CreateDeckDialog(
                 dialog.positiveButton.isEnabled = false
                 return@input
             }
-            if (deckExists(getColUnsafe, maybeDeckName)) {
+            if (deckExists(getColUnsafe, maybeDeckName) && text.toString() != initialDeckName) {
                 dialog.getInputTextLayout().error = context.getString(R.string.deck_already_exists)
                 dialog.positiveButton.isEnabled = false
                 return@input

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -194,6 +194,15 @@ class CreateDeckDialogTest : RobolectricTest() {
         assertEquals(deckPicker.optionsMenuState!!.searchIcon, true)
     }
 
+    @Test
+    fun positiveButtonEnabledWhenPreviousNameMatchesNewName() {
+        val previousDeckName = "xyz"
+        testDialog(DeckDialogType.RENAME_DECK) {
+            input = previousDeckName
+            assertThat("Ok is enabled when the previous name matches the new name", positiveButton.isEnabled, equalTo(true))
+        }
+    }
+
     /**
      * Executes [callback] on the [MaterialDialog] created from [CreateDeckDialog]
      */


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Not to show the "Deck already exists" message initially.
Added the unit test .

## Fixes
* Fixes #15944 

## Approach
Added a check in which current test sequence of dialog box is matched with initial deck name
` text.toString() != initialDeckName`


## How Has This Been Tested?

Tested with multiple  deck names and works fine.
Also the unit test is added which has passed the test.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
