### PR TITLE
chore: add tooltip text in instant note editor buttons

### DIFF
--- a/AnkiDroid/src/main/res/layout/instant_editor_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/instant_editor_dialog.xml
@@ -62,10 +62,12 @@
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:tooltipText="@string/change_editor_mode"
             app:icon="@drawable/ic_mode_edit_white" />
 
         <com.google.android.material.button.MaterialButton
             android:id="@+id/increment_cloze_button"
+            android:tooltipText="@string/change_cloze_mode"
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -76,6 +78,7 @@
             style="@style/Widget.Material3.Button.IconButton.Filled.Tonal"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:tooltipText="@string/open_note_editor"
             app:icon="@drawable/ic_round_open_in_new" />
 
     </LinearLayout>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -277,6 +277,9 @@ also changes the interval of the card"
     <string name="open">Open</string>
     <string name="change_cloze_number">Change cloze number</string>
     <string name="cloze_number">Cloze number:</string>
+    <string name="change_editor_mode">Change editor mode</string>
+    <string name="open_note_editor">Open note editor</string>
+    <string name="change_cloze_mode">Change cloze mode</string>
 
     <!-- Outdated WebView dialog -->
     <string name="webview_update_message">The system WebView is outdated. Some features won’t work correctly. Please update it.\n\nInstalled version: %1$d\nMinimum required version: %2$d</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added tooltip text for buttons in instant note editor

## Fixes
* Fixes #16893

## How Has This Been Tested?
Google emualtor API35
<img width="325" alt="Screenshot 2024-08-19 at 4 17 14 PM" src="https://github.com/user-attachments/assets/6b13affb-b142-4f57-b40c-88b24bda55dc">


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
