### PR TITLE
No Flag Icon not showing on light theme, Fixed #16622

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -33,7 +33,7 @@ enum class Flag(
     @DrawableRes val drawableRes: Int,
     @ColorRes val browserColorRes: Int?
 ) {
-    NONE(0, R.id.flag_none, R.drawable.ic_flag_transparent, null),
+    NONE(0, R.id.flag_none, R.drawable.ic_flag_lightgrey, null),
     RED(1, R.id.flag_red, R.drawable.ic_flag_red, R.color.flag_red),
     ORANGE(2, R.id.flag_orange, R.drawable.ic_flag_orange, R.color.flag_orange),
     GREEN(3, R.id.flag_green, R.drawable.ic_flag_green, R.color.flag_green),

--- a/AnkiDroid/src/main/res/drawable/ic_flag_lightgrey.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_lightgrey.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="@color/material_grey_600">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
+      android:fillColor="#00000000"
+      android:strokeColor="#FFFFFF"/>
+</vector>


### PR DESCRIPTION
Fixes #16622 

**No Flag Icon not showing on light theme**

I have changed the icon color to light grey.

<img src="https://github.com/ankidroid/Anki-Android/assets/82767208/783d1eff-96f7-4c61-8e64-225d5533a588" alt="dark" width="200"/>

<img src="https://github.com/ankidroid/Anki-Android/assets/82767208/52470ef0-369c-4d80-b35d-2271ee535cfd" alt="light" width="200"/>
