### PR TITLE
Summarizes show answer long-press time title & summary

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -142,8 +142,8 @@
     <string name="vertical_centering_summ">Center the content of cards vertically</string>
     <string name="pref_double_tap_time_interval" maxLength="41">Double tap time interval (milliseconds)</string>
     <string name="pref_double_tap_time_interval_summary">A second tap of the answer buttons will be ignored if this time has not elapsed. This prevents accidental double taps</string>
-    <string name="pref_show_answer_long_press" maxLength="41">Show answer long-press time (ms)</string>
-    <string name="pref_show_answer_long_press_summary">Minimum long-press time before the show answer button will register a touch. May reduce the chance of accidental extra button presses. Default is 0ms</string>
+    <string name="pref_show_answer_long_press_time" maxLength="41">Show answer long-press time</string>
+    <string name="pref_show_answer_long_press_time_summary">Minimum pressing time before the show answer button registers a touch.</string>
     <string name="show_estimates" maxLength="41">Show button time</string>
     <string name="show_estimates_summ">Show next review time on answer buttons</string>
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>

--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -58,8 +58,8 @@
     <com.ichi2.preferences.SliderPreference
         android:defaultValue="0"
         android:key="@string/pref_card_minimal_click_time"
-        android:summary="@string/pref_show_answer_long_press_summary"
-        android:title="@string/pref_show_answer_long_press"
+        android:summary="@string/pref_show_answer_long_press_time_summary"
+        android:title="@string/pref_show_answer_long_press_time"
         android:valueFrom="0"
         android:valueTo="2000"
         app:displayFormat="@string/pref_milliseconds"/>


### PR DESCRIPTION
## Purpose / Description
The original summary for the Show answer long-press time is too lengthy, so it has been shortened to convey only what is necessary.

## Fixes
* Fixes #16081 

## How Has This Been Tested?
On Realme 6 & Emulator

## Screen Recording
https://github.com/ankidroid/Anki-Android/assets/91668590/20d09386-3b63-4c74-b9e8-f83f0c815b3f

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
