### PR TITLE
fix:[BUG] Key Labels Not Displaying in Landscape Mode

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
@@ -14,43 +14,47 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/key_picker_selected_key"
+    <LinearLayout
+        android:gravity="center"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintDimensionRatio="w,1:1"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:gravity="center"
-        android:textSize="24sp"
-        android:textAlignment="center"
-        android:text="@string/key_picker_default_press_key"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        app:layout_constraintBottom_toTopOf="@id/warning"
+        app:layout_constraintWidth_max="320dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/warning"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textColor="?attr/colorError"
-        tools:text="Already used in X"
-        android:layout_margin="6dp"
-        android:visibility="gone"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/key_picker_selected_key"
-        android:drawableStart="@drawable/ic_warning"
-        android:drawableTint="?attr/colorError"
-        android:drawablePadding="4dp"
-        tools:visibility="visible"
-        />
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/key_picker_selected_key"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:text="@string/key_picker_default_press_key"
+            android:textSize="24sp" />
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/warning"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_margin="6dp"
+            android:drawablePadding="4dp"
+            android:drawableStart="@drawable/ic_warning"
+            android:drawableTint="?attr/colorError"
+            android:textColor="?attr/colorError"
+            android:visibility="gone"
+            tools:text="Already used in X"
+            tools:visibility="visible" />
+
+    </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Key Labels Not Displaying in Landscape Mode

## Fixes
* Fixes #16935 

## Approach
use linear layout 

## How Has This Been Tested?
Tested on Android Device 

## UI Screenshots
![WhatsApp Image 2024-09-13 at 11 26 13 PM](https://github.com/user-attachments/assets/c7ff30ca-576c-48ed-9dfe-b5065c74ca7c)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
