### PR TITLE
fix: play web audios

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundPlayer.kt
@@ -404,6 +404,10 @@ fun AbstractFlashcardViewer.createSoundErrorListener(): SoundErrorListener {
         }
 
         override fun onError(uri: Uri): SoundErrorBehavior {
+            if (uri.scheme != "file") {
+                return CONTINUE_AUDIO
+            }
+
             try {
                 val file = uri.toFile()
                 // There is a multitude of transient issues with the MediaPlayer. (1, -1001) for example

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -74,7 +74,12 @@ class SoundTagPlayer(private val soundUriBase: String) {
                     continuation.resume(Unit)
                 }
             }
-            val soundUri = Uri.parse(soundUriBase + Uri.encode(tag.filename))
+            val tagUri = Uri.parse(tag.filename)
+            val soundUri = if (tagUri.scheme != null) {
+                tagUri
+            } else {
+                Uri.parse(soundUriBase + Uri.encode(tag.filename))
+            }
             setAudioAttributes(music)
             setOnErrorListener { mp, what, extra ->
                 Timber.w("Media error %d", what)
@@ -89,7 +94,7 @@ class SoundTagPlayer(private val soundUriBase: String) {
             }
 
             try {
-                awaitSetDataSource(soundUri)
+                awaitSetDataSource(soundUri.toString())
             } catch (e: Exception) {
                 continuation.ensureActive()
                 val continuationBehavior = soundErrorListener?.onError(soundUri) ?: SoundErrorBehavior.CONTINUE_AUDIO
@@ -149,8 +154,8 @@ class SoundTagPlayer(private val soundUriBase: String) {
      * @throws java.io.FileNotFoundException file is not found
      * @throws java.io.IOException: Prepare failed.: status=0x1
      */
-    private fun MediaPlayer.awaitSetDataSource(uri: Uri) {
-        setDataSource(uri.path)
+    private fun MediaPlayer.awaitSetDataSource(uri: String) {
+        setDataSource(uri)
         prepare()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -130,6 +130,10 @@ abstract class CardViewerViewModel(
     private fun createSoundErrorListener(): SoundErrorListener {
         return object : SoundErrorListener {
             override fun onError(uri: Uri): SoundErrorBehavior {
+                if (uri.scheme != "file") {
+                    return SoundErrorBehavior.CONTINUE_AUDIO
+                }
+
                 val file = uri.toFile()
                 // There is a multitude of transient issues with the MediaPlayer.
                 // Retrying fixes most of these


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
web audios couldn't be played with sound:

## Fixes
* Fixes #16041

## Approach
I passed the whole url if it already had a scheme

## How Has This Been Tested?

I used the provided deck in #16041 and it worked

## Learning (optional, can help others)

setDataSource accepts uri strings directly

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
