### PR TITLE
Update top bar setting description

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -149,7 +149,7 @@
     <string name="show_large_answer_buttons" maxLength="41">Show large answer buttons</string>
     <string name="show_large_answer_buttons_summ">Show answer button in 2 rows</string>
     <string name="show_top_bar" maxLength="41">Show top bar</string>
-    <string name="show_top_bar_summ">Show card counts, flag and mark in top bar</string>
+    <string name="show_top_bar_summary">Show card counts, answer timer, flag and mark in top bar</string>
     <string name="show_progress" maxLength="41">Show remaining</string>
     <string name="show_progress_summ">Show remaining card count</string>
     <string name="show_eta" maxLength="41">Show ETA</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -98,7 +98,7 @@
         <SwitchPreferenceCompat
             android:key="@string/show_topbar_preference"
             android:defaultValue="true"
-            android:summary="@string/show_top_bar_summ"
+            android:summary="@string/show_top_bar_summary"
             android:title="@string/show_top_bar" />
         <SwitchPreferenceCompat
             android:key="@string/show_progress_preference"


### PR DESCRIPTION
## Purpose / Description
Update the description of the "Show top bar" setting to include a mention of the answer timer. This change clarifies that the answer timer will be displayed when the top bar is enabled, addressing user confusion about the functionality.

## Fixes
* Fixes #16698

## Approach
Modified the string resource for the "Show top bar" setting to mention the answer timer explicitly.

## How Has This Been Tested?
Realme 6 and Emulator

## Screenshot
![photo_2024-07-08_02-55-40](https://github.com/ankidroid/Anki-Android/assets/91668590/3134b936-2d5a-4054-9f29-5ef85c745539)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
