### PR TITLE
Scroll save cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -715,11 +715,25 @@ open class CardBrowser :
         if (postAutoScroll) {
             postAutoScroll = false
         }
+
+        val card = viewModel.findCardById(oldCardId)
+        if (card != null) {
+            viewModel.saveScrollState(card.position, oldCardTopOffset)
+        }
     }
 
     override fun onResume() {
         super.onResume()
         selectNavigationItem(R.id.nav_browser)
+
+        val scrollOffset = viewModel.getScrollOffset()
+        val scrollPosition = viewModel.getScrollPosition()
+        val cardPosition = viewModel.findCardById(oldCardId)?.position
+        if (scrollPosition != null && ((cardPosition == null) || cardPosition != scrollPosition)) {
+            oldCardTopOffset = scrollOffset ?: 0
+            autoScrollTo(scrollPosition)
+            shouldRestoreScroll = true
+        }
     }
 
     @KotlinCleanup("Add a few variables to get rid of the !!")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1859,7 +1859,7 @@ open class CardBrowser :
      */
     private fun createViewModel() = ViewModelProvider(
         viewModelStore,
-        CardBrowserViewModel.factory(AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository, cacheDir),
+        CardBrowserViewModel.factory(AnkiDroidApp.instance.sharedPrefsLastDeckIdRepository, cacheDir)(this, null),
         defaultViewModelCreationExtras
     )[CardBrowserViewModel::class.java]
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -91,12 +91,13 @@ class CardBrowserViewModel(
 
     val flowOfFilterQuery = MutableSharedFlow<String>()
 
-    val scrollPosition: Int
-        get() = state["SCROLL_POSITION"] ?: 0
-
-    fun saveScrollPosition(position: Int) {
-        state["SCROLL_POSITION"] = position
+    fun saveScrollState(position: Int, offset: Int) {
+        state[SCROLL_POSITION_KEY] = position
+        state[SCROLL_OFFSET_KEY] = offset
     }
+
+    fun getScrollPosition(): Int? = state[SCROLL_POSITION_KEY]
+    fun getScrollOffset(): Int? = state[SCROLL_OFFSET_KEY]
 
     /**
      * Whether the browser is working in Cards mode or Notes mode.
@@ -558,6 +559,8 @@ class CardBrowserViewModel(
     companion object {
         const val DISPLAY_COLUMN_1_KEY = "cardBrowserColumn1"
         const val DISPLAY_COLUMN_2_KEY = "cardBrowserColumn2"
+        private const val SCROLL_POSITION_KEY = "scroll_position"
+        private const val SCROLL_OFFSET_KEY = "scroll_offset"
         fun factory(lastDeckIdRepository: LastDeckIdRepository, cacheDir: File, preferencesProvider: SharedPreferencesProvider? = null): (SavedStateRegistryOwner, Bundle?) -> AbstractSavedStateViewModelFactory {
             return { owner, defaultArgs ->
                 object : AbstractSavedStateViewModelFactory(owner, defaultArgs) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Persist Selected Cards Scroll state after switching to dark mode

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15441

## Approach
Save selected cards position and scroll offset, restore it **only** if necessary, specifically if user switched to dark mode outisde of cardBrowser

## How Has This Been Tested?
Manually

## Checklist

- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Example



https://github.com/ankidroid/Anki-Android/assets/67738637/dc5f7a68-1f5b-43f9-a59f-f2e5d65fe317


