### PR TITLE
Move Decks with Drag and Drop

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -280,15 +280,13 @@ class Decks(private val col: Collection) {
      *************************************************************
      */
 
-    @RustCleanup("implement and make public")
-    @Suppress("unused", "unused_parameter")
     /**
      * Rename one or more source decks that were dropped on [newParent].
      *
      * If [newParent] is `0`, decks will be placed at the top level.
      */
-    private fun reparent(deckIds: List<DeckId>, newParent: DeckId): OpChangesWithCount {
-        TODO()
+    fun reparent(deckIds: List<DeckId>, newParent: DeckId): OpChangesWithCount {
+        return col.backend.reparentDecks(deckIds, newParent)
     }
 
     /*

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -164,6 +164,19 @@
                 app:backgroundTint="?attr/fab_normal"
                 app:fabSize="normal"
                 />
+            <com.google.android.material.floatingactionbutton.FloatingActionButton
+                android:id="@+id/fab_done"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="10dp"
+                android:layout_marginStart="10dp"
+                android:layout_marginBottom="17dp"
+                android:layout_marginTop="10dp"
+                android:visibility="gone"
+                app:srcCompat="@drawable/ic_done_white"
+                app:backgroundTint="?attr/fab_normal"
+                app:fabSize="normal"
+                />
         </LinearLayout>
 
     </LinearLayout>

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -69,5 +69,9 @@
         <item
             android:id="@+id/action_export"
             android:menuCategory="secondary" />
+        <item
+            android:id="@+id/move_decks"
+            android:menuCategory="secondary"
+            android:title="@string/move_decks"/>
     </group>
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -50,6 +50,7 @@
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>
     <string name="no_cards_placeholder_description">Start adding cards\nusing the + icon.</string>
+    <string name="moving_decks">Drag and Drop to move Decks</string>
 
     <!-- The deck picker via AnkiStatsTaskHandler.java -->
 

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -63,6 +63,9 @@
     <string name="ease_button_good">Good</string>
     <string name="ease_button_easy">Easy</string>
     <string name="menu_import">Import</string>
+    <string name="move_decks">Move Decks</string>
+    <string name="move_decks_mode_exited">Left Move Decks mode</string>
+    <string name="move_decks_mode_entered">Entered Move Decks mode</string>
     <string name="undo">Undo</string>
     <string name="redo">Redo</string>
     <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
We propose a _Move Decks_ feature using drag and drop, so that we can move decks into and out of other decks on our phones, and not have to use Anki via computer just to do this.
## How to use it: 
- Go to the options menu in the DeckPicker screen and click the Move Decks option. 
- Drag and drop decks to move them: 
    - If you want to turn a deck A into a subdeck of a deck B, drag A until it's above B and drop it there;
    - If you want a deck to stop being a subdeck of another, drag it into an area of the screen without decks (above or below). 
- To exit the Move Decks mode, click the Floating Done button at the end of the screen.

## Implements
* Implements #14544

## Approach
We implemented drag and drop based on how Anki Desktop does it, to ensure consistency between both platforms (We also considered using [Tasks'](https://tasks.org/) approach because of how they do indentation). To implement the "Done button" we replicated the code of the "Add button" already present in AnkiDroid, to avoid changing AnkiDroid's design.

#### What we did:
 - Added a new _Move Decks_ option to the _Options Menu_ in the DeckPicker. When clicked, it will enable the "drag and drop mode" and:
    -  disable the `pullToSyncWrapper` (to allow dragging down);
    -  switch the _Floating Add Button_ (fabMain) for a _Floating Done Button_ (fabDone);
    -  change the `supportActionBar` subtitle to an informative message and temporarily showing a _Snackbar_ informing the user that they have entered the "Move Decks mode". 

- Added a _Floating Done Button_, which returns the `DeckPicker` to its normal state.

## Screenshots and Video
![AnkiDragNDrop_GIF](https://github.com/ankidroid/Anki-Android/assets/93283175/3dcbcece-842b-4922-ae4c-beec8c04df7c)

<table>
  <tr>
    <td>
      <img src="https://github.com/ankidroid/Anki-Android/assets/93283175/3ef5a2f7-3526-41b4-9602-27c5e678aa9f" alt="img 1" height="600">
    </td>
    <td>
      <img src="https://github.com/ankidroid/Anki-Android/assets/93283175/be201e6a-c60e-45e1-b800-253a8e55fc1e" alt="img 2"  height="600">
    </td>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/ankidroid/Anki-Android/assets/93283175/db79dda8-02e0-4691-b83f-f8cd91764375" alt="img 3" height="600">
    </td>
    <td>
      <img src="https://github.com/ankidroid/Anki-Android/assets/93283175/faddb0ca-fc13-408f-b54b-e6b7d09db751" alt="img 4" height="600">
    </td>
  </tr>
</table>


## How Has This Been Tested?

To test we used both our phones (Samsung S21 Ultra, Samsung A33) and an emulator.
We refactored an old unit test for `reparent` that was commented and updated it to contain the correct order for decks (based on anki desktop)

## Learning 

To implement this feature we ended up using ItemTouchHelper as it made enabling the movement required to drag and drop very easy. It was also extremely simple to retrieve the element underneath the one being dragged. 

As alluded to previously, we tried to look at other apps for inspiration, one that we came across was [Tasks](https://tasks.org/). Tasks' way to handle reordering tasks is worth considering as the indent gives the user a better perception on what indent level each task (in our case deck) is.

## Collaborator
This feature was co-developed by @powy-e.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)