### PR TITLE
Test : toast should be shown on successful deck creation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -26,7 +26,6 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
@@ -48,7 +47,6 @@ import timber.log.Timber
  *
  * required property: [onNewDeckCreated]. Called on successful creation of a deck
  */
-@NeedsTest("Ensure a toast is shown on a successful action")
 class CreateDeckDialog(
     private val context: Context,
     private val title: Int,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -21,6 +21,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.test.core.app.ActivityScenario
+import androidx.test.platform.app.InstrumentationRegistry
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.IntroductionActivity
@@ -101,6 +102,18 @@ class CreateDeckDialogTest : RobolectricTest() {
             }
             createDeckDialog.createDeck(deckName)
         }
+    }
+
+    @Test
+    fun testToastShownOnCreateDeckSuccess() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val dialog = CreateDeckDialog(context, R.string.new_deck, DeckDialogType.DECK, null)
+        var toastShown = false
+        dialog.onNewDeckCreated = { _ ->
+            toastShown = true
+        }
+        dialog.createDeck("Test Deck")
+        assertThat("Toast should be shown on successful deck creation", toastShown, equalTo(true))
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Test to ensure a toast is shown on a successful deck creation.

## How Has This Been Tested?
Locally

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
