### PR TITLE
Remove unused calls to updateValuesForDeck()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2278,7 +2278,6 @@ open class DeckPicker :
                     Timber.d("rebuildFiltered: doInBackground - RebuildCram")
                     decks.select(did)
                     sched.rebuildDyn(decks.selected())
-                    updateValuesFromDeck()
                 }
             }
             updateDeckList()
@@ -2293,7 +2292,6 @@ open class DeckPicker :
                 withCol {
                     Timber.d("doInBackgroundEmptyCram")
                     sched.emptyDyn(decks.selected())
-                    updateValuesFromDeck()
                 }
             }
             updateDeckList()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CreateCustomStudySessionListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CreateCustomStudySessionListener.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.dialogs.customstudy
 
 import com.ichi2.anki.CollectionManager
-import com.ichi2.async.updateValuesFromDeck
 import timber.log.Timber
 
 class CreateCustomStudySessionListener(val callback: Callback) {
@@ -42,7 +41,6 @@ suspend fun rebuildCram(listener: CreateCustomStudySessionListener) {
     CollectionManager.withCol {
         Timber.d("doInBackground - rebuildCram()")
         sched.rebuildDyn(decks.selected())
-        updateValuesFromDeck()
     }
     listener.onPostExecute()
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR removes some call to _updateValuesFromDeck_ which in my opinion are useless. The method doesn't seem to produce side effects as it just queries the scheduler for counts and makes two queries on the database. At the use site the value returned by the method call isn't used at all.

Removing these calls would be helpful for fixing #14793 and also makes the app slightly faster by removing those database queries for certain actions. 

## How Has This Been Tested?

Ran the app and tested the options where the change occurred, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
