### PR TITLE
lint: fix typos - usernames

### DIFF
--- a/.idea/dictionaries/usernames.xml
+++ b/.idea/dictionaries/usernames.xml
@@ -2,6 +2,9 @@
   <dictionary name="usernames">
     <words>
       <w>Abdalla</w>
+      <w>Abhiram</w>
+      <w>Ahnaf</w>
+      <w>Akshay</w>
       <w>Akshit</w>
       <w>Almas</w>
       <w>Azevedo</w>
@@ -18,6 +21,7 @@
       <w>Dwivedi</w>
       <w>Follestad</w>
       <w>Freidle</w>
+      <w>Garbus</w>
       <w>Goel</w>
       <w>Gruber</w>
       <w>Guelman</w>
@@ -26,6 +30,8 @@
       <w>Jolta</w>
       <w>Kael</w>
       <w>Kistner</w>
+      <w>Kshitij</w>
+      <w>Kushwaha</w>
       <w>Lerda</w>
       <w>Lokegaonkar</w>
       <w>Madar</w>
@@ -35,6 +41,7 @@
       <w>Nagold</w>
       <w>Oakkitten</w>
       <w>Oltmanns</w>
+      <w>Patil</w>
       <w>Piyush</w>
       <w>Prateek</w>
       <w>Prehn</w>
@@ -64,8 +71,10 @@
       <w>Weitkemper</w>
       <w>Woitaschek</w>
       <w>Yadav</w>
+      <w>Zaur</w>
       <w>bresan</w>
       <w>joshakaw</w>
+      <w>krmanik</w>
       <w>lukstbit</w>
       <w>mikunimaru</w>
       <w>msync</w>


### PR DESCRIPTION
Noticed we'd missed off Akshay when doing a PR, then roughly audited the list

Search:

```
Copyright \(c\) \d\d2\d (?!(David|Brayan|Shridhar|Mike|Mark|Akshay|Norbert|Timothy|Ankitects|Andrew|Nicola|Nicolas|Mani|Ashish|Tushar|Kostas|mikunimaru|Oakkitten|Shai|Brian Da|Akshit|Divyansh|Arthur|Paul|Tim|Edu|Dorrin|Tarek|The|Square|Anish|Vaibhavi|Kael|lukstbit|krmanik|Nicolai|Mrudul))
```