### PR TITLE
feat(libAnki): implement decks.cardCount()

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -229,11 +229,15 @@ class Decks(private val col: Collection) {
         return len(this.allNamesAndIds())
     }
 
-    @RustCleanup("implement and make public")
     @LibAnkiAlias("card_count")
-    @Suppress("unused", "unused_parameter")
-    private fun cardCount(vararg decks: DeckId, includeSubdecks: Boolean): Int {
-        TODO()
+    fun cardCount(vararg decks: DeckId, includeSubdecks: Boolean): Int {
+        val dids = decks.toMutableSet()
+        if (includeSubdecks) {
+            // dids.update([child[1] for did in dids for child in self.children(did)])
+            dids.addAll(dids.flatMap { did -> children(did) }.map { nameAndId -> nameAndId.second })
+        }
+        val strIds = Utils.ids2str(dids)
+        return col.db.queryScalar("select count() from cards where did in $strIds or odid in $strIds")
     }
 
     @RustCleanup("implement and make public")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DecksTest.kt
@@ -170,6 +170,48 @@ class DecksTest : JvmTest() {
         assertThat(filtered.isFiltered, equalTo(true))
     }
 
+    @Test
+    fun testCardCount() {
+        val decks = col.decks
+        var addedNoteCount = 0
+
+        fun addNote(did: DeckId): NoteId {
+            val note = col.newNote().apply {
+                setItem("Front", (++addedNoteCount).toString())
+                notetype.put("did", did)
+            }
+            col.addNote(note)
+            return note.id
+        }
+
+        val parentDid = addDeck("Deck").also { did -> addNote(did) }
+        val childDid = addDeck("Deck::Subdeck").also { did -> addNote(did) }
+
+        val noteToMakeDynamic: NoteId
+        val deckWithNoChildren = addDeck("DeckWithTwo").also { did ->
+            addNote(did)
+            addNote(did)
+            noteToMakeDynamic = addNote(did)
+        }
+        val filteredDeck = addDynamicDeck("filtered", search = "nid:$noteToMakeDynamic")
+
+        assertThat("all decks", decks.cardCount(parentDid, childDid, deckWithNoChildren, includeSubdecks = false), equalTo(5))
+        assertThat("all decks with subdecks", decks.cardCount(parentDid, childDid, deckWithNoChildren, includeSubdecks = true), equalTo(5))
+
+        assertThat("top level decks, no children", decks.cardCount(parentDid, deckWithNoChildren, includeSubdecks = false), equalTo(4))
+        assertThat("top level decks, with children", decks.cardCount(parentDid, deckWithNoChildren, includeSubdecks = true), equalTo(5))
+
+        assertThat("parent deck, no children", decks.cardCount(parentDid, includeSubdecks = false), equalTo(1))
+        assertThat("parent deck, with children", decks.cardCount(parentDid, includeSubdecks = true), equalTo(2))
+
+        assertThat("single deck, multiple cards, no children", decks.cardCount(deckWithNoChildren, includeSubdecks = false), equalTo(3))
+        assertThat("single deck, multiple cards, with children", decks.cardCount(deckWithNoChildren, includeSubdecks = true), equalTo(3))
+
+        assertThat("filtered deck", decks.cardCount(filteredDeck, includeSubdecks = false), equalTo(1))
+
+        assertThat("filtered and home deck", decks.cardCount(deckWithNoChildren, filteredDeck, includeSubdecks = false), equalTo(3))
+    }
+
     companion object {
         // Used in other class to populate decks.
         @Suppress("SpellCheckingInspection")

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -130,9 +130,15 @@ interface TestClass {
         }
     }
 
-    fun addDynamicDeck(name: String?): DeckId {
+    fun addDynamicDeck(name: String, search: String? = null): DeckId {
         return try {
-            col.decks.newFiltered(name!!)
+            col.decks.newFiltered(name).also { did ->
+                if (search == null) return@also
+                val deck = col.decks.get(did)!!
+                deck.getJSONArray("terms").getJSONArray(0).put(0, search)
+                col.decks.save(deck)
+                col.sched.rebuildDyn(did)
+            }
         } catch (filteredAncestor: BackendDeckIsFilteredException) {
             throw RuntimeException(filteredAncestor)
         }


### PR DESCRIPTION
For potential use in the DeckPicker widget GSoC project

Sourced from

https://github.com/ankitects/anki/blob/a179da382759b9c7f8265faf37efdcbb47d8ee08/pylib/anki/decks.py#L225

```python
    def card_count(
        self, dids: DeckId | Iterable[DeckId], include_subdecks: bool
    ) -> Any:
        if isinstance(dids, int):
            dids = {dids}
        else:
            dids = set(dids)
        if include_subdecks:
            dids.update([child[1] for did in dids for child in self.children(did)])
        str_ids = ids2str(dids)
        count = self.col.db.scalar(
            f"select count() from cards where did in {str_ids} or odid in {str_ids}"
        )
        return count
```

## How Has This Been Tested?

Unit tested 

I took a little more time to ensure the `odid` case was handled

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
