### PR TITLE
fix(note-editor): filtered card sent home after edit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1070,7 +1070,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             // Regular changes in note content
             var modified = false
             // changed did? this has to be done first as remFromDyn() involves a direct write to the database
-            if (currentEditedCard != null && currentEditedCard!!.did != deckId) {
+            if (currentEditedCard != null && currentEditedCard!!.currentDeckId().did != deckId) {
                 reloadRequired = true
                 undoableOp { setDeck(listOf(currentEditedCard!!.id), deckId) }
                 // refresh the card object to reflect the database changes from above
@@ -1080,6 +1080,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 // then set the card ID to the new deck
                 currentEditedCard!!.did = deckId
                 modified = true
+                Timber.d("deck ID updated to '%d'", deckId)
             }
             // now load any changes to the fields from the form
             for (f in editFields!!) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -426,6 +426,26 @@ class NoteEditorTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `editing card in filtered deck retains deck`() = runTest {
+        val homeDeckId = addDeck("A")
+        val note = addNoteUsingBasicModel().updateCards { did = homeDeckId }
+        moveToDynamicDeck(note)
+
+        // ensure note is correctly setup
+        assertThat("home deck", note.firstCard().oDid, equalTo(homeDeckId))
+        assertThat("current deck", note.firstCard().did, not(equalTo(homeDeckId)))
+
+        getNoteEditorEditingExistingBasicNote(note, REVIEWER, NoteEditor::class.java).apply {
+            setField(0, "Hello")
+            saveNote()
+        }
+
+        // ensure note is correctly setup
+        assertThat("after: home deck", note.firstCard().oDid, equalTo(homeDeckId))
+        assertThat("after: current deck", note.firstCard().did, not(equalTo(homeDeckId)))
+    }
+
     private fun moveToDynamicDeck(note: Note): DeckId {
         val dyn = addDynamicDeck("All")
         col.decks.select(dyn)


### PR DESCRIPTION
If a card in a filtered deck was edited, it was returned home


## Fixes
* Fixes #16522
* Cause: https://github.com/ankidroid/Anki-Android/commit/b455b7b135a8eb003efd862412013ccdbf8196c4 

## How Has This Been Tested?
Unit tested

In Emulator:
* Card in filtered deck
* Tested editing the content -> same deck
* Tested editing the deck -> changed deck  


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)