### PR TITLE
Fix: Ensure "Media Sync Aborted" Message Displays Correctly After Canceling Media Sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -358,6 +358,7 @@ suspend fun monitorMediaSync(
 ) {
     val backend = CollectionManager.getBackend()
     val scope = CoroutineScope(Dispatchers.IO)
+    var isAborted = false
 
     val dialog = withContext(Dispatchers.Main) {
         AlertDialog.Builder(deckPicker)
@@ -367,6 +368,7 @@ suspend fun monitorMediaSync(
                 scope.cancel()
             }
             .setNegativeButton(TR.syncAbortButton()) { _, _ ->
+                isAborted = true
                 cancelMediaSync(backend)
             }
             .show()
@@ -386,7 +388,7 @@ suspend fun monitorMediaSync(
                 dialog.setMessage(text)
                 delay(100)
             }
-            showMessage(TR.syncMediaComplete())
+            showMessage(if (isAborted) TR.syncMediaAborted() else TR.syncMediaComplete())
         } catch (_: BackendInterruptedException) {
             showMessage(TR.syncMediaAborted())
         } catch (_: CancellationException) {


### PR DESCRIPTION
## Purpose / Description
The issue addressed in this PR involves an incorrect message being displayed when media sync is canceled. Instead of showing "Media sync aborted," the system often shows "Media sync complete." This issue was observed when tapping "Cancel" in the "Media Sync Log" dialog box.

## Fixes
* Fixes #16631 

## How Has This Been Tested?
Realme 6 (API-30) and Emulator

## Screenshot
![photo_2024-09-01_15-48-10](https://github.com/user-attachments/assets/e2163994-b8fa-4eda-b322-8f492f55dc18)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
