### PR TITLE
test(card-browser-view-model): increase coverage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -364,8 +364,14 @@ class CardBrowserViewModel(
      * @return the number of deleted notes
      */
     suspend fun deleteSelectedNotes(): Int {
+        // PERF: use `undoableOp(this)` & notify CardBrowser of changes
+        // this does a double search
         val cardIds = queryAllSelectedCardIds()
         return undoableOp { removeNotes(cids = cardIds) }.count
+            .also {
+                endMultiSelectMode()
+                refreshSearch()
+            }
     }
 
     fun setCardsOrNotes(newValue: CardsOrNotes) = viewModelScope.launch {
@@ -740,6 +746,8 @@ class CardBrowserViewModel(
         }
         return searchJob!!
     }
+
+    private suspend fun refreshSearch() = launchSearchForCards()?.join()
 
     private suspend fun clearCardsList() {
         cards.reset()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -628,7 +628,12 @@ class CardBrowserViewModel(
         setFilterQuery("tag:marked")
     }
 
-    suspend fun searchForSuspendedCards() = setFilterQuery("is:suspended")
+    suspend fun searchForSuspendedCards() {
+        // only intended to be used if the user has no selection
+        if (hasSelectedAnyRows()) return
+        setFilterQuery("is:suspended")
+    }
+
     suspend fun setFlagFilter(flag: Flag) {
         Timber.i("filtering to flag: %s", flag)
         val flagSearchTerm = "flag:${flag.code}"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -622,7 +622,11 @@ class CardBrowserViewModel(
         launchSearchForCards(filterQuery)
     }
 
-    suspend fun searchForMarkedNotes() = setFilterQuery("tag:marked")
+    suspend fun searchForMarkedNotes() {
+        // only intended to be used if the user has no selection
+        if (hasSelectedAnyRows()) return
+        setFilterQuery("tag:marked")
+    }
 
     suspend fun searchForSuspendedCards() = setFilterQuery("is:suspended")
     suspend fun setFlagFilter(flag: Flag) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.browser
 
 import android.os.Parcel
 import android.os.Parcelable
+import androidx.annotation.CheckResult
 import androidx.core.content.edit
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -598,6 +599,7 @@ class CardBrowserViewModel(
         }
     }
 
+    @CheckResult
     suspend fun saveSearch(searchName: String, searchTerms: String): SaveSearchResult {
         Timber.d("saving user search")
         var alreadyExists = false

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -575,6 +575,33 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `notes - search for suspended`() = runTest {
+        addNoteUsingBasicAndReversedModel("hello", "world").also { note ->
+            col.sched.suspendCards(listOf(note.cardIds(col).first()))
+        }
+        addNoteUsingBasicAndReversedModel("hello2", "world")
+
+        runViewModelNotesTest {
+            searchForSuspendedCards()
+            waitForSearchResults()
+            assertThat("A suspended card is found for the note", rowCount, equalTo(1))
+        }
+    }
+
+    @Test
+    fun `cards - search for suspended`() = runTest {
+        addNoteUsingBasicAndReversedModel("hello", "world").also { note ->
+            col.sched.suspendCards(listOf(note.cardIds(col).first()))
+        }
+
+        runViewModelTest {
+            searchForSuspendedCards()
+            waitForSearchResults()
+            assertThat("one suspended cards of a note is found", rowCount, equalTo(1))
+        }
+    }
+
     private fun runViewModelNotesTest(
         notes: Int = 0,
         manualInit: Boolean = true,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -602,6 +602,55 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `notes - preview intent`() = runViewModelNotesTest(notes = 5) {
+        assertThat("note count", col.noteCount(), equalTo(5))
+        assertThat("card count", col.cardCount(), equalTo(10))
+        val data = queryPreviewIntentData()
+        assertThat(data.currentIndex, equalTo(0))
+
+        data.previewerIdsFile.getCardIds().also { actualCardIds ->
+            assertThat("previewing a note previews cards", actualCardIds, hasSize(5))
+
+            val firstCardIds = col.findCards("")
+                .filter { col.getCard(it).ord == 0 }
+
+            assertThat("first card ids", firstCardIds, hasSize(5))
+
+            // TODO: this behaviour is unconfirmed in Anki Desktop
+            assertThat(
+                "previewing first card in each note",
+                actualCardIds.toLongArray(),
+                equalTo(firstCardIds.toLongArray())
+            )
+        }
+    }
+
+    @Test
+    fun `cards - preview intent - no selection`() = runViewModelTest(notes = 2) {
+        val data = queryPreviewIntentData()
+        assertThat(data.currentIndex, equalTo(0))
+        assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+    }
+
+    @Test
+    fun `cards - preview intent - selection`() = runViewModelTest(notes = 2) {
+        selectRowsWithPositions(0).also {
+            val data = queryPreviewIntentData()
+            assertThat(data.currentIndex, equalTo(0))
+            assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+        }
+
+        selectNone()
+
+        // ensure currentIndex changes
+        selectRowsWithPositions(1).also {
+            val data = queryPreviewIntentData()
+            assertThat(data.currentIndex, equalTo(1))
+            assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+        }
+    }
+
     private fun runViewModelNotesTest(
         notes: Int = 0,
         manualInit: Boolean = true,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -68,13 +68,25 @@ import kotlin.test.assertNull
 class CardBrowserViewModelTest : JvmTest() {
     @Test
     fun `delete search history - Issue 14989`() = runViewModelTest {
-        saveSearch("hello", "aa")
+        saveSearch("hello", "aa").also { result ->
+            assertThat(result, equalTo(SaveSearchResult.SUCCESS))
+        }
         savedSearches().also { searches ->
             assertThat("filters after saving", searches.size, equalTo(1))
             assertThat("filters after saving", searches["hello"], equalTo("aa"))
         }
         removeSavedSearch("hello")
         assertThat("filters should be empty after removing", savedSearches().size, equalTo(0))
+    }
+
+    @Test
+    fun `saving search with same name fails`() = runViewModelTest {
+        saveSearch("hello", "aa").also { result ->
+            assertThat("saving a new search succeeds", result, equalTo(SaveSearchResult.SUCCESS))
+        }
+        saveSearch("hello", "bb").also { result ->
+            assertThat("saving with same name fails", result, equalTo(SaveSearchResult.ALREADY_EXISTS))
+        }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -497,6 +497,34 @@ class CardBrowserViewModelTest : JvmTest() {
         assertThat(ids.single(), equalTo(cards[0].card.nid))
     }
 
+    @Test
+    fun `cards - delete one`() = runViewModelTest(notes = 2) {
+        assertThat("initial card count", col.cardCount(), equalTo(2))
+        selectRowsWithPositions(0)
+
+        ensureOpsExecuted(1) {
+            deleteSelectedNotes()
+        }
+
+        assertThat("1 card deleted", col.cardCount(), equalTo(1))
+        assertThat("no selection after", selectedRowCount(), equalTo(0))
+        assertThat("one row removed", rowCount, equalTo(1))
+    }
+
+    @Test
+    fun `notes - delete one`() = runViewModelNotesTest(notes = 2) {
+        assertThat("initial card count", col.cardCount(), equalTo(4))
+        selectRowsWithPositions(0)
+
+        ensureOpsExecuted(1) {
+            deleteSelectedNotes()
+        }
+
+        assertThat("1 note deleted - 2 cards deleted", col.cardCount(), equalTo(2))
+        assertThat("no selection after", selectedRowCount(), equalTo(0))
+        assertThat("one row removed", rowCount, equalTo(1))
+    }
+
     private fun runViewModelNotesTest(
         notes: Int = 0,
         manualInit: Boolean = true,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.SortType.EASE
 import com.ichi2.anki.model.SortType.NO_SORTING
 import com.ichi2.anki.model.SortType.SORT_FIELD
+import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
@@ -544,6 +545,34 @@ class CardBrowserViewModelTest : JvmTest() {
         assertThat("1 note deleted - 2 cards deleted", col.cardCount(), equalTo(2))
         assertThat("no selection after", selectedRowCount(), equalTo(0))
         assertThat("one row removed", rowCount, equalTo(1))
+    }
+
+    @Test
+    fun `notes - search for marked`() = runTest {
+        addNoteUsingBasicAndReversedModel("hello", "world").also { note ->
+            NoteService.toggleMark(note)
+        }
+        addNoteUsingBasicAndReversedModel("hello2", "world")
+
+        runViewModelNotesTest {
+            searchForMarkedNotes()
+            waitForSearchResults()
+            assertThat("A marked note is found", rowCount, equalTo(1))
+        }
+    }
+
+    @Test
+    fun `cards - search for marked`() = runTest {
+        addNoteUsingBasicAndReversedModel("hello", "world").also { note ->
+            NoteService.toggleMark(note)
+        }
+        addNoteUsingBasicAndReversedModel("hello2", "world")
+
+        runViewModelTest {
+            searchForMarkedNotes()
+            waitForSearchResults()
+            assertThat("both cards of a marked note are found", rowCount, equalTo(2))
+        }
     }
 
     private fun runViewModelNotesTest(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -290,6 +290,15 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     @Test
+    fun `executing select all twice does nothing`() = runViewModelTest(notes = 2) {
+        assertThat(selectedRowCount(), equalTo(0))
+        selectAll()
+        assertThat(selectedRowCount(), equalTo(2))
+        selectAll()
+        assertThat(selectedRowCount(), equalTo(2))
+    }
+
+    @Test
     fun `changing column index 1`() = runViewModelTest {
         flowOfColumnIndex1.test {
             ignoreEventsDuringViewModelInit()


### PR DESCRIPTION
## Purpose / Description
I think this is the last one - I want to get code coverage up on this

**Later intentions**
Firstly I'm going to change the Browser to use Anki Desktop for the searching and rendering, which modifies how the class handles 'notes' mode, so I want decent coverage here

Currently the class is keyed on `CardId`, after the backend, it will be keyed on `CardId | NoteId`, and the backend will handle rendering

Afterwards, I will rewrite the search process to enable a multitude of filters using chips, modifying the state of the class from:

* no search
* searched/deck selected - nothing selected
* selected

into:

* rows selected
* nothing selected

where searching is a separate dimension of state

## How Has This Been Tested?
Unit Tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
