### PR TITLE
Download crowdin en-translation

### DIFF
--- a/lint-release.xml
+++ b/lint-release.xml
@@ -55,6 +55,7 @@
         <ignore path="res/values-da/" />
         <ignore path="res/values-de/" />
         <ignore path="res/values-el/" />
+        <ignore path="res/values-en/" />
         <ignore path="res/values-eo/" />
         <ignore path="res/values-es-rAR/" />
         <ignore path="res/values-es-rES/" />

--- a/tools/localization/src/constants.ts
+++ b/tools/localization/src/constants.ts
@@ -94,6 +94,7 @@ export const LANGUAGES = [
     "da",
     "de",
     "el",
+    "en-GB",
     "eo",
     "es-AR",
     "es-ES",
@@ -176,7 +177,7 @@ export const LANGUAGES = [
 ];
 
 // languages which are localized for more than one region
-export const LOCALIZED_REGIONS = ["es", "pt", "zh"];
+export const LOCALIZED_REGIONS = ["en", "es", "pt", "zh"];
 
 export const XML_LICENSE_HEADER = `<?xml version="1.0" encoding="utf-8"?> 
  <!--


### PR DESCRIPTION
This PR would only ensure that the translation tool download the crowdin en translation. English (GB). It does not yet add it to ankidroid, because I do not know how to use it with en-gb from anki. In particular, I want to makes sure that users using "english" keep getting the content of values by default instead of values-en. And that only the one using English (gb) gets the English version.

It may have to be reverted if I can't make it work.

In Bug: #16820, @BrayanDSO noted that we normally only start a language when 01-core is 100% done. In the case of English, I doubt it's actually required, given that en (GB) is very similar to en, and that would just be requesting useless extra work from the translators.