### PR TITLE
Fixe NPE in note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1055,8 +1055,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         } else {
             // Check whether note type has been changed
             val newModel = currentlySelectedNotetype
-            val oldModel = if (currentEditedCard == null) null else currentEditedCard!!.noteType(getColUnsafe)
-            if (newModel != oldModel) {
+            val oldModel = currentEditedCard?.noteType(getColUnsafe)
+            if (newModel?.id != oldModel?.id) {
                 reloadRequired = true
                 if (modelChangeCardMap!!.size < editorNote!!.numberOfCards(getColUnsafe) || modelChangeCardMap!!.containsValue(
                         null


### PR DESCRIPTION
After reproducing https://github.com/ankidroid/Anki-Android/issues/16702, I discovered that actually, the part of the
code where the NPE occurred should not have been reached.

newModel and oldModel are two distinct objects representing the same
note type. And JSonObject's equality is defined as pointer
equality. Using id instead of actual note type repair the bug.

Since, in AnkiDroid, editing the note type through the reviewer, can't
lead to adding or removing field, this is safe to consider that if the
id is equal, the objects are equal as far as the list of field is concerned.

I fear I don't see how to test it easily. It seems it require
AndroidTest and not unit tests, and I can't find example of note editor
test. Furthermore note editor will be replaced soon, so I don't expect
it's such a big deal.

* Fixed #16702

----

* Probably Closes #16569 (I think this is a duplicate)

Related PRs:
* Closes #16719
* Closes #16575