### PR TITLE
fix(audio-recorder): crash if saving immediately

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/audio/AudioRecordingController.kt
@@ -43,6 +43,7 @@ import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.elapsed
 import com.ichi2.anki.utils.formatAsString
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.audio.AudioRecordingController.RecordingState.AppendToRecording
 import com.ichi2.audio.AudioRecordingController.RecordingState.ImmediatePlayback
 import com.ichi2.compat.CompatHelper
@@ -276,6 +277,8 @@ class AudioRecordingController :
         }
     }
 
+    /** Called on pause, and when 'done' is pressed */
+    @NeedsTest("16321: record -> 'done' without pressing save")
     fun onViewFocusChanged() {
         Timber.i("activity paused: stopping recording/resetting player")
         if (isRecording || isRecordingPaused) {
@@ -434,7 +437,6 @@ class AudioRecordingController :
     fun toggleSave(vibrate: Boolean = true) {
         Timber.i("recording completed")
         if (vibrate) CompatHelper.compat.vibrate(context, 20)
-        setUiState(state.afterSave())
         stopAndSaveRecording()
         // show this snackbar only in the edit field/multimedia activity
         if (inEditField) (context as Activity).showSnackbar(context.resources.getString(R.string.audio_saved))
@@ -571,6 +573,7 @@ class AudioRecordingController :
         }
         isRecording = false
         isAudioRecordingSaved = true
+        setUiState(state.afterSave())
         // save recording only in the edit field not in the reviewer but save it temporarily
         if (inEditField) saveRecording()
     }


### PR DESCRIPTION
` if (isRecording || isRecordingPaused) {` returned true

so `clearRecording` was called even though `stop()` has been called

which crashed.

```
Done -> stopAndSaveRecording()
then -> done() -> onViewFocusChanged()
```


Cause: cad603ef08a3a0d7ef4f54a8260e3cc7409c3d27
I missed that `stopAndSaveRecording` was public

## Fixes
* Fixes #16321

## Approach
We fix this by setting the state to CLEARED after stopAndSaveRecording

## How Has This Been Tested?
S21

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
