### PR TITLE
NF: NoteEditor onKeyUp return true

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -788,6 +788,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
     @KotlinCleanup("convert KeyUtils to extension functions")
     override fun onKeyUp(keyCode: Int, event: KeyEvent): Boolean {
         if (toolbar.onKeyUp(keyCode, event)) {
+            // Toolbar was able to handle this key event. No need to handle it in NoteEditor too.
             return true
         }
         when (keyCode) {
@@ -795,20 +796,25 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                 // disable it in case of image occlusion
                 if (allowSaveAndPreview()) {
                     launchCatchingTask { saveNote() }
+                    return true
                 }
             }
             KeyEvent.KEYCODE_D -> // null check in case Spinner is moved into options menu in the future
                 if (event.isCtrlPressed) {
                     launchCatchingTask { deckSpinnerSelection!!.displayDeckSelectionDialog() }
+                    return true
                 }
             KeyEvent.KEYCODE_L -> if (event.isCtrlPressed) {
                 showCardTemplateEditor()
+                return true
             }
             KeyEvent.KEYCODE_N -> if (event.isCtrlPressed && noteTypeSpinner != null) {
                 noteTypeSpinner!!.performClick()
+                return true
             }
             KeyEvent.KEYCODE_T -> if (event.isCtrlPressed && event.isShiftPressed) {
                 showTagsDialog()
+                return true
             }
             KeyEvent.KEYCODE_C -> {
                 if (event.isCtrlPressed && event.isShiftPressed) {
@@ -817,6 +823,7 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     if (!isClozeType) {
                         showSnackbar(R.string.note_editor_insert_cloze_no_cloze_note_type)
                     }
+                    return true
                 }
             }
             KeyEvent.KEYCODE_P -> {
@@ -824,19 +831,20 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
                     Timber.i("Ctrl+P: Preview Pressed")
                     if (allowSaveAndPreview()) {
                         launchCatchingTask { performPreview() }
+                        return true
                     }
                 }
             }
-            else -> {}
         }
 
         // 7573: Ctrl+Shift+[Num] to select a field
         if (event.isCtrlPressed && event.isShiftPressed) {
-            // map: '0' -> 9; '1' to 0
-            KeyUtils.getDigit(event)?.let { digit ->
-                val indexBase10 = ((digit - 1) % 10 + 10) % 10
-                selectFieldIndex(indexBase10)
-            }
+            val digit = KeyUtils.getDigit(event) ?: return super.onKeyUp(keyCode, event)
+            // '0' is after '9' on the keyboard, so a user expects '10'
+            val humanReadableDigit = if (digit == 0) 10 else digit
+            // Subtract 1 to map to field index. '1' is the first field (index 0)
+            selectFieldIndex(humanReadableDigit - 1)
+            return true
         }
         return super.onKeyUp(keyCode, event)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/KeyUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/KeyUtilsTest.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2024 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import android.view.KeyEvent
+import android.view.KeyEvent.ACTION_UP
+import android.view.KeyEvent.KEYCODE_0
+import android.view.KeyEvent.KEYCODE_9
+import android.view.KeyEvent.KEYCODE_ENDCALL
+import android.view.KeyEvent.KEYCODE_STAR
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.utils.KeyUtils.getDigit
+import com.ichi2.utils.KeyUtils.isDigit
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class KeyUtilsTest {
+    @Test
+    fun testIsDigit() {
+        assertTrue(isDigit(KeyEvent(ACTION_UP, KEYCODE_0)))
+        assertTrue(isDigit(KeyEvent(ACTION_UP, KEYCODE_9)))
+        assertFalse(isDigit(KeyEvent(ACTION_UP, KEYCODE_STAR)))
+        assertFalse(isDigit(KeyEvent(ACTION_UP, KEYCODE_ENDCALL)))
+    }
+
+    @Test
+    fun testGetDigit() {
+        assertEquals(0, getDigit(KeyEvent(ACTION_UP, KEYCODE_0)))
+        assertEquals(9, getDigit(KeyEvent(ACTION_UP, KEYCODE_9)))
+        assertEquals(null, getDigit(KeyEvent(ACTION_UP, KEYCODE_STAR)))
+        assertEquals(null, getDigit(KeyEvent(ACTION_UP, KEYCODE_ENDCALL)))
+    }
+}


### PR DESCRIPTION
I don't expect it was causing a bug, but `onKeyUp` almost always returned false, even when the key press was handled.

This is now corrected.

I had trouble understanding the `selectFieldIndex` part. I hope I improved it. Also added a unit test, given the simplicity of this part of the code.

I wanted to test the remaining of KeyUtils, but got error messages, telling me

java.lang.RuntimeException: Method getUnicodeChar in android.view.KeyEvent not mocked. See https://developer.android.com/r/studio-ui/build/not-mocked for details.
	at android.view.KeyEvent.getUnicodeChar(KeyEvent.java)
	at com.ichi2.utils.KeyUtils.getDigit(KeyUtils.kt:30)

I'd be interested in help if it's quick to do. But otherwise, it's not worth losing time on it.



This should hopefully not conflict much with https://github.com/ankidroid/Anki-Android/pull/16597/ given that "return true" would be useful even when using fragment