### PR TITLE
Exclude robolectric deps from release

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -345,7 +345,7 @@ dependencies {
         testImplementation files("../../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")
     } else {
         implementation libs.ankiBackend.backend
-        implementation libs.ankiBackend.testing
+        testImplementation libs.ankiBackend.testing
     }
 
     // May need a resolution strategy for support libs to our versions


### PR DESCRIPTION
Robolectric test dependencies have been included in builds since release 2.18alpha7 (https://github.com/ankidroid/Anki-Android/compare/v2.18alpha6...v2.18alpha7). This PR aims to fix that and restore the original behavior of Gradle builds, resulting in smaller output APKs.
Related: https://github.com/ankidroid/Anki-Android/issues/16626