### PR TITLE
Changed color of the checkbox in alertdialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CustomDialogFragment.kt
@@ -1,0 +1,51 @@
+package com.ichi2.anki.dialogs
+
+import android.app.Dialog
+import android.content.res.Configuration
+import android.os.Bundle
+import androidx.core.content.ContextCompat
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import com.ichi2.anki.R
+
+class CustomDialogFragment(
+    private val title: Int,
+    private val items: Array<String>,
+    private val checkedItems: BooleanArray,
+    private val positiveButton: Int,
+    private val negativeButton: Int,
+    private val onPositiveClick: (selectedItems: BooleanArray) -> Unit
+) : DialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        val theme = if (currentNightMode == Configuration.UI_MODE_NIGHT_YES) {
+            R.style.CustomDialogTheme_Dark
+        } else {
+            R.style.CustomDialogTheme_Light
+        }
+    return activity?.let {
+        val builder = AlertDialog.Builder(requireContext(), theme)
+        builder.setTitle(title)
+            .setMultiChoiceItems(items, checkedItems) { _, which, isChecked ->
+                checkedItems[which] = isChecked
+            }
+            .setPositiveButton(positiveButton) { _, _ ->
+                onPositiveClick(checkedItems)
+            }
+            .setNegativeButton(negativeButton) { dialog, _ ->
+                dialog.cancel()
+            }
+        val dialog = builder.create()
+        dialog.setOnShowListener {
+            dialog.getButton(AlertDialog.BUTTON_POSITIVE).setTextColor(ContextCompat.getColor(requireContext(),
+                R.color.material_light_blue_500
+            ))
+            dialog.getButton(AlertDialog.BUTTON_NEGATIVE).setTextColor(ContextCompat.getColor(requireContext(),
+                R.color.material_light_blue_500
+            ))
+        }
+        dialog
+    } ?: throw IllegalStateException("Activity cannot be null")
+}
+}

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -60,6 +60,32 @@
         <item name="android:fontFamily">@string/font_fontFamily_medium</item>
     </style>
 
+       <!-- Light Theme Dialog ManageSpaceActivity -->
+<style name="CustomDialogTheme.Light" parent="Theme.MaterialComponents.Light.Dialog.Alert">
+    <!-- Background color -->
+    <item name="android:colorBackground">@color/white</item>
+    <!-- Title color -->
+    <item name="android:textColorPrimary">@color/black</item>
+    <!-- Message color -->
+    <item name="android:textColorSecondary">@color/black</item>
+
+    <item name="colorControlActivated">@color/material_light_blue_500</item>
+
+</style>
+
+<!-- Dark Theme Dialog for ManageSpaceActivity -->
+<style name="CustomDialogTheme.Dark" parent="Theme.MaterialComponents.Dialog.Alert">
+    <!-- Background color -->
+    <item name="android:colorBackground">@color/material_theme_grey</item>
+    <!-- Title color -->
+    <item name="android:textColorPrimary">@color/white</item>
+    <!-- Message color -->
+    <item name="android:textColorSecondary">@color/white</item>
+
+    <item name="colorControlActivated">@color/material_light_blue_500</item>
+
+</style>
+
     <!-- Styles for each of the 4 answer buttons -->
     <style name="AgainButton">
         <item name="answerButtonBackground">?attr/againButtonBackground</item>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To change the color of the checkbox in the delete alertbox.

## Fixes
* Fixes #15174

## Approach
I have created a new custom dialog for it.

## How Has This Been Tested?
This has been tested in both the physical device as well as emulator. Please see the attached screenshots below.
![image](https://github.com/ankidroid/Anki-Android/assets/58774753/fb1ae959-eba3-43ac-b99a-10022cc0c223)
![image](https://github.com/ankidroid/Anki-Android/assets/58774753/59040daa-023e-459f-8a8d-4a4f198ad229)

## Learning (optional, can help others)
The await-dialog on default doesn't provide us with changes we need to create a custom dialog for it.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
