### PR TITLE
fix: reviewer `fetch` and `XMLHttpRequest` issues

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/js-api.js
+++ b/AnkiDroid/src/main/assets/scripts/js-api.js
@@ -85,7 +85,7 @@ class AnkiDroidJS {
     }
 
     handleRequest = async (endpoint, data) => {
-        const url = `${ankidroid.postBaseUrl}jsapi/${endpoint}`;
+        const url = `/jsapi/${endpoint}`;
         try {
             const response = await fetch(url, {
                 method: "POST",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -231,8 +231,6 @@ abstract class AbstractFlashcardViewer :
     @get:VisibleForTesting
     var cardContent: String? = null
         private set
-    private val baseUrl
-        get() = getMediaBaseUrl(CollectionHelper.getMediaDirectory(this).path)
 
     private var viewerUrl: String? = null
     private val fadeDuration = 300
@@ -1502,7 +1500,7 @@ abstract class AbstractFlashcardViewer :
         if (card != null) {
             card.settings.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
             card.loadDataWithBaseURL(
-                baseUrl,
+                server.baseUrl(),
                 content,
                 "text/html",
                 null,
@@ -2265,9 +2263,6 @@ abstract class AbstractFlashcardViewer :
         override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
             pageRenderStopwatch.reset()
             pageFinishedFired = false
-            val script = "globalThis.ankidroid = globalThis.ankidroid || {};" +
-                "ankidroid.postBaseUrl = `${server.baseUrl()}`"
-            view?.evaluateJavascript(script, null)
         }
 
         override fun shouldInterceptRequest(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -53,7 +53,6 @@ open class AnkiServer(
                 Timber.d("Rejecting GET request to server %s", session.uri)
                 newFixedLengthResponse(Response.Status.NOT_FOUND, null, null)
             }
-            Method.OPTIONS -> buildResponse(null)
             else -> {
                 Timber.d("Ignored request of unhandled method %s, uri %s", session.method, session.uri)
                 newFixedLengthResponse(null)
@@ -70,11 +69,6 @@ open class AnkiServer(
             newFixedLengthResponse(null)
         } else {
             newChunkedResponse(status, mimeType, ByteArrayInputStream(data))
-        }.apply {
-            addHeader("Access-Control-Allow-Origin", "*")
-            addHeader("Access-Control-Allow-Headers", "Content-Type")
-            addHeader("Access-Control-Allow-Methods", "POST")
-            addHeader("Access-Control-Max-Age", "7200")
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -36,11 +36,11 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
-import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.R
 import com.ichi2.anki.ViewerResourceHandler
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.localizedErrorMessage
+import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.packageManager
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat
@@ -87,9 +87,9 @@ abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
                 // allow videos to autoplay via our JavaScript eval
                 mediaPlaybackRequiresUserGesture = false
             }
-            val baseUrl = CollectionHelper.getMediaDirectory(requireContext()).toURI().toString()
+
             loadDataWithBaseURL(
-                baseUrl,
+                "http://${AnkiServer.LOCALHOST}/",
                 stdHtml(requireContext(), Themes.currentTheme.isNightMode),
                 "text/html",
                 null,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

#16140 was an experiment to return to the 2.16.5 way of loading media, which worked by using the `collection.media` directory as base url. The pros were that files load faster and the URL is constant, so localStorage works. The cons were that it needs to accept CORS requests and doesn't work with JS `fetch` and `XMLHttpRequest`

For now my goal is just to restore compatibility with all decks. The new performance is still quite good, just ain't the best one anymore. Some ways to improve performance can be investigated later, *if necessary*, but now compatibility is the priority.

## Fixes
* Fixes #16456
* Fixes #16426

## Approach

Revert #16140

Doesn't need a backend upgrade

## How Has This Been Tested?

- Seek works on videos
- JS's `fetch` works
- The JS api still works

[loading.webm](https://github.com/ankidroid/Anki-Android/assets/69634269/a715e7f9-4566-42b3-8b88-e1e23143ec94)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
