### PR TITLE
fix(deck-order-suggestion): exclude times

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -231,5 +231,8 @@ class CreateDeckDialog(
     }
 }
 
+// to not match times. Example: "12:34:56"
+// we use (?:[^:]|^) to ensure ":56" doesn't match
+// we use (?:[^:]|$) to ensure "12:" doesn't match
 @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-fun CharSequence.containsNumberLargerThanNine(): Boolean = Regex("""[1-9]\d+""").find(this) != null
+fun CharSequence.containsNumberLargerThanNine(): Boolean = Regex("""(?:[^:]|^)[1-9]\d+(?:[^:]|$)""").find(this) != null

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -272,5 +272,8 @@ class CreateDeckDialogNonAndroidTest {
         assertLargerThanNine("Ten or greater", "10. - Chemicals", true)
         assertLargerThanNine("Ten or greater", "99. - Chemicals", true)
         assertLargerThanNine("zero prefix", "09. - Chemicals", false)
+        assertLargerThanNine("time", "10:50:59", false)
+        assertLargerThanNine("time", "Filtered Deck 22:34", false)
+        assertLargerThanNine("suffix", "Deck 34", true)
     }
 }


### PR DESCRIPTION
When we're helping a user order decks as: ['01', '02', '10'] we wanted to show the suggestion if a digit >= 10 is entered

But NOT a time, as these don't have ordering issues

Discovered when creating a filtered deck, as the time is automatically added. Thanks to Brayan

## Fixes
* Related: #16036

## Approach
Regex

## How Has This Been Tested?
Unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
