### PR TITLE
fix: use android import for crash report dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -17,12 +17,12 @@
 package com.ichi2.anki.analytics
 
 import android.annotation.SuppressLint
+import android.app.AlertDialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
 import android.widget.CheckBox
 import android.widget.EditText
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/AvoidAlertDialogUsage.kt
@@ -21,6 +21,7 @@ import com.android.tools.lint.client.api.UElementHandler
 import com.android.tools.lint.detector.api.*
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
+import com.ichi2.anki.lint.utils.LintUtils
 import org.jetbrains.uast.UElement
 import org.jetbrains.uast.UImportStatement
 
@@ -57,7 +58,9 @@ class AvoidAlertDialogUsage : Detector(), SourceCodeScanner {
         return object : UElementHandler() {
             override fun visitImportStatement(node: UImportStatement) {
                 val importReference = node.asSourceString()
-                if (importReference.contains("android.app.AlertDialog")) {
+                if (importReference.contains("android.app.AlertDialog") &&
+                    !LintUtils.isAnAllowedClass(context.uastFile!!.classes, "AnkiDroidCrashReportDialog")
+                ) {
                     context.report(
                         ISSUE,
                         node,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
use android import for crash report dialog instead of androidx as crash report acitivity is a external dependecy activity and using androidx requires theme.appCompat

## Fixes
* Fixes #16604 

## How Has This Been Tested?
Locally tested on emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
