### PR TITLE
Fix: navbar color in NoteEditor.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -95,6 +95,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
 import com.ichi2.anki.utils.ext.isImageOcclusion
 import com.ichi2.anki.utils.getTimestamp
+import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -430,7 +431,9 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             closeCardEditorWithCheck()
         }
 
-        setNavigationBarColor(R.attr.toolbarBackgroundColor)
+        if (!navBarNeedsScrim) {
+            setNavigationBarColor(R.attr.toolbarBackgroundColor)
+        }
     }
 
     @NeedsTest("Test when the user directly passes image to the edit note field")


### PR DESCRIPTION
## Purpose / Description
Fixed navbar color in NoteEditor.kt

## Fixes
Fixes #16573 

## How Has This Been Tested?

![image (5)](https://github.com/ankidroid/Anki-Android/assets/91668590/fe765291-0644-4d80-86a8-4b013bf03af9)

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
