### PR TITLE
fix: sync Anki Desktop `typeans` CSS

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -48,7 +48,15 @@ body.ankidroid_dark_mode {
 
 #typeans {
   width: 100%;
+  /* https://anki.tenderapp.com/discussions/beta-testing/1854-using-margin-auto-causes-horizontal-scrollbar-on-typesomething */
+  box-sizing: border-box;
+  /* #15535 - Not in libAnki - Android's Droid Sans Mono is insufficient for IPA */
   font-family: "Free Mono";
+}
+
+code#typeans {
+  white-space: pre-wrap;
+  font-variant-ligatures: none;
 }
 
 .typePrompt {


### PR DESCRIPTION
## Purpose / Description
A specific user complaint about white-space, but there was also other inconsistencies

## Fixes
* Fixes #16100

## Approach
Sync from:

https://github.com/ankitects/anki/blob/97efd49cd8db15a84d2ae2701d21b8283e37bc8c/ts/reviewer/reviewer.scss#L76-L79

I haven't changed colors to match Anki Desktop, as I felt this would require more discussion

## How Has This Been Tested?
⚠️ Briefly.

Visually, no change seemed to occur

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
