### PR TITLE
fix: lateinit property of questions and answers not initialised

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -46,6 +46,7 @@ open class SingleFragmentActivity : AnkiActivity() {
         setTransparentStatusBar()
 
         // avoid recreating the fragment on configuration changes
+        // the fragment should handle state restoration
         if (savedInstanceState != null) {
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -148,6 +148,24 @@ class CardMediaPlayer : Closeable {
         }
     }
 
+    /**
+     * Ensures that [questions] and [answers] are loaded
+     *
+     * Does not affect playback if they are
+     */
+    suspend fun ensureCardSoundsLoaded(card: Card) {
+        if (this::questions.isInitialized) return
+
+        Timber.i("loading sounds for card %d", card.id)
+        val renderOutput = withCol { card.renderOutput(this) }
+        this.questions = renderOutput.questionAvTags
+        this.answers = renderOutput.answerAvTags
+
+        if (!this::config.isInitialized || !config.appliesTo(card)) {
+            config = withCol { CardSoundConfig.create(card) }
+        }
+    }
+
     suspend fun playAllSoundsForSide(cardSide: CardSide): Job? {
         if (!isEnabled) return null
         playSoundsJob {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.hasTag
 import com.ichi2.libanki.note
@@ -72,9 +73,19 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
     ********************************************************************************************* */
 
     /** Call this after the webView has finished loading the page */
+    @NeedsTest("16302 - a sound-only card on the back/flipped with 'don't keep activities'")
+    @NeedsTest("16302 - on config changes, sound continues to play")
     override fun onPageFinished(isAfterRecreation: Boolean) {
         if (isAfterRecreation) {
-            launchCatchingIO { showCard(showAnswerOnReload) }
+            launchCatchingIO {
+                showCard(showAnswerOnReload)
+                // isAfterRecreation can either mean:
+                // * after config change (ViewModel exists)
+                // * after recreation (ViewModel did not exist)
+                // if the ViewModel existed, we want to continue playing audio
+                // if not, we want to setup the sound player
+                cardMediaPlayer.ensureCardSoundsLoaded(currentCard.await())
+            }
             return
         }
         launchCatchingIO {


### PR DESCRIPTION
`isAfterRecreation = true` -> sounds were not loaded

This was triggered if "Don't keep activities" was set

## Fixes
* Fixes #16302
* Fixes #16305

## Approach
Load sounds if `isAfterRecreation`
## How Has This Been Tested?
Manually on my S21:

* Enable don't keep activities
* reproduce the crash with an audio-only card
  * Either:
    * Being on the front and flipping the card
    * Being on the back
  * Then close + open the app  
 
Fix the code by adding `loadAndPlaySounds`

Crashes were no longer reproducible

## Learning (optional, can help others)
S21 seems to be very buggy with gesture nav + Don't keep activities, was difficult to get to the app picker

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
