### PR TITLE
Feat[Multimedia]: render `svg` using webview

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -22,21 +22,26 @@ import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
+import android.graphics.drawable.BitmapDrawable
 import android.net.Uri
 import android.os.Bundle
 import android.provider.MediaStore
 import android.view.View
-import android.widget.ImageView
+import android.webkit.WebView
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.canhub.cropper.CropException
 import com.google.android.material.button.MaterialButton
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.DrawingActivity
 import com.ichi2.anki.R
@@ -49,6 +54,8 @@ import com.ichi2.anki.multimedia.MultimediaUtils.createCachedFile
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
 import com.ichi2.anki.multimedia.MultimediaUtils.createNewCacheImageFile
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.convertToString
+import com.ichi2.anki.utils.ext.toBase64Png
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.imagecropper.ImageCropper
@@ -69,12 +76,13 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.text.NumberFormat
 
+private const val SVG_IMAGE = "image/svg+xml"
+
 @NeedsTest("Ensure correct option is executed i.e. gallery or camera")
 class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_image) {
     override val title: String
         get() = resources.getString(R.string.multimedia_editor_popup_image)
 
-    private lateinit var imagePreview: ImageView
     private lateinit var imageFileSize: TextView
 
     private lateinit var selectedImageOptions: ImageOptions
@@ -97,7 +105,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
                 }
 
                 Activity.RESULT_OK -> {
-                    view?.findViewById<TextView>(R.id.no_image_textview)?.visibility = View.GONE
                     val data = result.data
                     if (data == null) {
                         Timber.w("handleSelectImageIntent() no intent provided")
@@ -129,7 +136,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
                 }
 
                 Activity.RESULT_OK -> {
-                    view?.findViewById<TextView>(R.id.no_image_textview)?.visibility = View.GONE
                     val intent = result.data ?: return@registerForActivityResult
                     Timber.d("Intent not null, handling the result")
                     handleDrawingResult(intent)
@@ -155,7 +161,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
 
                 isPictureTaken -> {
                     Timber.d("Image successfully captured")
-                    view?.findViewById<TextView>(R.id.no_image_textview)?.visibility = View.GONE
                     handleTakePictureResult(viewModel.currentMultimediaPath.value)
                 }
 
@@ -187,7 +192,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
                         updateAndDisplayImageSize(cropResultData.uriPath)
                         viewModel.updateCurrentMultimediaPath(cropResultData.uriPath)
                         viewModel.updateCurrentMultimediaUri(cropResultData.uriContent)
-                        imagePreview.setImageURI(cropResultData.uriContent)
+                        previewImage(cropResultData.uriContent)
                     }
                 }
                 else -> {
@@ -266,7 +271,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMenu(multimediaMenu)
-        imagePreview = view.findViewById(R.id.image_preview)
         imageFileSize = view.findViewById(R.id.image_size_textview)
 
         handleImageUri()
@@ -277,8 +281,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         fun processExternalImage(uri: Uri): Uri? = internalizeUri(uri)?.let { Uri.fromFile(it) }
 
         if (imageUri != null) {
-            view?.findViewById<TextView>(R.id.no_image_textview)?.visibility = View.GONE
-
             val internalUri = imageUri?.let { processExternalImage(it) }
             handleSelectImageIntent(internalUri)
         } else {
@@ -397,7 +399,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         val drawImagePath = internalizedPick.absolutePath
         Timber.i("handleDrawingResult() Decoded image: '%s'", drawImagePath)
 
-        imagePreview.setImageURI(imageUri)
+        previewImage(imageUri)
         viewModel.updateCurrentMultimediaPath(drawImagePath)
         viewModel.updateCurrentMultimediaUri(imageUri)
         updateAndDisplayImageSize(drawImagePath)
@@ -413,7 +415,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         val imageFile = File(imagePath)
         viewModel.updateCurrentMultimediaPath(imagePath)
         viewModel.updateCurrentMultimediaUri(getUriForFile(imageFile))
-        imagePreview.setImageURI(getUriForFile(imageFile))
+        viewModel.currentMultimediaUri.value?.let { previewImage(it) }
         updateAndDisplayImageSize(imagePath)
 
         showCropDialog(getString(R.string.crop_image))
@@ -467,62 +469,143 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         }
     }
 
+    /**
+     * Handles the selected image from the intent by previewing it in a WebView and internalizing the URI.
+     * Updates the ViewModel with the selected image's path and size.
+     *
+     * @param imageUri The URI of the selected image.
+     */
     private fun handleSelectImageIntent(imageUri: Uri?) {
-        val mimeType = imageUri?.let { context?.contentResolver?.getType(it) }
-        if (mimeType == "image/svg+xml") {
-            Timber.i("Selected image is an SVG.")
-            view?.findViewById<TextView>(R.id.no_image_textview)?.apply {
-                text = resources.getString(R.string.multimedia_editor_svg_preview)
-                visibility = View.VISIBLE
-            }
-        } else {
-            // reset the no preview text
-            view?.findViewById<TextView>(R.id.no_image_textview)?.apply {
-                text = null
-                visibility = View.GONE
-            }
-        }
-
         if (imageUri == null) {
             Timber.w("handleSelectImageIntent() selectedImage was null")
             showSomethingWentWrong()
             return
         }
 
+        previewImage(imageUri)
+
+        // Handle internalizing the URI (optional)
         val internalizedPick = internalizeUri(imageUri)
         if (internalizedPick == null) {
-            Timber.w(
-                "handleSelectImageIntent() unable to internalize image from Uri %s",
-                imageUri
-            )
+            Timber.w("handleSelectImageIntent() unable to internalize image from Uri %s", imageUri)
             showSomethingWentWrong()
             return
         }
 
+        // Update ViewModel with image data
         val imagePath = internalizedPick.absolutePath
 
         try {
-            // set this first, if it blows up we don't want to set the others...
-            imagePreview.setImageURI(imageUri)
-
             // if that worked, the image was not too large / good format, update viewModel
             viewModel.updateCurrentMultimediaUri(imageUri)
             viewModel.updateCurrentMultimediaPath(imagePath)
         } catch (e: Exception) {
             Timber.w(e, "handleSelectImageIntent() unable to set image for preview")
             // clear the image out of the preview so we may recover
-            imagePreview.setImageURI(null)
             showSomethingWentWrong()
             return
         }
         viewModel.selectedMediaFileSize = internalizedPick.length()
+
+        // Optionally update and display the image size
         updateAndDisplayImageSize(imagePath)
+    }
+
+    /**
+     * Previews the selected image in a WebView.
+     * Handles both SVG and non-SVG images (e.g., JPG, PNG) and displays the image based on its MIME type.
+     *
+     * @param imageUri The URI of the selected image.
+     */
+    private fun previewImage(imageUri: Uri) {
+        val mimeType = context?.contentResolver?.getType(imageUri)
+
+        // Get the WebView and set it visible
+        view?.findViewById<WebView>(R.id.multimedia_webview)?.apply {
+            visibility = View.VISIBLE
+
+            // Load image based on its MIME type
+            // SVGs require special handling due to their XML-based format and rendering complexities.
+            // Raster images (e.g., JPG, PNG) can be rendered directly using an <img> tag in HTML.
+            when (mimeType) {
+                SVG_IMAGE -> loadSvgImage(imageUri)
+                else -> loadImage(imageUri)
+            }
+        }
+    }
+
+    /**
+     * Loads and previews an SVG image in the WebView.
+     *
+     * @param imageUri The URI of the SVG image.
+     */
+    private fun WebView.loadSvgImage(imageUri: Uri) {
+        val svgData = loadSvgFromUri(imageUri)
+        if (svgData != null) {
+            Timber.i("Selected image is an SVG.")
+
+            loadDataWithBaseURL(null, svgData, SVG_IMAGE, "UTF-8", null)
+        } else {
+            Timber.w("Failed to load SVG from URI")
+            showErrorInWebView()
+        }
+    }
+
+    /**
+     * Loads and previews a non-SVG image (e.g., JPG, PNG) in the WebView.
+     *
+     * @param imageUri The URI of the non-SVG image.
+     */
+    private fun WebView.loadImage(imageUri: Uri) {
+        Timber.i("Loading non-SVG image using WebView")
+        val imagePath = imageUri.toString()
+        val htmlData = """
+        <html>
+            <body style="margin:0;padding:0;">
+                <img src="$imagePath" style="width:100%;height:auto;" />
+            </body>
+        </html>
+        """.trimIndent()
+
+        loadDataWithBaseURL(null, htmlData, "text/html", "UTF-8", null)
+    }
+
+    /** Shows an error image along with an error text **/
+    private fun showErrorInWebView() {
+        val base64Image = getBitmapDrawable(R.drawable.ic_image_not_supported).toBase64Png()
+
+        val errorHtml = """
+        <html>
+            <body style="text-align:center;">
+                <img src="data:image/png;base64,$base64Image" alt="${TR.notetypeErrorNoImageToShow()}"/>
+            </body>
+        </html>
+        """.trimIndent()
+
+        view?.findViewById<WebView>(R.id.multimedia_webview)?.loadDataWithBaseURL(null, errorHtml, "text/html", "UTF-8", null)
     }
 
     private fun requestCrop() {
         val imageUri = viewModel.currentMultimediaUri.value ?: return
         val intent = com.ichi2.imagecropper.ImageCropperLauncher.ImageUri(imageUri).getIntent(requireContext())
         imageCropperLauncher.launch(intent)
+    }
+
+    /**
+     * Loads an SVG file from the given URI and returns its content as a string.
+     *
+     * @param uri The URI of the SVG file to be loaded.
+     * @return The content of the SVG file as a string, or null if an error occurs.
+     */
+    private fun loadSvgFromUri(uri: Uri): String? {
+        return try {
+            context?.contentResolver?.openInputStream(uri)?.use { inputStream ->
+                inputStream.convertToString()
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Error reading SVG from URI")
+            null
+        }
     }
 
     private fun handleCropResultError(error: Exception) {
@@ -580,7 +663,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             // TODO: see if we can use one value to the viewModel
             viewModel.updateCurrentMultimediaUri(imageUri)
             viewModel.updateCurrentMultimediaPath(outFile.path)
-            imagePreview.setImageURI(imageUri)
+            previewImage(imageUri)
             viewModel.selectedMediaFileSize = outFile.length()
             updateAndDisplayImageSize(outFile.path)
 
@@ -663,3 +746,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         DRAWING
     }
 }
+
+private fun Fragment.getBitmapDrawable(@DrawableRes resId: Int) =
+    ContextCompat.getDrawable(requireContext(), resId) as BitmapDrawable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/BitmapDrawable.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/BitmapDrawable.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ * Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.graphics.Bitmap.CompressFormat
+import android.graphics.drawable.BitmapDrawable
+import android.util.Base64
+import android.webkit.WebView
+import java.io.ByteArrayOutputStream
+
+/**
+ * Converts a [BitmapDrawable] into a Base64 PNG, typically for displaying in a [WebView]
+ */
+fun BitmapDrawable.toBase64Png() = ByteArrayOutputStream().use { outputStream ->
+    // quality (100) is ignored as PNG is lossless
+    bitmap.compress(CompressFormat.PNG, 100, outputStream)
+    val byteArray = outputStream.toByteArray()
+    Base64.encodeToString(byteArray, Base64.DEFAULT)
+}

--- a/AnkiDroid/src/main/res/layout/fragment_multimedia_image.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_multimedia_image.xml
@@ -34,18 +34,8 @@
             app:layout_constraintBottom_toTopOf="@id/image_size_textview"
             style="@style/CardView.PreviewerStyle" >
 
-            <TextView
-                android:id="@+id/no_image_textview"
-                android:paddingBottom="30dp"
-                android:gravity="center"
-                android:layout_gravity="bottom"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"/>
-
-            <ImageView
-                android:src="@drawable/ic_image_not_supported"
-                android:id="@+id/image_preview"
-                android:scaleType="fitCenter"
+            <WebView
+                android:id="@+id/multimedia_webview"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"/>
 

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -37,7 +37,6 @@
 
     <!-- not a good message, when an unexpected error happens -->
     <string name="multimedia_editor_something_wrong">Something went wrong</string>
-    <string name="multimedia_editor_svg_preview">SVGs are not available for preview</string>
     <string name="multimedia_editor_png_paste_error">Error converting clipboard image to png: %s</string>
     <string name="multimedia_editor_attach_mm_content" comment="used for screen readers. Not visible to the user">Attach multimedia content to the %1$s field</string>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Render SVG instead of showing a warning text.

Blocked by
* #17014

## Fixes
* Fixes #17029

## Approach
Use a webview to render an SVG in it

## How Has This Been Tested?
Tested on OnePlus Nord CE:
![image](https://github.com/user-attachments/assets/567753ef-e5e9-44b1-8b8b-6c6055c3e819)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
