### PR TITLE
Fix #15356: Fixed bug causing system bars to reappear in full screen after navigatin menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -103,7 +103,6 @@ open class Reviewer :
     private val customSchedulingKey = TimeManager.time.intTimeMS().toString()
     private var hasDrawerSwipeConflicts = false
     private var showWhiteboard = true
-    private var prefFullscreenReview = false
     private lateinit var colorPalette: LinearLayout
     private var toggleStylus = false
 
@@ -196,17 +195,6 @@ open class Reviewer :
     override fun onPause() {
         answerTimer.pause()
         super.onPause()
-    }
-
-    override fun onResume() {
-        when {
-            stopTimerOnAnswer && isDisplayingAnswer -> {}
-            else -> launchCatchingTask { answerTimer.resume() }
-        }
-        super.onResume()
-        if (typeAnswer?.autoFocusEditText() == true) {
-            answerField?.focusWithKeyboard()
-        }
     }
 
     override fun onDestroy() {
@@ -1344,6 +1332,32 @@ open class Reviewer :
         }
     }
 
+    override fun onResume() {
+        if (prefFullscreenReview) {
+            val toolbarTemp = findViewById<Toolbar>(R.id.toolbar)
+            val answerButtonsTemp = findViewById<View>(R.id.answer_options_layout)
+            val topbarTemp = findViewById<View>(R.id.top_bar)
+
+            hideViewWithAnimation(toolbarTemp)
+            if (fullscreenMode == FullScreenMode.FULLSCREEN_ALL_GONE) {
+                hideViewWithAnimation(topbarTemp)
+                hideViewWithAnimation(answerButtonsTemp)
+            }
+        }
+
+        when {
+            stopTimerOnAnswer && isDisplayingAnswer -> {}
+            else -> launchCatchingTask { answerTimer.resume() }
+        }
+        super.onResume()
+        if (typeAnswer?.autoFocusEditText() == true) {
+            answerField?.focusWithKeyboard()
+        }
+
+        Timber.d("System UI visibility change.  on resume called")
+        Timber.d("System UI visibility change.  pref full screen : $prefFullscreenReview")
+    }
+
     @Suppress("deprecation") // #9332: UI Visibility -> Insets
     private fun setFullScreen(a: AbstractFlashcardViewer) {
         // Set appropriate flags to enable Sticky Immersive mode.
@@ -1576,6 +1590,9 @@ open class Reviewer :
         private const val REQUEST_AUDIO_PERMISSION = 0
         private const val ANIMATION_DURATION = 200
         private const val TRANSPARENCY = 0.90f
+
+        @JvmStatic
+        var prefFullscreenReview = false
 
         /** Default (500ms) time for action snackbars, such as undo, bury and suspend */
         const val ACTION_SNACKBAR_TIME = 500

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -1,14 +1,16 @@
-<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
-android:layout_width="match_parent"
-android:layout_height="match_parent"
-android:focusableInTouchMode="true"
-xmlns:android="http://schemas.android.com/apk/res/android">
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:focusableInTouchMode="true">
     <!-- Main content that takes up the fullscreen -->
     <RelativeLayout
         android:id="@+id/fullscreen_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <include layout="@layout/reviewer_topbar"
+
+        <include
+            layout="@layout/reviewer_topbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"/>
@@ -16,25 +18,32 @@ xmlns:android="http://schemas.android.com/apk/res/android">
             layout="@layout/reviewer_mic_tool_bar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_below="@id/top_bar" />
-        <include layout="@layout/reviewer_flashcard_fullscreen"
+            android:layout_below="@id/top_bar"/>
+
+        <include
+            layout="@layout/reviewer_flashcard_fullscreen"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@id/mic_tool_bar_layer"/>
+
         <include
             layout="@layout/reviewer_whiteboard_editor"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_centerHorizontal="true"
-            android:layout_above="@+id/bottom_area_layout"/>
-        <include layout="@layout/reviewer_answer_buttons"/>
+            android:layout_above="@+id/bottom_area_layout"
+            android:layout_centerHorizontal="true"/>
+
+        <include
+            layout="@layout/reviewer_answer_buttons"/>
     </RelativeLayout>
     <!-- Controls that are overlaid over the main content when the user interrupts immersive mode -->
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:fitsSystemWindows="true">
-        <include layout="@layout/toolbar"
+
+        <include
+            layout="@layout/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="top"/>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -1,9 +1,8 @@
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:tools="http://schemas.android.com/tools"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:focusableInTouchMode="true"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:focusableInTouchMode="true">
     <!-- AbstractFlashcardViewer pulls layout params from parent, casting it as RelativeLayout -->
     <RelativeLayout
         android:layout_width="match_parent"
@@ -12,12 +11,14 @@
         <include
             layout="@layout/reviewer_mic_tool_bar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"
+            android:visibility="gone"/>
 
         <include
             layout="@layout/reviewer_flashcard_fullscreen_noanswers"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+            android:layout_height="wrap_content"/>
+
         <!-- Controls that are overlaid over the main content when the user interrupts immersive mode -->
         <RelativeLayout
             android:id="@+id/front_frame"
@@ -25,18 +26,22 @@
             android:layout_height="match_parent"
             android:fitsSystemWindows="true">
 
-            <include layout="@layout/toolbar"/>
-            <include layout="@layout/reviewer_topbar"
+            <include layout="@layout/toolbar" android:visibility="gone"/>
+
+            <include
+                layout="@layout/reviewer_topbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_below="@id/toolbar"/>
+                android:layout_below="@id/toolbar" />
+
             <include
                 layout="@layout/reviewer_whiteboard_editor"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_centerHorizontal="true"
-                android:layout_above="@+id/bottom_area_layout"/>
-            <include layout="@layout/reviewer_answer_buttons"/>
+                android:layout_above="@+id/bottom_area_layout"
+                android:layout_centerHorizontal="true" />
+
+            <include layout="@layout/reviewer_answer_buttons" android:visibility="gone" />
 
         </RelativeLayout>
     </RelativeLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This commit addresses the issue where the system bars were reappearing even when the application was in full screen mode, specifically after navigating to the menu and returning to the deck.

## Fixes
* Fixes #15356

## Approach
The onResume() method in Reviewer.kt was modified to preserve the full screen state by adding a Jvm static variable. Additionally, modifications were made to the following XML files:
- reviewer_fullscreen.xml
- reviewer_fullscreen_noanswers.xml

## How Has This Been Tested?
Tested in my personal device connected to the android studio.

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
