### PR TITLE
improvement(rename-flag): remove 'ok/cancel'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagRenameDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagRenameDialog.kt
@@ -28,10 +28,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
-import com.ichi2.anki.showThemedToast
 import com.ichi2.utils.customView
-import com.ichi2.utils.negativeButton
-import com.ichi2.utils.positiveButton
 import com.ichi2.utils.title
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -48,33 +45,12 @@ class FlagRenameDialog : DialogFragment() {
         val builder = AlertDialog.Builder(requireContext()).apply {
             customView(view = dialogView, 4, 4, 4, 4)
             title(R.string.rename_flag)
-            // positiveButton is set in onResume so dialog is not always dismissed
-            positiveButton(R.string.dialog_ok, click = null)
-            negativeButton(R.string.dialog_cancel)
         }
         val dialog = builder.create()
 
         recyclerView = dialogView.findViewById(R.id.recyclerview_flags)
         setupRecyclerView()
         return dialog
-    }
-
-    override fun onResume() {
-        super.onResume()
-        (dialog as AlertDialog).positiveButton.setOnClickListener {
-            // TODO: Extract pending changes from the adapter and save them
-            if (!::flagAdapter.isInitialized) return@setOnClickListener
-            val pendingChanges = flagAdapter.currentList.filter { it.isInEditMode }
-            if (pendingChanges.any()) {
-                Timber.i("Attempted to close with %d pending changes", pendingChanges.size)
-                showThemedToast(R.string.confirm_before_saving, true)
-                return@setOnClickListener
-            }
-
-            Timber.i("Closing dialog", pendingChanges.size)
-            activity?.invalidateOptionsMenu()
-            dismiss()
-        }
     }
 
     override fun onDismiss(dialog: DialogInterface) {

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -278,7 +278,4 @@ also changes the interval of the card"
 
     <!-- Outdated WebView dialog -->
     <string name="webview_update_message">The system WebView is outdated. Some features won’t work correctly. Please update it.\n\nInstalled version: %1$d\nMinimum required version: %2$d</string>
-
-    <!-- Rename Flags -->
-    <string name="confirm_before_saving">Confirm all changes before saving</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description
* This made it more obvious that the 'tick' should be pressed
* Cancel didn't work as expected
* OK didn't perform saves

## Fixes
* Prompted by https://github.com/ankidroid/Anki-Android/pull/16244#issuecomment-2180497998
* Related: #16205

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Emulator - 
<img width="403" alt="Screenshot 2024-06-20 at 13 15 10" src="https://github.com/ankidroid/Anki-Android/assets/62114487/070af653-0f7b-491c-940b-2d967280671d">

I can still edit flag names

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
