### PR TITLE
NF: Improve typing of `findViewById`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -13,11 +13,16 @@ import android.media.AudioManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.view.*
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.view.Window
+import android.view.WindowManager
 import android.view.animation.Animation
 import android.widget.ProgressBar
 import androidx.activity.result.ActivityResultLauncher
 import androidx.annotation.AttrRes
+import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.annotation.StringRes
 import androidx.annotation.UiThread
@@ -27,7 +32,9 @@ import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.browser.customtabs.CustomTabColorSchemeParams
-import androidx.browser.customtabs.CustomTabsIntent.*
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_DARK
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_LIGHT
+import androidx.browser.customtabs.CustomTabsIntent.COLOR_SCHEME_SYSTEM
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import androidx.fragment.app.DialogFragment
@@ -36,7 +43,8 @@ import androidx.fragment.app.FragmentManager
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
-import com.ichi2.anim.ActivityTransitionAnimation.Direction.*
+import com.ichi2.anim.ActivityTransitionAnimation.Direction.DEFAULT
+import com.ichi2.anim.ActivityTransitionAnimation.Direction.NONE
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.DialogHandler
@@ -48,6 +56,7 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
 import com.ichi2.async.CollectionLoader
+import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
 import com.ichi2.compat.customtabs.CustomTabsFallback
 import com.ichi2.compat.customtabs.CustomTabsHelper
@@ -298,6 +307,21 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener {
         deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         startActivity(deckPicker)
     }
+
+    // Not overridden because Activity.requireViewById is final.
+    // Delete this implementation and replace all call by `RequireViewById` once minimal version is 28.
+    /**
+     * @return the view with [id].
+     * @throws IllegalArgumentException if no view with such id exists.
+     * @see Activity.requireViewById
+     */
+    fun <T : View> requireViewByID(@IdRes id: Int): T = CompatHelper.compat.requireViewById(this, id)
+
+    /**
+     * Same as [Activity.findViewById] but ensures the typer considers the result as nullable.
+     * @return the view with [id] or `null`.
+     */
+    fun <T : View> findViewByID(@IdRes id: Int): T? = findViewById(id)
 
     fun showProgressBar() {
         val progressBar = findViewById<ProgressBar>(R.id.progress_bar)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -127,6 +127,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
+import com.ichi2.compat.requireViewByID
 import com.ichi2.libanki.*
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.DeckNode
@@ -234,7 +235,7 @@ open class DeckPicker :
         }
     }
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        anchorView = findViewById<FloatingActionButton>(R.id.fab_main)
+        anchorView = requireViewByID<FloatingActionButton>(R.id.fab_main)
         addCallback(activeSnackbarCallback)
     }
 
@@ -439,10 +440,10 @@ open class DeckPicker :
 
         setContentView(R.layout.homescreen)
         handleStartup()
-        val mainView = findViewById<View>(android.R.id.content)
+        val mainView = requireViewByID<View>(android.R.id.content)
 
         // check, if tablet layout
-        studyoptionsFrame = findViewById(R.id.studyoptions_fragment)
+        studyoptionsFrame = findViewByID(R.id.studyoptions_fragment)
         // set protected variable from NavigationDrawerActivity
         fragmented = studyoptionsFrame != null && studyoptionsFrame!!.visibility == View.VISIBLE
 
@@ -456,9 +457,9 @@ open class DeckPicker :
         initNavigationDrawer(mainView)
         title = resources.getString(R.string.app_name)
 
-        deckPickerContent = findViewById(R.id.deck_picker_content)
-        recyclerView = findViewById(R.id.files)
-        noDecksPlaceholder = findViewById(R.id.no_decks_placeholder)
+        deckPickerContent = requireViewByID(R.id.deck_picker_content)
+        recyclerView = requireViewByID(R.id.files)
+        noDecksPlaceholder = requireViewByID(R.id.no_decks_placeholder)
 
         deckPickerContent.visibility = View.GONE
         noDecksPlaceholder.visibility = View.GONE
@@ -474,7 +475,7 @@ open class DeckPicker :
         recyclerView.addItemDecoration(dividerDecorator)
 
         // Add background to Deckpicker activity
-        val view = if (fragmented) findViewById(R.id.deckpicker_xl_view) else findViewById<View>(R.id.root_layout)
+        val view = if (fragmented) requireViewByID(R.id.deckpicker_xl_view) else requireViewByID<View>(R.id.root_layout)
 
         var hasDeckPickerBackground = false
         try {
@@ -498,7 +499,7 @@ open class DeckPicker :
         }
         recyclerView.adapter = deckListAdapter
 
-        pullToSyncWrapper = findViewById<SwipeRefreshLayout?>(R.id.pull_to_sync_wrapper).apply {
+        pullToSyncWrapper = requireViewByID<SwipeRefreshLayout>(R.id.pull_to_sync_wrapper).apply {
             setDistanceToTriggerSync(SWIPE_TO_SYNC_TRIGGER_DISTANCE)
             setOnRefreshListener {
                 Timber.i("Pull to Sync: Syncing")
@@ -512,7 +513,7 @@ open class DeckPicker :
         // Setup the FloatingActionButtons, should work everywhere with min API >= 15
         floatingActionMenu = DeckPickerFloatingActionMenu(this, view, this)
 
-        reviewSummaryTextView = findViewById(R.id.today_stats_text_view)
+        reviewSummaryTextView = requireViewByID(R.id.today_stats_text_view)
 
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
@@ -744,7 +745,7 @@ open class DeckPicker :
     // throws doesn't seem to be checked by the compiler - consider it to be documentation
     @Throws(OutOfMemoryError::class)
     private fun applyDeckPickerBackground(): Boolean {
-        val backgroundView = findViewById<ImageView>(R.id.background)
+        val backgroundView = requireViewByID<ImageView>(R.id.background)
         // Allow the user to clear data and get back to a good state if they provide an invalid background.
         if (!this.sharedPrefs().getBoolean("deckPickerBackground", false)) {
             Timber.d("No DeckPicker background preference")
@@ -809,7 +810,7 @@ open class DeckPicker :
 
         val syncItem = menu.findItem(R.id.action_sync)
         val progressIndicator = syncItem.actionView
-            ?.findViewById<LinearProgressIndicator>(R.id.progress_indicator)
+            ?.requireViewByID<LinearProgressIndicator>(R.id.progress_indicator)
 
         val workManager = WorkManager.getInstance(this)
         val flow = workManager.getWorkInfosForUniqueWorkFlow(UniqueWorkNames.SYNC_MEDIA)
@@ -872,10 +873,10 @@ open class DeckPicker :
                     .also { cachedMigrationProgressMenuItemActionView = it }
 
                 val progressIndicator = actionView
-                    .findViewById<CircularProgressIndicator>(R.id.progress_indicator)
+                    .requireViewByID<CircularProgressIndicator>(R.id.progress_indicator)
                     .apply { max = Int.MAX_VALUE }
 
-                actionView.findViewById<ImageButton>(R.id.button).also { button ->
+                actionView.requireViewByID<ImageButton>(R.id.button).also { button ->
                     button.setOnClickListener { warnNoSyncDuringMigration() }
                     TooltipCompat.setTooltipText(button, getText(R.string.show_migration_progress))
                 }
@@ -1579,7 +1580,7 @@ open class DeckPicker :
         text: CharSequence,
         duration: Int = Snackbar.LENGTH_LONG
     ) {
-        val view: View? = findViewById(R.id.root_layout)
+        val view: View? = findViewByID(R.id.root_layout)
         if (view != null) {
             view.post {
                 showSnackbar(text, duration)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -30,6 +30,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.CheckResult
+import androidx.annotation.IdRes
+import com.ichi2.anki.AnkiActivity
 import java.io.*
 import java.util.*
 
@@ -77,6 +79,12 @@ interface Compat {
     fun resolveActivity(packageManager: PackageManager, intent: Intent, flags: ResolveInfoFlagsCompat): ResolveInfo?
     fun resolveService(packageManager: PackageManager, intent: Intent, flags: ResolveInfoFlagsCompat): ResolveInfo?
     fun queryIntentActivities(packageManager: PackageManager, intent: Intent, flags: ResolveInfoFlagsCompat): List<ResolveInfo>
+
+    /** @see AnkiActivity.requireViewById*/
+    fun <T : View> requireViewById(activity: AnkiActivity, @IdRes id: Int): T
+
+    /** @see View.requireViewById*/
+    fun <T : View> requireViewById(view: View, @IdRes id: Int): T
 
     /**
      * Retrieve extended data from the intent.
@@ -223,3 +231,14 @@ interface Compat {
     @Suppress("PropertyName")
     val AXIS_GESTURE_SCROLL_Y_DISTANCE: Int
 }
+
+// Delete this method when min SDK is 28. Then, use `requireViewById` instead.
+/**
+ * @see View.requireViewById
+ */
+fun <T : View> View.requireViewByID(@IdRes id: Int) = CompatHelper.compat.requireViewById<T>(this, id)
+
+/**
+ * @see View.findViewById The return value is considered as nullable by the type-checker.
+ */
+fun <T : View> View.findViewByID(@IdRes id: Int): T? = findViewById(id)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
@@ -30,7 +30,9 @@ import android.os.Environment
 import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
+import androidx.annotation.IdRes
 import androidx.appcompat.widget.TooltipCompat
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
@@ -223,6 +225,20 @@ open class CompatV23 : Compat {
         flags: ResolveInfoFlagsCompat
     ): List<ResolveInfo> {
         return packageManager.queryIntentActivities(intent, flags.value.toInt())
+    }
+
+    // Until API 27. Also delete `AnkiActivity.requireViewById` when deleting this implementation.
+    override fun <T : View> requireViewById(activity: AnkiActivity, @IdRes id: Int): T {
+        val view = activity.findViewById<T>(id)
+            ?: throw IllegalArgumentException("ID does not reference a View inside this Activity")
+        return view
+    }
+
+    // Until API 27. Also delete `View.requireViewById` when deleting this implementation.
+    override fun <T : View> requireViewById(view: View, @IdRes id: Int): T {
+        val view = view.findViewById<T>(id)
+            ?: throw IllegalArgumentException("ID does not reference a View inside this Activity")
+        return view
     }
 
     // Until API 33

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.kt
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.compat
+
+import android.annotation.TargetApi
+import android.view.View
+import androidx.annotation.IdRes
+import com.ichi2.anki.AnkiActivity
+
+@TargetApi(28)
+open class CompatV28 : CompatV26(), Compat {
+    override fun <T : View> requireViewById(activity: AnkiActivity, @IdRes id: Int): T = activity.requireViewById(id)
+    override fun <T : View> requireViewById(view: View, @IdRes id: Int): T = view.requireViewById(id)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -30,7 +30,7 @@ import java.io.IOException
 
 /** Implementation of [Compat] for SDK level 29  */
 @TargetApi(29)
-open class CompatV29 : CompatV26(), Compat {
+open class CompatV29 : CompatV28(), Compat {
     override fun hasVideoThumbnail(path: String): Boolean? {
         return try {
             ThumbnailUtils.createVideoThumbnail(File(path), THUMBNAIL_MINI_KIND, null)


### PR DESCRIPTION
`findViewById`, being java code without `@Nullable` or `@NotNull` annotation, returns a value that we sometime consider nullable and sometime not null. The type checker does not help here.

In API 28 we have `requireViewById` that returns a non null value. We can't directly use it, but we can copy its definition into `requireViewByID` and use it. If one day min sdk becomes 28, a search/replace will allow us to use directly `requireViewById`.

This PR introduce the method and give an example of its usage.

Created to start fixing Bug #16708.