### PR TITLE
Fix displayed name of attached file when name contains extra points characters

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/BasicMediaClipFieldController.kt
@@ -146,6 +146,13 @@ class BasicMediaClipFieldController : FieldControllerBase(), IFieldController {
                     )
                     return
                 }
+            } else if (mediaClipFullNameParts.size > 2) {
+                // there's at least one extra point in the filename besides the point delimiter for extension
+                val lastPointIndex = mediaClipFullName.lastIndexOf(".")
+                mediaClipFullNameParts = arrayOf(
+                    mediaClipFullName.substring(0 until lastPointIndex),
+                    mediaClipFullName.substring(lastPointIndex + 1)
+                )
             }
         }
 


### PR DESCRIPTION
## Purpose / Description

The previous code was blindly splitting after "." which meant that a filename containing extra "." was displayed just as the before and after parts of the first "." char encountered(discarding everything else).

The new code will consider the last "."  encountered of the filename( which should be the "." delimiter for the extension) and split on that if the filename contains extra "." .

## Fixes
* Fixes #16045

## How Has This Been Tested?

Manually tested the code with normal and faulty filenames.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
