### PR TITLE
Align search view close icon align to end [DeckPicker]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -792,6 +792,7 @@ open class DeckPicker :
         menu.findItem(R.id.action_export)?.title = TR.exportingExport()
         setupSearchIcon(menu.findItem(R.id.deck_picker_action_filter))
         toolbarSearchView = menu.findItem(R.id.deck_picker_action_filter).actionView as SearchView
+        toolbarSearchView?.maxWidth = Integer.MAX_VALUE
         // redraw menu synchronously to avoid flicker
         updateMenuFromState(menu)
         // ...then launch a task to possibly update the visible icons.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
DeckPicker SearchView cancel icon is misaligned in landscape mode

## Fixes
* Related #15950 

## Approach
By setting searchView width to max, close icon moves to end

## How Has This Been Tested?
Physical Device (Realme 9)
![WhatsApp Image 2024-04-06 at 9 10 02 PM](https://github.com/ankidroid/Anki-Android/assets/65113071/b5970ddf-acaf-46e2-90ec-31e50cdbd8dc)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
