### PR TITLE
fix(set-due-date): small phone layout 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -215,6 +215,11 @@ class SetDueDateDialog : DialogFragment() {
             view.findViewById<TextView>(R.id.date_single_label).text =
                 resources.getQuantityString(R.plurals.set_due_date_single_day_label, viewModel.cardCount)
         }
+
+        override fun onResume() {
+            super.onResume()
+            this.requireView().requestLayout() // update the height of the ViewPager
+        }
     }
 
     /**
@@ -256,7 +261,7 @@ class SetDueDateDialog : DialogFragment() {
 
         override fun onResume() {
             super.onResume()
-            this.requireView().requestLayout() // fix the height not being changed
+            this.requireView().requestLayout() // update the height of the ViewPager
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -34,6 +34,9 @@ import timber.log.Timber
  */
 typealias NumberOfDaysInFuture = Int
 
+/**
+ * [ViewModel] for [SetDueDateDialog]
+ */
 class SetDueDateViewModel : ViewModel() {
     /** Whether the value may be submitted */
     val isValidFlow = MutableStateFlow(false)

--- a/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
@@ -17,7 +17,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:paddingHorizontal="16dp"
+    android:paddingHorizontal="24dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -26,7 +26,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingTop="8dp"
-        android:layout_marginStart="8dp"
         style="@style/TextAppearance.Material3.LabelLarge"
         tools:text="Show card in range"
         app:layout_constraintEnd_toEndOf="parent"
@@ -70,7 +69,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
-        android:layout_marginEnd="8dp"
         android:minEms="6"
         app:expandedHintEnabled="false"
         app:suffixText="days"

--- a/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
@@ -35,37 +35,52 @@
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/date_range_start_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:layout_height="0dp"
         android:layout_marginTop="8dp"
         android:paddingBottom="8dp"
+        android:minEms="6"
         app:expandedHintEnabled="false"
         app:suffixText="days"
+        app:layout_constraintStart_toStartOf="@+id/date_range_label"
         app:layout_constraintTop_toBottomOf="@+id/date_range_label">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/date_range_start"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:hint="@string/set_due_date_range_start"
             android:inputType="number"
             android:maxLength="5" />
     </com.google.android.material.textfield.TextInputLayout>
 
+
+    <com.google.android.material.textview.MaterialTextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/range_delimiter"
+        android:textSize="24sp"
+        app:layout_constraintBottom_toBottomOf="@+id/date_range_start_layout"
+        app:layout_constraintEnd_toStartOf="@+id/date_range_end_layout"
+        app:layout_constraintStart_toEndOf="@+id/date_range_start_layout"
+        app:layout_constraintTop_toTopOf="@+id/date_range_start_layout"
+        />
+
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/date_range_end_layout"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:minEms="6"
         app:expandedHintEnabled="false"
-        app:layout_constraintTop_toBottomOf="@+id/date_range_start_layout"
-        app:suffixText="days">
+        app:suffixText="days"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/date_range_label">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/date_range_end"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:hint="@string/set_due_date_range_end"
             android:inputType="number"
             android:maxLength="5" />
     </com.google.android.material.textfield.TextInputLayout>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -269,5 +269,7 @@ also changes the interval of the card"
         <item quantity="other">days</item>
     </plurals>
     <string name="range_delimiter" comment="Placed between two input boxes to denote a range">–</string>
+    <string name="set_due_date_range_start" comment="'Set Due Date' may change the due date of a card to a random number of days in the future. This labels the 'minimum' value of this range (inclusive)">From</string>
+    <string name="set_due_date_range_end" comment="'Set Due Date' may change the due date of a card to a random number of days in the future. This labels the 'maximum' value of this range (inclusive)">To</string>
 
 </resources>


### PR DESCRIPTION
## Purpose / Description

![image](https://github.com/ankidroid/Anki-Android/assets/62114487/1472151b-b00e-4f09-a6af-8b459046868c)

## Fixes
* Fixes #16200

## Approach
* Define `layout-w340dp` where the EditTexts are stacked vertically

## How Has This Been Tested?
![Screenshot 2024-04-18 at 16 41 09](https://github.com/ankidroid/Anki-Android/assets/62114487/7cf11abd-8864-40d1-ac8b-0e22a026da1d)

## Learning (optional, can help others)
320dp was insufficient, 340 seems fine


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
