### PR TITLE
Fix crash with custom study(with preview cards) when deleting parent deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -689,6 +689,8 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, Toolbar.OnMen
     }
 
     override fun opExecuted(changes: OpChanges, handler: Any?) {
-        refreshInterface(true)
+        if (activity != null) {
+            refreshInterface(true)
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description

Deleting the deck was triggering a _ChangeManager.opExecuted_ call for _StudyOptionsFragment_ which crashed as it wasn't attached to the activity anymore.

## Fixes
* Fixes #16042

## How Has This Been Tested?

Manually tested the bug scenario.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
