### PR TITLE
[GSoC'24] Enhancement: add long press listener on cloze button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -319,6 +319,14 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
         return combinedWords
     }
 
+    fun updateClozeNumber(word: String, newClozeNumber: Int): String {
+        return clozePattern.replace(word) { matchResult ->
+            val content = matchResult.groupValues[2]
+            val punctuation = matchResult.groupValues[3]
+            "{{c$newClozeNumber::$content}}$punctuation"
+        }
+    }
+
     /**
      * Removes the cloze deletion marker and surrounding delimiters from a word.
      *

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -278,6 +278,8 @@ also changes the interval of the card"
     <string name="cloze_note_required">Cloze Type Note Required</string>
     <string name="cloze_not_found_message">No Cloze type note found, open the Note Editor or try again after adding a Cloze type note.</string>
     <string name="open">Open</string>
+    <string name="change_cloze_number">Change cloze number</string>
+    <string name="cloze_number">Cloze number:</string>
 
     <!-- Outdated WebView dialog -->
     <string name="webview_update_message">The system WebView is outdated. Some features won’t work correctly. Please update it.\n\nInstalled version: %1$d\nMinimum required version: %2$d</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR further improvise the instant editor by allowing user to manually edit the cloze number by long pressing the cloze number button in the dialog 

## How Has This Been Tested?

Tested on OnePlus Nord CE:
https://github.com/user-attachments/assets/62f532cf-8fd6-42ba-a665-26b0201c128d

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
