### PR TITLE
build(ci): upload unit test logs as artifact on failure

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -91,6 +91,22 @@ jobs:
         with:
           arguments: jacocoUnitTestReport --daemon
 
+      - name: Store Logcat as Artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: logcat-${{ matrix.name }}
+          # look for the `<system-out>` element in the XML files in `test-results`
+          # The folder contains far too much data:
+          # * .bin files
+          # * XML rather than TXT
+          # * Files are mostly JaCoCo issues logged to stderr (#16180)
+          # * All tests are logged, rather than just failures
+          # despite this, it's a great start
+          # look to see if there's a dependency we can use, arther than improving this
+          path: |
+            **/build/test-results/
+
       - name: Stop Gradle
         if: contains(matrix.os, 'windows')
         uses: gradle/gradle-build-action@v3

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -50,6 +50,7 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.json.JSONException
 import org.junit.*
+import org.junit.rules.TestName
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
@@ -81,9 +82,13 @@ open class RobolectricTest : AndroidTest {
     @get:Rule
     val ignoreFlakyTests = IgnoreFlakyTestsInCIRule()
 
+    @get:Rule
+    val testName = TestName()
+
     @Before
     @CallSuper
     open fun setUp() {
+        println("""-- executing test "${testName.methodName}"""")
         TimeManager.resetWith(MockTime(2020, 7, 7, 7, 0, 0, 0, 10))
         throwOnShowError = true
 
@@ -165,6 +170,7 @@ open class RobolectricTest : AndroidTest {
         }
         Dispatchers.resetMain()
         runBlocking { CollectionManager.discardBackend() }
+        println("""-- completed test "${testName.methodName}"""")
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -32,10 +32,15 @@ import org.hamcrest.Matcher
 import org.junit.After
 import org.junit.Assume
 import org.junit.Before
+import org.junit.Rule
+import org.junit.rules.TestName
 import timber.log.Timber
 import timber.log.Timber.Forest.plant
 
 open class JvmTest : TestClass {
+    @get:Rule
+    val testName = TestName()
+
     private fun maybeSetupBackend() {
         RustBackendLoader.ensureSetup()
     }
@@ -53,6 +58,7 @@ open class JvmTest : TestClass {
     @Before
     @CallSuper
     open fun setUp() {
+        println("""-- executing test "${testName.methodName}"""")
         TimeManager.resetWith(MockTime(2020, 7, 7, 7, 0, 0, 0, 10))
 
         ChangeManager.clearSubscribers()
@@ -94,6 +100,7 @@ open class JvmTest : TestClass {
         Dispatchers.resetMain()
         runBlocking { CollectionManager.discardBackend() }
         Timber.uprootAll()
+        println("""-- executing test "${testName.methodName}"""")
     }
 
     fun <T> assumeThat(actual: T, matcher: Matcher<T>?) {


### PR DESCRIPTION
## Purpose / Description

We had flaky Windows tests, I could not reproduce locally and wanted CI logs

## Fixes
* Fixes #16174
* See #16180

## Approach
Upload `test-results` as an artifact: `logcat-{{ matrix.name }}`


## How Has This Been Tested?
Tested on https://github.com/ankidroid/Anki-Android/pull/16128 (After this, I changed the folder name from `reports` -> `logcat-${{ matrix.name }}` )

https://github.com/ankidroid/Anki-Android/actions/runs/8688261435?pr=16181

![Screenshot 2024-04-15 at 12 38 53](https://github.com/ankidroid/Anki-Android/assets/62114487/c825d019-6a08-4473-a9ac-eec6f97d5a6b)


## Learning (optional, can help others)
Should have done this a long time ago

We should GitHub Actions when wanting to improve this

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
