### PR TITLE
Change the instance cloze builder Regex pattern

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -250,13 +250,12 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
         }
         intClozeList.add(currentClozeNumber)
 
-        val punctuation: String? = matcher?.groups?.get(2)?.value
-        if (!punctuation.isNullOrEmpty()) {
-            val capturedWord = matcher.groups[1]?.value
-            clozeText = "{{c$clozeNumber::$capturedWord}}$punctuation"
-        } else {
-            clozeText = "{{c$clozeNumber::$text}}"
-        }
+        // Extract the first, second, and third regex groups from the matcher
+        val punctuationAtStart: String? = matcher?.groups?.get(1)?.value
+        val capturedWord: String? = matcher?.groups?.get(2)?.value
+        val punctuationAtEnd: String? = matcher?.groups?.get(4)?.value
+
+        clozeText = "$punctuationAtStart{{c$clozeNumber::$capturedWord}}$punctuationAtEnd"
 
         return clozeText
     }
@@ -274,7 +273,7 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
      */
     fun getWordClozeNumber(word: String): Int? {
         val matcher = clozePattern.find(word)
-        return matcher?.groups?.get(1)?.value?.toIntOrNull()
+        return matcher?.groups?.get(2)?.value?.toIntOrNull()
     }
 
     fun getWordsFromFieldText(): List<String> {
@@ -321,9 +320,10 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
 
     fun updateClozeNumber(word: String, newClozeNumber: Int): String {
         return clozePattern.replace(word) { matchResult ->
-            val content = matchResult.groupValues[2]
-            val punctuation = matchResult.groupValues[3]
-            "{{c$newClozeNumber::$content}}$punctuation"
+            val punctutationAtStart = matchResult.groupValues[1]
+            val content = matchResult.groupValues[3]
+            val punctutationAtEnd = matchResult.groupValues[4]
+            "$punctutationAtStart{{c$newClozeNumber::$content}}$punctutationAtEnd"
         }
     }
 
@@ -337,7 +337,7 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
     fun getCleanClozeWords(word: String): String {
         val regex = clozePattern
         return regex.replace(word) { matchResult ->
-            (matchResult.groups[2]?.value ?: "") + (matchResult.groups[3]?.value ?: "")
+            (matchResult.groups[1]?.value ?: "") + (matchResult.groups[3]?.value ?: "") + (matchResult.groups[4]?.value ?: "")
         }
     }
 
@@ -352,7 +352,7 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
      */
     private fun processClozeUndo(text: String): String? {
         val matchResult = clozePattern.find(text)
-        val capturedClozeNumber = matchResult?.groups?.get(1)?.value
+        val capturedClozeNumber = matchResult?.groups?.get(2)?.value
         if (capturedClozeNumber != null && currentClozeNumber - capturedClozeNumber.toInt() == 1) {
             decrementClozeNumber()
         }
@@ -362,12 +362,13 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
             return null
         }
 
-        matchResult.groups[1]?.value?.toInt()?.let { shouldResetClozeNumber(it) }
+        matchResult.groups[2]?.value?.toInt()?.let { shouldResetClozeNumber(it) }
 
-        if (matchResult.groups[3]?.value != null) {
-            return matchResult.groups[2]?.value + matchResult.groups[3]?.value
-        }
-        return matchResult.groups[2]?.value
+        val punctuationAtStart: String? = matchResult?.groups?.get(1)?.value ?: ""
+        val capturedWord: String? = matchResult?.groups?.get(3)?.value ?: ""
+        val punctuationAtEnd: String? = matchResult?.groups?.get(4)?.value ?: ""
+
+        return punctuationAtStart + capturedWord + punctuationAtEnd
     }
 
     fun setEditorMode(mode: InstantNoteEditorActivity.EditMode) {
@@ -441,7 +442,7 @@ sealed class SaveNoteResult {
  * used in educational materials. The pattern follows the format:
  * {{c`number`::`content`}} (optional punctuation)
  */
-val clozePattern = Regex("""\{\{c(\d+)::([^}]+?)\}\}(\p{Punct}+)?""")
+val clozePattern = Regex("""(\p{Punct}+)?\{\{c(\d+)::([^}]+?)\}\}(\p{Punct}+)?""")
 
 private val punctuationPattern = Regex("""\p{Punct}+$""")
 
@@ -449,4 +450,4 @@ private val punctuationPattern = Regex("""\p{Punct}+$""")
 private val spaceRegex = Regex("\\s+")
 
 /** Used to build cloze text here word is not null **/
-private val clozeBuilderPattern = "([\\w\\p{Pd}\\p{Pc}]+)(\\p{Punct}*)".toRegex()
+private val clozeBuilderPattern = "(\\p{Punct}*)((?:\\w|\\p{Pd}|\\p{Pc}|'|(\\(\\w+\\)))+)(\\p{Punct}*)".toRegex()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelParameterizedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelParameterizedTest.kt
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.instanteditor
+
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.instanteditor.InstantEditorViewModelTest.Companion.runInstantEditorViewModelTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner as Parameterized
+
+@RunWith(Parameterized::class)
+class InstantEditorViewModelParameterizedTest : RobolectricTest() {
+    @JvmField // required for Parameter
+    @Parameterized.Parameter(0)
+    var input: String? = null
+
+    @JvmField // required for Parameter
+    @Parameterized.Parameter(1)
+    var expected: String? = null
+
+    @Test
+    fun `buildClozeText punctuation handling`() = runInstantEditorViewModelTest {
+        val result = buildClozeText(input!!)
+        assertEquals(expected, result)
+        val undone = buildClozeText(result)
+        assertEquals("applying buildClozeText twice should not change the input", input, undone)
+    }
+
+    companion object {
+        @Parameterized.Parameters(name = "{0} -> {1}")
+        @JvmStatic // required for initParameters
+        fun initParameters(): Collection<Array<out Any>> {
+            return listOf(
+                arrayOf("Student's", "{{c1::Student's}}"),
+                arrayOf("Note(s)", "{{c1::Note(s)}}"),
+                arrayOf("20%", "{{c1::20}}%"),
+                arrayOf("hello-world", "{{c1::hello-world}}"),
+                arrayOf("hello_world", "{{c1::hello_world}}"),
+                arrayOf("(hello)", "({{c1::hello}})"),
+                arrayOf("[hello]", "[{{c1::hello}}]"),
+                arrayOf("{hello}", "{{{c1::hello}}}"),
+                arrayOf("test,", "{{c1::test}},"),
+                arrayOf("{{c1::test}},", "test,")
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.instantnoteeditor.InstantEditorViewModel
 import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.instantnoteeditor.SaveNoteResult
+import com.ichi2.testutils.TestClass
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -87,22 +88,6 @@ class InstantEditorViewModelTest : RobolectricTest() {
     }
 
     @Test
-    fun `buildClozeText handles punctuation at end`() = runViewModelTest {
-        val text = "test,"
-        val result = buildClozeText(text)
-
-        assertEquals("{{c1::test}},", result)
-    }
-
-    @Test
-    fun `buildClozeText handles cloze punctuation at end`() = runViewModelTest {
-        val text = "{{c1::test}},"
-        val result = buildClozeText(text)
-
-        assertEquals("test,", result)
-    }
-
-    @Test
     fun buildClozeTextTest() = runViewModelTest {
         val text = "test"
         val result = buildClozeText(text)
@@ -142,7 +127,8 @@ class InstantEditorViewModelTest : RobolectricTest() {
             "{{c1::word}}" to "word",
             "{{c2::another}}" to "another",
             "{{c4::help}}!!" to "help!!",
-            "no cloze" to "no cloze"
+            "no cloze" to "no cloze",
+            "[{{c6::word}}]" to "[word]"
         )
 
         testCases.forEach { (input, expected) ->
@@ -183,10 +169,7 @@ class InstantEditorViewModelTest : RobolectricTest() {
     private fun runViewModelTest(
         initViewModel: () -> InstantEditorViewModel = { InstantEditorViewModel() },
         testBody: suspend InstantEditorViewModel.() -> Unit
-    ) = runTest {
-        val viewModel = initViewModel()
-        testBody(viewModel)
-    }
+    ) = runInstantEditorViewModelTest(initViewModel, testBody)
 
     private fun saveNoteResult(result: SaveNoteResult): String? {
         return when (result) {
@@ -198,6 +181,17 @@ class InstantEditorViewModelTest : RobolectricTest() {
             }
 
             is SaveNoteResult.Warning -> result.message
+        }
+    }
+
+    companion object {
+        context (TestClass)
+        fun runInstantEditorViewModelTest(
+            initViewModel: () -> InstantEditorViewModel = { InstantEditorViewModel() },
+            testBody: suspend InstantEditorViewModel.() -> Unit
+        ) = runTest {
+            val viewModel = initViewModel()
+            testBody(viewModel)
         }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The previous regex pattern for building cloze text ignores all punctuations except for underscores and dashes. As a result, for some texts like `Student's` or `Note(s)`, it only considered the text up to the first punctuation mark.

## Fixes
* Fixes #16784

## Approach
I changed the regex pattern to consider apostrophe and parentheses characters as part of the main cloze text.

## How Has This Been Tested?

To ensure the new code works correctly, I wrote some unit tests. Additionally, I provided a screenshot demonstrating these changes.

![Fix cloze builder problem](https://github.com/user-attachments/assets/989eee0b-ce8c-4b3d-bc0c-a64e7cddae7f)


## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
