### PR TITLE
autoclose permission screen after all files permission (i.e. only in `full` builds)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
@@ -38,7 +38,11 @@ class Full30and31PermissionsFragment : PermissionsFragment(R.layout.permissions_
 
     private val accessAllFilesLauncher = registerForActivityResult(
         ActivityResultContracts.StartActivityForResult()
-    ) {}
+    ) {
+        if (hasAllPermissions()) {
+            requireActivity().finish()
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsFragment.kt
@@ -41,11 +41,13 @@ abstract class PermissionsFragment(@LayoutRes contentLayoutId: Int) : Fragment(c
     val permissionItems: List<PermissionItem>
         by lazy { view?.allViews?.filterIsInstance<PermissionItem>()?.toList() ?: emptyList() }
 
+    protected fun hasAllPermissions() = permissionItems.all { it.isGranted }
+
     override fun onResume() {
         super.onResume()
         permissionItems.forEach { it.updateSwitchCheckedStatus() }
         (activity as? PermissionsActivity)?.setContinueButtonEnabled(
-            permissionItems.all { it.isGranted }
+            hasAllPermissions()
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
@@ -36,7 +36,14 @@ import com.ichi2.utils.Permissions.canManageExternalStorage
  */
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 class TiramisuPermissionsFragment : PermissionsFragment(R.layout.permissions_tiramisu) {
-    private val accessAllFilesLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {}
+
+    private val accessAllFilesLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        if (hasAllPermissions()) {
+            requireActivity().finish()
+        }
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

I noticed that I had to do an extra tap after giving the all files permission, so I thought to autoclose the permissions' screen to continue into the app

## Fixes

I thought to directly do the PR instead of doing an issue

## Approach

I finish the activity if all permissions were granted

## How Has This Been Tested?

I tested in the emulator by giving the all files permissions after it was asked

## Learning (optional, can help others)

Nothing

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
