### PR TITLE
Migrate `AsyncDialogs` to Material 3

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
@@ -14,18 +14,18 @@
 
 package com.ichi2.anki.ui.dialogs.tools
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface.BUTTON_POSITIVE
 import androidx.annotation.StringRes
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 
-open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builder) {
+open class AsyncDialogBuilder(private val alertDialogBuilder: MaterialAlertDialogBuilder) {
     lateinit var continuation: Continuation<DialogResult>
 
-    var onShowListener: ((AlertDialog) -> Unit)? = null
+    var onShowListener: ((androidx.appcompat.app.AlertDialog) -> Unit)? = null
 
     private lateinit var checkedItems: BooleanArray
 
@@ -63,14 +63,14 @@ open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builde
             is CheckedItems.Some -> checkedItems.checkedItems.clone()
         }
 
-        fun enableDisablePositiveButton(dialog: AlertDialog) {
+        fun enableDisablePositiveButton(dialog: androidx.appcompat.app.AlertDialog) {
             dialog.getButton(BUTTON_POSITIVE).isEnabled = this.checkedItems.contains(true)
         }
 
         alertDialogBuilder.setMultiChoiceItems(items.toTypedArray(), this.checkedItems) {
                 dialog, position, isChecked ->
             this.checkedItems[position] = isChecked
-            if (disablePositiveButtonIfNoItemsChosen) enableDisablePositiveButton(dialog as AlertDialog)
+            if (disablePositiveButtonIfNoItemsChosen) enableDisablePositiveButton(dialog as androidx.appcompat.app.AlertDialog)
         }
 
         if (disablePositiveButtonIfNoItemsChosen) onShowListener = ::enableDisablePositiveButton
@@ -78,7 +78,7 @@ open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builde
 }
 
 /**
- * A clutch that delegates calls to [AlertDialog.Builder].
+ * A clutch that delegates calls to [MaterialAlertDialogBuilder].
  * All defined methods have the exact same signature.
  *
  * TODO When context receivers are finalized, remove this class and instead say:
@@ -89,18 +89,18 @@ open class AsyncDialogBuilder(private val alertDialogBuilder: AlertDialog.Builde
  *       ...
  *   }
  */
-class CompoundDialogBuilder(private val alertDialogBuilder: AlertDialog.Builder) : AsyncDialogBuilder(alertDialogBuilder) {
-    /** @see AlertDialog.Builder.setTitle */
-    fun setTitle(@StringRes titleId: Int): AlertDialog.Builder = alertDialogBuilder.setTitle(titleId)
+class CompoundDialogBuilder(private val alertDialogBuilder: MaterialAlertDialogBuilder) : AsyncDialogBuilder(alertDialogBuilder) {
+    /** @see MaterialAlertDialogBuilder.setTitle */
+    fun setTitle(@StringRes titleId: Int): MaterialAlertDialogBuilder = alertDialogBuilder.setTitle(titleId)
 
-    /** @see AlertDialog.Builder.setTitle */
-    fun setTitle(title: CharSequence): AlertDialog.Builder = alertDialogBuilder.setTitle(title)
+    /** @see MaterialAlertDialogBuilder.setTitle */
+    fun setTitle(title: CharSequence): MaterialAlertDialogBuilder = alertDialogBuilder.setTitle(title)
 
-    /** @see AlertDialog.Builder.setMessage */
-    fun setMessage(@StringRes messageId: Int): AlertDialog.Builder = alertDialogBuilder.setMessage(messageId)
+    /** @see MaterialAlertDialogBuilder.setMessage */
+    fun setMessage(@StringRes messageId: Int): MaterialAlertDialogBuilder = alertDialogBuilder.setMessage(messageId)
 
-    /** @see AlertDialog.Builder.setMessage */
-    fun setMessage(message: CharSequence): AlertDialog.Builder = alertDialogBuilder.setMessage(message)
+    /** @see MaterialAlertDialogBuilder.setMessage */
+    fun setMessage(message: CharSequence): MaterialAlertDialogBuilder = alertDialogBuilder.setMessage(message)
 }
 
 sealed interface DialogResult {
@@ -129,11 +129,11 @@ sealed interface DialogResult {
  *     }
  *
  * In order for this to properly work,
- * instead of using [AlertDialog.Builder] methods that take listeners,
+ * instead of using [MaterialAlertDialogBuilder] methods that take listeners,
  * use an [AsyncDialogBuilder] method of the same name without one.
  */
 suspend fun Context.awaitDialog(block: CompoundDialogBuilder.() -> Unit): DialogResult {
-    val alertDialogBuilder = AlertDialog.Builder(this)
+    val alertDialogBuilder = MaterialAlertDialogBuilder(this)
     val compoundDialogBuilder = CompoundDialogBuilder(alertDialogBuilder)
 
     compoundDialogBuilder.block()

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -176,4 +176,5 @@
     <attr name="checkMediaListForeground" format="color" />
 
     <attr name="progressDialogButtonTextColor" format="color"/>
+    <attr name="materialAlertDialogPrimaryColor" format="color"/>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -218,6 +218,10 @@
         <item name="checkboxStyle">@style/AlertDialogCheckBox.Style</item>
     </style>
 
+    <style name="ThemeOverlay.App.MaterialAlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
+        <item name="colorPrimary">?attr/materialAlertDialogPrimaryColor</item>
+    </style>
+
     <style name="CustomButtonBarButtonStyle" parent="Widget.AppCompat.Button.ButtonBar.AlertDialog">
         <item name="android:textColor">?attr/progressDialogButtonTextColor</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -105,6 +105,9 @@
         <!-- AlertDialogTheme-->
         <item name="alertDialogTheme">@style/AlertDialogStyle</item>
 
+        <!-- MaterialAlertDialog-->
+        <item name="materialAlertDialogPrimaryColor">@color/theme_black_primary_dark</item>
+
     </style>
 
     <style name="SnackbarTextStyleBlack" parent="@style/Widget.MaterialComponents.Snackbar.TextView">

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -149,6 +149,9 @@
         <!-- AlertDialogTheme-->
         <item name="alertDialogTheme">@style/AlertDialogStyle</item>
         <item name="tabStyle">@style/Widget.MaterialComponents.TabLayout</item>
+
+        <!--MaterialAlertDialogTheme-->
+        <item name="materialAlertDialogPrimaryColor">@color/theme_dark_primary</item>
     </style>
 
     <style name="Theme_Dark" parent="Base.Theme.Dark"/>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -137,6 +137,9 @@
         <item name="checkMediaListForeground">@color/material_grey_700</item>
         <item name="progressDialogButtonTextColor">@color/material_light_blue_500</item>
         <item name="tabStyle">@style/Widget.MaterialComponents.TabLayout</item>
+
+        <!-- Material Alert Dialog-->
+        <item name="materialAlertDialogPrimaryColor">@color/material_light_blue_500</item>
     </style>
 
     <style name="Theme_Light" parent="Base.Theme.Light"/>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -69,6 +69,8 @@
         <item name="dialogBackground">@color/white</item>
         <item name="progressDialogButtonTextColor">@color/theme_plain_primary</item>
 
+        <!-- MaterialAlertDialog-->
+        <item name="materialAlertDialogPrimaryColor">@color/theme_plain_primary</item>
     </style>
 
     <style name="Theme_Light.Plain" parent="Base.Theme.Light.Plain"/>


### PR DESCRIPTION
## Description
Currently the issue was that the colour of the checkbox was not matching with the APP theme `@color/material_light_blue_500`.  Initially, my thought process was to add a style in the Theme to ensure the checkbox color matches the app theme. However, I later realized that migrating to Material3 would be a better approach, as it allows the checkbox color to adapt dynamically based on the app theme. Since we plan to migrate to Material3 eventually, this seems like the most forward-thinking solution.

* 🌟 h/t to thank @SanjaySargam  for helping inspire this solution with #15184

* 🌟 h/t to thank @Thejas775 for helping inspire this solution with #16485

## Fixes
* Fixes : #15174
* Related : #13878

## Steps to Reproduce
1. App Info
2. Go to Manage Space
3. Click on Delete backups
4. Click on any one of the Checkbox Item


## Screenshot/Video

https://github.com/ankidroid/Anki-Android/assets/60827173/d72e6ef2-66be-48ab-a0a2-00378ed5e7dc



## Approach
In the PR :)



## Learning (optional, can help others)
https://github.com/material-components/material-components-android/blob/master/docs/components/Dialog.md


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
