### PR TITLE
refactor: Kotlin 2.0 deprecations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -668,9 +668,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         if (editFields != null && !editFields!!.isEmpty()) {
             // EXTRA_TEXT_FROM_SEARCH_VIEW takes priority over other intent inputs
             if (!getTextFromSearchView.isNullOrEmpty()) {
-                editFields!!.first!!.setText(getTextFromSearchView)
+                editFields!!.first()!!.setText(getTextFromSearchView)
             }
-            editFields!!.first!!.requestFocus()
+            editFields!!.first()!!.requestFocus()
         }
 
         if (caller == CALLER_IMG_OCCLUSION) {
@@ -969,7 +969,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             closeEditorAfterSave = true
             closeIntent = Intent().apply { putExtra(EXTRA_ID, intent.getStringExtra(EXTRA_ID)) }
         } else if (!editFields!!.isEmpty()) {
-            editFields!!.first!!.focusWithKeyboard()
+            editFields!!.first()!!.focusWithKeyboard()
         }
 
         if (closeEditorAfterSave) {
@@ -1261,7 +1261,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             // Note: We're not being accurate here - the initial value isn't actually what's supplied in the layout.xml
             // So a value of 18sp in the XML won't be 18sp on the TextView, but it's close enough.
             // Values are setFontSize are whole when returned.
-            val sp = TextViewUtil.getTextSizeSp(editFields!!.first!!)
+            val sp = TextViewUtil.getTextSizeSp(editFields!!.first()!!)
             return sp.roundToInt().toString()
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -83,7 +83,7 @@ open class PageWebViewClient : WebViewClient() {
         }
     }
 
-    @Suppress("DEPRECATION") // still needed for API 23
+    @Suppress("DEPRECATION", "OVERRIDE_DEPRECATION") // still needed for API 23
     override fun shouldOverrideUrlLoading(view: WebView?, url: String?): Boolean {
         if (view == null || url == null) return super.shouldOverrideUrlLoading(view, url)
         if (handleUrl(view, url)) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/AutoFocusEditTextPreference.kt
@@ -32,6 +32,7 @@ interface AutoFocusable {
 // used in .xml files
 @Suppress("deprecation", "unused")
 open class AutoFocusEditTextPreference(context: Context?, attrs: AttributeSet?) : android.preference.EditTextPreference(context, attrs), AutoFocusable {
+    @Suppress("OVERRIDE_DEPRECATION") // TODO: Why?
     override fun onBindDialogView(view: View?) {
         super.onBindDialogView(view)
         autoFocusAndMoveCursorToEnd(editText)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
@@ -28,7 +28,7 @@ import com.ichi2.utils.KotlinCleanup
 import java.lang.NumberFormatException
 
 // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use IncrementerNumberRangePreferenceCompat
-@Suppress("deprecation")
+@Suppress("deprecation", "OVERRIDE_DEPRECATION")
 @KotlinCleanup("_editText")
 class IncrementerNumberRangePreference : NumberRangePreference {
     private val linearLayout = LinearLayout(context)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -23,7 +23,7 @@ import android.view.View
 import com.ichi2.anki.AnkiDroidApp
 import timber.log.Timber
 
-@Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use NumberRangePreferenceCompat
+@Suppress("deprecation", "OVERRIDE_DEPRECATION") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use NumberRangePreferenceCompat
 open class NumberRangePreference : android.preference.EditTextPreference, AutoFocusable {
     protected val min: Int
     private val max: Int

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -28,7 +28,7 @@ import org.json.JSONArray
 import org.json.JSONException
 import timber.log.Timber
 
-@Suppress("deprecation") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
+@Suppress("deprecation", "OVERRIDE_DEPRECATION") // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019
 class StepsPreference : android.preference.EditTextPreference, AutoFocusable {
     private val allowEmpty: Boolean
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -77,6 +77,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
                 .updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), buildUpdate(context, true))
         }
 
+        @Deprecated("Implement onStartCommand(Intent, int, int) instead.") // TODO
         override fun onStart(intent: Intent, startId: Int) {
             Timber.i("SmallWidget: OnStart")
             val updateViews = buildUpdate(this, true)

--- a/lint-rules/build.gradle.kts
+++ b/lint-rules/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -10,9 +11,9 @@ tasks.withType(JavaCompile::class).configureEach {
 }
 
 tasks.withType(KotlinCompile::class).all {
-    kotlinOptions {
+    compilerOptions {
         // starting with AGP 7.4.0 we need to target JVM 11 bytecode
-        jvmTarget = JavaVersion.VERSION_11.toString()
+        jvmTarget = JvmTarget.JVM_11
     }
 }
 


### PR DESCRIPTION
I wanted this in as a separate refactor, rather than squashing in with the dependency upgrade

We want to ignore these commits in `git blame`

❓ reviewers: I would mildly prefer if you squashed this

I felt the split-out commits were useful for review, but don't provide value in the history

## Fixes
* Unblocks https://github.com/ankidroid/Anki-Android/pull/16440

## How Has This Been Tested?
⚠️ Untested, all should be non-functional

After these changes, I checked for Kotlin 2.0 compatibility:

```
Code inspection did not find anything to report. 19,698 files processed in 'Project 'Anki-Android
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
