### PR TITLE
test: compare whole string not first char in NoteEditor test

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/NoteEditorIntentTest.kt
@@ -58,7 +58,7 @@ class NoteEditorIntentTest : InstrumentedTest() {
             val editor = activity.getEditor()
             currentFieldStrings = editor.currentFieldStrings[0]
         }
-        MatcherAssert.assertThat(currentFieldStrings!![0], Matchers.equalTo("sample text"))
+        MatcherAssert.assertThat(currentFieldStrings!!, Matchers.equalTo("sample text"))
     }
 
     @Test


### PR DESCRIPTION
this test is marked flaky so it won't ever run in CI but it was failing locally for me every time as it was comparing the first char of the string it pulled to a string, instead of string vs string

Going to do the very rare / not normally recommended YOLO-merge on this because it meets some strict criteria:

- it changes test code only
- it is obviously correct on visual inspection
- it is not code that runs in CI ever so there is nothing CI could tell us that would inform whether to merge or not
- it definitely broke locally every time and definitely works afterwards

failure message wsa "expected 'sample text' / actual 's'" which is kind of obvious...

