### PR TITLE
fix(tags-dialog): crash handling unicode tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -31,7 +31,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.utils.ext.convertToString
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TagsUtil
@@ -415,13 +414,13 @@ class TagsFile(path: String) : File(path), Parcelable {
             // https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/formats.md
             val string = Json.encodeToString(data)
             Timber.d("persisting tags to disk, length: %d", string.length)
-            outputStream.writeBytes(string)
+            outputStream.writeUTF(string)
         }
     }
 
     fun getData() = DataInputStream(FileInputStream(this)).use { inputStream ->
         // PERF!!: This takes ~2 seconds with AnKing
-        Json.decodeFromString<TagsData>(inputStream.convertToString())
+        Json.decodeFromString<TagsData>(inputStream.readUTF())
     }
 
     override fun describeContents(): Int = 0

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -44,6 +44,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
+import timber.log.Timber
 import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
@@ -634,6 +635,21 @@ class TagsDialogTest : RobolectricTest() {
             editText.text.insert(0, " ")
             Assert.assertEquals("Should not crash.", "::", editText.text.toString())
         }
+    }
+
+    @Test
+    fun `unicode tags can be serialized 16576`() {
+        val type = TagsDialog.DialogType.FILTER_BY_TAG
+        val allTags = listOf("02动作状态")
+
+        val args = TagsDialog(ParametersUtils.whatever())
+            .withTestArguments(type, emptyList(), allTags)
+            .arguments
+        val mockListener = Mockito.mock(TagsDialogListener::class.java)
+        val factory = TagsDialogFactory(mockListener)
+        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
+        scenario.moveToState(Lifecycle.State.STARTED)
+        scenario.onFragment { Timber.d("Dialog successfully opened") }
     }
 
     // these are called 'withTestArguments' due to "extension is shadowed by a member" warnings


### PR DESCRIPTION
## Purpose / Description
When deserializing, we called the wrong method so there was an unknown byte as a prefix

`convertToString` was our method, not intended to be used on a `DataStream`

This then failed the string -> JSON conversion

## Fixes
* Fixes #16476

## Approach
* encode as UTF8 instead

## How Has This Been Tested?
Unit test

* Tested provided collection [see issue]
* Tested personal collection


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
