### PR TITLE
fix: `Processing...` popup in app startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1038,6 +1038,15 @@ open class DeckPicker :
         }
     }
 
+    private suspend fun updateUndoMenuState() {
+        withOpenColOrNull {
+            optionsMenuState = optionsMenuState?.copy(
+                undoLabel = undoLabel(),
+                undoAvailable = undoAvailable()
+            )
+        }
+    }
+
     private fun updateSearchVisibilityFromState(menu: Menu) {
         optionsMenuState?.run {
             menu.findItem(R.id.deck_picker_action_filter).isVisible = searchIcon
@@ -2132,7 +2141,7 @@ open class DeckPicker :
                 }
                 onDecksLoaded(deckDueTree, collectionHasNoCards)
 
-                updateMenuState()
+                updateUndoMenuState()
             }
         }
     }


### PR DESCRIPTION
## Purpose / Description

8e0b537b1d9fe464a82dad68e8bc744c1cbced4c introduced a call to `updateMenuState()` at the loadDeckCounts job to update the undo label state when the deck is reloaded.

Following the method name, the whole menu is updated instead of only the undo label, which includes checking if there are changes to sync remotely, and that takes time, so it shouldn't be done if not necessary.

## Fixes
* Fixes #16693
* Fixes #16768

## Approach
Update only undo when decks are changed

## How Has This Been Tested?

With the same steps of #16390 in the emulator with API 34

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
