### PR TITLE
[GSoC'24] chore: extract `ActionMode.Callback` from NoteEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CustomActionModeCallback.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CustomActionModeCallback.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.os.Build
+import android.view.ActionMode
+import android.view.Menu
+import android.view.MenuItem
+import android.view.View
+import androidx.annotation.RequiresApi
+
+/**
+ * Custom ActionMode.Callback implementation for adding and handling cloze deletion action
+ * button in the text selection menu or long press.
+ */
+class CustomActionModeCallback(
+    private val isClozeType: Boolean,
+    private val clozeMenuTitle: String,
+    private val clozeMenuId: Int,
+    private val onActionItemSelected: (mode: ActionMode, item: MenuItem) -> Boolean
+) : ActionMode.Callback {
+    @RequiresApi(Build.VERSION_CODES.N)
+    private val setLanguageId = View.generateViewId()
+
+    override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
+        return true
+    }
+
+    override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
+        // Adding the cloze deletion floating context menu item, but only once.
+        if (menu.findItem(clozeMenuId) != null) {
+            return false
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && menu.findItem(setLanguageId) != null) {
+            return false
+        }
+
+        val item: MenuItem? = menu.findItem(android.R.id.pasteAsPlainText)
+        val platformPasteMenuItem: MenuItem? = menu.findItem(android.R.id.paste)
+        if (item != null && platformPasteMenuItem != null) {
+            item.isVisible = false
+        }
+
+        val initialSize = menu.size()
+        if (isClozeType) {
+            menu.add(
+                Menu.NONE,
+                clozeMenuId,
+                0,
+                clozeMenuTitle
+            )
+        }
+        return initialSize != menu.size()
+    }
+
+    override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
+        return onActionItemSelected(mode, item)
+    }
+
+    override fun onDestroyActionMode(mode: ActionMode) {
+        // Left empty on purpose
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1537,7 +1537,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             editLineView.setEnableAnimation(animationEnabled())
 
             // Use custom implementation of ActionMode.Callback customize selection and insert menus
-            editLineView.setActionModeCallbacks(ActionModeCallback(newEditText))
+            editLineView.setActionModeCallbacks(getActionModeCallback(newEditText, View.generateViewId()))
             editLineView.setHintLocale(getHintLocaleForField(editLineView.name))
             initFieldEditText(newEditText, i, !editModelMode)
             editFields!!.add(newEditText)
@@ -1580,6 +1580,23 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             editLineView.isVisible = i !in indicesToHide
             fieldsLayoutContainer!!.addView(editLineView)
         }
+    }
+
+    private fun getActionModeCallback(textBox: FieldEditText, clozeMenuId: Int): ActionMode.Callback {
+        return CustomActionModeCallback(
+            isClozeType,
+            getString(R.string.multimedia_editor_popup_cloze),
+            clozeMenuId,
+            onActionItemSelected = { mode, item ->
+                if (item.itemId == clozeMenuId) {
+                    convertSelectedTextToCloze(textBox, AddClozeType.INCREMENT_NUMBER)
+                    mode.finish()
+                    true
+                } else {
+                    false
+                }
+            }
+        )
     }
 
     private fun onImagePaste(editText: EditText, uri: Uri): Boolean {
@@ -2313,67 +2330,6 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
 
         override fun onNothingSelected(parent: AdapterView<*>?) {
             // Do Nothing
-        }
-    }
-
-    /**
-     * Custom ActionMode.Callback implementation for adding and handling cloze deletion action
-     * button in the text selection menu.
-     */
-    private inner class ActionModeCallback(
-        private val textBox: FieldEditText
-    ) : ActionMode.Callback {
-        private val clozeMenuId = View.generateViewId()
-
-        @RequiresApi(Build.VERSION_CODES.N)
-        private val setLanguageId = View.generateViewId()
-        override fun onCreateActionMode(mode: ActionMode, menu: Menu): Boolean {
-            return true
-        }
-
-        override fun onPrepareActionMode(mode: ActionMode, menu: Menu): Boolean {
-            // Adding the cloze deletion floating context menu item, but only once.
-            if (menu.findItem(clozeMenuId) != null) {
-                return false
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && menu.findItem(setLanguageId) != null) {
-                return false
-            }
-
-            // Removes paste as plain text from ContextMenu in NoteEditor
-            val item: MenuItem? = menu.findItem(android.R.id.pasteAsPlainText)
-            val platformPasteMenuItem: MenuItem? = menu.findItem(android.R.id.paste)
-            if (item != null && platformPasteMenuItem != null) {
-                item.isVisible = false
-            }
-
-            val initialSize = menu.size()
-            if (isClozeType) {
-                // 10644: Do not pass in a R.string as the final parameter as MIUI on Android 12 crashes.
-                menu.add(
-                    Menu.NONE,
-                    clozeMenuId,
-                    0,
-                    getString(R.string.multimedia_editor_popup_cloze)
-                )
-            }
-            return initialSize != menu.size()
-        }
-
-        @SuppressLint("SetTextI18n")
-        override fun onActionItemClicked(mode: ActionMode, item: MenuItem): Boolean {
-            val itemId = item.itemId
-            return if (itemId == clozeMenuId) {
-                convertSelectedTextToCloze(textBox, AddClozeType.INCREMENT_NUMBER)
-                mode.finish()
-                true
-            } else {
-                false
-            }
-        }
-
-        override fun onDestroyActionMode(mode: ActionMode) {
-            // Left empty on purpose
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Extracting the ActionMode Callback from note editor so that it can be reused in instant note editor 

## How Has This Been Tested?
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/c45f47c6-9e12-44f6-bbfc-449e7b6677ee)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
