### PR TITLE
Fix missing class errors for classes in common module

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -27,11 +27,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
     }
 }
 

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -19,3 +19,17 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# FIXME remove this entire Android 4.2 workaround from 12/3/15 timrae commit for 2.15.x+
+# Samsung Android 4.2 bug workaround
+# https://code.google.com/p/android/issues/detail?id=78377
+-keepattributes **
+-keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
+#5806 - Class: ActionBarOverflow
+-keep public class android.support.v7.internal.view.menu.** { *; }
+-keep public class androidx.appcompat.view.menu.** { *; }
+-dontpreverify
+-dontoptimize
+-dontshrink
+-dontwarn **
+-dontnote **


### PR DESCRIPTION
## Purpose / Description
I think this is a proguard related issue as the code works in debug and fails in release.
Running `./gradlew  :common:assembleRelease` shows no classes /proguard mapping is produced and this is verified by adding -`printusage [filename]` in the proguard rules which lists the classes in the common module as unused and a target for removal. See the documentation for the -dontshrink rule https://www.guardsquare.com/manual/configuration/usage .
To fix this I copied the rules we have in the main module.

I also added a second commit to change the compatibility in common module  to Java 11 which is used by all other modules.

## Fixes
* Fixes #16619

## How Has This Been Tested?

Not that much testing.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
