### PR TITLE
test: fail on unhandled exception

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -88,6 +88,9 @@ open class RobolectricTest : AndroidTest {
     @get:Rule
     val testName = TestName()
 
+    @get:Rule
+    val failOnUnhandledExceptions = FailOnUnhandledExceptionRule()
+
     @Before
     @CallSuper
     open fun setUp() {

--- a/testlib/build.gradle.kts
+++ b/testlib/build.gradle.kts
@@ -44,6 +44,7 @@ android {
 
 dependencies {
     implementation(project(":AnkiDroid"))
+    implementation(libs.jakewharton.timber)
     compileOnly(libs.kotlinx.coroutines.core)
     compileOnly(libs.hamcrest)
     compileOnly(libs.junit.jupiter)

--- a/testlib/src/main/java/com/ichi2/testutils/FailOnUnhandledExceptionRule.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/FailOnUnhandledExceptionRule.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import timber.log.Timber
+
+/**
+ * (#16253) Under unit tests, ACRA may infinitely loop when trying to handle an unhandled exception
+ *
+ * The default test behavior is to suppress an exception
+ *
+ * This rule replaces both UsageAnalytics and ACRA, ensuring a failure is reported
+ *
+ * When applying this rule, it SHOULD be applied after Application.onCreate, otherwise the exception
+ * handlers will override it
+ *
+ * This is not validated as `@Config(application = EmptyApplication::class)` is a valid
+ * use case where `exceptionHandler` is null
+ */
+class FailOnUnhandledExceptionRule : TestRule {
+
+    private var uncaughtException: Throwable? = null
+    private var exceptionHandler: Thread.UncaughtExceptionHandler? = null
+
+    var isEnabled = true
+
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                if (!isEnabled) return base.evaluate()
+
+                Timber.v("test: applying exception handler override")
+                exceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+                Thread.setDefaultUncaughtExceptionHandler { _: Thread?, throwable: Throwable ->
+                    Timber.e("test: unhandled exception", throwable)
+                    uncaughtException = throwable
+                }
+
+                try {
+                    base.evaluate()
+                } finally {
+                    Timber.v("test: removing exception handler override")
+                    Thread.setDefaultUncaughtExceptionHandler(exceptionHandler)
+                }
+
+                // throw instead of asserting to get the full stack trace
+                uncaughtException?.let { throw IllegalStateException("unhandled exception", it) }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Previously, an unhandled exception would hang, now it fails

## Fixes
* Issue #16253

## Approach
Assert no unhandled exceptions are thrown

## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/actions/runs/8859797884

```
WhiteboardDefaultForegroundColorTest > [1] > testDefaultForegroundColor[1] FAILED
    java.lang.IllegalStateException: unhandled exception
        at com.ichi2.testutils.FailOnUnhandledExceptionRule$apply$1.evaluate(FailOnUnhandledExceptionRule.kt:64)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:588)
        at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$2(SandboxTestRunner.java:290)
        at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:101)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)

        Caused by:
        net.ankiweb.rsdroid.exceptions.BackendInvalidInputException$BackendCollectionAlreadyOpenException: CollectionAlreadyOpen
            at net.ankiweb.rsdroid.exceptions.BackendInvalidInputException$Companion.fromInvalidInputError(BackendInvalidInputException.kt:34)
            at net.ankiweb.rsdroid.BackendException$Companion.fromError(BackendException.kt:114)
            at net.ankiweb.rsdroid.BackendKt.unpackResult(Backend.kt:271)
            at net.ankiweb.rsdroid.BackendKt.access$unpackResult(Backend.kt:1)
            at net.ankiweb.rsdroid.Backend$runMethodRaw$1.invoke(Backend.kt:118)
            at net.ankiweb.rsdroid.Backend$runMethodRaw$1.invoke(Backend.kt:117)
            at net.ankiweb.rsdroid.Backend.withBackend(Backend.kt:131)
            at net.ankiweb.rsdroid.Backend.runMethodRaw(Backend.kt:117)
            at anki.backend.GeneratedBackend.openCollectionRaw(GeneratedBackend.kt:102)
            at anki.backend.GeneratedBackend.openCollection(GeneratedBackend.kt:109)
            at net.ankiweb.rsdroid.Backend.openCollection(Backend.kt:98)
            at net.ankiweb.rsdroid.Backend.openCollection(Backend.kt:57)
            at com.ichi2.libanki.Storage.openDB$AnkiDroid_playDebug(Storage.kt:52)
            at com.ichi2.libanki.Collection.reopen(Collection.kt:206)
            at com.ichi2.libanki.Collection.reopen$default(Collection.kt:203)
            at com.ichi2.libanki.Collection.<init>(Collection.kt:138)
            at com.ichi2.libanki.Storage.collection(Storage.kt:40)
            at com.ichi2.anki.CollectionManager.ensureOpenInner(CollectionManager.kt:230)
            at com.ichi2.anki.CollectionManager.access$ensureOpenInner(CollectionManager.kt:39)
            at com.ichi2.anki.CollectionManager$withCol$2.invoke(CollectionManager.kt:101)
            at com.ichi2.anki.CollectionManager$withCol$2.invoke(CollectionManager.kt:100)
            at com.ichi2.anki.CollectionManager$withQueue$2.invokeSuspend(CollectionManager.kt:86)
            at app//kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
            at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
            at kotlinx.coroutines.EventLoop.processUnconfinedEvent(EventLoop.common.kt:65)
            at kotlinx.coroutines.internal.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuation.kt:[371](https://github.com/ankidroid/Anki-Android/actions/runs/8859797884/job/24330353482?pr=16281#step:8:373))
            at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(Cancellable.kt:26)
            at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable$default(Cancellable.kt:21)
            at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.kt:88)
            at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.kt:123)
            at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(Builders.common.kt:52)
            at kotlinx.coroutines.BuildersKt.launch(Unknown Source)
            at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(Builders.common.kt:43)
            at kotlinx.coroutines.BuildersKt.launch$default(Unknown Source)
            at com.ichi2.anki.Reviewer.addFlags(Reviewer.kt:659)
            at com.ichi2.anki.Reviewer.onCreateOptionsMenu(Reviewer.kt:676)
            at android.app.Activity.$$robo$$android_app_Activity$onCreatePanelMenu(Activity.java:4343)
            at android.app.Activity.onCreatePanelMenu(Activity.java)
            at androidx.activity.ComponentActivity.onCreatePanelMenu(ComponentActivity.java:520)
            at androidx.appcompat.view.WindowCallbackWrapper.onCreatePanelMenu(WindowCallbackWrapper.java:94)
            at androidx.appcompat.app.AppCompatDelegateImpl$AppCompatWindowCallback.onCreatePanelMenu(AppCompatDelegateImpl.java:3442)
            at androidx.appcompat.app.ToolbarActionBar.populateOptionsMenu(ToolbarActionBar.java:458)
            at androidx.appcompat.app.ToolbarActionBar$1.run(ToolbarActionBar.java:58)
            at android.os.Handler.$$robo$$android_os_Handler$handleCallback(Handler.java:942)
            at android.os.Handler.handleCallback(Handler.java)
            at android.os.Handler.$$robo$$android_os_Handler$dispatchMessage(Handler.java:99)
            at android.os.Handler.dispatchMessage(Handler.java)
            at org.robolectric.shadows.ShadowPausedLooper$IdlingRunnable.doRun(ShadowPausedLooper.java:573)
            at org.robolectric.shadows.ShadowPausedLooper$ControlRunnable.run(ShadowPausedLooper.java:536)
            at org.robolectric.shadows.ShadowPausedLooper.executeOnLooper(ShadowPausedLooper.java:629)
            at org.robolectric.shadows.ShadowPausedLooper.idle(ShadowPausedLooper.java:104)
            at org.robolectric.shadows.ShadowPausedLooper.idleIfPaused(ShadowPausedLooper.java:177)
            at org.robolectric.android.controller.ActivityController.visible(ActivityController.java:232)
            at com.ichi2.anki.RobolectricTest$Companion.startActivityNormallyOpenCollectionWithIntent(RobolectricTest.kt:284)
            at com.ichi2.anki.RobolectricTest.startActivityNormallyOpenCollectionWithIntent(RobolectricTest.kt)
            at com.ichi2.anki.RobolectricTest.startActivityNormallyOpenCollectionWithIntent$AnkiDroid_playDebugUnitTest(RobolectricTest.kt:342)
            at com.ichi2.anki.WhiteboardDefaultForegroundColorTest.getForegroundColor(WhiteboardDefaultForegroundColorTest.kt:43)
            at com.ichi2.anki.WhiteboardDefaultForegroundColorTest.testDefaultForegroundColor(WhiteboardDefaultForegroundColorTest.kt:38)
```

```
TemplatePreviewerViewModelTest > getCurrentTabIndex returns the correct tab if the first cloze isn't 1 and ord isn't 0 FAILED
    kotlinx.coroutines.test.UncaughtExceptionsBeforeTest: There were uncaught exceptions before the test started. Please avoid this, as such exceptions are also reported in a platform-dependent manner so that they are not lost.
        at kotlinx.coroutines.test.TestScopeImpl.enter(TestScope.kt:239)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:309)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:168)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at com.ichi2.testutils.TestClass.runTest(TestClass.kt:238)
        at com.ichi2.testutils.TestClass.runTest$default(TestClass.kt:227)
        at com.ichi2.anki.previewer.TemplatePreviewerViewModelTest.runClozeTest(TemplatePreviewerViewModelTest.kt:61)
        at com.ichi2.anki.previewer.TemplatePreviewerViewModelTest.getCurrentTabIndex returns the correct tab if the first cloze isn't 1 and ord isn't 0(TemplatePreviewerViewModelTest.kt:38)
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
