### PR TITLE
[GSoC'24] Highlight selected preference setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -54,7 +54,7 @@ class Preferences :
     PreferenceFragmentCompat.OnPreferenceStartFragmentCallback,
     SearchPreferenceResultListener {
 
-    private fun hasLateralNavigation(): Boolean {
+    fun hasLateralNavigation(): Boolean {
         return findViewById<FragmentContainerView>(R.id.lateral_nav_container) != null
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/HeaderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/HeaderPreference.kt
@@ -19,6 +19,8 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.withStyledAttributes
 import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.LanguageUtils
 import com.ichi2.anki.R
 
@@ -33,6 +35,8 @@ constructor(
     defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
     defStyleRes: Int = androidx.preference.R.style.Preference
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+    private var isHighlighted = false
+    private val highlightColor: Int = MaterialColors.getColor(context, R.attr.currentDeckBackgroundColor, 0)
 
     init {
         context.withStyledAttributes(attrs, R.styleable.HeaderPreference) {
@@ -41,6 +45,18 @@ constructor(
                 summary = buildHeaderSummary(*entries)
             }
         }
+    }
+
+    override fun onBindViewHolder(holder: PreferenceViewHolder) {
+        super.onBindViewHolder(holder)
+        if (isHighlighted) {
+            holder.itemView.setBackgroundColor(highlightColor)
+        }
+    }
+
+    fun setHighlighted(highlight: Boolean) {
+        isHighlighted = highlight
+        notifyChanged()
     }
 
     companion object {

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -104,15 +104,15 @@
         android:icon="@drawable/ic_tune_white"
         app:summaryEntries="@array/advanced_summary_entries">
     </com.ichi2.preferences.HeaderPreference>
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:key="@string/pref_dev_options_screen_key"
         android:title="@string/pref_cat_dev_options"
         android:icon="@drawable/ic_code"
         android:fragment="com.ichi2.anki.preferences.DevOptionsFragment"
         app:isPreferenceVisible="false">
-    </Preference>
+    </com.ichi2.preferences.HeaderPreference>
     <!-- About -->
-    <Preference
+    <com.ichi2.preferences.HeaderPreference
         android:key="@string/about_screen_key"
         android:icon="@drawable/ic_outline_info_24"
         android:title="@string/pref_cat_about_title"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In tablet mode, the selected settings preference category is not highlighted. It would be better if we highlight the preference to have better user experience.


## Approach
Highlight GeneralSettings preference as default
use onPreferenceTreeClick function and remove highlight from previously selected preference and highlight the current preference

## How Has This Been Tested?
Emulator

https://github.com/ankidroid/Anki-Android/assets/65113071/5a73461b-b068-4cd4-acae-bb3c4949a2bc

Chromebook
[Screen recording 2024-05-19 11.47.35.webm](https://github.com/ankidroid/Anki-Android/assets/65113071/6afbe134-97b8-4ad8-9710-32618ac869e8)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
