### PR TITLE
Fix: use field check from backend and display error accordingly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteFieldsCheckResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteFieldsCheckResult.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Context
+import anki.notes.NoteFieldsCheckResponse
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.NoteFieldsCheckResult.*
+import com.ichi2.anki.utils.ext.isImageOcclusion
+import com.ichi2.libanki.Note
+import timber.log.Timber
+
+/**
+ * The result of [checking note fields][Note.fieldsCheck], either a [Success], or [Failure] with
+ * user-readable message
+ *
+ * @see NoteFieldsCheckResponse.State
+ * @see checkNoteFieldsResponse
+ */
+sealed interface NoteFieldsCheckResult {
+    data object Success : NoteFieldsCheckResult
+
+    /** @property localizedMessage user-readable error message */
+    data class Failure(private val localizedMessage: String?) : NoteFieldsCheckResult {
+        fun getLocalizedMessage(context: Context) = localizedMessage ?: context.getString(R.string.something_wrong)
+    }
+}
+
+/**
+ * Validates fields of a note; produces a human-readable error on failure
+ *
+ * @see NoteFieldsCheckResult
+ * @see Note.fieldsCheck
+ **/
+suspend fun checkNoteFieldsResponse(note: Note): NoteFieldsCheckResult {
+    Timber.d("validating note fields")
+    val fieldsCheckState = withCol { note.fieldsCheck(this) }
+
+    return when (fieldsCheckState) {
+        NoteFieldsCheckResponse.State.NORMAL, NoteFieldsCheckResponse.State.DUPLICATE
+        -> Success
+
+        NoteFieldsCheckResponse.State.EMPTY -> if (note.notetype.isImageOcclusion) {
+            Failure(TR.notetypesNoOcclusionCreated2())
+        } else {
+            Failure(TR.addingTheFirstFieldIsEmpty())
+        }
+
+        NoteFieldsCheckResponse.State.MISSING_CLOZE ->
+            Failure(TR.addingYouHaveAClozeDeletionNote())
+
+        NoteFieldsCheckResponse.State.NOTETYPE_NOT_CLOZE ->
+            Failure(TR.addingClozeOutsideClozeNotetype())
+
+        NoteFieldsCheckResponse.State.FIELD_NOT_CLOZE ->
+            Failure(TR.addingClozeOutsideClozeField())
+
+        NoteFieldsCheckResponse.State.UNRECOGNIZED ->
+            Failure(localizedMessage = null)
+    }
+}

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -96,8 +96,6 @@
     <string name="cardeditor_title_edit_card">Edit note</string>
     <string name="discard">Discard</string>
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
-    <string name="note_editor_no_first_field">The first field is empty</string>
-    <string name="note_editor_no_cloze_delations">This note type must contain cloze deletions</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
     <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
     <string name="saving_facts">Saving note</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -41,6 +41,7 @@ import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
+import com.ichi2.testutils.getString
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -79,12 +80,13 @@ class NoteEditorTest : RobolectricTest() {
     }
 
     @Test
-    fun errorSavingNoteWithNoFirstFieldDisplaysNoFirstField() {
+    fun errorSavingNoteWithNoFirstFieldDisplaysNoFirstField() = runTest {
         val noteEditor = getNoteEditorAdding(NoteType.BASIC)
             .withNoFirstField()
             .build()
-        val actualResourceId = noteEditor.addNoteErrorResource
-        assertThat(actualResourceId, equalTo(R.string.note_editor_no_first_field))
+        noteEditor.saveNote()
+        val actualResourceId = noteEditor.snackbarErrorText
+        assertThat(actualResourceId, equalTo(CollectionManager.TR.addingTheFirstFieldIsEmpty()))
     }
 
 //    @Test
@@ -111,30 +113,36 @@ class NoteEditorTest : RobolectricTest() {
 //    }
 
     @Test
-    fun errorSavingClozeNoteWithNoFirstFieldDisplaysClozeError() {
+    fun errorSavingClozeNoteWithNoFirstFieldDisplaysClozeError() = runTest {
         val noteEditor = getNoteEditorAdding(NoteType.CLOZE)
             .withNoFirstField()
             .build()
-        val actualResourceId = noteEditor.addNoteErrorResource
-        assertThat(actualResourceId, equalTo(R.string.note_editor_no_cloze_delations))
+        noteEditor.saveNote()
+        val actualResourceId = noteEditor.snackbarErrorText
+        assertThat(actualResourceId, equalTo(CollectionManager.TR.addingTheFirstFieldIsEmpty()))
     }
 
     @Test
-    fun errorSavingClozeNoteWithNoClozeDeletionsDisplaysClozeError() {
+    fun errorSavingClozeNoteWithNoClozeDeletionsDisplaysClozeError() = runTest {
         val noteEditor = getNoteEditorAdding(NoteType.CLOZE)
             .withFirstField("NoCloze")
             .build()
-        val actualResourceId = noteEditor.addNoteErrorResource
-        assertThat(actualResourceId, equalTo(R.string.note_editor_no_cloze_delations))
+        noteEditor.saveNote()
+        val actualResourceId = noteEditor.snackbarErrorText
+        assertThat(
+            actualResourceId,
+            equalTo(CollectionManager.TR.addingYouHaveAClozeDeletionNote())
+        )
     }
 
     @Test
-    fun errorSavingNoteWithNoTemplatesShowsNoCardsCreated() {
+    fun errorSavingNoteWithNoTemplatesShowsNoCardsCreated() = runTest {
         val noteEditor = getNoteEditorAdding(NoteType.BACK_TO_FRONT)
             .withFirstField("front is not enough")
             .build()
-        val actualResourceId = noteEditor.addNoteErrorResource
-        assertThat(actualResourceId, equalTo(R.string.note_editor_no_cards_created))
+        noteEditor.saveNote()
+        val actualResourceId = noteEditor.snackbarErrorText
+        assertThat(actualResourceId, equalTo(getString(R.string.note_editor_no_cards_created)))
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
AnkiDroid used custom made check on field but since Anki already has a method to do so, this PR updates that issue of manual check and check the field content via the Anki method.

## Fixes
* Fixes #16419

## Approach
Use method from backend

## How Has This Been Tested?
When first field is empty:
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/86744831-7add-4614-93f1-5f09cfa0f0e5)

When content has no cloze:
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/1e03f092-a929-4e16-a15f-b339573d7a71)

Wrong cloze field:
![image](https://github.com/ankidroid/Anki-Android/assets/48384865/3bbada4f-e961-4219-bd98-ca59dc12cef5)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
