### PR TITLE
Unicode character instead of three dots for ellipsis

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -22,6 +22,7 @@ import com.android.resources.ResourceFolderType
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
+import com.ichi2.anki.lint.utils.ext.isRightToLeftLanguage
 import org.w3c.dom.Element
 
 /**
@@ -86,6 +87,12 @@ class TranslationTypo : ResourceXmlDetector(), XmlScanner {
         // Only check <string> or <plurals><item>, not the container
         if ("resources" == element.tagName) {
             return
+        }
+
+        // use the unicode character instead of three dots for ellipsis
+        // ignore RTL to reduce maintenance: GitHub incorrectly displays ellipsis, so hard to review
+        if (element.textContent.contains("...") && !context.isRightToLeftLanguage()) {
+            context.report(ISSUE, context.getElementLocation(element), "should use unicode '&#8230;' instead of three dots for ellipsis")
         }
 
         // casing of 'JavaScript'

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.utils.ext
+
+import com.android.tools.lint.detector.api.XmlContext
+
+private val rtlLanguages = listOf("ar", "ckb", "fa", "heb", "ur")
+    .map { "values-$it" }
+    .toHashSet()
+
+fun XmlContext.isRightToLeftLanguage(): Boolean = rtlLanguages.contains(file.parentFile.name)


### PR DESCRIPTION
## Purpose / Description
This PR addresses a lint improvement in which `...` is replaced with unicode `&#8230;`.

## Fixes
* Fixes #16269

## Approach
Added a function in `TranslationTypo.visitElement()`  to check if the text contains `...` or not.

## How Has This Been Tested?
I test by running lint test and it shows 
`Error: should use unicode '&#8230;' instead of three dots for ellipsis [TranslationTypo from com.ichi2.anki:lint-rules]
    <string name="dialog_processing">Processing...</string>`


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
