### PR TITLE
feat(tool): format issue/PR links in Discord

### DIFF
--- a/tools/discord/format-for-discord.sh
+++ b/tools/discord/format-for-discord.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Placed in the public domain by David Allison <davidallisongithub@gmail.com>
+
+# Converts an AnkiDroid issue/pull request ID to a well-formatted Discord link
+#
+# Input:
+# ./format-for-discord 16804
+#
+# Output:
+# [#16804: refactor/docs: `libs.versions.toml` changelogs/renames](<https://github.com/ankidroid/Anki-Android/issues/16804>)
+#
+# The output appears on Discord as the following, with no link preview
+# #16804: refactor/docs: `libs.versions.toml` changelogs/renames
+
+# SECURITY: This script assumes that Issue/PR titles are non-malicious.
+# A malicious actor is able to 'break out' of the link formatting and insert custom text
+# into a Discord message
+
+OWNER=ankidroid
+REPO=Anki-Android
+
+# validate: arg 1 is a number >= 1
+[[ $1 =~ [[:digit:]]+ && $1 -ge 1 ]] || { echo "arg 1 must be a positive integer. Received '$1'"; exit 1; }
+
+# https://docs.github.com/en/rest/issues/issues?apiVersion=2022-11-28#get-an-issue
+# The GitHub API treats every pull request as an issue, so we only need the ID
+ISSUE_NUMBER=$1
+ISSUE_TITLE=$(curl -L --silent  \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "https://api.github.com/repos/$OWNER/$REPO/issues/$ISSUE_NUMBER" | jq -r '.title')
+
+# A number which is too high results in 'null', we may also want to check the API response
+# at a later date (HTTP 429)
+[[ "$ISSUE_TITLE" != null ]] || { echo "failed to read issue $ISSUE_NUMBER.\
+ See: https://github.com/$OWNER/$REPO/issues/$ISSUE_NUMBER"; exit 1; }
+
+# Discord syntax is standard markdown: [title](url)
+# Wrapping a URL in <> means that it doesn't display a link preview
+
+# Looks like: "#16804: refactor/docs: `libs.versions.toml` changelogs/renames"
+# Links to: https://github.com/ankidroid/Anki-Android/issues/16804
+# Redirects to: https://github.com/ankidroid/Anki-Android/pull/16804
+echo "[#$ISSUE_NUMBER: $ISSUE_TITLE](<https://github.com/$OWNER/$REPO/issues/$ISSUE_NUMBER>)"

--- a/tools/discord/macos-clipboard-to-discord.sh
+++ b/tools/discord/macos-clipboard-to-discord.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+# Placed in the public domain by David Allison <davidallisongithub@gmail.com>
+
+# If the clipboard contains a link to an AnkiDroid Issue/PR, replace it with a well-formatted
+# link for use in Discord.
+#
+# Input:
+# ./macos-clipboard-to-discord.sh
+# with 'https://github.com/ankidroid/Anki-Android/pull/16804' on the clipboard
+#
+# Output:
+# copied '[#16804: refactor/docs: `libs.versions.toml` changelogs/renames](<https://github.com/ankidroid/Anki-Android/issues/16804>)' to clipboard
+#
+# The above link is displayed in Discord as the following, with no link preview:
+# #16804: refactor/docs: `libs.versions.toml` changelogs/renames
+#
+# See:
+# ./format-for-discord
+
+
+OWNER=ankidroid
+REPO=Anki-Android
+
+ISSUE_REGEX=https://github.com/$OWNER/$REPO/issues/\(\[\[:digit:\]\]+\)
+PR_REGEX=https://github.com/$OWNER/$REPO/pull/\(\[\[:digit:\]\]+\)
+
+CLIPBOARD=$(pbpaste)
+
+if ! [[ "$CLIPBOARD" =~ $ISSUE_REGEX ]] && ! [[ "$CLIPBOARD" =~ $PR_REGEX ]]; then
+  echo "No issue/PR link found on clipboard"
+  exit 1
+fi
+
+ISSUE_NUMBER="${BASH_REMATCH[1]}"
+# format-for-discord accepts either a PR number or an issue number
+OUTPUT_FOR_DISCORD=$(./format-for-discord.sh "$ISSUE_NUMBER")
+
+echo "$OUTPUT_FOR_DISCORD" | pbcopy
+echo "copied '$OUTPUT_FOR_DISCORD' to clipboard"


### PR DESCRIPTION
Scratching my own itch with this one

**Result:**
<img width="746" alt="Screenshot 2024-08-02 at 16 37 22" src="https://github.com/user-attachments/assets/906d88de-b22d-490f-b357-3d916b5ecfd5">

Links to the repo are unpleasant to see:

* Link previews are too large & distracting
* Links without a preview give no context

I want Discord output which both gives context, and is compact

`macos-clipboard-to-discord` converts an issue link: `https://github.com/ankidroid/Anki-Android/pull/16804`

into:
* A link with text: `#16804: refactor/docs: `libs.versions.toml` changelogs/renames`
* Without a preview
* Redirecting to the correct PR

`./format-for-discord` performs this formatting: accepting a PR/Issue number: 16804 and outputting the above to stdout


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
