### PR TITLE
Fix adding a notetype when using the name of a standard notetype

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -47,7 +47,7 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
     private lateinit var dialogView: View
     suspend fun showAddNewNotetypeDialog() {
         dialogView = LayoutInflater.from(activity).inflate(R.layout.dialog_new_note_type, null)
-        val optionsToDisplay = activity.withProgress {
+        val (allOptions, currentNames) = activity.withProgress {
             withCol {
                 val standardNotetypesModels = StockNotetype.Kind.entries
                     .filter { it != StockNotetype.Kind.UNRECOGNIZED }
@@ -59,10 +59,14 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
                             isStandard = true
                         )
                     }
-                mutableListOf<NotetypeBasicUiModel>().apply {
-                    addAll(standardNotetypesModels)
-                    addAll(getNotetypeNames().map { it.toUiModel() })
-                }
+                val foundNotetypes = getNotetypeNames()
+                Pair(
+                    mutableListOf<NotetypeBasicUiModel>().apply {
+                        addAll(standardNotetypesModels)
+                        addAll(foundNotetypes.map { it.toUiModel() })
+                    },
+                    foundNotetypes.map { it.name }
+                )
             }
         }
         val dialog = AlertDialog.Builder(activity).apply {
@@ -73,7 +77,7 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
                 val selectedPosition =
                     dialogView.findViewById<Spinner>(R.id.notetype_new_type).selectedItemPosition
                 if (selectedPosition == AdapterView.INVALID_POSITION) return@positiveButton
-                val selectedOption = optionsToDisplay[selectedPosition]
+                val selectedOption = allOptions[selectedPosition]
                 if (selectedOption.isStandard) {
                     addStandardNotetype(newName, selectedOption)
                 } else {
@@ -82,17 +86,20 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
             }
             negativeButton(R.string.dialog_cancel)
         }.show()
-        dialog.initializeViewsWith(optionsToDisplay)
+        dialog.initializeViewsWith(allOptions, currentNames)
     }
 
-    private fun AlertDialog.initializeViewsWith(optionsToDisplay: List<NotetypeBasicUiModel>) {
+    private fun AlertDialog.initializeViewsWith(
+        optionsToDisplay: List<NotetypeBasicUiModel>,
+        currentNames: List<String>
+    ) {
         val addPrefixStr = context.resources.getString(R.string.model_browser_add_add)
         val clonePrefixStr = context.resources.getString(R.string.model_browser_add_clone)
         val nameInput = dialogView.findViewById<EditText>(R.id.notetype_new_name)
         nameInput.addTextChangedListener { editableText ->
             val currentName = editableText?.toString() ?: ""
             positiveButton.isEnabled =
-                currentName.isNotEmpty() && !optionsToDisplay.map { it.name }.contains(currentName)
+                currentName.isNotEmpty() && !currentNames.contains(currentName)
         }
         dialogView.findViewById<Spinner>(R.id.notetype_new_type).apply {
             onItemSelectedListener = object : AdapterView.OnItemSelectedListener {


### PR DESCRIPTION
## Purpose / Description

The previous code verified the name entered by the user against all notetpes names, existing names + names of the standard notetypes. Changed to check only against existing notetype names.

## Fixes
* Fixes #15643

## How Has This Been Tested?

Tried to add a notetype with a standard name(after deleting that notetype).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
