### PR TITLE
fix(previewer): cards' ord couldn't be changed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -58,7 +58,7 @@ class TemplatePreviewerViewModel(
     private val note: Deferred<Note>
     private val templateNames: Deferred<List<String>>
     private val clozeOrds: Deferred<List<Int>>?
-    override var currentCard: Deferred<Card>
+    override lateinit var currentCard: Deferred<Card>
 
     init {
         note = asyncIO {
@@ -73,17 +73,7 @@ class TemplatePreviewerViewModel(
                 tags = arguments.tags
             }
         }
-        currentCard = asyncIO {
-            val note = note.await()
-            withCol {
-                note.ephemeralCard(
-                    col = this,
-                    ord = ordFlow.value,
-                    customNoteType = notetype,
-                    fillEmpty = fillEmpty
-                )
-            }
-        }
+
         if (isCloze) {
             val clozeNumbers = asyncIO {
                 val note = note.await()
@@ -114,7 +104,18 @@ class TemplatePreviewerViewModel(
             return
         }
         launchCatchingIO {
-            ordFlow.collectLatest {
+            ordFlow.collectLatest { ord ->
+                currentCard = asyncIO {
+                    val note = note.await()
+                    withCol {
+                        note.ephemeralCard(
+                            col = this,
+                            ord = ord,
+                            customNoteType = notetype,
+                            fillEmpty = fillEmpty
+                        )
+                    }
+                }
                 showQuestion()
                 loadAndPlaySounds(CardSide.QUESTION)
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
@@ -25,6 +25,7 @@ import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
+import kotlin.test.assertNotEquals
 
 @RunWith(AndroidJUnit4::class)
 class TemplatePreviewerViewModelTest : JvmTest() {
@@ -45,6 +46,17 @@ class TemplatePreviewerViewModelTest : JvmTest() {
             onTabSelected(0) // 0 will be c4 (ord 3), 1: c7 (ord 6), 2: c9 (ord 8)
             assertThat(ordFlow.value, equalTo(3))
         }
+
+    @Test
+    fun `card ords are changed`() {
+        runClozeTest(fields = mutableListOf("{{c1::one}} {{c2::bar}}")) {
+            onPageFinished(false)
+            val ord1 = currentCard.await().ord
+            onTabSelected(1)
+            val ord2 = currentCard.await().ord
+            assertNotEquals(ord1, ord2)
+        }
+    }
 
     private fun runClozeTest(ord: Int = 0, fields: MutableList<String>? = null, block: suspend TemplatePreviewerViewModel.() -> Unit) = runTest {
         val notetype = col.notetypes.byName("Cloze")!!


### PR DESCRIPTION
## Fixes
* Fixes #16155

## Approach

update currentCard if ord is changed

## How Has This Been Tested?

With the issue steps in emulator 34. Also unit tested

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
