### PR TITLE
[Cleanup] Fix Android Studio java warnings in anki/servicelayer #13282

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt
@@ -48,11 +48,11 @@ import java.io.File
  *
  * See: [migrateFiles]
  *
- * Preconditions (verified inside [migrateEssentialFiles] and [migrateFiles] - exceptions thrown if not met):
+ * Preconditions (verified inside [MigrateEssentialFiles] and [migrateFiles] - exceptions thrown if not met):
  * * Collection is not corrupt and can be opened
  * * Collection basic check passes [UserActionRequiredException.CheckDatabaseException]
  * * Collection can be closed and locked
- * * User has space to move files [UserActionRequiredException.OutOfSpaceException] (the size of essential files + [SAFETY_MARGIN_BYTES]
+ * * User has space to move files [UserActionRequiredException.OutOfSpaceException] (the size of essential files + [ScopedStorageService.SAFETY_MARGIN_BYTES]
  * * A migration is not currently taking place
  */
 open class MigrateEssentialFiles
@@ -139,7 +139,7 @@ internal constructor(
     /**
      * Copies [file] to [destinationDirectory], retaining the same filename
      */
-    fun copyTopLevelFile(file: File, destinationDirectory: Directory) {
+    private fun copyTopLevelFile(file: File, destinationDirectory: Directory) {
         val destinationPath = File(destinationDirectory.directory, file.name).path
         Timber.i("Migrating essential file: '${file.name}'")
         Timber.d("Copying '$file' to '$destinationPath'")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt
@@ -413,7 +413,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
         var terminatedWith: Exception? = null
             private set
 
-        val retriedDirectories = hashSetOf<File>()
+        private val retriedDirectories = hashSetOf<File>()
 
         val loggedExceptions = mutableListOf<Exception>()
         private var consecutiveExceptionsWithoutProgress = 0
@@ -589,7 +589,7 @@ open class MigrateUserData protected constructor(val source: Directory, val dest
     /** Returns a sequence of the Files or Directories in [source] which are to be migrated */
     private fun getUserDataFiles() = getDirectoryContent().filter { isUserData(it) }
 
-    fun isEssentialFileName(name: String): Boolean {
+    private fun isEssentialFileName(name: String): Boolean {
         return MigrateEssentialFiles.PRIORITY_FILES.flatMap { it.potentialFileNames }.contains(name)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MoveDirectory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MoveDirectory.kt
@@ -50,7 +50,7 @@ data class MoveDirectory(val source: Directory, val destination: File) : Operati
      * Create an empty directory at destination.
      * Return whether it was successful.
      */
-    internal fun createDirectory(context: MigrationContext): Boolean {
+    private fun createDirectory(context: MigrationContext): Boolean {
         Timber.d("creating directory '$destination'")
         createDirectory(destination)
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Get to know the project. Fixed some android studio warnings and weak warnings as per #13282.

## Fixes
AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MigrateEssentialFiles.kt: fixed typos in references to functions and constants.
AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveDirectory.kt: fixed import paths and made a function private.
AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/MoveFileOrDirectory.kt: removed unused import.
AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/scopedstorage/migrateuserdata/MigrateUserData.kt: made relevant functions private.

## Checklist
_Please, go through these checks before submitting the PR._

- [X ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
