### PR TITLE
build(deps): update backend to `io.github.david-allison` (v0.1.35)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - "dependencies"
   ignore:
   # Ignore all Rust backend updates, these are always done as manual pulls
-  - dependency-name: io.github.david-allison-1:anki-android-backend
+  - dependency-name: io.github.david-allison:anki-android-backend
 - package-ecosystem: npm
   directory: "/tools/localization"
   schedule:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ androidxUiautomator = "2.3.0"
 androidxViewpager2 = "1.0.0"
 androidxWebkit = "1.10.0"
 annotations = "24.1.0"
-ankidroidBackend = '0.1.34-anki23.12.1'
+ankidroidBackend = '0.1.35-anki23.12.1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"
@@ -104,8 +104,8 @@ materialDialogs-input = { module = "com.afollestad.material-dialogs:input", vers
 desugar-jdk-libs-nio = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "desugar-jdk-libs-nio" }
 drakeet-drawer = { module = "com.drakeet.drawer:drawer", version.ref = "drawer" }
 mikehardy-google-analytics-java7 = { module = "net.mikehardy:google-analytics-java7", version.ref = "mikehardyGoogleAnalyticsJava7" }
-ankiBackend-backend = { module = "io.github.david-allison-1:anki-android-backend", version.ref = "ankidroidBackend" }
-ankiBackend-testing = { module = "io.github.david-allison-1:anki-android-backend-testing", version.ref = "ankidroidBackend" }
+ankiBackend-backend = { module = "io.github.david-allison:anki-android-backend", version.ref = "ankidroidBackend" }
+ankiBackend-testing = { module = "io.github.david-allison:anki-android-backend-testing", version.ref = "ankidroidBackend" }
 java-semver = { module = "com.github.zafarkhaja:java-semver", version.ref = "javaSemver" }
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }


### PR DESCRIPTION
and bump version to `0.1.35-anki23.12.1`

Updates: dependencies

https://github.com/ankidroid/Anki-Android-Backend/compare/357abc2d08f49b5b9308bd19bb7e844263517833...70674f6a2a455886af2ec04f327387e5ad3088b0

This PR ensures the mechanism is working so we can upgrade to `-anki24.04`

`io.github.david-allison-1` was burned by a security researcher and it was easier to republish

https://repo1.maven.org/maven2/io/github/david-allison/anki-android-backend/0.1.35-anki23.12.1/

See the following for why we changed the `groupId`:

* https://redirect.github.com/ankidroid/Anki-Android-Backend/issues/347
* https://redirect.github.com/ankidroid/Anki-Android-Backend/pull/361
* https://github.com/ankidroid/Anki-Android-Backend/commit/70674f6a2a455886af2ec04f327387e5ad3088b0


## Fixes
* Part of Issue #16064

## How Has This Been Tested?
YOLOing (CI)

## Approach

* search for 'david-allison-1'
   * skipped a `gist`
* bump version number 

## Learning
I have a slight pang of regret for changing my GitHub name

We should have moved on DNS sooner


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
