### PR TITLE
fix: limit parameter of schedule URI returns the same data

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -334,10 +334,15 @@ class CardContentProvider : ContentProvider() {
                 }
 
                 // retrieve the number of cards provided by the selection parameter "limit"
+                val cards = col.backend.getQueuedCards(
+                    fetchLimit = limit,
+                    intradayLearningOnly = false
+                ).cardsList.map { Card(it.card) }
+
+                val buttonCount = 4
                 var k = 0
                 while (k < limit) {
-                    val currentCard = col.sched.card ?: break
-                    val buttonCount = 4
+                    val currentCard = cards.getOrNull(k) ?: break
                     val buttonTexts = JSONArray()
                     var i = 0
                     while (i < buttonCount) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I had some trouble integrating the AnkiDroid API in my app, mainly because some confusion on my part with the `CONTENT_URI` of `ReviewInfo` which `deckID` and `limit` aren't query parameters, not following the pattern of the others availables URIs. 

So I created the another URI to use the deck id as an appended path and passing limit as an optional query parameter, e.g. `/schedule/123456789?limit=5` leaving the existing one to not break any app that already uses it.

Also I found out that the `limit` parameter doesn't work in the existing schedule URI, returning the same card data N times and fixed this in this PR.

## Fixes
* Fixes #16772

## Approach
Creation of new URI in `CardContentProvider` and creation of `getQueuedCards()` function to solve the limit parameter issue.

## How Has This Been Tested?

Querying the `FlashCardsContract.ReviewInfo.CONTENT_URI` with appended path (new URI) and using selection arguments as the example provided in this file. The minimum working example I provided in the issue might help.

Used an Android 12 device.
 
## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
