### PR TITLE
tweak: add a new string for "Backup" title

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -232,7 +232,7 @@
     <!-- scoped storage -->
     <string name="backup_your_collection">Backup your collection</string>
     <string name="backup_collection_message">You haven\'t backed up your collection in a while. You should do this now to prevent data loss</string>
-    <string name="button_backup">Backup</string>
+    <string name="button_backup" comment="Backup as action. Verb-like usage.">Backup</string>
     <string name="button_disable_reminder">Disable reminder</string>
     <string name="button_backup_later" comment="dismiss the 'Backup' dialog for around 2 weeks">Later</string>
     <string name="button_do_not_show_again" comment="permanently dismisses a dialog">Don\'t show again</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -304,6 +304,9 @@ this formatter is used if the bind only applies to both the question and the ans
     <!-- #######################################################################################
          #################################### Backup options ###################################
          ####################################################################################### -->
+    <string name="pref_backup_title" maxLength="41"
+        comment="Titles for Backup category or screen in Settings. Noun."
+        >Backup</string>
     <string name="pref__backups_help__summary"><![CDATA[
         AnkiDroid periodically backs up your collection.
         After backups are more than two days old,

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -91,7 +91,7 @@
     <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.BackupLimitsSettingsFragment"
         android:key="@string/pref_backup_limits_screen_key"
-        android:title="@string/button_backup"
+        android:title="@string/pref_backup_title"
         android:icon="@drawable/ic_backup_restore"
         app:summaryEntries="@array/backup_limits_summary_entries">
     </com.ichi2.preferences.HeaderPreference>

--- a/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
@@ -2,7 +2,7 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-    android:title="@string/button_backup">
+    android:title="@string/pref_backup_title">
     <!-- Includes modified text from `TR.preferencesBackupExplanation()`
          and `TR.preferencesNoteMediaIsNotBackedUp()`. -->
     <com.ichi2.preferences.HtmlHelpPreference


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description

In some languages, the string translated from "Backup" (for dialog button) might possibly not work well as the titles of "Backup" in Settings. I assume it is like "notify" doesn't always work well as an alternative of "notification" in English.

![image](https://github.com/user-attachments/assets/39f065f7-8684-40fb-a894-28445f5d3285)
https://crowdin.com/editor/ankidroid/7303/en-eo?view=comfortable&filter=basic&value=0#q=6536137


This commit will add a new string for "Backup" title(s) in addition to the existing "Backup" string for dialog button.
This allows translators to translate the former as noun usage and the latter as verb-like usage separately.


(I'm not sure if it is worth adding the new string for the issue above, but suggested it for consideration.)



## Fixes
N/A

## Approach
Add a new string

## How Has This Been Tested?
Checked on a physical device.

No change in appearance.
<img src="https://github.com/user-attachments/assets/1f5eb388-0c83-4db7-98bb-9dfc6f145c56" width="320px">


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
