### PR TITLE
Fix: Display Correct Filtered Deck Name In Edit Note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1788,7 +1788,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         fun calculateDeckId(): DeckId {
             if (deckId != 0L) return deckId
             if (note != null && !addNote && currentEditedCard != null) {
-                return currentEditedCard!!.did
+                return CardUtils.getDeckIdForCard(currentEditedCard!!)
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To show the correct deck name on the Edit Note screen, when reviewing filtered deck. 

## Fixes
* Fixes #15919 <!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
The deck field always showed as the first deck among all decks, rather than displaying the actual deck of the note. This occurred because the dropDownDecks list did not contain the filteredDecks, thus it couldn't find the deck with that ID.

To fix this, I set showFilteredDecks to true, and in the initializeNoteEditorDeckSpinner function, I made includeFiltered equal to showFilteredDecks.


## How Has This Been Tested?
Tested on Android device

## Screenshots

<details>
  <summary>Deck List</summary>

![Screenshot_20240327-030600](https://github.com/ankidroid/Anki-Android/assets/25331865/8b04cc61-3712-448b-b8ef-9f9182dc2524)
</details>

<details>
  <summary>Before</summary>

![Screenshot_20240327-030838](https://github.com/ankidroid/Anki-Android/assets/25331865/20a4ce51-32c9-4571-b5ec-4d73a0a02c65)</details>

<details>
  <summary>After fix - </summary>

![Screenshot_20240327-030613](https://github.com/ankidroid/Anki-Android/assets/25331865/27f5b7cc-20b8-4d74-8539-762caa5cb639)
</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
