### PR TITLE
test: tablet layout is based on xlarge not sw600dp values overlay

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -28,7 +28,7 @@ import androidx.test.espresso.matcher.ViewMatchers.*
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import com.ichi2.anki.TestUtils.activityInstance
 import com.ichi2.anki.TestUtils.clickChildViewWithId
-import com.ichi2.anki.TestUtils.isScreenSw600dp
+import com.ichi2.anki.TestUtils.isTablet
 import com.ichi2.anki.TestUtils.wasBuiltOnCI
 import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
@@ -58,7 +58,7 @@ class DeckPickerTest : InstrumentedTest() {
         assumeFalse("Test flaky in CI - #9282, skipping", wasBuiltOnCI())
 
         // For mobile. If it is not a mobile, then test will be ignored.
-        assumeTrue(!isScreenSw600dp)
+        assumeTrue(!isTablet)
         val testString = System.currentTimeMillis().toString() + ""
         createDeckWithCard(testString)
 
@@ -88,7 +88,7 @@ class DeckPickerTest : InstrumentedTest() {
         assumeFalse("Test flaky in CI - #9282, skipping", wasBuiltOnCI())
 
         // For tablet. If it is not a tablet, then test will be ignored.
-        assumeTrue(isScreenSw600dp)
+        assumeTrue(isTablet)
         val testString = System.currentTimeMillis().toString() + ""
         createDeckWithCard(testString)
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/TestUtils.kt
@@ -17,13 +17,13 @@
 package com.ichi2.anki
 
 import android.app.Activity
+import android.content.res.Configuration
 import android.view.View
 import androidx.test.espresso.UiController
 import androidx.test.espresso.ViewAction
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.runner.lifecycle.ActivityLifecycleMonitorRegistry
 import androidx.test.runner.lifecycle.Stage
-import com.ichi2.anki.test.R
 import org.hamcrest.Matcher
 
 object TestUtils {
@@ -48,10 +48,15 @@ object TestUtils {
         }
 
     /**
-     * Returns true if device is a tablet
+     * Returns true if device is a tablet - tablet layout is in 'xlarge' values overlay,
+     * so test for that screen layout in our resources configuration
      */
-    val isScreenSw600dp: Boolean
-        get() = activityInstance!!.resources.getBoolean(R.bool.is_big_screen)
+    val isTablet: Boolean
+        get() = (
+            activityInstance!!.resources.configuration.screenLayout and
+                Configuration.SCREENLAYOUT_SIZE_MASK
+            ) ==
+            Configuration.SCREENLAYOUT_SIZE_XLARGE
 
     /**
      * Click on a view using its ID inside a RecyclerView item

--- a/AnkiDroid/src/androidTest/res/values-sw600dp/bools.xml
+++ b/AnkiDroid/src/androidTest/res/values-sw600dp/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-	<bool name="is_big_screen">true</bool>
-</resources>

--- a/AnkiDroid/src/androidTest/res/values/bools.xml
+++ b/AnkiDroid/src/androidTest/res/values/bools.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-	<bool name="is_big_screen">false</bool>
-</resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

this tablet-detection test started failing on newer/larger emulators that I'm probing locally, and it appears the root cause is that our tablet layout is triggered by the xlarge resource configuration but the test utility was based sw600dp resource configuration overlay

The lack of fidelity resulted in test failures locally

## Fixes

This is just a tangential yak-shave as I'm trying to figure out why gradle internally deadlocks on the dependency-updates branch failing the build so that I can get the gradle plugin update in so that @lukstbit doesn't have the annoying error message about needing to update 😆 

## Approach

1- Figure out how we actually determine whether to display tablet layout or not (appears to be values-xlarge ?)
2- Determine how test utility is determining tablet layout (bools in values vs values-sw600dp in androidTest/res ?)
3- Realize that those things have substantial overlap but are not the same
4- Get rid of the androidTest/res values-sw600dp bools and instead use detection of xlarge layout in test utility for tablet detection

## How Has This Been Tested?

Locally on an API34 emulator using the Pixel7 template which is apparently larger than most people use, but is not a tablet

it failed this test before because the test utility thought it would be a tablet with tablet layout, but the app was rendering non-tablet

Now it is correctly skipping the tablet layout tests

## Learning (optional, can help others)
I learned how AnkiDroid is doing it's layout switch 🤷 

Some inspiration from here https://stackoverflow.com/a/51082295/9910298

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
