### PR TITLE
Fix incorrect key handling in some screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -712,11 +712,12 @@ open class CardBrowser :
                 if (event.isCtrlPressed && event.isAltPressed) {
                     Timber.i("Ctrl+Alt+T: Toggle cards/notes")
                     showOptionsDialog()
-                } else {
-                    Timber.i("T: Show filter by tags dialog")
+                    return true
+                } else if (event.isCtrlPressed) {
+                    Timber.i("Ctrl+T: Show filter by tags dialog")
                     showFilterByTagsDialog()
+                    return true
                 }
-                return true
             }
             KeyEvent.KEYCODE_S -> {
                 if (event.isCtrlPressed && event.isShiftPressed) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -656,9 +656,15 @@ open class CardBrowser :
                     Timber.i("Ctrl+E: Add Note")
                     launchCatchingTask { addNoteFromCardBrowser() }
                     return true
-                } else {
+                } else if (searchView?.isIconified == true) {
                     Timber.i("E: Edit note")
+                    // search box is not available so treat the event as a shortcut
                     openNoteEditorForCurrentlySelectedNote()
+                    return true
+                } else {
+                    Timber.i("E: Character added")
+                    // search box might be available and receiving input so treat this as usual text
+                    return false
                 }
             }
             KeyEvent.KEYCODE_D -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -689,9 +689,16 @@ open class CardBrowser :
                 }
             }
             KeyEvent.KEYCODE_FORWARD_DEL, KeyEvent.KEYCODE_DEL -> {
-                Timber.i("Delete pressed - Delete Selected Note")
-                deleteSelectedNotes()
-                return true
+                if (searchView?.isIconified == false) {
+                    Timber.i("Delete pressed - Search active, deleting character")
+                    // the search box is available and could potentially receive input so handle the
+                    // DEL as a simple text deletion and not as a keyboard shortcut
+                    return false
+                } else {
+                    Timber.i("Delete pressed - Delete Selected Note")
+                    deleteSelectedNotes()
+                    return true
+                }
             }
             KeyEvent.KEYCODE_F -> {
                 if (event.isCtrlPressed) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -375,8 +375,9 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 }
                 else -> return super.onKeyUp(keyCode, event)
             }
+            return true
         }
-        return true
+        return super.onKeyUp(keyCode, event)
     }
 
     @get:VisibleForTesting


### PR DESCRIPTION
## Purpose / Description

This PR fixes the linked issues + one more(edit note screen is shown on every E event) by properly following the contract of the onKeyUp method of returning true only if the event is handled there and using a modifier to not trigger on simple key events/checking the state of the search box to see if it's regular input.

In CardBrowser I introduced two new shortcuts by using the modifier that was not used in that when selection clause:

old: _T -> Show filter by tags dialog_ vs. new: _Ctrl+T: Show filter by tags dialog_

Feel free to propose other shortcuts.

@SanjaySargam I've made this PR to help seeing that you still have work on the Gsoc front.

## Fixes
* Fixes  #16955
* Fixes #16984
* Fixes #16983

## How Has This Been Tested?

I don't see the previous behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
