### PR TITLE
fix: handle backend-col already open to fix CI failure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -353,7 +353,6 @@ open class Reviewer :
         }
         val flag = Flag.entries.find { it.ordinal == item.itemId }
         flag?.let {
-            Timber.i("Reviewer:: onOptionItemSelected Flag - $it clicked")
             onFlag(currentCard, it)
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -50,7 +50,6 @@ import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.utils.performClickIfEnabled
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class PreviewerFragment :
     CardViewerFragment(R.layout.previewer),
@@ -199,7 +198,6 @@ class PreviewerFragment :
     override fun onMenuItemClick(item: MenuItem): Boolean {
         val flag = Flag.entries.find { it.ordinal == item.itemId }
         flag?.let {
-            Timber.i("PreviewerFragment:: onMenuItemClick Flag - $it clicked")
             viewModel.setFlag(it)
             return true
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
CI fails giving col already open 

Many solutions were tried the only thing that worked *for the moment* was a revert of the commit that started it

- adding `= runTest` to all reviewer touches in, this causes problems as some tests require GestureHandler to initialize which requires a valid Looper on the thread and `runTest` context is a non-main-thread / no-Looper context
- simply ignoring some tests - this would require ignoring a *lot* of tests

A real solution will involve:
- altering collection exception handling behavior when running in Robolectric context such that backend already open exception is re-thrown as an Error and thus converts the failure from a slow-hang to a fail-fast
- looking at thread affinity rules for collection handling in windows context so that it is really serialized, it appears there is a threading issue and this is the *real* root cause

## Fixes 
* Does not quite fix but is remediation for https://github.com/ankidroid/Anki-Android/issues/16253

## How Has This Been Tested?
Needs testing on CI

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
