### PR TITLE
Improve the dialog's features related to BackendSyncException

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -87,6 +87,7 @@
     <string name="dialog_positive_overwrite">Overwrite</string>
     <string name="dialog_positive_repair">Repair</string>
     <string name="dialog_positive_replace">Replace</string>
+    <string name="dialog_go_to_setting">Go to setting</string>
 
     <string name="dialog_collection_path_not_dir">The path specified wasn’t a valid directory</string>
     <string name="dialog_invalid_custom_certificate">The provided text does not resolve to a valid PEM-encoded X509 certificate</string>
@@ -222,6 +223,7 @@
     sched V2. For V1, it was counting the number of repetitions of cards in learning. This approximation is acceptable
     for the sake of simplicity and because V1 will leave.-->
     <string name="deck_picker_counts">Open the deck overview page containing the number of cards to see today.</string>
+    <string name="InvalidClockDialog">Your clock is currently set to:</string>
 
     <string name="import_deck_package">Deck package (.apkg)</string>
     <string name="import_collection_package">Collection package (.colpkg)</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After clicking the sync button, if your current time is invalid, a dialog will appear notifying you that your time settings are incorrect. This dialog now includes a "Go to Settings" button, allowing you to easily adjust your date and time to the correct settings. Additionally, the dialog displays the current time for your reference.

## Fixes
* Fixes #16978


## How Has This Been Tested?
Here is a screenshot of the result:

![Screenshot 2024-09-05 114330](https://github.com/user-attachments/assets/46838d16-6c6c-41cf-a56d-b6ac52fe0c09)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
