### PR TITLE
remove all cards count  subtitle

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2152,9 +2152,8 @@ open class DeckPicker :
             val res = resources
 
             if (due != null && supportActionBar != null) {
-                val cardCount = withCol { cardCount() }
-                val subTitle: String = if (due == 0) {
-                    res.getQuantityString(R.plurals.deckpicker_title_zero_due, cardCount, cardCount)
+                val subTitle = if (due == 0) {
+                    null
                 } else {
                     res.getQuantityString(R.plurals.widget_cards_due, due, due)
                 }

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -170,11 +170,6 @@
     <string name="sync_conflict_title_new">Select collection to keep</string>
     <string name="sync_conflict_replace_title">Replace collection</string>
 
-    <plurals name="deckpicker_title_zero_due">
-        <item quantity="one">%1$d card (0 due)</item>
-        <item quantity="other">%1$d cards (0 due)</item>
-    </plurals>
-
     <!-- Generic errors -->
     <string name="error__etc__cannot_write_to_or_create_file"
         >Cannot write to or create file %s</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

https://forums.ankiweb.net/t/remove-total-number-of-cards-from-main-menu/48972

> When no cards are due, AnkiDroid shows the total number of cards in the main menu.
>
> IMO, this doesn’t solve any purpose and is just a distraction. So, I suggest removing it.

## Fixes
* Fixes this request in the forums https://forums.ankiweb.net/t/remove-total-number-of-cards-from-main-menu/48972

## Approach
remove the subtitle if there aren't any cards due

## How Has This Been Tested?

In an Android 14 emulator by finishing all cards so there aren't any cards due

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
