### PR TITLE
fix: unnecessary camera permission check

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -27,8 +27,6 @@
 <!--    <uses-feature android:name. We must ensure this is never called when running on API 23.-->
     <uses-sdk tools:overrideLibrary="androidx.draganddrop"/>
 
-    <uses-feature android:name="android.hardware.camera" android:required="false" />
-    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />
     <uses-feature android:name="android.software.app_widgets" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki.multimedia
 
-import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -55,7 +54,6 @@ import com.ichi2.utils.BitmapUtil
 import com.ichi2.utils.ExifUtil
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.ImageUtils
-import com.ichi2.utils.Permissions
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -143,6 +141,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
      * Launches the device's camera to take a picture.
      * This launcher is registered using `ActivityResultContracts.TakePicture()`.
      */
+    @NeedsTest("Works fine without permission as we use Camera as feature")
     private val cameraLauncher =
         registerForActivityResult(ActivityResultContracts.TakePicture()) { isPictureTaken ->
             when {
@@ -240,35 +239,8 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         imagePreview = view.findViewById(R.id.image_preview)
         imageFileSize = view.findViewById(R.id.image_size_textview)
 
-        if (selectedImageOptions == ImageOptions.CAMERA) {
-            if (!hasCameraPermission()) {
-                return
-            }
-        }
-
         handleImageUri()
         setupDoneButton()
-    }
-
-    private val requestPermissionLauncher = registerForActivityResult(
-        ActivityResultContracts.RequestPermission()
-    ) { isGranted ->
-        if (isGranted) {
-            Timber.d("Camera permission granted")
-            handleSelectedImageOptions()
-        } else {
-            Timber.d("Camera permission denied")
-            showErrorDialog(resources.getString(R.string.multimedia_editor_camera_permission_refused))
-        }
-    }
-
-    private fun hasCameraPermission(): Boolean {
-        if (!Permissions.canRecordAudio(requireContext())) {
-            Timber.i("Requesting Audio Permissions")
-            requestPermissionLauncher.launch(Manifest.permission.CAMERA)
-            return false
-        }
-        return true
     }
 
     private fun handleImageUri() {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -54,10 +54,6 @@ object Permissions {
         Manifest.permission.WRITE_EXTERNAL_STORAGE
     )
 
-    fun canUseCamera(context: Context): Boolean {
-        return hasPermission(context, Manifest.permission.CAMERA)
-    }
-
     fun canRecordAudio(context: Context): Boolean {
         return hasPermission(context, Manifest.permission.RECORD_AUDIO)
     }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -125,7 +125,6 @@
 
     <!-- Multimedia - Edit Field Activity -->
     <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>
-    <string name="multimedia_editor_camera_permission_refused">Could not obtain camera permission. Functionality has been disabled.</string>
     <string name="multimedia_editor_failed">Failed to open Multimedia Editor</string>
 
     <!-- Multimedia - Audio View -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
We use camera as feature in the manifest file and not as `<uses-permission android:name="android.permission.CAMERA" />` so the current check always returns false and the user is unable to open the camera options, the PR fixes that

We don't have camera permission in the manifest file, We are using it as a feature
The current code won't allow the camera to be launched since it is not having the permission neither have we declared it.
It was removed earlier by Brayan
* #14162

the check was not their originally in the new code but was introduced in
https://github.com/ankidroid/Anki-Android/pull/16798/commits/cd037564b47c9feb55c3f5bcbfd1117319e126ac

## How Has This Been Tested?
Google emualtor API 24 & API35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
