### PR TITLE
Focus keyboard on RenameCardTemplateDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RenameCardTemplateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RenameCardTemplateDialog.kt
@@ -36,6 +36,7 @@ class RenameCardTemplateDialog {
             }
                 .input(
                     hint = CollectionManager.TR.actionsNewName(),
+                    displayKeyboard = true,
                     allowEmpty = false,
                     prefill = prefill,
                     waitForPositiveButton = true,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Focus keyboard.

## Approach
Set `displayKeyboard ` is true

## How Has This Been Tested?

https://github.com/ankidroid/Anki-Android/assets/119813120/e9b4481d-1638-4493-b2c1-fef51b8bacea



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
