### PR TITLE
tests: fix for Kotlin 2.0

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -436,7 +436,7 @@ open class RobolectricTest : AndroidTest {
 
     private fun validateRunWithAnnotationPresent() {
         try {
-            ApplicationProvider.getApplicationContext()
+            ApplicationProvider.getApplicationContext<Application>()
         } catch (e: IllegalStateException) {
             if (e.message != null && e.message!!.startsWith("No instrumentation registered!")) {
                 // Explicitly ignore the inner exception - generates line noise


### PR DESCRIPTION
The generic needs to apply to both `EmptyApplication` and `AnkiDroidApp`

```
    java.lang.ClassCastException: class com.ichi2.anki.AnkiDroidApp cannot be cast to class java.lang.Void (com.ichi2.anki.AnkiDroidApp is in unnamed module of loader org.robolectric.internal.AndroidSandbox$SdkSandboxClassLoader @29f72685; java.lang.Void is in module java.base of loader 'bootstrap')
        at com.ichi2.anki.RobolectricTest.validateRunWithAnnotationPresent(RobolectricTest.kt:439)
        at com.ichi2.anki.RobolectricTest.setUp(RobolectricTest.kt:105)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
        at com.ichi2.testutils.FailOnUnhandledExceptionRule$apply$1.evaluate(FailOnUnhandledExceptionRule.kt:57)
        at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:489)
        at org.robolectric.internal.SandboxTestRunner$2.lambda$evaluate$2(SandboxTestRunner.java:291)
        at org.robolectric.internal.bytecode.Sandbox.lambda$runOnMainThread$0(Sandbox.java:104)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```