### PR TITLE
fix: `getWebviewUserAgent` executes on Main Thread

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -19,10 +19,13 @@ package com.ichi2.anki.servicelayer
 import android.content.Context
 import android.os.Build
 import android.webkit.WebView
+import androidx.annotation.MainThread
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.utils.VersionUtils.pkgVersionName
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.acra.util.Installation
 import timber.log.Timber
 import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
@@ -35,7 +38,7 @@ object DebugInfoService {
      * Note that the `FSRS` parameter can be null if the collection doesn't exist or the config is not set.
      */
     suspend fun getDebugInfo(info: Context): String {
-        val webviewUserAgent = getWebviewUserAgent(info)
+        val webviewUserAgent = withContext(Dispatchers.Main) { getWebviewUserAgent(info) }
         // isFSRSEnabled is null on startup
         val isFSRSEnabled = getFSRSStatus()
         return """
@@ -63,6 +66,7 @@ object DebugInfoService {
         """.trimIndent()
     }
 
+    @MainThread
     private fun getWebviewUserAgent(context: Context): String? {
         try {
             return WebView(context).settings.userAgentString


### PR DESCRIPTION
Cause
* 4506cb4d09376b3da5d4476e5d3cd8a6edc1dfd0
* #15749

`getDebugInfo` was made `suspend`, which meant that `getWebviewUserAgent` was run on `Dispatchers.IO`



## Fixes
* Fixes #16077

## Approach
* `withContext(Dispatcher.Main)`
* `@MainThread`

## How Has This Been Tested?
API 33 Emulator

```diff
Hardware = ranchu

- Webview User Agent = null
+ Webview User Agent = Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64 Build/TE1A.220922.034; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/103.0.5060.71 Mobile Safari/537.36

ACRA UUID = 31776800-d1f6-4bdd-837e-0266faf77e9c
```

## Learning (optional, can help others)
The things which Android should lint but doesn't grows day by day

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
