### PR TITLE
fix menu in template editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -638,9 +638,7 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                     insertField(bundle.getString(InsertFieldDialog.KEY_INSERTED_FIELD)!!)
                 }
             }
-            if (!templateEditor.fragmented) {
-                setupMenu()
-            }
+            setupMenu()
         }
 
         private fun initTabLayoutMediator() {
@@ -669,7 +667,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
             (requireActivity() as MenuHost).addMenuProvider(
                 object : MenuProvider {
                     override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
-                        menu.clear()
                         menuInflater.inflate(R.menu.card_template_editor, menu)
                         setupCommonMenu(menu)
                     }

--- a/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:id="@+id/root_layout"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    tools:context=".CardTemplateEditor">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/root_layout">
+    android:id="@+id/root_layout"
+    tools:context=".CardTemplateEditor"
+    >
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/card_template_editor_top.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_top.xml
@@ -14,7 +14,9 @@
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/ActionBarStyle"
         app:navigationContentDescription="@string/abc_action_bar_up_description"
-        app:navigationIcon="?attr/homeAsUpIndicator"/>
+        app:navigationIcon="?attr/homeAsUpIndicator"
+        app:menu="@menu/card_template_editor"
+        />
 
     <com.google.android.material.tabs.TabLayout
         style="@style/TabLayoutStyle"


### PR DESCRIPTION
this was very hard to do because CardTemplateEditor is tightly coupled with CardTemplateFragment, so most changes break something even if not related

## Fixes
* Fixes #16992

## How Has This Been Tested?

The menu shows up in a tablet emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
