### PR TITLE
fix navbar color in reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -67,6 +67,7 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.utils.remainingTime
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.audio.AudioRecordingController
@@ -187,7 +188,7 @@ open class Reviewer :
         textBarReview = findViewById(R.id.review_number)
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
-        if (sharedPrefs().getString("answerButtonPosition", "bottom") == "bottom") {
+        if (sharedPrefs().getString("answerButtonPosition", "bottom") == "bottom" && !navBarNeedsScrim) {
             setNavigationBarColor(R.attr.showAnswerColor)
         }
         if (!sharedPrefs().getBoolean("showDeckTitle", false)) {


### PR DESCRIPTION
## Purpose / Description

* Fixes #15912

## Fixes

* Fixes #15912

## Approach

only apply the style if on gestures mode

## How Has This Been Tested?

### Gestures

<details>

![Screenshot_20240607_114606](https://github.com/ankidroid/Anki-Android/assets/65715921/93f05db6-7966-44f4-b524-6e8efa891f4d)

</details>

### Buttons

<details>

![Screenshot_20240607_114829](https://github.com/ankidroid/Anki-Android/assets/65715921/e85aab9c-bfc6-4c47-96b2-ca3737e36aa3)

</details>

## Learning (optional, can help others)

I researched a lot but didn't discover how to check how to scrim.

After reading some PRs is that I found the navBarNeedsScrim property in the repo

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
