### PR TITLE
fix: NoteEditor flaky test

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -537,7 +537,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         // ImageIntentManager.saveImageUri(imageUri)
         // the field won't exist so it will always be a new card
         val note = getCurrentMultimediaEditableNote()
-        if (note == null) {
+        if (note.isEmpty) {
             Timber.w("Note is null, returning")
             return
         }
@@ -1582,11 +1582,10 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         insertStringInField(getFieldForTest(fieldIndex), newString)
     }
 
-    @KotlinCleanup("fix the requireNoNulls")
-    private suspend fun getCurrentMultimediaEditableNote(): MultimediaEditableNote? {
+    private suspend fun getCurrentMultimediaEditableNote(): MultimediaEditableNote {
         val note = NoteService.createEmptyNote(editorNote!!.notetype)
         val fields = currentFieldStrings.requireNoNulls()
-        withCol { NoteService.updateMultimediaNoteFromFields(this@withCol, fields, editorNote!!.mid, note!!) }
+        withCol { NoteService.updateMultimediaNoteFromFields(this@withCol, fields, editorNote!!.mid, note) }
 
         return note
     }
@@ -1749,7 +1748,8 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     private fun handleMultimediaActions(fieldIndex: Int) {
         // Based on the type of multimedia action received, perform the corresponding operation
         lifecycleScope.launch {
-            val note: MultimediaEditableNote = getCurrentMultimediaEditableNote() ?: return@launch
+            val note: MultimediaEditableNote = getCurrentMultimediaEditableNote()
+            if (note.isEmpty) return@launch
 
             multimediaViewModel.multimediaAction.first { action ->
                 when (action) {
@@ -1870,7 +1870,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     private fun addMediaFileToField(index: Int, field: IField) {
         lifecycleScope.launch {
             val note = getCurrentMultimediaEditableNote()
-            note?.setField(index, field)
+            note.setField(index, field)
             val fieldEditText = editFields!![index]
 
             // Import field media

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -276,6 +276,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             if (result.resultCode == RESULT_CANCELED) {
                 Timber.d("Multimedia result canceled")
                 val index = result.data?.extras?.getInt(MULTIMEDIA_RESULT_FIELD_INDEX) ?: return@NoteEditorActivityResultCallback
+                showMultimediaBottomSheet()
                 handleMultimediaActions(index)
                 return@NoteEditorActivityResultCallback
             }
@@ -1687,6 +1688,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                 mediaButton.setBackgroundResource(R.drawable.ic_attachment)
 
                 mediaButton.setOnClickListener {
+                    showMultimediaBottomSheet()
                     handleMultimediaActions(i)
                 }
 
@@ -1728,6 +1730,13 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         )
     }
 
+    @VisibleForTesting
+    fun showMultimediaBottomSheet() {
+        Timber.d("Showing MultimediaBottomSheet fragment")
+        val multimediaBottomSheet = MultimediaBottomSheet()
+        multimediaBottomSheet.show(parentFragmentManager, "MultimediaBottomSheet")
+    }
+
     /**
      * Handles user interactions with the multimedia options for a specific field in a note.
      *
@@ -1737,11 +1746,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
      *
      * @param fieldIndex the index of the field in the note where the multimedia content should be added
      */
-    fun handleMultimediaActions(fieldIndex: Int) {
-        Timber.d("Showing MultimediaBottomSheet fragment")
-        val multimediaBottomSheet = MultimediaBottomSheet()
-        multimediaBottomSheet.show(parentFragmentManager, "MultimediaBottomSheet")
-
+    private fun handleMultimediaActions(fieldIndex: Int) {
         // Based on the type of multimedia action received, perform the corresponding operation
         lifecycleScope.launch {
             val note: MultimediaEditableNote = getCurrentMultimediaEditableNote() ?: return@launch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
@@ -105,6 +105,9 @@ class MultimediaEditableNote : IMultimediaEditableNote {
         return IOUtils.deserialize(IField::class.java, IOUtils.serialize(f!!))
     }
 
+    val isEmpty: Boolean
+        get() = fields.isNullOrEmpty()
+
     companion object {
         private const val serialVersionUID = -6161821367135636659L
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -51,31 +51,30 @@ object NoteService {
     /**
      * Creates an empty Note from given Model
      *
-     * @param model the model in JSOBObject format
-     * @return a new note instance
+     * @param model the model in JSONObject format
+     * @return a new MultimediaEditableNote instance
      */
-    fun createEmptyNote(model: JSONObject): MultimediaEditableNote? {
+    fun createEmptyNote(model: JSONObject): MultimediaEditableNote {
+        val note = MultimediaEditableNote()
         try {
             val fieldsArray = model.getJSONArray("flds")
             val numOfFields = fieldsArray.length()
-            if (numOfFields > 0) {
-                val note = MultimediaEditableNote()
-                note.setNumFields(numOfFields)
-                for (i in 0 until numOfFields) {
-                    val fieldObject = fieldsArray.getJSONObject(i)
-                    val uiTextField = TextField()
-                    uiTextField.name = fieldObject.getString("name")
-                    uiTextField.text = fieldObject.getString("name")
-                    note.setField(i, uiTextField)
+            note.setNumFields(numOfFields)
+
+            for (i in 0 until numOfFields) {
+                val fieldObject = fieldsArray.getJSONObject(i)
+                val uiTextField = TextField().apply {
+                    name = fieldObject.getString("name")
+                    text = fieldObject.getString("name")
                 }
-                note.modelId = model.getLong("id")
-                return note
+                note.setField(i, uiTextField)
             }
+            note.modelId = model.getLong("id")
         } catch (e: JSONException) {
-            // TODO Auto-generated catch block
-            Timber.w(e)
+            Timber.w(e, "Error parsing model: %s", model)
+            // Return note with default/empty fields
         }
-        return null
+        return note
     }
 
     fun updateMultimediaNoteFromFields(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -203,7 +203,7 @@ class NoteEditorTest : RobolectricTest() {
         val intent = NoteEditorLauncher.AddNote().getIntent(targetContext)
         ActivityScenario.launchActivityForResult<SingleFragmentActivity>(intent).use { scenario ->
             scenario.onNoteEditor { noteEditor ->
-                noteEditor.handleMultimediaActions(0)
+                noteEditor.showMultimediaBottomSheet()
 
                 onView(withId(R.id.multimedia_action_image)).inRoot(isDialog()).check(matches(isDisplayed()))
                 onView(withId(R.id.multimedia_action_audio)).inRoot(isDialog()).check(matches(isDisplayed()))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The NPE was caused due to the `getCurrentMultimediaEditableNote` method being called when showing the bottom sheet but to test the bottom sheet we dont need that, so separating the logic to show the media sheet and then testing it.

## Fixes
* Fixes #16886

## How Has This Been Tested?
Locally tested, test successful 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
