### PR TITLE
feat(card-browser): Chip Based Filtering [Tags, Flags & State]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1173,12 +1173,6 @@ open class CardBrowser :
                 searchForMarkedNotes()
                 return true
             }
-
-            @NeedsTest("filter-suspended query needs testing")
-            R.id.action_show_suspended -> {
-                searchForSuspendedCards()
-                return true
-            }
             R.id.action_search_by_tag -> {
                 showFilterByTagsDialog()
                 return true
@@ -1675,7 +1669,7 @@ open class CardBrowser :
     @RustCleanup("this isn't how Desktop Anki does it")
     override fun onSelectedTags(selectedTags: List<String>, indeterminateTags: List<String>, stateFilter: CardStateFilter) {
         when (tagsDialogListenerAction) {
-            TagsDialogListenerAction.FILTER -> filterByTags(selectedTags, stateFilter)
+            TagsDialogListenerAction.FILTER -> filterByTags(selectedTags)
             TagsDialogListenerAction.EDIT_TAGS -> launchCatchingTask {
                 editSelectedCardsTags(selectedTags, indeterminateTags)
             }
@@ -1703,9 +1697,9 @@ open class CardBrowser :
         }
     }
 
-    private fun filterByTags(selectedTags: List<String>, cardState: CardStateFilter) =
+    private fun filterByTags(selectedTags: List<String>) =
         launchCatchingTask {
-            viewModel.filterByTags(selectedTags, cardState)
+            viewModel.filterByTags(selectedTags)
         }
 
     /**
@@ -2342,7 +2336,7 @@ open class CardBrowser :
     fun filterByTag(vararg tags: String) {
         tagsDialogListenerAction = TagsDialogListenerAction.FILTER
         onSelectedTags(tags.toList(), emptyList(), CardStateFilter.ALL_CARDS)
-        filterByTags(tags.toList(), CardStateFilter.ALL_CARDS)
+        filterByTags(tags.toList())
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -73,6 +73,7 @@ import com.ichi2.anki.browser.SearchParameters
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.getLabel
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
+import com.ichi2.anki.browser.toQuery
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -80,6 +80,11 @@ enum class Flag(
         }
 
         /**
+         * Usage:
+         * ```kotlin
+         * Flag.queryDisplayNames().map { (flag, displayName) -> ... }
+         * ```
+         *
          * @return A mapping from each [Flag] to its display name (optionally user-defined)
          */
         suspend fun queryDisplayNames(): Map<Flag, String> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetDialogFragmentFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetDialogFragmentFix.kt
@@ -1,0 +1,47 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.Context
+import android.content.res.Configuration
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.ichi2.anki.convertDpToPixel
+
+// https://stackoverflow.com/questions/41591733
+open class BottomSheetDialogFragmentFix : BottomSheetDialogFragment() {
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        fixBottomSheetPeekHeight() // After device rotation
+    }
+
+    override fun onResume() {
+        super.onResume()
+        fixBottomSheetPeekHeight() // When showing for the first time
+    }
+
+    private fun fixBottomSheetPeekHeight() {
+        (dialog as? BottomSheetDialog)?.behavior?.peekHeight =
+            if (requireContext().isLandscape) {
+                convertDpToPixel(512f, requireContext()).toInt()
+            } else {
+                BottomSheetBehavior.PEEK_HEIGHT_AUTO
+            }
+    }
+}
+
+private val Context.isLandscape get() =
+    resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetFragment.kt
@@ -48,7 +48,13 @@ open class BottomSheetFragment : BottomSheetDialogFragmentFix() {
 
         adapter.onItemCheckedListener = { _ -> onItemsSelected(adapter.checkedItemIds) }
         adapter.onItemClickedListener = { id ->
-            onItemsSelected(if (id == ALL_ITEMS_ID) emptySet() else setOf(id))
+            val newSelection = when (id) {
+                CLEAR_SEARCH_ID -> emptySet()
+                // If the item is selected and tapped again, deselect it
+                adapter.checkedItemIds.singleOrNull() -> emptySet()
+                else -> setOf(id)
+            }
+            onItemsSelected(newSelection)
             dismiss()
         }
 
@@ -98,4 +104,4 @@ private fun EditText.addOnChangeListener(listener: (before: String, after: Strin
     })
 }
 
-const val ALL_ITEMS_ID = -123L
+const val CLEAR_SEARCH_ID = -123L

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BottomSheetFragment.kt
@@ -1,0 +1,59 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.R
+import kotlinx.coroutines.runBlocking
+
+open class BottomSheetFragment : BottomSheetDialogFragmentFix() {
+    open val layoutResource = R.layout.bottom_sheet_list_without_filter
+
+    protected lateinit var adapter: TemplatedTreeAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        adapter = TemplatedTreeAdapter(requireContext())
+        // TODO: This isn't good
+        // In TagsSheetFragment, `layoutResource` depends on the number of tags, set in `onPrepareAdapter`
+        runBlocking { onPrepareAdapter() }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val layout = inflater.inflate(layoutResource, container, false)
+
+        val listRecyclerView = layout.findViewById<RecyclerView>(R.id.list)
+
+        adapter.onItemCheckedListener = { _ -> onItemsSelected(adapter.checkedItemIds) }
+        adapter.onItemClickedListener = { id ->
+            onItemsSelected(if (id == ALL_ITEMS_ID) emptySet() else setOf(id))
+            dismiss()
+        }
+
+        listRecyclerView.adapter = adapter
+
+        return layout
+    }
+
+    open suspend fun onPrepareAdapter() {}
+
+    open fun onItemsSelected(ids: Set<Long>) {}
+}
+
+const val ALL_ITEMS_ID = -123L

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -655,29 +655,6 @@ class CardBrowserViewModel(
     private fun <T> Flow<T>.ignoreValuesFromViewModelLaunch(): Flow<T> =
         this.filter { initCompleted }
 
-    /**
-     * Searches for all marked notes and replaces the current search results with these marked notes.
-     */
-    suspend fun searchForMarkedNotes() {
-        // only intended to be used if the user has no selection
-        if (hasSelectedAnyRows()) return
-        launchSearchForCards(searchTerms.copy(userInput = "tag:marked"))
-    }
-
-    suspend fun searchForSuspendedCards() {
-        // only intended to be used if the user has no selection
-        if (hasSelectedAnyRows()) return
-        launchSearchForCards(searchTerms.copy(userInput = "is:suspended"))
-    }
-
-    suspend fun filterByTags(selectedTags: List<String>) {
-        // join selectedTags as "tag:$tag" with " or " between them
-        val tagsConcat = selectedTags.joinToString(" or ") { tag -> "\"tag:$tag\"" }
-        // Only if we added anything to the tag list
-        val tagFilter = if (selectedTags.isEmpty()) "" else "($tagsConcat)"
-        launchSearchForCards(searchTerms.copy(userInput = tagFilter))
-    }
-
     /** Previewing */
     suspend fun queryPreviewIntentData(): PreviewerDestination {
         // If in NOTES mode, we show one Card per Note, as this matches Anki Desktop

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -35,7 +35,6 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.PreviewerDestination
 import com.ichi2.anki.export.ExportDialogFragment.ExportType
 import com.ichi2.anki.launchCatchingIO
-import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
@@ -665,23 +664,18 @@ class CardBrowserViewModel(
         launchSearchForCards(searchTerms.copy(userInput = "tag:marked"))
     }
 
-    /**
-     * Searches for all suspended cards and replaces the current search results with these suspended cards.
-     */
     suspend fun searchForSuspendedCards() {
         // only intended to be used if the user has no selection
         if (hasSelectedAnyRows()) return
         launchSearchForCards(searchTerms.copy(userInput = "is:suspended"))
     }
 
-    suspend fun filterByTags(selectedTags: List<String>, cardState: CardStateFilter) {
-        val sb = StringBuilder(cardState.toSearch)
+    suspend fun filterByTags(selectedTags: List<String>) {
         // join selectedTags as "tag:$tag" with " or " between them
         val tagsConcat = selectedTags.joinToString(" or ") { tag -> "\"tag:$tag\"" }
-        if (selectedTags.isNotEmpty()) {
-            sb.append("($tagsConcat)") // Only if we added anything to the tag list
-        }
-        launchSearchForCards(searchTerms.copy(userInput = sb.toString()))
+        // Only if we added anything to the tag list
+        val tagFilter = if (selectedTags.isEmpty()) "" else "($tagsConcat)"
+        launchSearchForCards(searchTerms.copy(userInput = tagFilter))
     }
 
     /** Previewing */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -111,13 +111,12 @@ class CardBrowserViewModel(
 
     val flowOfSearchState = MutableSharedFlow<SearchState>()
 
-    var searchTerms = ""
+    var searchTerms = SearchParameters.EMPTY
         private set
-    private var restrictOnDeck: String = ""
 
     /** text in the search box (potentially unsubmitted) */
     // this does not currently bind to the value in the UI and is only used for posting
-    val flowOfFilterQuery = MutableSharedFlow<String>()
+    val flowOfFilterQuery = MutableSharedFlow<SearchParameters>()
 
     /**
      * Whether the browser is working in Cards mode or Notes mode.
@@ -204,15 +203,15 @@ class CardBrowserViewModel(
     val lastDeckId: DeckId?
         get() = lastDeckIdRepository.lastDeckId
 
-    suspend fun setDeckId(deckId: DeckId) {
+    fun setDeckId(deckId: DeckId) {
         Timber.i("setting deck: %d", deckId)
         lastDeckIdRepository.lastDeckId = deckId
-        restrictOnDeck = if (deckId == ALL_DECKS_ID) {
-            ""
+        val newDeckRestriction = if (deckId == ALL_DECKS_ID) {
+            setOf()
         } else {
-            val deckName = withCol { decks.name(deckId) }
-            "deck:\"$deckName\" "
+            setOf(deckId)
         }
+        searchTerms = searchTerms.copy(deckIds = newDeckRestriction)
         flowOfDeckId.update { deckId }
     }
 
@@ -273,12 +272,16 @@ class CardBrowserViewModel(
 
         var selectAllDecks = false
         when (options) {
-            is CardBrowserLaunchOptions.SystemContextMenu -> { searchTerms = options.search.toString() }
+            is CardBrowserLaunchOptions.SystemContextMenu -> {
+                searchTerms = searchTerms.copy(userInput = options.search.toString())
+            }
             is CardBrowserLaunchOptions.SearchQueryJs -> {
-                searchTerms = options.search
+                searchTerms = searchTerms.copy(userInput = options.search)
                 selectAllDecks = options.allDecks
             }
-            is CardBrowserLaunchOptions.DeepLink -> { searchTerms = options.search }
+            is CardBrowserLaunchOptions.DeepLink -> {
+                searchTerms = searchTerms.copy(userInput = options.search)
+            }
             null -> {}
         }
 
@@ -644,7 +647,7 @@ class CardBrowserViewModel(
     private fun <T> Flow<T>.ignoreValuesFromViewModelLaunch(): Flow<T> =
         this.filter { initCompleted }
 
-    suspend fun setFilterQuery(filterQuery: String) {
+    suspend fun setFilterQuery(filterQuery: SearchParameters) {
         this.flowOfFilterQuery.emit(filterQuery)
         launchSearchForCards(filterQuery)
     }
@@ -655,7 +658,7 @@ class CardBrowserViewModel(
     suspend fun searchForMarkedNotes() {
         // only intended to be used if the user has no selection
         if (hasSelectedAnyRows()) return
-        setFilterQuery("tag:marked")
+        setFilterQuery(searchTerms.copy(userInput = "tag:marked"))
     }
 
     /**
@@ -664,18 +667,19 @@ class CardBrowserViewModel(
     suspend fun searchForSuspendedCards() {
         // only intended to be used if the user has no selection
         if (hasSelectedAnyRows()) return
-        setFilterQuery("is:suspended")
+        setFilterQuery(searchTerms.copy(userInput = "is:suspended"))
     }
 
     suspend fun setFlagFilter(flag: Flag) {
         Timber.i("filtering to flag: %s", flag)
         val flagSearchTerm = "flag:${flag.code}"
-        val searchTerms = when {
-            searchTerms.contains("flag:") -> searchTerms.replaceFirst("flag:.".toRegex(), flagSearchTerm)
-            searchTerms.isNotEmpty() -> "$flagSearchTerm $searchTerms"
+        val userInput = searchTerms.userInput
+        val updatedInput = when {
+            userInput.contains("flag:") -> userInput.replaceFirst("flag:.".toRegex(), flagSearchTerm)
+            userInput.isNotEmpty() -> "$flagSearchTerm $userInput"
             else -> flagSearchTerm
         }
-        setFilterQuery(searchTerms)
+        setFilterQuery(searchTerms.copy(userInput = updatedInput))
     }
 
     suspend fun filterByTags(selectedTags: List<String>, cardState: CardStateFilter) {
@@ -685,7 +689,7 @@ class CardBrowserViewModel(
         if (selectedTags.isNotEmpty()) {
             sb.append("($tagsConcat)") // Only if we added anything to the tag list
         }
-        setFilterQuery(sb.toString())
+        setFilterQuery(searchTerms.copy(userInput = sb.toString()))
     }
 
     /** Previewing */
@@ -749,7 +753,7 @@ class CardBrowserViewModel(
      */
     fun endMultiSelectMode() = selectNone()
 
-    suspend fun launchSearchForCards(searchQuery: String): Job? {
+    suspend fun launchSearchForCards(searchQuery: SearchParameters): Job? {
         searchTerms = searchQuery
         return launchSearchForCards()
     }
@@ -763,11 +767,7 @@ class CardBrowserViewModel(
         // update the UI while we're searching
         clearCardsList()
 
-        val query: String = if (searchTerms.contains("deck:")) {
-            "($searchTerms)"
-        } else {
-            if ("" != searchTerms) "$restrictOnDeck($searchTerms)" else restrictOnDeck
-        }
+        val query: String = searchTerms.toQuery()
 
         searchJob?.cancel()
         searchJob = launchCatchingIO(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
@@ -32,6 +32,7 @@ class CardStateSheetFragment : BottomSheetFragment() {
                 icon = state.icon,
                 text = state.label,
                 subtitle = state.subtitle,
+                indent = 0,
                 checkable = true
             )
         }
@@ -60,6 +61,7 @@ private val clearFilterSourceItem = TemplatedTreeAdapter.SourceItem(
     id = ALL_ITEMS_ID,
     icon = R.drawable.ic_clear_white,
     text = "Clear filter",
+    indent = -1,
     checkable = false
 )
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
@@ -32,7 +32,7 @@ class CardStateSheetFragment : BottomSheetFragment() {
                 icon = state.icon,
                 text = state.label,
                 subtitle = state.subtitle,
-                indent = 0,
+                indent = -1,
                 checkable = true
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
@@ -1,0 +1,91 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.fragment.app.activityViewModels
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.launchCatchingTask
+
+class CardStateSheetFragment : BottomSheetFragment() {
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+
+    private val searchParameters: SearchParameters
+        get() = viewModel.searchTerms
+
+    override suspend fun onPrepareAdapter() {
+        val cardStateItems = State.entries.map { state ->
+            TemplatedTreeAdapter.SourceItem(
+                id = state.id,
+                icon = state.icon,
+                text = state.label,
+                subtitle = state.subtitle,
+                checkable = true
+            )
+        }
+
+        val sourceItems = if (searchParameters.states.isEmpty()) {
+            cardStateItems
+        } else {
+            cardStateItems.withItemPrepended(clearFilterSourceItem)
+        }
+
+        adapter.update(
+            sourceItems = sourceItems,
+            checkedItemIds = viewModel.searchTerms.states.map { it.id }.toSet()
+        )
+    }
+
+    override fun onItemsSelected(ids: Set<Long>) {
+        val state = ids.mapNotNull { id -> State.fromId(id) }.toSet()
+        launchCatchingTask { viewModel.launchSearchForCards(viewModel.searchTerms.copy(states = state)) }
+    }
+
+    companion object { const val TAG = "CardStateSheetFragment" }
+}
+
+private val clearFilterSourceItem = TemplatedTreeAdapter.SourceItem(
+    id = ALL_ITEMS_ID,
+    icon = R.drawable.ic_clear_white,
+    text = "Clear filter",
+    checkable = false
+)
+
+enum class State(
+    val id: Long,
+    val icon: Int?,
+    val subtitle: String,
+    val search: String
+) {
+    New(0, R.drawable.ic_card_state_new, "Cards that have not been studied", "is:new"),
+    Learning(1, R.drawable.ic_card_state_learning, "Cards that are still being learnt", "is:learn"),
+    Review(2, R.drawable.ic_card_state_review, "Cards that use Anki's long-term scheduler", "is:review"),
+    Buried(3, R.drawable.ic_card_state_buried, "Cards which aren't shown today", "is:buried"),
+    Suspended(4, R.drawable.ic_suspend, "Cards which aren't shown unless unsuspended", "is:suspended")
+    ;
+
+    val label: String
+        get() = when (this) {
+            New -> TR.statisticsCountsNewCards()
+            Learning -> TR.statisticsCountsLearningCards()
+            Review -> TR.browsingSidebarCardStateReview()
+            Buried -> TR.statisticsCountsBuriedCards()
+            Suspended -> TR.browsingSuspended()
+        }
+
+    companion object {
+        fun fromId(id: Long): State? = State.entries.firstOrNull { it.id == id }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardStateSheetFragment.kt
@@ -58,7 +58,7 @@ class CardStateSheetFragment : BottomSheetFragment() {
 }
 
 private val clearFilterSourceItem = TemplatedTreeAdapter.SourceItem(
-    id = ALL_ITEMS_ID,
+    id = CLEAR_SEARCH_ID,
     icon = R.drawable.ic_clear_white,
     text = "Clear filter",
     indent = -1,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -22,23 +22,29 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 
 fun CardBrowser.setupChips(chips: ChipGroup) {
-    chips.findViewById<Chip>(R.id.chip_tag)
-        .setOnClickListener { chip ->
+    chips.findViewById<Chip>(R.id.chip_tag).apply {
+        text = TR.browsingSidebarTags()
+        setOnClickListener { chip ->
             (chip as Chip).isChecked = !chip.isChecked
             TagsSheetFragment().show(supportFragmentManager, TagsSheetFragment.TAG)
         }
+    }
 
-    chips.findViewById<Chip>(R.id.chip_flag)
-        .setOnClickListener { chip ->
+    chips.findViewById<Chip>(R.id.chip_flag).apply {
+        text = TR.browsingFlag()
+        setOnClickListener { chip ->
             (chip as Chip).isChecked = !chip.isChecked
             FlagsSheetFragment().show(supportFragmentManager, FlagsSheetFragment.TAG)
         }
+    }
 
-    chips.findViewById<Chip>(R.id.chip_state)
-        .setOnClickListener { chip ->
+    chips.findViewById<Chip>(R.id.chip_state).apply {
+        text = baseContext.getString(R.string.browser_card_state)
+        setOnClickListener { chip ->
             (chip as Chip).isChecked = !chip.isChecked
             CardStateSheetFragment().show(supportFragmentManager, CardStateSheetFragment.TAG)
         }
+    }
 }
 
 // TODO: Context Parameter
@@ -78,6 +84,9 @@ suspend fun CardBrowser.updateChips(
                 inactiveText = baseContext.getString(R.string.browser_card_state),
                 activeTextGetter = { state -> state.label }
             )
+            // display the icon associated with the first selected state
+            val firstSelection = newSearchParameters.states.firstOrNull()
+            chip.setChipIconResource(firstSelection?.icon ?: R.drawable.ic_card_state)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -1,0 +1,68 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.Flag
+import com.ichi2.anki.R
+
+fun CardBrowser.setupChips(chips: ChipGroup) {
+    chips.findViewById<Chip>(R.id.chip_flag)
+        .setOnClickListener { chip ->
+            (chip as Chip).isChecked = !chip.isChecked
+            FlagsSheetFragment().show(supportFragmentManager, FlagsSheetFragment.TAG)
+        }
+}
+
+// TODO: Context Parameter
+suspend fun CardBrowser.updateChips(
+    chips: ChipGroup,
+    oldSearchParameters: SearchParameters,
+    newSearchParameters: SearchParameters
+) {
+    if (oldSearchParameters.flags != newSearchParameters.flags) {
+        val flagNames = Flag.queryDisplayNames()
+        chips.findViewById<Chip>(R.id.chip_flag).let { chip ->
+            chip.update(
+                activeItems = newSearchParameters.flags,
+                inactiveText = TR.browsingFlag(),
+                activeTextGetter = { flag -> flagNames[flag]!! }
+            )
+            // text shows "Red + 1" if there are multiple flags, so show the first flag icon
+            val firstFlagOrDefault = newSearchParameters.flags.firstOrNull() ?: Flag.NONE
+            chip.setChipIconResource(firstFlagOrDefault.drawableRes)
+        }
+    }
+}
+
+private fun <T> Chip.update(activeItems: Collection<T>, inactiveText: String, activeTextGetter: (T) -> String) {
+    if (activeItems.isEmpty()) {
+        isChecked = false
+        text = inactiveText
+    } else {
+        isChecked = true
+        val firstSelectedItemName = activeTextGetter(activeItems.first())
+        text = if (activeItems.size == 1) {
+            firstSelectedItemName
+        } else {
+            // Display the first filter, along with the count of additional applied filters:
+            // e.g. ["Tag1", "Tag2", "Tag3"] -> "Tag1 +2"
+            context.getString(R.string.chip_filter_multiple_selections, firstSelectedItemName, (activeItems.size - 1))
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -27,6 +27,12 @@ fun CardBrowser.setupChips(chips: ChipGroup) {
             (chip as Chip).isChecked = !chip.isChecked
             FlagsSheetFragment().show(supportFragmentManager, FlagsSheetFragment.TAG)
         }
+
+    chips.findViewById<Chip>(R.id.chip_state)
+        .setOnClickListener { chip ->
+            (chip as Chip).isChecked = !chip.isChecked
+            CardStateSheetFragment().show(supportFragmentManager, CardStateSheetFragment.TAG)
+        }
 }
 
 // TODO: Context Parameter
@@ -46,6 +52,16 @@ suspend fun CardBrowser.updateChips(
             // text shows "Red + 1" if there are multiple flags, so show the first flag icon
             val firstFlagOrDefault = newSearchParameters.flags.firstOrNull() ?: Flag.NONE
             chip.setChipIconResource(firstFlagOrDefault.drawableRes)
+        }
+    }
+
+    if (oldSearchParameters.states != newSearchParameters.states) {
+        chips.findViewById<Chip>(R.id.chip_state).let { chip ->
+            chip.update(
+                activeItems = newSearchParameters.states,
+                inactiveText = baseContext.getString(R.string.browser_card_state),
+                activeTextGetter = { state -> state.label }
+            )
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -22,6 +22,12 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 
 fun CardBrowser.setupChips(chips: ChipGroup) {
+    chips.findViewById<Chip>(R.id.chip_tag)
+        .setOnClickListener { chip ->
+            (chip as Chip).isChecked = !chip.isChecked
+            TagsSheetFragment().show(supportFragmentManager, TagsSheetFragment.TAG)
+        }
+
     chips.findViewById<Chip>(R.id.chip_flag)
         .setOnClickListener { chip ->
             (chip as Chip).isChecked = !chip.isChecked
@@ -52,6 +58,16 @@ suspend fun CardBrowser.updateChips(
             // text shows "Red + 1" if there are multiple flags, so show the first flag icon
             val firstFlagOrDefault = newSearchParameters.flags.firstOrNull() ?: Flag.NONE
             chip.setChipIconResource(firstFlagOrDefault.drawableRes)
+        }
+    }
+
+    if (oldSearchParameters.tags != newSearchParameters.tags) {
+        chips.findViewById<Chip>(R.id.chip_tag).let { chip ->
+            chip.update(
+                activeItems = newSearchParameters.tags,
+                inactiveText = TR.browsingSidebarTags(),
+                activeTextGetter = { tag -> tag.substringAfterLast("::") }
+            )
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
@@ -42,7 +42,7 @@ class FlagsSheetFragment : BottomSheetFragment() {
         } else {
             flagsSourceItems.withItemPrepended(
                 TemplatedTreeAdapter.SourceItem(
-                    id = ALL_ITEMS_ID,
+                    id = CLEAR_SEARCH_ID,
                     icon = R.drawable.ic_clear_white,
                     text = "Clear filter",
                     indent = -1,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
@@ -14,7 +14,6 @@
 
 package com.ichi2.anki.browser
 
-import android.content.DialogInterface
 import androidx.fragment.app.activityViewModels
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
@@ -54,14 +53,6 @@ class FlagsSheetFragment : BottomSheetFragment() {
             sourceItems = sourceItems,
             checkedItemIds = searchParameters.flags.map { it.code.toLong() }.toSet()
         )
-    }
-
-    override fun onCancel(dialog: DialogInterface) {
-        super.onCancel(dialog)
-        // refresh the 'clear filter' item
-        //   The DiffCallback animation on adding/removing the first item does not look pleasant
-        //   so we don't add "Clear Filter" while the dialog is open
-        launchCatchingTask { onPrepareAdapter() }
     }
 
     override fun onItemsSelected(ids: Set<Long>) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
@@ -32,6 +32,7 @@ class FlagsSheetFragment : BottomSheetFragment() {
                     id = flag.code.toLong(),
                     icon = flag.drawableRes,
                     text = displayName,
+                    indent = 0,
                     checkable = true
                 )
             }
@@ -44,6 +45,7 @@ class FlagsSheetFragment : BottomSheetFragment() {
                     id = ALL_ITEMS_ID,
                     icon = R.drawable.ic_clear_white,
                     text = "Clear filter",
+                    indent = -1,
                     checkable = false
                 )
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
@@ -32,7 +32,7 @@ class FlagsSheetFragment : BottomSheetFragment() {
                     id = flag.code.toLong(),
                     icon = flag.drawableRes,
                     text = displayName,
-                    indent = 0,
+                    indent = -1,
                     checkable = true
                 )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FlagsSheetFragment.kt
@@ -1,0 +1,76 @@
+ /*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.DialogInterface
+import androidx.fragment.app.activityViewModels
+import com.ichi2.anki.Flag
+import com.ichi2.anki.R
+import com.ichi2.anki.launchCatchingTask
+
+class FlagsSheetFragment : BottomSheetFragment() {
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+
+    private val searchParameters: SearchParameters
+        get() = viewModel.searchTerms
+
+    override suspend fun onPrepareAdapter() {
+        val flagsSourceItems = Flag.queryDisplayNames()
+            .map { (flag, displayName) ->
+                TemplatedTreeAdapter.SourceItem(
+                    id = flag.code.toLong(),
+                    icon = flag.drawableRes,
+                    text = displayName,
+                    checkable = true
+                )
+            }
+
+        val sourceItems = if (searchParameters.flags.isEmpty()) {
+            flagsSourceItems
+        } else {
+            flagsSourceItems.withItemPrepended(
+                TemplatedTreeAdapter.SourceItem(
+                    id = ALL_ITEMS_ID,
+                    icon = R.drawable.ic_clear_white,
+                    text = "Clear filter",
+                    checkable = false
+                )
+            )
+        }
+
+        adapter.update(
+            sourceItems = sourceItems,
+            checkedItemIds = searchParameters.flags.map { it.code.toLong() }.toSet()
+        )
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        // refresh the 'clear filter' item
+        //   The DiffCallback animation on adding/removing the first item does not look pleasant
+        //   so we don't add "Clear Filter" while the dialog is open
+        launchCatchingTask { onPrepareAdapter() }
+    }
+
+    override fun onItemsSelected(ids: Set<Long>) {
+        launchCatchingTask {
+            viewModel.launchSearchForCards(
+                searchParameters.copy(flags = ids.map { id -> Flag.fromCode(id.toInt()) }.toSet())
+            )
+        }
+    }
+
+    companion object { const val TAG = "FlagsSheetFragment" }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
@@ -24,13 +24,18 @@ data class SearchParameters(
     val userInput: String,
     val deckIds: Set<DeckId>,
     val tags: Set<String>,
-    val flags: Set<Flag>
+    val flags: Set<Flag>,
+    val states: Set<State>
 ) : Parcelable {
-    val isEmpty get() = userInput.isEmpty() && deckIds.isEmpty() && tags.isEmpty() && flags.isEmpty()
+    val isEmpty get() = userInput.isEmpty() &&
+        deckIds.isEmpty() &&
+        tags.isEmpty() &&
+        flags.isEmpty() &&
+        states.isEmpty()
     val isNotEmpty get() = !isEmpty
 
     companion object {
-        val EMPTY = SearchParameters("", emptySet(), emptySet(), emptySet())
+        val EMPTY = SearchParameters("", emptySet(), emptySet(), emptySet(), emptySet())
     }
 }
 
@@ -39,7 +44,8 @@ fun SearchParameters.toQuery() =
         userInput,
         deckIds.joinToString(" OR ") { "did:$it" },
         tags.joinToString(" OR ") { """"tag:$it"""" },
-        flags.joinToString(" OR ") { "flag:${it.code}" }
+        flags.joinToString(" OR ") { "flag:${it.code}" },
+        states.joinToString(" OR ") { it.search }
     )
         .filter { it.isNotEmpty() }
         .joinToString(" ") { "($it)" }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
@@ -1,0 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.os.Parcelable
+import com.ichi2.anki.Flag
+import com.ichi2.libanki.DeckId
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SearchParameters(
+    val userInput: String,
+    val deckIds: Set<DeckId>,
+    val tags: Set<String>,
+    val flags: Set<Flag>
+) : Parcelable {
+    val isEmpty get() = userInput.isEmpty() && deckIds.isEmpty() && tags.isEmpty() && flags.isEmpty()
+    val isNotEmpty get() = !isEmpty
+
+    companion object {
+        val EMPTY = SearchParameters("", emptySet(), emptySet(), emptySet())
+    }
+}
+
+fun SearchParameters.toQuery() =
+    listOf(
+        userInput,
+        deckIds.joinToString(" OR ") { "did:$it" },
+        tags.joinToString(" OR ") { """"tag:$it"""" },
+        flags.joinToString(" OR ") { "flag:${it.code}" }
+    )
+        .filter { it.isNotEmpty() }
+        .joinToString(" ") { "($it)" }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TagsSheetFragment.kt
@@ -111,7 +111,7 @@ class TagsSheetFragment : BottomSheetFragment() {
 }
 
 private val allTagsSourceItem = TemplatedTreeAdapter.SourceItem(
-    id = ALL_ITEMS_ID,
+    id = CLEAR_SEARCH_ID,
     icon = R.drawable.close_icon,
     text = "Clear filter",
     indent = -1,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TagsSheetFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TagsSheetFragment.kt
@@ -1,0 +1,121 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.fragment.app.activityViewModels
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.R
+import com.ichi2.anki.launchCatchingTask
+
+class TagsSheetFragment : BottomSheetFragment() {
+    override val filterHintResource = R.string.filter_hint_search_tags
+
+    override val layoutResource get() = if (tagRows.size > 10) {
+        R.layout.bottom_sheet_list_with_filter
+    } else {
+        R.layout.bottom_sheet_list_without_filter
+    }
+
+    // TODO: onPrepareAdapter is needed first
+    private var tagRows: List<Row> = listOf()
+    private var tagIdToName: Map<Long, String> = mapOf()
+
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+
+    override suspend fun onPrepareAdapter() {
+        tagRows = withCol { tags.all() }
+            .toSortedChainSetWithMissingParentsAdded()
+            .mapIndexed { index, chain ->
+                val icon = when {
+                    chain.equals("marked", ignoreCase = true) -> R.drawable.ic_marked
+                    chain.equals("leech", ignoreCase = true) -> R.drawable.ic_leech
+                    else -> R.drawable.ic_tag
+                }
+                Row(id = index.toLong(), icon, chain)
+            }
+            // PERF: This can be O(n) rather than O(n log n)
+            // order: [marked; leech; ...rest].
+            .sortedBy { row ->
+                when {
+                    row.chain.equals("marked", ignoreCase = true) -> 0
+                    row.chain.equals("leech", ignoreCase = true) -> 1
+                    else -> 2
+                }
+            }
+
+        tagIdToName = tagRows.associate { (id, _, chain) -> id to chain }
+
+        val tagNameToId = tagRows.associate { (id, _, chain) -> chain to id }
+
+        val sourceItems = if (viewModel.searchTerms.tags.any()) {
+            tagRows.toSourceItems(filter = "").withItemPrepended(allTagsSourceItem)
+        } else {
+            tagRows.toSourceItems(filter = "")
+        }
+
+        adapter.update(
+            sourceItems = sourceItems,
+            checkedItemIds = tagNameToId.values(viewModel.searchTerms.tags)
+        )
+    }
+
+    override fun onFilterInputChanged(filterInput: String) {
+        val tagsSourceItems = tagRows.toSourceItems(filterInput)
+        val sourceItems = if (viewModel.searchTerms.tags.any()) {
+            tagsSourceItems.withItemPrepended(allTagsSourceItem)
+        } else {
+            tagsSourceItems
+        }
+
+        adapter.update(
+            sourceItems = sourceItems,
+            collapsedItemIds = if (filterInput.isEmpty()) null else emptySet()
+        )
+    }
+
+    override fun onItemsSelected(ids: Set<Long>) {
+        launchCatchingTask {
+            viewModel.launchSearchForCards(viewModel.searchTerms.copy(tags = tagIdToName.values(ids)))
+        }
+    }
+
+    companion object { const val TAG = "TagsSheetFragment" }
+}
+
+private val allTagsSourceItem = TemplatedTreeAdapter.SourceItem(
+    id = ALL_ITEMS_ID,
+    icon = R.drawable.close_icon,
+    text = "Clear filter",
+    indent = -1,
+    checkable = false
+)
+
+private fun <K, V> Map<K, V>.values(keys: Set<K>) = keys.mapNotNull { this[it] }.toSet()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
@@ -15,6 +15,7 @@
 package com.ichi2.anki.browser
 
 import android.content.Context
+import androidx.annotation.DrawableRes
 
 class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
     /**
@@ -25,9 +26,10 @@ class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
         /** @see TreeAdapter.Item.id */
         val id: Long,
         /** @see TreeAdapter.Item.icon */
-        val icon: Int,
+        @DrawableRes val icon: Int?,
         /** @see TreeAdapter.Item.text */
         val text: CharSequence,
+        val subtitle: String? = null,
         /** Defines the possible values of [TreeAdapter.Item.checked] */
         val checkable: Boolean
     )
@@ -48,7 +50,7 @@ class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
                 else -> Checked.No
             }
 
-            items.add(Item(item.id, item.icon, item.text, checked))
+            items.add(Item(item.id, item.icon, item.text, item.subtitle, checked))
         }
 
         this.sourceItems = usedSourceItems

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
@@ -16,6 +16,8 @@ package com.ichi2.anki.browser
 
 import android.content.Context
 import androidx.annotation.DrawableRes
+import java.lang.String.CASE_INSENSITIVE_ORDER
+import java.util.TreeSet
 
 class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
     /**
@@ -30,38 +32,93 @@ class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
         /** @see TreeAdapter.Item.text */
         val text: CharSequence,
         val subtitle: String? = null,
+        /** @see TreeAdapter.Item.indent */
+        val indent: Int,
         /** Defines the possible values of [TreeAdapter.Item.checked] */
         val checkable: Boolean
     )
 
     fun update(
         sourceItems: List<SourceItem>? = null,
+        collapsedItemIds: Set<Long>? = null,
         checkedItemIds: Set<Long>? = null
     ) {
         val usedSourceItems = sourceItems ?: this.sourceItems
+        val usedCollapsedItemIds = collapsedItemIds ?: this.collapsedItemIds
         val usedCheckedItemIds = checkedItemIds ?: this.checkedItemIds
 
         val items = mutableListOf<Item>()
 
-        for (item in usedSourceItems) {
+        usedSourceItems.forEachWithNext { current, next ->
+            items.lastOrNull()?.let { last ->
+                if (current.indent > last.indent && last.collapsed == Collapsed.Yes) return@forEachWithNext
+            }
+
+            val collapsed = when {
+                next == null || current.indent >= next.indent -> Collapsed.NotCollapsible
+                current.id in usedCollapsedItemIds -> Collapsed.Yes
+                else -> Collapsed.No
+            }
+
             val checked = when {
-                !item.checkable -> Checked.NotCheckable
-                item.id in usedCheckedItemIds -> Checked.Yes
+                !current.checkable -> Checked.NotCheckable
+                current.id in usedCheckedItemIds -> Checked.Yes
                 else -> Checked.No
             }
 
-            items.add(Item(item.id, item.icon, item.text, item.subtitle, checked))
+            items.add(Item(current.id, current.icon, current.text, current.subtitle, current.indent, collapsed, checked))
         }
 
         this.sourceItems = usedSourceItems
 
-        setItems(items, usedCheckedItemIds)
+        setItems(items, usedCollapsedItemIds, usedCheckedItemIds)
     }
 
+    override fun updateCollapsedItemIds(ids: Set<Long>) = update(collapsedItemIds = ids)
     override fun updateCheckedItemIds(ids: Set<Long>) = update(checkedItemIds = ids)
 
     private var sourceItems: List<SourceItem> = listOf()
 }
 
+fun Iterable<String>.toSortedChainSetWithMissingParentsAdded() =
+    TreeSet(CASE_INSENSITIVE_ORDER).also { out ->
+        forEach { string ->
+            val segments = string.split("::")
+            (1..segments.size).forEach { end ->
+                out.add(segments.subList(0, end).joinToString("::"))
+            }
+        }
+    }
+
+data class Row(val id: Long, val icon: Int, val chain: String)
+
+fun Iterable<Row>.toSourceItems(filter: String):
+    List<TemplatedTreeAdapter.SourceItem> {
+    val flat = this.all { !it.chain.contains("::") }
+
+    val matchingChainsAndTheirParents = this
+        .map { it.chain }
+        .filter { it.contains(filter, ignoreCase = true) }
+        .toSortedChainSetWithMissingParentsAdded()
+
+    return this.mapNotNull { (id, icon, chain) ->
+        if (chain !in matchingChainsAndTheirParents) return@mapNotNull null
+
+        TemplatedTreeAdapter.SourceItem(
+            id = id,
+            icon = icon,
+            text = chain.substringAfterLast("::"),
+            indent = if (flat) -1 else chain.split("::").size - 1, // TODO better method?
+            checkable = true
+        )
+    }
+}
+
 fun List<TemplatedTreeAdapter.SourceItem>.withItemPrepended(sourceItem: TemplatedTreeAdapter.SourceItem) =
     listOf(sourceItem) + this
+
+private inline fun <E> List<E>.forEachWithNext(block: (E, E?) -> Unit) {
+    (0..lastIndex).forEach { idx ->
+        block(this[idx], if (idx == lastIndex) null else this[idx + 1])
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TemplatedTreeAdapter.kt
@@ -1,0 +1,65 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.Context
+
+class TemplatedTreeAdapter(context: Context) : TreeAdapter(context) {
+    /**
+     * A template for a [TreeAdapter.Item],
+     * excluding user-modifiable properties ([TreeAdapter.Item.checked], etc...)
+     */
+    data class SourceItem(
+        /** @see TreeAdapter.Item.id */
+        val id: Long,
+        /** @see TreeAdapter.Item.icon */
+        val icon: Int,
+        /** @see TreeAdapter.Item.text */
+        val text: CharSequence,
+        /** Defines the possible values of [TreeAdapter.Item.checked] */
+        val checkable: Boolean
+    )
+
+    fun update(
+        sourceItems: List<SourceItem>? = null,
+        checkedItemIds: Set<Long>? = null
+    ) {
+        val usedSourceItems = sourceItems ?: this.sourceItems
+        val usedCheckedItemIds = checkedItemIds ?: this.checkedItemIds
+
+        val items = mutableListOf<Item>()
+
+        for (item in usedSourceItems) {
+            val checked = when {
+                !item.checkable -> Checked.NotCheckable
+                item.id in usedCheckedItemIds -> Checked.Yes
+                else -> Checked.No
+            }
+
+            items.add(Item(item.id, item.icon, item.text, checked))
+        }
+
+        this.sourceItems = usedSourceItems
+
+        setItems(items, usedCheckedItemIds)
+    }
+
+    override fun updateCheckedItemIds(ids: Set<Long>) = update(checkedItemIds = ids)
+
+    private var sourceItems: List<SourceItem> = listOf()
+}
+
+fun List<TemplatedTreeAdapter.SourceItem>.withItemPrepended(sourceItem: TemplatedTreeAdapter.SourceItem) =
+    listOf(sourceItem) + this

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
@@ -1,0 +1,168 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.appcompat.content.res.AppCompatResources
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.NO_ID
+import com.ichi2.anki.R
+import com.ichi2.anki.browser.TreeAdapter.Item
+
+/**
+ * An [adapter][RecyclerView.Adapter], displaying a list of clickable items with text and an icon
+ *
+ * Typically used as a list of filters, to allows quick selection of a single filter, or checking
+ * multiple filters for use in an OR clause
+ *
+ * All items may be [clicked][onItemCheckedListener].
+ *
+ * Items may be [checked][onItemClickedListener] (dependent on [Item.checked]). Multiple items may
+ * be checked at the same time
+ */
+abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdapter.Holder>() {
+    init { this@TreeAdapter.setHasStableIds(true) }
+
+    enum class Checked { Yes, No, NotCheckable }
+
+    data class Item(
+        val id: Long,
+        val icon: Int,
+        val text: CharSequence,
+        val checked: Checked
+    )
+
+    var onItemClickedListener: ((Long) -> Unit) = { }
+    var onItemCheckedListener: ((Long) -> Unit) = { }
+
+    abstract fun updateCheckedItemIds(ids: Set<Long>)
+
+    protected fun setItems(items: List<Item>, checkedItemIds: Set<Long>) {
+        val diff = DiffUtil.calculateDiff(DiffCallback(this.items, items))
+
+        this.items = items
+        this.checkedItemIds = checkedItemIds
+
+        diff.dispatchUpdatesTo(this)
+    }
+
+    object UpdateCollapsedOrCheckedOnly
+
+    private class DiffCallback(old: List<Item>, new: List<Item>) : ListDiffCallback<Item>(old, new) {
+        override fun areItemsTheSame(old: Item, new: Item) = old.id == new.id
+        override fun areContentsTheSame(old: Item, new: Item) = old == new
+        override fun getChangePayload(old: Item, new: Item) =
+            if (old.icon != new.icon || old.text != new.text) {
+                null
+            } else {
+                UpdateCollapsedOrCheckedOnly
+            }
+    }
+
+    var checkedItemIds = setOf<Long>()
+        private set
+
+    private var items: List<Item> = listOf()
+
+    inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        val icon: ImageView = view.findViewById(R.id.icon)
+        val text: TextView = view.findViewById(R.id.text)
+        val checkbox: CheckBox = view.findViewById(R.id.checkbox)
+
+        init {
+            checkbox.setOnClickListenerWithId(this) { id ->
+                updateCheckedItemIds(checkedItemIds xor id)
+                onItemCheckedListener(id)
+            }
+
+            view.setOnClickListenerWithId(this) { id ->
+                onItemClickedListener(id)
+            }
+        }
+
+        fun fullBind(item: Item) {
+            text.text = item.text
+
+            icon.setImageDrawable(AppCompatResources.getDrawable(context, item.icon))
+
+            checkbox.isVisible = item.checked != Checked.NotCheckable
+            checkbox.isChecked = item.checked == Checked.Yes
+        }
+
+        fun bindChecked(item: Item) {
+            checkbox.isVisible = item.checked != Checked.NotCheckable
+            checkbox.isChecked = item.checked == Checked.Yes
+        }
+    }
+
+    override fun getItemId(position: Int) = items[position].id
+
+    override fun getItemCount() = items.size
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): Holder {
+        return Holder(inflater.inflate(R.layout.bottom_sheet_item, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int) {
+        holder.fullBind(items[position])
+    }
+
+    override fun onBindViewHolder(holder: Holder, position: Int, payloads: MutableList<Any>) {
+        if (payloads.any { it is UpdateCollapsedOrCheckedOnly }) {
+            holder.bindChecked(items[position])
+        } else {
+            holder.fullBind(items[position])
+        }
+    }
+
+    private val inflater = LayoutInflater.from(context)
+}
+
+private infix fun <E> Set<E>.xor(element: E) =
+    if (contains(element)) this - element else this + element
+
+// TODO: Context Parameter
+private fun View.setOnClickListenerWithId(
+    viewHolder: RecyclerView.ViewHolder,
+    block: (Long) -> Unit
+) {
+    setOnClickListener {
+        // TODO: The ripple effect does not occur properly on click
+        val id = viewHolder.itemId
+        if (id != NO_ID) block(id)
+    }
+}
+
+private abstract class ListDiffCallback<T>(val old: List<T>, val new: List<T>) : DiffUtil.Callback() {
+    abstract fun areItemsTheSame(old: T, new: T): Boolean
+    abstract fun areContentsTheSame(old: T, new: T): Boolean
+    abstract fun getChangePayload(old: T, new: T): Any?
+
+    override fun getOldListSize() = old.size
+    override fun getNewListSize() = new.size
+    override fun areItemsTheSame(oldPos: Int, newPos: Int) = areItemsTheSame(old[oldPos], new[newPos])
+    override fun areContentsTheSame(oldPos: Int, newPos: Int) = areContentsTheSame(old[oldPos], new[newPos])
+    override fun getChangePayload(oldPos: Int, newPos: Int) = getChangePayload(old[oldPos], new[newPos])
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
@@ -19,18 +19,22 @@ package com.ichi2.anki.browser
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
+import android.view.View.LAYOUT_DIRECTION_RTL
 import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
 import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.NO_ID
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.TreeAdapter.Item
+import com.ichi2.anki.convertDpToPixel
 
 /**
  * An [adapter][RecyclerView.Adapter], displaying a list of clickable items with text and an icon
@@ -46,6 +50,8 @@ import com.ichi2.anki.browser.TreeAdapter.Item
 abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdapter.Holder>() {
     init { this@TreeAdapter.setHasStableIds(true) }
 
+    enum class Collapsed { Yes, No, NotCollapsible }
+
     enum class Checked { Yes, No, NotCheckable }
 
     data class Item(
@@ -53,18 +59,22 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         @DrawableRes val icon: Int?,
         val text: CharSequence,
         val subtitle: String?,
+        val indent: Int,
+        val collapsed: Collapsed,
         val checked: Checked
     )
 
     var onItemClickedListener: ((Long) -> Unit) = { }
     var onItemCheckedListener: ((Long) -> Unit) = { }
 
+    abstract fun updateCollapsedItemIds(ids: Set<Long>)
     abstract fun updateCheckedItemIds(ids: Set<Long>)
 
-    protected fun setItems(items: List<Item>, checkedItemIds: Set<Long>) {
+    protected fun setItems(items: List<Item>, collapsedItemIds: Set<Long>, checkedItemIds: Set<Long>) {
         val diff = DiffUtil.calculateDiff(DiffCallback(this.items, items))
 
         this.items = items
+        this.collapsedItemIds = collapsedItemIds
         this.checkedItemIds = checkedItemIds
 
         diff.dispatchUpdatesTo(this)
@@ -76,19 +86,22 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         override fun areItemsTheSame(old: Item, new: Item) = old.id == new.id
         override fun areContentsTheSame(old: Item, new: Item) = old == new
         override fun getChangePayload(old: Item, new: Item) =
-            if (old.icon != new.icon || old.text != new.text) {
+            if (old.icon != new.icon || old.text != new.text || old.indent != new.indent) {
                 null
             } else {
                 UpdateCollapsedOrCheckedOnly
             }
     }
 
+    var collapsedItemIds = setOf<Long>()
+        private set
     var checkedItemIds = setOf<Long>()
         private set
 
     private var items: List<Item> = listOf()
 
     inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
+        val chevron: ImageView = view.findViewById(R.id.chevron)
         val icon: ImageView = view.findViewById(R.id.icon)
         val text: TextView = view.findViewById(R.id.text)
         val subtitle: TextView = view.findViewById(R.id.subtitle)
@@ -106,6 +119,10 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         }
 
         fun fullBind(item: Item) {
+            chevron.updateLayoutParams<MarginLayoutParams> {
+                marginStart = (mandatoryMargin + indentMargin * item.indent).toInt()
+            }
+
             text.text = item.text
 
             subtitle.text = item.subtitle
@@ -115,11 +132,41 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
                 icon.setImageDrawable(AppCompatResources.getDrawable(context, iconToUse))
             }
 
+            // isVisible takes precedence over .alpha
+            chevron.visibility = if (item.indent == -1) View.GONE else View.VISIBLE
+            chevron.animate().cancel()
+
+            when (item.collapsed) {
+                Collapsed.No -> {
+                    chevron.alpha = 1f
+                    chevron.rotation = expandedChevronAngle
+                }
+                Collapsed.Yes -> {
+                    chevron.alpha = 1f
+                    chevron.rotation = collapsedChevronAngle
+                }
+                Collapsed.NotCollapsible -> {
+                    chevron.alpha = 0f
+                }
+            }
+
+            chevron.isClickable = item.collapsed != Collapsed.NotCollapsible
+
             checkbox.isVisible = item.checked != Checked.NotCheckable
             checkbox.isChecked = item.checked == Checked.Yes
         }
 
-        fun bindChecked(item: Item) {
+        fun bindCollapsedAndCheckedOnly(item: Item) {
+            chevron.animate().apply {
+                when (item.collapsed) {
+                    Collapsed.No -> rotation(expandedChevronAngle).alpha(1f)
+                    Collapsed.Yes -> rotation(collapsedChevronAngle).alpha(1f)
+                    Collapsed.NotCollapsible -> alpha(0f)
+                }
+            }.start()
+
+            chevron.isClickable = item.collapsed != Collapsed.NotCollapsible
+
             checkbox.isVisible = item.checked != Checked.NotCheckable
             checkbox.isChecked = item.checked == Checked.Yes
         }
@@ -139,14 +186,22 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
 
     override fun onBindViewHolder(holder: Holder, position: Int, payloads: MutableList<Any>) {
         if (payloads.any { it is UpdateCollapsedOrCheckedOnly }) {
-            holder.bindChecked(items[position])
+            holder.bindCollapsedAndCheckedOnly(items[position])
         } else {
             holder.fullBind(items[position])
         }
     }
 
+    private val mandatoryMargin = convertDpToPixel(0f, context)
+    private val indentMargin = convertDpToPixel(24f, context)
+
     private val inflater = LayoutInflater.from(context)
+
+    private val expandedChevronAngle = if (context.isRtl) -90f else 90f
+    private val collapsedChevronAngle = 0f
 }
+
+private val Context.isRtl get() = resources.configuration.layoutDirection == LAYOUT_DIRECTION_RTL
 
 private infix fun <E> Set<E>.xor(element: E) =
     if (contains(element)) this - element else this + element

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.DiffUtil
@@ -49,8 +50,9 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
 
     data class Item(
         val id: Long,
-        val icon: Int,
+        @DrawableRes val icon: Int?,
         val text: CharSequence,
+        val subtitle: String?,
         val checked: Checked
     )
 
@@ -89,6 +91,7 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
     inner class Holder(view: View) : RecyclerView.ViewHolder(view) {
         val icon: ImageView = view.findViewById(R.id.icon)
         val text: TextView = view.findViewById(R.id.text)
+        val subtitle: TextView = view.findViewById(R.id.subtitle)
         val checkbox: CheckBox = view.findViewById(R.id.checkbox)
 
         init {
@@ -105,7 +108,12 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         fun fullBind(item: Item) {
             text.text = item.text
 
-            icon.setImageDrawable(AppCompatResources.getDrawable(context, item.icon))
+            subtitle.text = item.subtitle
+            subtitle.isVisible = !subtitle.text.isNullOrEmpty()
+
+            item.icon?.let { iconToUse ->
+                icon.setImageDrawable(AppCompatResources.getDrawable(context, iconToUse))
+            }
 
             checkbox.isVisible = item.checked != Checked.NotCheckable
             checkbox.isChecked = item.checked == Checked.Yes

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/TreeAdapter.kt
@@ -59,6 +59,10 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         @DrawableRes val icon: Int?,
         val text: CharSequence,
         val subtitle: String?,
+        /**
+         * -1 is used as a sentinel value to define 'no indent', even if a chevron may appear
+         * on other elements
+         */
         val indent: Int,
         val collapsed: Collapsed,
         val checked: Checked
@@ -119,8 +123,11 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
         }
 
         fun fullBind(item: Item) {
-            chevron.updateLayoutParams<MarginLayoutParams> {
-                marginStart = (mandatoryMargin + indentMargin * item.indent).toInt()
+            chevron.isVisible = item.indent != -1
+            if (item.indent != -1) {
+                chevron.updateLayoutParams<MarginLayoutParams> {
+                    marginStart = (mandatoryMargin + indentMargin * item.indent).toInt()
+                }
             }
 
             text.text = item.text
@@ -132,8 +139,6 @@ abstract class TreeAdapter(val context: Context) : RecyclerView.Adapter<TreeAdap
                 icon.setImageDrawable(AppCompatResources.getDrawable(context, iconToUse))
             }
 
-            // isVisible takes precedence over .alpha
-            chevron.visibility = if (item.indent == -1) View.GONE else View.VISIBLE
             chevron.animate().cancel()
 
             when (item.collapsed) {
@@ -211,6 +216,7 @@ private fun View.setOnClickListenerWithId(
     viewHolder: RecyclerView.ViewHolder,
     block: (Long) -> Unit
 ) {
+    // TODO: The ripple effect does not occur properly
     setOnClickListener {
         // TODO: The ripple effect does not occur properly on click
         val id = viewHolder.itemId

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -25,6 +25,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.OnContextAndLongClickListener
@@ -178,16 +179,17 @@ class TagsDialog : AnalyticsDialogFragment {
         if (tags!!.isEmpty) {
             noTagsTextView?.visibility = View.VISIBLE
         }
-        val optionsGroup = tagsDialogView.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup)
-        for (i in 0 until optionsGroup.childCount) {
-            optionsGroup.getChildAt(i).id = i
+        tagsDialogView.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup).also { options ->
+            for (i in 0 until options.childCount) {
+                options.getChildAt(i).id = i
+            }
+            options.check(0)
+            selectedOption = radioButtonIdToCardState(options.checkedRadioButtonId)
+            options.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int -> selectedOption = radioButtonIdToCardState(checkedId) }
+            options.isVisible = type == DialogType.CUSTOM_STUDY_TAGS
         }
-        optionsGroup.check(0)
-        selectedOption = radioButtonIdToCardState(optionsGroup.checkedRadioButtonId)
-        optionsGroup.setOnCheckedChangeListener { _: RadioGroup?, checkedId: Int -> selectedOption = radioButtonIdToCardState(checkedId) }
         if (type == DialogType.EDIT_TAGS) {
             dialogTitle = resources.getString(R.string.card_details_tags)
-            optionsGroup.visibility = View.GONE
             positiveText = getString(R.string.dialog_ok)
             tagsArrayAdapter!!.tagContextAndLongClickListener =
                 OnContextAndLongClickListener { v ->

--- a/AnkiDroid/src/main/res/drawable/bg_input.xml
+++ b/AnkiDroid/src/main/res/drawable/bg_input.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
+    <corners android:radius="@dimen/popup_corner_radius" />
+    <solid android:color="#ddd" />
+</shape>

--- a/AnkiDroid/src/main/res/drawable/ic_card_state.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_card_state.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="6.35"
+    android:viewportHeight="6.35"
+    android:tint="?attr/toolbarIconColor">
+  <path
+      android:pathData="M3.175,3.175m-2.1167,0a2.1167,2.1167 0,1 1,4.2333 0a2.1167,2.1167 0,1 1,-4.2333 0"
+      android:strokeAlpha="0.951613"
+      android:strokeLineJoin="round"
+      android:strokeWidth="0.52916667"
+      android:fillColor="#00000000"
+      android:strokeColor="#000000"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_card_state_buried.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_card_state_buried.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M10,8l0,6l4.7,2.9l0.8,-1.2l-4,-2.4l0,-5.3z"/>
+
+    <path android:fillColor="@android:color/white" android:pathData="M17.92,12c0.05,0.33 0.08,0.66 0.08,1c0,3.9 -3.1,7 -7,7s-7,-3.1 -7,-7c0,-3.9 3.1,-7 7,-7c0.7,0 1.37,0.1 2,0.29V4.23C12.36,4.08 11.69,4 11,4c-5,0 -9,4 -9,9s4,9 9,9s9,-4 9,-9c0,-0.34 -0.02,-0.67 -0.06,-1H17.92z"/>
+
+    <path android:fillColor="@android:color/white" android:pathData="M20,5l0,-3l-2,0l0,3l-3,0l0,2l3,0l0,3l2,0l0,-3l3,0l0,-2z"/>
+
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_card_state_learning.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_card_state_learning.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/learnCountColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_card_state_new.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_card_state_new.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/newCountColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_card_state_review.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_card_state_review.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/reviewCountColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C6.47,2 2,6.47 2,12s4.47,10 10,10 10,-4.47 10,-10S17.53,2 12,2z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_leech.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_leech.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/toolbarIconColor"
+    android:viewportHeight="24"
+    android:viewportWidth="24">
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M22,10v8h-2v-8H22zM20,20v2h2v-2H20zM18,17.29C16.53,18.95 14.39,20 12,20c-4.41,0 -8,-3.59 -8,-8c0,-4.41 3.59,-8 8,-8v9l7.55,-7.55C17.72,3.34 15.02,2 12,2C6.48,2 2,6.48 2,12c0,5.52 4.48,10 10,10c2.25,0 4.33,-0.74 6,-2V17.29z" />
+
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_marked.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_marked.xml
@@ -1,0 +1,25 @@
+<!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<vector android:autoMirrored="true" android:height="24dp"
+    android:viewportHeight="6.35" android:viewportWidth="6.35"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android"
+    android:tint="?attr/toolbarIconColor">
+    <path android:fillColor="#00000000"
+        android:pathData="M2.732,0.8719C2.8646,0.8482 3.562,2.2041 3.6844,2.2602 3.8039,2.315 5.2531,1.9405 5.3151,2.0564 5.3786,2.1752 4.3046,3.2574 4.289,3.3912 4.2738,3.5218 5.0779,4.7843 4.9868,4.8791 4.8935,4.9762 3.5323,4.2892 3.4003,4.3157 3.2714,4.3416 2.3191,5.4965 2.2008,5.4391 2.0796,5.3804 2.3124,3.8735 2.2464,3.7562 2.1819,3.6416 0.7893,3.0928 0.8073,2.9625 0.8257,2.8291 2.3307,2.5849 2.422,2.4858 2.511,2.3891 2.6026,0.895 2.732,0.8719Z"
+        android:strokeColor="#000000" android:strokeLineCap="round"
+        android:strokeLineJoin="round" android:strokeWidth="0.529167"/>
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_tag.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_tag.xml
@@ -1,10 +1,26 @@
+<!--
+Pictogrammers Free License
+
+Last Updated: February 1st, 2023
+
+This package is released as free, open-source, and GPL friendly by
+the [Pictogrammers](https://pictogrammers.com/). You may use it
+for commercial projects, open-source projects, or anything really.
+
+# Icons: Apache 2.0 (https://www.apache.org/licenses/LICENSE-2.0)
+Some of the icons are redistributed under the Apache 2.0 license. All other
+icons are either redistributed under their respective licenses or are
+distributed under the Apache 2.0 license.
+
+https://pictogrammers.com/library/mdi/icon/tag-outline/
+-->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"
-    android:viewportWidth="24"
     android:viewportHeight="24"
-    android:tint="?attr/colorControlNormal">
-  <path
-      android:fillColor="@android:color/white"
-      android:pathData="M17.63,5.84C17.27,5.33 16.67,5 16,5L5,5.01C3.9,5.01 3,5.9 3,7v10c0,1.1 0.9,1.99 2,1.99L16,19c0.67,0 1.27,-0.33 1.63,-0.84L22,12l-4.37,-6.16z"/>
+    android:viewportWidth="24"
+    android:tint="?attr/toolbarIconColor">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M21.41 11.58L12.41 2.58A2 2 0 0 0 11 2H4A2 2 0 0 0 2 4V11A2 2 0 0 0 2.59 12.42L11.59 21.42A2 2 0 0 0 13 22A2 2 0 0 0 14.41 21.41L21.41 14.41A2 2 0 0 0 22 13A2 2 0 0 0 21.41 11.58M13 20L4 11V4H11L20 13M6.5 5A1.5 1.5 0 1 1 5 6.5A1.5 1.5 0 0 1 6.5 5Z" />
 </vector>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:background="?attr/selectableItemBackground"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:focusable="true"
+    android:clickable="true"
+    android:layoutDirection="locale"
+    android:paddingStart="14dp">
+
+    <ImageView
+        android:id="@+id/chevron"
+        style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
+        android:layout_width="40dp"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:paddingEnd="8dp"
+        android:layout_marginStart="8dp"
+        android:visibility="gone"
+        app:srcCompat="@drawable/ic_chevron_right_black"
+        />
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:layout_marginEnd="12dp"
+        />
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:gravity="start|center_vertical"
+        android:textAppearance="?android:textAppearanceMedium"
+        android:textDirection="locale"
+        android:textAlignment="gravity"
+        android:paddingEnd="8dp"
+        />
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:paddingEnd="24dp"
+        />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
@@ -23,13 +23,16 @@
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
     android:focusable="true"
     android:clickable="true"
-    android:layoutDirection="locale"
-    android:paddingStart="14dp">
+    android:layoutDirection="locale">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:layout_marginStart="8dp"
+        android:orientation="horizontal"
+        android:minWidth="?attr/minTouchTargetSize"
+        android:minHeight="?attr/minTouchTargetSize"
+        >
 
         <ImageView
             android:id="@+id/chevron"
@@ -37,9 +40,8 @@
             android:layout_width="40dp"
             android:layout_height="match_parent"
             android:gravity="center"
+            android:paddingStart="8dp"
             android:paddingEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:visibility="gone"
             app:srcCompat="@drawable/ic_chevron_right_black"
             />
 
@@ -48,6 +50,7 @@
             android:layout_width="24dp"
             android:layout_height="match_parent"
             android:gravity="center"
+            android:layout_marginStart="8dp"
             android:layout_marginEnd="12dp"
             tools:src="@drawable/ic_flag_transparent"
             />
@@ -85,7 +88,8 @@
         android:textAlignment="gravity"
         android:layout_marginTop="-8dp"
         android:paddingEnd="48dp"
-        tools:text="This is a long subtitle explaining really important things"
+        android:visibility="gone"
         android:paddingBottom="4dp"
+        tools:text="This is a long subtitle explaining really important things"
         />
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
@@ -17,7 +17,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
     android:background="?attr/selectableItemBackground"
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
     android:focusable="true"
@@ -25,42 +26,66 @@
     android:layoutDirection="locale"
     android:paddingStart="14dp">
 
-    <ImageView
-        android:id="@+id/chevron"
-        style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
-        android:layout_width="40dp"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:paddingEnd="8dp"
-        android:layout_marginStart="8dp"
-        android:visibility="gone"
-        app:srcCompat="@drawable/ic_chevron_right_black"
-        />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
 
-    <ImageView
-        android:id="@+id/icon"
-        android:layout_width="24dp"
-        android:layout_height="match_parent"
-        android:gravity="center"
-        android:layout_marginEnd="12dp"
-        />
+        <ImageView
+            android:id="@+id/chevron"
+            style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
+            android:layout_width="40dp"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:paddingEnd="8dp"
+            android:layout_marginStart="8dp"
+            android:visibility="gone"
+            app:srcCompat="@drawable/ic_chevron_right_black"
+            />
+
+        <ImageView
+            android:id="@+id/icon"
+            android:layout_width="24dp"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:layout_marginEnd="12dp"
+            tools:src="@drawable/ic_flag_transparent"
+            />
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="0dp"
+            android:layout_height="match_parent"
+            android:layout_weight="1"
+            android:gravity="start|center_vertical"
+            android:textAppearance="?android:textAppearanceMedium"
+            android:textDirection="locale"
+            android:textAlignment="gravity"
+            android:paddingEnd="8dp"
+            tools:text="Title"
+            />
+
+        <CheckBox
+            android:id="@+id/checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:paddingEnd="24dp"
+            />
+    </LinearLayout>
+
 
     <TextView
-        android:id="@+id/text"
-        android:layout_width="0dp"
+        android:id="@+id/subtitle"
+        android:paddingStart="36dp"
+        android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="1"
         android:gravity="start|center_vertical"
-        android:textAppearance="?android:textAppearanceMedium"
+        android:textAppearance="?android:textAppearanceSmall"
         android:textDirection="locale"
         android:textAlignment="gravity"
-        android:paddingEnd="8dp"
-        />
-
-    <CheckBox
-        android:id="@+id/checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:paddingEnd="24dp"
+        android:layout_marginTop="-8dp"
+        android:paddingEnd="48dp"
+        tools:text="This is a long subtitle explaining really important things"
+        android:paddingBottom="4dp"
         />
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_item.xml
@@ -13,7 +13,12 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<!--
+    Designed to align the leftmost image
+    (chevron/icon) with the menu icon in the app bar when inside a bottom sheet
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -23,73 +28,85 @@
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
     android:focusable="true"
     android:clickable="true"
-    android:layoutDirection="locale">
+    android:layoutDirection="locale"
+    android:paddingStart="14dp"
+    >
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+
+    <ImageView
+        android:id="@+id/chevron"
+        style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        app:layout_constraintBottom_toBottomOf="@+id/firstRowGuideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:srcCompat="@drawable/ic_chevron_right_black" />
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="2dp"
+        app:layout_constraintStart_toEndOf="@id/chevron"
+        app:layout_constraintTop_toTopOf="@+id/chevron"
+        app:layout_constraintBottom_toBottomOf="@+id/chevron"
+        tools:src="@drawable/ic_flag_transparent" />
+
+<!--
+    TODO: This should be centered if the only element
+     and not centered if a subtitle exists to save space
+-->
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:gravity="start|center_vertical"
+        android:paddingEnd="8dp"
+        android:textAlignment="gravity"
+        android:textAppearance="?android:textAppearanceMedium"
+        android:textDirection="locale"
         android:layout_marginStart="8dp"
+        app:layout_constraintEnd_toStartOf="@+id/checkbox"
+        app:layout_constraintStart_toEndOf="@id/icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="@+id/firstRowGuideline"
+        tools:text="Title" />
+
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:paddingEnd="16dp" />
+
+
+    <!-- Intended to be the same height as the Checkbox (since the checkbox is optional) -->
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/firstRowGuideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:minWidth="?attr/minTouchTargetSize"
-        android:minHeight="?attr/minTouchTargetSize"
-        >
-
-        <ImageView
-            android:id="@+id/chevron"
-            style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
-            android:layout_width="40dp"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:paddingStart="8dp"
-            android:paddingEnd="8dp"
-            app:srcCompat="@drawable/ic_chevron_right_black"
-            />
-
-        <ImageView
-            android:id="@+id/icon"
-            android:layout_width="24dp"
-            android:layout_height="match_parent"
-            android:gravity="center"
-            android:layout_marginStart="8dp"
-            android:layout_marginEnd="12dp"
-            tools:src="@drawable/ic_flag_transparent"
-            />
-
-        <TextView
-            android:id="@+id/text"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="1"
-            android:gravity="start|center_vertical"
-            android:textAppearance="?android:textAppearanceMedium"
-            android:textDirection="locale"
-            android:textAlignment="gravity"
-            android:paddingEnd="8dp"
-            tools:text="Title"
-            />
-
-        <CheckBox
-            android:id="@+id/checkbox"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:paddingEnd="24dp"
-            />
-    </LinearLayout>
-
+        app:layout_constraintGuide_begin="48dp" />
 
     <TextView
         android:id="@+id/subtitle"
-        android:paddingStart="36dp"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         android:gravity="start|center_vertical"
-        android:textAppearance="?android:textAppearanceSmall"
-        android:textDirection="locale"
-        android:textAlignment="gravity"
-        android:layout_marginTop="-8dp"
+        android:paddingBottom="12dp"
         android:paddingEnd="48dp"
+        android:textAlignment="gravity"
+        android:textAppearance="?android:textAppearanceSmall"
+        android:textColor="?android:attr/textColorSecondary"
+        android:textDirection="locale"
         android:visibility="gone"
-        android:paddingBottom="4dp"
+        android:layout_marginTop="-8dp"
+        app:layout_constraintStart_toStartOf="@+id/text"
+        app:layout_constraintTop_toBottomOf="@+id/firstRowGuideline"
+        app:layout_constraintEnd_toStartOf="@id/checkbox"
         tools:text="This is a long subtitle explaining really important things"
-        />
-</LinearLayout>
+        tools:visibility="visible" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_list_with_filter.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_list_with_filter.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    >
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:paddingTop="88dp"
+        android:paddingBottom="24dp"
+        android:clipToPadding="false"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/bottom_sheet_item"
+        />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginTop="24dp"
+        android:paddingHorizontal="16dp"
+        >
+
+        <!-- flagNoExtractUi prevents big editor from showing in landscape mode.
+             See https://stackoverflow.com/questions/4336762 -->
+        <EditText
+            android:id="@+id/filter"
+            android:layout_width="match_parent"
+            android:layout_height="48dp"
+            android:background="@drawable/bg_input"
+            android:backgroundTint="?attr/bottomSheetFilterBackgroundColor"
+            android:inputType="text"
+            android:singleLine="true"
+            android:paddingStart="24dp"
+            android:paddingEnd="48dp"
+            android:imeOptions="flagNoExtractUi"
+            tools:hint="Search"
+            />
+    </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/clear_filter"
+        style="@style/Widget.MaterialComponents.CompoundButton.CheckBox"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_gravity="end"
+        app:srcCompat="@drawable/close_icon"
+        android:alpha="0"
+        />
+<!--    app:tint="@color/m3_selection_control_button_tint"-->
+</FrameLayout>

--- a/AnkiDroid/src/main/res/layout/bottom_sheet_list_without_filter.xml
+++ b/AnkiDroid/src/main/res/layout/bottom_sheet_list_without_filter.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<androidx.recyclerview.widget.RecyclerView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/list"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="24dp"
+    android:paddingBottom="24dp"
+    android:clipToPadding="false"
+    app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+    />

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -48,9 +48,9 @@
                     style="@style/Chip.WithIcon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="Flags"
                     app:chipIcon="@drawable/ic_flag_transparent"
                     app:chipIconTint="@null"
+                    tools:text="Flags"
                     />
 
                 <com.google.android.material.chip.Chip
@@ -58,8 +58,9 @@
                     style="@style/Chip.WithIcon"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/browser_card_state"
                     app:chipIcon="@drawable/ic_card_state"
+                    app:chipIconTint="@null"
+                    android:text="@string/browser_card_state"
                     />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -42,6 +42,15 @@
                     app:chipIcon="@drawable/ic_flag_transparent"
                     app:chipIconTint="@null"
                     />
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_state"
+                    style="@style/Chip.WithIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/browser_card_state"
+                    app:chipIcon="@drawable/ic_card_state"
+                    />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>
 

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -5,7 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -32,6 +33,15 @@
                 android:layout_height="wrap_content"
                 android:elevation="0dp"
                 app:singleLine="true" >
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_tag"
+                    style="@style/Chip.WithIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_tag"
+                    tools:text="Tags"
+                    />
 
                 <com.google.android.material.chip.Chip
                     android:id="@+id/chip_flag"

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -14,6 +14,37 @@
 
         <include layout="@layout/toolbar" />
 
+
+        <HorizontalScrollView
+            android:id="@+id/browser_chips"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/colorBackground"
+            android:paddingHorizontal="8dp"
+            android:clipToPadding="false"
+            android:scrollbars="none"
+            app:layout_behavior="com.google.android.material.search.SearchBar$ScrollingViewBehavior" >
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/chip_group"
+                style="@style/Widget.Material3.ChipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:elevation="0dp"
+                app:singleLine="true" >
+
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_flag"
+                    style="@style/Chip.WithIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Flags"
+                    app:chipIcon="@drawable/ic_flag_transparent"
+                    app:chipIconTint="@null"
+                    />
+            </com.google.android.material.chip.ChipGroup>
+        </HorizontalScrollView>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:background="?android:attr/colorBackground"

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -68,13 +68,15 @@
             android:layout_width="match_parent"
             android:background="?android:attr/colorBackground"
             android:orientation="horizontal"
-            android:layout_height="?attr/listPreferredItemHeight">
+            android:layout_height="48dp"
+            android:layout_marginTop="-8dp" >
 
             <Spinner
                 android:id="@+id/browser_column1_spinner"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
+                android:dropDownVerticalOffset="8dp"
                 />
 
             <Spinner
@@ -82,6 +84,7 @@
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
                 android:layout_weight="1"
+                android:dropDownVerticalOffset="8dp"
                 />
         </LinearLayout>
 

--- a/AnkiDroid/src/main/res/layout/card_item_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_item_browser.xml
@@ -11,7 +11,6 @@
         android:focusableInTouchMode="false"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:visibility="gone"
         android:gravity= "center_vertical"/>
 
     <com.ichi2.ui.FixedTextView

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -24,12 +24,6 @@
     <item
         android:id="@+id/action_sort_by_size"
         android:title="@string/card_browser_change_display_order"/>
-    <item
-        android:id="@+id/action_show_marked"
-        android:title="@string/card_browser_show_marked"/>
-    <item
-        android:id="@+id/action_search_by_tag"
-        android:title="@string/card_browser_search_by_tag"/>
 
     <item
         ankidroid:showAsAction="ifRoom"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -35,15 +35,6 @@
         android:title="@string/card_browser_search_by_tag"/>
 
     <item
-        ankidroid:showAsAction="never"
-        android:id="@+id/action_search_by_flag"
-        android:title="@string/card_browser_search_by_flag">
-        <menu>
-            <!-- flags are dynamically added -->
-        </menu>
-    </item>
-
-    <item
         ankidroid:showAsAction="ifRoom"
         android:id="@+id/action_undo"
         android:title="@string/undo"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -28,9 +28,6 @@
         android:id="@+id/action_show_marked"
         android:title="@string/card_browser_show_marked"/>
     <item
-        android:id="@+id/action_show_suspended"
-        android:title="@string/card_browser_show_suspended"/>
-    <item
         android:id="@+id/action_search_by_tag"
         android:title="@string/card_browser_search_by_tag"/>
 

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -40,8 +40,6 @@
     </plurals>
     <string name="card_browser_change_deck">Change deck</string>
     <string name="delete_card_title">Delete note?</string>
-    <string name="card_browser_show_marked">Filter marked</string>
-    <string name="card_browser_search_by_tag">Filter by tag</string>
     <string name="card_browser_list_my_searches">My searches</string>
     <string name="card_browser_list_my_searches_save">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>
@@ -91,6 +89,8 @@
 
     <string name="browser_card_state" comment="A short word, to use on a chip control">State</string>
 
+    <!-- Bottom sheets -->
+    <string name="filter_hint_search_tags"><i>Search tags</i></string>
     <string name="chip_filter_multiple_selections" comment="Arg 1: Selected filter ('Red Flag')
     Arg 2: Number of additional selected filters (2: Green and Blue Flags)
     Example shown to use: 'Red +2'

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -43,7 +43,6 @@
     <string name="card_browser_show_marked">Filter marked</string>
     <string name="card_browser_show_suspended">Filter suspended</string>
     <string name="card_browser_search_by_tag">Filter by tag</string>
-    <string name="card_browser_search_by_flag">Filter by flag</string>
     <string name="card_browser_list_my_searches">My searches</string>
     <string name="card_browser_list_my_searches_save">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>
@@ -90,4 +89,10 @@
         <item quantity="one">%d card deleted</item>
         <item quantity="other">%d cards deleted</item>
     </plurals>
+
+    <string name="chip_filter_multiple_selections" comment="Arg 1: Selected filter ('Red Flag')
+    Arg 2: Number of additional selected filters (2: Green and Blue Flags)
+    Example shown to use: 'Red +2'
+    When displaying a chip control for a filter, if one element is selected, we display it
+If more than one element is selected, we also show the count of extra filters">%1$s +%2$d</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -41,7 +41,6 @@
     <string name="card_browser_change_deck">Change deck</string>
     <string name="delete_card_title">Delete note?</string>
     <string name="card_browser_show_marked">Filter marked</string>
-    <string name="card_browser_show_suspended">Filter suspended</string>
     <string name="card_browser_search_by_tag">Filter by tag</string>
     <string name="card_browser_list_my_searches">My searches</string>
     <string name="card_browser_list_my_searches_save">Save search</string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -90,6 +90,8 @@
         <item quantity="other">%d cards deleted</item>
     </plurals>
 
+    <string name="browser_card_state" comment="A short word, to use on a chip control">State</string>
+
     <string name="chip_filter_multiple_selections" comment="Arg 1: Selected filter ('Red Flag')
     Arg 2: Number of additional selected filters (2: Green and Blue Flags)
     Example shown to use: 'Red +2'

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -177,4 +177,12 @@
     <attr name="checkMediaListForeground" format="color" />
 
     <attr name="progressDialogButtonTextColor" format="color"/>
+
+    <attr name="bottomSheetFilterBackgroundColor" format="color|reference"/>
+
+    <attr name="chipInactiveStrokeColor" format="color"/>
+    <attr name="chipInactiveTextAndIconColor" format="color"/>
+    <attr name="chipActiveBackgroundColor" format="color"/>
+    <attr name="chipActiveTextAndIconColor" format="color"/>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -157,6 +157,23 @@
         <item name="android:tint">@color/black</item>
     </style>
 
+    <style name="Chip.WithIcon" parent="Widget.Material3.Chip.Suggestion">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Chip</item>
+        <item name="chipIconVisible">true</item>
+        <item name="chipIconTint">@color/m3_chip_text_color</item>
+        <item name="android:ellipsize">middle</item>
+        <item name="android:maxWidth">200dp</item>
+    </style>
+    <style name="ThemeOverlay.App.Chip" parent="">
+        <item name="colorOutline">?attr/chipInactiveStrokeColor</item>
+        <item name="colorOnSurfaceVariant">?attr/chipInactiveTextAndIconColor</item>
+        <item name="colorSecondaryContainer">?attr/chipActiveBackgroundColor</item>
+        <item name="colorOnSecondaryContainer">?attr/chipActiveTextAndIconColor</item>
+        <item name="colorSurface">@color/transparent</item> <!-- Container background -->
+        <item name="textAppearanceTitleSmall">@style/TextAppearance.Material3.TitleSmall</item>
+        <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
+    </style>
+
     <style name="reviewer_whiteboard_editor_button_style">
         <item name="android:layout_height">40dp</item>
         <item name="android:layout_width">40dp</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -123,6 +123,17 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <item name="android:navigationBarColor">@color/black</item>
 
+        <item name="chipInactiveStrokeColor">#6fff</item>
+        <item name="chipInactiveTextAndIconColor">#9fff</item>
+        <item name="chipActiveBackgroundColor">#4fff</item>
+        <item name="chipActiveTextAndIconColor">#fff</item>
+
+        <item name="bottomSheetFilterBackgroundColor">#606060</item>
+        <item name="chipInactiveStrokeColor">#6fff</item>
+        <item name="chipInactiveTextAndIconColor">#9fff</item>
+        <item name="chipActiveBackgroundColor">#4fff</item>
+        <item name="chipActiveTextAndIconColor">#fff</item>
+
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -114,6 +114,12 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <item name="editTextDisabled">@color/material_grey_500</item>
 
+        <item name="bottomSheetFilterBackgroundColor">#eee</item>
+        <item name="chipInactiveStrokeColor">#ddd</item>
+        <item name="chipInactiveTextAndIconColor">#444</item>
+        <item name="chipActiveBackgroundColor">#cef</item>
+        <item name="chipActiveTextAndIconColor">#023</item>
+
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -37,7 +37,6 @@ import com.ichi2.anki.browser.CardBrowserColumn.EASE
 import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
 import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserColumn.TAGS
-import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.model.CardsOrNotes.CARDS
@@ -1317,11 +1316,6 @@ suspend fun CardBrowser.searchCardsSync(query: String) {
 suspend fun CardBrowser.filterByTagSync(vararg tags: String) {
     filterByTag(*tags)
     viewModel.searchJob?.join()
-}
-
-suspend fun CardBrowserViewModel.setFlagFilterSync(flag: Flag) {
-    setFlagFilter(flag)
-    searchJob?.join()
 }
 
 fun TestClass.flagCardForNote(n: Note, flag: Flag) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -699,7 +699,7 @@ class CardBrowserTest : RobolectricTest() {
         }
 
         val cardBrowser = browserWithNoNewCards
-        cardBrowser.searchCards("Hello").join()
+        cardBrowser.searchCards(cardBrowser.viewModel.searchTerms.copy(userInput = "Hello")).join()
         waitForAsyncTasksToComplete()
         assertThat(
             "Card browser should have Test Deck as the selected deck",
@@ -1311,7 +1311,7 @@ val CardBrowser.validDecksForChangeDeck
     get() = runBlocking { getValidDecksForChangeDeck() }
 
 suspend fun CardBrowser.searchCardsSync(query: String) {
-    searchCards(query)
+    searchCards(viewModel.searchTerms.copy(userInput = query))
     viewModel.searchJob?.join()
 }
 suspend fun CardBrowser.filterByTagSync(vararg tags: String) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1314,8 +1314,7 @@ suspend fun CardBrowser.searchCardsSync(query: String) {
     viewModel.searchJob?.join()
 }
 suspend fun CardBrowser.filterByTagSync(vararg tags: String) {
-    filterByTag(*tags)
-    viewModel.searchJob?.join()
+    viewModel.launchSearchForCards(viewModel.searchTerms.copy(tags = tags.toSet()))?.join()
 }
 
 fun TestClass.flagCardForNote(n: Note, flag: Flag) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -780,6 +780,10 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 }
 
+private suspend fun CardBrowserViewModel.searchForSuspendedCards() {
+    launchSearchForCards(searchTerms.copy(states = setOf(State.Suspended)))?.join()
+}
+
 @Suppress("SameParameterValue")
 private fun CardBrowserViewModel.selectRowsWithPositions(vararg positions: Int) {
     for (pos in positions) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -41,7 +41,6 @@ import com.ichi2.anki.model.SortType.EASE
 import com.ichi2.anki.model.SortType.NO_SORTING
 import com.ichi2.anki.model.SortType.SORT_FIELD
 import com.ichi2.anki.servicelayer.NoteService
-import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
 import com.ichi2.libanki.Consts.QUEUE_TYPE_NEW
@@ -150,7 +149,7 @@ class CardBrowserViewModelTest : JvmTest() {
         val anotherCardWithRedFlag = addNoteUsingBasicModel("Second card with red flag", "Reverse")
         flagCardForNote(anotherCardWithRedFlag, Flag.RED)
 
-        setFlagFilterSync(Flag.RED)
+        launchSearchForCards(searchTerms.copy(flags = setOf(Flag.RED)))?.join()
 
         assertThat("Flagged cards should be returned", rowCount, equalTo(2))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -784,6 +784,10 @@ private suspend fun CardBrowserViewModel.searchForSuspendedCards() {
     launchSearchForCards(searchTerms.copy(states = setOf(State.Suspended)))?.join()
 }
 
+private suspend fun CardBrowserViewModel.searchForMarkedNotes() {
+    launchSearchForCards(searchTerms.copy(tags = setOf("marked")))?.join()
+}
+
 @Suppress("SameParameterValue")
 private fun CardBrowserViewModel.selectRowsWithPositions(vararg positions: Int) {
     for (pos in positions) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -225,21 +225,21 @@ class CardBrowserViewModelTest : JvmTest() {
     @Test
     fun `default init`() = runTest {
         viewModel().apply {
-            assertThat(searchTerms, equalTo(""))
+            assertThat(searchTerms.userInput, equalTo(""))
         }
     }
 
     @Test
     fun `Card Browser menu init`() = runTest {
         viewModel(intent = SystemContextMenu("Hello")).apply {
-            assertThat(searchTerms, equalTo("Hello"))
+            assertThat(searchTerms.userInput, equalTo("Hello"))
         }
     }
 
     @Test
     fun `Deep Link init`() = runTest {
         viewModel(intent = DeepLink("Hello")).apply {
-            assertThat(searchTerms, equalTo("Hello"))
+            assertThat(searchTerms.userInput, equalTo("Hello"))
         }
     }
 


### PR DESCRIPTION
> [!IMPORTANT]
> * Commit messages need work, as well as more attribution and thanks to OK
> * The textual descriptions on 'State' need a lot of bikeshedding
> * Some of the PR description should be applied as code comments
> * Hiding the toolbar on scroll needs to be implemented
>
> I feel the rest is ready for review
## Purpose / Description

This is an Android-based implementation of the sidebar in Anki Desktop which handles `[Tags; Flags; State]`

The implementation begins to productionize @oakkitten's [proposal](https://github.com/ankidroid/Anki-Android/issues/12554) for using [Material 3 Chips](https://m3.material.io/components/chips/overview) to filter categories in the Card Browser. 

* https://github.com/ankidroid/Anki-Android/issues/12554

A large amount of this Pull Request text is copied from the above. THANK YOU

<details>

<summary>Anki Desktop: Browser Sidebar</summary>
<img width="261" alt="Screenshot 2024-08-11 at 17 41 13" src="https://github.com/user-attachments/assets/ff9570d9-4ada-49e4-ae23-bc02fe2cf298">

</details>

### Images

<img width="250" alt="Screenshot 2024-08-11 at 19 28 25" src="https://github.com/user-attachments/assets/6bc47700-ddd8-4147-8cb1-08c9391beb54">

<img width="250" alt="Screenshot 2024-08-11 at 19 27 21" src="https://github.com/user-attachments/assets/39b6c830-7fc8-4aa5-970a-3b50eb51097c">
<img width="250" alt="Screenshot 2024-08-11 at 19 28 46" src="https://github.com/user-attachments/assets/88b26483-819f-408f-a219-0d94b36fbf61">
<img width="250" alt="Screenshot 2024-08-11 at 19 54 32" src="https://github.com/user-attachments/assets/1ed6f20d-f760-4ac7-9cd6-bfdc6ce171b4">

**new tag icons**
<img width="250" alt="Screenshot 2024-08-20 at 12 19 29" src="https://github.com/user-attachments/assets/032aa290-4478-4961-bdb0-1d708eaaede9">

### Behavior

#### Chip Group

<img width="391" alt="Screenshot 2024-08-11 at 18 02 41" src="https://github.com/user-attachments/assets/3474cbbb-9f2a-469e-b454-7f06e2b21dfe">

A single-line chip bar, horizontally scrollable, is placed below the toolbar. Tapping on a chip opens the according bottom sheet, where you can select one or multiple items. When you select items, search is instantly re-applied, and the chip change color, label and optionally, icon to reflect the selection. 

For example, `Flags` changes to `Red` if the red flag is selected or `Red +1` if an additional flag is selected. In the latter case, `Red` would be the flag which the user selected first.

In the case of Flags and State, the icon is updated to match the icon of the first selected flag/state

#### Scrolling

⚠️ TODO: The toolbar, along with the chip bar and the spinners bellow, is collapsed when the user scrolls down the list of cards.

#### Bottom Sheets

<img width="392" alt="Screenshot 2024-08-11 at 18 56 26" src="https://github.com/user-attachments/assets/151f4875-9cc7-4e9f-b3a1-f82fc6bcb260">

The bottom sheets show lists of items with icons, text, checkboxes and an optional description. To select items, you can:
  * **Tap on the item icon/label:** 
    * A quick way to select only one thing. The dialog will be closed, a  This will select the tapped item and close the dialog. If any other items were selected, those are de-selected. 
  * **Tap on the checkbox:** 
    * This does not dismiss the dialog and allows the user select multiple items. The dialog may be dismissed by swiping the sheet downwards, or tapping in the scrim area.

All the bottom sheets have a `Clear filter` icon without a checkbox. Tapping on it clears the selection and closes the dialog, stopping filtering by this category.

#### Chevrons / Indenting

**Context**: Hierarchical decks/tags

The bottom sheets can display directory tree-like items. Items that have subitems can be collapsed to hide those and show a clickable chevron to indicate collapsed state (`›`/`⌄`). If there are any chevrons, all items are shifted to the right to make place for the leftmost chevrons.

#### Searching

<img width="200" alt="Screenshot 2024-08-11 at 20 07 54" src="https://github.com/user-attachments/assets/2fa272e7-4d9c-43a2-b190-9c1dd1c8392f">

**Context**: User-defined categories: [Decks; Tags; Note Types]

If there are more than 10 items, a search input is visible with a hint: `Search tags`. Tapping on it expands the sheet to full screen (if enough items). A "clear search" button is shown when text is entered. When typing, items that do not contain the input are hidden, with the exception of any parent items, e.g., searching for `foo` would change

    * abc         
    * def                     * def
      * hello        -->         * hello
         * foo                     * foo
         * bar                * foo fighters
    * foo fighters

The bottom sheet survives rotation, preserving selection & scroll position.

#### State: Descriptions

<img width="392" alt="Screenshot 2024-08-11 at 18 58 46" src="https://github.com/user-attachments/assets/3af11b52-0272-44ed-8695-79404115c17b">

> [!NOTE] 
> The above screenshot is to demonstrate the UI only, please view the Pull Request for the current strings

The `State` control provides us with an opportunity to explain a number of Anki's concepts to users. I would strongly encourage us all to discuss these descriptions, as these will resolve a number of onboarding issues.

⚠️ My initial descriptions are not sufficient to be merged, and therefore are hardcoded in `CardSheetFragment::State`

### Feature Removals

This pull request removes the following menu items from the Card Browser. These were available from the Card Browser's menu when not in multi-select mode

* Filter marked: 
  * `marked` is implemented as a tag, which is displayed as a tag in the tag selection fragment. This tag is displayed with a distinct 'star' icon
* Filter suspended
  * `suspended` is an option in the **State** chip 
* Filter by tag
  * The **Tags** chip handles all functionality
  * ⚠️ The **All cards/New/Due** selector is not yet fully implemented
    * **New** is handled under **State**
    * ⚠️ Anki Desktop handled `is:due` under **Today**, which will be implemented in a later Pull Request 
* Filter by flag 
  * Handled, with more functionality (`OR`) under the **Flags** chip.


* Remove: `Ctrl+T` to filter by tag
* Remove: `Ctrl+M` to search for marked notes
* Remove: `Alt+S`  to Show suspended cards

### Future Extensions

The following chips are planned, mirroring Anki Desktop's functionality. These were not implemented as this Pull Request is already extremely unwieldy, and will likely result in a long review cycle.

* **Decks**
  * Introducing this would produce two UI elements which modify the same category in different ways: our current `ActionView`-based UI does not handle multiple decks in an `OR`
  * We should move to a material `SearchView/Bar` in the same commit, and this involved a fair amount of design improvements
* **Today**
  * Handling parameters: in `Again` -> `rated:1:1` needs a little work
  * These are parameters, BUT we don't display this in the search bar yet
* **Note Type**
  * Should be an easy implementation, low-yield and I initially chose categories which replaced menu items in the Browser

----

Anki Desktop's Backend contains [3 states](https://github.com/ankitects/anki/blob/5f80ddf27d1bac4966699a767d9277fda56dff18/rslib/src/search/parser.rs#L597-L615) which are not displayed in Anki Desktop:

* `is:due`
  * Exposed somewhat in "Today - Overdue":
  * `Overdue` -> `is:due -prop:due=0`

⚠️ I would support handling the following two states in this Pull Request, 
* `is:buried-manually`
* `is:buried-sibling`

----

* Long-press menus should be available
  * A user may rename a flag
  * A user may delete a tag 
  * A 'Learn More' menu item for states

----

* Each category is searched with `AND`, and items within categories with `OR`. 
   * An advanced search mode will be made available to expose additional filters (`nc:, `re:`), as well as logical options. This will be focused on changing the search text, to expose all of Anki Desktop's search functionality
   * Using the Ctrl/Alt modifiers in Anki Desktop will likely open up this advanced editor. Displaying logical search combinations using a checkbox-based UI is untenable

----

Selected tags may want to be moved to the top of the list when the selection dialog is reopened

----

### Visuals

* The chips can have transparent background which makes them behave *just* like Gmail chips in the sense that when you tap on them, the ripple effect only happens to the outline. Can be changed to a more usual behavior.

* When changing the items in the bottom sheet, default `RecyclerView` animations are run with the exception of the chevron animation. Instead of the default crossfade, when item's subitems are collapsed or shown, chevron is rotated 90°.

* Oakkitten created new icons, as seen in the screenshots
  * In tag list, the tag `marked` has a star icon.

* Text gravity depends on layout RTL regardless of text itself. Stuff like menus work this way.

### Caveats & considerations

* When the contents of the bottom sheet change height, the bottom sheet height change is not animated. Not sure what would be a good way to solve this.

* In dark mode, the bottom sheet does not expand to the status bar for some reason.

* Normally, the bottom sheet height is limited by its contents. It would be nice if when the user taps on the search input, the sheet would switch temporarily drop this limit, and keep the search input on top of the screen even if the list has few items. While the bottom sheet API should allow just that, the result is super buggy in many ways. Not sure if there's an easy workaround.

# Implementation

* `SearchParameters` is a parcelable data class that stores user input and all the filtering information. It makes `String` queries that can be passed to the backend.

* `Chips.kt` has functions that set up and update chips based on changes in `searchParameters`.

* `BottomSheetDialogFragmentFix` is a fix for an issue in `BottomSheetDialogFragment`; in landscape, the peek height of it is too small.

* `BottomSheetFragment` which is a subclass of ↑ is a base for all bottom sheets. It inflates the layout (with a `RecyclerView`, and with or without the search input) and wires together the views. Its subclasses are responsible to setting up the adapter and reacting to clicks, etc.

* `TreeAdapter` is a `RecyclerView.Adapter` which displays a flat list of `TreeAdapter.Item`. `TreeAdapter` is responsible the layout, event handling and display of the items via a `ViewHolder`. It handles notifying the `RecyclerView` of modification of the items via `DiffCallback`. See `R.layout.bottom_sheet_item` for the layout.
  * In particular, it handles the horizontal padding necessary for the chevrons/indented items

```ts
// TreeAdapter.Item
{
    id: Long,
    icon: DrawableRes?,
    text: CharSequence,
    subtitle: String?,
    indent: Int,
    collapsed: { Yes, No, NotCollapsible },
    checked: { Yes, No, NotCheckable }
}
```

* `TemplatedTreeAdapter` is a subclass of ↑. It holds an immutable list of `SourceItem`, along with the user's selection of expanded and checked items. The combination of `(SourceItem, checked, expanded)` produces a `TreeAdapter.Item`

```ts
// TemplatedTreeAdapter.SourceItem
{
    id: Long,
//    ... as above
    checkable: Boolean
}
```

Although we could use a tree structure, we can get away with a flat list. Consider a list of tags:

      foo::bar::baz
      zoo
      foo

  Let's call every string in this list “a chain”; a chain is a `::` separated string, and let's call what's between `::`s a chain link. If we add missing subchains (`foo::bar`), and case-insensitive sort, we get:

      foo
      foo::bar
      foo::bar::baz
      zoo

  And this is something that we can already show! The `text` would be the leaf chain (`foo`, `bar`), the `indent` would be the number of links in the chain.

  This is what `Iterable<Row>.toCheckableSourceItems()` and the code around it does; it takes a bunch of rows (⚠️ to be renamed, row is a chain with the associated ID and icon) and converts them to `TemplatedTreeAdapter.SourceItem`. So the path of transformation of data would be like this:

    * Get a set of chains from backend
    * Add missing subchains and sort
    * Convert the list to a list of `Row`s with IDs and icons
    * Convert the list of rows to a list of `SourceItem`s

All containers in question are (for the purpose of this) deeply immutable.

### Caveats & considerations

Oakkitten's Wizard extensions in the [linked issue](https://github.com/ankidroid/Anki-Android/issues/12554) are not implemented. 

If the card list has few items, dragging the empty area does not collapse/uncollapse the toolbar. This is probably a problem with the `ListView`. Wrapping it in `NestedScrollView` doesn't seem to work. I hope that changing it to a `RecyclerView` will resolve the issue.

Currently, bottom sheet fragments are aware of the collection and that's where these get the data in sync. I think they should be able to get that data cached. This is simple and this ensures that the adapter has the latest data. However, this means that on view recreation the data can change. For the most part this is not an issue, but tags are strings and don't have intrinsic IDs, and tag position in tag list is used instead. In theory, if for instance the tags change between activity recreations, you can have `RecyclerView` restored to a wrong position. I don't think this can lead to any important issues, but just to be safe the IDs can be somewhat stabilized by keeping a static map of tag to id, or interning strings maybe. (Is string interning fast?)

The collapse state of items is not saved and vanishes on activity recreation, and I don't think it's worth saving it.

The new icons should be optimized.

## How Has This Been Tested?

* Night mode
* Tested filtering by flag, tag and state
* Tested adding a tag: it appears when the fragment is next opened
* Tested using a large list of tags: `col.tags.all()` is fast
* Tested 'Clear filter'
* Tested RTL, all but the 'Search Tags' works, and I believe this is due to the String being in LTR
* Saved Searches include the filters and search string
* ⚠️ Test with AnKing tags


## Checklist
- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
