### PR TITLE
build(ci): decrease unit test timeout to 30 minutes

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -111,7 +111,7 @@ jobs:
     # Do not run the scheduled jobs on forks
     if: (github.event_name == 'schedule' && github.repository == 'ankidroid/Anki-Android') || (github.event_name != 'schedule')
     needs: matrix_prep
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     strategy:


### PR DESCRIPTION
Our longest unit test runner is Windows (~18 mins)

We are currently having timeout issues with this runner, hitting this 40 min timeout.

This saves about 7x10 minutes of CI time per day for failed runners

Save the trees
