### PR TITLE
Enhance DeckPicker search to include card browser

### DIFF
--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -6,7 +6,6 @@
         android:id="@+id/deck_picker_action_filter"
         android:icon="@drawable/ic_search_white"
         android:title="@string/search_decks"
-        android:visible="false"
         ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
     <group android:id="@+id/commonItems">


### PR DESCRIPTION
## Purpose / Description
This adds functionality to search your collection directly from the deck picker. This is useful for people like me who always click on the magnifying glass icon in the deck picker with the intent to search their card collection and then realize it does nothing but filter the deck list.

## Fixes
* Implements a feature suggested in #8158 (ticket has been closed previously)

## Approach
The search icon that appears in the deck picker in a collection with
>= 10 decks will currently display a search view for filtering decks.

This change keeps the behavior of filtering decks in the DeckPicker on typing in the search field, 
but changes the query submit behavior to open a CardBrowser search for the search query.
The search icon is made always visible, the minimum deck count condition is removed.

This is more intuitive and much more discoverable than the approach
proposed in #8158 of having short click/long click on the magnifying
glass icon in the Deck Picker toolbar open card search/deck filtering,
respectively.

## How Has This Been Tested?

Tested on a Pixel 3a by performing several filterings and searches.


https://github.com/user-attachments/assets/00e4cb9c-d5a1-4a05-9cee-a2b321001c1a



## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
