### PR TITLE
Fix: Autoplay audio on card previews only when setting is enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -166,6 +166,13 @@ class CardMediaPlayer : Closeable {
         }
     }
 
+    suspend fun autoplayAllSoundsForSide(cardSide: CardSide): Job? {
+        if (config.autoplay) {
+            return playAllSoundsForSide(cardSide)
+        }
+        return null
+    }
+
     suspend fun playAllSoundsForSide(cardSide: CardSide): Job? {
         if (!isEnabled) return null
         playSoundsJob {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -104,10 +104,10 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
             backSideOnly.emit(!backSideOnly.value)
             if (!backSideOnly.value && showingAnswer.value) {
                 showQuestion()
-                cardMediaPlayer.playAllSoundsForSide(CardSide.QUESTION)
+                cardMediaPlayer.autoplayAllSoundsForSide(CardSide.QUESTION)
             } else if (backSideOnly.value && !showingAnswer.value) {
                 showAnswerInternal()
-                cardMediaPlayer.playAllSoundsForSide(CardSide.ANSWER)
+                cardMediaPlayer.autoplayAllSoundsForSide(CardSide.ANSWER)
             }
         }
     }
@@ -147,7 +147,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
         launchCatchingIO {
             if (!showingAnswer.value && !backSideOnly.value) {
                 showAnswerInternal()
-                cardMediaPlayer.playAllSoundsForSide(CardSide.ANSWER)
+                cardMediaPlayer.autoplayAllSoundsForSide(CardSide.ANSWER)
             } else {
                 currentIndex.update { it + 1 }
             }
@@ -227,7 +227,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
             else -> CardSide.QUESTION
         }
         cardMediaPlayer.loadCardSounds(currentCard.await())
-        cardMediaPlayer.playAllSoundsForSide(side)
+        cardMediaPlayer.autoplayAllSoundsForSide(side)
     }
 
     /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L671) */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -178,7 +178,7 @@ class TemplatePreviewerViewModel(
 
     private suspend fun loadAndPlaySounds(side: CardSide) {
         cardMediaPlayer.loadCardSounds(currentCard.await())
-        cardMediaPlayer.playAllSoundsForSide(side)
+        cardMediaPlayer.autoplayAllSoundsForSide(side)
     }
 
     // https://github.com/ankitects/anki/blob/df70564079f53e587dc44f015c503fdf6a70924f/qt/aqt/clayout.py#L579


### PR DESCRIPTION
## Purpose / Description

Video demonstration of the card preview only auto playing the audio when the setting is on:
[preview_audio_autoplay_fix.webm](https://github.com/ankidroid/Anki-Android/assets/28263886/c31d166a-06a7-4a93-a4c8-e7197e904d5b)

## Fixes
* Fixes #16519



