### PR TITLE
test(ci): re-enable gradle cache on Windows

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -66,10 +66,9 @@ jobs:
           # Builds on other branches will only read from main branch cache writes
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-          gradle-home-cache-cleanup: true
-          # Windows runner currently having cache pollution issues, disable cache for the platform
-          # https://github.com/ankidroid/Anki-Android/issues/16161
-          cache-disabled: ${{ contains(matrix.os, 'windows') }}
+          # gradle-home-cache-cleanup is temporarily disabled to investigate cache pollution issues
+          # Requested in: https://github.com/gradle/actions/issues/167#issuecomment-2052352341
+          #   gradle-home-cache-cleanup: true
 
       - name: Clear Caches Optionally
         if: "${{ github.event.inputs.clearCaches != '' }}"


### PR DESCRIPTION
Changes requested for issue diagnostics in https://redirect.github.com/gradle/actions/issues/167#issuecomment-2052352341

* Related: #16161

## Approach
Reverts f9b7ee6818b680e9a97fd57c01e25626520578e0
* temporarily disable `gradle-home-cache-cleanup`
* remove `cache-disabled`


## How Has This Been Tested?
CI only

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
