### PR TITLE
fix: show search icon instantly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2359,6 +2359,7 @@ open class DeckPicker :
             if (fragmented) {
                 loadStudyOptionsFragment(false)
             }
+            invalidateOptionsMenu()
         }
         createDeckDialog.showDialog()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -345,7 +345,10 @@ class DeckPickerFloatingActionMenu(
                     CreateDeckDialog.DeckDialogType.DECK,
                     null
                 )
-                createDeckDialog.onNewDeckCreated = { deckPicker.updateDeckList() }
+                createDeckDialog.onNewDeckCreated = {
+                    deckPicker.updateDeckList()
+                    deckPicker.invalidateOptionsMenu()
+                }
                 createDeckDialog.showDialog()
             }
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Search icon does not shows immediately when deck length is atleast 10

## Fixes
* Fixes #16452 

## Approach
update options menu when new deck is created by calling `invalidateOptionsMenu()`

## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/119813120/ed7c65b6-12f3-4ba8-a136-f98a163a46d1


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
