### PR TITLE
pressing enter on physical keyboard change creates a new deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.dialogs
 
 import android.app.Activity
 import android.content.Context
+import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
@@ -91,10 +92,11 @@ class CreateDeckDialog(
             negativeButton(R.string.dialog_cancel)
             setView(R.layout.dialog_generic_text_input)
         }.input(prefill = initialDeckName, displayKeyboard = true, waitForPositiveButton = false) { dialog, text ->
-            // defining the action of done button in keyboard
+
+            // defining the action of done button in ImeKeyBoard and enter button in physical keyBoard
             val inputField = dialog.getInputField()
-            inputField.setOnEditorActionListener { _, actionId, _ ->
-                if (actionId == EditorInfo.IME_ACTION_DONE) {
+            inputField.setOnEditorActionListener { _, actionId, event ->
+                if (actionId == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
                     onPositiveButtonClicked()
                     true
                 } else {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
During creation of new deck after entering the name of deck pressing enter on the physical keyboard was changing focus to the cancel button 

## Fixes
* #16872

## Approach
adding a enter key listener along with IMEACTION done button listener 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)
This has been tested on API level 34 and as well as physical device samsung galaxy F23

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [*] You have a descriptive commit message with a short title (first line, max 50 chars).
- [*] You have commented your code, particularly in hard-to-understand areas
- [*] You have performed a self-review of your own code
- [*] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

https://github.com/user-attachments/assets/7052f435-464c-4c11-b15c-b38f7269e8fe

