### PR TITLE
Note editor back button request confirmation only in case of change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -251,7 +251,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
 
     /* indicates which activity called Note Editor */
     private var caller = 0
-    private var editFields: LinkedList<FieldEditText?>? = null
+    private var editFields: LinkedList<FieldEditText>? = null
     private var sourceText: Array<String?>? = null
     private val fieldState = FieldState.fromEditor(this)
     private lateinit var toolbar: Toolbar
@@ -737,9 +737,9 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                         .replaceFirst("\\[".toRegex(), "\u001f" + sourceText!![0] + "\u001f")
                     contents = contents.substring(0, contents.length - 1)
                 } else if (!editFields!!.isEmpty()) {
-                    editFields!![0]!!.setText(sourceText!![0])
+                    editFields!![0].setText(sourceText!![0])
                     if (editFields!!.size > 1) {
-                        editFields!![1]!!.setText(sourceText!![1])
+                        editFields!![1].setText(sourceText!![1])
                     }
                 }
             } else {
@@ -779,9 +779,9 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         if (editFields != null && !editFields!!.isEmpty()) {
             // EXTRA_TEXT_FROM_SEARCH_VIEW takes priority over other intent inputs
             if (!getTextFromSearchView.isNullOrEmpty()) {
-                editFields!!.first()!!.setText(getTextFromSearchView)
+                editFields!!.first().setText(getTextFromSearchView)
             }
-            editFields!!.first()!!.requestFocus()
+            editFields!!.first().requestFocus()
         }
 
         if (caller == CALLER_IMG_OCCLUSION) {
@@ -1048,7 +1048,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         // changed fields?
         if (isFieldEdited) {
             for (value in editFields!!) {
-                if (value?.text.toString() != "") {
+                if (value.text.toString() != "") {
                     return true
                 }
             }
@@ -1082,7 +1082,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             closeEditorAfterSave = true
             closeIntent = Intent().apply { putExtra(EXTRA_ID, requireArguments().getString(EXTRA_ID)) }
         } else if (!editFields!!.isEmpty()) {
-            editFields!!.first()!!.focusWithKeyboard()
+            editFields!!.first().focusWithKeyboard()
         }
 
         if (closeEditorAfterSave) {
@@ -1268,7 +1268,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         }
         if (editFields != null) {
             for (i in editFields!!.indices) {
-                val fieldText = editFields!![i]!!.text
+                val fieldText = editFields!![i].text
                 if (!fieldText.isNullOrEmpty()) {
                     menu.findItem(R.id.action_copy_note).isEnabled = true
                     break
@@ -1358,7 +1358,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             putBoolean(PREF_NOTE_EDITOR_CAPITALIZE, value)
         }
         for (f in editFields!!) {
-            f!!.setCapitalize(value)
+            f.setCapitalize(value)
         }
     }
 
@@ -1369,7 +1369,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         Timber.i("Setting font size to %d", fontSizeSp)
         this.sharedPrefs().edit { putInt(PREF_NOTE_EDITOR_FONT_SIZE, fontSizeSp) }
         for (f in editFields!!) {
-            f!!.textSize = fontSizeSp.toFloat()
+            f.textSize = fontSizeSp.toFloat()
         }
     }
 
@@ -1381,7 +1381,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             // Note: We're not being accurate here - the initial value isn't actually what's supplied in the layout.xml
             // So a value of 18sp in the XML won't be 18sp on the TextView, but it's close enough.
             // Values are setFontSize are whole when returned.
-            val sp = TextViewUtil.getTextSizeSp(editFields!!.first()!!)
+            val sp = TextViewUtil.getTextSizeSp(editFields!!.first())
             return sp.roundToInt().toString()
         }
 
@@ -1411,7 +1411,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     suspend fun performPreview() {
         val convertNewlines = shouldReplaceNewlines()
         fun String?.toFieldText(): String = NoteService.convertToHtmlNewline(this.toString(), convertNewlines)
-        val fields = editFields?.mapTo(mutableListOf()) { it!!.fieldText.toFieldText() } ?: mutableListOf()
+        val fields = editFields?.mapTo(mutableListOf()) { it.fieldText.toFieldText() } ?: mutableListOf()
         val tags = selectedTags ?: mutableListOf()
 
         val ord = if (editorNote!!.notetype.isCloze) {
@@ -1881,8 +1881,8 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             // Completely replace text for text fields (because current text was passed in)
             val formattedValue = field.formattedValue
             if (field.type === EFieldType.TEXT) {
-                fieldEditText!!.setText(formattedValue)
-            } else if (fieldEditText!!.text != null) {
+                fieldEditText.setText(formattedValue)
+            } else if (fieldEditText.text != null) {
                 insertStringInField(fieldEditText, formattedValue)
             }
             changed = true
@@ -1914,7 +1914,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     }
 
     private fun onToggleStickyText(toggleStickyButton: ImageButton?, index: Int) {
-        val text = editFields!![index]!!.fieldText
+        val text = editFields!![index].fieldText
         if (toggleStickyText[index] == null) {
             toggleStickyText[index] = text
             toggleStickyButton!!.background.alpha = 255
@@ -1930,7 +1930,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         for ((key) in toggleStickyText.toMap()) {
             // handle fields for different note type with different size
             if (key < editFields!!.size) {
-                toggleStickyText[key] = editFields!![key]?.fieldText
+                toggleStickyText[key] = editFields!![key].fieldText
             } else {
                 toggleStickyText.remove(key)
             }
@@ -1941,7 +1941,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         for ((key, value) in toggleStickyText) {
             // handle fields for different note type with different size
             if (key < editFields!!.size) {
-                editFields!![key]!!.setText(value)
+                editFields!![key].setText(value)
             }
         }
     }
@@ -2061,9 +2061,9 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         }
         for (i in editFields!!.indices) {
             if (i < len) {
-                editFields!![i]!!.setText(fields!![i])
+                editFields!![i].setText(fields!![i])
             } else {
-                editFields!![i]!!.setText("")
+                editFields!![i].setText("")
             }
         }
     }
@@ -2080,9 +2080,9 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         val dupeCode = editorNote!!.fieldsCheck(getColUnsafe)
         // Change bottom line color of text field
         if (dupeCode == NoteFieldsCheckResponse.State.DUPLICATE) {
-            field!!.setDupeStyle()
+            field.setDupeStyle()
         } else {
-            field!!.setDefaultStyle()
+            field.setDefaultStyle()
         }
         // Put back the old value so we don't interfere with modification detection
         editorNote!!.values()[0] = oldValue
@@ -2100,7 +2100,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
 
     /** Returns the value of the field at the given index  */
     private fun getCurrentFieldText(index: Int): String {
-        val fieldText = editFields!![index]!!.text ?: return ""
+        val fieldText = editFields!![index].text ?: return ""
         return fieldText.toString()
     }
 
@@ -2580,7 +2580,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                 editFields!!.size
             )
             for (e in editFields!!) {
-                val editable = e!!.text
+                val editable = e.text
                 val fieldValue = editable?.toString() ?: ""
                 fieldValues.add(fieldValue)
             }
@@ -2592,13 +2592,13 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     @VisibleForTesting
     fun setFieldValueFromUi(i: Int, newText: String?) {
         val editText = editFields!![i]
-        editText!!.setText(newText)
+        editText.setText(newText)
         EditFieldTextWatcher(i).afterTextChanged(editText.text!!)
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
     fun getFieldForTest(index: Int): FieldEditText {
-        return editFields!![index]!!
+        return editFields!![index]
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1938,12 +1938,14 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     }
 
     private fun updateFieldsFromStickyText() {
+        loadingStickyFields = true
         for ((key, value) in toggleStickyText) {
             // handle fields for different note type with different size
             if (key < editFields!!.size) {
                 editFields!![key].setText(value)
             }
         }
+        loadingStickyFields = false
     }
 
     @VisibleForTesting
@@ -2608,9 +2610,16 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         noteTypeSpinner!!.setSelection(position)
     }
 
+    /**
+     * Whether sticky fields are currently being loaded. In this card, don't consider the text chagned.
+     */
+    private var loadingStickyFields = false
     private inner class EditFieldTextWatcher(private val index: Int) : TextWatcher {
+
         override fun afterTextChanged(arg0: Editable) {
-            isFieldEdited = true
+            if (!loadingStickyFields) {
+                isFieldEdited = true
+            }
             if (index == 0) {
                 setDuplicateFieldStyles()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1896,14 +1896,14 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     }
 
     @NeedsTest("If a field is sticky after synchronization, the toggleStickyButton should be activated.")
-    private fun setToggleStickyButtonListener(toggleStickyButton: ImageButton?, index: Int) {
+    private fun setToggleStickyButtonListener(toggleStickyButton: ImageButton, index: Int) {
         if (currentFields.getJSONObject(index).getBoolean("sticky")) {
             toggleStickyText.getOrPut(index) { "" }
         }
         if (toggleStickyText[index] == null) {
-            toggleStickyButton!!.background.alpha = 64
+            toggleStickyButton.background.alpha = 64
         } else {
-            toggleStickyButton!!.background.alpha = 255
+            toggleStickyButton.background.alpha = 255
         }
         toggleStickyButton.setOnClickListener {
             onToggleStickyText(
@@ -1913,15 +1913,15 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         }
     }
 
-    private fun onToggleStickyText(toggleStickyButton: ImageButton?, index: Int) {
+    private fun onToggleStickyText(toggleStickyButton: ImageButton, index: Int) {
         val text = editFields!![index].fieldText
         if (toggleStickyText[index] == null) {
             toggleStickyText[index] = text
-            toggleStickyButton!!.background.alpha = 255
+            toggleStickyButton.background.alpha = 255
             Timber.d("Saved Text:: %s", toggleStickyText[index])
         } else {
             toggleStickyText.remove(index)
-            toggleStickyButton!!.background.alpha = 64
+            toggleStickyButton.background.alpha = 64
         }
     }
 


### PR DESCRIPTION
The sticky fields don't force the user to confirm when they tap the back button.

Also some slight cleaning.

I refrained from doing bigger cleaning because I know this code will go. But the nullability was trivial to check. And this bug was honestly frustrating me, and since it's quick to fix, I preferred not to wait for the new editor

Fixed: #16949