### PR TITLE
[GSoC'24] Add NoteEditor to CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -151,6 +151,13 @@ open class CardBrowser :
     TagsDialogListener,
     ChangeManager.Subscriber {
     /**
+     * Provides an instance of NoteEditorLauncher for adding a note
+     */
+    @get:VisibleForTesting
+    val addNoteLauncher: NoteEditorLauncher
+        get() = createAddNoteLauncher(viewModel, fragmented)
+
+    /**
      * Provides an instance of NoteEditorLauncher for editing a note
      */
     private val editNoteLauncher: NoteEditorLauncher
@@ -505,6 +512,8 @@ open class CardBrowser :
         if (!fragmented) {
             return
         }
+        // Show note editor frame
+        noteEditorFrame!!.isVisible = true
         val noteEditor = NoteEditor.newInstance(launcher)
         supportFragmentManager.commit {
             replace(R.id.note_editor_frame, noteEditor)
@@ -1592,12 +1601,12 @@ open class CardBrowser :
             showDialogFragment(dialog)
         }
 
-    @get:VisibleForTesting
-    val addNoteIntent: Intent
-        get() = createAddNoteIntent(this, viewModel)
-
     private fun addNoteFromCardBrowser() {
-        onAddNoteActivityResult.launch(addNoteIntent)
+        if (fragmented) {
+            loadNoteEditorFragmentIfFragmented(addNoteLauncher)
+        } else {
+            onAddNoteActivityResult.launch(addNoteLauncher.toIntent(this))
+        }
     }
 
     private val reviewerCardId: CardId
@@ -2020,10 +2029,10 @@ open class CardBrowser :
         fun clearLastDeckId() = SharedPreferencesLastDeckIdRepository.clearLastDeckId()
 
         @VisibleForTesting
-        fun createAddNoteIntent(
-            context: Context,
+        fun createAddNoteLauncher(
             viewModel: CardBrowserViewModel,
-        ): Intent = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel).toIntent(context)
+            inFragmentedActivity: Boolean = false,
+        ): NoteEditorLauncher = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel, inFragmentedActivity)
     }
 
     private fun calculateTopOffset(cardPosition: Int): Int {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -367,9 +367,11 @@ open class CardBrowser :
             showUndoSnackbar(TR.browsingCardsUpdated(changed.count))
         }
 
+    // TODO: Move this to ViewModel and test
     @VisibleForTesting
     fun onTap(id: CardOrNoteId) =
         launchCatchingTask {
+            cardsAdapter.focusedRow = id
             if (viewModel.isInMultiSelectMode) {
                 val wasSelected = viewModel.selectedRows.contains(id)
                 viewModel.toggleRowSelection(id)
@@ -706,6 +708,7 @@ open class CardBrowser :
         }
 
         fun onSelectedRowUpdated(id: CardOrNoteId?) {
+            cardsAdapter.focusedRow = id
             if (!viewModel.isInMultiSelectMode || viewModel.lastSelectedId == null) {
                 viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
             }
@@ -1783,7 +1786,7 @@ open class CardBrowser :
             // Hide note editor frame if deck is empty and fragmented
             noteEditorFrame?.visibility =
                 if (fragmented && !isDeckEmpty) {
-                    viewModel.currentCardId = viewModel.cards[0].toCardId(viewModel.cardsOrNotes)
+                    viewModel.currentCardId = (cardsAdapter.focusedRow ?: viewModel.cards[0]).toCardId(viewModel.cardsOrNotes)
                     loadNoteEditorFragmentIfFragmented(editNoteLauncher)
                     View.VISIBLE
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -491,6 +491,12 @@ open class CardBrowser :
     }
 
     /**
+     * Retrieves the `NoteEditor` fragment if it is present in the fragment container
+     */
+    val fragment: NoteEditor?
+        get() = supportFragmentManager.findFragmentById(R.id.note_editor_frame) as? NoteEditor
+
+    /**
      * Loads the NoteEditor fragment in container if the view is x-large.
      *
      * @param launcher The NoteEditorLauncher containing the necessary data to initialize the NoteEditor Fragment.
@@ -503,6 +509,8 @@ open class CardBrowser :
         supportFragmentManager.commit {
             replace(R.id.note_editor_frame, noteEditor)
         }
+        // invalidate options menu so that note editor menu will show
+        invalidateOptionsMenu()
     }
 
     fun notifyDataSetChanged() {
@@ -1068,6 +1076,10 @@ open class CardBrowser :
             showBackIcon()
             increaseHorizontalPaddingOfOverflowMenuIcons(menu)
         }
+        // Append note editor menu to card browser menu if fragmented
+        if (fragmented) {
+            fragment?.onCreateMenu(menu, menuInflater)
+        }
         actionBarMenu?.findItem(R.id.action_select_all)?.run {
             isVisible = !hasSelectedAllCards()
         }
@@ -1136,7 +1148,7 @@ open class CardBrowser :
     }
 
     private fun updatePreviewMenuItem() {
-        previewItem?.isVisible = viewModel.rowCount > 0
+        previewItem?.isVisible = !fragmented && viewModel.rowCount > 0
     }
 
     private fun updateMultiselectMenu() {
@@ -1189,7 +1201,7 @@ open class CardBrowser :
         // Note: Theoretically should not happen, as this should kick us back to the menu
         actionBarMenu.findItem(R.id.action_select_none).isVisible =
             viewModel.hasSelectedAnyRows()
-        actionBarMenu.findItem(R.id.action_edit_note).isVisible = canPerformMultiSelectEditNote()
+        actionBarMenu.findItem(R.id.action_edit_note).isVisible = !fragmented && canPerformMultiSelectEditNote()
         actionBarMenu.findItem(R.id.action_view_card_info).isVisible = canPerformCardInfo()
     }
 
@@ -1359,7 +1371,7 @@ open class CardBrowser :
                 showFindAndReplaceDialog()
             }
         }
-        return super.onOptionsItemSelected(item)
+        return fragmented && fragment!!.onMenuItemSelected(item)
     }
 
     private fun showCreateFilteredDeckDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1118,8 +1118,8 @@ open class CardBrowser :
             showBackIcon()
             increaseHorizontalPaddingOfOverflowMenuIcons(menu)
         }
-        // Append note editor menu to card browser menu if fragmented
-        if (fragmented) {
+        // Append note editor menu to card browser menu if fragmented and deck is not empty
+        if (fragmented && viewModel.rowCount != 0) {
             fragment?.onCreateMenu(menu, menuInflater)
         }
         actionBarMenu?.findItem(R.id.action_select_all)?.run {
@@ -1778,8 +1778,19 @@ open class CardBrowser :
         launchCatchingTask {
             Timber.i("CardBrowser:: Completed searchCards() Successfully")
             updateList()
-            viewModel.currentCardId = viewModel.cards[0].toCardId(viewModel.cardsOrNotes)
-            loadNoteEditorFragmentIfFragmented(editNoteLauncher)
+            // Check whether deck is empty or not
+            val isDeckEmpty = viewModel.rowCount == 0
+            // Hide note editor frame if deck is empty and fragmented
+            noteEditorFrame?.visibility =
+                if (fragmented && !isDeckEmpty) {
+                    viewModel.currentCardId = viewModel.cards[0].toCardId(viewModel.cardsOrNotes)
+                    loadNoteEditorFragmentIfFragmented(editNoteLauncher)
+                    View.VISIBLE
+                } else {
+                    invalidateOptionsMenu()
+                    View.GONE
+                }
+            // check whether mSearchView is initialized as it is lateinit property.
             if (searchView == null || searchView!!.isIconified) {
                 return@launchCatchingTask
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -94,6 +94,7 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
+import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
@@ -497,6 +498,37 @@ open class CardBrowser :
         super.setupBackPressedCallbacks()
     }
 
+    private fun showSaveChangesDialog(launcher: NoteEditorLauncher) {
+        DiscardChangesDialog.showDialog(
+            context = this,
+            positiveButtonText = this.getString(R.string.save),
+            negativeButtonText = this.getString(R.string.discard),
+            // The neutral button allows the user to back out of the action,
+            // e.g., if they accidentally triggered a navigation or card selection.
+            neutralButtonText = this.getString(R.string.dialog_cancel),
+            message = this.getString(R.string.save_changes_message),
+            positiveMethod = {
+                launchCatchingTask {
+                    fragment?.saveNote()
+                    loadNoteEditorFragment(launcher)
+                }
+            },
+            negativeMethod = {
+                loadNoteEditorFragment(launcher)
+            },
+            neutralMethod = {},
+        )
+    }
+
+    private fun loadNoteEditorFragment(launcher: NoteEditorLauncher) {
+        val noteEditor = NoteEditor.newInstance(launcher)
+        supportFragmentManager.commit {
+            replace(R.id.note_editor_frame, noteEditor)
+        }
+        // Invalidate options menu so that note editor menu will show
+        invalidateOptionsMenu()
+    }
+
     /**
      * Retrieves the `NoteEditor` fragment if it is present in the fragment container
      */
@@ -514,12 +546,13 @@ open class CardBrowser :
         }
         // Show note editor frame
         noteEditorFrame!!.isVisible = true
-        val noteEditor = NoteEditor.newInstance(launcher)
-        supportFragmentManager.commit {
-            replace(R.id.note_editor_frame, noteEditor)
+
+        // If there are unsaved changes in NoteEditor then show dialog for confirmation
+        if (fragment?.hasUnsavedChanges() == true) {
+            showSaveChangesDialog(launcher)
+        } else {
+            loadNoteEditorFragment(launcher)
         }
-        // invalidate options menu so that note editor menu will show
-        invalidateOptionsMenu()
     }
 
     fun notifyDataSetChanged() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -46,6 +46,8 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.fragment.app.FragmentContainerView
+import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -148,6 +150,15 @@ open class CardBrowser :
     DeckSelectionListener,
     TagsDialogListener,
     ChangeManager.Subscriber {
+    /**
+     * Provides an instance of NoteEditorLauncher for editing a note
+     */
+    private val editNoteLauncher: NoteEditorLauncher
+        get() =
+            NoteEditorLauncher.EditCard(viewModel.currentCardId, Direction.DEFAULT, fragmented).also {
+                Timber.i("editNoteLauncher: %s", it)
+            }
+
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let {
             launchCatchingTask { selectDeckAndSave(deck.deckId) }
@@ -160,6 +171,11 @@ open class CardBrowser :
     }
 
     lateinit var viewModel: CardBrowserViewModel
+
+    /**
+     * The frame containing the NoteEditor. Non null only in layout x-large.
+     */
+    private var noteEditorFrame: FragmentContainerView? = null
 
     private lateinit var deckSpinnerSelection: DeckSpinnerSelection
 
@@ -347,26 +363,20 @@ open class CardBrowser :
     fun onTap(id: CardOrNoteId) =
         launchCatchingTask {
             if (viewModel.isInMultiSelectMode) {
+                val wasSelected = viewModel.selectedRows.contains(id)
                 viewModel.toggleRowSelection(id)
                 viewModel.saveScrollingState(id)
                 viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
+                // Load NoteEditor on trailing side if card is selected
+                if (wasSelected) {
+                    viewModel.currentCardId = id.toCardId(viewModel.cardsOrNotes)
+                    loadNoteEditorFragmentIfFragmented(editNoteLauncher)
+                }
             } else {
                 val cardId = viewModel.queryDataForCardEdit(id)
                 openNoteEditorForCard(cardId)
             }
         }
-
-    @VisibleForTesting
-    fun onLongPress(id: CardOrNoteId) {
-        // click on whole cell triggers select
-        if (viewModel.isInMultiSelectMode && viewModel.lastSelectedId != null) {
-            viewModel.selectRowsBetween(viewModel.lastSelectedId!!, id)
-        } else {
-            viewModel.saveScrollingState(id)
-            viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
-            viewModel.toggleRowSelection(id)
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -393,6 +403,20 @@ open class CardBrowser :
 
         setContentView(R.layout.card_browser)
         initNavigationDrawer(findViewById(android.R.id.content))
+
+        noteEditorFrame = findViewById(R.id.note_editor_frame)
+
+        /**
+         * Check if noteEditorFrame is not null and if its visibility is set to VISIBLE.
+         * If both conditions are true, assign true to the variable [fragmented], otherwise assign false.
+         * [fragmented] will be true if the view size is large otherwise false
+         */
+        // TODO: Consider refactoring by storing noteEditorFrame and similar views in a sealed class (e.g., FragmentAccessor).
+        fragmented =
+            (noteEditorFrame?.visibility == View.VISIBLE).apply {
+                Timber.i("Using split Browser: %b", fragmented)
+            }
+
         // initialize the lateinit variables
         // Load reference to action bar title
         actionBarTitle = findViewById(R.id.toolbar_title)
@@ -407,7 +431,7 @@ open class CardBrowser :
                 this,
                 viewModel,
                 onTap = ::onTap,
-                onLongPress = ::onLongPress,
+                onLongPress = viewModel::handleRowLongPress,
             )
         cardsListView.adapter = cardsAdapter
         cardsAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
@@ -464,6 +488,21 @@ open class CardBrowser :
     override fun setupBackPressedCallbacks() {
         onBackPressedDispatcher.addCallback(this, multiSelectOnBackPressedCallback)
         super.setupBackPressedCallbacks()
+    }
+
+    /**
+     * Loads the NoteEditor fragment in container if the view is x-large.
+     *
+     * @param launcher The NoteEditorLauncher containing the necessary data to initialize the NoteEditor Fragment.
+     */
+    private fun loadNoteEditorFragmentIfFragmented(launcher: NoteEditorLauncher) {
+        if (!fragmented) {
+            return
+        }
+        val noteEditor = NoteEditor.newInstance(launcher)
+        supportFragmentManager.commit {
+            replace(R.id.note_editor_frame, noteEditor)
+        }
     }
 
     fun notifyDataSetChanged() {
@@ -616,6 +655,20 @@ open class CardBrowser :
             }
         }
 
+        fun onSelectedRowUpdated(id: CardOrNoteId?) {
+            if (!viewModel.isInMultiSelectMode || viewModel.lastSelectedId == null) {
+                viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
+            }
+        }
+
+        fun onSelectedCardUpdated(unit: Unit) {
+            if (fragmented) {
+                loadNoteEditorFragmentIfFragmented(editNoteLauncher)
+            } else {
+                onEditCardActivityResult.launch(editNoteLauncher.toIntent(this))
+            }
+        }
+
         viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
         viewModel.flowOfSearchQueryExpanded.launchCollectionInLifecycleScope(::onSearchQueryExpanded)
         viewModel.flowOfSelectedRows.launchCollectionInLifecycleScope(::onSelectedRowsChanged)
@@ -627,6 +680,8 @@ open class CardBrowser :
         viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
         viewModel.flowOfColumnHeadings.launchCollectionInLifecycleScope(::onColumnNamesChanged)
+        viewModel.rowLongPressFocusFlow.launchCollectionInLifecycleScope(::onSelectedRowUpdated)
+        viewModel.cardSelectionEventFlow.launchCollectionInLifecycleScope(::onSelectedCardUpdated)
     }
 
     fun isKeyboardVisible(view: View?): Boolean =
@@ -878,11 +933,7 @@ open class CardBrowser :
     @NeedsTest("note edits are saved")
     @NeedsTest("I/O edits are saved")
     private fun openNoteEditorForCard(cardId: CardId) {
-        currentCardId = cardId
-        val intent = NoteEditorLauncher.EditCard(currentCardId, Direction.DEFAULT).toIntent(this)
-        onEditCardActivityResult.launch(intent)
-        // #6432 - FIXME - onCreateOptionsMenu crashes if receiving an activity result from edit card when in multiselect
-        viewModel.endMultiSelectMode()
+        viewModel.handleCardSelection(cardId, fragmented)
     }
 
     /**
@@ -1670,27 +1721,31 @@ open class CardBrowser :
     @NeedsTest("searchView == null -> return early & ensure no snackbar when the screen is opened")
     @MainThread
     private fun redrawAfterSearch() {
-        Timber.i("CardBrowser:: Completed searchCards() Successfully")
-        updateList()
-        if (searchView == null || searchView!!.isIconified) {
-            return
-        }
-        updateList()
-        if (viewModel.hasSelectedAllDecks()) {
-            showSnackbar(subtitleText, Snackbar.LENGTH_SHORT)
-        } else {
-            // If we haven't selected all decks, allow the user the option to search all decks.
-            val message =
-                if (viewModel.rowCount == 0) {
-                    getString(R.string.card_browser_no_cards_in_deck, selectedDeckNameForUi)
-                } else {
-                    subtitleText
-                }
-            showSnackbar(message, Snackbar.LENGTH_INDEFINITE) {
-                setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
+        launchCatchingTask {
+            Timber.i("CardBrowser:: Completed searchCards() Successfully")
+            updateList()
+            viewModel.currentCardId = viewModel.cards[0].toCardId(viewModel.cardsOrNotes)
+            loadNoteEditorFragmentIfFragmented(editNoteLauncher)
+            if (searchView == null || searchView!!.isIconified) {
+                return@launchCatchingTask
             }
+            updateList()
+            if (viewModel.hasSelectedAllDecks()) {
+                showSnackbar(subtitleText, Snackbar.LENGTH_SHORT)
+            } else {
+                // If we haven't selected all decks, allow the user the option to search all decks.
+                val message =
+                    if (viewModel.rowCount == 0) {
+                        getString(R.string.card_browser_no_cards_in_deck, selectedDeckNameForUi)
+                    } else {
+                        subtitleText
+                    }
+                showSnackbar(message, Snackbar.LENGTH_INDEFINITE) {
+                    setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
+                }
+            }
+            updatePreviewMenuItem()
         }
-        updatePreviewMenuItem()
     }
 
     @MainThread
@@ -1793,7 +1848,7 @@ open class CardBrowser :
 
     private fun saveEditedCard() {
         Timber.d("CardBrowser - saveEditedCard()")
-        updateCardsInList(listOf(currentCardId))
+        updateCardsInList(listOf(viewModel.currentCardId))
     }
 
     private fun toggleSuspendCards() = launchCatchingTask { withProgress { viewModel.toggleSuspendCards().join() } }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1371,7 +1371,9 @@ class NoteEditor :
             menu.findItem(R.id.action_save).isVisible = iconVisible
             menu.findItem(R.id.action_preview).isVisible = iconVisible
         } else {
-            menu.findItem(R.id.action_add_note_from_note_editor).isVisible = true
+            // Hide add note item if fragment is in fragmented activity
+            // because this item is already present in CardBrowser
+            menu.findItem(R.id.action_add_note_from_note_editor).isVisible = !inFragmentedActivity
         }
         if (editFields != null) {
             for (i in editFields!!.indices) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1604,6 +1604,12 @@ class NoteEditor :
             // ensure there are no orphans from possible edit previews
             CardTemplateNotetype.clearTempNoteTypeFiles()
 
+            // Don't close this fragment if it is in fragmented activity
+            if (inFragmentedActivity) {
+                Timber.i("not closing activity: fragmented")
+                return
+            }
+
             Timber.i("Closing note editor")
 
             // Set the finish animation if there is one on the intent which created the activity

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -285,6 +285,13 @@ class NoteEditor :
 
     var clipboard: ClipboardManager? = null
 
+    /**
+     * Whether this is displayed in a fragment view.
+     * If true, this fragment is on the trailing side of the card browser.
+     */
+    private val inFragmentedActivity
+        get() = requireArguments().getBoolean(IN_FRAGMENTED_ACTIVITY)
+
     private val requestAddLauncher =
         registerForActivityResult(
             ActivityResultContracts.StartActivityForResult(),
@@ -539,6 +546,12 @@ class NoteEditor :
             )
             setIconColor(MaterialColors.getColor(requireContext(), R.attr.toolbarIconColor, 0))
         }
+
+        // Hide mainToolbar since CardBrowser handles the toolbar in fragmented activities.
+        if (inFragmentedActivity) {
+            mainToolbar.visibility = View.GONE
+        }
+
         try {
             setupEditor(getColUnsafe)
         } catch (ex: RuntimeException) {
@@ -1588,6 +1601,8 @@ class NoteEditor :
             }
             // ensure there are no orphans from possible edit previews
             CardTemplateNotetype.clearTempNoteTypeFiles()
+
+            Timber.i("Closing note editor")
 
             // Set the finish animation if there is one on the intent which created the activity
             val animation =
@@ -2882,6 +2897,7 @@ class NoteEditor :
         const val NOTE_CHANGED_EXTRA_KEY = "noteChanged"
         const val RELOAD_REQUIRED_EXTRA_KEY = "reloadRequired"
         const val EXTRA_IMG_OCCLUSION = "image_uri"
+        const val IN_FRAGMENTED_ACTIVITY = "inFragmentedActivity"
 
         // calling activity
         enum class NoteEditorCaller(
@@ -2915,6 +2931,11 @@ class NoteEditor :
         private const val PREF_NOTE_EDITOR_CAPITALIZE = "note_editor_capitalize"
         private const val PREF_NOTE_EDITOR_FONT_SIZE = "note_editor_font_size"
         private const val PREF_NOTE_EDITOR_CUSTOM_BUTTONS = "note_editor_custom_buttons"
+
+        fun newInstance(launcher: NoteEditorLauncher): NoteEditor =
+            NoteEditor().apply {
+                this.arguments = launcher.toBundle()
+            }
 
         private fun shouldReplaceNewlines(): Boolean =
             AnkiDroidApp.instance

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -63,6 +63,8 @@ class BrowserMultiColumnAdapter(
     private val onLongPress: (CardOrNoteId) -> Unit,
     private val onTap: (CardOrNoteId) -> Unit,
 ) : RecyclerView.Adapter<BrowserMultiColumnAdapter.MultiColumnViewHolder>() {
+    var focusedRow: CardOrNoteId? = null
+
     val fontSizeScalePercent =
         sharedPrefs().getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO)
 
@@ -246,7 +248,13 @@ class BrowserMultiColumnAdapter(
                 holder.columnViews[i].text = renderColumn(i)
             }
             holder.setIsSelected(isSelected)
-            holder.setColor(backendColorToColor(row.color))
+            val rowColor =
+                if (focusedRow == id) {
+                    ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
+                } else {
+                    backendColorToColor(row.color)
+                }
+            holder.setColor(rowColor)
             holder.setIsDeleted(false)
         } catch (e: BackendException) {
             holder.columnViews.forEach { it.text = e.localizedMessage }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -21,21 +21,29 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
+import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import timber.log.Timber
 
+// TODO: Clean up this code
 object DiscardChangesDialog {
     fun showDialog(
         context: Context,
         positiveButtonText: String = context.getString(R.string.discard),
         negativeButtonText: String = CollectionManager.TR.addingKeepEditing(),
+        neutralButtonText: String? = null,
         message: String = CollectionManager.TR.addingDiscardCurrentInput(),
+        negativeMethod: () -> Unit = {},
+        neutralMethod: (() -> Unit)? = null,
         positiveMethod: () -> Unit,
     ) = AlertDialog.Builder(context).show {
         Timber.i("showing 'discard changes' dialog")
         message(text = message)
         positiveButton(text = positiveButtonText) { positiveMethod() }
-        negativeButton(text = negativeButtonText)
+        negativeButton(text = negativeButtonText) { negativeMethod() }
+        if (neutralButtonText != null && neutralMethod != null) {
+            neutralButton(text = neutralButtonText) { neutralMethod() }
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -159,12 +159,14 @@ sealed interface NoteEditorLauncher : Destination {
     data class EditCard(
         val cardId: CardId,
         val animation: ActivityTransitionAnimation.Direction,
+        val inFragmentedActivity: Boolean = false,
     ) : NoteEditorLauncher {
         override fun toBundle(): Bundle =
             bundleOf(
                 NoteEditor.EXTRA_CALLER to NoteEditorCaller.EDIT.value,
                 NoteEditor.EXTRA_CARD_ID to cardId,
                 AnkiActivity.FINISH_ANIMATION_EXTRA to animation as Parcelable,
+                NoteEditor.IN_FRAGMENTED_ACTIVITY to inFragmentedActivity,
             )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -102,12 +102,14 @@ sealed interface NoteEditorLauncher : Destination {
      */
     data class AddNoteFromCardBrowser(
         val viewModel: CardBrowserViewModel,
+        val inFragmentedActivity: Boolean = false,
     ) : NoteEditorLauncher {
         override fun toBundle(): Bundle {
             val bundle =
                 bundleOf(
                     NoteEditor.EXTRA_CALLER to NoteEditorCaller.CARDBROWSER_ADD.value,
                     NoteEditor.EXTRA_TEXT_FROM_SEARCH_VIEW to viewModel.searchTerms,
+                    NoteEditor.IN_FRAGMENTED_ACTIVITY to inFragmentedActivity,
                 )
             if (viewModel.lastDeckId?.let { id -> id > 0 } == true) {
                 bundle.putLong(NoteEditor.EXTRA_DID, viewModel.lastDeckId!!)

--- a/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <include layout="@layout/toolbar" />
+        <LinearLayout
+            android:id="@+id/card_browser_xl_view"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:attr/colorBackground"
+            android:orientation="horizontal">
+            <include layout="@layout/cardbrowser"
+                android:layout_width="1dip"
+                android:layout_weight="3"
+                android:layout_height="match_parent"/>
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/note_editor_frame"
+                android:layout_weight="2"
+                android:layout_width="1dip"
+                android:layout_height="match_parent"/>
+        </LinearLayout>
+    </LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -1,51 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    android:id="@+id/root_layout"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    >
-
+    android:layout_height="match_parent">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical" >
-
+        android:orientation="vertical">
         <include layout="@layout/toolbar" />
-
-        <LinearLayout
-            android:id="@+id/browser_column_headings"
-            android:layout_width="match_parent"
-            android:background="@drawable/browser_heading_bottom_divider"
-            android:orientation="horizontal"
-            android:paddingVertical="2dp"
-            android:layout_height="wrap_content"
-            android:longClickable="true">
-
-        </LinearLayout>
-
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/browser_progress"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="gone"
-            />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/card_browser_list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:background="?android:attr/colorBackground"
-            android:overScrollFooter="@color/transparent"
-            android:clipToPadding="false"
-            android:paddingBottom="72dp"
-            android:drawSelectorOnTop="true"
-            tools:listitem="@layout/card_item_browser"
-            />
-
+        <include layout="@layout/cardbrowser" />
     </LinearLayout>
-
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/cardbrowser.xml
+++ b/AnkiDroid/src/main/res/layout/cardbrowser.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    >
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" >
+
+        <LinearLayout
+            android:id="@+id/browser_column_headings"
+            android:layout_width="match_parent"
+            android:background="@drawable/browser_heading_bottom_divider"
+            android:orientation="horizontal"
+            android:paddingVertical="2dp"
+            android:layout_height="wrap_content"
+            android:longClickable="true">
+
+        </LinearLayout>
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/browser_progress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/card_browser_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:attr/colorBackground"
+            android:overScrollFooter="@color/transparent"
+            android:clipToPadding="false"
+            android:paddingBottom="72dp"
+            android:drawSelectorOnTop="true"
+            tools:listitem="@layout/card_item_browser"
+            />
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -101,5 +101,7 @@
     <string name="include_column">Include column</string>
     <string name="exclude_column">Exclude column</string>
 
+    <string name="save_changes_message">Please save your changes first</string>
+
     <string name="browser_find_replace_loading_fields">Retrieving fields names&#8230;</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -82,6 +82,7 @@
     <!-- Deck list colors, divider, and expander -->
     <attr name="currentDeckBackground" format="reference"/>
     <attr name="currentDeckBackgroundColor" format="color"/>
+    <attr name="focusedRowBackgroundColor" format="color"/>
     <attr name="dynDeckColor" format="color"/>
     <attr name="deckDivider" format="reference"/>
     <attr name="expandRef" format="reference"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -30,6 +30,7 @@
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">@color/theme_black_row_current</item>
+        <item name="focusedRowBackgroundColor">@color/theme_black_row_current</item>
         <item name="dynDeckColor">#305683</item>
         <item name="deckDivider">@drawable/divider_black</item>
         <item name="expandRef">@drawable/ic_chevron_right_white</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -53,6 +53,7 @@
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">@color/theme_dark_row_current</item>
+        <item name="focusedRowBackgroundColor">@color/theme_dark_row_current</item>
         <item name="dynDeckColor">#6699d6</item>
         <item name="deckDivider">@drawable/divider_dark</item>
         <item name="expandRef">@drawable/ic_chevron_right_white</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -45,6 +45,7 @@
         <!-- Deck list colors and divider -->
         <item name="currentDeckBackground">@drawable/item_background_selected</item>
         <item name="currentDeckBackgroundColor">#ececec</item>
+        <item name="focusedRowBackgroundColor">#ececec</item>
         <item name="dynDeckColor">#2222bb</item>
         <item name="deckDivider">@drawable/divider</item>
         <item name="expandRef">@drawable/ic_chevron_right_black</item>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -560,7 +560,7 @@ class CardBrowserTest : RobolectricTest() {
 
             assertThat("The target deck should be selected", b.lastDeckId, equalTo(targetDid))
 
-            val addIntent = b.addNoteIntent
+            val addIntent = b.addNoteLauncher.toIntent(targetContext)
             val bundle = addIntent.getBundleExtra(SingleFragmentActivity.FRAGMENT_ARGS_EXTRA)
             IntentAssert.hasExtra(bundle, NoteEditor.EXTRA_DID, targetDid)
         }
@@ -574,7 +574,7 @@ class CardBrowserTest : RobolectricTest() {
 
         assertThat("The initial deck should be selected", b.lastDeckId, equalTo(initialDid))
 
-        val addIntent = b.addNoteIntent
+        val addIntent = b.addNoteLauncher.toIntent(targetContext)
         val bundle = addIntent.getBundleExtra(SingleFragmentActivity.FRAGMENT_ARGS_EXTRA)
         IntentAssert.hasExtra(bundle, NoteEditor.EXTRA_DID, initialDid)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1664,7 +1664,7 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
 
 fun CardBrowser.clickRowAtPosition(pos: Int) = onTap(viewModel.cards[pos])
 
-fun CardBrowser.longClickRowAtPosition(pos: Int) = onLongPress(viewModel.cards[pos])
+fun CardBrowser.longClickRowAtPosition(pos: Int) = viewModel.handleRowLongPress(viewModel.cards[pos])
 
 val CardBrowser.lastDeckId
     get() = viewModel.lastDeckId

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -158,7 +158,7 @@ class CardBrowserViewModelTest : JvmTest() {
 
             assertThat("All decks should be selected", hasSelectedAllDecks())
 
-            val addIntent = CardBrowser.createAddNoteIntent(mockIt(), this)
+            val addIntent = CardBrowser.createAddNoteLauncher(this).toIntent(mockIt())
             val bundle = addIntent.getBundleExtra(SingleFragmentActivity.FRAGMENT_ARGS_EXTRA)
             IntentAssert.doesNotHaveExtra(bundle, NoteEditor.EXTRA_DID)
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This feature aims to enhance the CardBrowser by adding a NoteEditor. This will allow users to edit card side by side on large screens

## Approach
1. Attach NoteEditor to CardBrowser
2. Move NoteEditor menu to CardBrowser menu
3. Hide fragment when deck is empty

## How Has This Been Tested?
Medium Tablet API 34

https://github.com/user-attachments/assets/78ada4c3-906a-402b-9432-a9e8691de71b


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)