### PR TITLE
feat: initial 'Remove account' implementation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -130,6 +130,16 @@ open class MyAccount : AnkiActivity() {
         }
     }
 
+    /**
+     * Opens the AnkiWeb 'remove account' WebView
+     * @see R.string.remove_account_url
+     */
+    private fun openRemoveAccountScreen() {
+        // BUG: custom sync server doesn't use this URL
+        // BUG: this redirects to the decks screen after login
+        openUrl(getString(R.string.remove_account_url))
+    }
+
     private fun resetPassword() {
         super.openUrl(Uri.parse(resources.getString(R.string.resetpw_url)))
     }
@@ -213,6 +223,9 @@ open class MyAccount : AnkiActivity() {
             usernameLoggedIn = findViewById(R.id.username_logged_in)
             findViewById<Button>(R.id.logout_button).apply {
                 setOnClickListener { logout() }
+            }
+            findViewById<Button>(R.id.remove_account_button).apply {
+                setOnClickListener { openRemoveAccountScreen() }
             }
             ankidroidLogo = findViewById(R.id.ankidroid_logo)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -35,6 +35,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.pages.RemoveAccountFragment
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.ext.removeFragmentFromContainer
@@ -183,7 +184,9 @@ open class MyAccount : AnkiActivity() {
             ankidroidLogo = it.findViewById(R.id.ankidroid_logo)
         }
         val loginButton = loginToMyAccountView.findViewById<Button>(R.id.login_button)
-
+        loginToMyAccountView.findViewById<Button>(R.id.privacy_policy_button).apply {
+            setOnClickListener { openAnkiDroidPrivacyPolicy() }
+        }
         username.setOnFocusChangeListener { _, hasFocus ->
             if (!hasFocus) {
                 val email = username.text.toString().trim()
@@ -256,6 +259,9 @@ open class MyAccount : AnkiActivity() {
             findViewById<Button>(R.id.remove_account_button).apply {
                 setOnClickListener { openRemoveAccountScreen() }
             }
+            findViewById<Button>(R.id.privacy_policy_button).apply {
+                setOnClickListener { openAnkiDroidPrivacyPolicy() }
+            }
             ankidroidLogo = findViewById(R.id.ankidroid_logo)
         }
 
@@ -285,6 +291,11 @@ open class MyAccount : AnkiActivity() {
         } else {
             ankidroidLogo.visibility = View.VISIBLE
         }
+    }
+
+    private fun openAnkiDroidPrivacyPolicy() {
+        Timber.i("Opening 'Privacy policy'")
+        showDialogFragment(HelpDialog.newPrivacyPolicyInstance())
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -59,18 +59,16 @@ open class MyAccount : AnkiActivity() {
             STATE_LOGGED_IN -> {
                 val username = baseContext.sharedPrefs().getString("username", "")
                 usernameLoggedIn.text = username
-                toolbar = loggedIntoMyAccountView.findViewById(R.id.toolbar)
-                if (toolbar != null) {
-                    toolbar!!.title =
+                toolbar = loggedIntoMyAccountView.findViewById<Toolbar?>(R.id.toolbar)?.also { toolbar ->
+                    toolbar.title =
                         getString(R.string.sync_account) // This can be cleaned up if all three main layouts are guaranteed to share the same toolbar object
                     setSupportActionBar(toolbar)
                 }
                 setContentView(loggedIntoMyAccountView)
             }
             STATE_LOG_IN -> {
-                toolbar = loginToMyAccountView.findViewById(R.id.toolbar)
-                if (toolbar != null) {
-                    toolbar!!.title = getString(R.string.sync_account) // This can be cleaned up if all three main layouts are guaranteed to share the same toolbar object
+                toolbar = loginToMyAccountView.findViewById<Toolbar?>(R.id.toolbar)?.also { toolbar ->
+                    toolbar.title = getString(R.string.sync_account) // This can be cleaned up if all three main layouts are guaranteed to share the same toolbar object
                     setSupportActionBar(toolbar)
                 }
                 setContentView(loginToMyAccountView)
@@ -211,13 +209,14 @@ open class MyAccount : AnkiActivity() {
         val lostEmail = loginToMyAccountView.findViewById<Button>(R.id.lost_mail_instructions)
         val lostMailUrl = Uri.parse(resources.getString(R.string.link_ankiweb_lost_email_instructions))
         lostEmail.setOnClickListener { openUrl(lostMailUrl) }
-        loggedIntoMyAccountView = layoutInflater.inflate(R.layout.my_account_logged_in, null)
-        usernameLoggedIn = loggedIntoMyAccountView.findViewById(R.id.username_logged_in)
-        val logoutButton = loggedIntoMyAccountView.findViewById<Button>(R.id.logout_button)
-        loggedIntoMyAccountView.let {
-            ankidroidLogo = it.findViewById(R.id.ankidroid_logo)
+        loggedIntoMyAccountView = layoutInflater.inflate(R.layout.my_account_logged_in, null).apply {
+            usernameLoggedIn = findViewById(R.id.username_logged_in)
+            findViewById<Button>(R.id.logout_button).apply {
+                setOnClickListener { logout() }
+            }
+            ankidroidLogo = findViewById(R.id.ankidroid_logo)
         }
-        logoutButton.setOnClickListener { logout() }
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             password.setAutoFillListener {
                 // disable "show password".
@@ -244,15 +243,6 @@ open class MyAccount : AnkiActivity() {
         } else {
             ankidroidLogo.visibility = View.VISIBLE
         }
-    }
-
-    override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {
-        if (keyCode == KeyEvent.KEYCODE_BACK && event.repeatCount == 0) {
-            Timber.i("MyAccount - onBackPressed()")
-            finish()
-            return true
-        }
-        return super.onKeyDown(keyCode, event)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -128,6 +128,18 @@ class HelpDialog : DialogFragment() {
             }
         }
 
+        fun newPrivacyPolicyInstance(): HelpDialog {
+            UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
+            val privacyId = mainHelpMenuItems.single { it.analyticsId == Actions.OPENED_PRIVACY }.id
+            val privacyItems = childHelpMenuItems.filter { it.parentId == privacyId }
+            return HelpDialog().apply {
+                arguments = bundleOf(
+                    ARG_MENU_TITLE to R.string.help_title_privacy,
+                    ARG_MENU_ITEMS to privacyItems.toTypedArray()
+                )
+            }
+        }
+
         /**
          * @param canRateApp a boolean that indicates if the system has an app to open to rate AnkiDroid
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/RemoveAccountFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/RemoveAccountFragment.kt
@@ -1,0 +1,151 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import android.os.Bundle
+import android.view.View
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.annotation.CallSuper
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import com.google.android.material.appbar.MaterialToolbar
+import com.ichi2.anki.R
+import com.ichi2.annotations.NeedsTest
+import timber.log.Timber
+
+/**
+ * Displays a WebView to remove an AnkiWeb account
+ *
+ * We use this as we need to control the 'after login' URL
+ *
+ * AnkiWeb currently redirects from 'https://ankiweb.net/account/remove-account ->
+ *
+ * * https://ankiweb.net/account/login
+ *
+ * then to either:
+ *
+ * * 'https://ankiweb.net/account/verify-email'
+ * * 'https://ankiweb.net/decks'
+ *
+ * @see com.ichi2.anki.MyAccount.openRemoveAccountScreen
+ * @see com.ichi2.anki.pages.PageFragment
+ */
+@NeedsTest("pressing 'back' on this screen closes it")
+class RemoveAccountFragment : Fragment(R.layout.page_fragment) {
+    private lateinit var webView: WebView
+
+    /**
+     * A count of the redirects performed, to ensure we don't get into an infinite loop
+     */
+    private var redirectCount = 0
+
+    /**
+     * Redirect from post-login pages (such as 'verify account') to the required page
+     */
+    private fun maybeRedirectToRemoveAccount(url: String): Boolean {
+        if (!urlsToRedirect.any { urlToRedirect -> url.startsWith(urlToRedirect) }) {
+            Timber.v("not redirecting to remove account: url does not match")
+            return false
+        }
+        redirectCount++
+        if (redirectCount > 3) {
+            Timber.w("not redirecting to remove account: over the redirect limit")
+            return false
+        }
+
+        Timber.i("redirecting to 'remove account'")
+        webView.loadUrl(getString(R.string.remove_account_url))
+        return true
+    }
+
+    @CallSuper
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        webView = view.findViewById<WebView>(R.id.webview).apply {
+            isVisible = true
+            with(settings) {
+                javaScriptEnabled = true
+                displayZoomControls = false
+                builtInZoomControls = true
+                setSupportZoom(true)
+            }
+            webViewClient = object : WebViewClient() {
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    request: WebResourceRequest?
+                ): Boolean {
+                    @Suppress("DEPRECATION")
+                    return shouldOverrideUrlLoading(view, request?.url.toString())
+                }
+
+                @Deprecated(
+                    "Deprecated in java, still needed for API 23",
+                    replaceWith = ReplaceWith("shouldOverrideUrlLoading")
+                )
+                override fun shouldOverrideUrlLoading(
+                    view: WebView?,
+                    url: String?
+                ): Boolean {
+                    if (url == null) return false
+                    return maybeRedirectToRemoveAccount(url)
+                }
+
+                override fun onPageFinished(view: WebView?, url: String?) {
+                    super.onPageFinished(view, url)
+                    if (url == null) return
+                    maybeRedirectToRemoveAccount(url)
+                }
+            }
+        }
+
+        // BUG: custom sync server doesn't use this URL
+        val url = getString(R.string.remove_account_url)
+        Timber.i("Loading '$url'")
+        webView.loadUrl(url)
+
+        view.findViewById<MaterialToolbar?>(R.id.toolbar)?.apply {
+            title = getString(R.string.remove_account)
+            setNavigationOnClickListener {
+                requireActivity().onBackPressedDispatcher.onBackPressed()
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * A page shown if an account requires re-verification
+         *
+         * > **Email Sent**
+         * > We've sent an email to email@exmaple.com to confirm your address is valid. If that is not your correct address, please change it.
+         * > **Status**
+         * > Your email provider has accepted the email we sent. If you do not see it in the next few minutes, please check your spam folder. Please click the link in the email to proceed.
+         * > If you would like to try sending another email, you can do so below. You can try again up to 3 times.
+         * > [Send Again]
+         */
+        private const val INVALID_VERIFY_ACCOUNT_URL = "https://ankiweb.net/account/verify-email"
+
+        /** A page shown if an account can log in normally */
+        private const val INVALID_AFTER_LOGIN_URL = "https://ankiweb.net/decks"
+
+        // WARN: the above URLs were not accessible in either onPageFinished or shouldOverrideUrlLoading
+        // This URL is, but may be subject to change
+        private const val AFTER_LOGIN_URL = "https://ankiweb.net/account/login?afterAuth=1"
+
+        val urlsToRedirect = listOf(AFTER_LOGIN_URL, INVALID_AFTER_LOGIN_URL, INVALID_VERIFY_ACCOUNT_URL)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentManager.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import androidx.annotation.LayoutRes
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentTransaction
+
+/**
+ * Removes the [android.app.Fragment] attached to a view
+ *
+ * @param containerViewId The layout provided to [FragmentTransaction.replace]
+ *
+ * @throws IllegalArgumentException If a fragment is not attached to [containerViewId]
+ */
+fun FragmentManager.removeFragmentFromContainer(@LayoutRes containerViewId: Int) {
+    val toRemove = requireNotNull(findFragmentById(containerViewId)) { "could not find fragment" }
+    beginTransaction()
+        .remove(toRemove)
+        .commit()
+}

--- a/AnkiDroid/src/main/res/layout/my_account.xml
+++ b/AnkiDroid/src/main/res/layout/my_account.xml
@@ -139,6 +139,19 @@
                     android:singleLine="true"
                     android:text="@string/sign_up" />
 
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/privacy_policy_button"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@null"
+                    android:textSize="@dimen/abc_text_size_button_material"
+                    style="@style/Widget.Material3.Button.TextButton"
+                    android:padding="3dp"
+                    android:layout_gravity="center"
+                    android:singleLine="true"
+                    android:text="@string/help_title_privacy" />
+
                 <!-- Added new button for lost email -->
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/lost_mail_instructions"

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -47,7 +47,9 @@
                 android:layout_height="wrap_content"
                 android:textSize="@dimen/md_title_textsize"
                 android:textStyle="bold"
-                android:layout_margin="@dimen/content_vertical_padding"/>
+                android:layout_margin="@dimen/content_vertical_padding"
+                tools:text="user@example.com"
+                />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/logout_button"

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -73,6 +73,18 @@
                 android:layout_margin="@dimen/content_vertical_padding"
                 />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/privacy_policy_button"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:textSize="@dimen/abc_text_size_button_material"
+                style="@style/Widget.Material3.Button.TextButton"
+                android:padding="3dp"
+                android:layout_gravity="center"
+                android:singleLine="true"
+                android:text="@string/help_title_privacy" />
+
         </LinearLayout>
     </RelativeLayout>
     <!-- opens a WebView for 'remove account', replaces the layout above -->

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -8,6 +8,7 @@
     android:layout_height="match_parent"
     android:fitsSystemWindows="true">
     <RelativeLayout
+        android:id="@+id/logged_in_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:foregroundGravity="center">
@@ -74,5 +75,13 @@
 
         </LinearLayout>
     </RelativeLayout>
+    <!-- opens a WebView for 'remove account', replaces the layout above -->
+    <FrameLayout
+        android:id="@+id/remove_account_frame"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        tools:context=".pages.RemoveAccountFragment"
+        />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
+++ b/AnkiDroid/src/main/res/layout/my_account_logged_in.xml
@@ -61,6 +61,17 @@
                 android:layout_margin="@dimen/content_vertical_padding"
                 />
 
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/remove_account_button"
+                app:backgroundTint="@color/material_red_500"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="200dp"
+                android:layout_gravity="center"
+                android:text="@string/remove_account"
+                android:layout_margin="@dimen/content_vertical_padding"
+                />
+
         </LinearLayout>
     </RelativeLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -291,4 +291,6 @@
     <string name="all_files_access_title"
         comment="Name of the “All files access” permission from Android 10 and after">All files access</string>
     <string name="image_occlusion">Image Occlusion</string>
+
+    <string name="remove_account" comment="open a website to start the deletion of an AnkiWeb account">Remove account</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -134,6 +134,7 @@
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>
     <string name="resetpw_url">https://ankiweb.net/account/resetpw</string>
     <string name="register_url">https://ankiweb.net/account/register</string>
+    <string name="remove_account_url">https://ankiweb.net/account/remove-account</string>
     <string name="link_reddit">https://www.reddit.com/r/Anki/</string>
     <string name="link_ankidroid_privacy_policy">https://github.com/ankidroid/Anki-Android/wiki/Privacy-Policy</string>
     <string name="link_ankiweb_privacy_policy">https://ankiweb.net/account/privacy</string>


### PR DESCRIPTION
## Purpose / Description
Google require that we more prominently display 'Delete Account'

## Fixes
* Some of #16256

----

* [x]  the path for requesting deletion is not prominently displayed (for example a little process diagram of "1) access this page 2) log in to the account 3) click delete account link" 4) confirm ?
    * [x] note that the destination URL of "remove-account" is not remembered for redirect after login if not authenticated which would be nice to have. So currently steps are "click remove-account link", "log in", "click account", "click remove account", "confirm", account is deleted...
* [ ] ⚠️ the name doesn't match - we are "AnkiDroid Flashcards" on Play Store listing but that is not listed on the page at all. This is difficult. We need to have that name on the Play Store, but the account is an "AnkiWeb" account based on the webpage. Is there a way to include some information on the deletion page that this account is used by all compatible Anki ecosystem apps including Anki Mobile, Anki Desktop, and AnkiDroid Flashcards?
* [x] Privacy Policy link



## Approach
* A 'remove account' button opens AnkiWeb
* A user must log in to AnkiWeb if they did not already do so in 'Shared Decks'
  * We perform an internal redirect back to the 'remove account' functionality
* A user must enter their password
* A user must type 'remove'


## How Has This Been Tested?
API 33 emulator

* with non-validated account
* with validated account

<img width="325" alt="Screenshot 2024-04-23 at 19 36 40" src="https://github.com/ankidroid/Anki-Android/assets/62114487/294122e0-455e-4096-9c3c-adf57c402a97">

<img width="373" alt="Screenshot 2024-04-23 at 19 37 08" src="https://github.com/ankidroid/Anki-Android/assets/62114487/f2afc0a4-bd24-4ae7-b06b-4ccc71a37692">


<img width="369" alt="Screenshot 2024-04-23 at 19 57 21" src="https://github.com/ankidroid/Anki-Android/assets/62114487/e455d6da-69df-45ac-b456-b8e8f53505d2">

<img width="317" alt="Screenshot 2024-04-23 at 20 33 05" src="https://github.com/ankidroid/Anki-Android/assets/62114487/e9787197-cca7-4125-b034-673cf7a1b213">

<img width="347" alt="Screenshot 2024-04-23 at 20 33 13" src="https://github.com/ankidroid/Anki-Android/assets/62114487/f6e8271d-119b-41e8-a12d-bbf0691faad1">


## Learning (optional, can help others)
Google 🤷‍♂️ ... happily let copycats into the store, still make us jump through hoops



## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
