### PR TITLE
refactor: make `CollectionHelper` an `object`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorTabOrderTest.kt
@@ -92,6 +92,6 @@ class NoteEditorTabOrderTest : NoteEditorTest() {
     }
 
     private fun ensureCollectionLoaded() {
-        CollectionHelper.instance.getColUnsafe(targetContext)
+        CollectionManager.getColUnsafe()
     }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -24,7 +24,7 @@ import android.content.ContentValues
 import android.database.CursorWindow
 import android.net.Uri
 import com.ichi2.anki.AbstractFlashcardViewer
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.provider.pureAnswer
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
@@ -1273,7 +1273,8 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     private fun reopenCol(): com.ichi2.libanki.Collection {
-        CollectionHelper.instance.closeCollection("ContentProviderTest: reopenCol")
+        Timber.i("closeCollection: %s", "ContentProviderTest: reopenCol")
+        CollectionManager.closeCollectionBlocking()
         return col
     }
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -24,7 +24,6 @@ import androidx.test.espresso.ViewInteraction
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import com.ichi2.annotations.DuplicatedCode
@@ -129,7 +128,6 @@ abstract class InstrumentedTest {
 
     /** Restore regular collection behavior  */
     private fun disableNullCollection() {
-        CollectionHelper.setInstanceForTesting(CollectionHelper())
         CollectionManager.emulateOpenFailure = false
     }
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -112,7 +112,8 @@ abstract class InstrumentedTest {
                 CollectionManager.getColUnsafe().debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
-            CollectionHelper.instance.closeCollection("InstrumentedTest: End")
+            Timber.i("closeCollection: %s", "InstrumentedTest: End")
+            CollectionManager.closeCollectionBlocking()
         } catch (ex: BackendException) {
             if ("CollectionNotOpen" == ex.message) {
                 Timber.w(ex, "Collection was already disposed - may have been a problem")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -102,7 +102,7 @@ abstract class InstrumentedTest {
     fun runBeforeEachTest() {
         closeAndroidNotRespondingDialog()
         // resolved issues with the collection being reused if useInMemoryDatabase is false
-        CollectionHelper.instance.setColForTests(null)
+        CollectionManager.setColForTests(null)
     }
 
     @After

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -108,10 +108,8 @@ abstract class InstrumentedTest {
     @After
     fun runAfterEachTest() {
         try {
-            if (CollectionHelper.instance.colIsOpenUnsafe()) {
-                InstrumentationRegistry.getInstrumentation().targetContext
-                CollectionManager.getColUnsafe()
-                    .debugEnsureNoOpenPointers()
+            if (CollectionManager.isOpenUnsafe()) {
+                CollectionManager.getColUnsafe().debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
             CollectionHelper.instance.closeCollection("InstrumentedTest: End")

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -47,7 +47,7 @@ import kotlin.test.fail
 
 abstract class InstrumentedTest {
     internal val col: Collection
-        get() = CollectionHelper.instance.getColUnsafe(testContext)!!
+        get() = CollectionManager.getColUnsafe()
 
     @get:Throws(IOException::class)
     protected val emptyCol: Collection
@@ -109,9 +109,8 @@ abstract class InstrumentedTest {
     fun runAfterEachTest() {
         try {
             if (CollectionHelper.instance.colIsOpenUnsafe()) {
-                CollectionHelper
-                    .instance
-                    .getColUnsafe(InstrumentationRegistry.getInstrumentation().targetContext)!!
+                InstrumentationRegistry.getInstrumentation().targetContext
+                CollectionManager.getColUnsafe()
                     .debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -540,7 +540,8 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
 
     fun closeCollectionAndFinish() {
         Timber.i("closeCollectionAndFinish()")
-        CollectionHelper.instance.closeCollection("AnkiActivity:closeCollectionAndFinish()")
+        Timber.i("closeCollection: %s", "AnkiActivity:closeCollectionAndFinish()")
+        CollectionManager.closeCollectionBlocking()
         finish()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -104,7 +104,7 @@ open class BackupManager {
         }
 
         // TODO: Probably not a good idea to do the backup while the collection is open
-        if (CollectionHelper.instance.colIsOpenUnsafe()) {
+        if (CollectionManager.isOpenUnsafe()) {
             Timber.w("Collection is already open during backup... we probably shouldn't be doing this")
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -93,13 +93,6 @@ open class CollectionHelper {
     }
 
     /**
-     * @return Whether or not [Collection] and its child database are open.
-     */
-    fun colIsOpenUnsafe(): Boolean {
-        return CollectionManager.isOpenUnsafe()
-    }
-
-    /**
      * This currently stores either:
      * An error message stating the reason that a storage check must be performed
      * OR

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -30,7 +30,6 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DB
 import com.ichi2.preferences.getOrSetString
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 import java.io.FileNotFoundException
@@ -38,303 +37,296 @@ import java.io.IOException
 import java.lang.Exception
 import kotlin.Throws
 
-/**
- * Singleton which opens, stores, and closes the reference to the Collection.
- */
-@KotlinCleanup("convert to object")
-open class CollectionHelper {
+object CollectionHelper {
+    // Name of anki2 file
+    const val COLLECTION_FILENAME = "collection.anki2"
 
-    companion object {
-        // Name of anki2 file
-        const val COLLECTION_FILENAME = "collection.anki2"
+    /**
+     * The preference key for the path to the current AnkiDroid directory
+     *
+     * This directory contains all AnkiDroid data and media for a given collection
+     * Except the Android preferences, cached files and [MetaDB]
+     *
+     * This can be changed by the [Preferences] screen
+     * to allow a user to access a second collection via the same AnkiDroid app instance.
+     *
+     * The path also defines the collection that the AnkiDroid API accesses
+     */
+    const val PREF_COLLECTION_PATH = "deckPath"
 
-        /**
-         * The preference key for the path to the current AnkiDroid directory
-         *
-         * This directory contains all AnkiDroid data and media for a given collection
-         * Except the Android preferences, cached files and [MetaDB]
-         *
-         * This can be changed by the [Preferences] screen
-         * to allow a user to access a second collection via the same AnkiDroid app instance.
-         *
-         * The path also defines the collection that the AnkiDroid API accesses
-         */
-        const val PREF_COLLECTION_PATH = "deckPath"
+    fun getCollectionSize(context: Context): Long? {
+        return try {
+            val path = getCollectionPath(context)
+            File(path).length()
+        } catch (e: Exception) {
+            Timber.e(e, "Error getting collection Length")
+            null
+        }
+    }
 
-        fun getCollectionSize(context: Context): Long? {
-            return try {
-                val path = getCollectionPath(context)
-                File(path).length()
-            } catch (e: Exception) {
-                Timber.e(e, "Error getting collection Length")
-                null
+    /**
+     * Create the AnkiDroid directory if it doesn't exist and add a .nomedia file to it if needed.
+     *
+     * The AnkiDroid directory is a user preference stored under [PREF_COLLECTION_PATH], and a sensible
+     * default is chosen if the preference hasn't been created yet (i.e., on the first run).
+     *
+     * The presence of a .nomedia file indicates to media scanners that the directory must be
+     * excluded from their search. We need to include this to avoid media scanners including
+     * media files from the collection.media directory. The .nomedia file works at the directory
+     * level, so placing it in the AnkiDroid directory will ensure media scanners will also exclude
+     * the collection.media sub-directory.
+     *
+     * @param path  Directory to initialize
+     * @throws StorageAccessException If no write access to directory
+     */
+    @Synchronized
+    @Throws(StorageAccessException::class)
+    fun initializeAnkiDroidDirectory(path: String) {
+        // Create specified directory if it doesn't exit
+        val dir = File(path)
+        if (!dir.exists() && !dir.mkdirs()) {
+            throw StorageAccessException("Failed to create AnkiDroid directory $path")
+        }
+        if (!dir.canWrite()) {
+            throw StorageAccessException("No write access to AnkiDroid directory $path")
+        }
+        // Add a .nomedia file to it if it doesn't exist
+        val nomedia = File(dir, ".nomedia")
+        if (!nomedia.exists()) {
+            try {
+                nomedia.createNewFile()
+            } catch (e: IOException) {
+                throw StorageAccessException("Failed to create .nomedia file", e)
             }
         }
+    }
 
-        /**
-         * Create the AnkiDroid directory if it doesn't exist and add a .nomedia file to it if needed.
-         *
-         * The AnkiDroid directory is a user preference stored under [PREF_COLLECTION_PATH], and a sensible
-         * default is chosen if the preference hasn't been created yet (i.e., on the first run).
-         *
-         * The presence of a .nomedia file indicates to media scanners that the directory must be
-         * excluded from their search. We need to include this to avoid media scanners including
-         * media files from the collection.media directory. The .nomedia file works at the directory
-         * level, so placing it in the AnkiDroid directory will ensure media scanners will also exclude
-         * the collection.media sub-directory.
-         *
-         * @param path  Directory to initialize
-         * @throws StorageAccessException If no write access to directory
-         */
-        @Synchronized
-        @Throws(StorageAccessException::class)
-        fun initializeAnkiDroidDirectory(path: String) {
-            // Create specified directory if it doesn't exit
-            val dir = File(path)
-            if (!dir.exists() && !dir.mkdirs()) {
-                throw StorageAccessException("Failed to create AnkiDroid directory $path")
+    /**
+     * Try to access the current AnkiDroid directory
+     * @return whether or not dir is accessible
+     * @param context to get directory with
+     */
+    fun isCurrentAnkiDroidDirAccessible(context: Context): Boolean {
+        return try {
+            initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory(context))
+            true
+        } catch (e: StorageAccessException) {
+            Timber.w(e)
+            false
+        }
+    }
+
+    /**
+     * Get the absolute path to a directory that is suitable to be the default starting location
+     * for the AnkiDroid directory.
+     *
+     * Currently, this is a directory named "AnkiDroid" at the top level of the non-app-specific external storage directory.
+     *
+     * When targeting API > 29, AnkiDroid will have to use Scoped Storage on any device of any API level.
+     * Scoped Storage only allows access to App-Specific directories (without permissions).
+     * Hence, AnkiDroid won't be able to access the directory used currently on all devices,
+     * regardless of their API level, once AnkiDroid targets API > 29.
+     * Instead, AnkiDroid will have to use an App-Specific directory to store the AnkiDroid directory.
+     * This applies to the entire AnkiDroid userbase.
+     *
+     * Currently, if `TESTING_SCOPED_STORAGE` is set to `true`, AnkiDroid uses its External
+     * App-Specific directory.
+     *
+     *
+     * External App-Specific Storage is used since the only advantage Internal App-Specific Storage has over External
+     * App-Specific storage is additional security, but AnkiDroid does not store sensitive data. Defaulting to
+     * External Storage preserves the current behavior of the App
+     * (AnkiDroid defaults to External before the Migration To Scoped Storage).
+     *
+     *
+     * TODO: If External Storage isn't emulated, allow users to choose between External & Internal App-Specific Storage
+     * instead of defaulting to External App-Specific Storage. This should be done since using either one may be more
+     * useful for them. If External Storage is emulated, there is no use in providing the option since Internal
+     * Storage can not provide more storage space than External Storage if External Storage is emulated.
+     *
+     * See the detailed explanation on storage locations & their classification below for more details.
+     *
+     * App-Specific storage refers to directories which are meant to store files that are meant to be used by a
+     * particular app. Each app has its own Internal & External App-Specific directory. Under Scoped Storage,
+     * an app can only access its own Internal & External App-Specific directory without needing permissions.
+     *
+     * Storage can be classified as Internal or External Storage.
+     *
+     * Internal Storage: This storage is characterized by the fact that it is always available since it always resides
+     * on the device's own non-removable storage.
+     *
+     *
+     * App-Specific Internal Storage can be accessed by ONLY the app which owns that directory (without any permissions).
+     * It cannot be accessed by any other apps.
+     * It cannot be accessed using the Files app on Android or by connecting a device to a pc via USB.
+     *
+     * External Storage:
+     *
+     * This storage is characterized only by the fact that it is not guaranteed to be available.
+     *
+     * It may be built-in, non-removable storage on the device which is being emulated to function like external storage.
+     * In this case, it doesn't offer more space than Internal Storage.
+     *
+     * Or, it may be removable storage like an SD Card.
+     *
+     * App-Specific External Storage can be accessed by the app it is owned by without any permissions.
+     * It can be accessed by any apps with the WRITE_EXTERNAL_STORAGE permission.
+     * It can also be accessed via the Android Files app or by connecting the device to a PC via USB.
+     *
+     * Note: The Files app can be misleading. On Samsung devices, clicking on Internal Storage it actually shows the
+     * emulated external storage (/storage/emulated/0/ in my case) - this is because from the point of view of the user,
+     * emulated external storage is just more internal storage since it is built into the phone. This is why vendors
+     * like Samsung may refer to external emulated storage as internal storage, even though for developers, they mean
+     * very different things as explained above.
+     *
+     * @return Absolute Path to the default location starting location for the AnkiDroid directory
+     */
+    // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
+    @CheckResult
+    fun getDefaultAnkiDroidDirectory(context: Context): String {
+        val legacyStorage = selectAnkiDroidFolder(context) != AppPrivateFolder
+        return if (!legacyStorage) {
+            File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid").absolutePath
+        } else {
+            legacyAnkiDroidDirectory
+        }
+    }
+
+    /**
+     * Returns the absolute path to the AnkiDroid directory under the primary/shared external storage directory.
+     * This directory may be in emulated external storage, or can be an SD Card directory.
+     *
+     *
+     * The path returned will no longer be accessible to AnkiDroid once targetSdk > 29
+     *
+     * @return Absolute path to the AnkiDroid directory in primary shared/external storage
+     */
+    val legacyAnkiDroidDirectory: String
+        get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid").absolutePath
+
+    /**
+     * Returns the absolute path to the AnkiDroid directory under the app-specific, primary/shared external storage
+     * directory.
+     *
+     *
+     * This directory may be in emulated external storage, or can be an SD Card directory.
+     * If it is actually external storage, i.e., removable storage like an SD Card, instead of storage
+     * built into the device itself, using this directory over internal storage can be beneficial since
+     * it may be able to store more data.
+     *
+     *
+     * AnkiDroid can access this directory without permissions, even under Scoped Storage
+     * Other apps can access this directory if they have the WRITE_EXTERNAL_STORAGE permission
+     *
+     * @param context Used to get the External App-Specific directory for AnkiDroid
+     * @return Returns the absolute path to the App-Specific External AnkiDroid directory
+     */
+    private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String {
+        return context.getExternalFilesDir(null)!!.absolutePath
+    }
+
+    /**
+     * @return Returns an array of [File]s reflecting the directories that AnkiDroid can access without storage permissions
+     * @see android.content.Context.getExternalFilesDirs
+     */
+    fun getAppSpecificExternalDirectories(context: Context): List<File> {
+        return context.getExternalFilesDirs(null).filterNotNull()
+    }
+
+    /**
+     * Returns the absolute path to the private AnkiDroid directory under the app-specific, internal storage directory.
+     *
+     *
+     * AnkiDroid can access this directory without permissions, even under Scoped Storage
+     * Other apps cannot access this directory, regardless of what permissions they have
+     *
+     * @param context Used to get the Internal App-Specific directory for AnkiDroid
+     * @return Returns the absolute path to the App-Specific Internal AnkiDroid Directory
+     */
+    fun getAppSpecificInternalAnkiDroidDirectory(context: Context): String {
+        return context.filesDir.absolutePath
+    }
+
+    /**
+     *
+     * @return the path to the actual [Collection] file
+     */
+    fun getCollectionPath(context: Context): String {
+        return File(getCurrentAnkiDroidDirectory(context), COLLECTION_FILENAME).absolutePath
+    }
+
+    /** A temporary override for [getCurrentAnkiDroidDirectory] */
+    var ankiDroidDirectoryOverride: String? = null
+
+    /**
+     * @return the absolute path to the AnkiDroid directory.
+     */
+    fun getCurrentAnkiDroidDirectory(context: Context): String {
+        return getCurrentAnkiDroidDirectoryOptionalContext(context.sharedPrefs()) { context }
+    }
+
+    fun getMediaDirectory(context: Context): File {
+        return File(getCurrentAnkiDroidDirectory(context), "collection.media")
+    }
+
+    /**
+     * An accessor which makes [Context] optional in the case that [PREF_COLLECTION_PATH] is set
+     *
+     * @return the absolute path to the AnkiDroid directory.
+     */
+    // This uses a lambda as we typically depends on the `lateinit` AnkiDroidApp.instance
+    // If we remove all Android references, we get a significant unit test speedup
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal fun getCurrentAnkiDroidDirectoryOptionalContext(preferences: SharedPreferences, context: () -> Context): String {
+        return if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
+            // create an "androidTest" directory inside the current collection directory which contains the test data
+            // "/AnkiDroid/androidTest" would be a new collection path
+            val currentCollectionDirectory = preferences.getOrSetString(PREF_COLLECTION_PATH) {
+                getDefaultAnkiDroidDirectory(context())
             }
-            if (!dir.canWrite()) {
-                throw StorageAccessException("No write access to AnkiDroid directory $path")
-            }
-            // Add a .nomedia file to it if it doesn't exist
-            val nomedia = File(dir, ".nomedia")
-            if (!nomedia.exists()) {
-                try {
-                    nomedia.createNewFile()
-                } catch (e: IOException) {
-                    throw StorageAccessException("Failed to create .nomedia file", e)
-                }
-            }
-        }
-
-        /**
-         * Try to access the current AnkiDroid directory
-         * @return whether or not dir is accessible
-         * @param context to get directory with
-         */
-        fun isCurrentAnkiDroidDirAccessible(context: Context): Boolean {
-            return try {
-                initializeAnkiDroidDirectory(getCurrentAnkiDroidDirectory(context))
-                true
-            } catch (e: StorageAccessException) {
-                Timber.w(e)
-                false
-            }
-        }
-
-        /**
-         * Get the absolute path to a directory that is suitable to be the default starting location
-         * for the AnkiDroid directory.
-         *
-         * Currently, this is a directory named "AnkiDroid" at the top level of the non-app-specific external storage directory.
-         *
-         * When targeting API > 29, AnkiDroid will have to use Scoped Storage on any device of any API level.
-         * Scoped Storage only allows access to App-Specific directories (without permissions).
-         * Hence, AnkiDroid won't be able to access the directory used currently on all devices,
-         * regardless of their API level, once AnkiDroid targets API > 29.
-         * Instead, AnkiDroid will have to use an App-Specific directory to store the AnkiDroid directory.
-         * This applies to the entire AnkiDroid userbase.
-         *
-         * Currently, if `TESTING_SCOPED_STORAGE` is set to `true`, AnkiDroid uses its External
-         * App-Specific directory.
-         *
-         *
-         * External App-Specific Storage is used since the only advantage Internal App-Specific Storage has over External
-         * App-Specific storage is additional security, but AnkiDroid does not store sensitive data. Defaulting to
-         * External Storage preserves the current behavior of the App
-         * (AnkiDroid defaults to External before the Migration To Scoped Storage).
-         *
-         *
-         * TODO: If External Storage isn't emulated, allow users to choose between External & Internal App-Specific Storage
-         * instead of defaulting to External App-Specific Storage. This should be done since using either one may be more
-         * useful for them. If External Storage is emulated, there is no use in providing the option since Internal
-         * Storage can not provide more storage space than External Storage if External Storage is emulated.
-         *
-         * See the detailed explanation on storage locations & their classification below for more details.
-         *
-         * App-Specific storage refers to directories which are meant to store files that are meant to be used by a
-         * particular app. Each app has its own Internal & External App-Specific directory. Under Scoped Storage,
-         * an app can only access its own Internal & External App-Specific directory without needing permissions.
-         *
-         * Storage can be classified as Internal or External Storage.
-         *
-         * Internal Storage: This storage is characterized by the fact that it is always available since it always resides
-         * on the device's own non-removable storage.
-         *
-         *
-         * App-Specific Internal Storage can be accessed by ONLY the app which owns that directory (without any permissions).
-         * It cannot be accessed by any other apps.
-         * It cannot be accessed using the Files app on Android or by connecting a device to a pc via USB.
-         *
-         * External Storage:
-         *
-         * This storage is characterized only by the fact that it is not guaranteed to be available.
-         *
-         * It may be built-in, non-removable storage on the device which is being emulated to function like external storage.
-         * In this case, it doesn't offer more space than Internal Storage.
-         *
-         * Or, it may be removable storage like an SD Card.
-         *
-         * App-Specific External Storage can be accessed by the app it is owned by without any permissions.
-         * It can be accessed by any apps with the WRITE_EXTERNAL_STORAGE permission.
-         * It can also be accessed via the Android Files app or by connecting the device to a PC via USB.
-         *
-         * Note: The Files app can be misleading. On Samsung devices, clicking on Internal Storage it actually shows the
-         * emulated external storage (/storage/emulated/0/ in my case) - this is because from the point of view of the user,
-         * emulated external storage is just more internal storage since it is built into the phone. This is why vendors
-         * like Samsung may refer to external emulated storage as internal storage, even though for developers, they mean
-         * very different things as explained above.
-         *
-         * @return Absolute Path to the default location starting location for the AnkiDroid directory
-         */
-        // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
-        @CheckResult
-        fun getDefaultAnkiDroidDirectory(context: Context): String {
-            val legacyStorage = selectAnkiDroidFolder(context) != AppPrivateFolder
-            return if (!legacyStorage) {
-                File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid").absolutePath
-            } else {
-                legacyAnkiDroidDirectory
-            }
-        }
-
-        /**
-         * Returns the absolute path to the AnkiDroid directory under the primary/shared external storage directory.
-         * This directory may be in emulated external storage, or can be an SD Card directory.
-         *
-         *
-         * The path returned will no longer be accessible to AnkiDroid once targetSdk > 29
-         *
-         * @return Absolute path to the AnkiDroid directory in primary shared/external storage
-         */
-        val legacyAnkiDroidDirectory: String
-            get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid").absolutePath
-
-        /**
-         * Returns the absolute path to the AnkiDroid directory under the app-specific, primary/shared external storage
-         * directory.
-         *
-         *
-         * This directory may be in emulated external storage, or can be an SD Card directory.
-         * If it is actually external storage, i.e., removable storage like an SD Card, instead of storage
-         * built into the device itself, using this directory over internal storage can be beneficial since
-         * it may be able to store more data.
-         *
-         *
-         * AnkiDroid can access this directory without permissions, even under Scoped Storage
-         * Other apps can access this directory if they have the WRITE_EXTERNAL_STORAGE permission
-         *
-         * @param context Used to get the External App-Specific directory for AnkiDroid
-         * @return Returns the absolute path to the App-Specific External AnkiDroid directory
-         */
-        private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String {
-            return context.getExternalFilesDir(null)!!.absolutePath
-        }
-
-        /**
-         * @return Returns an array of [File]s reflecting the directories that AnkiDroid can access without storage permissions
-         * @see android.content.Context.getExternalFilesDirs
-         */
-        fun getAppSpecificExternalDirectories(context: Context): List<File> {
-            return context.getExternalFilesDirs(null).filterNotNull()
-        }
-
-        /**
-         * Returns the absolute path to the private AnkiDroid directory under the app-specific, internal storage directory.
-         *
-         *
-         * AnkiDroid can access this directory without permissions, even under Scoped Storage
-         * Other apps cannot access this directory, regardless of what permissions they have
-         *
-         * @param context Used to get the Internal App-Specific directory for AnkiDroid
-         * @return Returns the absolute path to the App-Specific Internal AnkiDroid Directory
-         */
-        fun getAppSpecificInternalAnkiDroidDirectory(context: Context): String {
-            return context.filesDir.absolutePath
-        }
-
-        /**
-         *
-         * @return the path to the actual [Collection] file
-         */
-        fun getCollectionPath(context: Context): String {
-            return File(getCurrentAnkiDroidDirectory(context), COLLECTION_FILENAME).absolutePath
-        }
-
-        /** A temporary override for [getCurrentAnkiDroidDirectory] */
-        var ankiDroidDirectoryOverride: String? = null
-
-        /**
-         * @return the absolute path to the AnkiDroid directory.
-         */
-        fun getCurrentAnkiDroidDirectory(context: Context): String {
-            return getCurrentAnkiDroidDirectoryOptionalContext(context.sharedPrefs()) { context }
-        }
-
-        fun getMediaDirectory(context: Context): File {
-            return File(getCurrentAnkiDroidDirectory(context), "collection.media")
-        }
-
-        /**
-         * An accessor which makes [Context] optional in the case that [PREF_COLLECTION_PATH] is set
-         *
-         * @return the absolute path to the AnkiDroid directory.
-         */
-        // This uses a lambda as we typically depends on the `lateinit` AnkiDroidApp.instance
-        // If we remove all Android references, we get a significant unit test speedup
-        @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-        internal fun getCurrentAnkiDroidDirectoryOptionalContext(preferences: SharedPreferences, context: () -> Context): String {
-            return if (AnkiDroidApp.INSTRUMENTATION_TESTING) {
-                // create an "androidTest" directory inside the current collection directory which contains the test data
-                // "/AnkiDroid/androidTest" would be a new collection path
-                val currentCollectionDirectory = preferences.getOrSetString(PREF_COLLECTION_PATH) {
-                    getDefaultAnkiDroidDirectory(context())
-                }
-                File(
-                    currentCollectionDirectory,
-                    "androidTest"
-                ).absolutePath
-            } else if (ankiDroidDirectoryOverride != null) {
-                ankiDroidDirectoryOverride!!
-            } else {
-                preferences.getOrSetString(PREF_COLLECTION_PATH) {
-                    getDefaultAnkiDroidDirectory(
-                        context()
-                    )
-                }
+            File(
+                currentCollectionDirectory,
+                "androidTest"
+            ).absolutePath
+        } else if (ankiDroidDirectoryOverride != null) {
+            ankiDroidDirectoryOverride!!
+        } else {
+            preferences.getOrSetString(PREF_COLLECTION_PATH) {
+                getDefaultAnkiDroidDirectory(
+                    context()
+                )
             }
         }
+    }
 
-        /**
-         * Resets the AnkiDroid directory to the [getDefaultAnkiDroidDirectory]
-         * Note: if [android.R.attr.preserveLegacyExternalStorage] is in use
-         * this will represent a change from `/AnkiDroid` to `/Android/data/...`
-         */
-        fun resetAnkiDroidDirectory(context: Context) {
-            val preferences = context.sharedPrefs()
-            val directory = getDefaultAnkiDroidDirectory(context)
-            Timber.d("resetting AnkiDroid directory to %s", directory)
-            preferences.edit { putString(PREF_COLLECTION_PATH, directory) }
+    /**
+     * Resets the AnkiDroid directory to the [getDefaultAnkiDroidDirectory]
+     * Note: if [android.R.attr.preserveLegacyExternalStorage] is in use
+     * this will represent a change from `/AnkiDroid` to `/Android/data/...`
+     */
+    fun resetAnkiDroidDirectory(context: Context) {
+        val preferences = context.sharedPrefs()
+        val directory = getDefaultAnkiDroidDirectory(context)
+        Timber.d("resetting AnkiDroid directory to %s", directory)
+        preferences.edit { putString(PREF_COLLECTION_PATH, directory) }
+    }
+
+    @Throws(UnknownDatabaseVersionException::class)
+    fun getDatabaseVersion(context: Context): Int {
+        // backend can't open a schema version outside range, so fall back to a pure DB implementation
+        val colPath = getCollectionPath(context)
+        if (!File(colPath).exists()) {
+            throw UnknownDatabaseVersionException(FileNotFoundException(colPath))
         }
-
-        @Throws(UnknownDatabaseVersionException::class)
-        fun getDatabaseVersion(context: Context): Int {
-            // backend can't open a schema version outside range, so fall back to a pure DB implementation
-            val colPath = getCollectionPath(context)
-            if (!File(colPath).exists()) {
-                throw UnknownDatabaseVersionException(FileNotFoundException(colPath))
-            }
-            var db: DB? = null
-            return try {
-                db = DB.withAndroidFramework(context, colPath)
-                db.queryScalar("SELECT ver FROM col")
-            } catch (e: Exception) {
-                Timber.w(e, "Couldn't open the database to obtain collection version!")
-                throw UnknownDatabaseVersionException(e)
-            } finally {
-                db?.close()
-            }
+        var db: DB? = null
+        return try {
+            db = DB.withAndroidFramework(context, colPath)
+            db.queryScalar("SELECT ver FROM col")
+        } catch (e: Exception) {
+            Timber.w(e, "Couldn't open the database to obtain collection version!")
+            throw UnknownDatabaseVersionException(e)
+        } finally {
+            db?.close()
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -49,28 +49,17 @@ import kotlin.Throws
 @KotlinCleanup("convert to object")
 open class CollectionHelper {
     /**
-     * Get the single instance of the [Collection], creating it if necessary  (lazy initialization).
-     * @param context is no longer used, as the global AnkidroidApp instance is used instead
-     * @return instance of the Collection
-     */
-    @Synchronized
-    open fun getColUnsafe(context: Context?): Collection? {
-        return CollectionManager.getColUnsafe()
-    }
-
-    /**
      * Calls [getColUnsafe] inside a try / catch statement.
      * Send exception report if [reportException] is set and return null if there was an exception.
-     * @param context
      * @param reportException Whether to send a crash report if an [Exception] was thrown when opening the collection (excluding
      * [BackendDbLockedException] and [BackendDbFileTooNewException]).
      * @return the [Collection] if it could be obtained, `null` otherwise.
      */
     @Synchronized
-    fun tryGetColUnsafe(context: Context?, reportException: Boolean = true): Collection? {
+    fun tryGetColUnsafe(reportException: Boolean = true): Collection? {
         lastOpenFailure = null
         return try {
-            getColUnsafe(context)
+            CollectionManager.getColUnsafe()
         } catch (e: BackendDbLockedException) {
             lastOpenFailure = CollectionOpenFailure.LOCKED
             Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -45,14 +45,6 @@ import kotlin.Throws
 open class CollectionHelper {
 
     companion object {
-        var instance: CollectionHelper = CollectionHelper()
-            private set
-
-        @VisibleForTesting
-        internal fun setInstanceForTesting(newInstance: CollectionHelper) {
-            instance = newInstance
-        }
-
         // Name of anki2 file
         const val COLLECTION_FILENAME = "collection.anki2"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -210,12 +210,6 @@ open class CollectionHelper {
         FILE_TOO_NEW, CORRUPT, LOCKED, DISK_FULL
     }
 
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    @KotlinCleanup("maybe: call CollectionManager directly then remove method")
-    fun setColForTests(col: Collection?) {
-        CollectionManager.setColForTests(col)
-    }
-
     companion object {
         var instance: CollectionHelper = CollectionHelper()
             private set

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -45,15 +45,6 @@ import kotlin.Throws
  */
 @KotlinCleanup("convert to object")
 open class CollectionHelper {
-    /**
-     * Close the [Collection], optionally saving
-     * @param save whether or not save before closing
-     */
-    @Synchronized
-    fun closeCollection(reason: String?) {
-        Timber.i("closeCollection: %s", reason)
-        CollectionManager.closeCollectionBlocking()
-    }
 
     /**
      * This currently stores either:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki
 import android.content.Context
 import android.content.SharedPreferences
 import android.os.Environment
-import android.text.format.Formatter
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
@@ -31,7 +30,6 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DB
 import com.ichi2.preferences.getOrSetString
-import com.ichi2.utils.FileUtil
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
@@ -45,120 +43,6 @@ import kotlin.Throws
  */
 @KotlinCleanup("convert to object")
 open class CollectionHelper {
-
-    /**
-     * This currently stores either:
-     * An error message stating the reason that a storage check must be performed
-     * OR
-     * The current storage requirements, and the current available storage.
-     */
-    @KotlinCleanup("extract this to another file")
-    class CollectionIntegrityStorageCheck {
-        private val errorMessage: String?
-
-        // OR:
-        private val requiredSpace: Long?
-        private val freeSpace: Long?
-
-        private constructor(requiredSpace: Long, freeSpace: Long) {
-            this.freeSpace = freeSpace
-            this.requiredSpace = requiredSpace
-            errorMessage = null
-        }
-
-        private constructor(errorMessage: String) {
-            requiredSpace = null
-            freeSpace = null
-            this.errorMessage = errorMessage
-        }
-
-        fun shouldWarnOnIntegrityCheck(): Boolean {
-            return errorMessage != null || fileSystemDoesNotHaveSpaceForBackup()
-        }
-
-        private fun fileSystemDoesNotHaveSpaceForBackup(): Boolean {
-            // only to be called when mErrorMessage == null
-            if (freeSpace == null || requiredSpace == null) {
-                Timber.e("fileSystemDoesNotHaveSpaceForBackup called in invalid state.")
-                return true
-            }
-            Timber.d("Required Free Space: %d. Current: %d", requiredSpace, freeSpace)
-            return requiredSpace > freeSpace
-        }
-
-        fun getWarningDetails(context: Context): String {
-            if (errorMessage != null) {
-                return errorMessage
-            }
-            if (freeSpace == null || requiredSpace == null) {
-                Timber.e("CollectionIntegrityCheckStatus in an invalid state")
-                val defaultRequiredFreeSpace = defaultRequiredFreeSpace(context)
-                return context.resources.getString(
-                    R.string.integrity_check_insufficient_space,
-                    defaultRequiredFreeSpace
-                )
-            }
-            val required = Formatter.formatShortFileSize(context, requiredSpace)
-            val insufficientSpace = context.resources.getString(
-                R.string.integrity_check_insufficient_space,
-                required
-            )
-
-            // Also concat in the extra content showing the current free space.
-            val currentFree = Formatter.formatShortFileSize(context, freeSpace)
-            val insufficientSpaceCurrentFree = context.resources.getString(
-                R.string.integrity_check_insufficient_space_extra_content,
-                currentFree
-            )
-            return insufficientSpace + insufficientSpaceCurrentFree
-        }
-
-        companion object {
-
-            private fun fromError(errorMessage: String): CollectionIntegrityStorageCheck {
-                return CollectionIntegrityStorageCheck(errorMessage)
-            }
-
-            private fun defaultRequiredFreeSpace(context: Context): String {
-                val oneHundredFiftyMB =
-                    (150 * 1000 * 1000).toLong() // tested, 1024 displays 157MB. 1000 displays 150
-                return Formatter.formatShortFileSize(context, oneHundredFiftyMB)
-            }
-
-            fun createInstance(context: Context): CollectionIntegrityStorageCheck {
-                val maybeCurrentCollectionSizeInBytes = getCollectionSize(context)
-                if (maybeCurrentCollectionSizeInBytes == null) {
-                    Timber.w("Error obtaining collection file size.")
-                    val requiredFreeSpace = defaultRequiredFreeSpace(context)
-                    return fromError(
-                        context.resources.getString(
-                            R.string.integrity_check_insufficient_space,
-                            requiredFreeSpace
-                        )
-                    )
-                }
-
-                // This means that when VACUUMing a database, as much as twice the size of the original database file is
-                // required in free disk space. - https://www.sqlite.org/lang_vacuum.html
-                val requiredSpaceInBytes = maybeCurrentCollectionSizeInBytes * 2
-
-                // We currently use the same directory as the collection for VACUUM/ANALYZE due to the SQLite APIs
-                val collectionFile = File(getCollectionPath(context))
-                val freeSpace = FileUtil.getFreeDiskSpace(collectionFile, -1)
-                if (freeSpace == -1L) {
-                    Timber.w("Error obtaining free space for '%s'", collectionFile.path)
-                    val readableFileSize = Formatter.formatFileSize(context, requiredSpaceInBytes)
-                    return fromError(
-                        context.resources.getString(
-                            R.string.integrity_check_insufficient_space,
-                            readableFileSize
-                        )
-                    )
-                }
-                return CollectionIntegrityStorageCheck(requiredSpaceInBytes, freeSpace)
-            }
-        }
-    }
 
     companion object {
         var instance: CollectionHelper = CollectionHelper()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
@@ -1,0 +1,133 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import android.content.Context
+import android.text.format.Formatter
+import com.ichi2.utils.FileUtil
+import timber.log.Timber
+import java.io.File
+
+/**
+ * This currently stores either:
+ * An error message stating the reason that a storage check must be performed
+ * OR
+ * The current storage requirements, and the current available storage.
+ */
+class CollectionIntegrityStorageCheck {
+    private val errorMessage: String?
+
+    // OR:
+    private val requiredSpace: Long?
+    private val freeSpace: Long?
+
+    private constructor(requiredSpace: Long, freeSpace: Long) {
+        this.freeSpace = freeSpace
+        this.requiredSpace = requiredSpace
+        errorMessage = null
+    }
+
+    private constructor(errorMessage: String) {
+        requiredSpace = null
+        freeSpace = null
+        this.errorMessage = errorMessage
+    }
+
+    fun shouldWarnOnIntegrityCheck(): Boolean {
+        return errorMessage != null || fileSystemDoesNotHaveSpaceForBackup()
+    }
+
+    private fun fileSystemDoesNotHaveSpaceForBackup(): Boolean {
+        // only to be called when mErrorMessage == null
+        if (freeSpace == null || requiredSpace == null) {
+            Timber.e("fileSystemDoesNotHaveSpaceForBackup called in invalid state.")
+            return true
+        }
+        Timber.d("Required Free Space: %d. Current: %d", requiredSpace, freeSpace)
+        return requiredSpace > freeSpace
+    }
+
+    fun getWarningDetails(context: Context): String {
+        if (errorMessage != null) {
+            return errorMessage
+        }
+        if (freeSpace == null || requiredSpace == null) {
+            Timber.e("CollectionIntegrityCheckStatus in an invalid state")
+            val defaultRequiredFreeSpace = defaultRequiredFreeSpace(context)
+            return context.resources.getString(
+                R.string.integrity_check_insufficient_space,
+                defaultRequiredFreeSpace
+            )
+        }
+        val required = Formatter.formatShortFileSize(context, requiredSpace)
+        val insufficientSpace = context.resources.getString(
+            R.string.integrity_check_insufficient_space,
+            required
+        )
+
+        // Also concat in the extra content showing the current free space.
+        val currentFree = Formatter.formatShortFileSize(context, freeSpace)
+        val insufficientSpaceCurrentFree = context.resources.getString(
+            R.string.integrity_check_insufficient_space_extra_content,
+            currentFree
+        )
+        return insufficientSpace + insufficientSpaceCurrentFree
+    }
+
+    companion object {
+
+        private fun fromError(errorMessage: String): CollectionIntegrityStorageCheck {
+            return CollectionIntegrityStorageCheck(errorMessage)
+        }
+
+        private fun defaultRequiredFreeSpace(context: Context): String {
+            val oneHundredFiftyMB =
+                (150 * 1000 * 1000).toLong() // tested, 1024 displays 157MB. 1000 displays 150
+            return Formatter.formatShortFileSize(context, oneHundredFiftyMB)
+        }
+
+        fun createInstance(context: Context): CollectionIntegrityStorageCheck {
+            val maybeCurrentCollectionSizeInBytes = CollectionHelper.getCollectionSize(context)
+            if (maybeCurrentCollectionSizeInBytes == null) {
+                Timber.w("Error obtaining collection file size.")
+                val requiredFreeSpace = defaultRequiredFreeSpace(context)
+                return fromError(
+                    context.resources.getString(
+                        R.string.integrity_check_insufficient_space,
+                        requiredFreeSpace
+                    )
+                )
+            }
+
+            // This means that when VACUUMing a database, as much as twice the size of the original database file is
+            // required in free disk space. - https://www.sqlite.org/lang_vacuum.html
+            val requiredSpaceInBytes = maybeCurrentCollectionSizeInBytes * 2
+
+            // We currently use the same directory as the collection for VACUUM/ANALYZE due to the SQLite APIs
+            val collectionFile = File(CollectionHelper.getCollectionPath(context))
+            val freeSpace = FileUtil.getFreeDiskSpace(collectionFile, -1)
+            if (freeSpace == -1L) {
+                Timber.w("Error obtaining free space for '%s'", collectionFile.path)
+                val readableFileSize = Formatter.formatFileSize(context, requiredSpaceInBytes)
+                return fromError(
+                    context.resources.getString(
+                        R.string.integrity_check_insufficient_space,
+                        readableFileSize
+                    )
+                )
+            }
+            return CollectionIntegrityStorageCheck(requiredSpaceInBytes, freeSpace)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -67,7 +67,6 @@ import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
-import com.ichi2.anki.CollectionHelper.CollectionIntegrityStorageCheck
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CollectionManager.withOpenColOrNull

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2619,7 +2619,7 @@ class OneWaySyncDialog(val message: String?) : DialogHandlerMessage(
         val dialog = ConfirmationDialog()
         val confirm = Runnable {
             // Bypass the check once the user confirms
-            CollectionHelper.instance.getColUnsafe(AnkiDroidApp.instance)!!.modSchemaNoCheck()
+            CollectionManager.getColUnsafe().modSchemaNoCheck()
         }
         dialog.setConfirm(confirm)
         dialog.setArgs(message)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1923,7 +1923,7 @@ open class DeckPicker :
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     @RustCleanup("backup with 5 minute timer, instead of deck list refresh")
     fun updateDeckList() {
-        if (CollectionHelper.lastOpenFailure != null) {
+        if (!CollectionManager.isOpenUnsafe()) {
             return
         }
         if (Build.FINGERPRINT != "robolectric") {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -47,7 +47,7 @@ object InitialActivity {
         }
 
         // If we're OK, return null
-        if (CollectionHelper.instance.tryGetColUnsafe(context, reportException = false) != null) {
+        if (CollectionHelper.instance.tryGetColUnsafe(reportException = false) != null) {
             return null
         }
         if (!AnkiDroidApp.isSdCardMounted) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -139,7 +139,7 @@ class IntentHandler : Activity() {
         val deckId = intent.getLongExtra(ReminderService.EXTRA_DECK_ID, 0)
         Timber.i("Handling intent to review deck '%d'", deckId)
         val reviewIntent = Intent(this, Reviewer::class.java)
-        CollectionHelper.instance.getColUnsafe(this)!!.decks.select(deckId)
+        CollectionManager.getColUnsafe().decks.select(deckId)
         startActivity(reviewIntent)
         finish()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -163,7 +163,7 @@ class MediaRegistration(private val context: Context) {
         Timber.i("Adding media to collection: %s", imagePath)
         val f = File(imagePath)
         return try {
-            CollectionHelper.instance.getColUnsafe(context)!!.media.addFile(f)
+            CollectionManager.getColUnsafe().media.addFile(f)
             true
         } catch (e: IOException) {
             Timber.w(e, "Failed to add file")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -365,7 +365,7 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, Toolbar.OnMen
                 toolbar!!.setNavigationOnClickListener { (activity as AnkiActivity).finish() }
             }
         } catch (e: IllegalStateException) {
-            if (!CollectionHelper.instance.colIsOpenUnsafe()) {
+            if (!CollectionManager.isOpenUnsafe()) {
                 if (recur) {
                     Timber.i(e, "Database closed while working. Probably auto-sync. Will re-try after sleep.")
                     try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -493,7 +493,7 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, Toolbar.OnMen
     private val col: Collection?
         get() {
             try {
-                return CollectionHelper.instance.getColUnsafe(context)
+                return CollectionManager.getColUnsafe()
             } catch (e: Exception) {
                 // This may happen if the backend is locked or similar.
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -27,7 +27,7 @@ import com.ichi2.anki.AndroidTtsError
 import com.ichi2.anki.AndroidTtsError.TtsErrorCode
 import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CollectionHelper.Companion.getMediaDirectory
+import com.ichi2.anki.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.ReadText
 import com.ichi2.anki.cardviewer.SoundErrorBehavior.CONTINUE_AUDIO

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -21,7 +21,7 @@ import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.UIUtils.showThemedToast
@@ -65,7 +65,7 @@ class CreateDeckDialog(
     }
 
     private val getColUnsafe
-        get() = CollectionHelper.instance.getColUnsafe(context)!!
+        get() = CollectionManager.getColUnsafe()
 
     suspend fun showFilteredDeckDialog() {
         Timber.i("CreateDeckDialog::showFilteredDeckDialog")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -259,9 +259,12 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.backup_new_collection)
                     message(text = message)
                     positiveButton(R.string.dialog_positive_create) {
-                        val ch = CollectionHelper.instance
                         val time = TimeManager.time
-                        ch.closeCollection("DatabaseErrorDialog: Before Create New Collection")
+                        Timber.i(
+                            "closeCollection: %s",
+                            "DatabaseErrorDialog: Before Create New Collection"
+                        )
+                        CollectionManager.closeCollectionBlocking()
                         val path1 = CollectionHelper.getCollectionPath(requireActivity())
                         if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
                             ActivityCompat.recreate(activity as DeckPicker)
@@ -448,8 +451,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(R.string.new_unsafe_collection)
                     positiveButton(R.string.dialog_positive_create) {
                         Timber.w("Creating new collection")
-                        val ch = CollectionHelper.instance
-                        ch.closeCollection("DatabaseErrorDialog: Before Create New Collection")
+                        Timber.i(
+                            "closeCollection: %s",
+                            "DatabaseErrorDialog: Before Create New Collection"
+                        )
+                        CollectionManager.closeCollectionBlocking()
                         CollectionHelper.resetAnkiDroidDirectory(context)
                         context.closeCollectionAndFinish()
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -105,7 +105,6 @@ class CardContentProvider : ContentProvider() {
          * applied to more columns. "MID", "USN", "MOD" are not really user friendly.
          */
         private val sDefaultNoteProjectionDBAccess = FlashCardsContract.Note.DEFAULT_PROJECTION.clone()
-        private const val COL_NULL_ERROR_MSG = "AnkiDroid database inaccessible. Open AnkiDroid to see what's wrong."
 
         private fun sanitizeNoteProjection(projection: Array<String>?): Array<String> {
             if (projection.isNullOrEmpty()) {
@@ -192,8 +191,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceQueryOrInsertSecurity()) {
             throwSecurityException("query", uri)
         }
-        val col = CollectionHelper.instance.getColUnsafe(context!!)
-            ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
+        val col = CollectionManager.getColUnsafe()
         Timber.d(getLogMessage("query", uri))
 
         // Find out what data the user is requesting
@@ -390,8 +388,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceUpdateSecurity(uri)) {
             throwSecurityException("update", uri)
         }
-        val col = CollectionHelper.instance.getColUnsafe(context!!)
-            ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
+        val col = CollectionManager.getColUnsafe()
         Timber.d(getLogMessage("update", uri))
 
         // Find out what data the user is requesting
@@ -582,7 +579,10 @@ class CardContentProvider : ContentProvider() {
                         FlashCardsContract.ReviewInfo.NOTE_ID -> noteID = values.getAsLong(key)
                         FlashCardsContract.ReviewInfo.CARD_ORD -> cardOrd = values.getAsInteger(key)
                         FlashCardsContract.ReviewInfo.EASE -> ease = values.getAsInteger(key)
-                        FlashCardsContract.ReviewInfo.TIME_TAKEN -> timeTaken = values.getAsLong(key)
+                        FlashCardsContract.ReviewInfo.TIME_TAKEN ->
+                            timeTaken =
+                                values.getAsLong(key)
+
                         FlashCardsContract.ReviewInfo.BURY -> bury = values.getAsInteger(key)
                         FlashCardsContract.ReviewInfo.SUSPEND -> suspend = values.getAsInteger(key)
                     }
@@ -634,8 +634,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission()) {
             throwSecurityException("delete", uri)
         }
-        val col = CollectionHelper.instance.getColUnsafe(context!!)
-            ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
+        val col = CollectionManager.getColUnsafe()
         Timber.d(getLogMessage("delete", uri))
         return when (sUriMatcher.match(uri)) {
             NOTES_ID -> {
@@ -691,8 +690,7 @@ class CardContentProvider : ContentProvider() {
         if (valuesArr.isNullOrEmpty()) {
             return 0
         }
-        val col = CollectionHelper.instance.getColUnsafe(context!!)
-            ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
+        val col = CollectionManager.getColUnsafe()
         if (col.decks.isFiltered(deckId)) {
             throw IllegalArgumentException("A filtered deck cannot be specified as the deck in bulkInsertNotes")
         }
@@ -740,8 +738,7 @@ class CardContentProvider : ContentProvider() {
         if (!hasReadWritePermission() && shouldEnforceQueryOrInsertSecurity()) {
             throwSecurityException("insert", uri)
         }
-        val col = CollectionHelper.instance.getColUnsafe(context!!)
-            ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
+        val col = CollectionManager.getColUnsafe()
         Timber.d(getLogMessage("insert", uri))
 
         // Find out what data the user is requesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/receiver/SdCardReceiver.kt
@@ -19,7 +19,7 @@ package com.ichi2.anki.receiver
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import timber.log.Timber
 
 /**
@@ -35,8 +35,8 @@ class SdCardReceiver : BroadcastReceiver() {
             i.action = MEDIA_EJECT
             context.sendBroadcast(i)
             try {
-                val col = CollectionHelper.instance.getColUnsafe(context)
-                col?.close()
+                val col = CollectionManager.getColUnsafe()
+                col.close()
             } catch (e: Exception) {
                 Timber.w(e, "Exception while trying to close collection likely because it was already unmounted")
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -29,7 +29,7 @@ class BootService : BroadcastReceiver() {
             return
         }
         // There are cases where the app is installed, and we have access, but nothing exist yet
-        val col = getColSafe(context)
+        val col = getColSafe()
         if (col == null) {
             Timber.w("Boot Service did not execute - error loading collection")
             return
@@ -61,11 +61,11 @@ class BootService : BroadcastReceiver() {
         }
     }
 
-    private fun getColSafe(context: Context): Collection? {
+    private fun getColSafe(): Collection? {
         // #6239 - previously would crash if ejecting, we don't want a report if this happens so don't use
         // getInstance().getColSafe
         return try {
-            CollectionHelper.instance.getColUnsafe(context)
+            CollectionManager.getColUnsafe()
         } catch (e: Exception) {
             Timber.e(e, "Failed to get collection for boot service - possibly media ejecting")
             null
@@ -118,7 +118,7 @@ class BootService : BroadcastReceiver() {
             // TODO; We might want to use the BootService retry code here when called from preferences.
             val defValue = 4
             return try {
-                val col = CollectionHelper.instance.getColUnsafe(context)!!
+                val col = CollectionManager.getColUnsafe()
                 when (col.schedVer()) {
                     1 -> {
                         val sp = context.sharedPrefs()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -23,7 +23,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.Channel
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
@@ -63,16 +62,13 @@ class ReminderService : BroadcastReceiver() {
             Timber.w("onReceive - dConfId 0, returning")
             return
         }
-        val colHelper: CollectionHelper
-        val col: Collection?
-        try {
-            colHelper = CollectionHelper.instance
-            col = CollectionManager.getColUnsafe()
+        val col: Collection = try {
+            CollectionManager.getColUnsafe()
         } catch (t: Throwable) {
             Timber.w(t, "onReceive - unexpectedly unable to get collection. Returning.")
             return
         }
-        if (!colHelper.colIsOpenUnsafe()) {
+        if (!CollectionManager.isOpenUnsafe()) {
             Timber.w("onReceive - null or closed collection, unable to process reminders")
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -24,6 +24,7 @@ import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.Channel
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.libanki.Collection
@@ -66,12 +67,12 @@ class ReminderService : BroadcastReceiver() {
         val col: Collection?
         try {
             colHelper = CollectionHelper.instance
-            col = colHelper.getColUnsafe(context)
+            col = CollectionManager.getColUnsafe()
         } catch (t: Throwable) {
             Timber.w(t, "onReceive - unexpectedly unable to get collection. Returning.")
             return
         }
-        if (null == col || !colHelper.colIsOpenUnsafe()) {
+        if (!colHelper.colIsOpenUnsafe()) {
             Timber.w("onReceive - null or closed collection, unable to process reminders")
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionLoader.kt
@@ -19,8 +19,7 @@ package com.ichi2.async
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
-import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.Dispatchers
@@ -39,7 +38,7 @@ object CollectionLoader {
                 // load collection
                 try {
                     Timber.d("CollectionLoader accessing collection")
-                    val col = CollectionHelper.instance.getColUnsafe(AnkiDroidApp.instance.applicationContext)
+                    val col = CollectionManager.getColUnsafe()
                     Timber.i("CollectionLoader obtained collection")
                     col
                 } catch (e: RuntimeException) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -26,7 +26,7 @@ import android.database.SQLException
 import android.database.sqlite.SQLiteDatabase
 import androidx.annotation.WorkerThread
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.utils.KotlinCleanup
@@ -70,7 +70,8 @@ class DB(val database: SupportSQLiteDatabase) {
                 "DB.MyDbErrorHandler.onCorruption",
                 "Db has been corrupted: " + db.path
             )
-            CollectionHelper.instance.closeCollection("Database corrupted")
+            Timber.i("closeCollection: %s", "Database corrupted")
+            CollectionManager.closeCollectionBlocking()
             DatabaseErrorDialog.databaseCorruptFlag = true
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -28,7 +28,7 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.libanki.Collection
@@ -183,12 +183,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
         delegate.installViewFactory()
         delegate.onCreate(savedInstanceState)
         super.onCreate(savedInstanceState)
-        val col = CollectionHelper.instance.getColUnsafe(this)
-        if (col != null) {
-            this.col = col
-        } else {
-            finish()
-        }
+        this.col = CollectionManager.getColUnsafe()
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -526,7 +526,7 @@ class DeckPickerTest : RobolectricTest() {
             waitForAsyncTasksToComplete()
             assertThat(
                 "Collection should now be open",
-                CollectionHelper.instance.colIsOpenUnsafe()
+                CollectionManager.isOpenUnsafe()
             )
             assertThat(
                 CollectionType.SCHEMA_V_16.isCollection(
@@ -560,7 +560,7 @@ class DeckPickerTest : RobolectricTest() {
             waitForAsyncTasksToComplete()
             assertThat(
                 "Collection should not be open",
-                !CollectionHelper.instance.colIsOpenUnsafe()
+                !CollectionManager.isOpenUnsafe()
             )
             assertThat(
                 "An error dialog should be displayed",
@@ -584,7 +584,7 @@ class DeckPickerTest : RobolectricTest() {
             waitForAsyncTasksToComplete()
             assertThat(
                 "Collection should not be open",
-                !CollectionHelper.instance.colIsOpenUnsafe()
+                !CollectionManager.isOpenUnsafe()
             )
             assertThat(
                 "An error dialog should be displayed",
@@ -714,7 +714,7 @@ class DeckPickerTest : RobolectricTest() {
         // ensure collection not loaded yet
         assertThat(
             "collection should not be loaded",
-            CollectionHelper.instance.colIsOpenUnsafe(),
+            CollectionManager.isOpenUnsafe(),
             equalTo(false)
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -140,7 +140,7 @@ open class RobolectricTest : AndroidTest {
 
         try {
             if (CollectionHelper.instance.colIsOpenUnsafe()) {
-                CollectionHelper.instance.getColUnsafe(targetContext)!!.debugEnsureNoOpenPointers()
+                CollectionManager.getColUnsafe().debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
             CollectionHelper.instance.closeCollection("RobolectricTest: End")
@@ -299,7 +299,7 @@ open class RobolectricTest : AndroidTest {
      * we don't get two equal time. */
     override val col: Collection
         get() = try {
-            CollectionHelper.instance.getColUnsafe(targetContext)!!
+            CollectionManager.getColUnsafe()
         } catch (e: UnsatisfiedLinkError) {
             throw RuntimeException("Failed to load collection. Did you call super.setUp()?", e)
         }
@@ -310,10 +310,7 @@ open class RobolectricTest : AndroidTest {
     /** Call this method in your test if you to test behavior with a null collection  */
     protected fun enableNullCollection() {
         CollectionManager.closeCollectionBlocking()
-        CollectionHelper.setInstanceForTesting(object : CollectionHelper() {
-            @Synchronized
-            override fun getColUnsafe(context: Context?): Collection? = null
-        })
+        CollectionManager.setColForTests(null)
         CollectionManager.emulateOpenFailure = true
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -139,7 +139,7 @@ open class RobolectricTest : AndroidTest {
         controllersForCleanup.clear()
 
         try {
-            if (CollectionHelper.instance.colIsOpenUnsafe()) {
+            if (CollectionManager.isOpenUnsafe()) {
                 CollectionManager.getColUnsafe().debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -317,7 +317,6 @@ open class RobolectricTest : AndroidTest {
 
     /** Restore regular collection behavior  */
     protected fun disableNullCollection() {
-        CollectionHelper.setInstanceForTesting(CollectionHelper())
         CollectionManager.emulateOpenFailure = false
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -143,7 +143,8 @@ open class RobolectricTest : AndroidTest {
                 CollectionManager.getColUnsafe().debugEnsureNoOpenPointers()
             }
             // If you don't tear down the database you'll get unexpected IllegalStateExceptions related to connections
-            CollectionHelper.instance.closeCollection("RobolectricTest: End")
+            Timber.i("closeCollection: %s", "RobolectricTest: End")
+            CollectionManager.closeCollectionBlocking()
         } catch (ex: BackendException) {
             if ("CollectionNotOpen" == ex.message) {
                 Timber.w(ex, "Collection was already disposed - may have been a problem")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -89,7 +89,7 @@ open class RobolectricTest : AndroidTest {
         ChangeManager.clearSubscribers()
 
         // resolved issues with the collection being reused if useInMemoryDatabase is false
-        CollectionHelper.instance.setColForTests(null)
+        CollectionManager.setColForTests(null)
 
         maybeSetupBackend()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
@@ -139,7 +139,7 @@ class MigrateEssentialFilesTest : RobolectricTest() {
     @Test
     fun exception_thrown_if_database_corrupt() = runTest {
         checkCollectionAfter = false
-        val collectionAnki2Path = CollectionDBCorruption.closeAndCorrupt(targetContext)
+        val collectionAnki2Path = CollectionDBCorruption.closeAndCorrupt()
 
         val collectionSourcePath = File(collectionAnki2Path).parent!!
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFilesTest.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabaseCorruptException
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.servicelayer.DestFolderOverride
@@ -38,7 +37,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.kotlin.*
 import org.robolectric.shadows.ShadowStatFs
 import java.io.File
 import kotlin.io.path.Path
@@ -62,7 +60,7 @@ class MigrateEssentialFilesTest : RobolectricTest() {
     @Before
     override fun setUp() {
         // had interference between two tests
-        CollectionHelper.instance.setColForTests(null)
+        CollectionManager.setColForTests(null)
         super.setUp()
         defaultCollectionSourcePath = getMigrationSourcePath()
         // arbitrary large values

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/ReminderServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/ReminderServiceTest.kt
@@ -19,7 +19,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.RobolectricTest
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.equalTo
@@ -68,7 +68,7 @@ class ReminderServiceTest : RobolectricTest() {
 
         whenever(mockCol.sched).thenThrow(IllegalStateException("Unit test: simulating database exception"))
 
-        CollectionHelper.instance.setColForTests(mockCol)
+        CollectionManager.setColForTests(mockCol)
 
         buildDefaultDeckReminders()
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackendEmulatingOpenConflictTest.kt
@@ -16,7 +16,7 @@
 package com.ichi2.testutils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.RobolectricTest
 import net.ankiweb.rsdroid.BackendException.BackendDbException.*
 import org.junit.After
@@ -43,7 +43,7 @@ class BackendEmulatingOpenConflictTest : RobolectricTest() {
     fun assumeMocksAreValid() {
         assertThrows(
             BackendDbLockedException::class.java,
-            { CollectionHelper.instance.getColUnsafe(super.targetContext) }
+            { CollectionManager.getColUnsafe() }
         )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/CollectionDBCorruption.kt
@@ -16,8 +16,8 @@
 
 package com.ichi2.testutils
 
-import android.content.Context
 import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionManager
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
@@ -47,8 +47,8 @@ object CollectionDBCorruption {
      * Closes and corrupts [CollectionHelper]'s collection
      */
     @NeedsTest("test with a new collection")
-    fun closeAndCorrupt(context: Context): String {
-        val col = CollectionHelper.instance.getColUnsafe(context)!!
+    fun closeAndCorrupt(): String {
+        val col = CollectionManager.getColUnsafe()
         val path = col.path
         col.close()
         corrupt(path)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.testutils.rules
 
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.libanki.Collection
 import org.junit.rules.TestRule
@@ -54,7 +53,6 @@ class MockitoCollectionRule : TestRule {
     private fun removeCollectionMock() {
         Timber.v("removing collection mock")
         CollectionManager.setColForTests(null)
-        CollectionHelper.setInstanceForTesting(CollectionHelper())
     }
 
     private fun mockCollection() {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/rules/MockitoCollectionRule.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.testutils.rules
 
-import android.content.Context
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
 import com.ichi2.libanki.Collection
@@ -61,8 +60,5 @@ class MockitoCollectionRule : TestRule {
     private fun mockCollection() {
         Timber.v("mocking collection")
         CollectionManager.setColForTests(col)
-        CollectionHelper.setInstanceForTesting(object : CollectionHelper() {
-            override fun getColUnsafe(context: Context?) = col
-        })
     }
 }


### PR DESCRIPTION
The commits should be simple. Most of the diff is due to alignment after converting `CollectionHelper` into an `object`.

I didn't plan to do this refactor, nor I actually need it. I was just trying to debug something then ended up cleaning all of `CollectionHelper`

## Approach

In the commits

## How Has This Been Tested?

CI + With a corrupt collection by renaming any file to `collection.anki2` in an Android 34 emulator: 

[Screen_recording_20240328_134350.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/4900cd2b-feb6-407b-a98f-dd514a3dc319)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
