### PR TITLE
feat(check-pronunciation): Streamline UX

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -138,6 +138,8 @@ open class Reviewer :
 
     // Record Audio
     private var isMicToolBarVisible = false
+
+    /** Controller for 'Check Pronunciation' feature */
     private var audioRecordingController: AudioRecordingController? = null
     private var isAudioUIInitialized = false
     private lateinit var micToolBarLayer: LinearLayout

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -74,6 +74,7 @@ import com.ichi2.audio.AudioRecordingController.Companion.isAudioRecordingSaved
 import com.ichi2.audio.AudioRecordingController.Companion.isRecording
 import com.ichi2.audio.AudioRecordingController.Companion.setEditorStatus
 import com.ichi2.audio.AudioRecordingController.Companion.tempAudioPath
+import com.ichi2.audio.AudioRecordingController.RecordingState
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.sched.Counts
@@ -621,7 +622,12 @@ open class Reviewer :
             if (!isAudioUIInitialized) {
                 try {
                     audioRecordingController = AudioRecordingController()
-                    audioRecordingController?.createUI(this, micToolBarLayer)
+                    audioRecordingController?.createUI(
+                        this,
+                        micToolBarLayer,
+                        initialState = RecordingState.ImmediatePlayback.CLEARED,
+                        R.layout.activity_audio_recording_reviewer
+                    )
                 } catch (e: Exception) {
                     Timber.w(e, "unable to add the audio recorder to toolbar")
                     CrashReportService.sendExceptionReport(e, "Unable to create recorder tool bar")

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -523,11 +523,14 @@ class AudioRecordingController :
     fun updateUIForNewCard() {
         Timber.i("resetting audio recorder: new card shown")
         try {
-            if (isPlaying) {
-                discardAudio()
+            // transition to the 'CLEARED' state
+            if (state == AppendToRecording.CLEARED) {
+                return
             }
             if (isRecording || isRecordingPaused) {
                 clearRecording()
+            } else {
+                discardAudio()
             }
         } catch (e: Exception) {
             Timber.d("Unable to reset the audio recorder", e)

--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -158,27 +158,35 @@ class AudioRecordingController :
 
         audioTimer = AudioTimer(this, this)
         recordButton.setOnClickListener {
+            Timber.i("primary 'record' button clicked")
             controlAudioRecorder()
         }
 
         saveButton.setOnClickListener {
+            Timber.i("'save' button clicked")
             isAudioRecordingSaved = false
             toggleSave()
         }
 
         playAudioButton.setOnClickListener {
+            Timber.i("play/pause clicked")
             playPausePlayer()
         }
 
         cancelAudioRecordingButton.setOnClickListener {
+            // a recording is in progress and is cancelled
+            Timber.i("'clear recording' clicked")
             clearRecording()
         }
 
         discardRecordingButton.setOnClickListener {
+            // a recording has been completed, but we want to remake it
+            Timber.i("'discard recording' clicked")
             discardAudio()
         }
         orientationEventListener = object : OrientationEventListener(context) {
             override fun onOrientationChanged(orientation: Int) {
+                // BUG: Executes on trivial orientation changes, not just portrait <-> landscape
                 when (context.resources.configuration.orientation) {
                     Configuration.ORIENTATION_LANDSCAPE -> {
                         audioFileView.visibility = View.GONE
@@ -243,6 +251,7 @@ class AudioRecordingController :
     }
 
     fun onViewFocusChanged() {
+        Timber.i("activity paused: stopping recording/resetting player")
         if (isRecording || isPaused) {
             clearRecording()
         }
@@ -299,6 +308,7 @@ class AudioRecordingController :
     }
 
     fun toggleSave() {
+        Timber.i("recording completed")
         CompatHelper.compat.vibrate(context, 20)
         stopAndSaveRecording()
         playAudioButtonLayout.visibility = View.VISIBLE
@@ -309,6 +319,7 @@ class AudioRecordingController :
     }
 
     fun toggleToRecorder() {
+        Timber.i("recorder requested")
         if (audioPlayer!!.isPlaying) {
             audioPlayer?.stop()
         }
@@ -317,6 +328,7 @@ class AudioRecordingController :
         controlAudioRecorder()
     }
 
+    /** When the 'primary' button of the audio recorder is pressed */
     private fun controlAudioRecorder() {
         if (!canRecordAudio(context)) {
             Timber.w("Audio recording permission denied.")
@@ -339,6 +351,7 @@ class AudioRecordingController :
     fun playPausePlayer() {
         audioProgressBar.max = audioPlayer?.duration ?: 0
         if (!audioPlayer!!.isPlaying) {
+            Timber.i("saved recording: playing ")
             isPlaying = true
             try {
                 audioPlayer!!.start()
@@ -355,6 +368,7 @@ class AudioRecordingController :
                 strokeColor = ContextCompat.getColorStateList(context, R.color.audio_recorder_green)
             }
         } else {
+            Timber.i("saved recording: pausing")
             rewindAudioButton.isEnabled = false
             forwardAudioButton.isEnabled = false
             isPlaying = false
@@ -368,6 +382,7 @@ class AudioRecordingController :
         }
         val shortAudioDuration = 5000
         rewindAudioButton.setOnClickListener {
+            Timber.i("'back' pressed")
             val audioDuration = audioPlayer?.duration ?: 0
             if (audioDuration < shortAudioDuration) {
                 audioPlayer?.seekTo(0)
@@ -379,6 +394,7 @@ class AudioRecordingController :
             }
         }
         forwardAudioButton.setOnClickListener {
+            Timber.i("'forward' pressed")
             val audioDuration = audioPlayer?.duration ?: 0
             if (audioDuration < shortAudioDuration) {
                 audioPlayer?.seekTo(audioDuration)
@@ -391,6 +407,7 @@ class AudioRecordingController :
         }
 
         audioPlayer!!.setOnCompletionListener {
+            Timber.i("saved recording: completed")
             audioTimer.stop()
             rewindAudioButton.isEnabled = false
             forwardAudioButton.isEnabled = false
@@ -405,6 +422,7 @@ class AudioRecordingController :
     }
 
     private fun startRecording(context: Context, audioPath: String) {
+        Timber.i("starting recording")
         try {
             audioRecorder.startRecording(context, audioPath)
             isRecording = true
@@ -444,6 +462,7 @@ class AudioRecordingController :
     }
 
     private fun pauseRecorder() {
+        Timber.i("pausing recording")
         audioRecorder.pause()
         isPaused = true
         recordButton.setIconResource(R.drawable.ic_record)
@@ -451,6 +470,7 @@ class AudioRecordingController :
     }
 
     private fun resumeRecording() {
+        Timber.i("resuming recording")
         audioRecorder.resume()
         isPaused = false
         audioTimer.start()
@@ -487,6 +507,7 @@ class AudioRecordingController :
 
     // when answer button is clicked in reviewer
     fun updateUIForNewCard() {
+        Timber.i("resetting audio recorder: new card shown")
         try {
             if (isPlaying) {
                 discardAudio()

--- a/AnkiDroid/src/main/res/drawable/bg_rounded_drop_shadow.xml
+++ b/AnkiDroid/src/main/res/drawable/bg_rounded_drop_shadow.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<!--
+Drop shadow - Android tips & tricks - anonymous contributor
+ https://stackoverflow.com/a/24095309/
+ -->
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="#CABBBBBB"/>
+            <corners android:radius="16dp" />
+        </shape>
+    </item>
+
+    <item
+        android:left="0dp"
+        android:right="1dp"
+        android:top="0dp"
+        android:bottom="1dp">
+        <shape android:shape="rectangle">
+            <solid android:color="?android:attr/colorBackground"/>
+            <corners android:radius="16dp" />
+            <stroke android:color="#CABBBBBB" android:width="1dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/AnkiDroid/src/main/res/drawable/ic_play.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_play.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+<path android:fillColor="@android:color/white" android:pathData="M8,5v14l11,-7z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_record.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_record.xml
@@ -1,5 +1,5 @@
 <vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/white" android:pathData="M12,12m-8,0a8,8 0,1 1,16 0a8,8 0,1 1,-16 0"/>
+    <path android:fillColor="@android:color/white" android:pathData="M12,12m-7,0a7,7 0,1 1,14 0a7,7 0,1 1,-14 0"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_skip_next.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_skip_next.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="#000000">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M6,18l8.5,-6L6,6v12zM16,6v12h2V6h-2z"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_stop.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_stop.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M8,6h8c1.1,0 2,0.9 2,2v8c0,1.1 -0.9,2 -2,2H8c-1.1,0 -2,-0.9 -2,-2V8c0,-1.1 0.9,-2 2,-2z"/>
+
+</vector>

--- a/AnkiDroid/src/main/res/layout/activity_audio_recording_reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/activity_audio_recording_reviewer.xml
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2023 Ashish Yadav <mailtoashish693@gmail.com>
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<LinearLayout android:id="@+id/audioView"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:keepScreenOn="true"
+    tools:context="com.ichi2.audio.AudioRecordingController">
+
+    <RelativeLayout
+        android:id="@+id/record_buttons_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="8dp"
+        android:layout_marginHorizontal="16dp"
+        android:background="@drawable/bg_rounded_drop_shadow"
+        android:orientation="horizontal">
+
+        <com.ichi2.audio.AudioWaveform
+            android:id="@+id/audio_waveform_view"
+            android:layout_height="40dp"
+            android:layout_width="match_parent"
+            android:layout_alignParentStart="true"
+            android:layout_toStartOf="@+id/action_start_recording"
+            android:layout_centerVertical="true"
+            android:layout_marginStart="14dp"
+            android:paddingVertical="6dp"
+            android:background="?android:attr/colorBackground"
+            app:display_vertical_line="false" />
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/audio_progress_indicator"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="12dp"
+            android:layout_marginStart="14dp"
+            android:layout_centerVertical="true"
+            android:foregroundGravity="center"
+
+            android:layout_toStartOf="@+id/action_start_recording"
+
+            android:progress="0"
+
+            app:indicatorColor="@color/material_blue_500"
+            app:trackColor="@color/material_light_blue_100"
+            android:visibility="gone"
+            />
+
+        <!-- TODO: Icons are centered manually on the next two buttons-->
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/action_start_recording"
+            style="@style/Widget.Material3.Button.IconButton.Filled"
+
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:layout_centerVertical="true"
+            android:layout_toStartOf="@+id/action_cancel_recording"
+
+            android:layout_marginStart="2dp"
+            android:clickable="true"
+            android:focusable="true"
+
+            android:insetBottom="6dp"
+            android:insetLeft="6dp"
+            android:insetRight="6dp"
+            android:insetTop="6dp"
+
+            android:paddingStart="10dp"
+
+            app:backgroundTint="@color/material_grey_100"
+            app:icon="@drawable/ic_record"
+            app:iconGravity="textStart"
+            app:iconSize="24dp"
+            app:iconTint="@color/flag_red"
+            app:strokeColor="@color/flag_red"
+            app:strokeWidth="2dp" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/action_cancel_recording"
+            style="@style/Widget.Material3.Button.IconButton.Filled"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+
+            android:layout_alignParentEnd="true"
+
+            android:insetBottom="0dp"
+            android:insetLeft="0dp"
+            android:insetRight="0dp"
+            android:insetTop="0dp"
+
+            android:paddingStart="11dp"
+
+            app:backgroundTint="@color/transparent"
+            app:icon="@drawable/ic_clear_white"
+            app:iconTint="?attr/editTextColor"
+            app:iconSize="24dp"
+            />
+
+    </RelativeLayout>
+
+    <LinearLayout
+        android:visibility="gone"
+        android:id="@+id/play_buttons_layout"
+        android:layout_width="match_parent"
+        android:orientation="vertical"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.imageview.ShapeableImageView
+            android:id="@+id/audio_file_imageview"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="2dp"
+            android:minHeight="300px"
+            android:paddingVertical="6dp"
+            android:src="@drawable/round_audio_file_24"
+            android:tint="@color/material_blue_500" />
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="8dp"
+            android:gravity="center"
+            android:orientation="horizontal"
+            android:visibility="visible">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/action_rewind"
+                style="@style/Widget.Material3.Button.IconButton.Filled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="6dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:enabled="false"
+                app:backgroundTint="@color/material_blue_500"
+                app:icon="@drawable/baseline_replay_5_24"
+                app:iconPadding="0dp"
+                app:iconSize="22dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@id/action_play_recording"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/action_play_recording"
+                style="@style/Widget.Material3.Button.IconButton.Filled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="10dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:padding="10dp"
+                app:backgroundTint="@color/material_grey_100"
+                app:icon="@drawable/round_play_arrow_24"
+                app:iconPadding="0dp"
+                app:iconSize="50dp"
+                app:iconTint="@color/flag_red"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:strokeColor="@color/flag_red"
+                app:strokeWidth="4dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/action_forward"
+                style="@style/Widget.Material3.Button.IconButton.Filled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="6dp"
+                android:clickable="true"
+                android:focusable="true"
+                android:enabled="false"
+                app:backgroundTint="@color/material_blue_500"
+                app:icon="@drawable/baseline_forward_5_24"
+                app:iconPadding="0dp"
+                app:iconSize="22dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/action_play_recording"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/action_discard_recording"
+                style="@style/Widget.Material3.Button.IconButton.Filled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="6dp"
+                app:backgroundTint="@color/material_blue_500"
+                app:icon="@drawable/ic_delete"
+                app:iconPadding="0dp"
+                app:iconSize="22dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toEndOf="@id/action_forward"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:dividerThickness="2dp" />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -162,6 +162,11 @@
         <attr name="cycle_indeterminate_to_checked" format="boolean" />
     </declare-styleable>
 
+    <declare-styleable name="AudioWaveform">
+        <attr name="display_vertical_line" format="boolean" />
+        <attr name="android:background" />
+    </declare-styleable>
+
     <!-- Background color for Tab layout. It is essentially the color of the toolbar.
          The latter is set by colorPrimary, but theme overlay can't use it,
          as it itself overrides colorPrimary, which is used by the view directly. -->

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -125,5 +125,6 @@
     <!-- Audio Recorder Colors -->
     <color name="audio_recorder_red">#FF4747</color>
     <color name="audio_recorder_green">#6FF06F</color>
+    <color name="audio_recorder_grey">#444444</color>
 </resources>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -16,6 +16,8 @@
 
 package com.ichi2.anki
 
+import android.Manifest
+import android.app.Application
 import android.content.Context
 import android.content.DialogInterface.*
 import android.content.Intent
@@ -425,6 +427,12 @@ open class RobolectricTest : AndroidTest {
     @Suppress("MemberVisibilityCanBePrivate")
     fun editPreferences(action: SharedPreferences.Editor.() -> Unit) =
         getPreferences().edit(action = action)
+
+    protected fun grantRecordAudioPermission() {
+        val application = ApplicationProvider.getApplicationContext<Application>()
+        val app = Shadows.shadowOf(application)
+        app.grantPermissions(Manifest.permission.RECORD_AUDIO)
+    }
 
     private fun validateRunWithAnnotationPresent() {
         try {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimediacard/activity/MultimediaEditFieldActivityTestBase.kt
@@ -15,10 +15,7 @@
  */
 package com.ichi2.anki.multimediacard.activity
 
-import android.Manifest
-import android.app.Application
 import android.content.Intent
-import androidx.test.core.app.ApplicationProvider
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.IField
@@ -29,15 +26,9 @@ import com.ichi2.utils.KotlinCleanup
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
-import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
 
 abstract class MultimediaEditFieldActivityTestBase : RobolectricTest() {
-    protected fun grantRecordAudioPermission() {
-        val application = ApplicationProvider.getApplicationContext<Application>()
-        val app = Shadows.shadowOf(application)
-        app.grantPermissions(Manifest.permission.RECORD_AUDIO)
-    }
 
     protected fun getControllerForField(field: IField, note: IMultimediaEditableNote, fieldIndex: Int): IFieldController {
         val intent = Intent(Intent.ACTION_VIEW)


### PR DESCRIPTION
## Purpose / Description
A few issues/suggestions were raised in #16185 about the audio recorder changes introduced for #13043

* takes up too much space vertically
* increased number of touches required
* ❓ stops working after a while
* ❌ move the recorder to the bottom of the screen
* ✅ A long-press should start, releasing the long-press should stop

## Fixes
* Fixes #16185

## Approach

1) Major refactor to improve the state handling logic
2) Simplify the Reviewer state to the following, add a new layout and changes to the Waveform control:


```mermaid
stateDiagram-v2
    direction LR
    [*] --> Empty

    Empty --> Recording : ⏺️
    Recording --> Empty : ❎
    Recording --> Playback : ⏹️
    Playback --> Empty : ❎

    state Playback {
        [*]  --> p1
        p1: Paused
        p2: Playing

        p1 --> p2 : ▶️
        p2 --> p1 : ↩️
    }
```

3) Add 'on hold' logic for long presses



## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/62114487/6fb5c329-152e-4c89-b231-f2ac2ac4395c



## Learning (optional, can help others)
* `onStop`
* Adding custom attributes to Views
* MaterialButton is hard when it comes to centering icons

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
    - [ ] ⚠️ no issues with touch targets. Historical issues with 'item label' - proposing to extract to another issue
