### PR TITLE
build(ci): 'Anki Ecosystem Compatibility' should not go stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 3 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'
         stale-pr-message: 'Hello 👋, this PR has had no activity for more than 2 weeks and needs a reply from the author. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
-        exempt-issue-labels: 'Keep Open'
+        exempt-issue-labels: 'Keep Open,Anki Ecosystem Compatibility,Accepted'
         exempt-pr-labels: 'Keep Open'
         close-issue-reason: 'not_planned'
         days-before-issue-stale: 90


### PR DESCRIPTION
Anki Ecosystem Compatibility issues should all be fixed

## Fixes
* Fixes #16221

## Approach
Ignore the label

## How Has This Been Tested?
⚠️ needs CI to run for this one


## Learning (optional, can help others)

> Comma separated list of labels that can be assigned to pull requests to exclude them from being marked as stale (e.g: need-help,WIP)

docs: https://github.com/actions/stale?tab=readme-ov-file#exempt-pr-labels


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
