### PR TITLE
Let users specify a custom root certificate

### DIFF
--- a/AnkiDroid/src/main/res/values-af/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-af/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-am/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-am/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ar/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ar/10-preferences.xml
@@ -363,4 +363,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">تحميل...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">معالجة...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">لا يوجد مجموعة</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-az/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-az/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-be/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-be/10-preferences.xml
@@ -368,4 +368,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Атрыманне&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Падлік&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Калекцыя не існуе</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-bg/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-bg/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Изчислява се...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Колекцията не съществува.</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-bn/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-bn/10-preferences.xml
@@ -362,4 +362,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ca/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ca/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">S\'està obtenint dades...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">S\'està calculant&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">La col·lecció no existeix</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ckb/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ckb/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-cs/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-cs/10-preferences.xml
@@ -365,4 +365,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Načítání&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Vypočítává se&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Kolekce neexistuje</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-da/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-da/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-de/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-de/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Rufe ab...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Berechnen...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Sammlung ist nicht vorhanden</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-el/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-el/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Λήψη&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Υπολογισμός&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Η συλλογή δεν υπάρχει</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-eo/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-eo/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Kolekto ne ekzistas</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-es-rAR/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-es-rAR/10-preferences.xml
@@ -359,4 +359,5 @@ Puedes restaurar una colección desde una copia de seguridad en el menú de la l
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Obteniendo&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculando&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">La colección no existe</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-es-rES/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-es-rES/10-preferences.xml
@@ -359,4 +359,5 @@ Puedes restaurar una colección desde una copia de seguridad en el menú de la l
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Obteniendo&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculando&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">La colección no existe</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-et/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-et/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-eu/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-eu/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-fa/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fa/10-preferences.xml
@@ -359,4 +359,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">دریافت کردن&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">محاسبه کردن...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">مجموعه وجود ندارد</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-fi/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fi/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Haetaan&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Lasketaan&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Kokoelmaa ei ole olemassa</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-fil/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fil/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-fr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fr/10-preferences.xml
@@ -359,4 +359,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Récupération en  cours...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calcul en cours&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">La collection n\'existe pas</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-fy/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-fy/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ga/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ga/10-preferences.xml
@@ -370,4 +370,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-gl/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-gl/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-got/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-got/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-gu/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-gu/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-heb/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-heb/10-preferences.xml
@@ -366,4 +366,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">מייבא...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">מחשב&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">האוסף אינו קיים.</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-hi/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-hi/10-preferences.xml
@@ -350,4 +350,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">जानकारी प्राप्त हो रही है...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">गणना हो रही है...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">संग्रह मौजूद नहीं है</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-hr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-hr/10-preferences.xml
@@ -364,4 +364,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-hu/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-hu/10-preferences.xml
@@ -359,4 +359,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Letöltés&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Számolás&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Gyűjtemény nem létezik</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-hy/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-hy/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ind/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ind/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Mengambil&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Menghitung&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Koleksi tidak ada</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-is/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-is/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-it/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-it/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Recupero...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calcolo&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">La raccolta non esiste</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ja/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ja/10-preferences.xml
@@ -357,4 +357,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">取得中&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">計算中&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">コレクションが存在しません</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-jv/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-jv/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ka/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ka/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">მიმდინარეობს ამორჩევა&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">მიმდინარეობს გამოთვლა&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">კოლექცია არ არსებობს</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-kk/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-kk/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-km/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-km/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-kn/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-kn/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">ಲೆಕ್ಕಾಚಾರ ಮಾಡಲಾಗುತ್ತಿದೆ...</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ko/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ko/10-preferences.xml
@@ -357,4 +357,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ku/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ku/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ky/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ky/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-lt/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-lt/10-preferences.xml
@@ -367,4 +367,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-lv/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-lv/10-preferences.xml
@@ -364,4 +364,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-mk/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-mk/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ml/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ml/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-mn/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-mn/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-mr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-mr/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ms/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ms/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Memperoleh&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Mengira&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Koleksi tidak wujud</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-my/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-my/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-nl/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-nl/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Ophalen&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Berekenen&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collectie bestaat niet</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-nn/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-nn/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Henter...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Beregner&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Samlingen finnes ikke</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-no/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-no/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Henter...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Beregner&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Samlingen finnes ikke</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-or/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-or/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">ଆନୟନ ଚାଲିଛି&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">ଗଣନା ଚାଲିଛି&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">ସଂଗ୍ରହ ଵିଦ୍ୟମାନ ନାହିଁ</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-pa/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pa/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-pl/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pl/10-preferences.xml
@@ -366,4 +366,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Pobieranie&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Obliczanie&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Kolekcja nie istnieje</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-pt-rBR/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pt-rBR/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Buscando&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculando&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">A coleção não existe</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-pt-rPT/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">A recuperar...</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">A calcular&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">A colecção não existe.</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ro/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ro/10-preferences.xml
@@ -364,4 +364,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ru/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ru/10-preferences.xml
@@ -364,4 +364,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Данные получаются&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Вычисляется&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Коллекция не существует</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sat/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sat/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sc/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sc/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Recuperende&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Carculende&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Sa colletzione no esistit</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sk/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sk/10-preferences.xml
@@ -367,4 +367,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sl/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sl/10-preferences.xml
@@ -367,4 +367,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sq/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sq/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sr/10-preferences.xml
@@ -364,4 +364,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ss/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ss/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sv/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sv/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Hämtar&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Beräknar&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Samlingen finns inte</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-sw/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-sw/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ta/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ta/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-te/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-te/10-preferences.xml
@@ -360,4 +360,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-tg/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-tg/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-tgl/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-tgl/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-th/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-th/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ti/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ti/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-tn/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-tn/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-tr/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-tr/10-preferences.xml
@@ -359,4 +359,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Okunuyor&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Hesaplanıyor&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Koleksiyon mevcut değil</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ts/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ts/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-tt/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-tt/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-uk/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-uk/10-preferences.xml
@@ -367,4 +367,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Отримання&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Обчислення&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Колекції не існує</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ur/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ur/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-uz/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-uz/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-ve/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-ve/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-vi/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-vi/10-preferences.xml
@@ -356,4 +356,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Đang tìm nạp&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Đang tính toán&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Bộ sưu tập không tồn tại</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-wo/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-wo/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-xh/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-xh/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-yue/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-yue/10-preferences.xml
@@ -358,4 +358,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-zh-rCN/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-zh-rCN/10-preferences.xml
@@ -357,4 +357,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">获取中&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">计算中&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">集合不存在</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-zh-rTW/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-zh-rTW/10-preferences.xml
@@ -357,4 +357,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">正在擷取&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">正在計算&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">集合不存在</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values-zu/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values-zu/10-preferences.xml
@@ -361,4 +361,5 @@
     <string name="pref__etc__snackbar__fetching" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which is being fetched">Fetching&#8230;</string>
     <string name="pref__etc__snackbar__calculating" comment="Generic snackbar message to be shown when user taps on a preference,         the value of which, such as folder size on disk, is being calculated">Calculating&#8230;</string>
     <string name="pref__etc__snackbar__no_collection" comment="Generic snackbar message to be shown when user taps on a preference         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -431,4 +431,5 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="pref__etc__snackbar__no_collection"
         comment="Generic snackbar message to be shown when user taps on a preference
         that is not usable because the collection does not exist">Collection does not exist</string>
+    <string name="custom_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -143,6 +143,7 @@
     <!-- Custom sync server -->
     <string name="pref_custom_sync_server_screen_key">customSyncServerScreen</string>
     <string name="custom_sync_server_collection_url_key">syncBaseUrl</string>
+    <string name="custom_certificate_key">customCertificate</string>
     <!-- Advanced -->
     <string name="pref_advanced_screen_key">pref_screen_advanced</string>
     <string name="pref_cat_workarounds_key">category_workarounds</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -16,4 +16,8 @@
         android:title="@string/custom_sync_server_base_url_title"
         android:inputType="textUri"
         app:useSimpleSummaryProvider="true" />
+    <com.ichi2.preferences.VersatileTextWithASwitchPreference
+        android:key="@string/custom_certificate_key"
+        android:title="@string/custom_certificate_title"
+        android:inputType="textMultiLine" />
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
Since the new backend is forced on the newer Ankidroid releases, Android users cannot connect to their self-hosted sync server if it uses a self-signed certificate. The problem should be fixed with this PR. More than willing to accept any changes made to the UI part of this feature, it ain't that pretty.

* https://github.com/ankidroid/Anki-Android/labels/Blocked%20by%20dependency https://github.com/ankidroid/Anki-Android-Backend/pull/357. 

## Fixes
* Fixes #14686 

## Approach
Allow users to specify a custom root certificate to trust (in PEM format) and feed this through the backend.

## How Has This Been Tested?
Took the PEM-formatted root certificate I use for my local servers, and then copied the contents of it into the text field in the custom sync server section. After doing this, I don't get a error message telling me that the sync server certificate has an unknown issuer.

## Learning
[PEM, DER, CRT, and CER: X.509 Encodings and Conversions](https://www.ssl.com/guide/pem-der-crt-and-cer-x-509-encodings-and-conversions/)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

![Screenshot_20240325_223253](https://github.com/ankidroid/Anki-Android/assets/82241877/b9945e78-ac29-48dc-82c3-9c0d872fcf09)
(sorry for the flashbang)