### PR TITLE
fix: localizations not being added to values-iw

### DIFF
--- a/tools/localization/src/update.ts
+++ b/tools/localization/src/update.ts
@@ -180,59 +180,61 @@ export async function updateI18nFiles() {
         // but this comment hopefully clarifies for the reader that BCP47 / ISO-639-2 3-letter language tags do work in practice.
         //
         // The codes are not case-sensitive; the r prefix is used to distinguish the region portion. You cannot specify a region alone.
-        let androidLanguage = "";
+        let androidLanguages = [];
         const languageCode = language.split("-", 1)[0];
         if (LOCALIZED_REGIONS.includes(languageCode)) {
-            androidLanguage = language.replace("-", "-r"); // zh-CN becomes zh-rCN
+            androidLanguages = [language.replace("-", "-r")]; // zh-CN becomes zh-rCN
         } else {
-            androidLanguage = language.split("-", 1)[0]; // Example: es-ES becomes es
+            androidLanguages = [language.split("-", 1)[0]]; // Example: es-ES becomes es
         }
 
         switch (language) {
             case "yu":
-                androidLanguage = "yue";
+                androidLanguages = ["yue"];
                 break;
 
             case "he":
-                androidLanguage = "heb";
+                androidLanguages = ["heb", "iw"];
                 break;
 
             case "id":
-                androidLanguage = "ind";
+                androidLanguages = ["ind"];
                 break;
 
             case "tl":
-                androidLanguage = "tgl";
+                androidLanguages = ["tgl"];
                 break;
         }
 
-        console.log(
-            "\nCopying language files from " + language + " to " + androidLanguage,
-        );
-        const valuesDirectory = path.join(RES_VALUES_LANG_DIR + androidLanguage + "/");
-        createDirIfNotExisting(valuesDirectory);
-
-        // Copy localization files, mask chars and append gnu/gpl licence
-        for (const f of I18N_FILES) {
-            const fileExt = fileExtFor(f);
-            const translatedContent = fs.readFileSync(
-                TEMP_DIR + "/" + language + "/" + f + fileExt,
-                "utf-8",
+        androidLanguages.map(async androidLanguage => {
+            console.log(
+                "\nCopying language files from " + language + " to " + androidLanguage,
             );
-            anyError = !(await update(
-                valuesDirectory,
-                translatedContent,
-                f,
-                fileExt,
-                language,
-            ));
-        }
+            const valuesDirectory = path.join(RES_VALUES_LANG_DIR + androidLanguage + "/");
+            createDirIfNotExisting(valuesDirectory);
 
-        if (anyError) {
-            console.error(
-                "At least one file of the last handled language contains an error.",
-            );
-            anyError = true;
-        }
+            // Copy localization files, mask chars and append gnu/gpl licence
+            for (const f of I18N_FILES) {
+                const fileExt = fileExtFor(f);
+                const translatedContent = fs.readFileSync(
+                    TEMP_DIR + "/" + language + "/" + f + fileExt,
+                    "utf-8",
+                );
+                anyError = !(await update(
+                    valuesDirectory,
+                    translatedContent,
+                    f,
+                    fileExt,
+                    language,
+                ));
+            }
+
+            if (anyError) {
+                console.error(
+                    "At least one file of the last handled language contains an error.",
+                );
+                anyError = true;
+            }
+        });
     }
 }

--- a/tools/localization/src/update.ts
+++ b/tools/localization/src/update.ts
@@ -194,6 +194,8 @@ export async function updateI18nFiles() {
                 break;
 
             case "he":
+                // some Android phones use values-heb, some use values-iw - issue 9451
+                // the only way for Hebrew to work on all devices is to copy into both possible locations
                 androidLanguages = ["heb", "iw"];
                 break;
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Some devices rely on hebrew translations being in the `values-heb` resource directory and others rely on the translations being in `values-iw`. The solution seems to be to have those values duplicated into `values-iw` in addition to `values-heb`.

## Fixes
* Fixes #9451 <!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
_How does this change address the problem?_
This change reuses the same algorithm used for updating localization resources, with the addition of writing the contents of `values-he` to both `values-heb` and `values-iw`. The only difference now is that `androidLanguage` becomes an array of `androidLanguages`. `androidLanguage` originally represents the destination to copy to, so we iterate through this array to copy the current languages source files to the destinations we set. What this _should_ do is provide the necessary localization files for the devices that rely on them. This is mentioned in the issue, but it's the suggested solution here https://stackoverflow.com/a/8843293/9910298.

## How Has This Been Tested?

I haven't tested if this fixes the issue for the device in question. However, I have tested on my machine that it produces a `values-iw` directory with the correct contents. I've diffed it with `values-heb` and confirmed they're identical. 
Note: I used an old download of the Crowdin localization files, and there were a few things missing from it that the update script is built to throw an error if missing, e.g. the `values-sc` directory, and the `20-search-preference.xml` located in each localization directory. For those, I copied over those specific resources to the temp directory and it worked just fine after that. Let me know if the testing needs to be more rigorous.

## Learning (optional, can help others)
I'm somewhat familiar with Jest tests, and as I began to write tests for my changes, I noticed a few key problems to solve.

1. The working directory for my tests are different than the update script I was working with. This matters because the update script relies on relative paths to do its work. This is possible to fix with [process.chdir()](https://nodejs.org/api/process.html#processchdirdirectory)
2. Even if we were to run the update scripts as is in our tests, the cleanup would be awful since it mutates the files we're working with, and possibly slow, since it involves I/O operations.

A potential solution is to mock the filesystem module `fs` in our tests with an in-memory filesystem like [memfs](https://www.npmjs.com/package/memfs). An in memory filesystem mock would allow us to test certain features with granularity (i.e. throw an error if a necessary file is missing, or test if values-he is correctly duplicated in my case).

The tradeoff is that there is a lot of setup involved. I'm thinking it might be doable if we kept a rough json object, or wrote a builder that properly generates the contents of a typical download from Crowdin, but that can be discussed in more detail. 

_Links to blog posts, patterns, libraries or addons used to solve this problem_
- (Tried using this pattern here) https://stackoverflow.com/questions/74841423/how-to-mock-file-system-with-memfs-in-nodejs
- (I was going to mock the relative directories instead if we go with an in mem filesystem. it would look cleaner imo) https://jestjs.io/docs/mock-functions#mocking-partials
- (necessary context for mocking `fs`) https://jestjs.io/docs/manual-mocks#mocking-node-modules

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
