### PR TITLE
refactor:  idiomatic capitalization in libAnki

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -128,10 +128,10 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     private fun createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
-        val m = BackendUtils.from_json_bytes(
+        val m = BackendUtils.fromJsonBytes(
             col.getStockNotetypeLegacy(StockNotetype.Kind.KIND_BASIC)
         ).apply { set("name", name) }
-        col.addNotetypeLegacy(BackendUtils.to_json_bytes(m))
+        col.addNotetypeLegacy(BackendUtils.toJsonBytes(m))
         return col.notetypes.byName(name)!!
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -433,7 +433,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         withProgress(resources.getString(R.string.model_field_editor_changing)) {
             withCol {
                 Timber.d("doInBackgroundChangeSortField")
-                notetypes.set_sort_index(notetype, idx)
+                notetypes.setSortIndex(notetype, idx)
             }
         }
         initialize()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -262,7 +262,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             withProgress(message = getString(R.string.model_field_editor_changing)) {
                 val result = withCol {
                     try {
-                        notetypes.remField(notetype, noteFields.getJSONObject(currentPos))
+                        notetypes.remFieldLegacy(notetype, noteFields.getJSONObject(currentPos))
                         true
                     } catch (e: ConfirmModSchemaException) {
                         // Should never be reached
@@ -380,7 +380,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
                 val result = withCol {
                     Timber.d("doInBackgroundRepositionField")
                     try {
-                        notetypes.moveField(notetype, noteFields.getJSONObject(currentPos), index)
+                        notetypes.moveFieldLegacy(notetype, noteFields.getJSONObject(currentPos), index)
                         true
                     } catch (e: ConfirmModSchemaException) {
                         e.log()
@@ -404,7 +404,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
         val fieldLabel = fieldNameInput!!.text.toString()
             .replace("[\\n\\r]".toRegex(), "")
         val field = noteFields.getJSONObject(currentPos)
-        getColUnsafe.notetypes.renameField(notetype, field, fieldLabel)
+        getColUnsafe.notetypes.renameFieldLegacy(notetype, field, fieldLabel)
         initialize()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -166,7 +166,7 @@ fun DeckPicker.handleNewSync(
             updateLogin(baseContext, "", "")
             throw exc
         }
-        withCol { notetypes._clear_cache() }
+        withCol { notetypes.clearCache() }
         setLastSyncTimeToNow()
         refreshState()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -52,7 +52,7 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
                 val standardNotetypesModels = StockNotetype.Kind.entries
                     .filter { it != StockNotetype.Kind.UNRECOGNIZED }
                     .map {
-                        val stockNotetype = BackendUtils.from_json_bytes(getStockNotetypeLegacy(it))
+                        val stockNotetype = BackendUtils.fromJsonBytes(getStockNotetypeLegacy(it))
                         AddNotetypeUiModel(
                             id = it.number.toLong(),
                             name = stockNotetype.get("name") as String,
@@ -136,10 +136,10 @@ class AddNewNotesType(private val activity: ManageNotetypes) {
             activity.runAndRefreshAfter {
                 val kind = StockNotetype.Kind.forNumber(selectedOption.id.toInt())
                 val updatedStandardNotetype =
-                    BackendUtils.from_json_bytes(getStockNotetypeLegacy(kind)).apply {
+                    BackendUtils.fromJsonBytes(getStockNotetypeLegacy(kind)).apply {
                         set("name", newName)
                     }
-                addNotetypeLegacy(BackendUtils.to_json_bytes(updatedStandardNotetype))
+                addNotetypeLegacy(BackendUtils.toJsonBytes(updatedStandardNotetype))
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -901,7 +901,7 @@ class CardContentProvider : ContentProvider() {
                         ?: throw IllegalArgumentException("field name missing for model: $mid")
                     val field: JSONObject = notetypes.newField(name)
                     try {
-                        notetypes.addField(existingModel, field)
+                        notetypes.addFieldLegacy(existingModel, field)
 
                         val flds: JSONArray = existingModel.getJSONArray("flds")
                         return ContentUris.withAppendedId(uri, (flds.length() - 1).toLong())

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -90,7 +90,7 @@ class Decks(private val col: Collection) {
     @LibAnkiAlias("add_deck_legacy")
     private fun addDeckLegacy(deck: Deck): OpChangesWithId {
         val changes = col.backend.addDeckLegacy(
-            json = BackendUtils.to_json_bytes(deck)
+            json = BackendUtils.toJsonBytes(deck)
         )
         deck.id = changes.id
         return changes
@@ -137,7 +137,7 @@ class Decks(private val col: Collection) {
     @RustCleanup("rename once we've removed this")
     fun get(did: DeckId): Deck? {
         return try {
-            Deck(BackendUtils.from_json_bytes(col.backend.getDeckLegacy(did)))
+            Deck(BackendUtils.fromJsonBytes(col.backend.getDeckLegacy(did)))
         } catch (ex: BackendNotFoundException) {
             null
         }
@@ -173,7 +173,7 @@ class Decks(private val col: Collection) {
 
     @LibAnkiAlias("new_deck_legacy")
     private fun newDeckLegacy(filtered: Boolean): Deck {
-        val deck = BackendUtils.from_json_bytes(col.backend.newDeckLegacy(filtered))
+        val deck = BackendUtils.fromJsonBytes(col.backend.newDeckLegacy(filtered))
         return Deck(
             if (filtered) {
                 // until migrating to the dedicated method for creating filtered decks,
@@ -241,7 +241,7 @@ class Decks(private val col: Collection) {
     @Suppress("unused", "unused_parameter")
     private fun get(did: DeckId, default: Boolean = true): Deck? {
         return try {
-            Deck(BackendUtils.from_json_bytes(col.backend.getDeckLegacy(did)))
+            Deck(BackendUtils.fromJsonBytes(col.backend.getDeckLegacy(did)))
         } catch (ex: BackendNotFoundException) {
             null
         }
@@ -326,13 +326,13 @@ class Decks(private val col: Collection) {
     @LibAnkiAlias("config_dict_for_deck_id")
     fun configDictForDeckId(did: DeckId): DeckConfig {
         val conf = get(did)?.conf ?: 1
-        return DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(conf)))
+        return DeckConfig(BackendUtils.fromJsonBytes(col.backend.getDeckConfigLegacy(conf)))
     }
 
     /* Reverts to default if provided id missing */
     @LibAnkiAlias("get_config")
     fun getConfig(confId: DeckConfigId): DeckConfig =
-        DeckConfig(BackendUtils.from_json_bytes(col.backend.getDeckConfigLegacy(confId)))
+        DeckConfig(BackendUtils.fromJsonBytes(col.backend.getDeckConfigLegacy(confId)))
 
     @RustCleanup("implement and make public")
     @LibAnkiAlias("update_config")
@@ -372,7 +372,7 @@ class Decks(private val col: Collection) {
     @NotInLibAnki
     @RustCleanup("inline")
     private fun newDeckConfigLegacy(): DeckConfig {
-        return DeckConfig(BackendUtils.from_json_bytes(col.backend.newDeckConfigLegacy()))
+        return DeckConfig(BackendUtils.fromJsonBytes(col.backend.newDeckConfigLegacy()))
     }
 
     @RustCleanup("implement and make public")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -340,19 +340,19 @@ class Notetypes(val col: Collection) {
 
     /** Modifies schema */
     @LibAnkiAlias("add_field")
-    fun add_field(notetype: NotetypeJson, field: Field) {
+    fun addField(notetype: NotetypeJson, field: Field) {
         notetype.flds.append(field)
     }
 
     /** Modifies schema. */
     @LibAnkiAlias("remove_field")
-    fun remove_field(notetype: NotetypeJson, field: Field) {
+    fun removeField(notetype: NotetypeJson, field: Field) {
         notetype.flds.remove(field)
     }
 
     /** Modifies schema. */
     @LibAnkiAlias("reposition_field")
-    fun reposition_field(notetype: NotetypeJson, field: Field, idx: Int) {
+    fun repositionField(notetype: NotetypeJson, field: Field, idx: Int) {
         val oldidx = notetype.flds.index(field).get()
         if (oldidx == idx) {
             return
@@ -363,7 +363,7 @@ class Notetypes(val col: Collection) {
     }
 
     @LibAnkiAlias("rename_field")
-    fun rename_field(notetype: NotetypeJson, field: Field, new_name: String) {
+    fun renameField(notetype: NotetypeJson, field: Field, new_name: String) {
         assert(notetype.flds.jsonObjectIterable().contains(field))
         field["name"] = new_name
     }
@@ -378,26 +378,29 @@ class Notetypes(val col: Collection) {
     /*
      legacy
      */
-
-    fun addField(notetype: NotetypeJson, field: Field) {
-        add_field(notetype, field)
+    @RustCleanup("legacy")
+    fun addFieldLegacy(notetype: NotetypeJson, field: Field) {
+        addField(notetype, field)
         if (notetype.id != 0L) {
             save(notetype)
         }
     }
 
-    fun remField(notetype: NotetypeJson, field: Field) {
-        remove_field(notetype, field)
+    @RustCleanup("legacy")
+    fun remFieldLegacy(notetype: NotetypeJson, field: Field) {
+        removeField(notetype, field)
         save(notetype)
     }
 
-    fun moveField(notetype: NotetypeJson, field: Field, idx: Int) {
-        reposition_field(notetype, field, idx)
+    @RustCleanup("legacy")
+    fun moveFieldLegacy(notetype: NotetypeJson, field: Field, idx: Int) {
+        repositionField(notetype, field, idx)
         save(notetype)
     }
 
-    fun renameField(notetype: NotetypeJson, field: Field, newName: String) {
-        rename_field(notetype, field, newName)
+    @RustCleanup("legacy")
+    fun renameFieldLegacy(notetype: NotetypeJson, field: Field, newName: String) {
+        renameField(notetype, field, newName)
         save(notetype)
     }
 
@@ -410,7 +413,7 @@ class Notetypes(val col: Collection) {
     fun addFieldInNewModel(notetype: NotetypeJson, field: JSONObject) {
         Assert.that(isModelNew(notetype), "Model was assumed to be new, but is not")
         try {
-            addField(notetype, field)
+            addFieldLegacy(notetype, field)
         } catch (e: ConfirmModSchemaException) {
             Timber.w(e, "Unexpected mod schema")
             CrashReportService.sendExceptionReport(e, "addFieldInNewModel: Unexpected mod schema")
@@ -437,7 +440,7 @@ class Notetypes(val col: Collection) {
         // mod is already changed, it never has to throw
         // ConfirmModSchemaException.
         Assert.that(col.schemaChanged(), "Mod was assumed to be already changed, but is not")
-        addField(notetype, field)
+        addFieldLegacy(notetype, field)
     }
 
     fun addTemplateModChanged(notetype: NotetypeJson, template: JSONObject) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -203,7 +203,7 @@ class TemplateManager {
                     backend.renderUncommittedCardLegacy(
                         _note.toBackendNote(),
                         _card.ord,
-                        BackendUtils.to_json_bytes(_template!!.deepClone()),
+                        BackendUtils.toJsonBytes(_template!!.deepClone()),
                         fillEmpty,
                         true
                     )

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/backend/BackendUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/backend/BackendUtils.kt
@@ -19,12 +19,14 @@
 package com.ichi2.libanki.backend
 
 import com.google.protobuf.ByteString
+import com.ichi2.libanki.utils.LibAnkiAlias
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONArray
 import org.json.JSONObject
 
 object BackendUtils {
-    fun from_json_bytes(json: ByteString): JSONObject {
+    @LibAnkiAlias("from_json_bytes")
+    fun fromJsonBytes(json: ByteString): JSONObject {
         return JSONObject(json.toStringUtf8())
     }
 
@@ -39,5 +41,6 @@ object BackendUtils {
     }
 
     @RustCleanup("Confirm edge cases")
-    fun to_json_bytes(json: Any?): ByteString = toByteString(json)
+    @LibAnkiAlias("to_json_bytes")
+    fun toJsonBytes(json: Any?): ByteString = toByteString(json)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Counts.kt
@@ -26,8 +26,8 @@ class Counts(var new: Int = 0, var lrn: Int = 0, var rev: Int = 0) {
         NEW, LRN, REV
     }
 
-    fun addNew(new_: Int) {
-        new += new_
+    fun addNew(new: Int) {
+        this.new += new
     }
 
     fun addLrn(lrn: Int) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -101,7 +101,7 @@ class ModelFieldEditorTest(private val forbiddenCharacter: String) : Robolectric
                     // start ModelFieldEditor activity
                     val intent = Intent()
                     intent.putExtra("title", modelName)
-                    intent.putExtra("noteTypeID", col.notetypes.id_for_name(modelName)!!)
+                    intent.putExtra("noteTypeID", col.notetypes.idForName(modelName)!!)
                     val modelFieldEditor = startActivityNormallyOpenCollectionWithIntent(
                         this@ModelFieldEditorTest,
                         ModelFieldEditor::class.java,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -420,7 +420,7 @@ class NoteEditorTest : RobolectricTest() {
             editor.saveNote()
         }
 
-        col.notetypes._clear_cache()
+        col.notetypes.clearCache()
 
         assertThat("a note was added", col.noteCount(), equalTo(1))
         assertThat("note type deck is updated", col.notetypes.byName("Basic")!!.did, equalTo(reversedDeckId))

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -119,11 +119,11 @@ class CardTest : JvmTest() {
         val models = col.notetypes
         val model = models.byName("Basic")
         assertNotNull(model)
-        models.renameField(model, model.getJSONArray("flds").getJSONObject(0), "A")
-        models.renameField(model, model.getJSONArray("flds").getJSONObject(1), "B")
+        models.renameFieldLegacy(model, model.getJSONArray("flds").getJSONObject(0), "A")
+        models.renameFieldLegacy(model, model.getJSONArray("flds").getJSONObject(1), "B")
         val fld2 = models.newField("C")
         fld2.put("ord", JSONObject.NULL)
-        models.addField(model, fld2)
+        models.addFieldLegacy(model, fld2)
         val tmpls = model.getJSONArray("tmpls")
         tmpls.getJSONObject(0).put("qfmt", "{{A}}{{B}}{{C}}")
         // ensure first card is always generated,
@@ -169,11 +169,11 @@ class CardTest : JvmTest() {
         val model = models.byName("Basic")
         assertNotNull(model)
         val tmpls = model.getJSONArray("tmpls")
-        models.renameField(model, model.getJSONArray("flds").getJSONObject(0), "First")
-        models.renameField(model, model.getJSONArray("flds").getJSONObject(1), "Front")
+        models.renameFieldLegacy(model, model.getJSONArray("flds").getJSONObject(0), "First")
+        models.renameFieldLegacy(model, model.getJSONArray("flds").getJSONObject(1), "Front")
         val fld2 = models.newField("AddIfEmpty")
         fld2.put("name", "AddIfEmpty")
-        models.addField(model, fld2)
+        models.addFieldLegacy(model, fld2)
 
         // ensure first card is always generated,
         // because at last one card is generated

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -131,7 +131,7 @@ class NotetypeTest : JvmTest() {
         col.addNote(note)
         val m = col.notetypes.current()
         // make sure renaming a field updates the templates
-        col.notetypes.renameField(m, m.getJSONArray("flds").getJSONObject(0), "NewFront")
+        col.notetypes.renameFieldLegacy(m, m.getJSONArray("flds").getJSONObject(0), "NewFront")
         assertThat(
             m.getJSONArray("tmpls").getJSONObject(0).getString("qfmt"),
             containsString("{{NewFront}}")
@@ -139,7 +139,7 @@ class NotetypeTest : JvmTest() {
         val h = col.notetypes.scmhash(m)
         // add a field
         var field: JSONObject? = col.notetypes.newField("foo")
-        col.notetypes.addField(m, field!!)
+        col.notetypes.addFieldLegacy(m, field!!)
         assertEquals(
             listOf("1", "2", ""),
             col.getNote(
@@ -151,10 +151,10 @@ class NotetypeTest : JvmTest() {
         assertNotEquals(h, col.notetypes.scmhash(m))
         // rename it
         field = m.getJSONArray("flds").getJSONObject(2)
-        col.notetypes.renameField(m, field, "bar")
+        col.notetypes.renameFieldLegacy(m, field, "bar")
         assertEquals("", col.getNote(col.notetypes.nids(m)[0]).getItem("bar"))
         // delete back
-        col.notetypes.remField(m, m.getJSONArray("flds").getJSONObject(1))
+        col.notetypes.remFieldLegacy(m, m.getJSONArray("flds").getJSONObject(1))
         assertEquals(
             listOf("1", ""),
             col.getNote(
@@ -164,7 +164,7 @@ class NotetypeTest : JvmTest() {
             ).fields
         )
         // move 0 -> 1
-        col.notetypes.moveField(m, m.getJSONArray("flds").getJSONObject(0), 1)
+        col.notetypes.moveFieldLegacy(m, m.getJSONArray("flds").getJSONObject(0), 1)
         assertEquals(
             listOf("", "1"),
             col.getNote(
@@ -174,7 +174,7 @@ class NotetypeTest : JvmTest() {
             ).fields
         )
         // move 1 -> 0
-        col.notetypes.moveField(m, m.getJSONArray("flds").getJSONObject(1), 0)
+        col.notetypes.moveFieldLegacy(m, m.getJSONArray("flds").getJSONObject(1), 0)
         assertEquals(
             listOf("1", ""),
             col.getNote(
@@ -185,7 +185,7 @@ class NotetypeTest : JvmTest() {
         )
         // add another and put in middle
         field = col.notetypes.newField("baz")
-        col.notetypes.addField(m, field)
+        col.notetypes.addFieldLegacy(m, field)
         note = col.getNote(col.notetypes.nids(m)[0])
         note.setItem("baz", "2")
         note.flush()
@@ -198,7 +198,7 @@ class NotetypeTest : JvmTest() {
             ).fields
         )
         // move 2 -> 1
-        col.notetypes.moveField(m, m.getJSONArray("flds").getJSONObject(2), 1)
+        col.notetypes.moveFieldLegacy(m, m.getJSONArray("flds").getJSONObject(2), 1)
         assertEquals(
             listOf("1", "2", ""),
             col.getNote(
@@ -208,7 +208,7 @@ class NotetypeTest : JvmTest() {
             ).fields
         )
         // move 0 -> 2
-        col.notetypes.moveField(m, m.getJSONArray("flds").getJSONObject(0), 2)
+        col.notetypes.moveFieldLegacy(m, m.getJSONArray("flds").getJSONObject(0), 2)
         assertEquals(
             listOf("2", "", "1"),
             col.getNote(
@@ -218,7 +218,7 @@ class NotetypeTest : JvmTest() {
             ).fields
         )
         // move 0 -> 1
-        col.notetypes.moveField(m, m.getJSONArray("flds").getJSONObject(0), 1)
+        col.notetypes.moveFieldLegacy(m, m.getJSONArray("flds").getJSONObject(0), 1)
         assertEquals(
             listOf("", "2", "1"),
             col.getNote(

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -108,7 +108,7 @@ interface TestClass {
     fun addField(notetype: NotetypeJson, name: String) {
         val models = col.notetypes
         try {
-            models.addField(notetype, models.newField(name))
+            models.addFieldLegacy(notetype, models.newField(name))
         } catch (e: ConfirmModSchemaException) {
             throw RuntimeException(e)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
@@ -103,10 +103,10 @@ const val BASIC_MODEL_NAME = "Basic"
  * @return the new model
  */
 fun Collection.createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
-    val m = BackendUtils.from_json_bytes(
+    val m = BackendUtils.fromJsonBytes(
         getStockNotetypeLegacy(StockNotetype.Kind.KIND_BASIC)
     ).apply { set("name", name) }
-    addNotetypeLegacy(BackendUtils.to_json_bytes(m))
+    addNotetypeLegacy(BackendUtils.toJsonBytes(m))
     return notetypes.byName(name)!!
 }
 


### PR DESCRIPTION
## Purpose / Description
It was agreed we use camelCase consistently and that `snake_case` was to be applied via `@LibAnkiAlias`

## Fixes
* Fixes #11582

## Approach

* search for `fun.*_` inside `libAnki`
* rename
* A few methods would have conflicted. Either inline them if they're aliases, or handle them in a second commit

## How Has This Been Tested?
CI-only: refactor

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
