### PR TITLE
feat(ci): apk size comparison workflow

### DIFF
--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -1,0 +1,116 @@
+name: APK Size Comparison
+
+on:
+  workflow_dispatch:
+    inputs:
+      prNumber:
+        description: "Number of PR to calculate sizes for"
+        required: true
+        type: number
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+
+permissions:
+  contents: read
+  pull-requests: write
+
+
+jobs:
+  sizeCheck:
+    name: APK Size Check
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    env:
+      # could be better, '/home/runner' should be '~/' but neither that nor '$HOME' worked
+      STOREFILEDIR: /home/runner/src
+      STOREFILE: android-keystore
+      STOREPASS: testpass
+      KEYPASS: testpass
+      KEYALIAS: nrkeystorealias
+    steps:
+      - name: Configure JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Test Credential Prep
+        run: |
+          echo "KSTOREPWD=$STOREPASS" >> $GITHUB_ENV
+          echo "KEYPWD=$KEYPASS" >> $GITHUB_ENV
+          mkdir $STOREFILEDIR
+          cd $STOREFILEDIR
+          echo y | keytool -genkeypair -dname "cn=AnkiDroid, ou=ankidroid, o=AnkiDroid, c=US" -alias $KEYALIAS -keypass $KEYPASS -keystore "$STOREFILE" -storepass $STOREPASS -keyalg RSA -validity 20000
+        shell: bash
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        timeout-minutes: 5
+        with:
+          cache-read-only: true
+          gradle-home-cache-cleanup: true
+
+      - name: Checkout PR
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: 'refs/pull/${{ github.event.inputs.prNumber }}/head'
+
+      - name: Assemble PR APK
+        # This makes sure we fetch gradle network resources with a retry
+        uses: nick-invision/retry@v3
+        with:
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: ./gradlew :AnkiDroid:assemblePlayRelease --daemon
+
+      - name: Get PR APK size
+        run: echo NEWSIZE=`ls -lrt AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-arm64-v8a-release.apk | awk '{print $5}'` >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Assemble Baseline APK
+        # This makes sure we fetch gradle network resources with a retry
+        uses: nick-invision/retry@v3
+        with:
+          timeout_minutes: 10
+          retry_wait_seconds: 60
+          max_attempts: 3
+          command: ./gradlew :AnkiDroid:assemblePlayRelease --daemon
+
+      - name: Get Baseline APK size
+        run: echo OLDSIZE=`ls -lrt AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-arm64-v8a-release.apk | awk '{print $5}'` >> $GITHUB_ENV
+
+      - name: Post comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            var inputs = ${{ toJSON(inputs) }}
+            let prNumber = inputs['prNumber'];
+
+            async function getPullRequest() {
+                return await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: prNumber,
+                });
+            }
+            const pullRequestData = await getPullRequest();
+
+            async function addComment(prNumber, oldSize, newSize) {
+              return await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: `Old APK size: ${oldSize}
+                      New APK size: ${newSize}`
+              })
+            }
+            await addComment(prNumber, process.env.OLDSIZE, process.env.NEWSIZE);


### PR DESCRIPTION

## Purpose / Description

There was a question on PR #16601 about the size effect of the change

I've wanted to have objective data for this question on any PR for a while, and it's relatively easy to do

The only complication is that you want to do a release build (to make sure minimization happens etc), but to do that you need a keystore etc

Not too hard to handle though, so I've given a minimum-viable-product attempt here

## Approach

- setup tools
- setup test keystore
- do a main release build and get the size
- do a PR release build and get the size

If this works in a basic mode like this I will likely extend it immediately so that it posts a comment on the PR with the size difference

## How Has This Been Tested?

I should test this in my fork, but hopefully it runs on the PR here as well ?

## Learning (optional, can help others)

- stackoverflow still has all the answers (this time, how to use a single command-line to automate creation of a keystore)
- none of the APK size diff workflows are great - one is orphaned (microsoft), the other does debug builds 🤷, and that's all I found
- the workflow should be extended to post a comment with the size difference, looking in the logs is silly - but MVP first

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
