### PR TITLE
docs: add comment on when deprecated code may be removed

### DIFF
--- a/AnkiDroid/src/main/aidl/android/content/pm/IPackageStatsObserver.aidl
+++ b/AnkiDroid/src/main/aidl/android/content/pm/IPackageStatsObserver.aidl
@@ -26,6 +26,11 @@ import android.content.pm.PackageStats;
  * Some usage scenarios include deletion of cache directory, generate
  * statistics related to code, data, cache usage(TODO)
  * {@hide}
+ *
+ * This generates a deprecation warning during builds, and it would be great to remove it.
+ * There is only one usage: FileUtils::getUserDataAndCacheSizeUsingGetPackageSizeInfo
+ * The code that references this will no longer be needed after Build.VERSION_CODES >= 0
+ * or minSdk >= 26 - at that API level we should be able to remove all related code / deprecation
  */
 oneway interface IPackageStatsObserver {
     void onGetStatsCompleted(in PackageStats pStats, boolean succeeded);


### PR DESCRIPTION
## Purpose / Description

I dislike seeing this build-time deprecation warning every build, and investigated if we could remove this. We can't but I was able to see when, so I wrote it out in order to not forget and spend the time researching again

The comment I left should show up in standard searches for removable code based on VERSION_CODES / minSdk when we bump versions

This was added by David so if he can remember the code enough to say the comment is good, should be good...