### PR TITLE
[GSoC'24] Fix: cloze number incorrect on undo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -62,6 +62,10 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
     // List to store the cloze integers
     private val intClozeList = mutableListOf<Int>()
 
+    /** The number of words which are marked as cloze deletions */
+    @VisibleForTesting
+    val clozeDeletionCount get() = intClozeList.size
+
     private val _currentClozeMode = MutableStateFlow(InstantNoteEditorActivity.ClozeMode.INCREMENT)
 
     val currentClozeMode: StateFlow<InstantNoteEditorActivity.ClozeMode> = _currentClozeMode.asStateFlow()
@@ -178,14 +182,14 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
     }
 
     private fun shouldResetClozeNumber(number: Int) {
-        val index = intClozeList.indexOf(number)
-        if (index != -1) {
-            intClozeList.removeAt(index)
-        }
+        intClozeList.remove(number)
 
         // Reset cloze number if the list is empty
         if (intClozeList.isEmpty()) {
             _currentClozeNumber.value = 1
+        } else {
+            // not null for sure
+            _currentClozeNumber.value = intClozeList.maxOrNull()!! + 1
         }
     }
 
@@ -248,7 +252,7 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
         if (currentClozeMode.value == InstantNoteEditorActivity.ClozeMode.INCREMENT) {
             incrementClozeNumber()
         }
-        intClozeList.add(currentClozeNumber)
+        intClozeList.add(clozeNumber)
 
         val punctuation: String? = matcher?.groups?.get(2)?.value
         if (!punctuation.isNullOrEmpty()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -56,6 +56,37 @@ class InstantEditorViewModelTest : RobolectricTest() {
     }
 
     @Test
+    fun `test cloze number reset to 1`() = runViewModelTest {
+        val sentenceArray = mutableListOf("Hello", "world")
+
+        toggleAllClozeDeletions(sentenceArray)
+
+        assertEquals("all clozes are detected", clozeDeletionCount, 2)
+
+        toggleAllClozeDeletions(sentenceArray)
+
+        assertEquals("all cloze deletions are removed", clozeDeletionCount, 0)
+        assertEquals("cloze number is reset if there are no clozes", currentClozeNumber, 1)
+    }
+
+    @Test
+    fun `test cloze number is reset to max value from cloze list`() = runViewModelTest {
+        val sentenceArray = mutableListOf("Hello", "world", "this", "is", "test", "sentence")
+
+        // cloze on the first 3 words
+        toggleClozeDeletions(sentenceArray, 0, 1, 2)
+
+        // disable cloze on the first 2, leaving "this" as {{c3::
+        toggleClozeDeletions(sentenceArray, 0, 1)
+
+        assertEquals("cloze number is 'Current Cloze Number + 1'", currentClozeNumber, 4)
+
+        // remove the remaining cloze all clozes
+        toggleClozeDeletion(sentenceArray, 2)
+        assertEquals("cloze number is reset if all clozes are removed", currentClozeNumber, 1)
+    }
+
+    @Test
     fun testSavingNoteWithNoCloze() = runViewModelTest {
         editorNote.setField(0, "Hello")
         val result = checkAndSaveNote(targetContext)
@@ -200,4 +231,25 @@ class InstantEditorViewModelTest : RobolectricTest() {
             is SaveNoteResult.Warning -> result.message
         }
     }
+}
+
+context (InstantEditorViewModel)
+private fun toggleAllClozeDeletions(words: MutableList<String>) {
+    for (index in words.indices) {
+        words[index] = buildClozeText(words[index])
+    }
+}
+
+context (InstantEditorViewModel)
+@Suppress("SameParameterValue")
+private fun toggleClozeDeletions(words: MutableList<String>, vararg indices: Int) {
+    for (index in indices) {
+        words[index] = buildClozeText(words[index])
+    }
+}
+
+context (InstantEditorViewModel)
+@Suppress("SameParameterValue")
+private fun toggleClozeDeletion(words: MutableList<String>, index: Int) {
+    words[index] = buildClozeText(words[index])
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Cloze number is reset to 1 or the current cloze number is max of the close number list

## Fixes
* Fixes #16778

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Oneplus nord ce


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
