### PR TITLE
Added hint text on "Set due date"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -212,6 +212,11 @@ class SetDueDateDialog : DialogFragment() {
                         suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, currentValue ?: 0)
                     }
                     suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, 0)
+                    helperText = getString(
+                        R.string.set_due_date_hintText,
+                        resources.getQuantityString(R.plurals.set_due_date_label_suffix, 0), // 0 days
+                        resources.getQuantityString(R.plurals.set_due_date_label_suffix, 1) // 1 day
+                    )
                 }
             }
             view.findViewById<TextView>(R.id.date_single_label).text =

--- a/AnkiDroid/src/main/res/layout/set_due_date_single.xml
+++ b/AnkiDroid/src/main/res/layout/set_due_date_single.xml
@@ -44,6 +44,7 @@
         app:layout_constraintStart_toStartOf="@+id/date_single_label"
         app:layout_constraintTop_toBottomOf="@+id/date_single_label"
         app:expandedHintEnabled="false"
+        tools:helperText="Today is ‘0 days’, tomorrow is ‘1 day’, etc…">
         tools:suffixText="days">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -75,6 +75,7 @@
     <string name="card_browser_search_all_decks">Search all decks</string>
     <string name="card_browser_unknown_deck_name">Unknown</string>
     <string name="card_browser_truncate" comment="allows users to show less of a field value">Truncate content</string>
+    <string name="set_due_date_hintText" comment="plural set_due_date_label_suffix is used for parameters, parameter 1 is the plural for 0, parameter 2 is the plural for 1">Today is ‘0 %1$s’, tomorrow is ‘1 %2$s’, etc…</string>
     <plurals name="card_browser_export_cards">
         <item quantity="one">Export card</item>
         <item quantity="other">Export cards</item>


### PR DESCRIPTION
## Purpose
It would be helpful to add hint text to the "Set due date" field, clarifying that "0 days" indicates today, as it does in the desktop version.

## Fixes
* Fixes #16199

## How Has This Been Tested?
On Realme 6 & Emulator 

## Screenshot's
![image (3)](https://github.com/ankidroid/Anki-Android/assets/91668590/803113ba-d147-4b57-8f38-9b0b072c4ef5)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
