### PR TITLE
[GSoC'24] Add TemplatePreviewerFragment to CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -194,7 +194,8 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 ord = ord,
                 fields = note.fields,
                 tags = note.tags,
-                fillEmpty = true
+                fillEmpty = true,
+                inFragmentedActivity = fragmented
             )
             val details = TemplatePreviewerFragment.newInstance(args)
             supportFragmentManager.commit {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -602,6 +602,15 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
             initTabLayoutMediator()
+            templateEditor.slidingTabLayout?.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
+                override fun onTabSelected(p0: TabLayout.Tab?) {
+                    templateEditor.loadTemplatePreviewerFragmentIfFragmented()
+                }
+                override fun onTabUnselected(p0: TabLayout.Tab?) {
+                }
+                override fun onTabReselected(p0: TabLayout.Tab?) {
+                }
+            })
             parentFragmentManager.setFragmentResultListener(REQUEST_FIELD_INSERT, viewLifecycleOwner) { key, bundle ->
                 if (key == REQUEST_FIELD_INSERT) {
                     // this is guaranteed to be non null, as we put a non null value on the other side

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -570,6 +570,8 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
                 // update the tab
                 templateEditor.viewPager.adapter!!.notifyDataSetChanged()
+                // Update the tab name in previewer
+                templateEditor.loadTemplatePreviewerFragmentIfFragmented()
             }
         }
 
@@ -1028,12 +1030,21 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
         /**
          * Execute an action on the schema, asking the user to confirm that a full sync is ok
+         * If [schemaChangingAction] is successfully executed, then the template is reloaded.
+         *
+         * This method is always useful because all calls to executeWithSyncCheck may need to refresh the previewer.
+         * Due to conditional generation (e.g., {{#c5}}foo{{/c5}} which is non-empty only if it's the 5th card and is
+         * empty otherwise), it's important to reload the template. This is particularly useful for cloze types,
+         * where a card can move from the 5th to the 6th position due to adding an extra card type, causing content
+         * to change or be deleted.
+         *
          * @param schemaChangingAction The action to execute (adding / removing card)
          */
         private fun executeWithSyncCheck(schemaChangingAction: Runnable) {
             try {
                 templateEditor.getColUnsafe.modSchema()
                 schemaChangingAction.run()
+                templateEditor.loadTemplatePreviewerFragmentIfFragmented()
             } catch (e: ConfirmModSchemaException) {
                 e.log()
                 val d = ConfirmationDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -166,7 +166,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
 
         slidingTabLayout = findViewById(R.id.sliding_tabs)
         viewPager = findViewById(R.id.card_template_editor_pager)
-        setNavigationBarColor(R.attr.appBarColor)
+        setNavigationBarColor(R.attr.alternativeBackgroundColor)
 
         // Disable the home icon
         enableToolbar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -113,6 +113,12 @@ class TemplatePreviewerFragment :
     companion object {
         const val ARGS_KEY = "templatePreviewerArgs"
 
+        fun newInstance(arguments: TemplatePreviewerArguments): TemplatePreviewerFragment {
+            return TemplatePreviewerFragment().apply {
+                this.arguments = bundleOf(ARGS_KEY to arguments)
+            }
+        }
+
         fun getIntent(context: Context, arguments: TemplatePreviewerArguments): Intent {
             return CardViewerActivity.getIntent(
                 context,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -44,10 +44,16 @@ import timber.log.Timber
 class TemplatePreviewerFragment :
     CardViewerFragment(R.layout.template_previewer),
     BaseSnackbarBuilderProvider {
+    /**
+     * Whether this is displayed in a fragment view.
+     * If true, this fragment is on the trailing side of the card template editor.
+     */
+    private var inFragmentedActivity = false
+    private lateinit var templatePreviewerArguments: TemplatePreviewerArguments
 
     override val viewModel: TemplatePreviewerViewModel by viewModels {
-        val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
-        TemplatePreviewerViewModel.factory(arguments, CardMediaPlayer())
+        templatePreviewerArguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
+        TemplatePreviewerViewModel.factory(templatePreviewerArguments, CardMediaPlayer())
     }
     override val webView: WebView
         get() = requireView().findViewById(R.id.webview)
@@ -58,8 +64,17 @@ class TemplatePreviewerFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar)
+        // Retrieve the boolean argument "inFragmentedActivity" from the fragment's arguments bundle
+        inFragmentedActivity = templatePreviewerArguments.inFragmentedActivity
+        // If this fragment is a part of fragmented activity, then there is already a navigation icon an the activity.
+        // We hide the one specific to this fragment
+        if (inFragmentedActivity) {
+            toolbar.navigationIcon = null
+        } else {
+            toolbar.setNavigationOnClickListener {
+                requireActivity().onBackPressedDispatcher.onBackPressed()
+            }
         }
 
         val showAnswerButton = view.findViewById<MaterialButton>(R.id.show_answer).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -18,18 +18,20 @@ package com.ichi2.anki.previewer
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
 import androidx.appcompat.widget.ThemeUtils
+import androidx.appcompat.widget.Toolbar
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
+import com.ichi2.anki.CardTemplateEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
@@ -43,7 +45,8 @@ import timber.log.Timber
 
 class TemplatePreviewerFragment :
     CardViewerFragment(R.layout.template_previewer),
-    BaseSnackbarBuilderProvider {
+    BaseSnackbarBuilderProvider,
+    Toolbar.OnMenuItemClickListener {
     /**
      * Whether this is displayed in a fragment view.
      * If true, this fragment is on the trailing side of the card template editor.
@@ -64,7 +67,7 @@ class TemplatePreviewerFragment :
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val toolbar = view.findViewById<MaterialToolbar>(R.id.toolbar)
+        val toolbar = view.findViewById<Toolbar>(R.id.toolbar)
         // Retrieve the boolean argument "inFragmentedActivity" from the fragment's arguments bundle
         inFragmentedActivity = templatePreviewerArguments.inFragmentedActivity
         // If this fragment is a part of fragmented activity, then there is already a navigation icon an the activity.
@@ -123,6 +126,15 @@ class TemplatePreviewerFragment :
                 window.navigationBarColor = ThemeUtils.getThemeAttrColor(this, R.attr.alternativeBackgroundColor)
             }
         }
+        if (inFragmentedActivity) {
+            toolbar.setOnMenuItemClickListener(this)
+            toolbar.inflateMenu(R.menu.card_template_editor)
+            (activity as CardTemplateEditor).currentFragment?.setupCommonMenu(toolbar.menu)
+        }
+    }
+
+    override fun onMenuItemClick(item: MenuItem): Boolean {
+        return (activity as CardTemplateEditor).currentFragment?.handleCommonMenuItemSelected(item) == true
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -125,6 +125,7 @@ class TemplatePreviewerFragment :
             if (!navBarNeedsScrim) {
                 window.navigationBarColor = ThemeUtils.getThemeAttrColor(this, R.attr.alternativeBackgroundColor)
             }
+            window.statusBarColor = ThemeUtils.getThemeAttrColor(this, R.attr.appBarColor)
         }
         if (inFragmentedActivity) {
             toolbar.setOnMenuItemClickListener(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -237,7 +237,8 @@ data class TemplatePreviewerArguments(
     val tags: MutableList<String>,
     val id: Long = 0,
     val ord: Int = 0,
-    val fillEmpty: Boolean = false
+    val fillEmpty: Boolean = false,
+    val inFragmentedActivity: Boolean = false
 ) : Parcelable {
     val notetype: NotetypeJson get() = notetypeFile.getNotetype()
 }

--- a/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:id="@+id/card_template_editor_xl_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:orientation="horizontal">
+        <include layout="@layout/card_template_editor_activity"
+            android:layout_width="1dip"
+            android:layout_weight="1"
+            android:layout_height="match_parent"/>
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/template_previewer_fragment"
+            android:layout_weight="1"
+            android:layout_width="1dip"
+            android:layout_height="match_parent"/>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>
+

--- a/AnkiDroid/src/main/res/layout/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <include layout="@layout/card_template_editor_activity" />
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -47,7 +47,7 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         style="@style/BottomNavigationViewStyle"
-        android:background="?attr/appBarColor"
+        android:background="?attr/alternativeBackgroundColor"
         app:menu="@menu/card_template_editor_navigation_bar_menu"
         />
 

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -19,26 +19,14 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintTop_toTopOf="parent">
-
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
+            <include layout="@layout/toolbar" />
+            <com.google.android.material.tabs.TabLayout
+                android:id="@+id/tab_layout"
+                android:background="@color/transparent"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
-                app:navigationContentDescription="@string/abc_action_bar_up_description"
-                app:navigationIcon="?attr/homeAsUpIndicator"
-                android:background="?attr/alternativeBackgroundColor">
-
-                <com.google.android.material.tabs.TabLayout
-                    android:id="@+id/tab_layout"
-                    android:background="@color/transparent"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    app:tabMode="scrollable"
-                    />
-
-            </com.google.android.material.appbar.MaterialToolbar>
-
+                app:tabMode="scrollable"
+                />
         </com.google.android.material.appbar.AppBarLayout>
 
         <com.google.android.material.card.MaterialCardView

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -22,7 +22,7 @@
             <include layout="@layout/toolbar" />
             <com.google.android.material.tabs.TabLayout
                 android:id="@+id/tab_layout"
-                android:background="@color/transparent"
+                style="@style/TabLayoutStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:tabMode="scrollable"
@@ -32,7 +32,7 @@
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/webview_container"
             android:layout_width="match_parent"
-            android:layout_marginHorizontal="8dp"
+            android:layout_margin="8dp"
             android:layout_height="0dp"
             app:layout_constraintTop_toBottomOf="@id/appbar"
             app:layout_constraintBottom_toTopOf="@id/show_answer"
@@ -50,7 +50,7 @@
         <com.google.android.material.button.MaterialButton
             android:id="@+id/show_answer"
             android:layout_width="0dp"
-            android:layout_height="wrap_content"
+            android:layout_height="80dp"
             style="@style/Widget.Material3.Button.TextButton"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -171,6 +171,7 @@
          The latter is set by colorPrimary, but theme overlay can't use it,
          as it itself overrides colorPrimary, which is used by the view directly. -->
     <attr name="tabLayoutBackgroundColor" format="color"/>
+    <attr name="tabActiveIconColor" format="color"/>
 
     <attr name="checkMediaListBackground" format="color" />
     <attr name="checkMediaListForeground" format="color" />

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -140,10 +140,10 @@
         <item name="materialThemeOverlay">@style/ThemeOverlay.App.BottomNavigationView</item>
     </style>
     <style name="ThemeOverlay.App.BottomNavigationView" parent="">
-        <item name="colorSecondaryContainer">#fff</item> <!-- Selected item indicator -->
-        <item name="colorOnSecondaryContainer">?attr/tabLayoutBackgroundColor</item> <!-- Active icon -->
-        <item name="colorOnSurface">#fff</item> <!-- Active icon -->
-        <item name="colorOnSurfaceVariant">#fff</item> <!-- Inactive icon & label -->
+        <item name="colorSecondaryContainer">?attr/tabLayoutBackgroundColor</item> <!-- Selected item indicator -->
+        <item name="colorOnSecondaryContainer">?attr/tabActiveIconColor</item> <!-- Active icon -->
+        <item name="colorOnSurface">?attr/colorPrimary</item> <!-- Active icon -->
+        <item name="colorOnSurfaceVariant">?attr/colorPrimary</item> <!-- Inactive icon & label -->
         <item name="textAppearanceTitleSmall">@style/TextAppearance.Material3.TitleSmall</item>
         <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
     </style>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -26,6 +26,7 @@
         <item name="actionModeBackground">@color/theme_black_primary_dark</item>
         <!-- Tab layout -->
         <item name="tabLayoutBackgroundColor">@color/theme_black_primary_dark</item>
+        <item name="tabActiveIconColor">@color/material_blue_500</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">@color/theme_black_row_current</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -49,6 +49,7 @@
         <item name="actionModeBackground">@color/theme_dark_primary</item>
         <!-- Tab layout -->
         <item name="tabLayoutBackgroundColor">@color/theme_dark_primary</item>
+        <item name="tabActiveIconColor">@color/material_blue_500</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">@color/theme_dark_row_current</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -41,6 +41,7 @@
         <item name="actionModeBackground">?attr/colorPrimary</item>
         <!-- Tab layout -->
         <item name="tabLayoutBackgroundColor">?attr/colorPrimary</item>
+        <item name="tabActiveIconColor">@color/white</item>
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">#ececec</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -22,6 +22,7 @@
         <item name="actionModeBackground">@color/theme_plain_primary</item>
         <!-- Tab layout -->
         <item name="tabLayoutBackgroundColor">@color/theme_plain_primary</item>
+        <item name="tabActiveIconColor">@color/white</item>
         <!-- Reviewer colors -->
         <item name="topBarColor">@color/theme_plain_primary_light</item>
         <!-- Reviewer button drawables -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This feature aims to enhance the CardTemplateEditor by adding a TemplatePreviewerFragment. This will allow users to preview card templates in real-time, improving the usability and efficiency of template editing.

## Approach
Steps
1. Attach fragment to activity
2. Load fragment on preview button, performing actions and tab change
3. Remove back button when fragmented
4. Move menu contents to fragment
5. Customize UI

## How Has This Been Tested?
Emulator

https://github.com/ankidroid/Anki-Android/assets/65113071/8a410f3a-4da5-420e-ab6f-1dd5c459c541



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)