### PR TITLE
Fix #15553: Start of Next Day Not Working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1878,7 +1878,14 @@ open class DeckPicker :
             return
         }
 
-        withCol { decks.select(did) }
+        withCol {
+            // Force backend to reload the selected deck,
+            // to avoid a bug when moving start of next day to the past
+            if (focusedDeck == did) {
+                decks.select(0)
+            }
+            decks.select(did)
+        }
         // Also forget the last deck used by the Browser
         CardBrowser.clearLastDeckId()
         focusedDeck = did


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After finishing all cards for a day, changing Start of Next Day to the past and trying to access that same deck would result in a message saying that all cards were finished for the day.
Previously, this issue would require restarting anki.

## Fixes
* Fixes #15553

## Approach
I fixed this issue by selecting another deck and reselecting the deck again, prompting a reload of said deck.

## How Has This Been Tested?
By following @briankrznarich steps to reproduce the bug, on a physical device (Samsung A33 5G, Android 14)
> * With a rollover of 8pm, finish all cards for the day.
> * On the Deck Summary screen, at 2pm, with all cards finished, set the rollover to noon. (i.e. "the past")
> * On the Deck Screen, newly due cards appear (~500 for me)
> * Tap the deck to start reviewing

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
