### PR TITLE
Make text selectable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -83,6 +83,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
                     fileListTextView.append(unused.joinToString("\n"))
                     fileListTextView.isScrollbarFadingEnabled = unused.size <= fileListTextView.maxLines
                     fileListTextView.movementMethod = ScrollingMovementMethod.getInstance()
+                    fileListTextView.setTextIsSelectable(true)
                     dialog.setPositiveButton(R.string.check_media_delete_unused) { _, _ ->
                         (activity as MediaCheckDialogListener?)?.deleteUnused(unused)
                         dismissAllDialogFragments()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The text showing unused media files currently are not selectable

## Fixes
* Fixes #16019 

## Approach
set `isTextSelectable` to true

## How Has This Been Tested?
Physical Device ( Realme 9 )

https://github.com/ankidroid/Anki-Android/assets/65113071/ac58f2a2-9cb8-4dc3-a24b-5ce577d156ee

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
