### PR TITLE
fix language country with system default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/LanguageUtil.kt
@@ -218,7 +218,7 @@ object LanguageUtil {
             .getString("language", SYSTEM_LANGUAGE_TAG)!!
 
         val localeLanguage = if (langCode == SYSTEM_LANGUAGE_TAG) {
-            getSystemLocale().language
+            getSystemLocale().toLanguageTag()
         } else {
             langCode
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilRobolectricTest.kt
@@ -1,0 +1,38 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import net.ankiweb.rsdroid.BackendFactory
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class LanguageUtilRobolectricTest : RobolectricTest() {
+
+    @Test
+    @Config(qualifiers = "zn")
+    fun `Language without region is set`() {
+        assertEquals(BackendFactory.defaultLanguages, listOf("zn"))
+    }
+
+    @Test
+    @Config(qualifiers = "zn-rTW")
+    fun `Language with region is set`() {
+        assertEquals(BackendFactory.defaultLanguages, listOf("zn-TW"))
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #16183

## Approach
Use language tag isntead of language

## How Has This Been Tested?

I set my device language to chinese (taiwan) and opened the statistics page to see if it the issue was fixed:

![image](https://github.com/ankidroid/Anki-Android/assets/154519856/17a1b5ba-8ed2-48a3-aa33-4e930df1b821)

And it was alrgiht

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
