### PR TITLE
remove back button if fragmented

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -358,7 +358,10 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, Toolbar.OnMen
                 menu.findItem(R.id.action_undo).title = col?.undoLabel()
             }
             // Set the back button listener
-            if (!fragmented) {
+            if (fragmented) {
+                // when the fragment is attached to deck picker on large screen, the "back" button had no purpose, so it should be removed
+                toolbar!!.navigationIcon = null
+            } else {
                 val icon = AppCompatResources.getDrawable(requireContext(), R.drawable.ic_arrow_back_white)
                 icon!!.isAutoMirrored = true
                 toolbar!!.navigationIcon = icon


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Hide the back button in StudyOptionsFragment when fragmented

## Approach
set toolbar navigation icon to null

## How Has This Been Tested?
Physical Device ( ChromeBook )
![Screenshot 2024-06-11 11 49 03 AM](https://github.com/ankidroid/Anki-Android/assets/65113071/5c5f5b50-3c28-4fdd-9af6-5bf5fc527f9a)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
