### PR TITLE
test: fixup warning message when no coverage of type is found

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -190,7 +190,7 @@ tasks.register('assertNonzeroAndroidTestCoverage') {
                 continue;
 
             if (child.attribute("covered") == "0") {
-                logger.warn("jacoco registered zero code coverage for counter type %s", child.attribute("type"))
+                logger.warn("jacoco registered zero code coverage for counter type " + child.attribute("type"), null)
             } else {
                 hasCovered = true
             }


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description

The new zero coverage assertion added in #16643 tries to warn you if there is zero coverage of a certain type

But, it doesn't look like string format works in logger.warn, use concat

## How Has This Been Tested?

Saw this when trying to carry all this coverage work over to react-native-firebase and wanted to cross-pollinate the fix here

## Learning (optional, can help others)

Even the tests you run on your tests need tests

Turtles all the way down

