### PR TITLE
fix autosync interval

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -150,6 +150,9 @@ fun DeckPicker.handleNewSync(
             throw exc
         }
         withCol { notetypes._clear_cache() }
+        sharedPrefs().edit {
+            putLong("lastSyncTime", TimeManager.time.intTimeMS())
+        }
         refreshState()
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Sync time is never set so autosync always run when I open the app, or come back to the deck picker

## Fixes
* Fixes the interval bug

## Approach
I set the interval after syncing

## How Has This Been Tested?

I reopened the app before 10 minutes to see if autosync would happen

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
