### PR TITLE
Implement the desktop UI in StudyOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -18,7 +18,6 @@ package com.ichi2.async
 
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CardTemplateNotetype
-import com.ichi2.anki.StudyOptionsFragment
 import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NotetypeJson
@@ -36,28 +35,6 @@ fun deleteMedia(col: Collection, unused: List<String>): Int {
     // FIXME: this provides progress info that is not currently used
     col.media.removeFiles(unused)
     return unused.size
-}
-
-// TODO: Once [com.ichi2.async.CollectionTask.RebuildCram] and [com.ichi2.async.CollectionTask.EmptyCram]
-// are migrated to Coroutines, move this function to [com.ichi2.anki.StudyOptionsFragment]
-fun updateValuesFromDeck(col: Collection): StudyOptionsFragment.DeckStudyData? {
-    Timber.d("doInBackgroundUpdateValuesFromDeck")
-    return try {
-        val sched = col.sched
-        val counts = sched.counts()
-        val totalNewCount = sched.totalNewForCurrentDeck()
-        val totalCount = sched.cardCount()
-        StudyOptionsFragment.DeckStudyData(
-            counts.new,
-            counts.lrn,
-            counts.rev,
-            totalNewCount,
-            totalCount
-        )
-    } catch (e: RuntimeException) {
-        Timber.e(e, "doInBackgroundUpdateValuesFromDeck - an error occurred")
-        null
-    }
 }
 
 suspend fun renderBrowserQA(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -34,6 +34,7 @@ import anki.deck_config.UpdateDeckConfigsRequest
 import anki.decks.DeckTreeNode
 import anki.decks.FilteredDeckForUpdate
 import anki.decks.SetDeckCollapsedRequest
+import anki.decks.deck
 import com.google.protobuf.kotlin.toByteStringUtf8
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.backend.BackendUtils
@@ -196,6 +197,16 @@ class Decks(private val col: Collection) {
     @Suppress("unused")
     private fun deckTree(): DeckTreeNode {
         TODO()
+    }
+
+    @LibAnkiAlias("find_deck_in_tree")
+    fun findDeckInTree(node: DeckTreeNode, deckId: DeckId): DeckTreeNode? {
+        if (node.deckId == deckId) return node
+        for (child in node.childrenList) {
+            val foundNode = findDeckInTree(child, deckId)
+            if (foundNode != null) return foundNode
+        }
+        return null
     }
 
     @RustCleanup("implement and make public")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -453,16 +453,16 @@ open class Scheduler(val col: Collection) {
     }
 
     /**
-     * Returns a tree of decks with counts. If [deckId] is provided, only the according subtree is
+     * Returns a tree of decks with counts. If [topDeckId] is provided, only the according subtree is
      * returned.
      *
      * // TODO look into combining this method with parameterless deckDueTree
      */
     @LibAnkiAlias("deck_due_tree")
-    fun deckDueTree(deckId: DeckId? = null): DeckTreeNode? {
+    fun deckDueTree(topDeckId: DeckId? = null): DeckTreeNode? {
         val tree = col.backend.deckTree(now = time.intTime())
-        if (deckId != null) {
-            return col.decks.findDeckInTree(tree, deckId)
+        if (topDeckId != null) {
+            return col.decks.findDeckInTree(tree, topDeckId)
         }
         return tree
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -25,6 +25,7 @@ import anki.collection.OpChangesWithCount
 import anki.config.ConfigKey
 import anki.config.OptionalStringConfigKey
 import anki.config.optionalStringConfigKey
+import anki.decks.DeckTreeNode
 import anki.frontend.SchedulingStatesWithContext
 import anki.i18n.FormatTimespanRequest
 import anki.scheduler.BuryOrSuspendCardsRequest
@@ -449,6 +450,21 @@ open class Scheduler(val col: Collection) {
 
     fun deckDueTree(): DeckNode {
         return deckTree(true)
+    }
+
+    /**
+     * Returns a tree of decks with counts. If [deckId] is provided, only the according subtree is
+     * returned.
+     *
+     * // TODO look into combining this method with parameterless deckDueTree
+     */
+    @LibAnkiAlias("deck_due_tree")
+    fun deckDueTree(deckId: DeckId? = null): DeckTreeNode? {
+        val tree = col.backend.deckTree(now = time.intTime())
+        if (deckId != null) {
+            return col.decks.findDeckInTree(tree, deckId)
+        }
+        return tree
     }
 
     fun deckTree(includeCounts: Boolean): DeckNode {

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -1,176 +1,209 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/studyoptions_main"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:gravity="center">
-    <RelativeLayout
+    android:layout_height="match_parent">
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:orientation="vertical">
+        android:layout_height="match_parent">
         <androidx.appcompat.widget.Toolbar
             android:id="@+id/studyOptionsToolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
             android:theme="@style/ActionBarStyle"
-            android:layout_alignParentTop="true"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
             android:background="?attr/appBarColor"
             app:popupTheme="@style/ActionBar.Popup"
             app:navigationContentDescription="@string/abc_action_bar_up_description"
             app:navigationIcon="?attr/homeAsUpIndicator"/>
-        <LinearLayout
-            android:layout_below="@id/studyOptionsToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal">
-            <View
-                android:id="@+id/studyoptions_gradient"
-                android:layout_width="15dp"
-                android:layout_height="match_parent"
-                android:background="@drawable/shadow_left"
-                android:visibility="gone"/>
-            <RelativeLayout
+        <View
+            android:id="@+id/studyoptions_gradient"
+            android:layout_width="15dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/studyOptionsToolbar"
+            app:layout_constraintStart_toStartOf="parent"
+            android:background="@drawable/shadow_left"
+            android:visibility="gone"/>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/studyoptions_start"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="200dp"
+            android:layout_marginBottom="32dp"
+            android:text="@string/studyoptions_start"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"/>
+
+        <ScrollView
+            android:id="@+id/studyoptions_scrollview"
+            android:layout_above="@id/bottom_area_layout"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toBottomOf="@id/studyOptionsToolbar"
+            app:layout_constraintStart_toEndOf="@id/studyoptions_gradient"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toTopOf="@id/studyoptions_start"
+            android:paddingLeft="@dimen/study_options_padding"
+            android:paddingRight="@dimen/study_options_padding"
+            android:paddingBottom="16dp"
+            android:fadeScrollbars="false" >
+            <LinearLayout
+                android:id="@+id/studyoptions_scrollcontainer"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:id="@+id/studyoptions_mainframe"
-                android:paddingBottom="32dp">
-                <ScrollView
-                    android:id="@+id/studyoptions_scrollview"
-                    android:layout_above="@id/bottom_area_layout"
-                    android:layout_alignParentTop="true"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:paddingTop="16dp"
+                android:orientation="vertical">
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/studyoptions_deck_name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="@dimen/study_options_padding"
-                    android:paddingRight="@dimen/study_options_padding"
-                    android:paddingBottom="16dp"
-                    android:fadeScrollbars="false"
-                    android:fillViewport="true">
-                    <LinearLayout
-                        android:id="@+id/studyoptions_scrollcontainer"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:gravity="center"
-                        android:orientation="vertical">
+                    android:ellipsize="end"
+                    android:gravity="center"
+                    android:maxLines="3"
+                    android:textSize="28sp"
+                    android:textStyle="bold"
+                    tools:text="Deck name here"/>
 
-                        <com.ichi2.ui.FixedTextView
-                            android:id="@+id/studyoptions_deck_name"
-                            android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:ellipsize="end"
-                            android:gravity="center"
-                            android:maxLines="3"
-                            android:textSize="28sp"
-                            android:textStyle="bold" />
-
-                        <TableLayout
-                                android:id="@+id/studyoptions_deckcounts"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:gravity="center"
-                                android:layout_gravity="center_horizontal"
-                                android:layout_marginTop="16dp"
-                                android:layout_marginBottom="5dip"
-                                android:layout_marginEnd="3dip"
-                                android:layout_marginStart="5dip"
-                                android:orientation="vertical">
-
-                                <TableRow>
-
-                                    <com.ichi2.ui.FixedTextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:paddingStart="0dip"
-                                        android:paddingEnd="5dip"
-                                        android:text="@string/studyoptions_due_today"/>
-
-                                    <LinearLayout
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content">
-
-                                        <com.ichi2.ui.FixedTextView
-                                            android:id="@+id/studyoptions_new"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:textColor="?attr/newCountColor" />
-
-                                        <com.ichi2.ui.FixedTextView
-                                            android:id="@+id/studyoptions_lrn"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:layout_marginStart="5dip"
-                                            android:textColor="?attr/learnCountColor" />
-
-                                        <com.ichi2.ui.FixedTextView
-                                            android:id="@+id/studyoptions_rev"
-                                            android:layout_width="wrap_content"
-                                            android:layout_height="wrap_content"
-                                            android:layout_marginStart="5dip"
-                                            android:textColor="?attr/reviewCountColor" />
-                                    </LinearLayout>
-                                </TableRow>
-
-                                <TableRow>
-
-                                    <com.ichi2.ui.FixedTextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:paddingStart="0dip"
-                                        android:paddingEnd="5dip"
-                                        android:text="@string/studyoptions_new_total" />
-
-                                    <com.ichi2.ui.FixedTextView
-                                        android:id="@+id/studyoptions_total_new"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:gravity="end" />
-                                </TableRow>
-
-                                <TableRow>
-
-                                    <com.ichi2.ui.FixedTextView
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:paddingStart="0dip"
-                                        android:paddingEnd="5dip"
-                                        android:text="@string/studyoptions_total_cards" />
-
-                                    <com.ichi2.ui.FixedTextView
-                                        android:id="@+id/studyoptions_total"
-                                        android:layout_width="wrap_content"
-                                        android:layout_height="wrap_content"
-                                        android:gravity="end" />
-                                </TableRow>
-                            </TableLayout>
-                        <com.ichi2.ui.FixedTextView
-                            android:id="@+id/studyoptions_deck_description"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:gravity="center"/>
-
-                    </LinearLayout>
-                </ScrollView>
-                <LinearLayout
-                    android:id="@+id/bottom_area_layout"
-                    android:layout_width="wrap_content"
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/studyoptions_bury_counts_label"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentBottom="true"
-                    android:layout_centerHorizontal="true"
-                    android:orientation="vertical">
-                    <com.google.android.material.button.MaterialButton
-                        android:id="@+id/studyoptions_start"
+                    android:ellipsize="end"
+                    android:visibility="gone"
+                    android:gravity="center"
+                    tools:text="Counts differ"/>
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="wrap_content"
+                    android:layout_marginTop="16dp"
+                    android:layout_height="wrap_content">
+                    <TextView
+                        android:id="@+id/studyoptions_new_count_label"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:minWidth="200dp"
-                        android:text="@string/studyoptions_start"
-                        android:layout_gravity="center_horizontal"/>
-                </LinearLayout>
-            </RelativeLayout>
-        </LinearLayout>
-    </RelativeLayout>
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/barrier_labels"
+                        app:layout_constraintHorizontal_bias="0"
+                        tools:text="New:"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_learning_count_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_new_count_label"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/barrier_labels"
+                        app:layout_constraintHorizontal_bias="0"
+                        tools:text="Learning:"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_review_count_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_learning_count_label"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/barrier_labels"
+                        app:layout_constraintHorizontal_bias="0"
+                        tools:text="To Review:"/>
+
+                    <androidx.constraintlayout.widget.Barrier
+                        android:id="@+id/barrier_labels"
+                        app:barrierDirection="end"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        app:constraint_referenced_ids="studyoptions_learning_count_label, studyoptions_review_count_label, studyoptions_new_count_label"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_new_count"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/barrier_labels"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_new_count_label"
+                        android:layout_marginStart="8dp"
+                        android:textColor="?attr/newCountColor"
+                        android:layout_height="wrap_content"
+                        tools:text="234"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_new_bury"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:layout_constraintStart_toEndOf="@id/studyoptions_new_count"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_new_count_label"
+                        android:visibility="gone"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="?attr/buryCountColor"
+                        tools:text="+4"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_learning_count"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintStart_toEndOf="@id/barrier_labels"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_learning_count_label"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="?attr/learnCountColor"
+                        tools:text="3443"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_learning_bury"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintStart_toEndOf="@id/studyoptions_learning_count"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_learning_count_label"
+                        android:visibility="gone"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="?attr/buryCountColor"
+                        tools:text="+23"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_review_count"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintStart_toEndOf="@id/barrier_labels"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_review_count_label"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="?attr/reviewCountColor"
+                        tools:text="15"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_review_bury"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintStart_toEndOf="@id/studyoptions_review_count"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_review_count_label"
+                        android:visibility="gone"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        android:textColor="?attr/buryCountColor"
+                        tools:text="+105"/>
+
+                    <androidx.constraintlayout.widget.Group
+                        android:id="@+id/group_counts"
+                        app:constraint_referenced_ids="studyoptions_new_count,studyoptions_new_count_label,studyoptions_new_bury,studyoptions_learning_count,studyoptions_learning_count_label,studyoptions_learning_bury,studyoptions_review_count,studyoptions_review_count_label,studyoptions_review_bury"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+                <com.ichi2.ui.FixedTextView
+                    android:id="@+id/studyoptions_deck_description"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:gravity="center"
+                    android:layout_marginTop="16dp"
+                    tools:text="See shared deck for more info"/>
+            </LinearLayout>
+        </ScrollView>
+    </androidx.constraintlayout.widget.ConstraintLayout>
     <include layout="@layout/anki_progress"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -28,10 +28,8 @@
     <string name="drawing">Drawing</string>
     <string name="send_feedback">Send feedback</string>
 
-    <string name="studyoptions_due_today">Due today:</string>
-    <string name="studyoptions_new_total">Total new cards:</string>
-    <string name="studyoptions_total_cards">Total cards:</string>
     <string name="studyoptions_start">Study</string>
+    <string name="studyoptions_buried_count">+%d buried</string>
 
     <!-- DeckPicker.kt -->
     <string name="expand">Expand</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -94,6 +94,7 @@
     <attr name="learnCountColor" format="color"/>
     <attr name="reviewCountColor" format="color"/>
     <attr name="zeroCountColor" format="color"/>
+    <attr name="buryCountColor" format="color"/>
     <!-- Reviewer button backgrounds -->
     <attr name="answerButtonBackground" format="color"/>
     <attr name="againButtonBackground" format="color"/>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -135,5 +135,9 @@
     <color name="good_button_text">@color/material_green_900</color>
     <color name="easy_button_bg">@color/material_light_blue_100</color>
     <color name="easy_button_text">@color/material_light_blue_900</color>
+
+    <!-- color used for bury count in study options(same as anki for light and dark) -->
+    <color name="disabled_gray_light">#858585</color>
+    <color name="disabled_gray_dark">#fcfcfc</color>
 </resources>
 

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -38,6 +38,7 @@
         <item name="newCountColor">@color/material_blue_700</item>
         <item name="learnCountColor">@color/material_red_400</item>
         <item name="reviewCountColor">@color/material_green_400</item>
+        <item name="buryCountColor">@color/disabled_gray_dark</item>
         <item name="zeroCountColor">#202020</item>
         <!-- Reviewer colors -->
         <item name="showAnswerColor">@color/theme_black_primary</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -61,6 +61,7 @@
         <item name="newCountColor">@color/material_indigo_200</item>
         <item name="learnCountColor">@color/material_red_200</item>
         <item name="reviewCountColor">@color/material_green_200</item>
+        <item name="buryCountColor">@color/disabled_gray_dark</item>
         <item name="zeroCountColor">#404040</item>
         <!-- Reviewer colors -->
         <item name="againButtonBackground">@color/material_red_800</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -53,6 +53,7 @@
         <item name="newCountColor">@color/material_indigo_700</item>
         <item name="learnCountColor">@color/material_red_700</item>
         <item name="reviewCountColor">@color/material_green_700</item>
+        <item name="buryCountColor">@color/disabled_gray_light</item>
         <item name="zeroCountColor">#1f000000</item>
         <!-- Reviewer colors -->
         <item name="againButtonBackground">@color/material_red_700</item>


### PR DESCRIPTION
## Purpose / Description

While working towards fixing #14793 I got sidetracked and implemented this so StudyOptionsFragment follows the desktop ui + it shows the bury counts(which weren't being shown) if the related deck options are enabled.

Some notes on the changes:
- the previous code showed the total cards count in the deck. As the desktop screen didn't show this I removed it. Can be brought back with ease if requested using the cardCount() method which was just added to out codebase.
- the previous code showed the total new cards count in the deck. As the desktop screen didn't show this I removed it. This can also be brought back for normal decks, however the related backend method doesn't work for filtered decks so we would need to either don't show this count for filtered decks or use the old code(which I'm actively trying to purge).
- the description was kept at the bottom, as it could be quite long there's no need to have it at the top to push the important count numbers below.
- bury counts colors are taken from the anki codebase

Some images:

_Current screen_ vs. _Changed screen + bury count + bury notice label_
<img src="https://github.com/user-attachments/assets/332b0bd8-64fb-43a1-b8ac-bdd4719c9858" width="380px" height="720px"/><img src="https://github.com/user-attachments/assets/a5b759a3-f423-4a23-8656-f011cd6c9841" width="380px" height="720px"/>

Desktop ui:
![Screenshot from 2024-08-24 10-42-01](https://github.com/user-attachments/assets/6b2d1f2b-35c2-4429-b067-f0b58b2a7069)


## How Has This Been Tested?

Saw if the buried counts appear + ran the tests. Personally I don't use the option to bury so it would be great if someone actively using buried cards tests this.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
