### PR TITLE
fix: `BACKEND_VERSION` build field

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -46,7 +46,7 @@ android {
         applicationId "com.ichi2.anki"
         buildConfigField "Boolean", "CI", (System.getenv("CI") == "true").toString()
         buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
-        buildConfigField "String", "BACKEND_VERSION", "\"${libs.versions.ankidroidBackend}\""
+        buildConfigField "String", "BACKEND_VERSION", "\"${libs.versions.ankidroidBackend.get()}\""
         buildConfigField "Boolean", "ENABLE_LEAK_CANARY", "false"
         buildConfigField "Boolean", "ALLOW_UNSAFE_MIGRATION", "false"
         buildConfigField "String", "GIT_COMMIT_HASH", "\"${gitCommitHash()}\""


### PR DESCRIPTION
## Fixes
* Exposed by issue #16077
* Fixes #16079

## Approach
Call `.get()`

## How Has This Been Tested?

> [!WARNING]
> I didn't feel a unit test was of value here, as there's no required format of our dependency version

Checked `BuildConfig.java`

previously: `provider(?)`
now: `0.1.36-anki24.04`

![Screenshot 2024-04-03 at 02 36 37](https://github.com/ankidroid/Anki-Android/assets/62114487/7058378e-9b6c-4847-89ab-43e5a18d92dc)



## Learning (optional, can help others)
* Cause: bb0c4a85bf71f442170cf7626a60bd6892c35649
* PR: #15966

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
