### PR TITLE
20s Timeout in JvmTest and RobolectricTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -55,7 +55,6 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.json.JSONException
 import org.junit.*
-import org.junit.rules.RuleChain
 import org.junit.rules.TestName
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
@@ -95,10 +94,8 @@ open class RobolectricTest : AndroidTest {
     @get:Rule
     val failOnUnhandledExceptions = FailOnUnhandledExceptionRule()
 
-    private val rule: TimeoutRule = TimeoutRule.seconds(20)
-
-    @get : Rule
-    var chain: RuleChain = RuleChain.outerRule(rule)
+    @get:Rule
+    val timeoutRule: TimeoutRule = TimeoutRule.seconds(60)
 
     @Before
     @CallSuper

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -55,10 +55,12 @@ import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.json.JSONException
 import org.junit.*
+import org.junit.rules.RuleChain
 import org.junit.rules.TestName
 import org.robolectric.Robolectric
 import org.robolectric.Shadows
 import org.robolectric.android.controller.ActivityController
+import org.robolectric.junit.rules.TimeoutRule
 import org.robolectric.shadows.ShadowDialog
 import org.robolectric.shadows.ShadowLog
 import org.robolectric.shadows.ShadowLooper
@@ -92,6 +94,11 @@ open class RobolectricTest : AndroidTest {
 
     @get:Rule
     val failOnUnhandledExceptions = FailOnUnhandledExceptionRule()
+
+    private val rule: TimeoutRule = TimeoutRule.seconds(20)
+
+    @get : Rule
+    var chain: RuleChain = RuleChain.outerRule(rule)
 
     @Before
     @CallSuper

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -33,13 +33,20 @@ import org.junit.After
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
+import org.junit.rules.RuleChain
 import org.junit.rules.TestName
+import org.robolectric.junit.rules.TimeoutRule
 import timber.log.Timber
 import timber.log.Timber.Forest.plant
 
 open class JvmTest : TestClass {
     @get:Rule
     val testName = TestName()
+
+    private val rule: TimeoutRule = TimeoutRule.seconds(20)
+
+    @get : Rule
+    var chain: RuleChain = RuleChain.outerRule(rule)
 
     private fun maybeSetupBackend() {
         RustBackendLoader.ensureSetup()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -33,7 +33,6 @@ import org.junit.After
 import org.junit.Assume
 import org.junit.Before
 import org.junit.Rule
-import org.junit.rules.RuleChain
 import org.junit.rules.TestName
 import org.robolectric.junit.rules.TimeoutRule
 import timber.log.Timber
@@ -41,12 +40,10 @@ import timber.log.Timber.Forest.plant
 
 open class JvmTest : TestClass {
     @get:Rule
+    val timeoutRule: TimeoutRule = TimeoutRule.seconds(60)
+
+    @get:Rule
     val testName = TestName()
-
-    private val rule: TimeoutRule = TimeoutRule.seconds(20)
-
-    @get : Rule
-    var chain: RuleChain = RuleChain.outerRule(rule)
 
     private fun maybeSetupBackend() {
         RustBackendLoader.ensureSetup()


### PR DESCRIPTION
## Purpose / Description
The purpose of the PR is to add a 20s timeout in `JvmTest` and `RobolectricTest`

## Fixes
* Fixes #16435

## Approach
Added TimeoutRule from this linked commit https://github.com/robolectric/robolectric/commit/5554acdd9c35f15381b0289e0c94f1a08aa39826

## How Has This Been Tested?
Tested this by running it on my local device.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
