### PR TITLE
[GSoC'24] Refactor DeckPicker to Single Menu Layout

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2059,7 +2059,8 @@ open class DeckPicker :
         hideProgressBar()
         // Make sure the fragment is visible
         if (fragmented) {
-            studyoptionsFrame!!.visibility = View.VISIBLE
+            invalidateOptionsMenu()
+            studyoptionsFrame!!.visibility = if (collectionIsEmpty) View.GONE else View.VISIBLE
         }
         dueTree = result
         launchCatchingTask { renderPage(collectionIsEmpty) }

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -1,14 +1,15 @@
 <menu xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
-    tools:context=".DeckPicker">
-    <group android:id="@+id/allItems">
-        <item
-            android:id="@+id/deck_picker_action_filter"
-            android:icon="@drawable/ic_search_white"
-            android:title="@string/search_decks"
-            ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
-            ankidroid:showAsAction="always|collapseActionView"/>
+    >
+    <item
+        android:id="@+id/deck_picker_action_filter"
+        android:icon="@drawable/ic_search_white"
+        android:title="@string/search_decks"
+        android:visible="false"
+        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:showAsAction="always|collapseActionView"/>
+    <group android:id="@+id/commonItems">
         <item
             android:id="@+id/action_migration_progress"
             android:visible="false"
@@ -67,7 +68,7 @@
             android:menuCategory="secondary"
             android:title="@string/menu_import"/>
         <item
-            android:id="@+id/action_export"
+            android:id="@+id/action_export_collection"
             android:menuCategory="secondary" />
     </group>
 </menu>

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -1,7 +1,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto" >
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
     <item
-        android:id="@+id/action_undo"
+        android:id="@+id/action_undo_study_options"
         android:enabled="true"
         android:icon="@drawable/ic_undo_white"
         android:title="@string/undo"
@@ -40,8 +41,15 @@
         android:visibility = "gone"/>
     <item
         android:id="@+id/action_export"
-        android:title="@string/export_deck"
-        android:visibility = "gone"/>
+        tools:text="Export"
+        android:visibility="gone">
+        <menu>
+            <item
+                android:id="@+id/action_export_deck"
+                android:menuCategory="secondary"
+                android:title="@string/export_deck" />
+        </menu>
+    </item>
     <item
         android:id="@+id/action_unbury"
         android:title="@string/unbury"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -125,6 +125,7 @@
     <string name="sync_cancel_message" tools:ignore="UnusedResources">Cancelling…\nThis may take some time.</string>
     <string name="syncing_media">Syncing media</string>
     <string name="export_deck">Export deck</string>
+    <string name="export_collection">Export collection</string>
     <string name="nothing">Nothing</string>
 
     <!-- Card template editor -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR aims to 

1. Convert deckpicker to have single menu
2. Remove StudyOptionsFragment when collection is empty
3. Remove back button when fragmented

## Approach
Moved menu items from DeckPicker screen to StudyOptionsFragment

## How Has This Been Tested?
Emulator

https://github.com/ankidroid/Anki-Android/assets/65113071/78a26dbf-eb91-4bef-ac08-9b01eb3b6bc9

Chromebook
[Screen recording 2024-05-22 11.08.56.webm](https://github.com/ankidroid/Anki-Android/assets/65113071/4723287c-5c48-4b97-94cd-319699dbacd9)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
