### PR TITLE
Fix refresh of DeckPicker UI after a new collection import

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2634,9 +2634,14 @@ open class DeckPicker :
     }
 
     override fun onImportColpkg(colpkgPath: String?) {
-        invalidateOptionsMenu()
-        updateDeckList()
-        importColpkgListener?.onImportColpkg(colpkgPath)
+        launchCatchingTask {
+            // as the current collection is closed before importing a new collection, make sure the
+            // new collection is open before the code to update the DeckPicker ui runs
+            withCol { }
+            invalidateOptionsMenu()
+            updateDeckList()
+            importColpkgListener?.onImportColpkg(colpkgPath)
+        }
     }
 
     override fun onMediaSyncCompleted(data: SyncCompletion) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Before the new collection import, the current collection is closed. After the collection import succeeds DeckPicker runs code to update its UI but that code encounters a closed collection. The fix introduces an empty call to _withCol {}_ to make sure the collection is open and available before any of the code that updates the UI in DeckPicker runs.

## Fixes
* Fixes #16325
* Fixes #16257

## How Has This Been Tested?

Manually tested a new collection import + ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
