### PR TITLE
add filtered deck option to browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -77,6 +77,7 @@ import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog
+import com.ichi2.anki.dialogs.CreateDeckDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -927,6 +928,7 @@ open class CardBrowser :
                     subMenu ->
                 setupFlags(subMenu, Mode.SINGLE_SELECT)
             }
+            menu.findItem(R.id.action_create_filtered_deck).title = TR.qtMiscCreateFilteredDeck()
             saveSearchItem = menu.findItem(R.id.action_save_search)
             saveSearchItem?.isVisible = false // the searchview's query always starts empty.
             mySearchesItem = menu.findItem(R.id.action_list_my_searches)
@@ -1251,8 +1253,25 @@ open class CardBrowser :
             R.id.action_export_selected -> {
                 exportSelected()
             }
+            R.id.action_create_filtered_deck -> {
+                showCreateFilteredDeckDialog()
+            }
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    private fun showCreateFilteredDeckDialog() {
+        val dialog = CreateDeckDialog(this, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null)
+        dialog.onNewDeckCreated = {
+            val intent = Intent(this, FilteredDeckOptions::class.java)
+            intent.putExtra("search", viewModel.searchTerms)
+            startActivity(intent)
+        }
+        launchCatchingTask {
+            withProgress {
+                dialog.showFilteredDeckDialog()
+            }
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -26,6 +26,7 @@ import android.preference.EditTextPreference
 import android.preference.ListPreference
 import android.preference.Preference
 import android.preference.PreferenceCategory
+import androidx.core.content.edit
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
@@ -222,6 +223,11 @@ class FilteredDeckOptions :
         } else {
             pref = DeckPreferenceHack()
             pref.registerOnSharedPreferenceChangeListener(this)
+            extras?.getString("search")?.let { search ->
+                pref.edit {
+                    putString("search", search)
+                }
+            }
             addPreferences(col)
             buildLists()
             updateSummaries()

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -63,4 +63,10 @@
         android:title="@string/study_options"
         ankidroid:showAsAction="never"/>
 
+    <item
+        android:id="@+id/action_create_filtered_deck"
+        ankidroid:showAsAction="never"
+        tools:title="Create filtered deck..."
+        />
+
 </menu>


### PR DESCRIPTION
## Fixes
* Fixes #12444

## Approach

I implemented the create filtered deck option feature

## How Has This Been Tested?

[filtered.webm](https://github.com/user-attachments/assets/3e68ae3d-beea-4511-8b4a-b1ec0f4ee473)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
