### PR TITLE
[GSoC'24] Feature: enable instant editor for public use

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -597,20 +597,19 @@
         Task affinity allows us to separate the activity allowing us to define that an activity belongs to a
         different task, it ensures that the activity does not interfere with other tasks in our application.
          -->
-        <!-- TODO: enable the filter once we are done and set export as true -->
         <activity
             android:name="com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity"
-            android:exported="false"
+            android:exported="true"
             android:label="@string/instant_card"
             android:launchMode="singleInstance"
             android:excludeFromRecents="true"
             android:taskAffinity=""
             android:theme="@style/Theme.AppCompat.Transparent.NoActionBar" >
-<!--            <intent-filter>-->
-<!--                <action android:name="android.intent.action.SEND" />-->
-<!--                <category android:name="android.intent.category.DEFAULT" />-->
-<!--                <data android:mimeType="text/plain" />-->
-<!--            </intent-filter>-->
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+            </intent-filter>
         </activity>
 
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.preferences
 
 import android.content.Context
-import android.content.Intent
 import androidx.appcompat.app.AlertDialog
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
@@ -25,7 +24,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.OnboardingUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
@@ -87,14 +85,6 @@ class DevOptionsFragment : SettingsFragment() {
         // Reset onboarding
         requirePreference<Preference>(R.string.pref_reset_onboarding_key).setOnPreferenceClickListener {
             OnboardingUtils.reset(requireContext())
-            false
-        }
-        // Instant Editor
-        requirePreference<Preference>(R.string.pref_open_instant_editor).setOnPreferenceClickListener {
-            val intent = Intent(activity, InstantNoteEditorActivity::class.java).apply {
-                putExtra("extra_text_key", "Hello developer this is a test sentence. You can test turning text to cloze here")
-            }
-            startActivity(intent)
             false
         }
 

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -320,8 +320,6 @@
     <string name="show_onboarding_desc">Display feature tutorial to learn more about the app</string>
     <string name="reset_onboarding_desc">Show all tutorials again</string>
 
-    <!-- Instant Editor -->
-    <string name="open_instant_editor">Open Instant Editor</string>
     <!-- Multimedia UI -->
     <string name="new_multimedia_ui">New multimedia UI</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -197,9 +197,6 @@
     <string name="pref_weekly_backups_to_keep_key">weekly_backups_to_keep</string>
     <string name="pref_monthly_backups_to_keep_key">monthly_backups_to_keep</string>
 
-    <!-- Instant Editor -->
-    <string name="pref_open_instant_editor">openInstantEditor</string>
-
     <!-- Reviewer options -->
     <string name="hide_system_bars_key">hideSystemBars</string>
     <string name="ignore_display_cutout_key">ignoreDisplayCutout</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -70,9 +70,6 @@
         android:title="@string/reset_onboarding"
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>
-    <Preference
-        android:title="@string/open_instant_editor"
-        android:key="@string/pref_open_instant_editor"/>
     <SwitchPreferenceCompat
         android:title="@string/new_multimedia_ui"
         android:key="@string/pref_new_multimedia_ui"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR lift off instant editor from dev settings and set it for public use

## Approach
Remove Instant editor from dev setting and enable the intent filters and set exported to true

## How Has This Been Tested?
Tested locally/ Oneplus Nord ce:
![image](https://github.com/user-attachments/assets/8f90af5f-14de-4805-9cdd-db6529e19ed5)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
