### PR TITLE
fix: [maybe] NullPointerException on subscriber.get() 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
@@ -35,6 +35,7 @@ import anki.collection.OpChangesWithCount
 import anki.collection.OpChangesWithId
 import anki.import_export.ImportResponse
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.CrashReportService
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
@@ -60,7 +61,12 @@ object ChangeManager {
     private fun notifySubscribers(changes: OpChanges, handler: Any?) {
         val expired = mutableListOf<WeakReference<Subscriber>>()
         for (subscriber in subscribers) {
-            val ref = subscriber.get()
+            val ref = try {
+                subscriber.get()
+            } catch (e: Exception) {
+                CrashReportService.sendExceptionReport(e, "notifySubscribers", "16217: invalid subscriber")
+                null
+            }
             if (ref == null) {
                 expired.add(subscriber)
             } else {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.lang.ref.WeakReference
+import java.util.concurrent.CopyOnWriteArrayList
 
 object ChangeManager {
     interface Subscriber {
@@ -49,7 +50,8 @@ object ChangeManager {
         fun opExecuted(changes: OpChanges, handler: Any?)
     }
 
-    private val subscribers = mutableListOf<WeakReference<Subscriber>>()
+    // Maybe fixes #16217 - CopyOnWriteArrayList makes this object thread-safe
+    private val subscribers = CopyOnWriteArrayList(mutableListOf<WeakReference<Subscriber>>())
 
     fun subscribe(subscriber: Subscriber) {
         subscribers.add(WeakReference(subscriber))


### PR DESCRIPTION
## Purpose / Description
```
java.lang.NullPointerException: Attempt to invoke virtual method 'java.lang.Object java.lang.ref.Reference.get()' on a null object reference
	at com.ichi2.libanki.ChangeManager.notifySubscribers(SourceFile:24)
	at com.ichi2.libanki.ChangeManager.notifySubscribers$AnkiDroid_fullRelease(SourceFile:65)
	at com.ichi2.libanki.ChangeManagerKt$undoableOp$3$1.invokeSuspend(SourceFile:17)
	at com.ichi2.libanki.ChangeManagerKt$undoableOp$3$1.invoke(SourceFile:2)
	at com.ichi2.libanki.ChangeManagerKt$undoableOp$3$1.invoke(SourceFile:1)
	at kotlinx.coroutines.intrinsics.UndispatchedKt.startUndispatchedOrReturn(SourceFile:8)
	at kotlinx.coroutines.BuildersKt__Builders_commonKt.withContext(SourceFile:54)
	at kotlinx.coroutines.BuildersKt.withContext(SourceFile:1)
	at com.ichi2.libanki.ChangeManagerKt.undoableOp(SourceFile:96)
	at com.ichi2.libanki.ChangeManagerKt$undoableOp$1.invokeSuspend(Unknown Source:10)
```

## Fixes
* Maybe Fixes #16217

## Approach
Make object thread-safe

## How Has This Been Tested?
Untested as I could not reproduce the underlying issue

## Learning (optional, can help others)
`mutableListOf` = `ArrayList` which is not thread safe

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
