### PR TITLE
fix: DeckOptions on API 23

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -83,14 +83,30 @@ open class PageWebViewClient : WebViewClient() {
         }
     }
 
+    @Suppress("DEPRECATION") // still needed for API 23
+    override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
+        if (view == null || url == null) return super.shouldOverrideUrlLoading(view, url)
+        if (handleUrl(view, url)) {
+            return true
+        }
+        return super.shouldOverrideUrlLoading(view, url)
+    }
+
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
         if (view == null || request == null) return super.shouldOverrideUrlLoading(view, request)
-        if (request.url.toString() == "page-fully-loaded:") {
+        if (handleUrl(view, request.url.toString())) {
+            return true
+        }
+        return super.shouldOverrideUrlLoading(view, request)
+    }
+
+    private fun handleUrl(view: WebView, url: String): Boolean {
+        if (url == "page-fully-loaded:") {
             Timber.v("displaying WebView after '$promiseToWaitFor' executed")
             view.isVisible = true
             return true
         }
-        return super.shouldOverrideUrlLoading(view, request)
+        return false
     }
 }
 


### PR DESCRIPTION
URL was changed to `page-fully-loaded:` which caused a failure

Massive thank you to our backers for this one!

## Fixes
* Fixes #15790

## Approach
* Handle `page-fully-loaded:`

## How Has This Been Tested?
* Huawei P8 Lite - Android 6.0 (ALE-L21)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
