### PR TITLE
Migrate MaterialDialog to AlertDialog in ModelFieldEditorTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -16,12 +16,14 @@
 
 package com.ichi2.anki
 
+import android.content.DialogInterface
 import android.content.Intent
+import android.view.ContextThemeWrapper
 import android.widget.EditText
-import com.afollestad.materialdialogs.MaterialDialog
-import com.afollestad.materialdialogs.WhichButton
-import com.afollestad.materialdialogs.actions.getActionButton
+import androidx.appcompat.app.AlertDialog
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -77,8 +79,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
 
         // set field name to forbidden string and click confirm
         fieldNameInput.setText(fieldName)
-        dialog.getActionButton(WhichButton.POSITIVE)
-            .performClick()
+        dialog.getButton(DialogInterface.BUTTON_POSITIVE).performClick()
         advanceRobolectricLooperWithSleep()
         return fieldName
     }
@@ -91,9 +92,9 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
      * @return The dialog
      */
     @Throws(RuntimeException::class)
-    private fun buildAddEditFieldDialog(fieldNameInput: EditText, fieldOperationType: FieldOperationType): MaterialDialog {
-        return MaterialDialog(targetContext)
-            .positiveButton {
+    private fun buildAddEditFieldDialog(fieldNameInput: EditText, fieldOperationType: FieldOperationType): AlertDialog {
+        return AlertDialog.Builder(ContextThemeWrapper(targetContext, R.style.Theme_Light)).show {
+            positiveButton(text = "") {
                 try {
                     val modelName = "Basic"
 
@@ -102,7 +103,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
                     intent.putExtra("title", modelName)
                     intent.putExtra("noteTypeID", col.notetypes.id_for_name(modelName)!!)
                     val modelFieldEditor = startActivityNormallyOpenCollectionWithIntent(
-                        this,
+                        this@ModelFieldEditorTest,
                         ModelFieldEditor::class.java,
                         intent
                     )
@@ -116,6 +117,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
                     throw RuntimeException(exception)
                 }
             }
+        }
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description

Quick MaterialDialog -> AlertDialog migration.

## Fixes
* Related to #13315

## How Has This Been Tested?

Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
