### PR TITLE
Rename "Cancel" of Media Sync to "Abort"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -366,7 +366,7 @@ suspend fun monitorMediaSync(
             .setPositiveButton(R.string.dialog_continue) { _, _ ->
                 scope.cancel()
             }
-            .setNegativeButton(R.string.dialog_cancel) { _, _ ->
+            .setNegativeButton(TR.syncAbortButton()) { _, _ ->
                 cancelMediaSync(backend)
             }
             .show()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -113,7 +113,7 @@ class SyncMediaWorker(
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = applicationContext.getString(R.string.dialog_cancel)
+        val cancelTitle = CollectionManager.TR.syncAbortButton()
         val notification = buildNotification {
             setContentTitle(title)
             setOngoing(true)
@@ -148,7 +148,7 @@ class SyncMediaWorker(
 
     private fun getProgressNotification(progress: CharSequence): Notification {
         val title = applicationContext.getString(R.string.syncing_media)
-        val cancelTitle = applicationContext.getString(R.string.dialog_cancel)
+        val cancelTitle = CollectionManager.TR.syncAbortButton()
 
         return buildNotification {
             setContentTitle(title)


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description

Change the media sync negative button's label in terms of its role and consistency with Anki Desktop

---
AnkiDroid
<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/00d26e8f-997e-486a-8cb2-aae16f397eb1" width="320px">



<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/d3d40f02-6f5b-4b23-b157-a368fd4fb9bd" width="320px">


_ _ 

<img src="https://github.com/ankidroid/Anki-Android/assets/10436072/5dda8eb4-92fc-4af1-936e-4d223029ec7e" width="320px">

---
Anki Desktop
![image](https://github.com/ankidroid/Anki-Android/assets/10436072/c1e0c839-e9bd-404b-804a-058f6df74555)

![image](https://github.com/ankidroid/Anki-Android/assets/10436072/a9fee2a2-7c75-43ec-80c6-107d180f005c)

## Fixes
* Related: #16631 

## Approach
Reuse Anki Desktop string

## How Has This Been Tested?

Tested on physical device (Android 11)
![image](https://github.com/ankidroid/Anki-Android/assets/10436072/b6acce82-13a3-48fe-a3e9-31c6f84d2228)
![image](https://github.com/ankidroid/Anki-Android/assets/10436072/551cd736-ebc7-472e-9fb1-53c28444483d)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
