### PR TITLE
chore(card-browser): logs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -386,12 +386,14 @@ class CardBrowserViewModel(
 
     fun selectAll() {
         if (_selectedRows.addAll(cards.wrapped)) {
+            Timber.d("selecting all: %d item(s)", cards.wrapped.size)
             refreshSelectedRowsFlow()
         }
     }
 
     fun selectNone() {
         if (_selectedRows.isEmpty()) return
+        Timber.d("selecting none")
         _selectedRows.clear()
         refreshSelectedRowsFlow()
     }
@@ -482,6 +484,7 @@ class CardBrowserViewModel(
                 sched.suspendCards(cardIds).changes
             }
         }
+        Timber.d("finished 'toggleSuspendCards'")
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -232,8 +232,10 @@ open class Scheduler(val col: Collection) {
      * @param ids Id of cards to suspend
      */
     open fun suspendCards(ids: Iterable<CardId>): OpChangesWithCount {
+        val cids = ids.toList()
+        Timber.i("suspending %d card(s)", cids.size)
         return col.backend.buryOrSuspendCards(
-            cardIds = ids.toList(),
+            cardIds = cids,
             noteIds = listOf(),
             mode = BuryOrSuspendCardsRequest.Mode.SUSPEND
         )
@@ -251,8 +253,10 @@ open class Scheduler(val col: Collection) {
      * @param ids Id of cards to unsuspend
      */
     open fun unsuspendCards(ids: Iterable<CardId>): OpChanges {
+        val cids = ids.toList()
+        Timber.i("unsuspending %d card(s)", cids.size)
         return col.backend.restoreBuriedAndSuspendedCards(
-            cids = ids.toList()
+            cids = cids
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -104,7 +104,7 @@ open class JvmTest : TestClass {
         Dispatchers.resetMain()
         runBlocking { CollectionManager.discardBackend() }
         Timber.uprootAll()
-        println("""-- executing test "${testName.methodName}"""")
+        println("""-- completed test "${testName.methodName}"""")
     }
 
     fun <T> assumeThat(actual: T, matcher: Matcher<T>?) {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestChangeSubscriber.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestChangeSubscriber.kt
@@ -45,6 +45,7 @@ suspend fun ensureOpsExecuted(count: Int, block: suspend () -> Unit) {
         Timber.d("ChangeManager op detected")
         changes++
     }
+    Timber.v("Listening for ChangeManager ops")
     block()
     // we should be fine to not cleanup here, as the subscriber goes out of scope
     assertThat("ChangeManager: expected $count calls", changes, equalTo(count))


### PR DESCRIPTION
* Diagnostics for https://github.com/ankidroid/Anki-Android/issues/16541

```
-- executing test "suspend - notes - some notes suspended"
Backend: Opening rust backend with lang=[en-US]
Media: dir /var/folders/ym/nqynp93d4j74dpzw20sq4wq00000gn/T/robolectric-CardBrowserViewModelTest_suspend_-_notes_-_some_notes_suspended5512359334772938846/external-files/Android/data/com.ichi2.anki.debug/AnkiDroid/collection.media
Collection: (Re)opening Database: /var/folders/ym/nqynp93d4j74dpzw20sq4wq00000gn/T/robolectric-CardBrowserViewModelTest_suspend_-_notes_-_some_notes_suspended5512359334772938846/external-files/Android/data/com.ichi2.anki.debug/AnkiDroid/collection.anki2
CollectionManager: blocked main thread for 174ms:
com.ichi2.testutils.JvmTest.getCol(JvmTest.kt:55)
CardBrowserViewModel: CardBrowserViewModel::init
CardBrowserViewModel: setting deck: 1
CardBrowserViewModel: initCompleted
CardBrowserViewModel$launchSearchForCards: performing search: 'deck:"Default" '
CardBrowserViewModel$launchSearchForCards: Search returned 2 card(s)
Scheduler: suspending 2 card(s)
TestChangeSubscriberKt: Listening for ChangeManager ops
CardBrowserViewModel: selecting all: 2 items
Scheduler: suspending 4 card(s)
TestChangeSubscriberKt: ChangeManager op detected
CardBrowserViewModel$toggleSuspendCards: finished 'toggleSuspendCards'
Collection: Collection closed
Backend: Closing rust backend
-- completed test "suspend - notes - some notes suspended"
```