### PR TITLE
[GSoC'24] Refactor: cloze builder pattern for words

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -441,4 +441,4 @@ private val punctuationPattern = Regex("""\p{Punct}+$""")
 private val spaceRegex = Regex("\\s+")
 
 /** Used to build cloze text here word is not null **/
-private val clozeBuilderPattern = "(\\w+)(\\p{Punct}*)".toRegex()
+private val clozeBuilderPattern = "([\\w\\p{Pd}\\p{Pc}]+)(\\p{Punct}*)".toRegex()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -152,6 +152,21 @@ class InstantEditorViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `test words with internal punctuation`() = runViewModelTest {
+        val text = "hello-world"
+        val result = buildClozeText(text)
+
+        assertEquals("{{c1::hello-world}}", result)
+    }
+
+    @Test
+    fun `test words with internal underscore punctuation`() = runViewModelTest {
+        val text = "hello_world"
+        val result = buildClozeText(text)
+        assertEquals("{{c1::hello_world}}", result)
+    }
+
+    @Test
     fun testSwitchingBetweenEditModes() = runViewModelTest {
         val word = "Word!"
         val expectedCloze = "{{c1::Word}}!"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR handles the issue that arises when there is a hyphen when the words i.e. `Hello-World`. 
In this updated pattern allows for matching words that include punctuation.

## How Has This Been Tested?
Tested on Oneplus Nord CE

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
