### PR TITLE
fix(i18n): sync_translations PR creation is async, await it

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -96,7 +96,7 @@ jobs:
               ("0" + now.getUTCHours()).slice(-2) + ":" +
               ("0" + now.getUTCMinutes()).slice(-2);
             try {  
-              github.rest.pulls.create({              
+              await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: "Updated strings from Crowdin " + formattedDate,


### PR DESCRIPTION
## Purpose / Description

we need to handle the asynchronous nature of the call that might throw an error, otherwise we can never actually catch the error if the PR already exists, and the workflow appears to fail even though it's fine

## Fixes

No issue logged but this has been low-level bugging me forever, and I've been low-level looking at it periodically forever

Finally realized what the problem was

Apologies for just pasting a graphic in but this is what I'm trying to avoid / fix:

<img width="1148" alt="image" src="https://github.com/ankidroid/Anki-Android/assets/782704/8739d69f-2291-4269-91d0-6a0032a4c990">


("Unhandled" because even though a try/catch should handle any thrown thing, it's async and the error isn't thrown until we're out of the try/catch scope 💡 ! )

## Approach

Stew on it, then add an await to the call since it is async

## How Has This Been Tested?

Testing shmesting who needs it (kidding, but can only test easily once it's merged and then we run sync translations script twice without merging in between...

## Learning (optional, can help others)

How simple things can still take a while


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
