### PR TITLE
fix(tests): allow update to espresso 3.6.1

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 
 import android.annotation.SuppressLint
 import androidx.recyclerview.widget.RecyclerView
+import androidx.test.espresso.Espresso.closeSoftKeyboard
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.Espresso.pressBack
 import androidx.test.espresso.action.ViewActions.*


### PR DESCRIPTION
`ViewActions.closeSoftKeyboard` became `@CheckResult`

`androidx.test.espresso.Espresso.closeSoftKeyboard` is not

## Fixes
* Unblocks #16657

## How Has This Been Tested?
Checked out 16657 and applied the patch. No red underline in the IDE 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
