### PR TITLE
Fix: Lint to avoid using android.app.AlertDialog

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -21,6 +21,7 @@ import com.android.tools.lint.client.api.IssueRegistry
 import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
+import com.ichi2.anki.lint.rules.AvoidAlertDialogUsage
 import com.ichi2.anki.lint.rules.CopyrightHeaderExists
 import com.ichi2.anki.lint.rules.DirectCalendarInstanceUsage
 import com.ichi2.anki.lint.rules.DirectDateInstantiation
@@ -62,7 +63,8 @@ class IssueRegistry : IssueRegistry() {
                 FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
                 FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
                 VariableNamingDetector.ISSUE,
-                InvalidStringFormatDetector.ISSUE
+                InvalidStringFormatDetector.ISSUE,
+                AvoidAlertDialogUsage.ISSUE
             )
         }
     override val api: Int

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2024 Sumit Singh <sumitsinghkoranga7@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:Suppress("UnstableApiUsage")
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.*
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import org.jetbrains.uast.UElement
+import org.jetbrains.uast.UImportStatement
+
+/**
+ * This custom Lint rule raises a warning if a developer uses the `android.app.AlertDialog` class.
+ */
+class AvoidAlertDialogUsage : Detector(), SourceCodeScanner {
+
+    companion object {
+        @VisibleForTesting
+        const val ID = "AvoidAlertDialogUsage"
+
+        @VisibleForTesting
+        const val DESCRIPTION = "Use androidx.appcompat.app.AlertDialog instead of android.app.AlertDialog"
+        private const val EXPLANATION = "Using `android.app.AlertDialog` is discouraged. " +
+            "Please use `androidx.appcompat.app.AlertDialog` instead for better compatibility and features."
+        private val implementation = Implementation(AvoidAlertDialogUsage::class.java, Scope.JAVA_FILE_SCOPE)
+        val ISSUE: Issue = Issue.create(
+            ID,
+            DESCRIPTION,
+            EXPLANATION,
+            Constants.ANKI_TIME_CATEGORY,
+            Constants.ANKI_TIME_PRIORITY,
+            Constants.ANKI_TIME_SEVERITY,
+            implementation
+        )
+    }
+
+    override fun getApplicableUastTypes(): List<Class<out UElement>> {
+        return listOf(UImportStatement::class.java)
+    }
+
+    override fun createUastHandler(context: JavaContext): UElementHandler {
+        return object : UElementHandler() {
+            override fun visitImportStatement(node: UImportStatement) {
+                val importReference = node.asSourceString()
+                if (importReference.contains("android.app.AlertDialog")) {
+                    context.report(
+                        ISSUE,
+                        node,
+                        context.getLocation(node),
+                        DESCRIPTION,
+                        createFix()
+                    )
+                }
+            }
+        }
+    }
+
+    private fun createFix(): LintFix {
+        return fix()
+            .name("Replace with androidx.appcompat.app.AlertDialog")
+            .replace()
+            .text("android.app.AlertDialog")
+            .with("androidx.appcompat.app.AlertDialog")
+            .build()
+    }
+}


### PR DESCRIPTION
## Purpose / Description
This PR contain a custom lint rule aimed at flagging the use of android.app.AlertDialog. It encourages developers to switch to androidx.appcompat.app.AlertDialog for improved compatibility and features, promoting better coding practices and adherence to modern Android standards.

## Fixes
Fixes #16554 

## How Has This Been Tested?
Locally on Android Studio

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
