### PR TITLE
fix(broadcast-receivers): specify export behavior (API 34)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -44,6 +44,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.children
@@ -82,6 +83,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.OnlyOnce.Method.ANSWER_CARD
 import com.ichi2.anki.utils.OnlyOnce.preventSimultaneousExecutions
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat
 import com.ichi2.compat.ResolveInfoFlagsCompat
 import com.ichi2.libanki.*
@@ -757,7 +759,7 @@ abstract class AbstractFlashcardViewer :
             }
             val iFilter = IntentFilter()
             iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-            registerReceiver(unmountReceiver, iFilter)
+            registerReceiverCompat(unmountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -34,6 +34,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
@@ -91,6 +92,7 @@ import com.ichi2.anki.utils.roundedTimeSpanUnformatted
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.TimeManager
@@ -2096,7 +2098,7 @@ open class CardBrowser :
             }
             val iFilter = IntentFilter()
             iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-            registerReceiver(unmountReceiver, iFilter)
+            registerReceiverCompat(unmountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -47,6 +47,7 @@ import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
@@ -126,6 +127,7 @@ import com.ichi2.anki.worker.UniqueWorkNames
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.*
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.libanki.*
 import com.ichi2.libanki.exception.ConfirmModSchemaException
@@ -1892,7 +1894,7 @@ open class DeckPicker :
             val iFilter = IntentFilter()
             iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
             iFilter.addAction(SdCardReceiver.MEDIA_MOUNT)
-            registerReceiver(unmountReceiver, iFilter)
+            registerReceiverCompat(unmountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -47,6 +47,7 @@ import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.core.content.edit
@@ -98,6 +99,7 @@ import com.ichi2.anki.utils.getTimestamp
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.libanki.*
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks.Companion.CURRENT_DECK
@@ -1354,7 +1356,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
             }
             val iFilter = IntentFilter()
             iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-            registerReceiver(unmountReceiver, iFilter)
+            registerReceiverCompat(unmountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -31,11 +31,13 @@ import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.create
 import timber.log.Timber
@@ -151,7 +153,11 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
         }
         // Register broadcast receiver for download completion.
         Timber.d("Registering broadcast receiver for download completion")
-        activity?.registerReceiver(onComplete, IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE))
+        activity?.registerReceiverCompat(
+            onComplete,
+            IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED
+        )
 
         val currentFileName = URLUtil.guessFileName(
             fileToBeDownloaded.url,

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -15,9 +15,11 @@
  ****************************************************************************************/
 package com.ichi2.compat
 
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.Intent.CATEGORY_DEFAULT
+import android.content.IntentFilter
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.PackageManager.NameNotFoundException
@@ -26,6 +28,7 @@ import android.os.Build
 import android.os.Bundle
 import android.view.KeyCharacterMap.deviceHasKey
 import android.view.KeyEvent.*
+import androidx.core.content.ContextCompat
 import com.ichi2.compat.CompatHelper.Companion.compat
 import java.io.Serializable
 
@@ -164,5 +167,30 @@ class CompatHelper private constructor() {
         fun PackageManager.resolveActivityCompat(intent: Intent, flags: ResolveInfoFlagsCompat = ResolveInfoFlagsCompat.EMPTY): ResolveInfo? {
             return compat.resolveActivity(this, intent, flags)
         }
+
+        /**
+         * Register a broadcast receiver.
+         *
+         * @receiver Context to retrieve service from.
+         *
+         * @param receiver The BroadcastReceiver to handle the broadcast.
+         * @param filter Selects the Intent broadcasts to be received.
+         * @param flags – If this receiver is listening for broadcasts sent from other apps—even other
+         * apps that you own—use the [ContextCompat.RECEIVER_EXPORTED] flag.
+         *
+         * If instead this receiver is listening only for broadcasts sent by your app, or from the system,
+         * use the [ContextCompat.RECEIVER_NOT_EXPORTED] flag.
+         *
+         * @return The first sticky intent found that matches filter, or null if there are none.
+         *
+         * @see ContextCompat.registerReceiver
+         * @see Context.registerReceiver
+         */
+        fun Context.registerReceiverCompat(
+            receiver: BroadcastReceiver?,
+            filter: IntentFilter,
+            @ContextCompat.RegisterReceiverFlags flags: Int
+        ) =
+            ContextCompat.registerReceiver(this, receiver, filter, flags)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -28,9 +28,11 @@ import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.appcompat.widget.Toolbar
+import androidx.core.content.ContextCompat
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Deck
 import com.ichi2.utils.*
@@ -285,7 +287,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
         }
         val iFilter = IntentFilter()
         iFilter.addAction(SdCardReceiver.MEDIA_EJECT)
-        registerReceiver(unmountReceiver, iFilter)
+        registerReceiverCompat(unmountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
     }
 
     protected abstract fun closeWithResult()

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -25,6 +25,7 @@ import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
@@ -32,6 +33,7 @@ import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import kotlin.math.sqrt
@@ -120,7 +122,7 @@ class AnkiDroidWidgetSmall : AppWidgetProvider() {
                     val iFilter = IntentFilter()
                     iFilter.addAction(Intent.ACTION_MEDIA_MOUNTED)
                     iFilter.addDataScheme("file")
-                    AnkiDroidApp.instance.registerReceiver(mMountReceiver, iFilter)
+                    AnkiDroidApp.instance.registerReceiverCompat(mMountReceiver, iFilter, ContextCompat.RECEIVER_EXPORTED)
                 }
             } else {
                 // If we do not have a cached version, always update.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 compileSdk = "34"
 minSdk = "23"  # also in testlib/build.gradle.kts
-targetSdk = "33"  # also in  ../robolectricDownloader.gradle
+targetSdk = "34"  # also in  ../robolectricDownloader.gradle
 acra = '5.11.3'
 amazonappstorepublisher = "0.1.0"
 androidGradlePlugin = "8.5.0"


### PR DESCRIPTION
## Purpose / Description
In API 34, `registerReceiver` needs to either accept `RECEIVER_EXPORTED` or `RECEIVER_NOT_EXPORTED`,
otherwise an exception is thrown

## Fixes
* Fixes #16713
* Fixed #16711

## Approach
So, introduce `Context.registerReceiverCompat` to avoid code churn, and use it

## How Has This Been Tested?
I opened AnkiDroid using `targetSdk 34`. It opened, I then tried to download a deck and it seemed to work


## Learning (optional, can help others)

https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported
## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
