### PR TITLE
fix: deckpicker to use transparent status bar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
@@ -17,7 +17,6 @@ package com.ichi2.anki
 
 import android.content.BroadcastReceiver
 import android.net.Uri
-import android.os.Bundle
 import android.view.Menu
 import android.view.View
 import androidx.annotation.AttrRes
@@ -65,11 +64,6 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout) {
      */
     protected open fun onCollectionLoaded(col: Collection) {
         hideProgressBar()
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        requireActivity().window.statusBarColor = ThemeUtils.getThemeAttrColor(requireContext(), R.attr.appBarColor)
-        super.onViewCreated(view, savedInstanceState)
     }
 
     // Helper functions: These make fragment code shorter


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR fixes the status bar for ground color issue

## Fixes
* Fixes #16770 

## Approach
Status Bar transparent API is called just like note editor does

## How Has This Been Tested?
Google Emulator
![image](https://github.com/user-attachments/assets/884c5395-fdbe-4936-912f-88065b21ca5e)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
