### PR TITLE
test(card-browser-view-model): increase code coverage

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -402,6 +402,8 @@ dependencies {
         exclude module: "protobuf-lite"
     }
     testImplementation libs.androidx.work.testing
+    // for testing flows
+    testImplementation libs.cashapp.turbine
 
     androidTestImplementation project(':testlib')
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -82,6 +82,7 @@ import kotlin.math.max
 import kotlin.math.min
 
 @NeedsTest("reverseDirectionFlow/sortTypeFlow are not updated on .launch { }")
+@NeedsTest("columIndex1/2 config is not not updated on init")
 @NeedsTest("13442: selected deck is not changed, as this affects the reviewer")
 @NeedsTest("search is called after launch()")
 class CardBrowserViewModel(
@@ -274,11 +275,19 @@ class CardBrowserViewModel(
         }
 
         flowOfColumnIndex1
-            .onEach { index -> sharedPrefs().edit { putInt(DISPLAY_COLUMN_1_KEY, index) } }
+            .ignoreValuesFromViewModelLaunch()
+            .onEach { index ->
+                Timber.d("updating %s", DISPLAY_COLUMN_1_KEY)
+                sharedPrefs().edit { putInt(DISPLAY_COLUMN_1_KEY, index) }
+            }
             .launchIn(viewModelScope)
 
         flowOfColumnIndex2
-            .onEach { index -> sharedPrefs().edit { putInt(DISPLAY_COLUMN_2_KEY, index) } }
+            .ignoreValuesFromViewModelLaunch()
+            .onEach { index ->
+                Timber.d("updating %s", DISPLAY_COLUMN_2_KEY)
+                sharedPrefs().edit { putInt(DISPLAY_COLUMN_2_KEY, index) }
+            }
             .launchIn(viewModelScope)
 
         performSearchFlow.onEach {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.browser
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager
@@ -214,6 +215,37 @@ class CardBrowserViewModelTest : JvmTest() {
 
         runViewModelTest(notes = 1) {
             assertThat("1 row returned", rowCount, equalTo(1))
+        }
+    }
+
+    fun `selected rows are refreshed`() = runViewModelTest(notes = 2) {
+        flowOfSelectedRows.test {
+            // initially, flowOfSelectedRows should not have emitted anything
+            expectNoEvents()
+
+            selectAll()
+            assertThat("initial selection", awaitItem().size, equalTo(2))
+
+            selectNone()
+            assertThat("deselected all", awaitItem().size, equalTo(0))
+
+            toggleRowSelectionAtPosition(0)
+            assertThat("selected row", awaitItem().size, equalTo(1))
+
+            toggleRowSelectionAtPosition(0)
+            assertThat("deselected rows", awaitItem().size, equalTo(0))
+
+            selectRowAtPosition(0)
+            assertThat("select rows explicitly", awaitItem().size, equalTo(1))
+
+            selectRowAtPosition(0)
+            expectNoEvents()
+
+            selectRowsBetweenPositions(0, 1)
+            assertThat("select rows between positions", awaitItem().size, equalTo(2))
+
+            selectRowsBetweenPositions(0, 1)
+            expectNoEvents()
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.browser
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
@@ -274,6 +275,42 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `changing column index 1`() = runViewModelTest {
+        flowOfColumnIndex1.test {
+            ignoreEventsDuringViewModelInit()
+
+            assertThat("default column1Index value", column1Index, equalTo(0))
+
+            setColumn1Index(1)
+
+            assertThat("flowOfColumnIndex1", awaitItem(), equalTo(1))
+            assertThat("column1Index", column1Index, equalTo(1))
+
+            // expect no change if the value is selected again
+            setColumn1Index(1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `changing column index 2`() = runViewModelTest {
+        flowOfColumnIndex2.test {
+            ignoreEventsDuringViewModelInit()
+
+            assertThat("default column2Index value", column2Index, equalTo(0))
+
+            setColumn2Index(1)
+
+            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(1))
+            assertThat("column2Index", column2Index, equalTo(1))
+
+            // expect no change if the value is selected again
+            setColumn2Index(1)
+            expectNoEvents()
+        }
+    }
+
     private fun runViewModelTest(notes: Int = 0, manualInit: Boolean = true, testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
         for (i in 0 until notes) {
             addNoteUsingBasicModel()
@@ -319,6 +356,21 @@ class CardBrowserViewModelTest : JvmTest() {
 private fun CardBrowserViewModel.selectRowsWithPositions(vararg positions: Int) {
     for (pos in positions) {
         selectRowAtPosition(pos)
+    }
+}
+
+/**
+ * Helper for testing flows:
+ *
+ * A MutableStateFlow can either emit a value or not emit a value
+ * depending on whether a consumer subscribes before or after the task launched
+ * from init is completed
+ */
+private fun <T> TurbineTestContext<T>.ignoreEventsDuringViewModelInit() {
+    try {
+        expectMostRecentItem()
+    } catch (e: AssertionError) {
+        // explicitly ignored: no items
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -38,6 +38,7 @@ import com.ichi2.testutils.createTransientDirectory
 import com.ichi2.testutils.mockIt
 import kotlinx.coroutines.flow.first
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
@@ -246,6 +247,30 @@ class CardBrowserViewModelTest : JvmTest() {
 
             selectRowsBetweenPositions(0, 1)
             expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `selected card and note ids`() {
+        val notes = List(2) { addNoteUsingBasicAndReversedModel() }
+
+        val nids = notes.map { it.id }.toTypedArray()
+        val cids = notes.flatMap { it.cids() }.toTypedArray()
+
+        runViewModelTest {
+            setCardsOrNotes(CardsOrNotes.CARDS).join()
+            selectAll()
+            assertThat("cards: rowCount", rowCount, equalTo(4))
+            assertThat("cards: cids", queryAllSelectedCardIds(), containsInAnyOrder(*cids))
+            assertThat("cards: nids", queryAllSelectedNoteIds(), containsInAnyOrder(*nids))
+
+            selectNone()
+
+            setCardsOrNotes(CardsOrNotes.NOTES).join()
+            selectAll()
+            assertThat("notes: rowCount", rowCount, equalTo(2))
+            assertThat("notes: cids", queryAllSelectedCardIds(), containsInAnyOrder(*cids))
+            assertThat("notes: nids", queryAllSelectedNoteIds(), containsInAnyOrder(*nids))
         }
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,7 @@ sharedPreferencesMock = "1.2.4"
 slf4jTimber = "3.1"
 timber = "5.0.1"
 triplet = "3.9.1"
+turbine = "1.1.0"
 workRuntimeKtx = "2.9.0"
 
 [libraries]
@@ -151,6 +152,7 @@ mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockito
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+cashapp-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]
 


### PR DESCRIPTION
## Purpose / Description
Improving code coverage on `CardBrowserViewModel`, this was the first reasonable place to start adding tests

If successful, this will turn a number of partially covered paths greeen

I was surprised with how high the test coverage of the ViewModel is already, but I'd like to make an example of it before I go and refactor the `CardBrowser`

## Approach / How Has This Been Tested?
Test Only

⚠️ Due to the implementation, the collection returned from each `emit` is currently the same. This is subject to change in the future

## Learning (optional, can help others)
This introduces Turbine, a Google-recommended library for testing flows

https://github.com/cashapp/turbine - last commit two weeks ago

https://developer.android.com/kotlin/flow/test


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)