### PR TITLE
refactor(note-editor): improve nullability

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1829,8 +1829,8 @@ class NoteEditor : AnkiActivity(), DeckSelectionListener, SubtitleListener, Tags
         }
     }
 
-    private fun startMultimediaFieldEditor(index: Int, note: IMultimediaEditableNote?, imageUri: Uri? = null) {
-        val field = note!!.getField(index)!!
+    private fun startMultimediaFieldEditor(index: Int, note: IMultimediaEditableNote, imageUri: Uri? = null) {
+        val field = note.getField(index)!!
         val editCard = Intent(this@NoteEditor, MultimediaEditFieldActivity::class.java)
         editCard.putExtra(MultimediaEditFieldActivity.INTENT_IMAGE_URI, imageUri)
         editCard.putExtra(MultimediaEditFieldActivity.EXTRA_MULTIMEDIA_EDIT_FIELD_ACTIVITY, MultimediaEditFieldActivityExtra(index, field, note))


### PR DESCRIPTION
for `startMultimediaFieldEditor`

Kotlin Cleanup - parameter should not have been nullable

Split out from a review comment on:

* https://github.com/ankidroid/Anki-Android/pull/16673/

## Approach
* make param non-null

## How Has This Been Tested?
Compile-only change. If it compiles, it works

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
