### PR TITLE
Fix: remove step size from slider pref

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -62,6 +62,5 @@
         android:title="@string/pref_show_answer_long_press"
         android:valueFrom="0"
         android:valueTo="2000"
-        android:stepSize="100"
         app:displayFormat="@string/pref_milliseconds"/>
 </PreferenceScreen>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Step size of 100 causes issue for existing user using the feature as they might not have the current value set to multiple of 100
hence it will be best to remove the step size
## Fixes
* Fixes #16028


## How Has This Been Tested?
Tested on Google Emulator API 34

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
