### PR TITLE
build(deps): have dependabot ignore anki-android-backend dep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
   - "dependencies"
   ignore:
   # Ignore all Rust backend updates, these are always done as manual pulls
-  - dependency-name: io.github.david-allison:anki-android-backend
+  - dependency-name: ankiBackend
 - package-ecosystem: npm
   directory: "/tools/localization"
   schedule:


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Dependabot resumed proposing PRs for this dependency (for example #16607) after moving to the version catalog style of version specification in gradle, which has been confusing me.

I believe it is because the name now needs to be the version catalog alias name, not the maven repository coordinates, with my hunch based on the naming of the PRs now being an update for `ankiBackend` vs the coordinates first

## Fixes
* Related #16607

## Approach

Attempts to divine why they are proposed again by using the name of the PR, and just putting that in there

## How Has This Been Tested?

The only way to test it will be to merge this PR, then bump backend, then see if dependabot proposes a PR for the backend bump

