### PR TITLE
fix(card-browser): incorrect 'notes' sort order

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -303,7 +303,7 @@ class CardBrowserViewModel(
             flowOfCardsOrNotes.update { cardsOrNotes }
 
             withCol {
-                sortTypeFlow.update { SortType.fromCol(config, sharedPrefs()) }
+                sortTypeFlow.update { SortType.fromCol(config, cardsOrNotes, sharedPrefs()) }
                 reverseDirectionFlow.update { ReverseDirection.fromConfig(config) }
             }
             Timber.i("initCompleted")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -88,7 +88,8 @@ class CardBrowserViewModel(
     private val lastDeckIdRepository: LastDeckIdRepository,
     private val cacheDir: File,
     options: CardBrowserLaunchOptions?,
-    preferences: SharedPreferencesProvider
+    preferences: SharedPreferencesProvider,
+    private val manualInit: Boolean = false
 ) : ViewModel(), SharedPreferencesProvider by preferences {
 
     // Set by the UI to determine the number of cards to preload before returning search results
@@ -306,8 +307,17 @@ class CardBrowserViewModel(
                 reverseDirectionFlow.update { ReverseDirection.fromConfig(config) }
             }
             Timber.i("initCompleted")
-            flowOfInitCompleted.update { true }
+
+            if (!manualInit) {
+                flowOfInitCompleted.update { true }
+            }
         }
+    }
+
+    @VisibleForTesting
+    fun manualInit() {
+        require(manualInit) { "'manualInit' should be true" }
+        flowOfInitCompleted.update { true }
     }
 
     /** Whether any rows are selected */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
@@ -55,6 +55,8 @@ enum class SortType(val ankiSortType: String?, val cardBrowserLabelIndex: Int) {
         config.set("sortType", this.ankiSortType ?: SORT_FIELD.ankiSortType)
         config.set("noteSortType", this.ankiSortType ?: SORT_FIELD.ankiSortType)
         preferences.edit {
+            // TODO: This should be changed to use the collection
+            // and have a different value for cards & notes
             putBoolean("cardBrowserNoSorting", this@SortType == NO_SORTING)
         }
     }
@@ -64,8 +66,9 @@ enum class SortType(val ankiSortType: String?, val cardBrowserLabelIndex: Int) {
         if (this == NO_SORTING) SortOrder.NoOrdering() else SortOrder.UseCollectionOrdering()
 
     companion object {
-        fun fromCol(config: Config, preferences: SharedPreferences): SortType {
-            val colOrder = config.get<String>("sortType")
+        fun fromCol(config: Config, cardsOrNotes: CardsOrNotes, preferences: SharedPreferences): SortType {
+            val configKey = if (cardsOrNotes == CardsOrNotes.CARDS) "sortType" else "noteSortType"
+            val colOrder = config.get<String>(configKey)
             val type = entries.firstOrNull { it.ankiSortType == colOrder } ?: NO_SORTING
             if (type == SORT_FIELD && preferences.getBoolean("cardBrowserNoSorting", false)) {
                 return NO_SORTING

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -206,7 +206,7 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
-    private fun runViewModelTest(notes: Int = 0, testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
+    private fun runViewModelTest(notes: Int = 0, manualInit: Boolean = true, testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
         for (i in 0 until notes) {
             addNoteUsingBasicModel()
         }
@@ -214,8 +214,13 @@ class CardBrowserViewModelTest : JvmTest() {
             lastDeckIdRepository = SharedPreferencesLastDeckIdRepository(),
             cacheDir = createTransientDirectory(),
             options = null,
-            preferences = AnkiDroidApp.sharedPreferencesProvider
+            preferences = AnkiDroidApp.sharedPreferencesProvider,
+            manualInit = manualInit
         )
+        // makes ignoreValuesFromViewModelLaunch work under test
+        if (manualInit) {
+            viewModel.manualInit()
+        }
         testBody(viewModel)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -206,6 +206,17 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `sort order from notes is selected - 16514`() {
+        col.config.set("sortType", "noteCrt")
+        col.config.set("noteSortType", "_field_Frequency")
+        with(col) { CardsOrNotes.NOTES.saveToCollection() }
+
+        runViewModelTest(notes = 1) {
+            assertThat("1 row returned", rowCount, equalTo(1))
+        }
+    }
+
     private fun runViewModelTest(notes: Int = 0, manualInit: Boolean = true, testBody: suspend CardBrowserViewModel.() -> Unit) = runTest {
         for (i in 0 until notes) {
             addNoteUsingBasicModel()


### PR DESCRIPTION
## Fixes
* Fixes #16514

## Approach
* fix a bug in tests (`manualInit`)
* Obtain the sort type from `noteSortType` config if notes are desired

## How Has This Been Tested?
Unit tests + tested on-device with user's collection

## Learning (optional, can help others)
* When cards & notes were introduced, we did not test thoroughly, there've been a number of bugs here

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
