### PR TITLE
chore/fix: remove runOnUiThread in CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -282,6 +282,7 @@ class CardBrowserViewModel(
         undoableOp { removeNotes(cids = selectedRowIds) }.count
 
     fun setCardsOrNotes(newValue: CardsOrNotes) = viewModelScope.launch {
+        Timber.i("setting mode to %s", newValue)
         withCol {
             // Change this to only change the preference on a state change
             newValue.saveToCollection()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -434,6 +434,7 @@ class CardBrowserTest : RobolectricTest() {
 
         val b = browserWithNoNewCards
         b.viewModel.setFlagFilter(Flag.RED)
+        waitForAsyncTasksToComplete()
 
         assertThat("Flagged cards should be returned", b.viewModel.rowCount, equalTo(2))
     }
@@ -718,6 +719,7 @@ class CardBrowserTest : RobolectricTest() {
 
         val cardBrowser = browserWithNoNewCards
         cardBrowser.searchCards("Hello")
+        waitForAsyncTasksToComplete()
         assertThat(
             "Card browser should have Test Deck as the selected deck",
             cardBrowser.selectedDeckNameForUi,
@@ -726,6 +728,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat("Result should be empty", cardBrowser.viewModel.rowCount, equalTo(0))
 
         cardBrowser.searchAllDecks()
+        waitForAsyncTasksToComplete()
         assertThat("Result should contain one card", cardBrowser.viewModel.rowCount, equalTo(1))
     }
 
@@ -736,10 +739,11 @@ class CardBrowserTest : RobolectricTest() {
         addNoteUsingBasicAndReversedModel("Hello", "Anki")
 
         browserWithNoNewCards.apply {
-            searchAllDecks()
+            searchAllDecks().join()
             with(viewModel) {
                 assertThat("Result should contain 4 cards", rowCount, equalTo(4))
-                setCardsOrNotes(NOTES)
+                setCardsOrNotes(NOTES).join()
+                waitForAsyncTasksToComplete()
                 assertThat("Result should contain 2 cards (one per note)", rowCount, equalTo(2))
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -22,7 +22,6 @@ import android.text.TextUtils
 import android.view.View
 import android.widget.ListView
 import android.widget.Spinner
-import androidx.annotation.StringRes
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.fragment.app.Fragment
@@ -35,7 +34,8 @@ import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_1_KEY
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_2_KEY
-import com.ichi2.anki.model.CardsOrNotes.*
+import com.ichi2.anki.model.CardsOrNotes.CARDS
+import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.SortType
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.libanki.CardId
@@ -57,7 +57,12 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.*
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
 import org.junit.Assert
 import org.junit.Ignore
 import org.junit.Test
@@ -67,7 +72,6 @@ import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import timber.log.Timber
 import java.util.Calendar
-import java.util.Locale
 import java.util.Random
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
@@ -770,23 +774,6 @@ class CardBrowserTest : RobolectricTest() {
                 equalTo(true)
             )
         }
-    }
-
-    private fun assertUndoDoesNotContain(browser: CardBrowser, @StringRes resId: Int) {
-        val shadowActivity = shadowOf(browser)
-        val item = shadowActivity.optionsMenu.findItem(R.id.action_undo)
-        val expected = browser.getString(resId)
-        assertThat(
-            item.title.toString(),
-            not(containsString(expected.lowercase(Locale.getDefault())))
-        )
-    }
-
-    private fun assertUndoContains(browser: CardBrowser, @StringRes resId: Int) {
-        val shadowActivity = shadowOf(browser)
-        val item = shadowActivity.optionsMenu.findItem(R.id.action_undo)
-        val expected = browser.getString(resId)
-        assertThat(item.title.toString(), containsString(expected.lowercase(Locale.getDefault())))
     }
 
     private fun getCheckedCard(b: CardBrowser): CardCache {


### PR DESCRIPTION
## Purpose / Description
Split out from https://github.com/ankidroid/Anki-Android/pull/16128/ - was very frustrating to track down

## How Has This Been Tested?
Unit tested and had a brief test manually

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
