### PR TITLE
Make permission item fully touchable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionItem.kt
@@ -82,7 +82,18 @@ class PermissionItem(context: Context, attrs: AttributeSet) : FrameLayout(contex
                 }
             }
         }
+        setOnClickListener {
+            if (!isGranted) {
+                Timber.i("Permission item clicked, requesting permission")
+                listener?.invoke()
+            } else {
+                switch.isChecked = !switch.isChecked
+            }
+        }
+        updateSwitchCheckedStatus()
     }
+
+    private var listener: (() -> Unit)? = null
 
     /**
      * Checks the switch if the permission is granted,
@@ -97,6 +108,7 @@ class PermissionItem(context: Context, attrs: AttributeSet) : FrameLayout(contex
      * The listener isn't invoked if the permission is already granted
      * */
     fun setOnSwitchClickListener(listener: () -> Unit) {
+        this.listener = listener
         switch.setOnClickListener {
             if (!isGranted) {
                 Timber.i("permission switch pressed")

--- a/AnkiDroid/src/main/res/layout/permission_item.xml
+++ b/AnkiDroid/src/main/res/layout/permission_item.xml
@@ -5,8 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/listPreferredItemHeight"
-    android:paddingTop="16dp"
+    android:paddingVertical="16dp"
     android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:background="?attr/selectableItemBackground"
     android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
     tools:context=".ui.windows.permissions.PermissionItem">
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In PermissionActivity, the permission item is not fully touchable, unlike in the settings.

## Approach
setOnClickListener on root layout.

## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/119813120/b256bfce-0b05-4121-9ab6-d705c24b5514


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
