### PR TITLE
Fix "Strings" label case in label workflow

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,7 +12,6 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
     - uses: actions/github-script@v7
       with:
         script: |
@@ -66,7 +65,7 @@ jobs:
                 }
 
                 // add post merge comments for 'strings' labeled PR
-                if (label.name == "strings") {
+                if (label.name == "Strings") {
                   addPostMergeComments();
                 }
             }
@@ -102,7 +101,7 @@ jobs:
                 "ankidroid-titles",
             ];
 
-            let stringsLabel = "strings";
+            let stringsLabel = "Strings";
 
             async function addLabel(labels) {
               await github.rest.issues.addLabels({


### PR DESCRIPTION
## Purpose / Description

A small fix to use the proper case for the _Strings_ label in the associated workflow file(where it's compared with what comes from the API). 

## How Has This Been Tested?

Not tested, it doesn't work now so it can't get any worse.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
