### PR TITLE
Scheduled flake hammer

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   scan_conflicts:
+    # Do not run the scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'ankidroid/Anki-Android') || (github.event_name != 'schedule')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -23,7 +23,8 @@ on:
           - '["windows-latest"]'
           - '["macos-14"]'
           - '["ubuntu-latest"]'
-
+  schedule:
+    - cron: "42 0 * * *"
   pull_request:
   push:
     # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
@@ -32,13 +33,17 @@ on:
   merge_group:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # if a workflow is run against the same ref, only one at a time...
+  # ...but allow different triggers to run concurrent (push, manual flake run, scheduled flake run...)
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
   # We want to generate our matrix dynamically
   # Initial job generates the matrix as a JSON, and following job will use deserialize and use the result
   matrix_prep:
+    # Do not run the scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'ankidroid/Anki-Android') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.build-matrix.outputs.result }}
@@ -73,6 +78,15 @@ jobs:
               console.log('iterationArray is: ' + iterationArray)
             }
 
+            // If we are running on a schedule it's our periodic passive scan for flakes
+            // Goal is to run enough iterations on all systems that we have confidence there are no flakes
+            if (context.eventName === "schedule") {
+              const iterationCount = 15
+              for (let i = 1; i <= iterationCount; i++) {
+                iterationArray.push(i);
+              }
+            }
+
             let includeArray = [];
             for(const os of osArray) {
               // we do this work to define 'name' so we don't need to update branch protection rules
@@ -94,6 +108,8 @@ jobs:
   # it will run unit tests on whatever OS combinations are desired
   unit:
     name: JUnit Tests (${{ matrix.name }} run ${{ matrix.iteration }})
+    # Do not run the scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'ankidroid/Anki-Android') || (github.event_name != 'schedule')
     needs: matrix_prep
     timeout-minutes: 40
     env:


### PR DESCRIPTION
We are still seeing some hanging issues and I want to passively detect them now and forever

Related
- #16197 
- #16279 

Idea is: once a day run 15 iterations on each OS

Limitation is: github has scheduling latency, so do not expect it to run at *exactly* the time, but it should run daily

Extra credit: only run this job on main repo, not on forks, and also fix the conflict scan so it only runs on main repo not forks

Testing: https://github.com/mikehardy/Anki-Android/actions/workflows/tests_unit.yml