### PR TITLE
fix: custom scheduling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2263,6 +2263,8 @@ abstract class AbstractFlashcardViewer :
         override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
             pageRenderStopwatch.reset()
             pageFinishedFired = false
+            val script = "globalThis.ankidroid = globalThis.ankidroid || {}; ankidroid.postBaseUrl = ``"
+            view?.evaluateJavascript(script, null)
         }
 
         override fun shouldInterceptRequest(


### PR DESCRIPTION
`postBaseUrl` will be necessary until the backend isn't updated.

Reproduction steps:
1. Add some JS to the Deck's custom scheduling. e.g. `console.log("foo")`
2. Open a deck

Expected: message is logged
Error:  `ReferenceError` in the console or logcat


## Fixes
* Fixes #16465

## Approach

Add postBaseUrl back while the backend isn't updated

## How Has This Been Tested?

Same repro steps. 

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
