### PR TITLE
test(custom-scheduler): stabilize custom scheduler testing

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -27,12 +27,11 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.tests.libanki.RetryRule
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
 import com.ichi2.libanki.Collection
-import com.ichi2.testutils.Flaky
-import com.ichi2.testutils.OS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
@@ -56,8 +55,10 @@ class ReviewerFragmentTest : InstrumentedTest() {
     @get:Rule
     val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
 
+    @get:Rule
+    val retry = RetryRule(10)
+
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithCustomData() {
         setNewReviewer()
         col.cardStateCustomizer =
@@ -95,7 +96,6 @@ class ReviewerFragmentTest : InstrumentedTest() {
     }
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithRuntimeError() {
         setNewReviewer()
         // Issue 15035 - runtime errors weren't handled

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -29,13 +29,12 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.tests.libanki.RetryRule
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.ThreadUtils
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.anki.testutil.notificationPermission
 import com.ichi2.libanki.Collection
-import com.ichi2.testutils.Flaky
-import com.ichi2.testutils.OS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Rule
@@ -59,8 +58,10 @@ class ReviewerTest : InstrumentedTest() {
     @get:Rule
     val runtimePermissionRule = grantPermissions(storagePermission, notificationPermission)
 
+    @get:Rule
+    val retry = RetryRule(10)
+
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithCustomData() {
         col.cardStateCustomizer =
             """
@@ -108,7 +109,6 @@ class ReviewerTest : InstrumentedTest() {
     }
 
     @Test
-    @Flaky(os = OS.ALL, "Fails on CI with timing issues frequently")
     fun testCustomSchedulerWithRuntimeError() {
         // Issue 15035 - runtime errors weren't handled
         col.cardStateCustomizer = "states.this_is_not_defined.normal.review = 12;"


### PR DESCRIPTION
## Purpose / Description

After implementing the reviewer fragment thing in the new reviewer with #16455 the custom scheduler test was failing for me on the command line so my customary / frequent `./gradlew jacocoTestReport` did not pass

I believe others did not notice it because:

1- it is not executed in CI because of a Flaky annotation
2- I suppose people developing locally either don't run tests or run them from Android Studio? I use the command line

I need that to pass, so I looked into it, and this or something like this will fix it

## Fixes
* Fixes regression from  #16455

## Approach

1- realize by view hierarchy inspection that the hierarchies are different from the command line and from Android Studio. I have no idea. They are though. So...allow either name for the the layout flip or ease 3 button view resource to match 🤷 
2- realize that timing issues are still present (even for me locally) but if we use the otherwise-unused retry rule with a retry of 3, it works every time locally! So I am passing now
3- try to get this working in CI so it doesn't start silently failing again and sending me on a yak shave. Bumping retry to 10 seems to do it? 🙏 

Note there was a line-ending issue in initial push that has been peeled off to #16536 

## How Has This Been Tested?

It's all tests, it is made of tests. But this was a flake, so it has a a higher burden of proof. I'm 9 for 9 running this so I think I actually stabilized it

## Learning (optional, can help others)

- New emulator on new ubuntu runner is pretty quick, default view match timeout is 10s and we don't need 30s anymore
- we already had a retry rule which was cool
- view hierarchies can be different between command line and android studio, and I can't even begin to explain that
- I cannot find a way to run *just* a single test or regex of tests from the androidTest hierarchy via command line 🤷 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
