### PR TITLE
docs: refine bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -20,7 +20,7 @@ body:
       label: Does it also happen in the desktop version?
       description: If so, please report it in [Anki Forums](https://forums.ankiweb.net) instead
       options:
-        - label: This bug does not occur in the latest version of Anki
+        - label: This bug does not occur in the latest version of Anki Desktop
           required: false
 
   - type: textarea
@@ -35,15 +35,7 @@ body:
     id: expected-behaviour
     attributes:
       label: Expected behaviour
-      description: Briefly describe what should have happened
-    validations:
-      required: true
-
-  - type: textarea
-    id: actual-behaviour
-    attributes:
-      label: Actual behaviour
-      description: Briefly describe what happened
+      description: Briefly describe what happened, and what should have happened
     validations:
       required: true
 
@@ -51,7 +43,7 @@ body:
     id: debug-info
     attributes:
       label: Debug info
-      description: Refer to the [support page](https://ankidroid.org/docs/help.html) if you are unsure where to get the "debug info"
+      description: Settings - About (bottom of the list) - Copy debug info
       placeholder: AnkiDroid Debug Info (Starts with "AnkiDroid Version")
       render: text
     validations:
@@ -69,8 +61,6 @@ body:
       label: Research
       description: Confirm the points below
       options:
-        - label: I am reporting a bug specific to AnkiDroid (Android app)
-          required: true
         - label: I have checked the [manual](https://ankidroid.org/docs/manual.html) and the [FAQ](https://github.com/ankidroid/Anki-Android/wiki/FAQ) and could not find a solution to my issue
           required: true
         - label: (Optional) I have confirmed the issue is not resolved in the latest alpha release ([instructions](https://docs.ankidroid.org/manual.html#betaTesting))


### PR DESCRIPTION
A user said:

> it asks whether the bug is specific to AnkiDroid twice

So we remove the second confirmation

> * What are the steps to reproduce? Alright, gimme a minute
> * Expected behavior? Does this have to be a separate field?
> * Actual behavior? Does this really have to be a separate field?

I have consolidated 'Expected' and 'Actual' behavior

> * Debug info? I... uhhh... ok, I give up.
> ...
> should probably elaborate this a bit, to make
> it more clear where to find this info

Since we've been using the new Settings for a while I have made this less ambiguous


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


----

We can further refine if we receive bug reports which would have been fixed in the original version. I'd rather optimize slightly for ease of reporting