### PR TITLE
Match the color of status bar with Statistic toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -41,7 +41,7 @@ class Statistics : PageFragment(R.layout.statistics) {
 
         view.findViewById<AppBarLayout>(R.id.app_bar)
             .addLiftOnScrollListener { _, backgroundColor ->
-                activity?.window!!.statusBarColor = backgroundColor
+                activity?.window?.statusBarColor = backgroundColor
             }
 
         view.findViewById<MaterialToolbar>(R.id.toolbar).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -22,6 +22,7 @@ import android.print.PrintAttributes
 import android.print.PrintManager
 import android.view.View
 import androidx.core.content.ContextCompat.getSystemService
+import com.google.android.material.appbar.AppBarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
@@ -37,6 +38,12 @@ class Statistics : PageFragment(R.layout.statistics) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        view.findViewById<AppBarLayout>(R.id.app_bar)
+            .addLiftOnScrollListener { _, backgroundColor ->
+                activity?.window!!.statusBarColor = backgroundColor
+            }
+
         view.findViewById<MaterialToolbar>(R.id.toolbar).apply {
             inflateMenu(R.menu.statistics)
             menu.findItem(R.id.action_export_stats).title = CollectionManager.TR.statisticsSavePdf()

--- a/AnkiDroid/src/main/res/layout/statistics.xml
+++ b/AnkiDroid/src/main/res/layout/statistics.xml
@@ -18,7 +18,8 @@
             app:layout_constraintTop_toTopOf="parent"
             app:navigationContentDescription="@string/abc_action_bar_up_description"
             app:navigationIcon="?attr/homeAsUpIndicator"
-            app:layout_scrollFlags="scroll|enterAlways|snap" />
+            app:layout_scrollFlags="scroll|enterAlways|snap"
+            android:fitsSystemWindows="true" />
     </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.core.widget.NestedScrollView


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this is to match the color of status bar with the statistics toolbar.

## Fixes
* Fixes #16034 

## Approach
I added a scroll listener which changes the color of the status bar according to the Material toolbar which changes it's color when user scrolls.

## How Has This Been Tested?
I tested the app by scrolling the screen.

## Screenshot
<img src="https://github.com/ankidroid/Anki-Android/assets/77337791/a2b7467d-317d-43f1-91bb-aadf05ad43ba.jpg" height="600">

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
