### PR TITLE
fix: SliderPreference - listener added many times

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -234,6 +234,7 @@ class Preferences :
                 config.set("rollover", hours)
                 scheduleNotification(TimeManager.time, context)
             }
+            Timber.i("set day offset: '%d'", hours)
         }
         suspend fun getDayOffset(): Int {
             return withCol { config.get("rollover") ?: 4 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
@@ -27,6 +27,7 @@ import androidx.preference.PreferenceViewHolder
 import com.google.android.material.slider.Slider
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.getFormattedStringOrPlurals
+import com.ichi2.annotations.NeedsTest
 
 /**
  * Similar to [androidx.preference.SeekBarPreference],
@@ -53,6 +54,7 @@ import com.ichi2.anki.utils.getFormattedStringOrPlurals
  *       which will be replaced by the preference value.
  *       `displayValue` is always true if a `displayFormat` is provided.
  */
+@NeedsTest("onTouchListener is only called once")
 class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preference(context, attrs) {
     private var valueFrom: Int = 0
     private var valueTo: Int = 0
@@ -61,6 +63,20 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
     private var summaryFormatResource: Int? = null
     private var displayValue: Boolean = false
     private var displayFormat: String? = null
+
+    // flyweight pattern: all listeners for an instance of the class as the same
+    // We also need to avoid any method-level closures: this callback is unused
+    // the second time `onBindViewHolder` is called
+    private val onTouchListener = object : Slider.OnSliderTouchListener {
+        override fun onStartTrackingTouch(slider: Slider) {}
+
+        override fun onStopTrackingTouch(slider: Slider) {
+            val sliderValue = slider.value.toInt()
+            if (callChangeListener(sliderValue)) {
+                value = sliderValue
+            }
+        }
+    }
 
     var value: Int = valueFrom
         set(value) {
@@ -112,18 +128,8 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
         slider.stepSize = stepSize
         slider.value = value.toFloat()
 
-        slider.addOnSliderTouchListener(
-            object : Slider.OnSliderTouchListener {
-                override fun onStartTrackingTouch(slider: Slider) {}
-
-                override fun onStopTrackingTouch(slider: Slider) {
-                    val sliderValue = slider.value.toInt()
-                    if (callChangeListener(sliderValue)) {
-                        value = sliderValue
-                    }
-                }
-            }
-        )
+        // set the listener once: avoid any method-level closures
+        slider.setOnSliderTouchListenerOnce(onTouchListener)
 
         val summaryView = holder.findViewById(android.R.id.summary) as TextView
         summaryFormatResource?.let {
@@ -137,6 +143,22 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
                 ?: value.toString()
         } else {
             displayValueTextView.visibility = View.GONE
+        }
+    }
+
+    companion object {
+        /**
+         * [Slider] has no easy means of de-duplicating listeners
+         * If a listener has already been added using this method. This does nothing
+         * @see [Slider.addOnSliderTouchListener]
+         *
+         * @param listener A [Slider.OnSliderTouchListener].
+         * Must not use method-level state, as this method does not replace the listener
+         */
+        private fun Slider.setOnSliderTouchListenerOnce(listener: Slider.OnSliderTouchListener) {
+            if (this.getTag(R.id.tag_slider_listener_set) != null) return
+            this.addOnSliderTouchListener(listener)
+            this.setTag(R.id.tag_slider_listener_set, "set")
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
@@ -72,7 +72,7 @@ class SliderPreference(context: Context, attrs: AttributeSet? = null) : Preferen
 
         override fun onStopTrackingTouch(slider: Slider) {
             val sliderValue = slider.value.toInt()
-            if (callChangeListener(sliderValue)) {
+            if (sliderValue != value && callChangeListener(sliderValue)) {
                 value = sliderValue
             }
         }

--- a/AnkiDroid/src/main/res/values/tags.xml
+++ b/AnkiDroid/src/main/res/values/tags.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!-- Usage: setTag(R.id.tag_slider_listener_set, value) -->
+<resources>
+    <item type="id" name="tag_slider_listener_set"/>
+</resources>


### PR DESCRIPTION
## Purpose / Description
Each move of the slider, another listener was added

This was because `onBindViewHolder` was called multiple times leading to multiple calls of `addOnSliderTouchListener`

## Fixes
* Fixes #16111

## Approach

Define `setOnSliderTouchListenerOnce` and a tag, only set the listener once.

The listener did not use any holder-specific variables, `slider.value` was fine to use

## How Has This Been Tested?
Logcat output change

```diff
set day offset: '5'
set day offset: '4'
- set day offset: '4'
```

## Learning (optional, can help others)
**Learning**

never used `setTag` before; it needs a `R.id`

**Other Considerations**


Since in future a user may decide to use view.addOnSliderTouchListener, we didn't want to call `clearOnSliderTouchListeners()`;

`removeOnSliderTouchListener()` could be used, but it seemed wasteful to remove and then re-add the same listener instance.

Plus, if the instance DID use captured variables, we couldn't call `removeOnSliderTouchListener`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
