### PR TITLE
Enabling the onboarding feature

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CustomMaterialTapTargetPromptBuilder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CustomMaterialTapTargetPromptBuilder.kt
@@ -27,7 +27,7 @@ import uk.co.samuelwall.materialtaptargetprompt.extras.backgrounds.RectangleProm
 import uk.co.samuelwall.materialtaptargetprompt.extras.focals.CirclePromptFocal
 import uk.co.samuelwall.materialtaptargetprompt.extras.focals.RectanglePromptFocal
 
-class CustomMaterialTapTargetPromptBuilder<T>(val activity: Activity, private val featureIdentifier: T) : MaterialTapTargetPrompt.Builder(activity) where T : Enum<T>, T : OnboardingFlag {
+class CustomMaterialTapTargetPromptBuilder<T>(val activity: Activity, private val featureIdentifier: T) : MaterialTapTargetPrompt.Builder(activity) where T : Enum<T>, T : OnboardingEntry {
 
     private fun createRectangle(): CustomMaterialTapTargetPromptBuilder<T> {
         promptFocal = RectanglePromptFocal()
@@ -84,7 +84,7 @@ class CustomMaterialTapTargetPromptBuilder<T>(val activity: Activity, private va
         // This will prevent click on any outside view when user tries to dismiss the feature prompt
         captureTouchEventOutsidePrompt = true
 
-        OnboardingUtils.setVisited(featureIdentifier, activity)
+        featureIdentifier.setVisited(activity)
         return super.show()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -584,8 +584,6 @@ open class DeckPicker :
 
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
-        Onboarding.DeckPicker(this, recyclerViewLayoutManager).onCreate()
-
         launchShowingHidingEssentialFileMigrationProgressDialog()
 
         InitialActivity.checkWebviewVersion(packageManager, this)
@@ -2330,6 +2328,7 @@ open class DeckPicker :
         }
         val currentFilter = if (toolbarSearchView != null) toolbarSearchView!!.query else null
 
+        Onboarding.DeckPicker(this, recyclerViewLayoutManager).onCreate()
         if (isEmpty) {
             if (supportActionBar != null) {
                 supportActionBar!!.subtitle = null
@@ -2584,7 +2583,7 @@ open class DeckPicker :
     }
 
     /**
-     * The number of decks which are visible to the user (excluding decks if the parent is collapsed).
+     * The number of decks which are visible to the user (it does not count any deck with a collapsed ancestor).
      * Not the total number of decks
      */
     @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
@@ -2592,10 +2591,13 @@ open class DeckPicker :
         get() = deckListAdapter.itemCount
 
     /**
-     * Check if at least one deck is being displayed.
+     * Check if at least one non empty deck is displayed.
      */
-    fun hasAtLeastOneDeckBeingDisplayed(): Boolean {
-        return deckListAdapter.itemCount > 0 && recyclerViewLayoutManager.getChildAt(0) != null
+    fun hasAtLeastOneDeckAndOneCard(): Boolean {
+        // The first part checks that there is a card
+        // The second that the decks are loaded in the view.
+        return deckListAdapter.due?.let { it > 0 } == true &&
+            recyclerViewLayoutManager.getChildAt(0) != null
     }
 
     private enum class DeckSelectionType {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -23,6 +23,7 @@ import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.edit
+import com.ichi2.anki.OnboardingUtils.Companion.SHOW_ONBOARDING
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption
 import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.handleCollectionSetupOption
@@ -73,7 +74,11 @@ class IntroductionActivity : AnkiActivity() {
 
     private fun startDeckPicker(result: Int = RESULT_START_NEW) {
         Timber.i("Opening deck picker, login: %b", result == RESULT_SYNC_PROFILE)
-        this.sharedPrefs().edit { putBoolean(INTRODUCTION_SLIDES_SHOWN, true) }
+        this.sharedPrefs().edit {
+            putBoolean(INTRODUCTION_SLIDES_SHOWN, true)
+            // This ensures that onboarding is only displayed to new users.
+            putBoolean(SHOW_ONBOARDING, true)
+        }
         val deckPicker = Intent(this, DeckPicker::class.java)
         deckPicker.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         if (result == RESULT_SYNC_PROFILE) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Onboarding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Onboarding.kt
@@ -129,17 +129,23 @@ abstract class Onboarding<Feature>(
         private val recyclerViewLayoutManager: LinearLayoutManager
     ) : Onboarding<DeckPicker.DeckPickerOnboardingEnum>(activityContext, mutableListOf()) {
 
+        private var displayedTutorial = false
+
         init {
             tutorials.add(TutorialArguments(DeckPickerOnboardingEnum.FAB, this::showTutorialForFABIfNew))
-            tutorials.add(TutorialArguments(DeckPickerOnboardingEnum.DECK_NAME, this::showTutorialForDeckIfNew, activityContext::hasAtLeastOneDeckBeingDisplayed))
-            tutorials.add(TutorialArguments(DeckPickerOnboardingEnum.COUNTS_LAYOUT, this::showTutorialForCountsLayoutIfNew, activityContext::hasAtLeastOneDeckBeingDisplayed))
+            tutorials.add(TutorialArguments(DeckPickerOnboardingEnum.DECK_NAME, this::showTutorialForDeckIfNew) { !displayedTutorial && activityContext.hasAtLeastOneDeckAndOneCard() })
+            tutorials.add(TutorialArguments(DeckPickerOnboardingEnum.COUNTS_LAYOUT, this::showTutorialForCountsLayoutIfNew) { !displayedTutorial && activityContext.hasAtLeastOneDeckAndOneCard() })
         }
 
         private fun showTutorialForFABIfNew() {
+            displayedTutorial = true
             CustomMaterialTapTargetPromptBuilder(activityContext, DeckPickerOnboardingEnum.FAB)
                 .createCircleWithDimmedBackground()
                 .setFocalColourResource(R.color.material_blue_500)
-                .setDismissedListener { onCreate() }
+                .setDismissedListener {
+                    onCreate()
+                    displayedTutorial = false
+                }
                 .setTarget(R.id.fab_main)
                 .setPrimaryText(R.string.fab_tutorial_title)
                 .setSecondaryText(R.string.fab_tutorial_desc)
@@ -147,18 +153,26 @@ abstract class Onboarding<Feature>(
         }
 
         private fun showTutorialForDeckIfNew() {
+            displayedTutorial = true
             CustomMaterialTapTargetPromptBuilder(activityContext, DeckPickerOnboardingEnum.DECK_NAME)
                 .createRectangleWithDimmedBackground()
-                .setDismissedListener { showTutorialForCountsLayoutIfNew() }
-                .setTarget(recyclerViewLayoutManager.getChildAt(0)?.findViewById(R.id.deck_name_linear_layout))
+                .setDismissedListener {
+                    showTutorialForCountsLayoutIfNew()
+                    displayedTutorial = false
+                }
+                .setTarget(recyclerViewLayoutManager.getChildAt(0)!!.findViewById<View>(R.id.deck_name_linear_layout))
                 .setPrimaryText(R.string.start_studying)
                 .setSecondaryText(R.string.start_studying_desc)
                 .show()
         }
 
         private fun showTutorialForCountsLayoutIfNew() {
+            displayedTutorial = true
             CustomMaterialTapTargetPromptBuilder(activityContext, DeckPickerOnboardingEnum.COUNTS_LAYOUT)
                 .createRectangleWithDimmedBackground()
+                .setDismissedListener {
+                    displayedTutorial = false
+                }
                 .setTarget(recyclerViewLayoutManager.getChildAt(0)?.findViewById(R.id.counts_layout))
                 .setPrimaryText(R.string.menu__study_options)
                 .setSecondaryText(R.string.study_options_desc)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingEntry.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingEntry.kt
@@ -17,6 +17,11 @@
 
 package com.ichi2.anki
 
+import android.content.Context
+import androidx.core.content.edit
+import com.ichi2.anki.preferences.sharedPrefs
+import java.util.BitSet
+
 /**
  * Enumeration related to onboarding to use fixed integral values for enum constants
  * instead of using ordinals and ensuring that the used values are distinct. Implement this
@@ -25,18 +30,50 @@ package com.ichi2.anki
  * For removing constants, comment out the constant instead of removing it so that older values
  * are not used again.
  */
-interface OnboardingFlag {
+interface OnboardingEntry {
+    /**
+     * Constant used to represent preference key for screens.
+     * Values once defined should not be changed.
+     */
+    val preferenceKeyForThisView: String
 
     /**
      * Distinct values should be used in a particular onboarding enum class.
      * The returned value should be between 0 and 63, the position range of bits in Long.
      */
-    fun getOnboardingEnumValue(): Int
+    val bitFlag: Int
     // TODO: Add lint check.
 
+    /** The bitset of visited bitFlag for this view */
+    private fun getVisitedSet(context: Context): BitSet {
+        return BitSet.valueOf(
+            longArrayOf(
+                context.sharedPrefs().getLong(preferenceKeyForThisView, 0)
+            )
+        )
+    }
+
     /**
-     * Constant used to represent preference key for screens.
-     * Values once defined should not be changed.
+     * Whether this onboarding entry was visited.
      */
-    fun getFeatureConstant(): String
+    fun isVisited(context: Context): Boolean {
+        return getVisitedSet(context).get(bitFlag)
+    }
+
+    /**
+     * Set the tutorial for a feature as visited.
+     */
+    fun setVisited(context: Context) {
+        val visitedFeatures = getVisitedSet(context)
+
+        // Set the bit at the index defined for a feature once the tutorial for that feature is seen by the user.
+        visitedFeatures.set(bitFlag)
+
+        context.sharedPrefs().edit {
+            putLong(
+                preferenceKeyForThisView,
+                visitedFeatures.toLongArray()[0]
+            )
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/OnboardingUtils.kt
@@ -23,7 +23,6 @@ import androidx.core.content.edit
 import com.ichi2.anki.IntroductionActivity.Companion.INTRODUCTION_SLIDES_SHOWN
 import com.ichi2.anki.preferences.sharedPrefs
 import timber.log.Timber
-import java.util.BitSet
 
 class OnboardingUtils {
 
@@ -47,47 +46,6 @@ class OnboardingUtils {
          * They all get reset when reset is pressed. */
         fun addFeatures(featureCategory: Iterable<String>) {
             featureCategory.forEach(::addFeature)
-        }
-
-        /**
-         * Check if the tutorial for a feature should be displayed or not.
-         */
-        fun isVisited(featureIdentifier: OnboardingFlag, context: Context): Boolean {
-            // Return if onboarding is not enabled.
-            if (!context.sharedPrefs().getBoolean(SHOW_ONBOARDING, false)) {
-                return true
-            }
-
-            val visitedFeatures = getAllVisited(context, featureIdentifier.getFeatureConstant())
-
-            // If the bit at an index is set, then the corresponding tutorial has been seen.
-            // Return true if seen, otherwise false.
-            return visitedFeatures.get(featureIdentifier.getOnboardingEnumValue())
-        }
-
-        /**
-         * Set the tutorial for a feature as visited.
-         */
-        fun setVisited(featureIdentifier: OnboardingFlag, context: Context) {
-            val visitedFeatures = getAllVisited(context, featureIdentifier.getFeatureConstant())
-
-            // Set the bit at the index defined for a feature once the tutorial for that feature is seen by the user.
-            visitedFeatures.set(featureIdentifier.getOnboardingEnumValue())
-
-            context.sharedPrefs().edit {
-                putLong(
-                    featureIdentifier.getFeatureConstant(),
-                    visitedFeatures.toLongArray()[0]
-                )
-            }
-        }
-
-        /**
-         * Returns a BitSet where the set bits indicate the visited screens.
-         */
-        private fun getAllVisited(context: Context, featureConstant: String): BitSet {
-            val currentValue = context.sharedPrefs().getLong(featureConstant, 0)
-            return BitSet.valueOf(longArrayOf(currentValue))
         }
 
         fun reset(context: Context) {

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -66,10 +66,6 @@
         android:title="@string/reset_onboarding"
         android:summary="@string/reset_onboarding_desc"
         android:key="@string/pref_reset_onboarding_key"/>
-    <Preference
-        android:title="@string/reset_onboarding"
-        android:summary="@string/reset_onboarding_desc"
-        android:key="@string/pref_reset_onboarding_key"/>
     <PreferenceCategory
         android:title="Create fake media"
         >

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -630,7 +630,7 @@ class DeckPickerTest : RobolectricTest() {
         )
         assertThat(
             "Deck is being displayed",
-            deckPicker.hasAtLeastOneDeckBeingDisplayed(),
+            deckPicker.hasAtLeastOneDeckAndOneCard(),
             equalTo(true)
         )
     }
@@ -646,7 +646,7 @@ class DeckPickerTest : RobolectricTest() {
         )
         assertThat(
             "No deck is being displayed",
-            deckPicker.hasAtLeastOneDeckBeingDisplayed(),
+            deckPicker.hasAtLeastOneDeckAndOneCard(),
             equalTo(false)
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingEntryTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingEntryTest.kt
@@ -30,7 +30,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class OnboardingFlagTest : RobolectricTest() {
+class OnboardingEntryTest : RobolectricTest() {
 
     companion object {
         const val FIRST_ENUM = "FirstEnum"
@@ -97,37 +97,29 @@ class OnboardingFlagTest : RobolectricTest() {
         assertTrue(isVisited(SecondEnum.LAST))
     }
 
-    private enum class FirstEnum(var valueFirst: Int) : OnboardingFlag {
+    private enum class FirstEnum(var valueFirst: Int) : OnboardingEntry {
         FIRST(0),
         MIDDLE(1);
 
-        override fun getOnboardingEnumValue(): Int {
-            return valueFirst
-        }
+        override val bitFlag = valueFirst
 
-        override fun getFeatureConstant(): String {
-            return FIRST_ENUM
-        }
+        override val preferenceKeyForThisView = FIRST_ENUM
     }
 
-    private enum class SecondEnum(var valueSecond: Int) : OnboardingFlag {
+    private enum class SecondEnum(valueSecond: Int) : OnboardingEntry {
         MIDDLE(0),
         LAST(1);
 
-        override fun getOnboardingEnumValue(): Int {
-            return valueSecond
-        }
+        override val bitFlag = valueSecond
 
-        override fun getFeatureConstant(): String {
-            return SECOND_ENUM
-        }
+        override val preferenceKeyForThisView = SECOND_ENUM
     }
 
-    private fun isVisited(featureIdentifier: OnboardingFlag): Boolean {
+    private fun isVisited(featureIdentifier: OnboardingEntry): Boolean {
         return OnboardingUtils.isVisited(featureIdentifier, targetContext)
     }
 
-    private fun setVisited(featureIdentifier: OnboardingFlag) {
+    private fun setVisited(featureIdentifier: OnboardingEntry) {
         OnboardingUtils.setVisited(featureIdentifier, targetContext)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/OnboardingUtilsTest.kt
@@ -39,7 +39,7 @@ class OnboardingUtilsTest {
         assertThat("All onboarding identifiers are available for reset", onboardingIdentifiers, containsInAnyOrder(featuresAvailableForReset))
     }
 
-    enum class Feature : OnboardingFlag
+    enum class Feature : OnboardingEntry
 
     private fun getConstantValue(it: KCallable<*>): String = it.call(null) as String
 }


### PR DESCRIPTION
As far as I remember, we never launched this GSoC 21 feature because it was not good enough according to some maintainers.
Personally, I expect that it's still a net positive to users. And if we get feedback, it'll be easier to iterate on it when it's actually getting used. So, I'm very much in favor of releasing it. And doing the work for it.

* The first commit enable the onboarding feature for any new user.
In order to find new user, I decided to simply check for the one who see the introduction activity.
* Commits 2 do some code cleaning.
* Commit 3 remove a duplicate entry in the preference. This is the only commit I expect to be non controversial.
* Commit 4 repair a bug that caused some feature never to be displayed in the deck picker