### PR TITLE
chore: ignore Kotlin 2 `.salive` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ AnkiDroid/ACRA-INSTALLATION
 
 #ignore the local insufficient memory for the Java Runtime Environment files
 hs_err_pid*
+
+# Ignore kotlin 2.0 compiler files (.salive: session-is-alive)
+# https://github.com/JetBrains/kotlin/blob/ca34e5d2fd255ed0501bae4fae3d3691dc40d375/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt#L458
+/.kotlin


### PR DESCRIPTION
This appears to be a 'session-is-alive' file which appears when compiling

https://github.com/JetBrains/kotlin/blob/ca34e5d2fd255ed0501bae4fae3d3691dc40d375/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt#L458

Example:

`.kotlin/sessions/kotlin-compiler-9293527262404664068.salive`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
