### PR TITLE
fix: prevent highlight with bluetooth controller

### DIFF
--- a/AnkiDroid/src/main/res/values/disable-fullscreen-keyboard-highlight.xml
+++ b/AnkiDroid/src/main/res/values/disable-fullscreen-keyboard-highlight.xml
@@ -16,6 +16,6 @@
 
 <resources>
     <style name="ThemeOverlay.DisableKeyboardHighlight" parent="">
-        <item name="android:colorControlHighlight">@color/transparent</item>
+        <item name="android:selectableItemBackground">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR will fix the highlight issue described in #14142 by again adjusting the resource XML configuration, eliminating the persistent dark highlight issue.

Ref PR: https://github.com/ankidroid/Anki-Android/pull/14231
Ref Issues: https://github.com/ankidroid/Anki-Android/issues/15164; https://github.com/ankidroid/Anki-Android/issues/14411

## Fixes
* Fixes #14262

## Approach
The correction involves modifying the XML definitions for highlight behavior. This change ensures the item highlight remains transparent, addressing the issue directly.

## How Has This Been Tested?
Tested on a physical Android device (OnePlus 8 Pro) with a Bluetooth controller. Without the change, the screen highlights; with the change, it does not.

## Learning (optional, can help others)
This was my first contribution to the codebase. I still have much to learn but heavily utilized ChatGPT for guidance.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
