### PR TITLE
feat: Toggle check pronunciation feature

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -45,7 +45,6 @@ import anki.frontend.SetSchedulingStatesRequest
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
-import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Whiteboard.Companion.createInstance
 import com.ichi2.anki.Whiteboard.OnPaintColorChangeListener
@@ -141,7 +140,7 @@ open class Reviewer :
     // Record Audio
     private var isMicToolBarVisible = false
 
-    /** Controller for 'Check Pronunciation' feature */
+    /** Controller for 'Voice Playback' feature */
     private var audioRecordingController: AudioRecordingController? = null
     private var isAudioUIInitialized = false
     private lateinit var micToolBarLayer: LinearLayout
@@ -330,6 +329,12 @@ open class Reviewer :
             toggleStylus = MetaDB.getWhiteboardStylusState(this, parentDid)
             whiteboard!!.toggleStylus = toggleStylus
         }
+
+        val isMicToolbarEnabled = MetaDB.getMicToolbarState(this, parentDid)
+        if (isMicToolbarEnabled) {
+            openMicToolbar()
+        }
+
         launchCatchingTask {
             withCol { startTimebox() }
             updateCardAndRedraw()
@@ -383,7 +388,7 @@ open class Reviewer :
                 playSounds(true)
             }
             R.id.action_toggle_mic_tool_bar -> {
-                Timber.i("Reviewer:: Record mic")
+                Timber.i("Reviewer:: Voice playback visibility set to %b", !isMicToolBarVisible)
                 // Check permission to record and request if not granted
                 openOrToggleMicToolbar()
             }
@@ -643,6 +648,10 @@ open class Reviewer :
             micToolBarLayer.visibility = View.VISIBLE
         }
         isMicToolBarVisible = !isMicToolBarVisible
+
+        MetaDB.storeMicToolbarState(this, parentDid, isMicToolBarVisible)
+
+        refreshActionBar()
     }
 
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
@@ -839,6 +848,13 @@ open class Reviewer :
         if (!buryNoteAvailable() && !actionButtons.status.buryIsDisabled()) {
             menu.findItem(R.id.action_bury).isVisible = false
             menu.findItem(R.id.action_bury_card).isVisible = true
+        }
+
+        val voicePlaybackIcon = menu.findItem(R.id.action_toggle_mic_tool_bar)
+        if (isMicToolBarVisible) {
+            voicePlaybackIcon.setTitle(R.string.menu_disable_voice_playback)
+        } else {
+            voicePlaybackIcon.setTitle(R.string.menu_enable_voice_playback)
         }
 
         onboarding.onCreate()

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -178,7 +178,7 @@
         ankidroid:showAsAction="ifRoom"/>
     <item
         android:id="@+id/action_toggle_mic_tool_bar"
-        android:title="@string/menu_toggle_mic_tool_bar"
+        android:title="@string/menu_enable_voice_playback"
         android:icon="@drawable/ic_action_mic"
         ankidroid:showAsAction="never"/>
     <item

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -90,7 +90,8 @@
     <string name="menu_search">Lookup in %1$s</string>
     <string name="menu_mark_note">Mark note</string>
     <string name="menu_unmark_note">Unmark note</string>
-    <string name="menu_toggle_mic_tool_bar">Check pronunciation</string>
+    <string name="menu_enable_voice_playback">Enable voice playback</string>
+    <string name="menu_disable_voice_playback">Disable voice playback</string>
     <string name="new_deck">Create deck</string>
     <string name="new_dynamic_deck">Create filtered deck</string>
     <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -123,7 +123,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_toggle_mic_toolbar_key"
-            android:title="@string/menu_toggle_mic_tool_bar"
+            android:title="@string/menu_enable_voice_playback"
             app:useSimpleSummaryProvider="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/menu_dismiss_note" >

--- a/AnkiDroid/src/test/java/com/ichi2/audio/AudioRecordingControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/audio/AudioRecordingControllerTest.kt
@@ -46,7 +46,7 @@ class AudioRecordingControllerAndroidTest : RobolectricTest() {
 
     @Test
     @Ignore("does not fail when expected under Robolectric")
-    fun `Check Pronunciation handles onPause`() = withCheckPronunciation {
+    fun `Voice Playback handles onPause`() = withVoicePlayback {
         Timber.v("start recording")
         layout.findViewById<MaterialButton?>(R.id.action_start_recording).performClick()
         Timber.v("stop recording")
@@ -59,7 +59,7 @@ class AudioRecordingControllerAndroidTest : RobolectricTest() {
     }
 
     /** Applies [block] to a [AudioRecordingController] generated for the [Reviewer] */
-    private fun withCheckPronunciation(block: AudioRecordingController.() -> Unit) {
+    private fun withVoicePlayback(block: AudioRecordingController.() -> Unit) {
         ShadowMediaPlayer.setMediaInfoProvider { ShadowMediaPlayer.MediaInfo(200, 1) }
         val layout = LinearLayout(targetContext)
         Themes.setTheme(targetContext)


### PR DESCRIPTION
## Purpose / Description
Currently the 'Check pronunciation' menu item needs to be selected every time a new review session starts. Now with this feature, the enabled state persists between review sessions and is specific to each deck. Additionally the menu item has be renamed to reflect the enabled state of the feature (i.e. whether it will be enabled or disabled when the menu item is clicked).

[Toggle voice playback.webm](https://github.com/ankidroid/Anki-Android/assets/28263886/4c45fe0a-9522-428c-b29d-317487f753de)

## Fixes
* Fixes #16288 

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
