### PR TITLE
NF: Don't update the deck list when the deck picker is hidden

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2661,7 +2661,10 @@ open class DeckPicker :
     override fun opExecuted(changes: OpChanges, handler: Any?) {
         if (changes.studyQueues && handler !== this) {
             invalidateOptionsMenu()
-            updateDeckList()
+            if (!activityPaused) {
+                // No need to update while the activity is paused, because `onResume` calls `refreshState` that calls `updateDeckList`.
+                updateDeckList()
+            }
         }
     }
 


### PR DESCRIPTION
I discover that each time an action occur in the reviewer, the deck picker is updated. This is uselessly costly.

I tested and when going back to the deck picker, I still get the up to date data immediately.