### PR TITLE
Document the reason for dynamic shortcuts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -437,6 +437,13 @@ abstract class NavigationDrawerActivity :
 
         const val EXTRA_STARTED_WITH_SHORTCUT = "com.ichi2.anki.StartedWithShortcut"
 
+        // The main reason to use dynamic shortcut is that it ensures that they are only available when permission is granted to access the collection.
+        // Even if we were going to ensure that all shortcut can deal nicely with missing permission, we probably would still need to use dynamic shortcuts because:
+        // * this ensure we don't offer shortcut until we have permission to access the collection
+        // * to use static shortcut, the package name must be given in res/shortcuts.xml. See https://developer.android.com/develop/ui/views/launch/shortcuts/creating-shortcuts#static
+        // * AnkiDroid package name is not constant. For example in debug variant, it is com.ichi2.anki.debug
+        // * having variables in shortcuts used to be doable with https://plugins.gradle.org/plugin/de.timfreiheit.resourceplaceholders, however
+        // * after manually testing it, and looking at open issue https://github.com/timfreiheit/ResourcePlaceholdersPlugin/issues/13 , it seems this was broken with recent version of gradle
         fun enablePostShortcut(context: Context) {
             if (!IntentHandler.grantedStoragePermissions(context, showToast = false)) {
                 Timber.w("No storage access, not enabling shortcuts")


### PR DESCRIPTION
I was very surprised to see we used dynamic and not static one. I tried to transform them into static shortcut, which seems cleaner. And realized that we can't for a very absurd technical reason.

So I document it here, hoping nobody else will lose time on it.