### PR TITLE
fix: lateinit property of questions and answers not initialised

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -226,6 +226,7 @@ class CardMediaPlayer : Closeable {
      */
     private suspend fun playAllSoundsInternal(cardSide: CardSide, isAutomaticPlayback: Boolean) {
         if (!isEnabled) return
+        if (!isQuestionsAnswersInitialised()) return
         val soundList = when (cardSide) {
             CardSide.QUESTION -> questions
             CardSide.ANSWER -> answers
@@ -291,8 +292,13 @@ class CardMediaPlayer : Closeable {
         return@withContext true
     }
 
-    fun hasSounds(displayAnswer: Boolean): Boolean =
-        if (displayAnswer) answers.any() else questions.any()
+    fun hasSounds(displayAnswer: Boolean): Boolean {
+        if (!isQuestionsAnswersInitialised()) {
+            // Questions or Answers property not initialized, return false
+            return false
+        }
+        return if (displayAnswer) answers.any() else questions.any()
+    }
 
     /**
      * Plays all sounds for the current side, calling [onSoundGroupCompleted] when completed
@@ -341,6 +347,10 @@ class CardMediaPlayer : Closeable {
     fun onVideoPaused() {
         Timber.i("video paused")
         soundTagPlayer.videoPlayer.onVideoPaused()
+    }
+
+    private fun isQuestionsAnswersInitialised(): Boolean {
+        return (this::questions.isInitialized || this::answers.isInitialized)
     }
 
     companion object {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
fix: lateinit property of questions and answers not initialised

## Fixes
* Fixes #16302 

## Approach
Make use if `isInitialised` property to identify if the `lateinit` defined variables are initialised before using.
 
## How Has This Been Tested?

NOTE: This hasn't been tested yet as the crash has not been reproduced yet.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
