### PR TITLE
Fix missing return for special ankiAddTagToNote endpoint.

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/js-api.js
+++ b/AnkiDroid/src/main/assets/scripts/js-api.js
@@ -123,6 +123,7 @@ Object.keys(jsApiList).forEach(method => {
             const data = JSON.stringify({ noteId, tag });
             return await this.handleRequest(endpoint, data);
         };
+        return;
     }
     if (method === "ankiTtsSpeak") {
         AnkiDroidJS.prototype[method] = async function (text, queueMode = 0) {


### PR DESCRIPTION
## Purpose / Description
Add missing return for new ankiAddTagToNote API which otherwise will not forward the right parameters to the underlying server.

## How Has This Been Tested?
No extra testing.
