### PR TITLE
fix sync tooltip text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -995,14 +995,16 @@ open class DeckPicker :
         }
         menuItem.isVisible = true
 
-        menuItem.setTitle(
-            when (state.syncIcon) {
-                SyncIconState.Normal, SyncIconState.PendingChanges -> R.string.button_sync
-                SyncIconState.OneWay -> R.string.sync_menu_title_one_way_sync
-                SyncIconState.NotLoggedIn -> R.string.sync_menu_title_no_account
-            }
-        )
-        val provider = MenuItemCompat.getActionProvider(menuItem) as? SyncActionProvider ?: return
+        val provider = MenuItemCompat.getActionProvider(menuItem) as? SyncActionProvider
+            ?: return
+        val tooltipText = when (state.syncIcon) {
+            SyncIconState.Normal, SyncIconState.PendingChanges -> R.string.button_sync
+            SyncIconState.OneWay -> R.string.sync_menu_title_one_way_sync
+            SyncIconState.NotLoggedIn -> R.string.sync_menu_title_no_account
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            provider.setTooltipText(getString(tooltipText))
+        }
         when (state.syncIcon) {
             SyncIconState.Normal -> {
                 BadgeDrawableBuilder.removeBadge(provider)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SyncActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SyncActionProvider.kt
@@ -18,9 +18,11 @@ package com.ichi2.anki
 import android.app.Activity
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.view.isVisible
 import com.google.android.material.progressindicator.LinearProgressIndicator
@@ -56,5 +58,10 @@ class SyncActionProvider(context: Context) : ActionProviderCompat(context) {
         }
 
         return view
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun setTooltipText(value: CharSequence) {
+        syncButton?.tooltipText = value
     }
 }

--- a/AnkiDroid/src/main/res/layout/sync_progress_layout.xml
+++ b/AnkiDroid/src/main/res/layout/sync_progress_layout.xml
@@ -12,6 +12,7 @@
         android:layout_height="@dimen/touch_target"
         app:srcCompat="@drawable/ic_sync"
         style="@android:style/Widget.ActionButton"
+        android:tooltipText="@string/button_sync"
         android:tint="@color/white"
         tools:tint="?attr/colorControlNormal"
         />


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #16343

## Approach
set the tooltip programatically. It requires Android O, so in Android N and lower it will show just Sync

## How Has This Been Tested?

I long pressed the icon to see if the tooltip is shown

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
