### PR TITLE
Added Unit test for makeBackendUsable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -50,7 +50,6 @@ import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.services.BootService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
-import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ExceptionUtil
@@ -370,7 +369,6 @@ open class AnkiDroidApp : Application(), Configuration.Provider {
         }
 
         /** Load the libraries to allow access to Anki-Android-Backend */
-        @NeedsTest("Not calling this in the ContentProvider should have failed a test")
         fun makeBackendUsable(context: Context) {
             // Robolectric uses RustBackendLoader.ensureSetup()
             if (Build.FINGERPRINT == "robolectric") return

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppTest.kt
@@ -15,6 +15,8 @@
  */
 package com.ichi2.anki
 
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.testutils.AnkiAssert
@@ -35,5 +37,11 @@ class AnkiDroidAppTest {
         // It's meant to be non-null, but it's developer-defined, and we don't want a crash in the reporting dialog
         //noinspection ConstantConditions
         AnkiAssert.assertDoesNotThrow { sendExceptionReport(message, "AnkiDroidAppTest") }
+    }
+
+    @Test
+    fun makeBackendUsableDoesNotThrowException() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        AnkiAssert.assertDoesNotThrow { AnkiDroidApp.makeBackendUsable(context) }
     }
 }


### PR DESCRIPTION
## Purpose / Description
Added Unit test to function with @NeedsTest.

## Fixes
* Created test for makeBackendUsable to address "Not calling this in the ContentProvider should have failed a test".

## Approach
- Unit test completed.
## How Has This Been Tested?
- Ran the Unit test multiple times, and ensured it is passing.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
