### PR TITLE
release: switch 2.19 to beta version series, beta play store track

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -86,8 +86,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode=21900112
-        versionName="2.19alpha12"
+        versionCode=21900200
+        versionName="2.19beta0"
         minSdk libs.versions.minSdk.get().toInteger()
 
         // Stays until this is in a release: https://github.com/google/desugar_jdk_libs/commit/c01a5446ca13586b801dbba4d83c6821337b3cc2
@@ -265,7 +265,7 @@ android {
 
 play {
     serviceAccountCredentials.set(file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json"))
-    track.set('alpha')
+    track.set('beta')
 }
 
 // Install Git pre-commit hook for Ktlint


### PR DESCRIPTION

Let's ship 2.19!

Normally I just do this on main and push it, but I thought it would be instructive to have it in the PR history so anyone could use it as reference for how to do it.

Note that we set the version code and string initially to zero / zeros, the release script will increment by one to make it 2.19beta1 / version code with beta 1

Next step after this is merged: anyone can hit the publish button - it's not a formal release so it doesn't require the release notes up to date yet or anything. Beta releases work similar to alpha releases in that sense.