### PR TITLE
Test release build in emulator tests + minor fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,11 +2,6 @@ name: Code Quality Checks
 
 on:
   workflow_dispatch:
-    inputs:
-      clearCaches:
-        description: "Clear workflow caches where possible"
-        required: false
-        type: string
   pull_request:
   push:
     # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
@@ -43,14 +38,6 @@ jobs:
           # Comment this and the with: above out for performance testing on a branch
           cache-read-only: ${{ github.ref != 'refs/heads/main' }}
           gradle-home-cache-cleanup: true
-
-      - name: Clear Caches Optionally
-        if: "${{ github.event.inputs.clearCaches != '' }}"
-        shell: bash
-        run: |
-          du -sk ~/.gradle
-          rm -fr ~/.gradle
-          du -sk ~/.gradle || echo ~/.gradle is gone
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -2,11 +2,6 @@ name: Emulator Tests
 
 on:
   workflow_dispatch:
-    inputs:
-      clearCaches:
-        description: "Clear workflow caches where possible"
-        required: false
-        type: string
   pull_request:
   push:
     # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
@@ -77,17 +72,6 @@ jobs:
           key: avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1-${{ github.event.inputs.clearCaches }}
           restore-keys: |
             avd-${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-v1
-
-      - name: Clear Caches Optionally
-        if: "${{ github.event.inputs.clearCaches != '' }}"
-        shell: bash
-        run: |
-          du -sk ~/.gradle
-          du -sk ~/.android
-          rm -fr ~/.gradle
-          rm -fr ~/.android
-          du -sk ~/.gradle || echo ~/.gradle is gone
-          du -sk ~/.android || echo ~/.android is gone
 
       - name: Warm Gradle Cache
         # This makes sure we fetch gradle network resources with a retry

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -20,6 +20,13 @@ jobs:
     timeout-minutes: 75
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      TEST_RELEASE_BUILD: true
+      # could be better, '/home/runner' should be '~/' but neither that nor '$HOME' worked
+      STOREFILEDIR: /home/runner/src
+      STOREFILE: android-keystore
+      STOREPASS: testpass
+      KEYPASS: testpass
+      KEYALIAS: nrkeystorealias
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +40,15 @@ jobs:
         # This is useful for benchmarking, do 0, 1, 2, etc (up to 256 max job-per-matrix limit) for averages
         iteration: [0]
     steps:
+      - name: Test Credential Prep
+        run: |
+          echo "KSTOREPWD=$STOREPASS" >> $GITHUB_ENV
+          echo "KEYPWD=$KEYPASS" >> $GITHUB_ENV
+          mkdir $STOREFILEDIR
+          cd $STOREFILEDIR
+          echo y | keytool -genkeypair -dname "cn=AnkiDroid, ou=ankidroid, o=AnkiDroid, c=US" -alias $KEYALIAS -keypass $KEYPASS -keystore "$STOREFILE" -storepass $STOREPASS -keyalg RSA -validity 20000
+        shell: bash
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 50
@@ -80,7 +96,7 @@ jobs:
           timeout_minutes: 15
           retry_wait_seconds: 60
           max_attempts: 3
-          command: ./gradlew packagePlayDebug packagePlayDebugAndroidTest --daemon
+          command: ./gradlew packagePlayRelease packagePlayReleaseAndroidTest --daemon
 
       - name: AVD Boot and Snapshot Creation
         # Only generate a snapshot for saving if we are on main branch with a cache miss

--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -147,17 +147,12 @@ jobs:
             sleep 5
             ./gradlew uninstallAll jacocoAndroidTestReport --daemon
 
-      - name: Compress Emulator Log
-        if: always()
-        run: gzip -9 adb-log.txt
-        shell: bash
-
       - name: Upload Emulator Log
         uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.api-level }}-${{ matrix.arch }}-${{matrix.target}}-${{matrix.first-boot-delay}}-${{matrix.iteration}}-adb_logs
-          path: adb-log.txt.gz
+          path: adb-log.txt
 
       - name: Upload Emulator Screen Record
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -3,10 +3,6 @@ name: Unit Tests
 on:
   workflow_dispatch:
     inputs:
-      clearCaches:
-        description: "Clear workflow caches where possible, empty means false"
-        required: false
-        type: string
       iterations:
         description: "Number of iterations on each chosen operating system. Default 1. Max 85."
         required: true
@@ -150,14 +146,6 @@ jobs:
           # gradle-home-cache-cleanup is temporarily disabled to investigate cache pollution issues
           # Requested in: https://github.com/gradle/actions/issues/167#issuecomment-2052352341
           #   gradle-home-cache-cleanup: true
-
-      - name: Clear Caches Optionally
-        if: "${{ github.event.inputs.clearCaches != '' }}"
-        shell: bash
-        run: |
-          du -sk ~/.gradle
-          rm -fr ~/.gradle
-          du -sk ~/.gradle || echo ~/.gradle is gone
 
       - name: Gradle Dependency Download
         uses: nick-invision/retry@v3

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -42,6 +42,12 @@ android {
         aidl = true
     }
 
+    if (rootProject.testReleaseBuild) {
+        testBuildType "release"
+    } else {
+        testBuildType "debug"
+    }
+
     defaultConfig {
         applicationId "com.ichi2.anki"
         buildConfigField "Boolean", "CI", (System.getenv("CI") == "true").toString()
@@ -132,6 +138,7 @@ android {
             minifyEnabled true
             splits.abi.universalApk = universalApkEnabled // Build universal APK for release with `-Duniversal-apk=true`
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            testProguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro', 'proguard-test-rules.pro'
             signingConfig signingConfigs.release
 
             // syntax: assembleRelease -PcustomSuffix="suffix" -PcustomName="New name"
@@ -283,7 +290,7 @@ tasks.register('assertNonzeroAndroidTests') {
     }
 }
 afterEvaluate {
-    tasks.named('connectedPlayDebugAndroidTest').configure { finalizedBy('assertNonzeroAndroidTests') }
+    tasks.named(androidTestName).configure { finalizedBy('assertNonzeroAndroidTests') }
 }
 
 apply from: "./robolectricDownloader.gradle"

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -3,13 +3,13 @@ import groovy.transform.Memoized
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = "0.8.11"
+    toolVersion = "0.8.12"
 
 }
 
 android {
     testCoverage {
-        jacocoVersion '0.8.11'
+        jacocoVersion '0.8.12'
     }
 }
 

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -116,7 +116,7 @@ def testReport = tasks.register('jacocoTestReport', JacocoReport) {
 }
 testReport.configure {
     dependsOn('testPlayDebugUnitTest')
-    dependsOn('connectedPlayDebugAndroidTest')
+    dependsOn(rootProject.androidTestName)
 }
 
 // A unit-test only report task
@@ -166,4 +166,4 @@ def androidTestReport = tasks.register('jacocoAndroidTestReport', JacocoReport) 
             '**/*.ec'
     ])
 }
-androidTestReport.configure { dependsOn('connectedPlayDebugAndroidTest') }
+androidTestReport.configure { dependsOn(rootProject.androidTestName) }

--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -1,13 +1,9 @@
 # Add project specific ProGuard rules here.
-# By default, the flags in this file are appended to flags specified
-# in C:\Program Files (x86)\Android\android-sdk/tools/proguard/proguard-android.txt
-# You can edit the include path and order by changing the proguardFiles
-# directive in build.gradle.kts.
+# You can control the set of applied configuration files using the
+# proguardFiles setting in build.gradle.
 #
 # For more details, see
 #   http://developer.android.com/guide/developing/tools/proguard.html
-
-# Add any project specific keep options here:
 
 # If your project uses WebView with JS, uncomment the following
 # and specify the fully qualified class name to the JavaScript interface
@@ -16,16 +12,131 @@
 #   public *;
 #}
 
+# Uncomment this to preserve the line number information for
+# debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# If you keep the line number information, uncomment this to
+# hide the original source file name.
+#-renamesourcefileattribute SourceFile
+
 # FIXME remove this entire Android 4.2 workaround from 12/3/15 timrae commit for 2.15.x+
 # Samsung Android 4.2 bug workaround
 # https://code.google.com/p/android/issues/detail?id=78377
--keepattributes **
--keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
-#5806 - Class: ActionBarOverflow
--keep public class android.support.v7.internal.view.menu.** { *; }
--keep public class androidx.appcompat.view.menu.** { *; }
--dontpreverify
--dontoptimize
--dontshrink
--dontwarn **
--dontnote **
+#-keepattributes **
+#-keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
+##5806 - Class: ActionBarOverflow
+#-keep public class android.support.v7.internal.view.menu.** { *; }
+#-keep public class androidx.appcompat.view.menu.** { *; }
+#-dontpreverify
+#-dontoptimize
+#-dontshrink
+#-dontwarn **
+#-dontnote **
+
+#-dontobfuscate
+#-dontoptimize
+#-dontshrink
+
+-keep class com.ichi2.anki.** { *; }
+
+-keep class java.util.** { *; }
+-keep class java.util.concurrent.ThreadLocalRandom
+-keep class java.util.concurrent.** { *; }
+-keep class java.lang.ThreadLocal { *; }
+
+-dontwarn javax.naming.InvalidNameException
+-dontwarn javax.naming.NamingException
+-dontwarn javax.naming.directory.Attribute
+-dontwarn javax.naming.directory.Attributes
+-dontwarn javax.naming.ldap.LdapName
+-dontwarn javax.naming.ldap.Rdn
+-dontwarn org.ietf.jgss.GSSContext
+-dontwarn org.ietf.jgss.GSSCredential
+-dontwarn org.ietf.jgss.GSSException
+-dontwarn org.ietf.jgss.GSSManager
+-dontwarn org.ietf.jgss.GSSName
+-dontwarn org.ietf.jgss.Oid
+
+-dontwarn build.IgnoreJava8API
+-dontwarn com.github.luben.zstd.BufferPool
+-dontwarn com.github.luben.zstd.ZstdInputStream
+-dontwarn com.github.luben.zstd.ZstdOutputStream
+-dontwarn com.squareup.javapoet.AnnotationSpec$Builder
+-dontwarn com.squareup.javapoet.AnnotationSpec
+-dontwarn com.squareup.javapoet.ClassName
+-dontwarn java.awt.Dimension
+-dontwarn java.awt.DisplayMode
+-dontwarn java.awt.GraphicsDevice
+-dontwarn java.awt.GraphicsEnvironment
+-dontwarn java.awt.Toolkit
+-dontwarn java.lang.invoke.MethodHandleProxies
+-dontwarn javax.lang.model.SourceVersion
+-dontwarn javax.lang.model.element.AnnotationMirror
+-dontwarn javax.lang.model.element.AnnotationValue
+-dontwarn javax.lang.model.element.AnnotationValueVisitor
+-dontwarn javax.lang.model.element.Element
+-dontwarn javax.lang.model.element.ElementKind
+-dontwarn javax.lang.model.element.ElementVisitor
+-dontwarn javax.lang.model.element.ExecutableElement
+-dontwarn javax.lang.model.element.Modifier
+-dontwarn javax.lang.model.element.Name
+-dontwarn javax.lang.model.element.PackageElement
+-dontwarn javax.lang.model.element.QualifiedNameable
+-dontwarn javax.lang.model.element.TypeElement
+-dontwarn javax.lang.model.element.TypeParameterElement
+-dontwarn javax.lang.model.element.VariableElement
+-dontwarn javax.lang.model.type.ArrayType
+-dontwarn javax.lang.model.type.DeclaredType
+-dontwarn javax.lang.model.type.ErrorType
+-dontwarn javax.lang.model.type.ExecutableType
+-dontwarn javax.lang.model.type.IntersectionType
+-dontwarn javax.lang.model.type.NoType
+-dontwarn javax.lang.model.type.NullType
+-dontwarn javax.lang.model.type.PrimitiveType
+-dontwarn javax.lang.model.type.TypeKind
+-dontwarn javax.lang.model.type.TypeMirror
+-dontwarn javax.lang.model.type.TypeVariable
+-dontwarn javax.lang.model.type.TypeVisitor
+-dontwarn javax.lang.model.type.WildcardType
+-dontwarn javax.lang.model.util.AbstractElementVisitor8
+-dontwarn javax.lang.model.util.ElementFilter
+-dontwarn javax.lang.model.util.Elements
+-dontwarn javax.lang.model.util.SimpleAnnotationValueVisitor8
+-dontwarn javax.lang.model.util.SimpleElementVisitor8
+-dontwarn javax.lang.model.util.SimpleTypeVisitor8
+-dontwarn javax.lang.model.util.Types
+-dontwarn javax.tools.Diagnostic$Kind
+-dontwarn javax.tools.FileObject
+-dontwarn javax.tools.JavaFileManager$Location
+-dontwarn javax.tools.StandardLocation
+-dontwarn org.brotli.dec.BrotliInputStream
+-dontwarn org.jspecify.annotations.NullMarked
+-dontwarn org.objectweb.asm.AnnotationVisitor
+-dontwarn org.objectweb.asm.Attribute
+-dontwarn org.objectweb.asm.ClassReader
+-dontwarn org.objectweb.asm.ClassVisitor
+-dontwarn org.objectweb.asm.FieldVisitor
+-dontwarn org.objectweb.asm.Label
+-dontwarn org.objectweb.asm.MethodVisitor
+-dontwarn org.objectweb.asm.Type
+-dontwarn org.tukaani.xz.ARMOptions
+-dontwarn org.tukaani.xz.ARMThumbOptions
+-dontwarn org.tukaani.xz.DeltaOptions
+-dontwarn org.tukaani.xz.FilterOptions
+-dontwarn org.tukaani.xz.FinishableOutputStream
+-dontwarn org.tukaani.xz.FinishableWrapperOutputStream
+-dontwarn org.tukaani.xz.IA64Options
+-dontwarn org.tukaani.xz.LZMA2InputStream
+-dontwarn org.tukaani.xz.LZMA2Options
+-dontwarn org.tukaani.xz.LZMAInputStream
+-dontwarn org.tukaani.xz.LZMAOutputStream
+-dontwarn org.tukaani.xz.MemoryLimitException
+-dontwarn org.tukaani.xz.PowerPCOptions
+-dontwarn org.tukaani.xz.SPARCOptions
+-dontwarn org.tukaani.xz.SingleXZInputStream
+-dontwarn org.tukaani.xz.UnsupportedOptionsException
+-dontwarn org.tukaani.xz.X86Options
+-dontwarn org.tukaani.xz.XZ
+-dontwarn org.tukaani.xz.XZInputStream
+-dontwarn org.tukaani.xz.XZOutputStream

--- a/AnkiDroid/proguard-test-rules.pro
+++ b/AnkiDroid/proguard-test-rules.pro
@@ -13,3 +13,8 @@
 # no impact for these classes to be missing, ignore them
 -dontwarn com.google.protobuf.GeneratedMessageLite$MergeFromVisitor
 -dontwarn com.google.protobuf.GeneratedMessageLite$Visitor
+
+
+-keep class java.util.** { *; }
+-keep class java.util.concurrent.** { *; }
+-keep class java.lang.ThreadLocal { *; }

--- a/AnkiDroid/proguard-test-rules.pro
+++ b/AnkiDroid/proguard-test-rules.pro
@@ -1,0 +1,15 @@
+# These proguard rules are only needed when building
+# for the combination of testing and release mode
+# Certain androidx frameworks that are test-only have
+# issues with proguard / minimization in release mode
+
+# First build error in release mode for testing:
+#
+# ERROR: Missing classes detected while running R8. Please add the missing classes or apply additional keep rules that are generated in /Users/mike/work/ankidroid/Anki-Android/AnkiDroid/build/outputs/mapping/playReleaseAndroidTest/missing_rules.txt.
+# ERROR: R8: Missing class com.google.protobuf.GeneratedMessageLite$MergeFromVisitor (referenced from: java.lang.Object com.google.android.apps.common.testing.accessibility.framework.uielement.proto.AndroidFrameworkProtos$LayoutParamsProto.dynamicMethod(com.google.protobuf.GeneratedMessageLite$MethodToInvoke, java.lang.Object, java.lang.Object))
+# Missing class com.google.protobuf.GeneratedMessageLite$Visitor (referenced from: java.lang.Object com.google.android.apps.common.testing.accessibility.framework.proto.AccessibilityEvaluationProtos$AccessibilityEvaluation.dynamicMethod(com.google.protobuf.GeneratedMessageLite$MethodToInvoke, java.lang.Object, java.lang.Object) and 19 other contexts)
+#
+# We are not using automated accessibility testing, so there should be
+# no impact for these classes to be missing, ignore them
+-dontwarn com.google.protobuf.GeneratedMessageLite$MergeFromVisitor
+-dontwarn com.google.protobuf.GeneratedMessageLite$Visitor

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,6 +118,11 @@ val preDexEnabled by extra("true" == System.getProperty("pre-dex", "true"))
 // allows for universal APKs to be generated
 val universalApkEnabled by extra("true" == System.getProperty("universal-apk", "false"))
 
+val testReleaseBuild by extra(System.getenv("TEST_RELEASE_BUILD") == "true")
+var androidTestName by extra(
+    if (testReleaseBuild) "connectedPlayReleaseAndroidTest" else "connectedPlayDebugAndroidTest"
+)
+
 val gradleTestMaxParallelForks by extra(
     if (System.getProperty("os.name") == "Mac OS X") {
         // macOS reports hardware cores. This is accurate for CI, Intel (halved due to SMT) and Apple Silicon

--- a/common/proguard-rules.pro
+++ b/common/proguard-rules.pro
@@ -20,16 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# FIXME remove this entire Android 4.2 workaround from 12/3/15 timrae commit for 2.15.x+
-# Samsung Android 4.2 bug workaround
-# https://code.google.com/p/android/issues/detail?id=78377
--keepattributes **
--keep class !android.support.v7.view.menu.**,!android.support.design.internal.NavigationMenu,!android.support.design.internal.NavigationMenuPresenter,!android.support.design.internal.NavigationSubMenu,** {*;}
-#5806 - Class: ActionBarOverflow
--keep public class android.support.v7.internal.view.menu.** { *; }
--keep public class androidx.appcompat.view.menu.** { *; }
--dontpreverify
--dontoptimize
--dontshrink
--dontwarn **
--dontnote **
+-include ../AnkiDroid/proguard-rules.pro


### PR DESCRIPTION

## Purpose / Description

We want to test the release build of the APK in the emulator tests in order to exercise our proguard config and avoid unexpected release mode crashes

## Fixes
* Fixes #16625 
 
## Approach

The relevant commits have the details as well but the general approach is like so:

Users may not have correctly configured keystores for release APK
builds so it has to default off

Release builds currently use environment variables for keystore/key
password input, so use same pathway to switch to release testing

Switching to release testing means the 'Debug' gradle tasks completely
disappear and may not be referenced at all, they are replaced by the
'Release' variants, so make the task name dynamic and base it on presence
of the release mode testing environment variable

Some Android test frameworks do not minimize correctly out of the box,
so they need a separate proguard file

### Related items Fixed While There

- I took the opportunity to remove the "clearCaches" logic which I wrote and is now unused since github exposed cache management in web UI
- I bumped the jacoco dependency
- I stopped double-compressing logcat

## How Has This Been Tested?

Very carefully during development, but also I can see it in my local fork now on push, as the emulator test gradle targets are all 'Release' variant

Additionally, the first push of this PR does not include the fix from #16621 so we should reproduce the app crash / class not found error in the logcat and see a CI build failure until I rebase on main

## Learning (optional, can help others)

- you can control the gradle `testBuildType` if you like: https://stackoverflow.com/a/34778780/9910298
- some test frameworks have shrink issues, you can use specific `testProguardFiles` for them https://stackoverflow.com/q/53355600/9910298
- when you switch to release test build type it actually swaps out the whole gradle task set, which makes configuring dependency graphs etc the way we do require dynamic task naming for the antecedent tasks

## Future work

- make it so users can easily run this by putting the test keystore generation into gradle instead of keeping it in the workflow yaml (where it is duplicated now)
- store the APK size somewhere as an artifact for merges to main, for use in size comparisons
- compare the release APK size on PRs with the main APK size and post the information to the PR - so every PR gets the effect of the new 'Compare APK Size' workflow but with no extra build time needed

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
