### PR TITLE
feat: Hide 'Hard' and 'Easy' buttons setting in the new reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -215,6 +215,11 @@ class ReviewerFragment :
                 answerButtonsLayout.isVisible = false
             }
         }
+
+        if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
+            hardButton.isVisible = false
+            easyButton.isVisible = false
+        }
     }
 
     private fun setupCounts(view: View) {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -444,4 +444,5 @@ this formatter is used if the bind only applies to both the question and the ans
         >All</string>
     <string name="ignore_display_cutout" maxLength="41">Ignore display cutout</string>
     <string name="hide_answer_buttons" maxLength="41">Hide answer buttons</string>
+    <string name="hide_hard_and_easy" maxLength="41">Hide ‘Hard’ and ‘Easy’ buttons</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -201,6 +201,7 @@
     <string name="hide_system_bars_key">hideSystemBars</string>
     <string name="ignore_display_cutout_key">ignoreDisplayCutout</string>
     <string name="hide_answer_buttons_key">hideAnswerButtons</string>
+    <string name="hide_hard_and_easy_key">hideHardAndEasy</string>
 
     <string name="pref_new_multimedia_ui">newMultimediaUI</string>
 

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -21,4 +21,10 @@
         android:key="@string/hide_answer_buttons_key"
         android:title="@string/hide_answer_buttons"
         />
+
+    <SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="@string/hide_hard_and_easy_key"
+        android:title="@string/hide_hard_and_easy"
+        />
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
It is a frequently requested feature, helps a big number of users that only use two buttons, and it is quite simple to implement.

Apparently, Damien don't want to implement it in Anki for some kind of reason, but it takes a lot of less time to implement it than to read the more than 100 comments in the corresponding page at the forums to still reach to the same conclusion.

About the PR, if any string related changes are required, please push them or do them in another PR, because I don't have time to bikeshedding and won't do them.

## How Has This Been Tested?

Emulator 35:

<details><summary>Screenshot</summary>

![Screenshot_20240804_182727](https://github.com/user-attachments/assets/8d2532db-b232-4b0c-8a48-68ca960b4cd7)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
