### PR TITLE
fix(note-editor): display 'home' deck if filtered

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -914,7 +914,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         return true
     }
 
-    private fun hasUnsavedChanges(): Boolean {
+    @VisibleForTesting
+    fun hasUnsavedChanges(): Boolean {
         if (!collectionHasLoaded()) {
             return false
         }
@@ -928,7 +929,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
         }
         // changed deck?
-        if (!addNote && currentEditedCard != null && currentEditedCard!!.did != deckId) {
+        if (!addNote && currentEditedCard != null && currentEditedCard!!.currentDeckId().did != deckId) {
             return true
         }
         // changed fields?
@@ -1880,7 +1881,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         fun calculateDeckId(): DeckId {
             if (deckId != 0L) return deckId
             if (note != null && !addNote && currentEditedCard != null) {
-                return currentEditedCard!!.did
+                return currentEditedCard!!.currentDeckId().did
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {


### PR DESCRIPTION
## Purpose / Description
* If a note is edited from the Reviewer
* And the note is in a filtered deck

The 'current deck' should show the home deck

Before this change it showed the first deck

## Fixes
* Fixes #15919

## Approach
Use the home deck

## How Has This Been Tested?
Unit test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
