### PR TITLE
build(ci): re-enable gradle build cache

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -67,9 +67,6 @@ jobs:
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-home-cache-cleanup: true
-          # All runners have cache pollution issues, disable all caches
-          # https://github.com/gradle/actions/issues/47
-          cache-disabled: true
 
       - name: Clear Caches Optionally
         if: "${{ github.event.inputs.clearCaches != '' }}"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

We disabled the gradle cache due to corruption bugs:

* https://github.com/ankidroid/Anki-Android/commit/6768519cbbfab9be604ccf1f5393ed529364fd22
* https://github.com/ankidroid/Anki-Android/commit/5ad215734574f0d4e2e2790130d8bd54e7be033d


The underlying bug was closed and we're on Gradle 8.7:

----

> I'm going to close this issue now that Gradle 8.7 has been released with a fix.
> Please let us know if you continue to experience this problem with Gradle 8.7.

https://redirect.github.com/gradle/actions/issues/47#issuecomment-2030308363

`gradle-wrapper.properties` shows `distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip`

## Approach
Revert the above two commits

## How Has This Been Tested?
YOLO (CI only)

## Learning (optional, can help others)
* See discussion on https://github.com/gradle/actions/issues/47#issuecomment-2030308363

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
