### PR TITLE
fix:no warning on empty front template

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -324,7 +324,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
             // Storing a reference to the templateEditor allows us to use member variables
             templateEditor = activity as CardTemplateEditor
-
             val mainView = inflater.inflate(R.layout.card_template_editor_item, container, false)
             val cardIndex = requireArguments().getInt(CARD_INDEX)
             val tempModel = templateEditor.tempModel
@@ -552,7 +551,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 }
                 message(text = TR.cardTemplatesNoFrontField())
                 positiveButton(R.string.help) {
-                    openUrl(Uri.parse("https://docs.ankiweb.net/templates/errors.html#no-field-replacement-on-front-side"))
+                    openUrl(Uri.parse(getString(R.string.anki_field_replacement_url)))
                 }
                 negativeButton(R.string.dialog_ok)
             }

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -298,4 +298,5 @@
     <string name="show_onboarding" maxLength="41">Show onboarding walkthrough</string>
     <string name="show_onboarding_desc">Display feature tutorial to learn more about the app</string>
     <string name="reset_onboarding_desc">Show all tutorials again</string>
+    <string name="anki_field_replacement_url">https://docs.ankiweb.net/templates/errors.html#no-field-replacement-on-front-side</string>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Anki and Ankidroid both have same warning dialog when trying to save front card template

## Fixes 
* Fixes #16220 

## How Has This Been Tested?
Google Emulator
![image](https://github.com/ankidroid/Anki-Android/assets/115779647/35cdcecb-8068-4bd1-a51f-4c4cc993b14c)


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
