### PR TITLE
[GSoC'24] Enhancement of Media Drop Feature in NoteEditor

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -337,6 +337,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.browser
     implementation libs.androidx.core.ktx
+    implementation libs.androidx.draganddrop
     implementation libs.androidx.exifinterface
     implementation libs.androidx.fragment.ktx
     implementation libs.androidx.media

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -21,6 +21,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
+
+<!--    At the time of writing, ankidroid minSdk is 23. This library requires API 24.-->
+<!--    In order to use it, we use <uses-sdk tools:overrideLibrary instead of-->
+<!--    <uses-feature android:name. We must ensure this is never called when running on API 23.-->
+    <uses-sdk tools:overrideLibrary="androidx.draganddrop"/>
+
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -15,14 +15,17 @@
  */
 package com.ichi2.anki
 
+import android.content.ClipDescription
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.annotation.CheckResult
 import com.ichi2.anki.multimediacard.fields.ImageField
+import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.exception.EmptyMediaException
+import com.ichi2.utils.ClipboardUtil
 import com.ichi2.utils.ContentResolverUtil.getFileName
 import com.ichi2.utils.FileUtil.getFileNameAndExtension
 import timber.log.Timber
@@ -47,7 +50,7 @@ class MediaRegistration(private val context: Context) {
      * @return HTML referring to the loaded image
      */
     @Throws(IOException::class)
-    fun loadMediaIntoCollection(uri: Uri): String? {
+    fun loadMediaIntoCollection(uri: Uri, description: ClipDescription): String? {
         val fileName: String
         val filename = getFileName(context.contentResolver, uri)
         val fd = openInputStreamWithURI(uri)
@@ -59,9 +62,12 @@ class MediaRegistration(private val context: Context) {
         }
         var clipCopy: File
         var bytesWritten: Long
+        val isImage = ClipboardUtil.hasImage(description)
+        val isVideo = ClipboardUtil.hasVideo(description)
+
         openInputStreamWithURI(uri).use { copyFd ->
             // no conversion to jpg in cases of gif and jpg and if png image with alpha channel
-            if (shouldConvertToJPG(fileNameAndExtension.value, copyFd)) {
+            if (shouldConvertToJPG(fileNameAndExtension.value, copyFd, isImage)) {
                 clipCopy = File.createTempFile(fileName, ".jpg")
                 bytesWritten = CompatHelper.compat.copyFile(fd, clipCopy.absolutePath)
                 // return null if jpg conversion false.
@@ -81,11 +87,22 @@ class MediaRegistration(private val context: Context) {
         Timber.d("File was %d bytes", bytesWritten)
         if (bytesWritten > MEDIA_MAX_SIZE) {
             Timber.w("File was too large: %d bytes", bytesWritten)
-            showThemedToast(context, context.getString(R.string.note_editor_paste_too_large), false)
+            val message = if (isImage) {
+                context.getString(R.string.note_editor_image_too_large)
+            } else if (isVideo) {
+                context.getString(R.string.note_editor_video_too_large)
+            } else {
+                context.getString(R.string.note_editor_audio_too_large)
+            }
+            showThemedToast(context, message, false)
             File(tempFilePath).delete()
             return null
         }
-        val field = ImageField()
+        val field = if (isImage) {
+            ImageField()
+        } else {
+            MediaClipField()
+        }
         field.hasTemporaryMedia = true
         field.mediaPath = tempFilePath
         return field.formattedValue
@@ -112,7 +129,13 @@ class MediaRegistration(private val context: Context) {
         return true // successful conversion to jpg.
     }
 
-    private fun shouldConvertToJPG(fileNameExtension: String, fileStream: InputStream): Boolean {
+    private fun shouldConvertToJPG(fileNameExtension: String, fileStream: InputStream, isImage: Boolean): Boolean {
+        if (!isImage) {
+            return false
+        }
+        if (".svg" == fileNameExtension) {
+            return false
+        }
         if (".jpg" == fileNameExtension) {
             return false // we are already a jpg, no conversion
         }
@@ -129,11 +152,11 @@ class MediaRegistration(private val context: Context) {
         return fileNameAndExtension.key.length <= 3
     }
 
-    fun onPaste(uri: Uri): String? {
+    fun onPaste(uri: Uri, description: ClipDescription): String? {
         return try {
             // check if cache already holds registered file or not
             if (!pastedMediaCache.containsKey(uri.toString())) {
-                pastedMediaCache[uri.toString()] = loadMediaIntoCollection(uri)
+                pastedMediaCache[uri.toString()] = loadMediaIntoCollection(uri, description)
             }
             pastedMediaCache[uri.toString()]
         } catch (ex: NullPointerException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -23,6 +23,7 @@ import android.app.Activity
 import android.app.Activity.RESULT_CANCELED
 import android.content.BroadcastReceiver
 import android.content.ClipData
+import android.content.ClipDescription
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
@@ -67,7 +68,11 @@ import androidx.core.content.edit
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.os.BundleCompat
 import androidx.core.text.HtmlCompat
+import androidx.core.util.component1
+import androidx.core.util.component2
+import androidx.core.view.OnReceiveContentListener
 import androidx.core.view.isVisible
+import androidx.draganddrop.DropHelper
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import anki.config.ConfigKey
@@ -126,6 +131,7 @@ import com.ichi2.anki.utils.ext.isImageOcclusion
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.libanki.Card
@@ -144,6 +150,8 @@ import com.ichi2.libanki.load
 import com.ichi2.libanki.note
 import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.ClipboardUtil
+import com.ichi2.utils.ClipboardUtil.hasMedia
+import com.ichi2.utils.ClipboardUtil.items
 import com.ichi2.utils.HashUtil
 import com.ichi2.utils.ImageUtils
 import com.ichi2.utils.ImportUtils
@@ -169,7 +177,6 @@ import java.io.File
 import java.util.LinkedList
 import java.util.Locale
 import java.util.function.Consumer
-import kotlin.collections.ArrayList
 import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
@@ -332,6 +339,37 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             }
         }
     )
+
+    /**
+     * Listener for handling content received via drag and drop or copy and paste.
+     * This listener processes URIs contained in the payload and attempts to paste the content into the target EditText view.
+     */
+    private val onReceiveContentListener = OnReceiveContentListener { view, payload ->
+        val (uriContent, remaining) = payload.partition { item -> item.uri != null }
+
+        if (uriContent == null) {
+            return@OnReceiveContentListener remaining
+        }
+
+        val clip = uriContent.clip
+        val description = clip.description
+
+        if (!hasMedia(description)) {
+            return@OnReceiveContentListener remaining
+        }
+
+        for (uri in clip.items().map { it.uri }) {
+            try {
+                onPaste(view as EditText, uri, description)
+            } catch (e: Exception) {
+                Timber.w(e)
+                CrashReportService.sendExceptionReport(e, "NoteEditor::onReceiveContent")
+                return@OnReceiveContentListener remaining
+            }
+        }
+
+        return@OnReceiveContentListener remaining
+    }
 
     private inner class NoteEditorActivityResultCallback(private val callback: (result: ActivityResult) -> Unit) : ActivityResultCallback<ActivityResult> {
         override fun onActivityResult(result: ActivityResult) {
@@ -1592,12 +1630,23 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             val editLineView = editLines[i]
             customViewIds.add(editLineView.id)
             val newEditText = editLineView.editText
-            newEditText.setPasteListener { editText: EditText?, uri: Uri? ->
+            newEditText.setPasteListener { editText: EditText?, uri: Uri?, description: ClipDescription? ->
                 onPaste(
                     editText!!,
-                    uri!!
+                    uri!!,
+                    description!!
                 )
             }
+            CompatHelper.compat.configureView(
+                requireActivity(),
+                editLineView,
+                DropHelper.Options.Builder()
+                    .setHighlightColor(R.color.material_lime_green_A700)
+                    .setHighlightCornerRadiusPx(0)
+                    .addInnerEditTexts(newEditText)
+                    .build(),
+                onReceiveContentListener
+            )
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 if (i == 0) {
                     findViewById<View>(R.id.note_deck_spinner).nextFocusForwardId = newEditText.id
@@ -1835,8 +1884,8 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         }
     }
 
-    private fun onPaste(editText: EditText, uri: Uri): Boolean {
-        val mediaTag = mediaRegistration!!.onPaste(uri) ?: return false
+    private fun onPaste(editText: EditText, uri: Uri, description: ClipDescription): Boolean {
+        val mediaTag = mediaRegistration!!.onPaste(uri, description) ?: return false
         insertStringInField(editText, mediaTag)
         return true
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -108,6 +108,7 @@ import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.noteeditor.FieldState
 import com.ichi2.anki.noteeditor.FieldState.FieldChangeType
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.noteeditor.Toolbar
 import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.anki.pages.ImageOcclusion
@@ -173,7 +174,6 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.roundToInt
 import androidx.appcompat.widget.Toolbar as MainToolbar
-import com.ichi2.anki.noteeditor.Toolbar as Toolbar
 
 /**
  * Allows the user to edit a note, for instance if there is a typo. A card is a presentation of a note, and has two
@@ -626,7 +626,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                 // TODO: Support all extensions
                 //  See https://github.com/ankitects/anki/blob/6f3550464d37aee1b8b784e431cbfce8382d3ce7/rslib/src/image_occlusion/imagedata.rs#L154
                 if (ClipboardUtil.hasImage(clipboard)) {
-                    val uri = ClipboardUtil.getImageUri(clipboard)
+                    val uri = ClipboardUtil.getUri(clipboard)
                     val i = Intent().apply {
                         addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                         clipData = ClipData.newUri(requireActivity().contentResolver, uri.toString(), uri)
@@ -1592,8 +1592,8 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             val editLineView = editLines[i]
             customViewIds.add(editLineView.id)
             val newEditText = editLineView.editText
-            newEditText.setImagePasteListener { editText: EditText?, uri: Uri? ->
-                onImagePaste(
+            newEditText.setPasteListener { editText: EditText?, uri: Uri? ->
+                onPaste(
                     editText!!,
                     uri!!
                 )
@@ -1835,9 +1835,9 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         }
     }
 
-    private fun onImagePaste(editText: EditText, uri: Uri): Boolean {
-        val imageTag = mediaRegistration!!.onImagePaste(uri) ?: return false
-        insertStringInField(editText, imageTag)
+    private fun onPaste(editText: EditText, uri: Uri): Boolean {
+        val mediaTag = mediaRegistration!!.onPaste(uri) ?: return false
+        insertStringInField(editText, mediaTag)
         return true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.compat
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
@@ -30,6 +31,8 @@ import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import androidx.annotation.CheckResult
+import androidx.core.view.OnReceiveContentListener
+import androidx.draganddrop.DropHelper
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -200,6 +203,19 @@ interface Compat {
      */
     @Throws(IOException::class)
     fun contentOfDirectory(directory: File): FileStream
+
+    /**
+     * If possible, configures a [View] for drag and drop operations, including highlighting that
+     * indicates the view is a drop target. Sets a listener that enables the view to handle dropped data.
+     *
+     * @see DropHelper.configureView
+     */
+    fun configureView(
+        activity: Activity,
+        view: View,
+        options: DropHelper.Options,
+        onReceiveContentListener: OnReceiveContentListener
+    )
 
     /**
      * Converts a locale to a 'two letter' code (ISO-639-1 + ISO 3166-1 alpha-2)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV23.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.compat
 
+import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInfo
@@ -31,6 +32,8 @@ import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
 import androidx.appcompat.widget.TooltipCompat
+import androidx.core.view.OnReceiveContentListener
+import androidx.draganddrop.DropHelper
 import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.File
@@ -145,6 +148,16 @@ open class CompatV23 : Compat {
                 return paths[mOrd++]
             }
         }
+    }
+
+    // Until API 24
+    override fun configureView(
+        activity: Activity,
+        view: View,
+        options: DropHelper.Options,
+        onReceiveContentListener: OnReceiveContentListener
+    ) {
+        // No implementation possible.
     }
 
     // Until API 26

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV24.kt
@@ -17,9 +17,14 @@
 package com.ichi2.compat
 
 import android.annotation.TargetApi
+import android.app.Activity
 import android.icu.util.ULocale
 import android.view.MotionEvent
+import android.view.View
+import androidx.core.view.OnReceiveContentListener
+import androidx.draganddrop.DropHelper
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.utils.ClipboardUtil.MEDIA_MIME_TYPES
 import timber.log.Timber
 import java.util.Locale
 
@@ -38,6 +43,21 @@ open class CompatV24 : CompatV23(), Compat {
             Timber.w("Failed to normalize locale %s", locale, e)
             locale
         }
+    }
+
+    override fun configureView(
+        activity: Activity,
+        view: View,
+        options: DropHelper.Options,
+        onReceiveContentListener: OnReceiveContentListener
+    ) {
+        DropHelper.configureView(
+            activity,
+            view,
+            MEDIA_MIME_TYPES,
+            options,
+            onReceiveContentListener
+        )
     }
 
     override val AXIS_RELATIVE_X: Int = MotionEvent.AXIS_RELATIVE_X

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -54,7 +54,7 @@ object ClipboardUtil {
         ?.takeIf { it.itemCount > 0 }
         ?.getItemAt(0)
 
-    fun getImageUri(clipboard: ClipboardManager?): Uri? {
+    fun getUri(clipboard: ClipboardManager?): Uri? {
         return getFirstItem(clipboard)?.uri
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ClipboardUtil.kt
@@ -31,13 +31,13 @@ import com.ichi2.anki.snackbar.showSnackbar
 import timber.log.Timber
 
 object ClipboardUtil {
-    // JPEG is sent via pasted content
-    val IMAGE_MIME_TYPES = arrayOf("image/gif", "image/png", "image/jpg", "image/jpeg")
+    val IMAGE_MIME_TYPES = arrayOf("image/*")
+    val AUDIO_MIME_TYPES = arrayOf("audio/*")
+    val VIDEO_MIME_TYPES = arrayOf("video/*")
+    val MEDIA_MIME_TYPES = arrayOf(*IMAGE_MIME_TYPES, *AUDIO_MIME_TYPES, *VIDEO_MIME_TYPES)
 
     fun hasImage(clipboard: ClipboardManager?): Boolean {
-        return clipboard
-            ?.takeIf { it.hasPrimaryClip() }
-            ?.primaryClip
+        return clipboard?.primaryClip
             ?.let { hasImage(it.description) }
             ?: false
     }
@@ -48,24 +48,53 @@ object ClipboardUtil {
             ?: false
     }
 
-    private fun getFirstItem(clipboard: ClipboardManager?) = clipboard
-        ?.takeIf { it.hasPrimaryClip() }
-        ?.primaryClip
-        ?.takeIf { it.itemCount > 0 }
-        ?.getItemAt(0)
+    fun hasVideo(description: ClipDescription?): Boolean {
+        return description
+            ?.run { VIDEO_MIME_TYPES.any { hasMimeType(it) } }
+            ?: false
+    }
+
+    private fun ClipboardManager.getFirstItem() =
+        primaryClip?.takeIf { it.itemCount > 0 }?.getItemAt(0)
 
     fun getUri(clipboard: ClipboardManager?): Uri? {
-        return getFirstItem(clipboard)?.uri
+        return clipboard?.getFirstItem()?.uri
+    }
+
+    fun hasSVG(description: ClipDescription): Boolean {
+        return description.hasMimeType("image/svg+xml")
+    }
+
+    fun hasMedia(clipboard: ClipboardManager?): Boolean {
+        return clipboard?.primaryClip
+            ?.let { hasMedia(it.description) }
+            ?: false
+    }
+
+    fun hasMedia(description: ClipDescription?): Boolean {
+        return description
+            ?.run { MEDIA_MIME_TYPES.any { hasMimeType(it) } }
+            ?: false
+    }
+
+    fun ClipData.items() = sequence {
+        for (j in 0 until itemCount) {
+            yield(getItemAt(j))
+        }
+    }
+
+    fun getDescription(clipboard: ClipboardManager?): ClipDescription? {
+        return clipboard?.primaryClip?.description
     }
 
     @CheckResult
     fun getText(clipboard: ClipboardManager?): CharSequence? {
-        return getFirstItem(clipboard)?.text
+        return clipboard?.getFirstItem()?.text
     }
 
     @CheckResult
     fun getPlainText(clipboard: ClipboardManager?, context: Context): CharSequence? {
-        return getFirstItem(clipboard)?.coerceToText(context)
+        return clipboard?.getFirstItem()?.coerceToText(context)
     }
 }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -240,7 +240,9 @@
     <string name="toolbar_item_explain_edit_or_remove">Enter HTML to be inserted before and after the selected text\n\nLong press a toolbar item to edit or remove it</string>
     <string name="remove_toolbar_item">Remove Toolbar Item?</string>
 
-    <string name="note_editor_paste_too_large">The image is too large to paste, please insert the image manually</string>
+    <string name="note_editor_image_too_large">The image is too large, please insert the image manually</string>
+    <string name="note_editor_video_too_large">The video file is too large, please insert the video manually</string>
+    <string name="note_editor_audio_too_large">The audio file is too large, please insert the audio manually</string>
     <string name="ankidroid_cannot_open_after_backup_try_again"
         comment="After an Android backup is restored, AnkiDroid opens and shows this message.
         Opening AnkiDroid again will work correctly">

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ClipboardUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ClipboardUtilTest.kt
@@ -2,13 +2,33 @@
 
 package com.ichi2.utils
 
+import android.content.ClipData
 import android.content.ClipDescription
 import android.content.ClipboardManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.utils.ClipboardUtil.AUDIO_MIME_TYPES
+import com.ichi2.utils.ClipboardUtil.IMAGE_MIME_TYPES
+import com.ichi2.utils.ClipboardUtil.VIDEO_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.hasImage
+import com.ichi2.utils.ClipboardUtil.hasMedia
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class ClipboardUtilTest {
+
+    private lateinit var clipboardManager: ClipboardManager
+
+    @Before
+    fun setUp() {
+        clipboardManager = ApplicationProvider.getApplicationContext<Context>().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    }
+
     @Test
     fun hasImageClipboardManagerNullTest() {
         val clipboardManager: ClipboardManager? = null
@@ -19,5 +39,49 @@ class ClipboardUtilTest {
     fun hasImageDescriptionNullTest() {
         val clipDescription: ClipDescription? = null
         assertFalse(hasImage(clipDescription))
+    }
+
+    @Test
+    fun hasMediaClipboardManagerNullTest() {
+        val clipboardManager: ClipboardManager? = null
+        assertFalse(hasMedia(clipboardManager))
+    }
+
+    @Test
+    fun hasMediaDescriptionNullTest() {
+        val clipDescription: ClipDescription? = null
+        assertFalse(hasMedia(clipDescription))
+    }
+
+    @Test
+    fun hasMediaWithImageMimeTypeTest() {
+        val clipDescription = ClipDescription("label", IMAGE_MIME_TYPES)
+        val clipData = ClipData(clipDescription, ClipData.Item("image data"))
+        clipboardManager.setPrimaryClip(clipData)
+        assertTrue(hasMedia(clipboardManager))
+    }
+
+    @Test
+    fun hasMediaWithSVGMimeTypeTest() {
+        val clipDescription = ClipDescription("label", arrayOf("image/svg+xml"))
+        val clipData = ClipData(clipDescription, ClipData.Item("svg data"))
+        clipboardManager.setPrimaryClip(clipData)
+        assertTrue(hasMedia(clipboardManager))
+    }
+
+    @Test
+    fun hasMediaWithAudioMimeTypeTest() {
+        val clipDescription = ClipDescription("label", AUDIO_MIME_TYPES)
+        val clipData = ClipData(clipDescription, ClipData.Item("audio data"))
+        clipboardManager.setPrimaryClip(clipData)
+        assertTrue(hasMedia(clipboardManager))
+    }
+
+    @Test
+    fun hasMediaWithVideoMimeTypeTest() {
+        val clipDescription = ClipDescription("label", VIDEO_MIME_TYPES)
+        val clipData = ClipData(clipDescription, ClipData.Item("video data"))
+        clipboardManager.setPrimaryClip(clipData)
+        assertTrue(hasMedia(clipboardManager))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ androidxBrowser = "1.8.0"
 androidxConstraintlayout = "2.1.4"
 # https://developer.android.com/jetpack/androidx/releases/core
 androidxCoreKtx = "1.13.1"
+# https://developer.android.com/jetpack/androidx/releases/draganddrop
+androidxDragAndDrop = "1.0.0"
 # https://developer.android.com/jetpack/androidx/releases/exifinterface
 androidxExifinterface = "1.3.7"
 # https://developer.android.com/jetpack/androidx/releases/fragment
@@ -106,6 +108,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragmentKtx" }
 androidx-exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref = "androidxExifinterface" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCoreKtx" }
+androidx-draganddrop = { module = "androidx.draganddrop:draganddrop", version.ref = "androidxDragAndDrop" }
 androidx-browser = { module = "androidx.browser:browser", version.ref = "androidxBrowser" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppCompat" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "androidxAnnotation" }

--- a/testlib/src/main/AndroidManifest.xml
+++ b/testlib/src/main/AndroidManifest.xml
@@ -1,2 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest />
+<manifest xmlns:tools="http://schemas.android.com/tools">
+    <!--
+    Testlib's manifest should implicitly imports everything from `AnkiDroid/src/main/AndroidManifest.xml`,
+    except the imports done with `overrideLibrary` it seems. So we repeat the overridden imports below.
+    Otherwise, here is the error message we receive:
+
+    /Users/davidallison/StudioProjects/Anki-Android/testlib/build/intermediates/tmp/manifest/test/amazon/debug/tempFile1ProcessTestManifest12107165475509574808.xml:5:5-74 Error:
+        uses-sdk:minSdkVersion 23 cannot be smaller than version 24 declared in library [androidx.draganddrop:draganddrop:1.0.0] /Users/davidallison/.gradle/caches/8.9/transforms/20ebe1ae2c541e0d36502b025cdb232b/transformed/draganddrop-1.0.0/AndroidManifest.xml as the library might be using APIs not available in 23
+        Suggestion: use a compatible library with a minSdk of at most 23,
+            or increase this project's minSdk version to at least 24,
+            or use tools:overrideLibrary="androidx.draganddrop" to force usage (may lead to runtime failures)
+    -->
+    <uses-sdk tools:overrideLibrary="androidx.draganddrop"/>
+</manifest>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR enhances the existing functionality of dropping media files in the NoteEditor (FixedEditText). Previously, only photos could be dropped. With this enhancement, users can now also drop video and audio files into the FixedEditText.

## Approach
To implement this feature, I utilized the `DropHelper` class instead of the traditional drag-and-drop mechanisms.

**Why DropHelper?**
Simplified Implementation: DropHelper provides a straightforward and high-level API for managing drop actions, reducing the complexity of handling multiple types of media.

## How Has This Been Tested?
HP Chromebook
[Screen recording 2024-07-17 10.30.17 PM.webm](https://github.com/user-attachments/assets/1695385d-1f65-427f-8c4c-7cc531ec0ec4)


## Learning (optional, can help others)
https://medium.com/androiddevelopers/simplifying-drag-and-drop-3713d6ef526e
https://developer.android.com/reference/androidx/draganddrop/DropHelper

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
