### PR TITLE
grant audio capture permission to webview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1792,6 +1792,16 @@ abstract class AbstractFlashcardViewer :
 
         private lateinit var customView: View
 
+        override fun onPermissionRequest(request: PermissionRequest) {
+            if (PermissionRequest.RESOURCE_AUDIO_CAPTURE in request.resources) {
+                Timber.i("Granting audio capture permission to WebView")
+                request.grant(arrayOf(PermissionRequest.RESOURCE_AUDIO_CAPTURE))
+            } else {
+                Timber.i("Denying permissions to WebView")
+                request.deny()
+            }
+        }
+
         // used for displaying `<video>` in fullscreen.
         // This implementation requires configChanges="orientation" in the manifest
         // to avoid destroying the View if the device is rotated


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #16319

## Approach
Grant the audio capture permission

## How Has This Been Tested?

With the deck provided in the issue. Now the permission is granted.

## Learning (optional, can help others)

https://developer.android.com/reference/android/webkit/WebChromeClient#onPermissionRequest(android.webkit.PermissionRequest)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
