### PR TITLE
build(deps): document & consolidate 'kotlin' dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ json = "20240303"
 jsoup = "1.18.1"
 androidTestJunit = "1.2.1"
 junitJupiter= "5.11.0"
+# https://github.com/JetBrains/kotlin/releases/
 kotlin = '2.0.10'
 kotlinxSerializationJson = "1.7.1"
 ktlint = "11.6.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,8 +78,6 @@ jsoup = "1.18.1"
 androidTestJunit = "1.2.1"
 junitJupiter= "5.11.0"
 kotlin = '2.0.10'
-kotlinReflect = "2.0.10"
-kotlinTest = "2.0.10"
 kotlinxSerializationJson = "1.7.1"
 ktlint = "11.6.1"
 leakcanaryAndroid = "2.14"
@@ -180,10 +178,10 @@ json = { module = "org.json:json", version.ref = "json" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitJupiter" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junitJupiter" }
-kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlinReflect" }
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlinTest" }
-kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlinTest" }
-kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlinTest" }
+kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
+kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
+kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", version.ref = "kotlin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 mockito-inline = { module = "org.mockito:mockito-inline", version.ref = "mockitoInline" }
 mockito-kotlin = { module = "org.mockito.kotlin:mockito-kotlin", version.ref = "mockitoKotlin" }


### PR DESCRIPTION
## Purpose / Description

Agreed that the following are released in lockstep, so should be combined:

https://discord.com/channels/368267295601983490/701922522836369498/1276149849430954024

* [#16926: chore(deps): bump kotlinTest from 2.0.10 to 2.0.20](<https://github.com/ankidroid/Anki-Android/issues/16926>)
* [#16927: chore(deps): bump kotlin from 2.0.10 to 2.0.20](<https://github.com/ankidroid/Anki-Android/issues/16927>)
* [#16928: chore(deps): bump org.jetbrains.kotlin:kotlin-reflect from 2.0.10 to 2.0.20](<https://github.com/ankidroid/Anki-Android/issues/16928>)

----

* https://github.com/JetBrains/kotlin/releases/

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
