### PR TITLE
fix: 'Empty Cards' should refresh UI

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -85,6 +85,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import anki.collection.OpChanges
+import anki.collection.OpChangesWithCount
 import anki.sync.SyncStatusResponse
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.google.android.material.progressindicator.CircularProgressIndicator
@@ -2582,6 +2583,7 @@ open class DeckPicker :
         updateDeckList()
     }
 
+    @NeedsTest("ChangeManager receives changes only on success")
     private fun handleEmptyCards() {
         launchCatchingTask {
             val emptyCids = withProgress(R.string.emtpy_cards_finding) {
@@ -2598,8 +2600,8 @@ open class DeckPicker :
                     setMessage(getString(R.string.empty_cards_count, emptyCids.size))
                     setPositiveButton(R.string.dialog_positive_delete) { _, _ ->
                         launchCatchingTask {
-                            withProgress(TR.emptyCardsDeleting()) {
-                                withCol { removeCardsAndOrphanedNotes(emptyCids) }
+                            withProgress<OpChangesWithCount>(TR.emptyCardsDeleting()) {
+                                undoableOp { return@undoableOp removeCardsAndOrphanedNotes(emptyCids) }
                             }
                         }
                         showSnackbar(getString(R.string.empty_cards_deleted, emptyCids.size))

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -32,6 +32,8 @@ import androidx.annotation.WorkerThread
 import anki.card_rendering.EmptyCardsReport
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
+import anki.collection.opChanges
+import anki.collection.opChangesWithCount
 import anki.config.ConfigKey
 import anki.config.Preferences
 import anki.config.copy
@@ -571,8 +573,21 @@ class Collection(
         }
     }
 
-    fun removeCardsAndOrphanedNotes(cardIds: Iterable<Long>) {
+    fun removeCardsAndOrphanedNotes(cardIds: List<Long>): OpChangesWithCount {
+        // TODO: This should be handled in the backend with https://forums.ankiweb.net/t/removecards-should-return-opchangeswithcount/48597
+        Timber.d("removing ${cardIds.size} card(s)")
+        // Note: we do not want to remove the associated notes.
+        // This is for 'empty cards'  (e.g. fixing when cloze deletions are removed)
         backend.removeCards(cardIds)
+
+        return opChangesWithCount {
+            count = cardIds.size
+            changes = opChanges {
+                card = true
+                browserTable = true
+                studyQueues = true
+            }
+        }
     }
 
     fun addNote(note: Note, deckId: DeckId): OpChanges {


### PR DESCRIPTION
* Build & use an `OpChangesWithCount`
* Tested and undo is not affected

A feature request has been added for a better implementation

https://forums.ankiweb.net/t/removecards-should-return-opchangeswithcount/48597

* Fixes #16945

## How Has This Been Tested?

<details>

```
2024-08-25 09:14:42.077  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 112KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 10072KB/19MB, paused 389us,2.166ms total 70.567ms
2024-08-25 09:14:42.179  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:43.555  9086-9167  EGL_emulation           com.ichi2.anki.debug                 D  app_time_stats: avg=272.33ms min=11.25ms max=4109.21ms count=16
2024-08-25 09:14:43.577  9086-9205  Collection              com.ichi2.anki.debug                 D  removing 1 card(s)
2024-08-25 09:14:43.654  9086-9086  SnackbarsKt             com.ichi2.anki.debug                 D  displayed snackbar: 'Cards deleted: 1'
2024-08-25 09:14:43.655  9086-9086  WindowOnBackDispatcher  com.ichi2.anki.debug                 W  sendCancelIfRunning: isInProgress=false callback=android.view.ViewRootImpl$$ExternalSyntheticLambda11@3b94124
2024-08-25 09:14:43.665  9086-9167  HWUI                    com.ichi2.anki.debug                 D  endAllActiveAnimators on 0x7bda4be6c770 (RippleDrawable) with handle 0x7bdaebe496a0
2024-08-25 09:14:43.698  9086-9167  EGL_emulation           com.ichi2.anki.debug                 D  app_time_stats: avg=327.79ms min=1.61ms max=13918.32ms count=44
2024-08-25 09:14:43.703  9086-9086  DeckPicker              com.ichi2.anki.debug                 D  updateDeckList
2024-08-25 09:14:43.716  9086-9086  DeckPicker...teDeckList com.ichi2.anki.debug                 D  Refreshing deck list
2024-08-25 09:14:43.717  9086-9086  AbstractFlashcardViewer com.ichi2.anki.debug                 D  deferred refresh as activity was not STARTED
2024-08-25 09:14:43.717  9086-9086  ChangeManager           com.ichi2.anki.debug                 V  removing 1 expired subscribers
2024-08-25 09:14:43.718  9086-9086  DeckPicker              com.ichi2.anki.debug                 D  onCreateOptionsMenu()
2024-08-25 09:14:43.737  9086-9086  BadgeDrawableBuilder    com.ichi2.anki.debug                 D  Adding badge
2024-08-25 09:14:43.773  9086-9086  DeckPicker              com.ichi2.anki.debug                 I  Updating deck list UI
2024-08-25 09:14:43.774  9086-9086  DeckAdapter             com.ichi2.anki.debug                 D  buildDeckList
2024-08-25 09:14:43.780  9086-9086  DeckPicker              com.ichi2.anki.debug                 D  Startup - Deck List UI Completed
2024-08-25 09:14:43.820  9086-9086  ScopedStorageService    com.ichi2.anki.debug                 I  isLegacyStorage(): current dir: /storage/emulated/0/AnkiDroid
                                                                                                    scoped external dirs: /storage/emulated/0/Android/data/com.ichi2.anki.debug/files, /storage/1C04-1D02/Android/data/com.ichi2.anki.debug/files
                                                                                                    scoped internal dir: /data/user/0/com.ichi2.anki.debug/files
2024-08-25 09:14:43.820  9086-9086  ScopedStorageService    com.ichi2.anki.debug                 I  isLegacyStorage(): true
2024-08-25 09:14:43.821  9086-9086  BadgeDrawableBuilder    com.ichi2.anki.debug                 D  Adding badge
2024-08-25 09:14:43.857  9086-9603  DeckAdapter$DeckFilter  com.ichi2.anki.debug                 I  deck filter: 1
2024-08-25 09:14:44.301  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 845KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 10204KB/19MB, paused 504us,7.469ms total 116.566ms
2024-08-25 09:14:44.403  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:45.448  9086-9167  EGL_emulation           com.ichi2.anki.debug                 D  app_time_stats: avg=64.19ms min=2.61ms max=1217.47ms count=26
2024-08-25 09:14:46.466  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 356KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 10040KB/19MB, paused 761us,9.529ms total 59.931ms
2024-08-25 09:14:46.569  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:47.017  9086-9167  EGL_emulation           com.ichi2.anki.debug                 D  app_time_stats: avg=97.91ms min=12.11ms max=1316.03ms count=16
2024-08-25 09:14:48.630  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 180KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9988KB/19MB, paused 775us,7.195ms total 59.954ms
2024-08-25 09:14:48.734  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:50.787  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 68KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9984KB/19MB, paused 764us,5.400ms total 50.412ms
2024-08-25 09:14:50.889  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:52.934  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 68KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 508us,3.054ms total 43.720ms
2024-08-25 09:14:53.037  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:55.164  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 64KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 464us,4.618ms total 124.973ms
2024-08-25 09:14:55.267  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:57.320  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 96KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 480us,5.978ms total 49.433ms
2024-08-25 09:14:57.422  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:14:59.454  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 64KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 672us,3.051ms total 28.992ms
2024-08-25 09:14:59.556  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:15:00.025  9086-9086  DayRolloverHandler      com.ichi2.anki.debug                 V  received android.intent.action.TIME_TICK
2024-08-25 09:15:01.591  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 160KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 425us,3.140ms total 30.913ms
2024-08-25 09:15:01.693  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:15:03.773  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 64KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 394us,3.267ms total 78.416ms
2024-08-25 09:15:03.875  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notification: already requested missing POST_NOTIFICATIONS permission.
2024-08-25 09:15:05.906  9086-9103  chi2.anki.debug         com.ichi2.anki.debug                 I  Explicit concurrent mark compact GC freed 64KB AllocSpace bytes, 0(0B) LOS objects, 49% free, 9980KB/19MB, paused 663us,2.106ms total 27.895ms
2024-08-25 09:15:06.008  9086-9103  LeakCanary              com.ichi2.anki.debug                 D  Not showing notifi
```

</details>


⚠️ My IDE did not have syntax highlighting for this one.

There is a problem with `undoableOp` accepting `Unit` instead of `OpChangesWithCount` - so the generic needs to be explicit

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
