### PR TITLE
Switch from hardcoded signing config

### DIFF
--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -24,11 +24,9 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     env:
-      # could be better, '/home/runner' should be '~/' but neither that nor '$HOME' worked
-      STOREFILEDIR: /home/runner/src
-      STOREFILE: android-keystore
-      STOREPASS: testpass
-      KEYPASS: testpass
+      KEYSTORENAME: keystore
+      KEYSTOREPWD: testpass
+      KEYPWD: testpass
       KEYALIAS: nrkeystorealias
     steps:
       - name: Configure JDK
@@ -39,11 +37,9 @@ jobs:
 
       - name: Test Credential Prep
         run: |
-          echo "KSTOREPWD=$STOREPASS" >> $GITHUB_ENV
-          echo "KEYPWD=$KEYPASS" >> $GITHUB_ENV
-          mkdir $STOREFILEDIR
-          cd $STOREFILEDIR
-          echo y | keytool -genkeypair -dname "cn=AnkiDroid, ou=ankidroid, o=AnkiDroid, c=US" -alias $KEYALIAS -keypass $KEYPASS -keystore "$STOREFILE" -storepass $STOREPASS -keyalg RSA -validity 20000
+          export KEYSTOREPATH=$HOME/$KEYSTORENAME
+          echo "KEYSTOREPATH=$KEYSTOREPATH" >> $GITHUB_ENV
+          echo y | keytool -genkeypair -dname "cn=AnkiDroid, ou=ankidroid, o=AnkiDroid, c=US" -alias $KEYALIAS -keypass $KEYPWD -keystore $KEYSTOREPATH -storepass $KEYSTOREPWD -keyalg RSA -validity 20000
         shell: bash
 
       - name: Setup Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,15 +53,17 @@ jobs:
 
       - name: Credential Prep
         run: |
-          echo "KSTOREPWD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
+          export KEYSTOREPATH=$HOME/src/android-keystore
+          echo "KEYSTOREPATH=$KEYSTOREPATH" >> $GITHUB_ENV
+          echo "KEYALIAS=nrkeystorealias" >> $GITHUB_ENV
+          echo "KEYSTOREPWD=${{ secrets.KEYSTORE_PASSWORD }}" >> $GITHUB_ENV
           echo "KEYPWD=${{ secrets.KEYSTORE_KEY_PASSWORD }}" >> $GITHUB_ENV
           mkdir ~/src
           echo "${{ secrets.AMAZON_PUBLISH_CREDENTIALS }}" | base64 -d > ~/src/AnkiDroid-Amazon-Publish-Security-Profile.json.gz
           echo "${{ secrets.GOOGLE_PUBLISH_CREDENTIALS }}" | base64 -d > ~/src/AnkiDroid-GCP-Publish-Credentials.json.gz
           echo "${{ secrets.RELEASES_PUBLISH_TOKEN }}" | base64 -d > ~/src/my-github-personal-access-token.gz
-          echo "${{ secrets.KEYSTORE }}" | base64 -d > ~/src/android-keystore.gz
-          cd ~/src
-          gunzip *gz
+          echo "${{ secrets.KEYSTORE }}" | base64 -d > $KEYSTOREPATH.gz
+          gunzip $KEYSTOREPATH.gz
         shell: bash
 
       - name: Build and Release public release

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -85,9 +85,9 @@ android {
     }
     signingConfigs {
         release {
-            storeFile file("${homePath}/src/android-keystore")
-            keyAlias "nrkeystorealias"
-            storePassword System.getenv("KSTOREPWD")
+            storeFile file(System.getenv("KEYSTOREPATH") ?: "${homePath}/src/android-keystore")
+            storePassword System.getenv("KEYSTOREPWD") ?: System.getenv("KSTOREPWD")
+            keyAlias System.getenv("KEYALIAS") ?: "nrkeystorealias"
             keyPassword System.getenv("KEYPWD")
         }
     }

--- a/tools/check-keystore.sh
+++ b/tools/check-keystore.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ "$KEYSTOREPATH" == "" ]; then
+  read -rsp "Enter keystore path: " KEYSTOREPATH; echo
+  export KEYSTOREPATH
+fi
+
+if [ "$KEYSTOREPWD" == "" ]; then
+  read -rsp "Enter keystore password: " KEYSTOREPWD; echo
+  export KEYSTOREPWD
+fi
+
+if [ "$KEYALIAS" == "" ]; then
+  read -rsp "Enter key alias: " KEYALIAS; echo
+  export KEYALIAS
+fi
+
+if [ "$KEYPWD" == "" ]; then
+  read -rsp "Enter key password: " KEYPWD; echo
+  export KEYPWD
+fi

--- a/tools/local-release.sh
+++ b/tools/local-release.sh
@@ -3,15 +3,11 @@
 # This script assumes a few things -
 #
 # 1) you are in the main directory of the Anki source code (e.g. 'Anki-Android' is the current working directory)
-# 2) you have a Java keystore at the file path $home/src/android-keystore
-# 3) In that java keystore you have the key alias 'nrkeystorealias'
+# 2) you have a Java keystore, with a keystore+key password and key alias
 
 # It will ask you for your keystore and key password
 
-# Read the key passwords
-read -sp "Enter keystore password: " KSTOREPWD; echo
-read -sp "Enter key password: " KEYPWD; echo
-export KSTOREPWD
-export KEYPWD
+. tools/check-keystore.sh
+
 ./gradlew assembleRelease -Duniversal-apk=true
 ./tools/parallel-package-release.sh TEST

--- a/tools/parallel-package-release.sh
+++ b/tools/parallel-package-release.sh
@@ -3,9 +3,8 @@
 # This script assumes a few things -
 #
 # 1) you are in the main directory of the Anki source code (e.g. 'Anki-Android' is the current working directory)
-# 2) you have a Java keystore at the file path $home/src/android-keystore
-# 3) In that java keystore you have the key alias 'nrkeystorealias'
-# 4) you have no local changes in your working directory (e.g. "git reset --hard && git clean -f")
+# 2) you have a Java keystore, with a keystore+key password and key alias
+# 3) you have no local changes in your working directory (e.g. "git reset --hard && git clean -f")
 # If those assumptions are met, this script will generate 3 parallel builds that should be the same as your current checkout
 # They will be placed in the parent directory ('..') as 'AnkiDroid-<version>.parallel.<A B or C>.apk'
 
@@ -18,13 +17,7 @@ if [ "$TAG" == "" ]; then
     exit 1
 fi
 
-# Read the key passwords
-if [ "$KSTOREPWD" == "" ]; then
-  read -sp "Enter keystore password: " KSTOREPWD; echo
-  read -sp "Enter key password: " KEYPWD; echo
-  export KSTOREPWD
-  export KEYPWD
-fi
+. tools/check-keystore.sh
 
 # Get on to the tag requested
 #git checkout $TAG

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -100,13 +100,7 @@ git add $GRADLEFILE $CHANGELOG
 git commit -m "Bumped version to $VERSION"
 git tag v"$VERSION"
 
-# Read the key passwords if needed
-if [ "$KSTOREPWD" == "" ]; then
-  read -rsp "Enter keystore password: " KSTOREPWD; echo
-  read -rsp "Enter key password: " KEYPWD; echo
-  export KSTOREPWD
-  export KEYPWD
-fi
+. tools/check-keystore.sh
 
 # Build signed APK using Gradle and publish to Play.
 # Do this before building universal of the play flavor so the universal is not uploaded to Play Store


### PR DESCRIPTION
## Purpose / Description
Keystore variables are (partially) hardcoded right now. It is better if we switch to using environment variables for all of it.
Makes easier for devs to source their signing keys in the way they wish (e.g., custom keystore path, key alias).

## Fixes
N/A

## Approach
Use environment variables for all of signingConfig in build.gradle. Change relevant workflows and scripts to adapt.

## How Has This Been Tested?
tools/local-release.sh ran locally (until my laptop turned into a jet, then I settled with ./gradlew assemblePlayRelease)
I have adapted most of the things to match build.gradle, but not sure if e.g. the publish workflow still functions as it should after these changes. Needs to be tested.

## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
