### PR TITLE
Change conflicts workflow to allow more PRs to be checked

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -25,6 +25,7 @@ jobs:
                     repo: context.repo.repo,
                     state: 'open',
                     sort: 'created',
+                    per_page: 100,
                 });
             }
 


### PR DESCRIPTION
## Purpose / Description

Was preparing to merge #16685 but then I saw that it had conflicts although it didn't had the expected label. Looking though the workflow's logs it seemed the workflow didn't consider all opened pull requests as it was relying on the default page value(which is 30) when fetching the open pull requests. So the workflow checked just the oldest 30 opened pull requests.
I increased the per page value to 100 so the workflow now fetches the oldest 100 opened pull requests.
See [documentation for api used](https://octokit.github.io/rest.js/v20#pulls-list).


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
