### PR TITLE
Small cleaning of codes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -380,7 +380,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
         init {
             launchCatchingTask {
-                decksRoot = withCol { Pair(sched.deckDueTree(), this.isEmpty) }.first
+                decksRoot = withCol { Pair(sched.deckDueTree(), isEmpty) }.first
                 val allDecksSet = deckNames.filter { it.deckId != 0L }.mapNotNull { decksRoot.find(it.deckId) }.toSet()
                 if (deckNames.any { it.deckId == ALL_DECKS_ID }) {
                     val newDeckNode = DeckTreeNode.newBuilder()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -228,12 +228,13 @@ class Collection(
         config = Config(backend)
     }
 
-    /** Note: not in libanki.  Mark schema modified to force a full
+    /** Mark schema modified to force a full
      * sync, but with the confirmation checking function disabled This
      * is equivalent to `modSchema(False)` in Anki. A distinct method
      * is used so that the type does not states that an exception is
      * thrown when in fact it is never thrown.
      */
+    @NotInLibAnki
     fun modSchemaNoCheck() {
         db.execute(
             "update col set scm=?, mod=?",
@@ -315,20 +316,16 @@ class Collection(
     /**
      * Cards ******************************************************************** ***************************
      */
+
+    /**
+     * Returns whether the collection contains no cards.
+     */
+    @LibAnkiAlias("is_empty")
     val isEmpty: Boolean
         get() = db.queryScalar("SELECT 1 FROM cards LIMIT 1") == 0
 
     fun cardCount(): Int {
         return db.queryScalar("SELECT count() FROM cards")
-    }
-
-    // NOT IN LIBANKI //
-    fun cardCount(vararg dids: Long): Int {
-        return db.queryScalar("SELECT count() FROM cards WHERE did IN " + ids2str(dids))
-    }
-
-    fun isEmptyDeck(vararg dids: Long): Boolean {
-        return cardCount(*dids) == 0
     }
 
     /*
@@ -410,7 +407,8 @@ class Collection(
     data class CardIdToNoteId(val id: Long, val nid: Long)
 
     /** Return a list of card ids  */
-    @RustCleanup("Remove in V16.") // Not in libAnki
+    @RustCleanup("Remove in V16.")
+    @NotInLibAnki
     fun findOneCardByNote(query: String, order: SortOrder): List<CardId> {
         // This function shouldn't exist and CardBrowser should be modified to use Notes,
         // so not much effort was expended here
@@ -652,7 +650,7 @@ class Collection(
 
     //endregion
 
-    /** Not in libAnki  */
+    @NotInLibAnki
     @CheckResult
     fun filterToValidCards(cards: LongArray?): List<Long> {
         return db.queryLongList("select id from cards where id in " + ids2str(cards))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -580,6 +580,13 @@ class Decks(private val col: Collection) {
         return deck.getString("name") + DECK_SEPARATOR + subdeckName
     }
 
+    @NotInLibAnki
+    fun cardCount(did: DeckId): Int =
+        col.db.queryScalar("SELECT count() FROM cards WHERE did = ? ", did)
+
+    @NotInLibAnki
+    fun isEmpty(did: DeckId): Boolean = cardCount(did) == 0
+
     companion object {
         /* Parents/children */
 
@@ -614,7 +621,7 @@ class Decks(private val col: Collection) {
         /** Configuration saving the set of active decks (i.e. current decks and its descendants)  */
         const val ACTIVE_DECKS = "activeDecks"
 
-        // not in libAnki
+        @NotInLibAnki
         const val DECK_SEPARATOR = "::"
 
         @NotInLibAnki

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -45,6 +45,7 @@ import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.BackendUtils.to_json_bytes
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.libanki.utils.append
 import com.ichi2.libanki.utils.index
@@ -275,7 +276,7 @@ class Notetypes(val col: Collection) {
     ##################################################
      */
 
-    // not in libanki
+    @NotInLibAnki
     fun nids(model: NotetypeJson): List<int> = nids(model.getLong("id"))
 
     /** Note ids for M. */


### PR DESCRIPTION
First, I wanted to replace
`isEmpty` by `containsNoCard`. It seems interesting to note that this may still contains non-default note-type and decks, and still consider the collection empty.

This makes me look at Pairs, and found that, often, destructing the Pair seems more readable to me than using `.first` and `.second`. Especially when it eiher allows to have a single non-null assertion, or allows to have name value instead.
