### PR TITLE
fix: "MissingDefaultResource" lint: `iw`

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -77,6 +77,7 @@
         <ignore path="res/values-ind/" />
         <ignore path="res/values-is/" />
         <ignore path="res/values-it/" />
+        <ignore path="res/values-iw/" /> <!-- iw is special-cased: 0f795cea363ace67bd55ec56775c5beae73c7c9e -->
         <ignore path="res/values-ja/" />
         <ignore path="res/values-jv/" />
         <ignore path="res/values-ka/" />


### PR DESCRIPTION
The `MissingDefaultResource` lint should only be checked on `/values`

Added in 0f795cea363ace67bd55ec56775c5beae73c7c9e

`iw` = Hebrew

<!--- Please fill the necessary details below -->
## Purpose / Description
Hebrew was added to the app in a nonstandard manner:

* https://github.com/ankidroid/Anki-Android/pull/16316
* https://github.com/ankidroid/Anki-Android/issues/9451

But the results were not added to be ignored in our lint checks

## Fixes
* Unblocks https://github.com/ankidroid/Anki-Android/pull/16738

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
