### PR TITLE
chore: remove collection.log

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -59,10 +59,6 @@ object CollectionManager {
     @VisibleForTesting
     var emulateOpenFailure = false
 
-    /** A speed optimisation to remove the logging function of the collection */
-    @VisibleForTesting
-    var disableLogFile: Boolean = false
-
     /**
      * Execute the provided block on a serial background queue, to ensure
      * concurrent access does not happen.
@@ -231,7 +227,7 @@ object CollectionManager {
         if (collection == null || collection!!.dbClosed) {
             val path = collectionPathInValidFolder()
             collection =
-                collection(path, log = !disableLogFile, backend)
+                collection(path, backend)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -392,7 +392,7 @@ class CardContentProvider : ContentProvider() {
         }
         val col = CollectionHelper.instance.getColUnsafe(context!!)
             ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
-        col.log(getLogMessage("update", uri))
+        Timber.d(getLogMessage("update", uri))
 
         // Find out what data the user is requesting
         val match = sUriMatcher.match(uri)
@@ -636,7 +636,7 @@ class CardContentProvider : ContentProvider() {
         }
         val col = CollectionHelper.instance.getColUnsafe(context!!)
             ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
-        col.log(getLogMessage("delete", uri))
+        Timber.d(getLogMessage("delete", uri))
         return when (sUriMatcher.match(uri)) {
             NOTES_ID -> {
                 col.removeNotes(nids = listOf(uri.pathSegments[1].toLong()))
@@ -696,7 +696,7 @@ class CardContentProvider : ContentProvider() {
         if (col.decks.isFiltered(deckId)) {
             throw IllegalArgumentException("A filtered deck cannot be specified as the deck in bulkInsertNotes")
         }
-        col.log(String.format(Locale.US, "bulkInsertNotes: %d items.\n%s", valuesArr.size, getLogMessage("bulkInsert", null)))
+        Timber.d("bulkInsertNotes: %d items.\n%s", valuesArr.size, getLogMessage("bulkInsert", null))
 
         var result = 0
         for (i in valuesArr.indices) {
@@ -742,7 +742,7 @@ class CardContentProvider : ContentProvider() {
         }
         val col = CollectionHelper.instance.getColUnsafe(context!!)
             ?: throw IllegalStateException(COL_NULL_ERROR_MSG)
-        col.log(getLogMessage("insert", uri))
+        Timber.d(getLogMessage("insert", uri))
 
         // Find out what data the user is requesting
         return when (sUriMatcher.match(uri)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,7 +40,6 @@ import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.KotlinCleanup
-import com.ichi2.utils.VersionUtils
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
@@ -60,7 +59,6 @@ open class Collection(
      *  The path to the collection.anki2 database. Must be unicode and openable with [File].
      */
     val path: String,
-    private var debugLog: Boolean, // Not in libAnki.
     /**
      * Outside of libanki, you should not access the backend directly for collection operations.
      * Operations that work on a closed collection (eg importing), or do not require a collection
@@ -131,13 +129,10 @@ open class Collection(
     var ls: Long = 0
     // END: SQL table columns
 
-    private var logHnd: PrintWriter? = null
-
     init {
         media = Media(this)
         tags = Tags(this)
         val created = reopen()
-        log(path, VersionUtils.pkgVersionName)
         startReps = 0
         startTime = 0
         _loadScheduler()
@@ -193,7 +188,6 @@ open class Collection(
                 backend.closeCollection(downgrade)
             }
             dbInternal = null
-            _closeLog()
             Timber.i("Collection closed")
         }
     }
@@ -205,7 +199,6 @@ open class Collection(
             val (db_, created) = Storage.openDB(path, backend, afterFullSync)
             dbInternal = db_
             load()
-            _openLog()
             if (afterFullSync) {
                 _loadScheduler()
             }
@@ -568,62 +561,6 @@ open class Collection(
             }
         }
         return true
-    }
-
-    fun log(vararg objects: Any?) {
-        if (!debugLog) return
-
-        val unixTime = TimeManager.time.intTime()
-
-        val outerTraceElement = Thread.currentThread().stackTrace[3]
-        val fileName = outerTraceElement.fileName
-        val methodName = outerTraceElement.methodName
-
-        val objectsString = objects
-            .map { if (it is LongArray) it.contentToString() else it }
-            .joinToString(", ")
-
-        writeLog("[$unixTime] $fileName:$methodName() $objectsString")
-    }
-
-    private fun writeLog(s: String) {
-        logHnd?.let {
-            try {
-                it.println(s)
-            } catch (e: Exception) {
-                Timber.w(e, "Failed to write to collection log")
-            }
-        }
-        Timber.d(s)
-    }
-
-    private fun _openLog() {
-        if (!debugLog) {
-            return
-        }
-        Timber.i("Opening Collection Log")
-        try {
-            val lpath = File(path.replaceFirst("\\.anki2$".toRegex(), ".log"))
-            if (lpath.exists() && lpath.length() > 10 * 1024 * 1024) {
-                val lpath2 = File("$lpath.old")
-                if (lpath2.exists()) {
-                    lpath2.delete()
-                }
-                lpath.renameTo(lpath2)
-            }
-            logHnd = PrintWriter(BufferedWriter(FileWriter(lpath, true)), true)
-        } catch (e: IOException) {
-            // turn off logging if we can't open the log file
-            Timber.e("Failed to open collection.log file - disabling logging")
-            debugLog = false
-        }
-    }
-
-    private fun _closeLog() {
-        if (!debugLog) return
-        Timber.i("Closing Collection Log")
-        logHnd?.close()
-        logHnd = null
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
@@ -34,11 +34,10 @@ object Storage {
      * */
     fun collection(
         path: String,
-        log: Boolean = false,
         backend: Backend? = null
     ): Collection {
         val backend2 = backend ?: BackendFactory.getBackend()
-        return Collection(path, log, backend2)
+        return Collection(path, backend2)
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -74,8 +74,6 @@ open class RobolectricTest : AndroidTest {
         return true
     }
 
-    open val disableCollectionLogFile = true
-
     @get:Rule
     val taskScheduler = TaskSchedulerRule()
 
@@ -95,8 +93,6 @@ open class RobolectricTest : AndroidTest {
 
         maybeSetupBackend()
 
-        // disable the collection log file for a speed boost & reduce log output
-        CollectionManager.disableLogFile = disableCollectionLogFile
         // See the Android logging (from Timber)
         ShadowLog.stream = System.out
             // Filters for non-Timber sources. Prefer filtering in RobolectricDebugTree if possible

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicelayer/scopedstorage/ScopedStorageMigrationIntegrationTest.kt
@@ -50,9 +50,6 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
 
     override fun useInMemoryDatabase() = false
 
-    // we want collection.log to be tested
-    override val disableCollectionLogFile: Boolean = false
-
     @After
     override fun tearDown() {
         try {
@@ -86,7 +83,7 @@ class ScopedStorageMigrationIntegrationTest : RobolectricTest() {
         // close collection again so -wal doesn't end up in the list
         CollectionManager.ensureClosed()
 
-        // 5 files remain: [collection.log, collection.media.ad.db2, collection.anki2-journal, collection.anki2, .nomedia]
+        // 2 files remain: [collection.anki2, .nomedia]
         underTest.integrationAssertOnlyIntendedFilesRemain()
         assertThat(underTest.migratedFilesCount, equalTo(underTest.filesToMigrateCount))
 
@@ -246,7 +243,7 @@ private constructor(source: Directory, destination: Directory, val filesToMigrat
         if (sourceFilesCount == INTEGRATION_INTENDED_REMAINING_FILE_COUNT) {
             return
         }
-        fail("expected directory with 5 files, got: " + source.directory.listFiles()!!.map { it.name })
+        fail("expected directory with $INTEGRATION_INTENDED_REMAINING_FILE_COUNT files, got: " + source.directory.listFiles()!!.map { it.name })
     }
 
     private val conflictDirectory = File(source.directory, "conflict")
@@ -276,7 +273,8 @@ private constructor(source: Directory, destination: Directory, val filesToMigrat
 
     companion object {
         // media DB created on demand, and no -journal file in new backend
-        val INTEGRATION_INTENDED_REMAINING_FILE_COUNT: Int = 3
+        // collection.log no longer exists
+        val INTEGRATION_INTENDED_REMAINING_FILE_COUNT: Int = 2
 
         /**
          * A MigrateUserDataTest from inputSource to inputDestination (or transient directories if not provided)


### PR DESCRIPTION
Removed in Anki Desktop

> If you wanted to, you could remove collection logging completely - it was removed from pylib a while back.

dae

Replaced log calls with Timber.d

Removed methods/variables:

**Collection**
* debugLog
* logHnd
* fun log
* fun writeLog
* fun _openLog
* fun _closeLog

**CollectionManager**
* disableLogFile

**RobolectricTest**
* disableCollectionLogFile

**Removed Call**
`log(path, VersionUtils.pkgVersionName)`


## Fixes
* Fixes #14777

## How Has This Been Tested?
Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
