### PR TITLE
fix: TagsDialog crashes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1333,7 +1333,7 @@ open class CardBrowser :
                         .flatMap { nid: NoteId ->
                             progress++
                             val note = getNote(nid) // requires withCol
-                            val noteTags: List<String?> = note.tags
+                            val noteTags = note.tags.toSet()
                             allTags.filter { t: String? -> !noteTags.contains(t) }
                         }
                         .distinct()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1281,23 +1281,35 @@ open class CardBrowser :
             Timber.d("showEditTagsDialog: called with empty selection")
         }
         val allTags = getColUnsafe.tags.all()
-        val selectedNotes = selectedRowIds
-            .map { cardId: CardId? -> getColUnsafe.getCard(cardId!!).note(getColUnsafe) }
+        val selectedNoteIds = viewModel.queryAllSelectedNoteIds(getColUnsafe)
+
+        // TODO!! This is terribly slow on AnKing
+        val checkedTags = selectedNoteIds
+            .asSequence() // reduce memory pressure
+            .flatMap { nid -> getColUnsafe.getNote(nid).tags }
             .distinct()
-        val checkedTags = selectedNotes
-            .flatMap { note: Note -> note.tags }
-        if (selectedNotes.size == 1) {
+            .toList()
+
+        if (selectedNoteIds.size == 1) {
             Timber.d("showEditTagsDialog: edit tags for one note")
             tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
             val dialog = tagsDialogFactory.newTagsDialog().withArguments(TagsDialog.DialogType.EDIT_TAGS, checkedTags, allTags)
             showDialogFragment(dialog)
             return
         }
-        val uncheckedTags = selectedNotes
-            .flatMap { note: Note ->
+        // TODO!! This is terribly slow on AnKing
+        // PERF: This MUST be combined with the above sequence - this becomes O(2n) on a
+        // database operation performed over 30k times
+        val uncheckedTags = selectedNoteIds
+            .asSequence() // reduce memory pressure
+            .flatMap { nid: NoteId ->
+                val note = getColUnsafe.getNote(nid)
                 val noteTags: List<String?> = note.tags
                 allTags.filter { t: String? -> !noteTags.contains(t) }
             }
+            .distinct()
+            .toList()
+
         Timber.d("showEditTagsDialog: edit tags for multiple note")
         tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
         val dialog = tagsDialogFactory.newTagsDialog().withArguments(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -43,7 +43,6 @@ import com.ichi2.anki.setUserFlag
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
-import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
 import com.ichi2.libanki.Consts.QUEUE_TYPE_SIBLING_BURIED
@@ -179,7 +178,8 @@ class CardBrowserViewModel(
     }
 
     // TODO: move the tag computation to ViewModel
-    fun queryAllSelectedNoteIds(col: Collection): List<NoteId> = col.notesOfCards(selectedRowIds)
+    suspend fun queryAllSelectedNoteIds(): List<NoteId> =
+        withCol { notesOfCards(selectedRowIds) }
 
     var lastSelectedPosition = 0
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -166,7 +166,7 @@ class CardBrowserViewModel(
      * * [CardsOrNotes.CARDS] all selected card Ids
      * * [CardsOrNotes.NOTES] one selected Id for every note
      */
-    val selectedRowIds: List<Long>
+    val selectedRowIds: List<CardId>
         get() = selectedRows.map { c -> c.id }
 
     suspend fun queryAllSelectedCardIds(): List<CardId> = when (cardsOrNotes) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -43,10 +43,12 @@ import com.ichi2.anki.setUserFlag
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
 import com.ichi2.libanki.Consts.QUEUE_TYPE_SIBLING_BURIED
 import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.hasTag
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.Deferred
@@ -175,6 +177,9 @@ class CardBrowserViewModel(
             selectedRows
                 .flatMap { row -> withCol { cardIdsOfNote(nid = row.card.nid) } }
     }
+
+    // TODO: move the tag computation to ViewModel
+    fun queryAllSelectedNoteIds(col: Collection): List<NoteId> = col.notesOfCards(selectedRowIds)
 
     var lastSelectedPosition = 0
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -136,11 +136,13 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                          */
                         val currentDeck = requireArguments().getLong("did")
 
-                        val dialogFragment = TagsDialog().withArguments(
-                            TagsDialog.DialogType.CUSTOM_STUDY_TAGS,
-                            ArrayList(),
-                            ArrayList(collection.tags.byDeck(currentDeck))
-                        )
+                        val dialogFragment = with(requireContext()) {
+                            TagsDialog().withArguments(
+                                TagsDialog.DialogType.CUSTOM_STUDY_TAGS,
+                                ArrayList(),
+                                ArrayList(collection.tags.byDeck(currentDeck))
+                            )
+                        }
                         customStudyListener?.showDialogFragment(dialogFragment)
                     }
                     else -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -405,13 +405,16 @@ class TagsFile(path: String) : File(path), Parcelable {
      */
     constructor(directory: File, data: TagsData) : this(createTempFile("tagsDialog", ".tmp", directory).path) {
         DataOutputStream(FileOutputStream(this)).use { outputStream ->
-            // PERF: profile, then speed up if necessary
+            // PERF: Use an alternate format
             // https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats.md
-            outputStream.writeBytes(Json.encodeToString(data))
+            val string = Json.encodeToString(data)
+            Timber.d("persisting tags to disk, length: %d", string.length)
+            outputStream.writeBytes(string)
         }
     }
 
     fun getData() = DataInputStream(FileInputStream(this)).use { inputStream ->
+        // PERF!!: This takes ~2 seconds with AnKing
         Json.decodeFromString<TagsData>(inputStream.convertToString())
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -3,7 +3,10 @@ package com.ichi2.anki.dialogs.tags
 
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.Context
 import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
 import android.text.InputFilter
 import android.text.InputType
 import android.text.Spanned
@@ -14,16 +17,20 @@ import android.widget.EditText
 import android.widget.RadioGroup
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.convertToString
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TagsUtil
@@ -34,7 +41,15 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import timber.log.Timber
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
 
 class TagsDialog : AnalyticsDialogFragment {
     /**
@@ -93,6 +108,7 @@ class TagsDialog : AnalyticsDialogFragment {
      * @param allTags all possible tags in the collection
      * @return Initialized instance of [TagsDialog]
      */
+    context(Context)
     fun withArguments(type: DialogType, checkedTags: List<String>, allTags: List<String>): TagsDialog {
         return withArguments(type, checkedTags, null, allTags)
     }
@@ -106,31 +122,37 @@ class TagsDialog : AnalyticsDialogFragment {
      * @param allTags all possible tags in the collection
      * @return Initialized instance of [TagsDialog]
      */
+    context(Context)
     fun withArguments(
         type: DialogType,
         checkedTags: List<String>,
         uncheckedTags: List<String>?,
         allTags: List<String>
     ): TagsDialog {
-        val args = this.arguments ?: Bundle()
-        args.putInt(DIALOG_TYPE_KEY, type.ordinal)
-        args.putStringArrayList(CHECKED_TAGS_KEY, ArrayList(checkedTags))
-        if (uncheckedTags != null) {
-            args.putStringArrayList(UNCHECKED_TAGS_KEY, ArrayList(uncheckedTags))
-        }
-        args.putStringArrayList(ALL_TAGS_KEY, ArrayList(allTags))
-        arguments = args
+        val data = TagsFile.TagsData(type, checkedTags, uncheckedTags, allTags)
+        val file = TagsFile(cacheDir, data)
+        arguments = this.arguments ?: bundleOf(
+            ARG_TAGS_FILE to file
+        )
         return this
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         resizeWhenSoftInputShown(requireActivity().window)
-        type = DialogType.entries[requireArguments().getInt(DIALOG_TYPE_KEY)]
+
+        val tagsFile = requireNotNull(
+            BundleCompat.getParcelable(requireArguments(), ARG_TAGS_FILE, TagsFile::class.java)
+        ) {
+            "$ARG_TAGS_FILE is required"
+        }
+
+        val data = tagsFile.getData()
+        type = data.type
         tags = TagsList(
-            requireArguments().getStringArrayList(ALL_TAGS_KEY)!!,
-            requireArguments().getStringArrayList(CHECKED_TAGS_KEY)!!,
-            requireArguments().getStringArrayList(UNCHECKED_TAGS_KEY)
+            allTags = data.allTags,
+            checkedTags = data.checkedTags,
+            uncheckedTags = data.uncheckedTags
         )
         isCancelable = true
     }
@@ -322,10 +344,7 @@ class TagsDialog : AnalyticsDialogFragment {
     }
 
     companion object {
-        private const val DIALOG_TYPE_KEY = "dialog_type"
-        private const val CHECKED_TAGS_KEY = "checked_tags"
-        private const val UNCHECKED_TAGS_KEY = "unchecked_tags"
-        private const val ALL_TAGS_KEY = "all_tags"
+        private const val ARG_TAGS_FILE = "tagsFile"
 
         /**
          * The filter that constrains the inputted tag.
@@ -369,4 +388,58 @@ class TagsDialog : AnalyticsDialogFragment {
             sb
         }
     }
+}
+
+/**
+ * Temporary file containing the arguments [TagsDialog] uses
+ *
+ * to avoid [android.os.TransactionTooLargeException]
+ *
+ */
+@WorkerThread
+class TagsFile(path: String) : File(path), Parcelable {
+
+    /**
+     * @param directory parent directory of the file. Generally it should be the cache directory
+     * @param data data for the dialog to display. Typically [Context.getCacheDir]
+     */
+    constructor(directory: File, data: TagsData) : this(createTempFile("tagsDialog", ".tmp", directory).path) {
+        DataOutputStream(FileOutputStream(this)).use { outputStream ->
+            // PERF: profile, then speed up if necessary
+            // https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats.md
+            outputStream.writeBytes(Json.encodeToString(data))
+        }
+    }
+
+    fun getData() = DataInputStream(FileInputStream(this)).use { inputStream ->
+        Json.decodeFromString<TagsData>(inputStream.convertToString())
+    }
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        dest.writeString(path)
+    }
+
+    companion object {
+        @JvmField
+        @Suppress("unused")
+        val CREATOR = object : Parcelable.Creator<TagsFile> {
+            override fun createFromParcel(source: Parcel?): TagsFile {
+                return TagsFile(source!!.readString()!!)
+            }
+
+            override fun newArray(size: Int): Array<TagsFile> {
+                return arrayOf()
+            }
+        }
+    }
+
+    @Serializable
+    data class TagsData(
+        val type: TagsDialog.DialogType,
+        val checkedTags: List<String>,
+        val uncheckedTags: List<String>?,
+        val allTags: List<String>
+    )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -93,7 +93,7 @@ class TagsDialog : AnalyticsDialogFragment {
      * @param allTags all possible tags in the collection
      * @return Initialized instance of [TagsDialog]
      */
-    fun withArguments(type: DialogType, checkedTags: List<String?>, allTags: List<String?>): TagsDialog {
+    fun withArguments(type: DialogType, checkedTags: List<String>, allTags: List<String>): TagsDialog {
         return withArguments(type, checkedTags, null, allTags)
     }
 
@@ -108,9 +108,9 @@ class TagsDialog : AnalyticsDialogFragment {
      */
     fun withArguments(
         type: DialogType,
-        checkedTags: List<String?>,
+        checkedTags: List<String>,
         uncheckedTags: List<String>?,
-        allTags: List<String?>
+        allTags: List<String>
     ): TagsDialog {
         val args = this.arguments ?: Bundle()
         args.putInt(DIALOG_TYPE_KEY, type.ordinal)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -390,10 +390,10 @@ open class Card : Cloneable {
     @NotInLibAnki
     open class Cache : Cloneable {
         val col: Collection
-        val id: Long
+        val id: CardId
         private var _card: Card? = null
 
-        constructor(col: Collection, id: Long) {
+        constructor(col: Collection, id: CardId) {
             this.col = col
             this.id = id
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -44,7 +44,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
-import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
@@ -56,7 +55,7 @@ class TagsDialogTest : RobolectricTest() {
         val type = TagsDialog.DialogType.CUSTOM_STUDY_TAGS
         val allTags = listOf("1", "2", "3", "4")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, ArrayList(), allTags)
+            .withTestArguments(type, ArrayList(), allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -81,7 +80,7 @@ class TagsDialogTest : RobolectricTest() {
         val type = TagsDialog.DialogType.CUSTOM_STUDY_TAGS
         val allTags = listOf("1", "2", "3", "4")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, ArrayList(), allTags)
+            .withTestArguments(type, ArrayList(), allTags)
             .arguments
         val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light)
         scenario.moveToState(Lifecycle.State.STARTED)
@@ -117,7 +116,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("a", "b", "d", "e")
         val checkedTags = listOf("a", "b")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -152,7 +151,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("a", "b", "d", "e")
         val checkedTags = listOf("a", "b")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -190,7 +189,7 @@ class TagsDialogTest : RobolectricTest() {
         val expectedUncheckedTags = listOf("d", "e")
         val expectedIndeterminate = listOf("b")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, uncheckedTags, expectedAllTags)
+            .withTestArguments(type, checkedTags, uncheckedTags, expectedAllTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -245,7 +244,7 @@ class TagsDialogTest : RobolectricTest() {
             "sport::tennis"
         )
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -292,7 +291,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("common::speak", "common::speak::daily", "common::sport::tennis", "common::sport::football")
         val checkedTags = listOf("common::speak::daily", "common::sport::tennis")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -346,7 +345,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("common")
         val checkedTags = listOf("common")
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -394,7 +393,7 @@ class TagsDialogTest : RobolectricTest() {
             "common::sport::football::small"
         )
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -435,7 +434,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("common::speak", "common::sport::tennis")
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -482,7 +481,7 @@ class TagsDialogTest : RobolectricTest() {
         )
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -601,7 +600,7 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("hello::world")
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
-            .withArguments(type, checkedTags, allTags)
+            .withTestArguments(type, checkedTags, allTags)
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -636,6 +635,32 @@ class TagsDialogTest : RobolectricTest() {
             Assert.assertEquals("Should not crash.", "::", editText.text.toString())
         }
     }
+
+    // these are called 'withTestArguments' due to "extension is shadowed by a member" warnings
+    // this is needed so we can pass in 'targetContext' for context.cacheDir
+    private fun TagsDialog.withTestArguments(
+        type: TagsDialog.DialogType,
+        checkedTags: List<String>,
+        allTags: List<String>
+    ) =
+        with(this@TagsDialogTest.targetContext) {
+            withArguments(type = type, checkedTags = checkedTags, allTags = allTags)
+        }
+
+    private fun TagsDialog.withTestArguments(
+        type: TagsDialog.DialogType,
+        checkedTags: List<String>,
+        uncheckedTags: List<String>?,
+        allTags: List<String>
+    ) =
+        with(this@TagsDialogTest.targetContext) {
+            withArguments(
+                type = type,
+                checkedTags = checkedTags,
+                uncheckedTags = uncheckedTags,
+                allTags = allTags
+            )
+        }
 
     companion object {
         private fun mockLifecycleOwner(): LifecycleOwner {


### PR DESCRIPTION
## Purpose / Description

* Fix a `TransactionTooLargeException` and an `OutOfMemoryError`

This is a tradeoff of stability vs performance. We **should** do much better here in a follow-up 

## Fixes
* Fixes #16226
* Fixes #16351

## Approach
* Serialize to a file, rather than use Args
* Use `asSequence` to fix an OOM
  * This makes the dialog process 2x slower: we need to iterate the selected notes twice 
  * This may actually be faster after the PR on some collection, as we perform `select distinct nid` BEFORE loading the notes
* Add a progress dialog to help the user 

## How Has This Been Tested?
My S21, AnKing deck (31479 cards)

No longer crashes on AnKing
⚠️ It is still FAR too slow, needing to individually load 31k cards. This requires a follow-up issue

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
