### PR TITLE
Remove "app.brant.amazonappstorepublisher" plugin

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -2,7 +2,6 @@ plugins {
     // Gradle plugin portal
     alias(libs.plugins.tripletPlay)
     alias(libs.plugins.android.application)
-    alias(libs.plugins.amazonappstorepublisher)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.serialization)
@@ -267,13 +266,6 @@ android {
 play {
     serviceAccountCredentials.set(file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json"))
     track.set('alpha')
-}
-
-amazon {
-    securityProfile = file("${homePath}/src/AnkiDroid-Amazon-Publish-Security-Profile.json")
-    applicationId = "amzn1.devportal.mobileapp.524a424d314931494c55383833305539"
-    pathToApks = [ file("./build/outputs/apk/amazon/release/AnkiDroid-amazon-universal-release.apk") ]
-    replaceEdit = true
 }
 
 // Install Git pre-commit hook for Ktlint

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,20 +8,6 @@ import java.io.ByteArrayOutputStream
 import kotlin.math.max
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-buildscript {
-    configurations.configureEach {
-        resolutionStrategy.eachDependency {
-            val version = requested.version
-            if (requested.group == "org.jetbrains.kotlinx"
-                && requested.name.contains("kotlinx-serialization-runtime")
-                && (version != null && version.contains("0.11.0"))
-            ) {
-                useVersion("0.14.0")
-            }
-        }
-    }
-}
-
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.android.library) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,6 @@ compileSdk = "34"
 minSdk = "23"  # also in testlib/build.gradle.kts
 targetSdk = "34"  # also in  ../robolectricDownloader.gradle
 acra = '5.11.3'
-amazonappstorepublisher = "0.1.0"
 androidGradlePlugin = "8.5.1"
 androidxActivity = "1.9.0"
 androidxAnnotation = "1.8.0"
@@ -162,8 +161,6 @@ cashapp-turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine"
 
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
-amazonappstorepublisher = { id = "app.brant.amazonappstorepublisher", version.ref = "amazonappstorepublisher" }
-
 
 tripletPlay = { id = "com.github.triplet.play", version.ref = "triplet" }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,15 +3,6 @@ pluginManagement {
         google()
         gradlePluginPortal()
         mavenCentral()
-        maven(url = "https://jitpack.io") // only needed for the "amazonappstorepublisher" plugin
-    }
-    resolutionStrategy {
-        // TODO try to find another plugin for this functionality?
-        eachPlugin {
-            if (requested.id.id == "app.brant.amazonappstorepublisher") {
-                useModule("com.github.BrantApps.gradle-amazon-app-store-publisher:amazonappstorepublisher:master-SNAPSHOT")
-            }
-        }
     }
 }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

As discussed in Discord, this PR removes the amazon publishing plugin.
The plugin hasn't been update for quite a long time , it doesn't curently work for publising and it also breaks the build.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
