### PR TITLE
fix(i18n): file 15-markettitle.txt is gone, remove remnants

### DIFF
--- a/tools/localization/src/constants.ts
+++ b/tools/localization/src/constants.ts
@@ -62,7 +62,6 @@ export const I18N_FILES = [
     "11-arrays",
     "12-dont-translate",
     "14-marketdescription",
-    "15-markettitle",
     "16-multimedia-editor",
     "17-model-manager",
     "18-standard-models",

--- a/tools/localization/src/update.ts
+++ b/tools/localization/src/update.ts
@@ -81,7 +81,6 @@ async function replacechars(fileName: string): Promise<boolean> {
  */
 function fileExtFor(f: string): string {
     if (f == "14-marketdescription") return ".txt";
-    else if (f == "15-markettitle") return ".txt";
     else return ".xml";
 }
 

--- a/tools/localization/src/upload.ts
+++ b/tools/localization/src/upload.ts
@@ -38,13 +38,6 @@ export async function uploadI18nFiles() {
             let I18N_FILE_TARGET_NAME = `${file}.xml`;
             let I18N_FILE_SOURCE_NAME = `${I18N_FILES_DIR}${I18N_FILE_TARGET_NAME}`;
 
-            // special case, the title is just the name as one line, it is ephemeral so create it
-            if (file == "15-markettitle") {
-                I18N_FILE_TARGET_NAME = "15-markettitle.txt";
-                I18N_FILE_SOURCE_NAME = path.join(TEMP_DIR, "15-markettitle.txt");
-                fs.writeFileSync(I18N_FILE_SOURCE_NAME, TITLE_STR);
-            }
-
             // special case, the market description is a txt file from different location
             if (file == "14-marketdescription") {
                 I18N_FILE_TARGET_NAME = "14-marketdescription.txt";


### PR DESCRIPTION
## Purpose / Description

Related to PR 16348 - the file is no longer needed as it was for the special (now defunct) ChromeOS store. We stopped processing it, but we were still uploading it for translation (and the file was still up in crowdin so being downloaded...)

## Fixes
* Completes the work I did not realize still needed to happen from #16348
* Unblocks #16526

## Approach

1. try to figure out where 15-markettitle.xml is coming from, since we no longer handle it specially
2. realize it *used* to be handled by pulling the xml from the download from crowdin and moving it so the resources didn't have invalid XML
3. realize that the file was still up on crowdin even though we no longer need it! Delete it there
4. think you're done, re-run translation sync
5. realize that it failed for same reason because we still create / upload the ephemeral file to crowdin, so it's back, an undead file
6. delete it again on crowdin and remove the last remnants here

## How Has This Been Tested?

Untested but...this is the only way this file can go away - by removing the creation of it (and removing it on crowdin)

## Learning (optional, can help others)

You can delete files on crowdin completely, relatively easily! Careful

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
