### PR TITLE
build(deps): integrate new backend publish coordinates

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidxUiautomator = "2.3.0"
 androidxViewpager2 = "1.0.0"
 androidxWebkit = "1.10.0"
 annotations = "24.1.0"
-ankidroidBackend = '0.1.34-anki23.12.1'
+ankidroidBackend = '0.1.35-anki23.12.1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"
@@ -104,8 +104,8 @@ materialDialogs-input = { module = "com.afollestad.material-dialogs:input", vers
 desugar-jdk-libs-nio = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "desugar-jdk-libs-nio" }
 drakeet-drawer = { module = "com.drakeet.drawer:drawer", version.ref = "drawer" }
 mikehardy-google-analytics-java7 = { module = "net.mikehardy:google-analytics-java7", version.ref = "mikehardyGoogleAnalyticsJava7" }
-ankiBackend-backend = { module = "io.github.david-allison-1:anki-android-backend", version.ref = "ankidroidBackend" }
-ankiBackend-testing = { module = "io.github.david-allison-1:anki-android-backend-testing", version.ref = "ankidroidBackend" }
+ankiBackend-backend = { module = "io.github.david-allison:anki-android-backend", version.ref = "ankidroidBackend" }
+ankiBackend-testing = { module = "io.github.david-allison:anki-android-backend-testing", version.ref = "ankidroidBackend" }
 java-semver = { module = "com.github.zafarkhaja:java-semver", version.ref = "javaSemver" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Please DO NOT MERGE as is. This is starting as a simple test of integrating the version of Anki-Android-Backend that was apparently just published successfully on new maven central repository coordinates

It works locally for me and the first step is just to make sure it works here in CI as well

The second step will be to integrate anki upstream release 24.03 and this PR will be reborn with that release when it's ready. Until then it's just a basic proof the new coordinates work, and is draft

## Approach

Alter dependency to pull the dep from new coordinates, using the newly published version number

## How Has This Been Tested?

`./gradlew jacocoTestReport` locally

## Learning (optional, can help others)
Entropy is inexorable
