### PR TITLE
tests: reduce log spam in `ChangeManager`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
@@ -85,9 +85,9 @@ object ChangeManager {
         }
     }
 
-    @VisibleForTesting
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun clearSubscribers() {
-        Timber.d("clearing %d subscribers", subscribers.size)
+        subscribers.size.ifNotZero { size -> Timber.d("clearing %d subscribers", size) }
         subscribers.clear()
     }
 


### PR DESCRIPTION
No point in logging a no-op in `@Before`

removes log: `D/ChangeManager: clearing 0 subscribers`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
