### PR TITLE
build(ci): upload logs on timeout

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -92,7 +92,9 @@ jobs:
           arguments: jacocoUnitTestReport --daemon
 
       - name: Store Logcat as Artifact
-        if: failure()
+        # cancelled() handles test timeouts
+        # remove when test timeouts cause a failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v3
         with:
           name: logcat-${{ matrix.name }}


### PR DESCRIPTION
A timeout can cancel tests, which blocks log uploads

⚠️ Untested

* For Issue #16253

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif

https://docs.github.com/en/actions/learn-github-actions/expressions#cancelled
