### PR TITLE
refactor(card-browser): remove rowId references

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -372,7 +372,7 @@ class CardBrowserTest : RobolectricTest() {
         // check if all card flags turned green
         assertThat(
             "All cards should be flagged",
-            cardBrowser.viewModel.allCardIds
+            cardBrowser.viewModel.queryAllCardIds()
                 .map { cardId -> getCardFlagAfterFlagChangeDone(cardBrowser, cardId) }
                 .all { flag1 -> flag1 == Flag.GREEN.code }
         )
@@ -430,7 +430,7 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     @Flaky(os = OS.WINDOWS, "IllegalStateException: Card '1596783600440' not found")
-    fun previewWorksAfterSort() {
+    fun previewWorksAfterSort() = runTest {
         // #7286
         val cid1 = addNoteUsingBasicModel("Hello", "World").cards()[0].id
         val cid2 = addNoteUsingBasicModel("Hello2", "World2").cards()[0].id
@@ -441,7 +441,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(b.getPropertiesForCardId(cid2).position, equalTo(1))
 
         b.selectRowsWithPositions(0)
-        val previewIntent = b.viewModel.previewIntentData
+        val previewIntent = b.viewModel.queryPreviewIntentData()
         assertThat("before: index", previewIntent.currentIndex, equalTo(0))
         assertThat(
             "before: cards",
@@ -456,7 +456,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(b.getPropertiesForCardId(cid2).position, equalTo(0))
 
         b.replaceSelectionWith(intArrayOf(0))
-        val intentAfterReverse = b.viewModel.previewIntentData
+        val intentAfterReverse = b.viewModel.queryPreviewIntentData()
         assertThat("after: index", intentAfterReverse.currentIndex, equalTo(0))
         assertThat(
             "after: cards",
@@ -567,7 +567,7 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     @Ignore("Doesn't work - but should")
-    fun dataUpdatesAfterUndoReposition() {
+    fun dataUpdatesAfterUndoReposition() = runTest {
         val b = getBrowserWithNotes(1)
 
         b.selectRowsWithPositions(0)
@@ -747,14 +747,15 @@ class CardBrowserTest : RobolectricTest() {
         }
     }
 
-    private fun getCheckedCard(b: CardBrowser): CardCache {
-        val ids = b.viewModel.selectedRowIds
+    private suspend fun getCheckedCard(b: CardBrowser): CardCache {
+        val ids = b.viewModel.queryAllSelectedCardIds()
         assertThat("only one card expected to be checked", ids, hasSize(1))
         return b.getPropertiesForCardId(ids[0])
     }
 
-    private fun deleteCardAtPosition(browser: CardBrowser, positionToCorrupt: Int) {
-        removeCardFromCollection(browser.viewModel.allCardIds[positionToCorrupt])
+    private suspend fun deleteCardAtPosition(browser: CardBrowser, positionToCorrupt: Int) {
+        val id = browser.viewModel.queryCardIdAtPosition(positionToCorrupt)
+        removeCardFromCollection(id)
         browser.clearCardData(positionToCorrupt)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -189,7 +189,7 @@ class CardBrowserViewModelTest : JvmTest() {
     @Test
     fun `toggle bury - queue changes`() = runViewModelTest(notes = 1) {
         selectRowAtPosition(0)
-        fun getQueue() = col.getCard(selectedRowIds.single()).queue
+        suspend fun getQueue() = col.getCard(queryAllSelectedCardIds().single()).queue
 
         assertThat("initial queue = NEW", getQueue(), equalTo(QUEUE_TYPE_NEW))
 
@@ -470,14 +470,14 @@ class CardBrowserViewModelTest : JvmTest() {
 
     @Test
     fun `export - no selection`() = runViewModelTest(notes = 2) {
-        assertNull(getSelectionExportData(), "no export data if no selection")
+        assertNull(querySelectionExportData(), "no export data if no selection")
     }
 
     @Test
     fun `export - one card`() = runViewModelTest(notes = 2) {
         selectRowsWithPositions(0)
 
-        val (exportType, ids) = assertNotNull(getSelectionExportData())
+        val (exportType, ids) = assertNotNull(querySelectionExportData())
 
         assertThat(exportType, equalTo(ExportDialogFragment.ExportType.Cards))
         assertThat(ids, hasSize(1))
@@ -489,7 +489,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `export - one note`() = runViewModelNotesTest(notes = 2) {
         selectRowsWithPositions(0)
 
-        val (exportType, ids) = assertNotNull(getSelectionExportData())
+        val (exportType, ids) = assertNotNull(querySelectionExportData())
 
         assertThat(exportType, equalTo(ExportDialogFragment.ExportType.Notes))
         assertThat(ids, hasSize(1))


### PR DESCRIPTION
## Purpose / Description

CardBrowser will move to render using either the card id or the note id

Our data is currently ALWAYS CardIds, which may be transformed into NoteIds

We had code assuming that the CardId was always used which needed to be modified to handle the case that a DB call is needed to map NoteId <-> CardId

## Fixes
* Starts work on #11889

## Approach
* selectedRowIds
* allCardIds
  * Now needs to be `suspend`
* get[Selected]CardIdAtPosition
  * Now needs to be `suspend`


## How Has This Been Tested?
Unit tests + brief physical test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
