### PR TITLE
test(ci): fix windows timeout

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -30,8 +30,11 @@ import com.afollestad.materialdialogs.WhichButton
 import com.afollestad.materialdialogs.actions.getActionButton
 import com.afollestad.materialdialogs.customview.getCustomView
 import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.testutils.Flaky
+import com.ichi2.testutils.OS
 import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.RecyclerViewUtils
 import com.ichi2.ui.CheckBoxTriStates
@@ -47,7 +50,9 @@ import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
-class TagsDialogTest {
+// inheriting from RobolectricTest is required for @Flaky
+@Flaky(OS.WINDOWS, "16404: tests in this class occasionally hang")
+class TagsDialogTest : RobolectricTest() {
     @Test
     fun testTagsDialogCustomStudyOptionInterface() {
         val type = TagsDialog.DialogType.CUSTOM_STUDY_TAGS

--- a/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/IgnoreFlakyTestsInCIRule.kt
@@ -52,7 +52,7 @@ annotation class Flaky(val os: OS, val message: String = "")
 class IgnoreFlakyTestsInCIRule : TestRule {
     override fun apply(base: Statement, description: Description): Statement {
         if (!isRunningUnderCI) return base
-        val annotation = description.getAnnotation(Flaky::class.java) ?: return base
+        val annotation = description.getFlakyAnnotation() ?: return base
         if (!annotation.os.isRunning()) return base
         return object : Statement() {
             override fun evaluate() {
@@ -60,6 +60,14 @@ class IgnoreFlakyTestsInCIRule : TestRule {
                 Assume.assumeTrue(message, false)
             }
         }
+    }
+
+    /**
+     * Returns an instance of [Flaky] for the test if annotated,
+     * preferring the method-level annotation over the class-level annotation
+     */
+    private fun Description.getFlakyAnnotation(): Flaky? {
+        return getAnnotation(Flaky::class.java) ?: this.testClass.getAnnotation(Flaky::class.java)
     }
 
     companion object {


### PR DESCRIPTION
## Fixes
* Fixes #16404

## Approach

```patch
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision 7853f54d4bd1d3144b4922defbf98570fe578847)
+++ b/build.gradle	(revision 35e7f8fc0aa0d707c0908e3c47e86a9dc9c84320)
@@ -43,10 +43,10 @@
             project.android.testOptions.unitTests.all {
                 // tell backend to avoid rollover time, and disable interval fuzzing
                 environment "ANKI_TEST_MODE", "1"
-
                 useJUnitPlatform()
                 testLogging {
-                    events "failed", "skipped"
+                    // logging "started" helps us catch timeouts
+                    events "started", "passed", "failed", "skipped"
                     showStackTraces = true
                     exceptionFormat = "full"
                 }
```

This pointed to `TagsDialog` being the issue

Tried adding `: RobolectricTest()`, still failed

So I redefined `@Flaky` to work on classes, and ignored the tests


## How Has This Been Tested?
https://github.com/david-allison/Anki-Android/actions/runs/9150302436

![Screenshot 2024-05-19 at 21 39 31](https://github.com/ankidroid/Anki-Android/assets/62114487/a01bc49f-efc6-41e5-8f53-670565e45da2)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
