### PR TITLE
Remove maxLines attribute to allow multiline summaries in SliderPrefe…

### DIFF
--- a/AnkiDroid/src/main/res/layout/preference_slider.xml
+++ b/AnkiDroid/src/main/res/layout/preference_slider.xml
@@ -48,7 +48,6 @@
             android:layout_gravity="start"
             android:textAlignment="viewStart"
             android:textColor="?android:attr/textColorSecondary"
-            android:maxLines="4"
             style="@style/PreferenceSummaryTextStyle"
             tools:text="Summary"/>
         </RelativeLayout>


### PR DESCRIPTION
…rence

Previously, the maxLines attribute was set to 4 in the layout file associated with SliderPreference, restricting the summary view to display only up to 4 lines of text. This limitation hindered the ability to provide comprehensive information or descriptions within the summary.

By removing the maxLines attribute, the summary view can now accommodate multiple lines, allowing for more extensive descriptions or information to be displayed.

<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this commit is to address an issue where the summary in the SliderPreference was limited to displaying only four lines of text due to the presence of the maxLines attribute in the layout file. By removing this attribute, the commit aims to enable the summary to display multiple lines of text, allowing for more comprehensive information or descriptions to be presented to the user. This enhancement improves the usability of the SliderPreference by providing users with clearer and more detailed summaries, contributing to an enhanced user experience.

## Fixes
* Fixes #16081

## Approach
This change addresses the problem by removing the maxLines attribute from the layout file associated with the SliderPreference. Previously, this attribute limited the summary view to displaying only four lines of text, which was insufficient for providing detailed information or descriptions.

By removing the maxLines attribute, the summary view gains the flexibility to display multiple lines of text based on its content. This modification allows for more extensive descriptions or information to be presented within the summary, addressing the limitation and enhancing the user experience.

With this approach, users can now benefit from more informative summaries within the SliderPreference, improving their understanding of the preference's functionality or purpose. This change aligns with the goal of providing users with clearer and more detailed information, contributing to an overall improved user experience.

## How Has This Been Tested?

Edited the layout file associated with the SliderPreference (preference_slider.xml) to remove the maxLines attribute from the summary TextView.
Built and deployed the application on a physical device running Android 13.
Navigate to the screen containing the SliderPreference within the application's settings.
Observed the behavior of the summary displayed for the SliderPreference, ensuring that it now accommodates multiple lines of text.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
