### PR TITLE
test: fix hangs on Linux

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -68,36 +68,37 @@ class CustomStudyDialogTest : RobolectricTest() {
             .withArguments(CustomStudyDialog.ContextMenuOption.STUDY_AHEAD, 1)
             .arguments
         val factory = CustomStudyDialogFactory({ this.col }, mockListener)
-        val scenario = FragmentScenario.launch(CustomStudyDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onFragment { f: CustomStudyDialog ->
-            val dialog = assertNotNull(f.dialog as AlertDialog?)
-            dialog.performPositiveClick()
+        FragmentScenario.launch(CustomStudyDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onFragment { f: CustomStudyDialog ->
+                val dialog = assertNotNull(f.dialog as AlertDialog?)
+                dialog.performPositiveClick()
+            }
+            val customStudy = col.decks.current()
+            MatcherAssert.assertThat("Custom Study should be dynamic", customStudy.isFiltered)
+            MatcherAssert.assertThat("could not find deck: Custom study session", customStudy, notNullValue())
+            customStudy.remove("id")
+            customStudy.remove("mod")
+            customStudy.remove("name")
+            val expected = "{" +
+                "\"browserCollapsed\":false," +
+                "\"collapsed\":false," +
+                "\"delays\":null," +
+                "\"desc\":\"\"," +
+                "\"dyn\":1," +
+                "\"lrnToday\":[0,0]," +
+                "\"newToday\":[0,0]," +
+                "\"previewDelay\":0," +
+                "\"previewAgainSecs\":60,\"previewHardSecs\":600,\"previewGoodSecs\":0," +
+                "\"resched\":true," +
+                "\"revToday\":[0,0]," +
+                "\"separate\":true," +
+                "\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]]," +
+                "\"timeToday\":[0,0]," +
+                "\"usn\":-1" +
+                "}"
+            MatcherAssert.assertThat(customStudy, isJsonEqual(JSONObject(expected)))
         }
-        val customStudy = col.decks.current()
-        MatcherAssert.assertThat("Custom Study should be dynamic", customStudy.isFiltered)
-        MatcherAssert.assertThat("could not find deck: Custom study session", customStudy, notNullValue())
-        customStudy.remove("id")
-        customStudy.remove("mod")
-        customStudy.remove("name")
-        val expected = "{" +
-            "\"browserCollapsed\":false," +
-            "\"collapsed\":false," +
-            "\"delays\":null," +
-            "\"desc\":\"\"," +
-            "\"dyn\":1," +
-            "\"lrnToday\":[0,0]," +
-            "\"newToday\":[0,0]," +
-            "\"previewDelay\":0," +
-            "\"previewAgainSecs\":60,\"previewHardSecs\":600,\"previewGoodSecs\":0," +
-            "\"resched\":true," +
-            "\"revToday\":[0,0]," +
-            "\"separate\":true," +
-            "\"terms\":[[\"deck:\\\"Default\\\" prop:due<=1\",99999,6]]," +
-            "\"timeToday\":[0,0]," +
-            "\"usn\":-1" +
-            "}"
-        MatcherAssert.assertThat(customStudy, isJsonEqual(JSONObject(expected)))
     }
 
     @Test
@@ -118,12 +119,13 @@ class CustomStudyDialogTest : RobolectricTest() {
         whenever(mockCollection.sched).thenReturn(mockSched)
         whenever(mockSched.newCount()).thenReturn(0)
         val factory = CustomStudyDialogFactory({ mockCollection }, mockListener)
-        val scenario = FragmentScenario.launch(CustomStudyDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: CustomStudyDialog ->
-            val dialog = f.dialog as AlertDialog?
-            MatcherAssert.assertThat(dialog, IsNull.notNullValue())
-            onView(withText(R.string.custom_study_increase_new_limit)).inRoot(isDialog()).check(doesNotExist())
+        FragmentScenario.launch(CustomStudyDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory).use { scenario ->
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.onFragment { f: CustomStudyDialog ->
+                val dialog = f.dialog as AlertDialog?
+                MatcherAssert.assertThat(dialog, IsNull.notNullValue())
+                onView(withText(R.string.custom_study_increase_new_limit)).inRoot(isDialog()).check(doesNotExist())
+            }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -36,8 +36,6 @@ import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.RecyclerViewUtils
-import com.ichi2.testutils.common.Flaky
-import com.ichi2.testutils.common.OS
 import com.ichi2.ui.CheckBoxTriStates
 import com.ichi2.utils.ListUtil
 import org.hamcrest.MatcherAssert.assertThat
@@ -51,8 +49,6 @@ import timber.log.Timber
 import java.util.concurrent.atomic.AtomicReference
 
 @RunWith(AndroidJUnit4::class)
-// inheriting from RobolectricTest is required for @Flaky
-@Flaky(OS.WINDOWS, "16404: tests in this class occasionally hang")
 class TagsDialogTest : RobolectricTest() {
     @Test
     fun testTagsDialogCustomStudyOptionInterface() {
@@ -60,12 +56,10 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("1", "2", "3", "4")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, ArrayList(), allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -85,10 +79,8 @@ class TagsDialogTest : RobolectricTest() {
         val allTags = listOf("1", "2", "3", "4")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, ArrayList(), allTags)
-            .arguments
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+            .requireArguments()
+        runTagsDialogScenario(args) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
             val returnedList = AtomicReference<List<String>?>()
@@ -121,12 +113,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = listOf("a", "b")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -156,12 +146,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = listOf("a", "b")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -194,12 +182,10 @@ class TagsDialogTest : RobolectricTest() {
         val expectedIndeterminate = listOf("b")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, uncheckedTags, expectedAllTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -249,12 +235,10 @@ class TagsDialogTest : RobolectricTest() {
         )
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -296,12 +280,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = listOf("common::speak::daily", "common::sport::tennis")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -350,12 +332,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = listOf("common")
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -398,12 +378,10 @@ class TagsDialogTest : RobolectricTest() {
         )
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -439,12 +417,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -486,12 +462,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
 
@@ -605,12 +579,10 @@ class TagsDialogTest : RobolectricTest() {
         val checkedTags = emptyList<String>()
         val args = TagsDialog(ParametersUtils.whatever())
             .withTestArguments(type, checkedTags, allTags)
-            .arguments
+            .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f: TagsDialog ->
+        runTagsDialogScenario(args, factory) { f: TagsDialog ->
             val dialog = f.dialog as AlertDialog?
             assertThat(dialog, IsNull.notNullValue())
             val editText = f.getSearchView()!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)!!
@@ -707,6 +679,19 @@ class TagsDialogTest : RobolectricTest() {
                 allTags = allTags
             )
         }
+
+    private fun runTagsDialogScenario(
+        args: Bundle,
+        factory: TagsDialogFactory? = null,
+        block: (TagsDialog) -> Unit
+    ) {
+        FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory).use { scenario ->
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.onFragment { tagsDialog: TagsDialog ->
+                block(tagsDialog)
+            }
+        }
+    }
 
     companion object {
         private fun mockLifecycleOwner(): LifecycleOwner {


### PR DESCRIPTION
In PR 16620, I encountered the following error on
ubuntu CI

* #16620

After research, `CppAssetManager2` errors are typically due to memory leaks, often by not calling close on Scenarios

```
TagsDialogTest > test_SearchTag_spaceWillBeFilteredCorrectly FAILED
    java.lang.OutOfMemoryError: Java heap space
        at org.robolectric.res.android.ResourceTypes$ResTable_typeSpec.getSpecFlags(ResourceTypes.java:1095)
        at org.robolectric.res.android.LoadedArsc$TypeSpec.GetFlagsForEntryIndex(LoadedArsc.java:116)
        at org.robolectric.res.android.CppAssetManager2.FindEntry(CppAssetManager2.java:699)
        at org.robolectric.res.android.CppAssetManager2.GetResource(CppAssetManager2.java:869)
        at org.robolectric.res.android.CppAssetManager2.ResolveReference(CppAssetManager2.java:935)
        at org.robolectric.res.android.AttributeResolution10.ApplyStyle(AttributeResolution10.java:414)
        at org.robolectric.shadows.ShadowArscAssetManager10.nativeApplyStyle_measured(ShadowArscAssetManager10.java:1414)
        at org.robolectric.shadows.ShadowArscAssetManager10.lambda$nativeApplyStyle$1(ShadowArscAssetManager10.java:1374)
        at org.robolectric.shadows.ShadowArscAssetManager10$$Lambda/0x00007f40d092a740.run(Unknown Source)
        at org.robolectric.util.PerfStatsCollector.measure(PerfStatsCollector.java:82)
        at org.robolectric.shadows.ShadowArscAssetManager10.nativeApplyStyle(ShadowArscAssetManager10.java:1371)
        at java.base/java.lang.invoke.LambdaForm$DMH/0x00007f40d0946800.invokeStatic(LambdaForm$DMH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0948800.guardWithCatch(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0ab3400.delegate(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d094ac00.guard(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d094b000.linkToCallSite(LambdaForm$MH)
        at android.content.res.AssetManager.nativeApplyStyle(AssetManager.java)
        at android.content.res.AssetManager.applyStyle(AssetManager.java:1147)
        at java.base/java.lang.invoke.LambdaForm$DMH/0x00007f40d0941400.invokeSpecial(LambdaForm$DMH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0943c00.guardWithCatch(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0ab3000.delegate(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0946000.guard(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0946400.linkToCallSite(LambdaForm$MH)
        at android.content.res.AssetManager.applyStyle(AssetManager.java)
        at android.content.res.ResourcesImpl$ThemeImpl.obtainStyledAttributes(ResourcesImpl.java:1394)
        at java.base/java.lang.invoke.LambdaForm$DMH/0x00007f40d035d400.invokeSpecial(LambdaForm$DMH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d093fc00.guardWithCatch(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d035dc00.delegate(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0940c00.guard(LambdaForm$MH)
        at java.base/java.lang.invoke.LambdaForm$MH/0x00007f40d0941000.linkToCallSite(LambdaForm$MH)
        at android.content.res.ResourcesImpl$ThemeImpl.obtainStyledAttributes(ResourcesImpl.java)
        at android.content.res.Resources$Theme.obtainStyledAttributes(Resources.java:1692)
```

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## How Has This Been Tested?
Test only. It may be a fluke, but now the tests on the associated PR pass

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
