### PR TITLE
refactor(card-browser): updateSelectedCardsFlag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -483,10 +483,6 @@ open class CardBrowser :
         viewModel.flowOfInitCompleted.launchCollectionInLifecycleScope(::initCompletedChanged)
     }
 
-    fun searchWithFilterQuery(filterQuery: String) = launchCatchingTask {
-        viewModel.setFilterQuery(filterQuery)
-    }
-
     // Finish initializing the activity after the collection has been correctly loaded
     override fun onCollectionLoaded(col: Collection) {
         super.onCollectionLoaded(col)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -903,12 +903,12 @@ open class CardBrowser :
     @VisibleForTesting
     suspend fun updateSelectedCardsFlag(flag: Flag) {
         // list of cards with updated flags
-        val updatedCards = withProgress { viewModel.updateSelectedCardsFlag(flag) }
+        val updatedCardIds = withProgress { viewModel.updateSelectedCardsFlag(flag) }
         // TODO: try to offload the cards processing in updateCardsInList() on a background thread,
         // otherwise it could hang the main thread
-        updateCardsInList(updatedCards.map { it.id })
+        updateCardsInList(updatedCardIds)
         invalidateOptionsMenu() // maybe the availability of undo changed
-        if (updatedCards.any { card -> card.id == reviewerCardId }) {
+        if (updatedCardIds.any { it == reviewerCardId }) {
             reloadRequired = true
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -172,7 +172,7 @@ open class CardBrowser :
         }
         if (result.resultCode != RESULT_CANCELED) {
             Timber.i("CardBrowser:: CardBrowser: Saving card...")
-            launchCatchingTask { saveEditedCard() }
+            saveEditedCard()
         }
         val data = result.data
         if (data != null &&
@@ -910,7 +910,7 @@ open class CardBrowser :
         val updatedCards = withProgress { viewModel.updateSelectedCardsFlag(flag) }
         // TODO: try to offload the cards processing in updateCardsInList() on a background thread,
         // otherwise it could hang the main thread
-        updateCardsInList(updatedCards)
+        updateCardsInList(updatedCards.map { it.id })
         invalidateOptionsMenu() // maybe the availability of undo changed
         if (updatedCards.any { card -> card.id == reviewerCardId }) {
             reloadRequired = true
@@ -1422,13 +1422,6 @@ open class CardBrowser :
             return resources.getQuantityString(subtitleId, count, count)
         }
 
-    // convenience method for updateCardsInList(...)
-    private fun updateCardInList(card: Card) {
-        val cards: MutableList<Card> = ArrayList(1)
-        cards.add(card)
-        updateCardsInList(cards)
-    }
-
     /** Returns the decks which are valid targets for "Change Deck"  */
     suspend fun getValidDecksForChangeDeck(): List<DeckNameId> =
         deckSpinnerSelection.computeDropDownDecks(includeFiltered = false)
@@ -1474,29 +1467,23 @@ open class CardBrowser :
     fun filterByFlag(flag: Flag) = launchCatchingTask { viewModel.setFlagFilter(flag) }
 
     /**
-     * Loads/Reloads (Updates the Q, A & etc) of cards in the [cards] list
-     * @param cards Cards that were changed
+     * Loads/Reloads (Updates the Q, A & etc) of cards in the [cardIds] list
+     * @param cardIds Card IDs that were changed
      */
-    private fun updateCardsInList(cards: List<Card>) {
+    private fun updateCardsInList(cardIds: List<CardId>) {
         val idToPos = viewModel.cardIdToPositionMap
         // TODO: Inefficient
-        cards
-            .mapNotNull { c -> idToPos[c.id] }
+        cardIds
+            .mapNotNull { cid -> idToPos[cid] }
             .filterNot { pos -> pos >= viewModel.rowCount }
             .map { pos -> viewModel.getRowAtPosition(pos) }
             .forEach { it.load(true, viewModel.column1Index, viewModel.column2Index) }
         updateList()
     }
 
-    private suspend fun saveEditedCard() {
+    private fun saveEditedCard() {
         Timber.d("CardBrowser - saveEditedCard()")
-        val card = try {
-            withCol { getCard(currentCardId) }
-        } catch (e: Exception) {
-            Timber.i("edited card no longer exists")
-            return
-        }
-        updateCardInList(card)
+        updateCardsInList(listOf(currentCardId))
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -686,14 +686,10 @@ class CardBrowserViewModel(
         }
     }
 
-    suspend fun updateSelectedCardsFlag(flag: Flag): List<Card> {
+    suspend fun updateSelectedCardsFlag(flag: Flag): List<CardId> {
         val idsToChange = queryAllSelectedCardIds()
-        return withCol {
-            setUserFlag(flag, cids = idsToChange)
-            selectedRowIds
-                .map { getCard(it) }
-                .onEach { load() }
-        }
+        withCol { setUserFlag(flag, cids = idsToChange) }
+        return idsToChange
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -68,7 +68,7 @@ open class Card : Cloneable {
     private var elapsedTime: Long = 0
 
     @set:VisibleForTesting
-    var id: Long = 0
+    var id: CardId = 0
     var nid: NoteId = 0
     var did: DeckId = 0
     var ord = 0


### PR DESCRIPTION
## Purpose / Description

I was looking into `updateSelectedCardsFlag` and realized that `Collection.load()` was called in a loop, instead of `Card.load()`

Broken in https://github.com/ankidroid/Anki-Android/commit/0d69cacde9886feba40b98e19f851e62d5a29fcd

## Approach
* I removed the obviously broken code, and simplified the caller

## How Has This Been Tested?
No additional tests, I'll unit test this in a later commit

EDIT: Tested manually as this method had no coverage

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
