### PR TITLE
Fix #16044: Cannot Scroll to End of TemplateEditor

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -444,7 +444,7 @@
             android:label="@string/title_activity_template_editor"
             android:exported="false"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:windowSoftInputMode="stateAlwaysHidden|adjustPan"
+            android:windowSoftInputMode="stateAlwaysHidden|adjustResize"
             >
         </activity>
         <activity

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -31,6 +31,8 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
@@ -365,6 +367,18 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 }
             }
             editorEditText.addTextChangedListener(templateEditorWatcher)
+
+            /* When keyboard is visible, hide the bottom navigation bar to allow viewing
+            of all template text when resize happens */
+            ViewCompat.setOnApplyWindowInsetsListener(mainView) { _, insets ->
+                val imeIsVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
+                if (imeIsVisible) {
+                    bottomNavigation.visibility = View.GONE
+                } else {
+                    bottomNavigation.visibility = View.VISIBLE
+                }
+                insets
+            }
 
             return mainView
         }


### PR DESCRIPTION
## Purpose / Description
When the keyboard appears, we cannot scroll to the Bottom in Card Template Editor, making it hard to read and edit the end of the template's text once it reaches a certain length. This happens because the keyboard covers that part of the screen. 

## Fixes
* Fixes #16044

## Approach
In _CardTemplateEditor_'s activity in _AndroidManifest.xml_, `android:windowSoftInputMode` was `adjustPan` and not `adjustResize`. This change wasn't enough because it caused the _BottomNavigation_ bar to then became taller than expected and covered the editable text, allowing us to view only 1-2 lines of text. To solve this problem, I added code to function _onCreateView_ in _CardTemplateEditor.kt_ to detect when the keyboard appears and consequently change the visibility of _BottomNavigation_ bar. 
Now the _BottomNavigation_ bar is _visible_ when keyboard is closed, and _gone_ when it's open. This way, it covers none of the visible part above the keyboard and maintains its functionality when the user isn't writing. These changes combined make it so we can now scroll to the bottom and add text at the end, because the keyboard no longer covers it.

## How Has This Been Tested?
I executed the following test on a physical device (Samsung Galaxy S21 Ultra 5G, with Android version 14) which I connected via cable to my laptop. I ran the app using Android Studio. 
Test:
To proceed with the test, make sure that the template's text occupies the whole screen (ex: 25 lines). 

- Go to Manage Note Types and clicking on Edit Cards of the template. 
- Verifiy that the BottomNavigation bar appears and works without issue (test by clicking its buttons). 
- Click on the screen to open the keyboard. 
- While the keyboard is showing up, try to scroll to the bottom. 
- Verify that this works without issues, and that both the bottom part of the text is visible.
- Click on the screen to exit the keyboard, and verify that the BottomNavigation bar is there again, as intended. 

Repeat this a few times to ensure it always works, checking for the Front template, Back template and Styling.


I also ran all the integration and units tests with _./gradlew jacocoTestReport_. For this I used Java SDK 21, and an AndroidStudio Emulator: pixel 5 with 2GB of RAM and 5GB of both Internal Storage and SD card (and VM heap: 256 MB). 

Before Fix:
<img src="https://github.com/ankidroid/Anki-Android/assets/93283175/dd1180ef-a065-49d8-bd19-cb7b09812d24" alt="before" width="200"/>
After Fix:
<img src="https://github.com/ankidroid/Anki-Android/assets/93283175/0563628a-3ed5-4a26-a4b3-ac2ed38fcaff" alt="after" width="200"/>


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
