### PR TITLE
fix: 'iw' is a RTL language

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/ext/XmlContext.kt
@@ -18,7 +18,7 @@ package com.ichi2.anki.lint.utils.ext
 
 import com.android.tools.lint.detector.api.XmlContext
 
-private val rtlLanguages = listOf("ar", "ckb", "fa", "heb", "ur")
+private val rtlLanguages = listOf("ar", "ckb", "fa", "heb", "iw", "ur")
     .map { "values-$it" }
     .toHashSet()
 


### PR DESCRIPTION
Alias for Hebrew, Android needs both 'iw' and 'heb'

cause: 0f795cea363ace67bd55ec56775c5beae73c7c9e
* https://github.com/ankidroid/Anki-Android/issues/9451
* https://github.com/ankidroid/Anki-Android/pull/16316

----

* Unblocks https://github.com/ankidroid/Anki-Android/pull/16339