### PR TITLE
Added test for OnDeckSelected.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -120,7 +120,6 @@ open class CardBrowser :
     ChangeManager.Subscriber,
     ExportDialogsFactoryProvider {
 
-    @NeedsTest("15448: double-selecting deck does nothing")
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let {
             launchCatchingTask { selectDeckAndSave(deck.deckId) }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_1_KEY
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_2_KEY
+import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.model.CardsOrNotes.*
 import com.ichi2.anki.model.SortType
 import com.ichi2.anki.scheduling.ForgetCardsViewModel
@@ -134,6 +135,26 @@ class CardBrowserTest : RobolectricTest() {
         val browser = browserWithMultipleNotes
         selectOneOfManyCards(browser)
         assertThat(browser.isShowingSelectAll, equalTo(true))
+    }
+
+    @Test
+    fun testOnDeckSelected() = runBlocking {
+        // Arrange
+        val deckId = 123L
+        val selectableDeck = DeckSelectionDialog.SelectableDeck(deckId, "Test Deck")
+        val cardBrowser = getBrowserWithNotes(1)
+
+        // Act
+        cardBrowser.onDeckSelected(selectableDeck)
+
+        // Assert
+        assertEquals(deckId, cardBrowser.lastDeckId)
+
+        // Act again: select the same deck
+        cardBrowser.onDeckSelected(selectableDeck)
+
+        // Assert again: the deck selection should not change
+        assertEquals(deckId, cardBrowser.lastDeckId)
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -138,23 +138,22 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
-    fun testOnDeckSelected() = runBlocking {
+    fun testOnDeckSelected() = withBrowser(noteCount = 1) {
         // Arrange
         val deckId = 123L
         val selectableDeck = DeckSelectionDialog.SelectableDeck(deckId, "Test Deck")
-        val cardBrowser = getBrowserWithNotes(1)
 
         // Act
-        cardBrowser.onDeckSelected(selectableDeck)
+        this.onDeckSelected(selectableDeck)
 
         // Assert
-        assertEquals(deckId, cardBrowser.lastDeckId)
+        assertEquals(deckId, this.lastDeckId)
 
         // Act again: select the same deck
-        cardBrowser.onDeckSelected(selectableDeck)
+        this.onDeckSelected(selectableDeck)
 
         // Assert again: the deck selection should not change
-        assertEquals(deckId, cardBrowser.lastDeckId)
+        assertEquals(deckId, this.lastDeckId)
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Added Unit test to function with @NeedsTest.

## Fixes
* Created test for onDeckSelected to address "15448: double-selecting deck does nothing".

## Approach
- Unit test completed.
## How Has This Been Tested?
- Ran the Unit test multiple times, and ensured it is passing.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
