### PR TITLE
Fix #15553: Start of Next Day Not Working

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -32,6 +32,7 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import anki.config.copy
 import com.bytehamster.lib.preferencesearch.SearchPreferenceResult
 import com.bytehamster.lib.preferencesearch.SearchPreferenceResultListener
 import com.google.android.material.appbar.AppBarLayout
@@ -43,6 +44,8 @@ import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.undoableOp
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.setTransparentStatusBar
 import com.ichi2.utils.getInstanceFromClassName
@@ -229,15 +232,20 @@ class Preferences :
 
         /** Sets the hour that the collection rolls over to the next day  */
         @VisibleForTesting
+        @NeedsTest("ensure Start of Next Day is handled by the scheduler")
         suspend fun setDayOffset(context: Context, hours: Int) {
-            withCol {
-                config.set("rollover", hours)
-                scheduleNotification(TimeManager.time, context)
+            val prefs = withCol { getPreferences() }
+            val newPrefs = prefs.copy { scheduling = prefs.scheduling.copy { rollover = hours } }
+
+            undoableOp {
+                setPreferences(newPrefs)
             }
+            scheduleNotification(TimeManager.time, context)
             Timber.i("set day offset: '%d'", hours)
         }
+
         suspend fun getDayOffset(): Int {
-            return withCol { config.get("rollover") ?: 4 }
+            return withCol { getPreferences().scheduling.rollover }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.preferences.Preferences.Companion.setDayOffset
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.preferences.HeaderPreference
 import com.ichi2.testutils.getJavaMethodAsAccessible
-import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Before
@@ -53,7 +52,7 @@ class PreferencesTest : RobolectricTest() {
 
     @Test
     fun testDayOffsetExhaustive() {
-        runBlocking {
+        runTest {
             for (i in 0..23) {
                 setDayOffset(preferences, i)
                 assertThat(getDayOffset(), equalTo(i))
@@ -64,7 +63,7 @@ class PreferencesTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun testDayOffsetExhaustiveV2() {
-        runBlocking {
+        runTest {
             for (i in 0..23) {
                 setDayOffset(preferences, i)
                 assertThat(getDayOffset(), equalTo(i))
@@ -95,9 +94,9 @@ class PreferencesTest : RobolectricTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun setDayOffsetSetsConfig() {
-        val offset = runBlocking { getDayOffset() }
-        assertThat("Default offset should be 4", offset, equalTo(4))
-        runBlocking { setDayOffset(preferences, 2) }
-        assertThat("rollover config should be set to new value", col.config.get("rollover") ?: 4, equalTo(2))
+        runTest {
+            setDayOffset(preferences, 2)
+            assertThat("rollover config should be set to new value", col.config.get("rollover") ?: 4, equalTo(2))
+        }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After finishing all cards for a day, changing Start of Next Day to the past and trying to access that same deck would result in a message saying that all cards were finished for the day.
This was due to the fact that the scheduler did not update after the rollover change
Previously, this issue would require restarting anki.

## Fixes
* Fixes #15553

## Approach
_How does this change address the problem?_
`config.set("rollover", hours)` only updates the database, this change will eventually propagate, however the scheduler will not update what cards to show. This is caused by the transaction of config.set not requiring a queue rebuild (as it's only DeckConfig)
By calling `setPreferences(newPrefs)` this will reset scheduler_info as well as a transaction that will require a study queue rebuild.

## How Has This Been Tested?
By following @briankrznarich steps to reproduce the bug, on a physical device (Samsung A33 5G, Android 14)
> * With a rollover of 8pm, finish all cards for the day.
> * On the Deck Summary screen, at 2pm, with all cards finished, set the rollover to noon. (i.e. "the past")
> * On the Deck Screen, newly due cards appear (~500 for me)
> * Tap the deck to start reviewing

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
