### PR TITLE
build: update jitpack JDK used for build to 21

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -50,7 +50,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "21"
+          java-version: "21"  # also change jitpack.yml
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: "21"
+          java-version: "21"  # also change jitpack.yml
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v3

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,9 +1,14 @@
 # We want control over the SDK used to build since we need newer JDKs
+# Use the latest LTS supported by temurin with version format xx.yy.zz-tem (ignore sub-version)
+# You may find versions e.g. for JDK21 like so https://adoptium.net/temurin/archive/?version=21
+# You may verify that a JDK is installed by looking at the "sdk list java" output from, for example:
+# https://jitpack.io/com/github/ankidroid/Anki-Android/v2.18alpha7/build.log (just use a recent tag,
+# if it has not built yet you will have to wait for it to build then on refresh the build log should exist)
 before_install:
     - sdk update
     - sdk list java
-    - sdk install java 17.0.9-tem
-    - sdk use java 17.0.9-tem
+    - sdk install java 21.0.2-tem
+    - sdk use java 21.0.2-tem
 
 # We can do the absolute minimum to build the API module, no need to build AnkiDroid module
 install:


### PR DESCRIPTION
## Purpose / Description

When I bumped the e2e and unit test github runners to 21 I did not also bump the jitpack build, but I believe it is best to have them all using the same build toolchain

## Approach
I checked to make sure 21.0.2-tem existed, and I added a bunch of documentation on how exactly to figure out what string you use to specify a JDK and how to verify things etc

## How Has This Been Tested?

It's not easy to test these, you need a commit to exist and then you have to verify the commit

Now that the commit exists, I can do that, the URL will look like:

https://jitpack.io/com/github/mikehardy/Anki-Android/e907eb7e3ec365e52557ae896d63a3c141f50530/build.log

(that is: `https://jitpack.io/com/github/<USERNAME>/Anki-Android/<COMMIT SHA>/build.log`)

...and we have to wait to make sure it built - which it did, it worked ✅ 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
