### PR TITLE
fix: AppWidgetManager can be null

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -73,16 +73,16 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
         /** The cached number of total due cards.  */
         private var dueCardsCount = 0
         fun doUpdate(context: Context) {
-            AppWidgetManager.getInstance(context)
-                .updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), buildUpdate(context, true))
+            val appWidgetManager = getAppWidgetManager(context) ?: return
+            appWidgetManager.updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), buildUpdate(context, true))
         }
 
         @Deprecated("Implement onStartCommand(Intent, int, int) instead.") // TODO
         override fun onStart(intent: Intent, startId: Int) {
             Timber.i("SmallWidget: OnStart")
+            val manager = getAppWidgetManager(this) ?: return
             val updateViews = buildUpdate(this, true)
             val thisWidget = ComponentName(this, AnkiDroidWidgetSmall::class.java)
-            val manager = AppWidgetManager.getInstance(this)
             manager.updateAppWidget(thisWidget, updateViews)
         }
 
@@ -180,7 +180,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
         private var mMountReceiver: BroadcastReceiver? = null
         private var remounted = false
         private fun updateWidgetDimensions(context: Context, updateViews: RemoteViews, cls: Class<*>) {
-            val manager = AppWidgetManager.getInstance(context)
+            val manager = getAppWidgetManager(context) ?: return
             val ids = manager.getAppWidgetIds(ComponentName(context, cls))
             for (id in ids) {
                 val scale = context.resources.displayMetrics.density

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetPermissionReceiver.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.widget
 
-import android.appwidget.AppWidgetManager
 import android.content.BroadcastReceiver
 import android.content.ComponentName
 import android.content.Context
@@ -32,7 +31,7 @@ class WidgetPermissionReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         if (IntentHandler.grantedStoragePermissions(context, showToast = false)) {
-            val appWidgetManager = AppWidgetManager.getInstance(context)
+            val appWidgetManager = getAppWidgetManager(context) ?: return
             val widgetIds = appWidgetManager.getAppWidgetIds(ComponentName(context, AddNoteWidget::class.java))
             AddNoteWidget.updateWidgets(context, appWidgetManager, widgetIds)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetUtils.kt
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+
+/**
+ * @return An [AppWidgetManager] for the provided context, or `null`
+ *
+ * @see AppWidgetManager.getInstance
+ */
+// The call returns null on a Supernote A5X, but as the underlying platform call is in Java,
+// the result is assumed to be non-null in Kotlin
+fun getAppWidgetManager(context: Context): AppWidgetManager? =
+    AppWidgetManager.getInstance(context)

--- a/AnkiDroid/src/test/java/com/ichi2/widget/WidgetUtilsIntegrationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/widget/WidgetUtilsIntegrationTest.kt
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.RobolectricTest
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.AfterClass
+import org.junit.BeforeClass
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** @see getAppWidgetManager */
+@RunWith(AndroidJUnit4::class)
+class WidgetUtilsIntegrationTest : RobolectricTest() {
+    // on a Supernote A5X, AppWidgetManager.getInstance(context) returns null
+    @Test
+    fun `app runs with no widget manager`() {
+        super.startRegularActivity<DeckPicker>() // WARN: This didn't crash before fixes applied
+        WidgetPermissionReceiver().onReceive(targetContext, Intent())
+    }
+
+    companion object {
+        @BeforeClass
+        @JvmStatic
+        fun setUpClass() {
+            mockkStatic(AppWidgetManager::class)
+            every { AppWidgetManager.getInstance(any()) } answers { null }
+        }
+
+        @AfterClass
+        @JvmStatic
+        fun tearDownClass() {
+            unmockkStatic(AppWidgetManager::class)
+        }
+    }
+}


### PR DESCRIPTION
On a Supernote A5X, `AppWidgetManager.getInstance(context)` returns `null`

https://www.reddit.com/r/Supernote/comments/1dcqk47/comment/l7znpix/

## How Has This Been Tested?
Brief unit test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
