### PR TITLE
Fix: update set due date card snackbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -42,6 +42,7 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.requireAnkiActivity
@@ -287,15 +288,7 @@ private fun AnkiActivity.updateDueDate(viewModel: SetDueDateViewModel) = this@An
         showThemedToast(R.string.something_wrong, true)
         return@launchCatchingTask
     }
-
-    showSnackbar(
-        resources.getQuantityString(
-            R.plurals.reschedule_cards_dialog_acknowledge,
-            cardsUpdated,
-            cardsUpdated
-        ),
-        Snackbar.LENGTH_SHORT
-    )
+    showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
 }
 
 context (DialogFragment)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/SchedulerService.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.servicelayer
 
 import androidx.fragment.app.FragmentActivity
 import com.google.android.material.snackbar.Snackbar
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.withProgress
@@ -31,14 +32,7 @@ suspend fun FragmentActivity.rescheduleCards(cardIds: List<CardId>, newDays: Int
         }
     }
     val count = cardIds.size
-    showSnackbar(
-        resources.getQuantityString(
-            R.plurals.reschedule_cards_dialog_acknowledge,
-            count,
-            count
-        ),
-        Snackbar.LENGTH_SHORT
-    )
+    showSnackbar(TR.schedulingSetDueDateDone(count), Snackbar.LENGTH_SHORT)
 }
 
 suspend fun FragmentActivity.resetCards(

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -40,12 +40,6 @@
         <item quantity="other">%d cards reset</item>
     </plurals>
 
-    <!-- Reschedule Card Dialog -->
-    <plurals name="reschedule_cards_dialog_acknowledge">
-        <item quantity="one">%d card rescheduled</item>
-        <item quantity="other">%d cards rescheduled</item>
-    </plurals>
-
     <string name="answering_error_title">Database error</string>
     <string name="answering_error_message">Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
     <string name="answering_error_report">Report error</string>


### PR DESCRIPTION
## Purpose / Description
This pull request fixes the snackbar message in AnkiDroid when setting a card's due date. The current message says "1 card rescheduled," which is incorrect. The update changes it to "Set due date of 1 card" to accurately reflect the action taken by the user.


## Fixes
* Fixes #16732 

## How Has This Been Tested?
Realme 6 (API-30) and Emulator

## Screenshot
![image (8)](https://github.com/user-attachments/assets/7da5feba-1ce2-48a1-8841-9391fd925da9)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
