### PR TITLE
fix(note-editor): deck for new cards was not saved

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1009,6 +1009,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 updateField(f)
             }
             // Save deck to model
+            Timber.d("setting 'last deck' of note type %s to %d", editorNote!!.notetype.name, deckId)
             editorNote!!.notetype.put("did", deckId)
             // Save tags to model
             editorNote!!.setTagsFromStr(getColUnsafe, tagsAsString(selectedTags!!))
@@ -1021,7 +1022,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             // adding current note to collection
             withProgress(resources.getString(R.string.saving_facts)) {
                 undoableOp {
-                    notetypes.current().put("tags", tags)
+                    editorNote!!.notetype.put("tags", tags)
+                    notetypes.save(editorNote!!.notetype)
                     addNote(editorNote!!, deckId)
                 }
             }
@@ -1885,7 +1887,10 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {
-                return getColUnsafe.notetypes.current().did
+                return getColUnsafe.notetypes.current().let {
+                    Timber.d("Adding to deck of note type, noteType: %s", it.name)
+                    return@let it.did
+                }
             }
 
             val currentDeckId = getColUnsafe.config.get(CURRENT_DECK) ?: 1L


### PR DESCRIPTION
If a user went in and out of the 'add note' widget, the value was not persisted. It was only in the cache

## Fixes
* Fixes #13931

## Approach
* save the note type

## How Has This Been Tested?
Unit tested, brief test in the UI

## Learning (optional, can help others)
* `notetype` has a cache, and now should be saved

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
