### PR TITLE
Fix: unnecessary padding in my_account input layout

### DIFF
--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -31,10 +31,9 @@
                     android:id="@+id/ankidroid_logo"
                     android:layout_width="200dp"
                     app:srcCompat="@drawable/ankidroid_logo"
-                    android:layout_marginBottom="0dp"
+                    android:layout_marginBottom="@dimen/input_layout_padding"
                     android:layout_gravity="center"
-                    android:layout_height="200dp"
-                    />
+                    android:layout_height="200dp" />
 
                 <!--<com.ichi2.ui.FixedTextView-->
                 <!--android:id="@+id/sign_in"-->
@@ -55,7 +54,7 @@
                     android:hint="@string/username"
                     app:endIconMode="clear_text"
                     app:errorEnabled="true"
-                    android:layout_margin="@dimen/content_vertical_padding">
+                    android:layout_marginHorizontal="@dimen/input_layout_padding">
 
                     <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/username"
@@ -75,7 +74,7 @@
                     android:hint="@string/password"
                     app:endIconMode="password_toggle"
                     app:errorEnabled="true"
-                    android:layout_margin="@dimen/content_vertical_padding">
+                    android:layout_marginHorizontal="@dimen/input_layout_padding">
 
                     <com.ichi2.ui.TextInputEditField
                         android:id="@+id/password"

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -17,6 +17,7 @@
     <dimen name="dialog_frame_margin">24dp</dimen>
     <dimen name="title_frame_margin_bottom">16dp</dimen>
     <dimen name="content_vertical_padding">8dp</dimen>
+    <dimen name="input_layout_padding">8dp</dimen>
     <dimen name="icon_margin">16dp</dimen>
 
     <!-- Material design typography -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Minor change:
Removing unnecessary padding from the edit field layout, the input layout already have vertical padding and if we observe closely there is too much padding between the fields, also the errors are enabled which provide padding to the fields


## How Has This Been Tested?
Google emulator
Before: 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/0441d7be-b825-407b-80fc-4cbdb5c9bd2d)

After: 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/9584e107-824a-4cb9-9333-dcac90171739)


## Learning (optional, can help others)
I was working on the notification permission and discovered it, I enabled the error option when migrated the layout to M3, I should have removed it that PR only but over looked it at that time


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
