### PR TITLE
fix: IO type reappears when card is added

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -528,12 +528,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             else -> {}
         }
 
-        launchCatchingTask {
-            withCol {
-                addImageOcclusionNotetype()
-            }
-        }
-
         if (addNote) {
             editOcclusionsButton?.visibility = View.GONE
             selectImageForOcclusionButton?.setOnClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -661,9 +661,6 @@ open class Collection(
         return backend.clozeNumbersInNote(n.toBackendNote())
             .sorted()
     }
-    fun addImageOcclusionNotetype() {
-        backend.addImageOcclusionNotetype()
-    }
 
     fun getImageForOcclusionRaw(input: ByteArray): ByteArray {
         return backend.getImageForOcclusionRaw(input = input)


### PR DESCRIPTION
## Purpose / Description
Removed code from NoteEditor which was causing #16389 and also removed its fun from Collection.kt

## Fixes
* Fixes #16389 

## Approach
- Removed the lines mentioned in https://github.com/ankidroid/Anki-Android/pull/14884#discussion_r1420413957
- Also removed it's relevant fun in Collection.kt 

## How Has This Been Tested?

Compiles and builds, and bug squashed.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)



