### PR TITLE
feat(browser)!: use backend for column definitions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -483,10 +483,10 @@ open class CardBrowser :
                 ).apply {
                     setDropDownViewResource(R.layout.spinner_custom_layout)
                 }
+                setSelection(COLUMN1_KEYS.indexOf(viewModel.column1))
                 onItemSelectedListener = BasicItemSelectedListener { pos, _ ->
                     viewModel.setColumn1(COLUMN1_KEYS[pos])
                 }
-                setSelection(COLUMN1_KEYS.indexOf(viewModel.column1))
             }
 
             // Setup the column 2 heading as a spinner so that users can easily change the column type
@@ -499,11 +499,11 @@ open class CardBrowser :
                     // The custom layout for the adapter is used to prevent the overlapping of various interactive components on the screen
                     setDropDownViewResource(R.layout.spinner_custom_layout)
                 }
+                setSelection(COLUMN2_KEYS.indexOf(viewModel.column2))
                 // Create a new list adapter with updated column map any time the user changes the column
                 onItemSelectedListener = BasicItemSelectedListener { pos, _ ->
                     viewModel.setColumn2(COLUMN2_KEYS[pos])
                 }
-                setSelection(COLUMN2_KEYS.indexOf(viewModel.column2))
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
@@ -41,6 +41,7 @@ import timber.log.Timber
  * @see BrowserConfig.activeColumnsKey
  */
 class BrowserColumnCollection(val columns: List<CardBrowserColumn>) {
+    val backendKeys: Iterable<String> get() = columns.map { it.ankiColumnKey }
     val count = columns.size
     operator fun get(index: Int) = columns[index]
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
@@ -84,7 +84,7 @@ class BrowserColumnCollection(val columns: List<CardBrowserColumn>) {
             val key = mode.toPreferenceKey()
             val preferenceValue = value.columns
                 .joinToString(separator = SEPARATOR_CHAR.toString()) { it.ankiColumnKey }
-            Timber.d("updating '%s' to '%s'", key, preferenceValue)
+            Timber.d("updating '%s' [%s] to '%s'", key, mode, preferenceValue)
             prefs.edit { putString(key, preferenceValue) }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.SharedPreferences
+import androidx.annotation.CheckResult
+import androidx.core.content.edit
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.model.CardsOrNotes.CARDS
+import com.ichi2.anki.model.CardsOrNotes.NOTES
+import com.ichi2.libanki.BrowserConfig
+import com.ichi2.libanki.BrowserConfig.ACTIVE_CARD_COLUMNS_KEY
+import com.ichi2.libanki.BrowserConfig.ACTIVE_NOTE_COLUMNS_KEY
+import com.ichi2.libanki.BrowserDefaults
+import net.ankiweb.rsdroid.Backend
+import timber.log.Timber
+
+/**
+ * A collection of columns available in the [browser][CardBrowser]
+ *
+ * These are stored in [SharedPreferences] under either:
+ * * [ACTIVE_CARD_COLUMNS_KEY]
+ * * [ACTIVE_NOTE_COLUMNS_KEY]
+ *
+ * @see Backend.setActiveBrowserColumns
+ * @see BrowserConfig.activeColumnsKey
+ */
+class BrowserColumnCollection(val columns: List<CardBrowserColumn>) {
+    val count = columns.size
+    operator fun get(index: Int) = columns[index]
+
+    companion object {
+        private const val SEPARATOR_CHAR = '|'
+
+        @CheckResult
+        fun load(prefs: SharedPreferences, mode: CardsOrNotes): BrowserColumnCollection {
+            val key = mode.toPreferenceKey()
+            val columns = try {
+                val value = prefs.getString(key, mode.defaultColumns())!!
+                value.split(SEPARATOR_CHAR).map { CardBrowserColumn.fromColumnKey(it) }
+            } catch (e: Exception) {
+                Timber.w(e, "error loading columns, returning default")
+                val value = mode.defaultColumns()
+                value.split(SEPARATOR_CHAR).map { CardBrowserColumn.fromColumnKey(it) }
+            }
+            return BrowserColumnCollection(columns)
+        }
+
+        /**
+         * @param block Update the column list here. `null` meaning 'none'
+         */
+        fun update(
+            prefs: SharedPreferences,
+            mode: CardsOrNotes,
+            block: (MutableList<CardBrowserColumn?>) -> Boolean
+        ) {
+            val valuesToUpdate: MutableList<CardBrowserColumn?> = load(prefs, mode).columns.toMutableList()
+            if (!block(valuesToUpdate)) {
+                Timber.d("no changes requested")
+                return
+            }
+            // as in AnkiMobile, this converts: [QUESTION, NONE, TAGS] into [QUESTION, TAGS]
+            val updatedValues = valuesToUpdate.filterNotNull()
+            save(prefs, mode, BrowserColumnCollection(updatedValues))
+        }
+
+        fun save(prefs: SharedPreferences, mode: CardsOrNotes, value: BrowserColumnCollection) {
+            val key = mode.toPreferenceKey()
+            val preferenceValue = value.columns
+                .joinToString(separator = SEPARATOR_CHAR.toString()) { it.ankiColumnKey }
+            Timber.d("updating '%s' to '%s'", key, preferenceValue)
+            prefs.edit { putString(key, preferenceValue) }
+        }
+
+        private fun CardsOrNotes.toPreferenceKey() =
+            BrowserConfig.activeColumnsKey(isNotesMode = this == NOTES)
+
+        private fun CardsOrNotes.defaultColumns() =
+            (if (this == CARDS) BrowserDefaults.CARD_COLUMNS else BrowserDefaults.NOTE_COLUMNS)
+                .joinToString(separator = SEPARATOR_CHAR.toString())
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserColumn.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserColumn.kt
@@ -16,21 +16,16 @@
 
 package com.ichi2.anki.browser
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
 import anki.search.BrowserColumns
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
-import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_1_KEY
-import com.ichi2.anki.browser.CardBrowserViewModel.Companion.DISPLAY_COLUMN_2_KEY
 import net.ankiweb.rsdroid.Backend
-import timber.log.Timber
 
 /**
  * A column available in the [browser][CardBrowser]
  *
- * @see COLUMN1_KEYS: from preference [DISPLAY_COLUMN_1_KEY] to [R.array.browser_column1_headings]
- * @see COLUMN2_KEYS: from preference [DISPLAY_COLUMN_2_KEY] to [R.array.browser_column2_headings]
+ * @see COLUMN1_KEYS: maps to [R.array.browser_column1_headings]
+ * @see COLUMN2_KEYS: maps to [R.array.browser_column2_headings]
  * @see CardBrowser.CardCache.getColumnHeaderText - how columns are rendered
  *
  * @param ankiColumnKey The key used in [Backend.setActiveBrowserColumns]
@@ -124,35 +119,12 @@ enum class CardBrowserColumn(val ankiColumnKey: String) {
         // Note: the last 6 are currently hidden
         val COLUMN2_KEYS = arrayOf(ANSWER, CARD, DECK, NOTE_TYPE, QUESTION, TAGS, LAPSES, REVIEWS, INTERVAL, EASE, DUE, CHANGED, CREATED, EDITED)
 
-        fun SharedPreferences.loadBrowserColumn(index: Int): CardBrowserColumn {
-            return when (index) {
-                0 -> COLUMN1_KEYS[getInt(DISPLAY_COLUMN_1_KEY, 0)]
-                1 -> COLUMN2_KEYS[getInt(DISPLAY_COLUMN_2_KEY, 0)]
-                else -> {
-                    Timber.w("Unexpected column access: %d", index)
-                    QUESTION
-                }
-            }
-        }
-
-        fun save(prefs: SharedPreferences, columnIndex: Int, value: CardBrowserColumn) {
-            if (columnIndex != 0 && columnIndex != 1) return
-            val (key, array) = when (columnIndex) {
-                0 -> Pair(DISPLAY_COLUMN_1_KEY, COLUMN1_KEYS)
-                1 -> Pair(DISPLAY_COLUMN_2_KEY, COLUMN2_KEYS)
-                else -> throw IllegalStateException()
-            }
-
-            Timber.i("updating '%s' to '%s'", key, value)
-            val index = array.indexOf(value)
-            if (index == -1) {
-                Timber.w("illegal value: %s", value)
-                return
-            }
-            prefs.edit { putInt(key, index) }
-        }
+        fun fromColumnKey(key: String): CardBrowserColumn =
+            entries.firstOrNull { it.ankiColumnKey == key }
+                ?: throw IllegalArgumentException("Invalid key: $key")
     }
 }
 
 fun List<BrowserColumns.Column>.find(column: CardBrowserColumn): BrowserColumns.Column =
-    this.first { it.key == column.ankiColumnKey }
+    this.firstOrNull { it.key == column.ankiColumnKey }
+        ?: throw IllegalArgumentException("Invalid column: ${column.ankiColumnKey}")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserColumn.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserColumn.kt
@@ -18,14 +18,13 @@ package com.ichi2.anki.browser
 
 import anki.search.BrowserColumns
 import com.ichi2.anki.CardBrowser
-import com.ichi2.anki.R
 import net.ankiweb.rsdroid.Backend
 
 /**
  * A column available in the [browser][CardBrowser]
  *
- * @see COLUMN1_KEYS: maps to [R.array.browser_column1_headings]
- * @see COLUMN2_KEYS: maps to [R.array.browser_column2_headings]
+ * @see COLUMN1_KEYS - values for first column
+ * @see COLUMN2_KEYS - values for second column
  * @see CardBrowser.CardCache.getColumnHeaderText - how columns are rendered
  *
  * @param ankiColumnKey The key used in [Backend.setActiveBrowserColumns]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -26,6 +26,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
+import anki.search.BrowserColumns
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.withCol
@@ -122,7 +123,7 @@ class CardBrowserViewModel(
      * Whether the browser is working in Cards mode or Notes mode.
      * default: [CARDS]
      * */
-    private val flowOfCardsOrNotes = MutableStateFlow(CARDS)
+    val flowOfCardsOrNotes = MutableStateFlow(CARDS)
     val cardsOrNotes get() = flowOfCardsOrNotes.value
 
     // card that was clicked (not marked)
@@ -140,6 +141,12 @@ class CardBrowserViewModel(
     val flowOfColumn2 = MutableStateFlow(CardBrowserColumn.ANSWER)
     val column1 get() = flowOfColumn1.value
     val column2 get() = flowOfColumn2.value
+
+    /** Potential headings for the first column */
+    lateinit var column1Candidates: List<BrowserColumns.Column>
+
+    /** Potential headings for the second column */
+    lateinit var column2Candidates: List<BrowserColumns.Column>
 
     val flowOfSearchQueryExpanded = MutableStateFlow(false)
 
@@ -306,12 +313,11 @@ class CardBrowserViewModel(
             val cardsOrNotes = withCol { CardsOrNotes.fromCollection() }
             flowOfCardsOrNotes.update { cardsOrNotes }
 
-            val columns = BrowserColumnCollection.load(sharedPrefs(), cardsOrNotes)
-            flowOfColumn1.update { columns.columns[0] }
-            flowOfColumn2.update { columns.columns[1] }
+            val allColumns = withCol { allBrowserColumns() }.associateBy { it.key }
+            column1Candidates = CardBrowserColumn.COLUMN1_KEYS.map { allColumns[it.ankiColumnKey]!! }
+            column2Candidates = CardBrowserColumn.COLUMN2_KEYS.map { allColumns[it.ankiColumnKey]!! }
 
-            // This impacts browserRowForId(), which we do not use yet
-            withCol { backend.setActiveBrowserColumns(columns.backendKeys) }
+            setupColumns(cardsOrNotes)
 
             withCol {
                 sortTypeFlow.update { SortType.fromCol(config, cardsOrNotes, sharedPrefs()) }
@@ -323,6 +329,16 @@ class CardBrowserViewModel(
                 flowOfInitCompleted.update { true }
             }
         }
+    }
+
+    private suspend fun setupColumns(cardsOrNotes: CardsOrNotes) {
+        Timber.d("loading columns columns for %s mode", cardsOrNotes)
+        val columns = BrowserColumnCollection.load(sharedPrefs(), cardsOrNotes)
+        flowOfColumn1.update { columns.columns[0] }
+        flowOfColumn2.update { columns.columns[1] }
+
+        // This impacts browserRowForId(), which we do not use yet
+        withCol { backend.setActiveBrowserColumns(columns.backendKeys) }
     }
 
     @VisibleForTesting
@@ -385,6 +401,7 @@ class CardBrowserViewModel(
             newValue.saveToCollection()
         }
         flowOfCardsOrNotes.update { newValue }
+        setupColumns(newValue)
     }
 
     fun setTruncated(value: Boolean) {
@@ -775,6 +792,7 @@ class CardBrowserViewModel(
     }
 
     private fun updateColumnCollection(block: (MutableList<CardBrowserColumn?>) -> Unit) {
+        Timber.d("updateColumnCollection")
         BrowserColumnCollection.update(sharedPrefs(), cardsOrNotes) {
             block(it)
             return@update true
@@ -891,3 +909,6 @@ class PreviewerIdsFile(path: String) : File(path), Parcelable {
         }
     }
 }
+
+fun BrowserColumns.Column.getLabel(cardsOrNotes: CardsOrNotes): String =
+    if (cardsOrNotes == CARDS) cardsModeLabel else notesModeLabel

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -310,6 +310,9 @@ class CardBrowserViewModel(
             flowOfColumn1.update { columns.columns[0] }
             flowOfColumn2.update { columns.columns[1] }
 
+            // This impacts browserRowForId(), which we do not use yet
+            withCol { backend.setActiveBrowserColumns(columns.backendKeys) }
+
             withCol {
                 sortTypeFlow.update { SortType.fromCol(config, cardsOrNotes, sharedPrefs()) }
                 reverseDirectionFlow.update { ReverseDirection.fromConfig(config) }

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -17,6 +17,7 @@
 package com.ichi2.async
 
 import com.ichi2.anki.*
+import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import kotlinx.coroutines.Dispatchers
@@ -64,8 +65,8 @@ suspend fun renderBrowserQA(
     cards: List<CardBrowser.CardCache>,
     startPos: Int,
     n: Int,
-    column1Index: Int,
-    column2Index: Int,
+    column1: CardBrowserColumn,
+    column2: CardBrowserColumn,
     onProgressUpdate: (Int) -> Unit
 ): Pair<List<CardBrowser.CardCache>, MutableList<Long>> = withContext(Dispatchers.IO) {
     Timber.d("doInBackgroundRenderBrowserQA")
@@ -104,7 +105,7 @@ suspend fun renderBrowserQA(
             continue
         }
         // Update item
-        card.load(false, column1Index, column2Index)
+        card.load(false, column1, column2)
         val progress = i.toFloat() / n * 100
         withContext(Dispatchers.Main) { onProgressUpdate(progress.toInt()) }
     }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -59,28 +59,6 @@
     <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
     <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
 
-    <!-- Browser -->
-    <string-array name="browser_column1_headings">
-        <item>Question</item>
-        <item>Sort field</item>
-    </string-array>
-    <string-array name="browser_column2_headings">
-        <item>Answer</item>
-        <item>Card</item>
-        <item>Deck</item>
-        <item>Note</item>
-        <item>Question</item>
-        <item>Tags</item>
-        <item>Lapses</item>
-        <item>Reviews</item>
-        <item>Interval</item>
-        <item>Ease</item>
-        <item>Due</item>
-        <item>Card Modified</item>
-        <item>Created</item>
-        <item>Note Modified</item>
-    </string-array>
-
     <string name="filter_by_flags">Flags</string>
 
     <!-- Custom study options -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/BrowserColumnCollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/BrowserColumnCollectionTest.kt
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.annotation.CheckResult
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.browser.CardBrowserColumn.DECK
+import com.ichi2.anki.browser.CardBrowserColumn.FSRS_STABILITY
+import com.ichi2.anki.browser.CardBrowserColumn.SFLD
+import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.model.CardsOrNotes.CARDS
+import com.ichi2.anki.model.CardsOrNotes.NOTES
+import com.ichi2.testutils.getSharedPrefs
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** @see BrowserColumnCollection */
+@RunWith(AndroidJUnit4::class)
+class BrowserColumnCollectionTest : RobolectricTest() {
+
+    val prefs = this.getSharedPrefs()
+
+    @Test
+    fun `cards - ensure sensible defaults`() {
+        val default = load(CARDS)
+        assertThat(default.toKeyArray(), equalTo(listOf("noteFld", "template", "cardDue", "deck")))
+    }
+
+    @Test
+    fun `notes - ensure sensible default`() {
+        val default = load(NOTES)
+        assertThat(default.toKeyArray(), equalTo(listOf("noteFld", "note", "template", "noteTags")))
+    }
+
+    @Test
+    fun `cards - update`() {
+        updateColumns(CARDS) { columns -> columns.add(DECK) }
+        val updated = load(CARDS)
+        assertThat(updated.columns.last(), equalTo(DECK))
+    }
+
+    @Test
+    fun `notes - update`() {
+        updateColumns(NOTES) { columns -> columns.add(DECK) }
+        val updated = load(NOTES)
+        assertThat(updated.columns.last(), equalTo(DECK))
+    }
+
+    @Test
+    fun `update with null column`() {
+        // in AnkiMobile, if you update a column to 'none', the values are rearranged
+        updateColumns(CARDS) { columns ->
+            columns.clear()
+            columns.add(SFLD)
+            columns.add(null)
+            columns.add(FSRS_STABILITY)
+            assertThat("size of updated columns", columns, hasSize(3))
+        }
+
+        val updated = load(CARDS)
+        assertThat("column size", updated.columns, hasSize(2))
+        assertThat("first columns is unchanged", updated[0], equalTo(SFLD))
+        assertThat("null column is replaced with third", updated[1], equalTo(FSRS_STABILITY))
+    }
+
+    private fun BrowserColumnCollection.toKeyArray() =
+        columns.map { it.ankiColumnKey }
+
+    @CheckResult
+    private fun load(cardsOrNotes: CardsOrNotes) =
+        BrowserColumnCollection.load(prefs, cardsOrNotes)
+
+    private fun updateColumns(
+        cardsOrNotes: CardsOrNotes,
+        block: (MutableList<CardBrowserColumn?>) -> Unit
+    ) {
+        BrowserColumnCollection.update(prefs, cardsOrNotes) {
+            block(it)
+            return@update true
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -25,6 +25,10 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditor
+import com.ichi2.anki.browser.CardBrowserColumn.ANSWER
+import com.ichi2.anki.browser.CardBrowserColumn.CARD
+import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
+import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.DeepLink
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.SystemContextMenu
 import com.ichi2.anki.export.ExportDialogFragment
@@ -313,36 +317,36 @@ class CardBrowserViewModelTest : JvmTest() {
 
     @Test
     fun `changing column index 1`() = runViewModelTest {
-        flowOfColumnIndex1.test {
+        flowOfColumn1.test {
             ignoreEventsDuringViewModelInit()
 
-            assertThat("default column1Index value", column1Index, equalTo(0))
+            assertThat("default column1 value", column1, equalTo(QUESTION))
 
-            setColumn1Index(1)
+            setColumn1(SFLD)
 
-            assertThat("flowOfColumnIndex1", awaitItem(), equalTo(1))
-            assertThat("column1Index", column1Index, equalTo(1))
+            assertThat("flowOfColumn1", awaitItem(), equalTo(SFLD))
+            assertThat("column1", column1, equalTo(SFLD))
 
             // expect no change if the value is selected again
-            setColumn1Index(1)
+            setColumn1(SFLD)
             expectNoEvents()
         }
     }
 
     @Test
     fun `changing column index 2`() = runViewModelTest {
-        flowOfColumnIndex2.test {
+        flowOfColumn2.test {
             ignoreEventsDuringViewModelInit()
 
-            assertThat("default column2Index value", column2Index, equalTo(0))
+            assertThat("default column2Index value", column2, equalTo(ANSWER))
 
-            setColumn2Index(1)
+            setColumn2(CARD)
 
-            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(1))
-            assertThat("column2Index", column2Index, equalTo(1))
+            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(CARD))
+            assertThat("column2Index", column2, equalTo(CARD))
 
             // expect no change if the value is selected again
-            setColumn2Index(1)
+            setColumn2(CARD)
             expectNoEvents()
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.browser.CardBrowserColumn.ANSWER
 import com.ichi2.anki.browser.CardBrowserColumn.CARD
+import com.ichi2.anki.browser.CardBrowserColumn.NOTE_TYPE
 import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
 import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.DeepLink
@@ -316,37 +317,73 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     @Test
-    fun `changing column index 1`() = runViewModelTest {
+    fun `cards - changing column index 1`() = runViewModelTest {
         flowOfColumn1.test {
             ignoreEventsDuringViewModelInit()
 
-            assertThat("default column1 value", column1, equalTo(QUESTION))
+            assertThat("default column1 value", column1, equalTo(SFLD))
 
-            setColumn1(SFLD)
+            setColumn1(QUESTION)
 
-            assertThat("flowOfColumn1", awaitItem(), equalTo(SFLD))
-            assertThat("column1", column1, equalTo(SFLD))
+            assertThat("flowOfColumn1", awaitItem(), equalTo(QUESTION))
+            assertThat("column1", column1, equalTo(QUESTION))
 
             // expect no change if the value is selected again
-            setColumn1(SFLD)
+            setColumn1(QUESTION)
             expectNoEvents()
         }
     }
 
     @Test
-    fun `changing column index 2`() = runViewModelTest {
+    fun `cards - changing column index 2`() = runViewModelTest {
         flowOfColumn2.test {
             ignoreEventsDuringViewModelInit()
 
-            assertThat("default column2Index value", column2, equalTo(ANSWER))
+            assertThat("default column2Index value", column2, equalTo(CARD))
 
-            setColumn2(CARD)
+            setColumn2(ANSWER)
 
-            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(CARD))
-            assertThat("column2Index", column2, equalTo(CARD))
+            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(ANSWER))
+            assertThat("column2Index", column2, equalTo(ANSWER))
 
             // expect no change if the value is selected again
-            setColumn2(CARD)
+            setColumn2(ANSWER)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `notes - changing column index 1`() = runViewModelNotesTest {
+        flowOfColumn1.test {
+            ignoreEventsDuringViewModelInit()
+
+            assertThat("default column1 value", column1, equalTo(SFLD))
+
+            setColumn1(QUESTION)
+
+            assertThat("flowOfColumn1", awaitItem(), equalTo(QUESTION))
+            assertThat("column1", column1, equalTo(QUESTION))
+
+            // expect no change if the value is selected again
+            setColumn1(QUESTION)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `notes - changing column index 2`() = runViewModelNotesTest {
+        flowOfColumn2.test {
+            ignoreEventsDuringViewModelInit()
+
+            assertThat("default column2Index value", column2, equalTo(NOTE_TYPE))
+
+            setColumn2(ANSWER)
+
+            assertThat("flowOfColumnIndex2", awaitItem(), equalTo(ANSWER))
+            assertThat("column2Index", column2, equalTo(ANSWER))
+
+            // expect no change if the value is selected again
+            setColumn2(ANSWER)
             expectNoEvents()
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.browser.CardBrowserColumn.ANSWER
 import com.ichi2.anki.browser.CardBrowserColumn.CARD
+import com.ichi2.anki.browser.CardBrowserColumn.FSRS_DIFFICULTY
 import com.ichi2.anki.browser.CardBrowserColumn.NOTE_TYPE
 import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
 import com.ichi2.anki.browser.CardBrowserColumn.SFLD
@@ -558,6 +559,22 @@ class CardBrowserViewModelTest : JvmTest() {
         assertThat(ids, hasSize(1))
 
         assertThat(ids.single(), equalTo(cards[0].card.nid))
+    }
+
+    @Test
+    fun `changing note types changes columns`() = runViewModelTest {
+        // BrowserColumnCollection contains BOTH notes and cards column configs
+        BrowserColumnCollection.update(sharedPrefs(), CardsOrNotes.NOTES) {
+            it[0] = QUESTION
+            it[1] = FSRS_DIFFICULTY
+            true
+        }
+
+        assertThat("column 2 before", column2, not(equalTo(FSRS_DIFFICULTY)))
+
+        setCardsOrNotes(CardsOrNotes.NOTES)
+
+        assertThat("column 2 after", column2, equalTo(FSRS_DIFFICULTY))
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
**Breaking**
Updates the default columns to use Anki Desktop values

**changes**
* Use Anki Desktop strings for columns
* Allow more than 2 columns to be saved in preferences
* Use a different collection of columns for notes and cards mode

## Fixes
* Prep for #11889

## Approach
* Extract saving columns into `CardBrowserColumn`
* Extract saving into `BrowserColumnCollection`, 
   * Move from storing `cardBrowserColumn1: 0` (an index into an internal array)
     *  `activeCols`: `question|answer`
     * `activeNoteCols`: `question|answer`
     * This allows multiple columns in the definitions
     * Upgrade from the old to the new preferences
* Handle loading different columns when moving from cards to notes mode
* Then update to use the backend strings instead of our strings

## How Has This Been Tested?
Unit tested and manually tested:

* Changing columns
* Upgrades
* Changing from Cards to Notes mode

## Learning (optional, can help others)
* wasted a couple hours with a bug in `launchCollectionInLifecycleScope` under test, causing the wrong values to be provided to the lambdas, causing an infinite loop in tests. Robolectric only


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
