### PR TITLE
Add support for custom certificate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -62,6 +62,7 @@ object SyncPreferences {
     const val CURRENT_SYNC_URI = "currentSyncUri"
     const val CUSTOM_SYNC_URI = "syncBaseUrl"
     const val CUSTOM_SYNC_ENABLED = CUSTOM_SYNC_URI + VersatileTextWithASwitchPreference.SWITCH_SUFFIX
+    const val CUSTOM_SYNC_CERTIFICATE = "customSyncCertificate"
 
     // Used in the legacy schema path
     const val HOSTNUM = "hostNum"
@@ -79,6 +80,11 @@ interface SyncCompletionListener {
 
 fun DeckPicker.syncAuth(): SyncAuth? {
     val preferences = this.sharedPrefs()
+
+    // Grab custom sync certificate from preferences (default is the empty string) and set it in CollectionManager
+    val currentSyncCertificate = preferences.getString(SyncPreferences.CUSTOM_SYNC_CERTIFICATE, "") ?: ""
+    CollectionManager.updateCustomCertificate(currentSyncCertificate)
+
     val hkey = preferences.getString(SyncPreferences.HKEY, null)
     val resolvedEndpoint = getEndpoint(this)
     return hkey?.let {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomSyncServerSettingsFragment.kt
@@ -17,10 +17,14 @@ package com.ichi2.anki.preferences
 
 import android.content.SharedPreferences
 import android.os.Bundle
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.SyncPreferences
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.preferences.VersatileTextPreference
+import com.ichi2.utils.show
 import okhttp3.HttpUrl.Companion.toHttpUrl
 
 class CustomSyncServerSettingsFragment : SettingsFragment() {
@@ -35,6 +39,23 @@ class CustomSyncServerSettingsFragment : SettingsFragment() {
                 VersatileTextPreference.Validator { value ->
                     if (value.isNotEmpty()) value.toHttpUrl()
                 }
+        }
+
+        requirePreference<VersatileTextPreference>(R.string.custom_sync_certificate_key).setOnPreferenceChangeListener { _, newValue: Any? ->
+            val newCert = newValue as String
+
+            // Empty string input causes the certificate to be unset in the backend, i.e., no error
+            if (!CollectionManager.updateCustomCertificate(newCert)) {
+                AlertDialog.Builder(requireContext()).show {
+                    setTitle(R.string.dialog_invalid_custom_certificate_title)
+                    setMessage(R.string.dialog_invalid_custom_certificate)
+                    setPositiveButton(R.string.dialog_ok) { _, _ -> }
+                }
+                return@setOnPreferenceChangeListener false
+            }
+
+            showSnackbar(R.string.dialog_updated_custom_certificate)
+            true
         }
     }
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -90,6 +90,9 @@
     <string name="dialog_positive_replace">Replace</string>
 
     <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
+    <string name="dialog_invalid_custom_certificate">The provided text does not resolve to a valid PEM-encoded X509 certificate</string>
+    <string name="dialog_invalid_custom_certificate_title">Error parsing certificate</string>
+    <string name="dialog_updated_custom_certificate">Certificate updated</string>
 
     <!-- Media checking -->
     <string name="check_media_title">Check media?</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -201,6 +201,7 @@
         <a href="%s">Learn more</a>
         ]]></string>
     <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>
+    <string name="custom_sync_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
     <!-- Key Bindings -->
     <string name="keyboard">Keyboard</string>
     <string name="bluetooth">Bluetooth</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -143,6 +143,7 @@
     <!-- Custom sync server -->
     <string name="pref_custom_sync_server_screen_key">customSyncServerScreen</string>
     <string name="custom_sync_server_collection_url_key">syncBaseUrl</string>
+    <string name="custom_sync_certificate_key">customSyncCertificate</string>
     <!-- Advanced -->
     <string name="pref_advanced_screen_key">pref_screen_advanced</string>
     <string name="pref_cat_workarounds_key">category_workarounds</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -16,4 +16,8 @@
         android:title="@string/custom_sync_server_base_url_title"
         android:inputType="textUri"
         app:useSimpleSummaryProvider="true" />
+    <com.ichi2.preferences.VersatileTextPreference
+        android:key="@string/custom_sync_certificate_key"
+        android:title="@string/custom_sync_certificate_title"
+        android:inputType="textMultiLine" />
 </PreferenceScreen>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -68,7 +68,8 @@ class PreferencesAnalyticsTest : RobolectricTest() {
         // potential personal data
         "syncAccount",
         "syncBaseUrl",
-        "language"
+        "language",
+        "customSyncCertificate"
     )
 
     @Test


### PR DESCRIPTION
Copied from https://github.com/ankidroid/Anki-Android/pull/15996
## Purpose / Description
Since the new backend is forced on the newer Ankidroid releases, Android users cannot connect to their self-hosted sync server if it uses a self-signed certificate. The problem should be fixed with this PR. More than willing to accept any changes made to the UI part of this feature, it ain't that pretty.

* https://github.com/ankidroid/Anki-Android/labels/Blocked%20by%20dependency https://github.com/ankidroid/Anki-Android-Backend/pull/381. 

## Fixes
* Fixes #14686 

## Approach
Allow users to specify a custom root certificate to trust (in PEM format) and feed this through the backend.

## How Has This Been Tested?
Took the PEM-formatted root certificate I use for my local servers, and then copied the contents of it into the text field in the custom sync server section. After doing this, I don't get a error message telling me that the sync server certificate has an unknown issuer.

## Learning
[PEM, DER, CRT, and CER: X.509 Encodings and Conversions](https://www.ssl.com/guide/pem-der-crt-and-cer-x-509-encodings-and-conversions/)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<details>

<summary><h2>Screenshot</h2></summary>

![Screenshot_20240325_223253](https://github.com/ankidroid/Anki-Android/assets/82241877/b9945e78-ac29-48dc-82c3-9c0d872fcf09)
(sorry for the flashbang)

</details>