### PR TITLE
Undo stroke in drawing editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
@@ -26,6 +26,8 @@ import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuItemCompat
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.themes.Themes
+import com.ichi2.utils.iconAlpha
 import timber.log.Timber
 import java.io.FileNotFoundException
 
@@ -63,6 +65,13 @@ class DrawingActivity : AnkiActivity() {
                 R.color.white
             )
         )
+
+        // undo button
+        val undoEnabled: Boolean = !whiteboard.undoEmpty()
+        val alphaUndo = if (undoEnabled) Themes.ALPHA_ICON_ENABLED_LIGHT else Themes.ALPHA_ICON_DISABLED_LIGHT
+        val undoIcon = menu.findItem(R.id.action_undo)
+        undoIcon.setEnabled(undoEnabled).iconAlpha = alphaUndo
+
         return super.onCreateOptionsMenu(menu)
     }
 
@@ -78,6 +87,12 @@ class DrawingActivity : AnkiActivity() {
                     colorPalette.visibility = View.VISIBLE
                 } else {
                     colorPalette.visibility = View.GONE
+                }
+            }
+            R.id.action_undo -> {
+                Timber.i("Drawing:: Undo button pressed")
+                if (!whiteboard.undoEmpty()) {
+                    whiteboard.undo()
                 }
             }
         }

--- a/AnkiDroid/src/main/res/drawable/eraser.xml
+++ b/AnkiDroid/src/main/res/drawable/eraser.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:tint="?attr/colorControlNormal"
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"

--- a/AnkiDroid/src/main/res/menu/drawing_menu.xml
+++ b/AnkiDroid/src/main/res/menu/drawing_menu.xml
@@ -2,6 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_undo"
+        android:icon="@drawable/eraser"
+        android:title="@string/undo_action_whiteboard_last_stroke"
+        ankidroid:showAsAction="always" />
+    <item
         android:id="@+id/action_whiteboard_edit"
         android:icon="@drawable/ic_mode_edit_white"
         android:title="@string/title_whiteboard_editor"


### PR DESCRIPTION
## Description
The drawing editor did not have any way of undoing a stroke so it was proposed to add an undo button.

Even before this change, when the whiteboard is enabled during a card review, there is an eraser menu icon which undos strokes:
![image](https://github.com/ankidroid/Anki-Android/assets/28263886/2acee676-8173-4fff-bfee-d7252ab0da29)

Therefore the same implementation was used for the drawing editor and the same eraser icon was used for consistency. However, its possible the icon could be mistaken for an eraser drawing tool, therefore the undo icon could be a good alternative.

With eraser icon (as implemented in this PR):
![image](https://github.com/ankidroid/Anki-Android/assets/28263886/26896e8d-8656-4405-a22b-5be303521b7c)

Undo icon as alterntive option:
![image](https://github.com/ankidroid/Anki-Android/assets/28263886/16dcd79a-1ad3-4c5d-ac72-ff9291b40c14)

Lastly when there are no strokes to erase, the icon is disabled but remains visible.

## Fixes
* Fixes #16241

## Video Demo
[undo_tool_demo.webm](https://github.com/ankidroid/Anki-Android/assets/28263886/37d6f846-f99a-428e-82fd-8337fcad9fe3)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
