### PR TITLE
fix: Inconsistent tag checkbox color

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -164,6 +164,7 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
                     node.checkBoxState = UNCHECKED
                 }
                 node.updateCheckBoxCycleStyle(tags)
+                node.vh?.checkBoxView?.refreshDrawableState()
             }
             update(this)
             for (ancestor in iterateAncestorsOf(this)) {
@@ -257,6 +258,7 @@ class TagsArrayAdapter(private val tags: TagsList, private val resources: Resour
             } else {
                 // tapping on a leaf node toggles the checkbox
                 vh.checkBoxView.performClick()
+                vh.checkBoxView.refreshDrawableState()
             }
         }
         // long clicking a tag opens the add tag dialog with the current tag as the prefix


### PR DESCRIPTION
## Purpose / Description
The problem was that despite the state within `CheckBoxTriStates.kt` getting updated when the tag list item was clicked (and the icon correctly changing), the `drawableState` would stay the same. As the button tint is linked to the drawableState, whatever was the current color of the checkbox, it would stay that way despite the icon changing.

The solution was to forcibly refresh the `drawableState` when the checkbox state is changed indirectly, either when clicking on the tag list item or when a parents tag state changes due to a child tag.

What I couldn't figure out is why the `drawableState` updates when the checkbox is clicked directly but not when the list item is clicked. The same `onClickListener` for the `checkBoxView` and other methods in `CheckBoxTriStates.kt` are hit in both scenarios so it must be some additional side affect.

[Tag Inconsistent Color Fix.webm](https://github.com/ankidroid/Anki-Android/assets/28263886/b073454b-af44-4ab4-bf14-0df8a8765d8b)


## Fixes
* Fixes #15196

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
