### PR TITLE
Add warning to WIP dev options

### DIFF
--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -180,6 +180,7 @@
     <string name="new_reviewer_pref_key">newReviewer</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
+    <string name="pref_cat_wip_key">workInProgressDevOptions</string>
     <!-- Developer options > Create fake media -->
     <string name="pref_fill_collection_key">fillCollection</string>
     <string name="pref_fill_collection_number_file_key">fillCollectionNumberFile</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -45,15 +45,6 @@
         android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
         android:key="@string/pref_lock_database_key"/>
     <SwitchPreferenceCompat
-        android:title="New reviewer"
-        android:key="@string/new_reviewer_pref_key"
-        android:defaultValue="false"/>
-    <Preference
-        android:title="New reviewer options"
-        android:key="@string/new_reviewer_options_key"
-        android:dependency="@string/new_reviewer_pref_key"
-        android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"/>
-    <SwitchPreferenceCompat
         android:title="New congrats screen"
         android:key="@string/new_congrats_screen_pref_key"
         android:defaultValue="false"/>
@@ -79,4 +70,21 @@
             android:title="Create files"
             />
     </PreferenceCategory>
+
+    <com.ichi2.anki.preferences.ExtendedPreferenceCategory
+        android:key="@string/pref_cat_wip_key"
+        android:title="Work in progress"
+        android:summary="Only for testing. Not suited for use. Don't create reports about them">
+
+        <SwitchPreferenceCompat
+            android:title="New reviewer"
+            android:key="@string/new_reviewer_pref_key"
+            android:defaultValue="false"/>
+        <Preference
+            android:title="New reviewer options"
+            android:key="@string/new_reviewer_options_key"
+            android:dependency="@string/new_reviewer_pref_key"
+            android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"/>
+
+    </com.ichi2.anki.preferences.ExtendedPreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Common users are using the "New reviewer" **developer option** as it's something aimed at them.

As the name say, it's a **developer option** aimed to devs so they can test the feature, but people misunderstand that and are creating issues in GitHub

## Approach

Add a written warning explaining that

If this doesn't work and people insist on creating issues in GitHub, next step will be to restrict the WIP features to DEBUG builds.

## How Has This Been Tested?

![image](https://github.com/user-attachments/assets/618b1e80-80fb-4dcd-a8e1-67eb6335210c)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- X ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
