### PR TITLE
Add: Remove button for deck picker background image

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -20,7 +20,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.preference.ListPreference
-import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
 import anki.config.ConfigKey
 import com.ichi2.anki.CollectionManager
@@ -41,24 +40,17 @@ import com.ichi2.utils.show
 import com.ichi2.utils.title
 import timber.log.Timber
 
-class AppearanceSettingsFragment : SettingsFragment() {
-    private var backgroundImage: Preference? = null
+class AppearanceSettingsFragment : SettingsFragment(), PreferenceSelectBackgroundImageListener {
     override val preferenceResource: Int
         get() = R.xml.preferences_appearance
     override val analyticsScreenNameConstant: String
         get() = "prefs.appearance"
+    private lateinit var preferenceSelectBackgroundImage: PreferenceSelectBackgroundImage
 
     override fun initSubscreen() {
-        // Configure background
-        backgroundImage = requirePreference<Preference>("deckPickerBackground")
-        backgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
-            try {
-                backgroundImageResultLauncher.launch("image/*")
-            } catch (ex: Exception) {
-                Timber.w(ex)
-            }
-            true
-        }
+        // Configure background preference listener
+        preferenceSelectBackgroundImage = findPreference("deckPickerBackground")!!
+        preferenceSelectBackgroundImage.preferenceSelectBackgroundImageListener(this)
 
         val appThemePref = requirePreference<ListPreference>(R.string.app_theme_key)
         val dayThemePref = requirePreference<ListPreference>(R.string.day_theme_key)
@@ -142,6 +134,18 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 launchCatchingTask { withCol { config.setBool(ConfigKey.Bool.HIDE_AUDIO_PLAY_BUTTONS, !(newValue as Boolean)) } }
             }
         }
+    }
+
+    override fun onImageSelectClicked() {
+        try {
+            backgroundImageResultLauncher.launch("image/*")
+        } catch (ex: Exception) {
+            Timber.w(ex)
+        }
+    }
+
+    override fun onImageRemoveClicked() {
+        showRemoveBackgroundImageDialog()
     }
 
     private fun showRemoveBackgroundImageDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceSelectBackgroundImage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceSelectBackgroundImage.kt
@@ -1,0 +1,40 @@
+package com.ichi2.anki.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.ichi2.anki.R
+
+interface PreferenceSelectBackgroundImageListener {
+    fun onImageSelectClicked()
+    fun onImageRemoveClicked()
+}
+
+class PreferenceSelectBackgroundImage @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet?,
+    defStyleAttr: Int = 0
+) : Preference(context, attrs, defStyleAttr) {
+
+    private var preferenceSelectBackgroundImageListener: PreferenceSelectBackgroundImageListener? = null
+
+    init {
+        widgetLayoutResource = R.layout.preference_deck_picker_background
+    }
+
+    fun preferenceSelectBackgroundImageListener(listener: PreferenceSelectBackgroundImageListener) {
+        preferenceSelectBackgroundImageListener = listener
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+        holder.findViewById(R.id.deck_picker_background_image_selector).setOnClickListener {
+            preferenceSelectBackgroundImageListener?.onImageSelectClicked()
+        }
+
+        holder.findViewById(R.id.deck_picker_background_image_remover).setOnClickListener {
+            preferenceSelectBackgroundImageListener?.onImageRemoveClicked()
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceSelectBackgroundImage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceSelectBackgroundImage.kt
@@ -1,3 +1,18 @@
+/*
+ *  Copyright (c) 2024 Mohd Raghib <raghib.khan76@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.ichi2.anki.preferences
 
 import android.content.Context

--- a/AnkiDroid/src/main/res/layout/preference_deck_picker_background.xml
+++ b/AnkiDroid/src/main/res/layout/preference_deck_picker_background.xml
@@ -1,0 +1,40 @@
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_alignParentStart="true"
+        android:layout_marginEnd="72dp"
+        android:id="@+id/deck_picker_background_image_selector">
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:src="@drawable/wallpaper_icon" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="24dp"
+            android:textAppearance="?android:attr/textAppearanceListItem"
+            android:text="@string/choose_an_image" />
+
+    </LinearLayout>
+
+    <ImageView
+        android:paddingStart="16dp"
+        android:paddingEnd="32dp"
+        android:id="@+id/deck_picker_background_image_remover"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentEnd="true"
+        android:src="@drawable/close_icon"
+         />
+
+</RelativeLayout>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -57,13 +57,13 @@
             app:useSimpleSummaryProvider="true"
             search:ignore="true"/>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/background_image_title" >
-        <Preference
+    <PreferenceCategory android:title="@string/background_image_title"
+        app:allowDividerBelow="false">
+        <com.ichi2.anki.preferences.PreferenceSelectBackgroundImage
             android:defaultValue="0"
             android:key="@string/pref_deck_picker_background_key"
             android:shouldDisableView="true"
-            android:icon="@drawable/wallpaper_icon"
-            android:title="@string/choose_an_image" />
+            />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_reviewer" >
         <Preference


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Add: Remove button for deck picker background image

## Fixes
* Fixes #16090 

## Approach
Created a custom preference for adding the option to remove the image along with selecting the image.

### Before

https://github.com/ankidroid/Anki-Android/assets/40427461/ec776769-51ce-4efd-b652-e10414f766fb



### After

https://github.com/ankidroid/Anki-Android/assets/40427461/1137b97e-c08d-4bc0-9e96-8234aa499f8d



## How Has This Been Tested?

Tested on:
Physical device - Pixel 6A (Android 13)
Emulator - Pixel 3a (Android 14)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
