### PR TITLE
feat: propose renaming decks to '01' to reorder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.app.Activity
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionHelper
@@ -103,6 +104,14 @@ class CreateDeckDialog(
             }
             dialog.getInputTextLayout().error = null
             dialog.positiveButton.isEnabled = true
+
+            // Users expect the ordering [1, 2, 10], but get [1, 10, 2]
+            // To fix: they need [01, 02, 10]. Show a hint to help them
+            dialog.getInputTextLayout().helperText = if (text.containsNumberLargerThanNine()) {
+                context.getString(R.string.create_deck_numeric_hint)
+            } else {
+                null
+            }
         }
         shownDialog = dialog
         return dialog
@@ -221,3 +230,6 @@ class CreateDeckDialog(
         }
     }
 }
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+fun CharSequence.containsNumberLargerThanNine(): Boolean = Regex("""[1-9]\d+""").find(this) != null

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -261,4 +261,5 @@
 
     <string name="deck_already_exists">Deck already exists</string>
 
+    <string name="create_deck_numeric_hint">If you have deck ordering issues (e.g. ‘10’ appears before ‘2’), replace ‘2’ with ‘02’</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -1,5 +1,6 @@
 /****************************************************************************************
  * Copyright (c) 2021 Akshay Jadhav <jadhavakshay0701@gmail.com>                        *
+ * Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>                      *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -33,7 +34,8 @@ import com.ichi2.utils.positiveButton
 import okhttp3.internal.closeQuietly
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.nullValue
-import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matcher
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -113,6 +115,28 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertionCalled()
             }
             createDeckDialog.renameDeck(deckNewName)
+        }
+    }
+
+    @Test
+    fun `deck ordering hint`() {
+        // The correct way to order a deck is ['01', '02', '10']
+        val expectedText = "If you have deck ordering issues (e.g. ‘10’ appears before ‘2’), replace ‘2’ with ‘02’"
+        testDialog(DeckDialogType.DECK) {
+            fun assertHelperText(reason: String?, matcher: Matcher<in CharSequence?>) =
+                assertThat(reason, getInputTextLayout().helperText, matcher)
+
+            input = "test"
+            assertHelperText("no number suggestion if text-only", nullValue())
+            input = "1. Cheese"
+            assertHelperText("no number suggestion if number is less than 10", nullValue())
+            input = "10. Cheese"
+            assertHelperText(
+                "Number suggestion if number is greater than or equal to 10",
+                equalTo(expectedText)
+            )
+            input = "1. Cheese"
+            assertHelperText("hint is removed if the number is removed", nullValue())
         }
     }
 
@@ -232,5 +256,21 @@ class CreateDeckDialogTest : RobolectricTest() {
     private fun deckTreeName(start: Int, end: Int, prefix: String): String {
         return List(end - start + 1) { "${prefix}${it + start}" }
             .joinToString("::")
+    }
+}
+
+/** Test of [CreateDeckDialog] */
+class CreateDeckDialogNonAndroidTest {
+    @Test
+    fun `number larger than nine detection`() {
+        fun assertLargerThanNine(reason: String?, input: String, result: Boolean) =
+            assertThat(reason, input.containsNumberLargerThanNine(), equalTo(result))
+
+        assertLargerThanNine("empty string", "", false)
+        assertLargerThanNine("text", "deck name", false)
+        assertLargerThanNine("less than ten", "9. - Chemicals", false)
+        assertLargerThanNine("Ten or greater", "10. - Chemicals", true)
+        assertLargerThanNine("Ten or greater", "99. - Chemicals", true)
+        assertLargerThanNine("zero prefix", "09. - Chemicals", false)
     }
 }


### PR DESCRIPTION
A regular complaint is that '10' is between '1' and '2' in the deck list

`['1', '10', '2']`

If a user renames a deck, the ordering is correct:

`['01', '02', '10']`

We should inform the user that this is the solution

## Fixes
* Fixes #16036

## Approach

![Screenshot 2024-04-01 at 18 15 35](https://github.com/ankidroid/Anki-Android/assets/62114487/06de5949-cf6e-45c0-8b03-0886f443d9bd)

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
