### PR TITLE
use appcompat AlertDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -17,12 +17,12 @@
 package com.ichi2.anki.analytics
 
 import android.annotation.SuppressLint
-import android.app.AlertDialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MigrationProgressDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MigrationProgressDialogFragment.kt
@@ -16,11 +16,11 @@
 
 package com.ichi2.anki.dialogs
 
-import android.app.AlertDialog
 import android.app.Dialog
 import android.os.Bundle
 import android.text.format.Formatter.formatShortFileSize
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
@@ -85,7 +85,7 @@ class MigrationProgressDialogFragment : DialogFragment() {
                 }
         }
 
-        return AlertDialog.Builder(activity)
+        return AlertDialog.Builder(requireActivity())
             .setView(layout)
             .setPositiveButton(R.string.dialog_ok) { _, _ -> dismiss() }
             .setNegativeButton(R.string.scoped_storage_learn_more) { _, _ ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/TtsVoicesDialogFragment.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.dialogs
 
-import android.app.AlertDialog
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.content.res.ColorStateList
@@ -28,6 +27,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.EditText
 import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doOnTextChanged
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
@@ -160,7 +160,7 @@ class TtsVoicesDialogFragment : DialogFragment() {
         viewModel.availableVoicesFlow.observe {
             if (it is TtsVoicesViewModel.VoiceLoadingState.Failure) {
                 progressBar.visibility = View.VISIBLE
-                AlertDialog.Builder(this.context)
+                AlertDialog.Builder(requireContext())
                     .setMessage(it.exception.localizedMessage)
                     .setOnDismissListener { this@TtsVoicesDialogFragment.dismiss() }
                     .show()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/activity/PickStringDialogFragment.kt
@@ -20,11 +20,11 @@
 package com.ichi2.anki.multimediacard.activity
 
 import android.R
-import android.app.AlertDialog
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.widget.ArrayAdapter
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import com.ichi2.utils.KotlinCleanup
 import java.util.*
@@ -40,7 +40,7 @@ class PickStringDialogFragment : DialogFragment() {
     @KotlinCleanup("requireActivity")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         // Use the Builder class for convenient dialog construction
-        val builder = AlertDialog.Builder(activity)
+        val builder = AlertDialog.Builder(requireActivity())
         builder.setTitle(title)
         val adapter = ArrayAdapter(
             requireActivity(),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/dialogs/tools/AsyncDialogs.kt
@@ -14,10 +14,10 @@
 
 package com.ichi2.anki.ui.dialogs.tools
 
-import android.app.AlertDialog
 import android.content.Context
 import android.content.DialogInterface.BUTTON_POSITIVE
 import androidx.annotation.StringRes
+import androidx.appcompat.app.AlertDialog
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I noticed that some dialogs were using android.AlertDialog instead of appcompat so I updated them

## Fixes
* Fixes #15174 after my other PR is merged as well

## Approach
Update the dialog library

## How Has This Been Tested?

In an Android 14 emulator by checking the Manage space dialogs

![image](https://github.com/ankidroid/Anki-Android/assets/154519856/cc4bf7e7-462d-483f-bb85-45f91111f518)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
