### PR TITLE
fix(test, ci): call gradle wrapper directly now that setup-gradle is used

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -62,13 +62,11 @@ jobs:
           command: ./gradlew :AnkiDroid:compilePlayDebugJavaWithJavac compileLint lint-rules:compileTestJava --daemon
 
       - name: Run Lint Debug
-        uses: gradle/gradle-build-action@v3
-        with:
-          # "lint" is run under the 'Amazon' flavor, so slow in CI
-          # "lintPlayRelease" doesn't test androidTest
-          # "lintPlayDebug" doesn't test the API
-          # "lintVitalFullRelease": if `main` resources are only used in `androidTest` (#15741)
-          arguments: lintPlayDebug :api:lintDebug ktLintCheck lintVitalFullRelease lint-rules:test --daemon
+        # "lint" is run under the 'Amazon' flavor, so slow in CI
+        # "lintPlayRelease" doesn't test androidTest
+        # "lintPlayDebug" doesn't test the API
+        # "lintVitalFullRelease": if `main` resources are only used in `androidTest` (#15741)
+        run: ./gradlew lintPlayDebug :api:lintDebug ktLintCheck lintVitalFullRelease lint-rules:test --daemon
 
         # Handled under the pre-commit hook: ./gradlew installGitHook
 

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -87,9 +87,7 @@ jobs:
           command: ./gradlew robolectricSdkDownload --daemon
 
       - name: Run Unit Tests
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: jacocoUnitTestReport --daemon
+        run: ./gradlew jacocoUnitTestReport --daemon
 
       - name: Store Logcat as Artifact
         if: failure()
@@ -109,9 +107,7 @@ jobs:
 
       - name: Stop Gradle
         if: contains(matrix.os, 'windows')
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: --stop
+        run: ./gradlew --stop
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION

## Purpose / Description

This was a missing second half of the forward port from "gradle-build-action" to "setup-gradle" - now that we call setup-gradle, for future gradle-related tasks in the workflow you just call the wrapper directly

## Fixes

Nothing documented, just saw a warning in the CI log file while working on #14434 

https://github.com/ankidroid/Anki-Android/actions/runs/8727634201/job/23945575470?pr=14434#step:19:3

## Approach

Read the docs
Implemented the recommended style for running gradle

## How Has This Been Tested?

Can't test it locally but if CI runs the tests, it worked

## Learning (optional, can help others)

https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#using-the-action-to-execute-gradle-via-the-arguments-parameter-is-deprecated

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
