### PR TITLE
fix: Use flags from col, dynamically loading them into the menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -713,6 +713,7 @@ open class CardBrowser :
             // restore drawer click listener and icon
             restoreDrawerIcon()
             menuInflater.inflate(R.menu.card_browser, menu)
+            addFlags(menu.findItem(R.id.action_search_by_flag).subMenu, Mode.SINGLE_SELECT)
             saveSearchItem = menu.findItem(R.id.action_save_search)
             saveSearchItem?.isVisible = false // the searchview's query always starts empty.
             mySearchesItem = menu.findItem(R.id.action_list_my_searches)
@@ -766,6 +767,7 @@ open class CardBrowser :
         } else {
             // multi-select mode
             menuInflater.inflate(R.menu.card_browser_multiselect, menu)
+            addFlags(menu.findItem(R.id.action_flag).subMenu, Mode.MULTI_SELECT)
             showBackIcon()
             increaseHorizontalPaddingOfOverflowMenuIcons(menu)
         }
@@ -789,6 +791,28 @@ open class CardBrowser :
         onSelectionChanged()
         updatePreviewMenuItem()
         return super.onCreateOptionsMenu(menu)
+    }
+
+    /**
+     * Representing different selection modes.
+     */
+    enum class Mode(val value: Int) {
+        SINGLE_SELECT(1000),
+        MULTI_SELECT(1001)
+    }
+
+    private fun addFlags(subMenu: SubMenu?, mode: Mode) {
+        lifecycleScope.launch {
+            val groupId = when (mode) {
+                Mode.SINGLE_SELECT -> mode.value
+                Mode.MULTI_SELECT -> mode.value
+            }
+
+            for (flag in Flag.entries) {
+                val title = flag.getName(resources)
+                subMenu?.add(groupId, flag.ordinal, Menu.NONE, title)?.setIcon(flag.drawableRes)
+            }
+        }
     }
 
     override fun onNavigationPressed() {
@@ -900,6 +924,16 @@ open class CardBrowser :
             undoSnackbar != null && undoSnackbar!!.isShown -> undoSnackbar!!.dismiss()
         }
 
+        val flag = Flag.entries.find { it.ordinal == item.itemId }
+        flag?.let {
+            when (item.groupId) {
+                Mode.SINGLE_SELECT.value -> filterByFlag(it)
+                Mode.MULTI_SELECT.value -> updateFlagForSelectedRows(it)
+                else -> return@let
+            }
+            return true
+        }
+
         when (item.itemId) {
             android.R.id.home -> {
                 viewModel.endMultiSelectMode()
@@ -960,70 +994,6 @@ open class CardBrowser :
             }
             R.id.action_search_by_tag -> {
                 showFilterByTagsDialog()
-                return true
-            }
-            R.id.action_flag_zero -> {
-                updateFlagForSelectedRows(Flag.NONE)
-                return true
-            }
-            R.id.action_flag_one -> {
-                updateFlagForSelectedRows(Flag.RED)
-                return true
-            }
-            R.id.action_flag_two -> {
-                updateFlagForSelectedRows(Flag.ORANGE)
-                return true
-            }
-            R.id.action_flag_three -> {
-                updateFlagForSelectedRows(Flag.GREEN)
-                return true
-            }
-            R.id.action_flag_four -> {
-                updateFlagForSelectedRows(Flag.BLUE)
-                return true
-            }
-            R.id.action_flag_five -> {
-                updateFlagForSelectedRows(Flag.PINK)
-                return true
-            }
-            R.id.action_flag_six -> {
-                updateFlagForSelectedRows(Flag.TURQUOISE)
-                return true
-            }
-            R.id.action_flag_seven -> {
-                updateFlagForSelectedRows(Flag.PURPLE)
-                return true
-            }
-            R.id.action_select_flag_zero -> {
-                filterByFlag(Flag.NONE)
-                return true
-            }
-            R.id.action_select_flag_one -> {
-                filterByFlag(Flag.RED)
-                return true
-            }
-            R.id.action_select_flag_two -> {
-                filterByFlag(Flag.ORANGE)
-                return true
-            }
-            R.id.action_select_flag_three -> {
-                filterByFlag(Flag.GREEN)
-                return true
-            }
-            R.id.action_select_flag_four -> {
-                filterByFlag(Flag.BLUE)
-                return true
-            }
-            R.id.action_select_flag_five -> {
-                filterByFlag(Flag.PINK)
-                return true
-            }
-            R.id.action_select_flag_six -> {
-                filterByFlag(Flag.TURQUOISE)
-                return true
-            }
-            R.id.action_select_flag_seven -> {
-                filterByFlag(Flag.PURPLE)
                 return true
             }
             R.id.action_delete_card -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -15,21 +15,43 @@
  */
 package com.ichi2.anki
 
+import android.content.res.Resources
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.utils.ext.getStringOrNull
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
+import org.json.JSONObject
 
-enum class Flag(val code: Int, @DrawableRes val drawableRes: Int, @ColorRes val browserColorRes: Int?) {
-    NONE(0, R.drawable.ic_flag_transparent, null),
-    RED(1, R.drawable.ic_flag_red, R.color.flag_red),
-    ORANGE(2, R.drawable.ic_flag_orange, R.color.flag_orange),
-    GREEN(3, R.drawable.ic_flag_green, R.color.flag_green),
-    BLUE(4, R.drawable.ic_flag_blue, R.color.flag_blue),
-    PINK(5, R.drawable.ic_flag_pink, R.color.flag_pink),
-    TURQUOISE(6, R.drawable.ic_flag_turquoise, R.color.flag_turquoise),
-    PURPLE(7, R.drawable.ic_flag_purple, R.color.flag_purple);
+enum class Flag(
+    val code: Int,
+    @DrawableRes val drawableRes: Int,
+    @ColorRes val browserColorRes: Int?,
+    private val defaultNameRes: Int
+) {
+    NONE(0, R.drawable.ic_flag_transparent, null, R.string.menu_flag_card_zero),
+    RED(1, R.drawable.ic_flag_red, R.color.flag_red, R.string.menu_flag_card_one),
+    ORANGE(2, R.drawable.ic_flag_orange, R.color.flag_orange, R.string.menu_flag_card_two),
+    GREEN(3, R.drawable.ic_flag_green, R.color.flag_green, R.string.menu_flag_card_three),
+    BLUE(4, R.drawable.ic_flag_blue, R.color.flag_blue, R.string.menu_flag_card_four),
+    PINK(5, R.drawable.ic_flag_pink, R.color.flag_pink, R.string.menu_flag_card_five),
+    TURQUOISE(6, R.drawable.ic_flag_turquoise, R.color.flag_turquoise, R.string.menu_flag_card_six),
+    PURPLE(7, R.drawable.ic_flag_purple, R.color.flag_purple, R.string.menu_flag_card_seven);
+
+    /**
+     * Retrieves the name associated with the flag.
+     * If an override for the flag name is provided in the configuration, it is fetched; otherwise,
+     * the default name resource ID is used to fetch the name from the application resources.
+     *
+     * @param resources The Resources object used to access application resources.
+     * @return The name associated with the flag, either fetched from overrides or default resources.
+     */
+    suspend fun getName(resources: Resources): String {
+        val overrides = withCol { config.getObject("flagLabels", JSONObject()) }
+        return overrides.getStringOrNull(code.toString()) ?: resources.getString(defaultNameRes)
+    }
 
     companion object {
         fun fromCode(code: Int): Flag {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -354,6 +354,7 @@ open class Reviewer :
         }
         val flag = Flag.entries.find { it.ordinal == item.itemId }
         flag?.let {
+            Timber.i("Reviewer:: onOptionItemSelected Flag - $it clicked")
             onFlag(currentCard, it)
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -40,6 +40,7 @@ import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import anki.frontend.SetSchedulingStatesRequest
 import com.google.android.material.color.MaterialColors
@@ -88,6 +89,7 @@ import com.ichi2.utils.HandlerUtils.getDefaultLooper
 import com.ichi2.utils.Permissions.canRecordAudio
 import com.ichi2.utils.ViewGroupUtils.setRenderWorkaround
 import com.ichi2.widget.WidgetStatus.updateInBackground
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.File
 
@@ -350,6 +352,11 @@ open class Reviewer :
         if (drawerToggle.onOptionsItemSelected(item)) {
             return true
         }
+        val flag = Flag.entries.find { it.ordinal == item.itemId }
+        flag?.let {
+            onFlag(currentCard, it)
+            return true
+        }
         when (item.itemId) {
             android.R.id.home -> {
                 Timber.i("Reviewer:: Home button pressed")
@@ -448,38 +455,6 @@ open class Reviewer :
             R.id.action_add_note_reviewer -> {
                 Timber.i("Reviewer:: Add note button pressed")
                 addNote()
-            }
-            R.id.action_flag_zero -> {
-                Timber.i("Reviewer:: No flag")
-                onFlag(currentCard, Flag.NONE)
-            }
-            R.id.action_flag_one -> {
-                Timber.i("Reviewer:: Flag one")
-                onFlag(currentCard, Flag.RED)
-            }
-            R.id.action_flag_two -> {
-                Timber.i("Reviewer:: Flag two")
-                onFlag(currentCard, Flag.ORANGE)
-            }
-            R.id.action_flag_three -> {
-                Timber.i("Reviewer:: Flag three")
-                onFlag(currentCard, Flag.GREEN)
-            }
-            R.id.action_flag_four -> {
-                Timber.i("Reviewer:: Flag four")
-                onFlag(currentCard, Flag.BLUE)
-            }
-            R.id.action_flag_five -> {
-                Timber.i("Reviewer:: Flag five")
-                onFlag(currentCard, Flag.PINK)
-            }
-            R.id.action_flag_six -> {
-                Timber.i("Reviewer:: Flag six")
-                onFlag(currentCard, Flag.TURQUOISE)
-            }
-            R.id.action_flag_seven -> {
-                Timber.i("Reviewer:: Flag seven")
-                onFlag(currentCard, Flag.PURPLE)
             }
             R.id.action_card_info -> {
                 Timber.i("Card Viewer:: Card Info")
@@ -692,12 +667,27 @@ open class Reviewer :
         startActivityWithAnimation(intent, animation)
     }
 
+    private val flagItemIds = mutableSetOf<Int>()
+
+    private fun addFlags(subMenu: SubMenu?) {
+        lifecycleScope.launch {
+            for (flag in Flag.entries) {
+                val title = flag.getName(resources)
+                val menuItem = subMenu?.add(Menu.NONE, flag.ordinal, Menu.NONE, title)?.setIcon(flag.drawableRes)
+                menuItem?.let {
+                    flagItemIds.add(it.itemId)
+                }
+            }
+        }
+    }
+
     // Related to https://github.com/ankidroid/Anki-Android/pull/11061#issuecomment-1107868455
     @NeedsTest("Order of operations needs Testing around Menu (Overflow) Icons and their colors.")
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         Timber.d("onCreateOptionsMenu()")
         // NOTE: This is called every time a new question is shown via invalidate options menu
         menuInflater.inflate(R.menu.reviewer, menu)
+        addFlags(menu.findItem(R.id.action_flag).subMenu)
         displayIcons(menu)
         actionButtons.setCustomButtonsStatus(menu)
         val alpha = Themes.ALPHA_ICON_ENABLED_LIGHT
@@ -708,23 +698,6 @@ open class Reviewer :
             markCardIcon.setTitle(R.string.menu_mark_note).setIcon(R.drawable.ic_star_border_white)
         }
         markCardIcon.iconAlpha = alpha
-
-        val flagIcon = menu.findItem(R.id.action_flag)
-        if (flagIcon != null) {
-            if (currentCard != null) {
-                when (currentCard!!.userFlag()) {
-                    1 -> flagIcon.setIcon(R.drawable.ic_flag_red)
-                    2 -> flagIcon.setIcon(R.drawable.ic_flag_orange)
-                    3 -> flagIcon.setIcon(R.drawable.ic_flag_green)
-                    4 -> flagIcon.setIcon(R.drawable.ic_flag_blue)
-                    5 -> flagIcon.setIcon(R.drawable.ic_flag_pink)
-                    6 -> flagIcon.setIcon(R.drawable.ic_flag_turquoise)
-                    7 -> flagIcon.setIcon(R.drawable.ic_flag_purple)
-                    else -> flagIcon.setIcon(R.drawable.ic_flag_transparent)
-                }
-            }
-            flagIcon.iconAlpha = alpha
-        }
 
         // Anki Desktop Translations
         menu.findItem(R.id.action_reschedule_card).title =
@@ -849,9 +822,12 @@ open class Reviewer :
         onboarding.onCreate()
 
         increaseHorizontalPaddingOfOverflowMenuIcons(menu)
-        tintOverflowMenuIcons(menu, skipIf = { isFlagResource(it.itemId) })
-
+        tintOverflowMenuIcons(menu, skipIf = { isFlagItem(it) })
         return super.onCreateOptionsMenu(menu)
+    }
+
+    private fun isFlagItem(menuItem: MenuItem): Boolean {
+        return flagItemIds.contains(menuItem.itemId)
     }
 
     @SuppressLint("RestrictedApi")
@@ -865,10 +841,6 @@ open class Reviewer :
         } catch (e: Error) {
             Timber.w(e, "Failed to display icons in Over flow menu")
         }
-    }
-
-    private fun isFlagResource(itemId: Int): Boolean {
-        return itemId == R.id.action_flag_seven || itemId == R.id.action_flag_six || itemId == R.id.action_flag_five || itemId == R.id.action_flag_four || itemId == R.id.action_flag_three || itemId == R.id.action_flag_two || itemId == R.id.action_flag_one
     }
 
     override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -123,6 +123,14 @@ class PreviewerFragment :
         }
 
         lifecycleScope.launch {
+            val submenu = menu.findItem(R.id.action_flag).subMenu
+            for (flag in Flag.entries) {
+                val title = flag.getName(resources)
+                submenu?.add(Menu.NONE, flag.ordinal, Menu.NONE, title)?.setIcon(flag.drawableRes)
+            }
+        }
+
+        lifecycleScope.launch {
             viewModel.flagCode
                 .flowWithLifecycle(lifecycle)
                 .collectLatest { flagCode ->
@@ -188,18 +196,15 @@ class PreviewerFragment :
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {
+        val flag = Flag.entries.find { it.ordinal == item.itemId }
+        flag?.let {
+            viewModel.setFlag(it)
+            return true
+        }
         when (item.itemId) {
             R.id.action_edit -> editCard()
             R.id.action_mark -> viewModel.toggleMark()
             R.id.action_back_side_only -> viewModel.toggleBackSideOnly()
-            R.id.action_flag_zero -> viewModel.setFlag(Flag.NONE)
-            R.id.action_flag_one -> viewModel.setFlag(Flag.RED)
-            R.id.action_flag_two -> viewModel.setFlag(Flag.ORANGE)
-            R.id.action_flag_three -> viewModel.setFlag(Flag.GREEN)
-            R.id.action_flag_four -> viewModel.setFlag(Flag.BLUE)
-            R.id.action_flag_five -> viewModel.setFlag(Flag.PINK)
-            R.id.action_flag_six -> viewModel.setFlag(Flag.TURQUOISE)
-            R.id.action_flag_seven -> viewModel.setFlag(Flag.PURPLE)
         }
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -50,6 +50,7 @@ import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.performClickIfEnabled
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class PreviewerFragment :
     CardViewerFragment(R.layout.previewer),
@@ -198,6 +199,7 @@ class PreviewerFragment :
     override fun onMenuItemClick(item: MenuItem): Boolean {
         val flag = Flag.entries.find { it.ordinal == item.itemId }
         flag?.let {
+            Timber.i("PreviewerFragment:: onMenuItemClick Flag - $it clicked")
             viewModel.setFlag(it)
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/JSONObject.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/JSONObject.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import org.json.JSONObject
+
+fun JSONObject.getStringOrNull(key: String): String? {
+    if (!has(key)) return null
+    return try {
+        getString(key)
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.json.Json
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 
 class Config(val backend: Backend) {
@@ -67,6 +68,17 @@ class Config(val backend: Backend) {
             default
         } catch (ex: SerializationException) {
             null
+        }
+    }
+
+    @NotInLibAnki
+    fun getObject(key: String, default: JSONObject): JSONObject {
+        return try {
+            JSONObject(backend.getConfigJson(key).toStringUtf8())
+        } catch (ex: BackendNotFoundException) {
+            default
+        } catch (ex: JSONException) {
+            default
         }
     }
 }

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -38,37 +38,7 @@
         android:id="@+id/action_search_by_flag"
         android:title="@string/card_browser_search_by_flag">
         <menu>
-            <item
-                android:id="@+id/action_select_flag_zero"
-                android:title="@string/menu_flag_card_zero"/>
-            <item
-                android:id="@+id/action_select_flag_one"
-                android:title="@string/menu_flag_card_one"
-                android:icon="@drawable/ic_flag_red"/>
-            <item
-                android:id="@+id/action_select_flag_two"
-                android:title="@string/menu_flag_card_two"
-                android:icon="@drawable/ic_flag_orange"/>
-            <item
-                android:id="@+id/action_select_flag_three"
-                android:title="@string/menu_flag_card_three"
-                android:icon="@drawable/ic_flag_green"/>
-            <item
-                android:id="@+id/action_select_flag_four"
-                android:title="@string/menu_flag_card_four"
-                android:icon="@drawable/ic_flag_blue"/>
-            <item
-                android:id="@+id/action_select_flag_five"
-                android:title="@string/menu_flag_card_five"
-                android:icon="@drawable/ic_flag_pink"/>
-            <item
-                android:id="@+id/action_select_flag_six"
-                android:title="@string/menu_flag_card_six"
-                android:icon="@drawable/ic_flag_turquoise"/>
-            <item
-                android:id="@+id/action_select_flag_seven"
-                android:title="@string/menu_flag_card_seven"
-                android:icon="@drawable/ic_flag_purple"/>
+            <!-- flags are dynamically added -->
         </menu>
     </item>
 

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -25,37 +25,7 @@
         android:title="@string/menu_flag_card"
         android:icon="@drawable/ic_flag_transparent">
       <menu>
-        <item
-            android:id="@+id/action_flag_zero"
-            android:title="@string/menu_flag_card_zero"/>
-        <item
-            android:id="@+id/action_flag_one"
-            android:title="@string/menu_flag_card_one"
-            android:icon="@drawable/ic_flag_red"/>
-        <item
-            android:id="@+id/action_flag_two"
-            android:title="@string/menu_flag_card_two"
-            android:icon="@drawable/ic_flag_orange"/>
-        <item
-            android:id="@+id/action_flag_three"
-            android:title="@string/menu_flag_card_three"
-            android:icon="@drawable/ic_flag_green"/>
-        <item
-            android:id="@+id/action_flag_four"
-            android:title="@string/menu_flag_card_four"
-            android:icon="@drawable/ic_flag_blue"/>
-      <item
-          android:id="@+id/action_flag_five"
-          android:title="@string/menu_flag_card_five"
-          android:icon="@drawable/ic_flag_pink"/>
-      <item
-          android:id="@+id/action_flag_six"
-          android:title="@string/menu_flag_card_six"
-          android:icon="@drawable/ic_flag_turquoise"/>
-      <item
-          android:id="@+id/action_flag_seven"
-          android:title="@string/menu_flag_card_seven"
-          android:icon="@drawable/ic_flag_purple"/>
+          <!-- flags are dynamically added -->
       </menu>
     </item>
 

--- a/AnkiDroid/src/main/res/menu/previewer.xml
+++ b/AnkiDroid/src/main/res/menu/previewer.xml
@@ -27,37 +27,7 @@
         android:icon="@drawable/ic_flag_transparent"
         app:showAsAction="always" >
         <menu>
-            <item
-                android:id="@+id/action_flag_zero"
-                android:title="@string/menu_flag_card_zero"/>
-            <item
-                android:id="@+id/action_flag_one"
-                android:title="@string/menu_flag_card_one"
-                android:icon="@drawable/ic_flag_red"/>
-            <item
-                android:id="@+id/action_flag_two"
-                android:title="@string/menu_flag_card_two"
-                android:icon="@drawable/ic_flag_orange"/>
-            <item
-                android:id="@+id/action_flag_three"
-                android:title="@string/menu_flag_card_three"
-                android:icon="@drawable/ic_flag_green"/>
-            <item
-                android:id="@+id/action_flag_four"
-                android:title="@string/menu_flag_card_four"
-                android:icon="@drawable/ic_flag_blue"/>
-            <item
-                android:id="@+id/action_flag_five"
-                android:title="@string/menu_flag_card_five"
-                android:icon="@drawable/ic_flag_pink"/>
-            <item
-                android:id="@+id/action_flag_six"
-                android:title="@string/menu_flag_card_six"
-                android:icon="@drawable/ic_flag_turquoise"/>
-            <item
-                android:id="@+id/action_flag_seven"
-                android:title="@string/menu_flag_card_seven"
-                android:icon="@drawable/ic_flag_purple"/>
+            <!-- flags are dynamically added -->
         </menu>
     </item>
     <item

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -58,37 +58,7 @@
         android:icon="@drawable/ic_flag_transparent"
         ankidroid:showAsAction="always" >
         <menu>
-            <item
-                android:id="@+id/action_flag_zero"
-                android:title="@string/menu_flag_card_zero"/>
-            <item
-                android:id="@+id/action_flag_one"
-                android:title="@string/menu_flag_card_one"
-                android:icon="@drawable/ic_flag_red"/>
-            <item
-                android:id="@+id/action_flag_two"
-                android:title="@string/menu_flag_card_two"
-                android:icon="@drawable/ic_flag_orange"/>
-            <item
-                android:id="@+id/action_flag_three"
-                android:title="@string/menu_flag_card_three"
-                android:icon="@drawable/ic_flag_green"/>
-            <item
-                android:id="@+id/action_flag_four"
-                android:title="@string/menu_flag_card_four"
-                android:icon="@drawable/ic_flag_blue"/>
-            <item
-                android:id="@+id/action_flag_five"
-                android:title="@string/menu_flag_card_five"
-                android:icon="@drawable/ic_flag_pink"/>
-            <item
-                android:id="@+id/action_flag_six"
-                android:title="@string/menu_flag_card_six"
-                android:icon="@drawable/ic_flag_turquoise"/>
-            <item
-                android:id="@+id/action_flag_seven"
-                android:title="@string/menu_flag_card_seven"
-                android:icon="@drawable/ic_flag_purple"/>
+            <!-- flags are dynamically added -->
         </menu>
     </item>
     <item

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -48,18 +48,10 @@ import org.json.JSONArray
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.test.assertFailsWith
 import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class ReviewerTest : RobolectricTest() {
-    @Test
-    fun verifyStartupNoCollection() {
-        enableNullCollection()
-        ActivityScenario.launch(Reviewer::class.java)
-            .use { scenario -> scenario.onActivity { reviewer: Reviewer -> assertFailsWith<Exception> { reviewer.getColUnsafe } } }
-    }
-
     @Ignore("flaky")
     @Test
     @RunInBackground


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
* Display Renamed Flags #16204 
This PR removes the static menu item - flags, from the menu and dynamically load the flag data which allow the user to access the renamed flags if they did rename them in Anki desktop 

## Fixes
* Fixes #16204

## Approach
Loaded flag from col

## How Has This Been Tested?
Anki ->
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/70239262-a716-4efa-8a7f-017b64391ac6)

AnkiDroid -> 
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/79fd23f9-6017-4878-800d-3f02c2e0baa6)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
