### PR TITLE
Make newer "Gallery" labels translatable from Crowdin

### DIFF
--- a/AnkiDroid/src/main/res/layout/bottomsheet_multimedia.xml
+++ b/AnkiDroid/src/main/res/layout/bottomsheet_multimedia.xml
@@ -45,7 +45,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center_vertical"
-            android:text="@string/pick_image_gallery"
+            android:text="@string/multimedia_editor_image_field_editing_galery"
             app:iconPadding="12dp" />
     </LinearLayout>
 

--- a/AnkiDroid/src/main/res/layout/image_occlusion_options_layout.xml
+++ b/AnkiDroid/src/main/res/layout/image_occlusion_options_layout.xml
@@ -67,7 +67,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:gravity="center_vertical"
-            android:text="@string/pick_image_gallery" />
+            android:text="@string/multimedia_editor_image_field_editing_galery" />
     </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
 Make the following "Gallery" labels translatable like other labels

 - the "Gallery" option label in the menu of "Select image" in "Image Occlusion" note type
 - the "Gallery" option label in the menu of multimedia file attachment in the note editor

**Samples** (Traditional Chinese)
<img src="https://github.com/user-attachments/assets/9f41f1f5-a525-4649-8638-a883d9cefc7e" width="320px"> <img src="https://github.com/user-attachments/assets/6c5a1b55-01d8-42db-ad29-bf19120b7766" width="320px">


## Fixes
N/A

## Approach
Use the existing "Gallery" string which is translatable from Crowdin


## How Has This Been Tested?
Tested in physical device (Android 11)
<img src="https://github.com/user-attachments/assets/761a91b1-cb77-4b59-a5eb-5c2f259f8f70" width="320px"> <img src="https://github.com/user-attachments/assets/d05a6b8e-d494-4bfb-91cc-5cd1c74e5f1c" width="320px"> 


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
