### PR TITLE
fix: IllegalStateException in audio player

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
@@ -480,8 +480,14 @@ class AudioRecordingController(
 
     fun toggleToRecorder() {
         Timber.i("recorder requested")
-        if (audioPlayer!!.isPlaying) {
-            audioPlayer?.stop()
+        try {
+            audioPlayer?.let { player ->
+                if (player.isPlaying) {
+                    player.stop()
+                }
+            }
+        } catch (e: IllegalStateException) {
+            Timber.w(e, "MediaPlayer is not in a valid state to check if it's playing")
         }
         controlAudioRecorder()
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the audio player in wrong state when trying to initialise from the gestures

## Fixes
* Fixes #16873

## How Has This Been Tested?
Google emulator API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
