### PR TITLE
Fixed keyboard done button during creation or renaming of deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.app.Activity
 import android.content.Context
+import android.view.inputmethod.EditorInfo
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
@@ -90,6 +91,16 @@ class CreateDeckDialog(
             negativeButton(R.string.dialog_cancel)
             setView(R.layout.dialog_generic_text_input)
         }.input(prefill = initialDeckName, displayKeyboard = true, waitForPositiveButton = false) { dialog, text ->
+            // defining the action of done button in keyboard
+            val inputField = dialog.getInputField()
+            inputField.setOnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    onPositiveButtonClicked()
+                    true
+                } else {
+                    false
+                }
+            }
             // we need the fully-qualified name for subdecks
             val maybeDeckName = fullyQualifyDeckName(dialogText = text)
             // if the name is empty, it seems distracting to show an error
@@ -220,6 +231,7 @@ class CreateDeckDialog(
                 displayFeedback(e.localizedMessage ?: e.message ?: "", Snackbar.LENGTH_LONG)
             }
         }
+        shownDialog?.dismiss()
     }
 
     private fun displayFeedback(message: String, duration: Int = Snackbar.LENGTH_SHORT) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -158,6 +158,7 @@ class CreateDeckDialog(
             Timber.d("CreateDeckDialog::createDeck - Not creating invalid deck name '%s'", deckName)
             displayFeedback(context.getString(R.string.invalid_deck_name), Snackbar.LENGTH_LONG)
         }
+        // AlertDialog should be dismissed after the Keyboard 'Done' or Deck 'Ok' button is pressed
         shownDialog?.dismiss()
     }
 
@@ -231,6 +232,7 @@ class CreateDeckDialog(
                 displayFeedback(e.localizedMessage ?: e.message ?: "", Snackbar.LENGTH_LONG)
             }
         }
+        // AlertDialog should be dismissed after the Keyboard 'Done' or Deck 'Ok' button is pressed
         shownDialog?.dismiss()
     }
 

--- a/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
@@ -18,6 +18,7 @@
 <com.google.android.material.textfield.TextInputLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/dialog_text_input_layout"
+    android:imeOptions="actionDone"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_margin="@dimen/content_vertical_padding"
@@ -32,5 +33,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:drawablePadding="8dp"
+        android:singleLine="true"
+        android:maxLines="1"
         />
 </com.google.android.material.textfield.TextInputLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->


## Purpose / Description
Pressing ImeAction button on keyboard during Deck Creation resulted in new line in TextField



## Fixes issue #16690

Defining a Done button click listener from the keyboard inside the input callback of the AlertDialog fixed this issue

## How Has This Been Tested?
on android 14 samsung f23 physical device

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

https://github.com/ankidroid/Anki-Android/assets/116078997/5d330151-1756-425f-8c0e-e08883762df9


