### PR TITLE
fix(tags-dialog): alignment of checkbox

### DIFF
--- a/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- -4dp end so the checkbox aligns with the OK button -->
 <LinearLayout android:id="@+id/tags_dialog_tag_item"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
@@ -11,7 +12,7 @@
     android:minHeight="?android:attr/listPreferredItemHeight"
     android:orientation="horizontal"
     android:paddingBottom="5dp"
-    android:paddingEnd="8dp"
+    android:paddingEnd="-4dp"
     android:paddingStart="8dp"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 


### PR DESCRIPTION
Cause: https://github.com/ankidroid/Anki-Android/commit/6119d5423324996ab4338643053aa31e3e0b5939

## Fixes
* Fixes #15205

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

**8dp**
![Screenshot 2024-04-30 at 21 17 49](https://github.com/ankidroid/Anki-Android/assets/62114487/6ca2abcd-5b85-4c19-b72b-8020621a4aba)

**0dp**
![Screenshot 2024-04-30 at 21 17 20](https://github.com/ankidroid/Anki-Android/assets/62114487/00dcd227-bc0d-400e-b537-b136666d94e3)

**-4dp**
![Screenshot 2024-04-30 at 21 22 11](https://github.com/ankidroid/Anki-Android/assets/62114487/7a7aea81-fd4f-4595-ab99-5dc73b84ad36)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
