### PR TITLE
fix: Single review activity instance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2196,6 +2196,7 @@ open class DeckPicker :
                 Intent(context, Reviewer::class.java)
                     .setAction(Intent.ACTION_VIEW)
                     .putExtra("deckId", did)
+                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
             )
             .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
             .setShortLabel(Decks.basename(getColUnsafe.decks.name(did)))

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -120,6 +120,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
                         val intent = Intent(context, Reviewer::class.java).apply {
                             action = Intent.ACTION_VIEW
                             putExtra("deckId", deck.deckId)
+                            addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
                         }
                         val pendingIntent = PendingIntent.getActivity(
                             context,


### PR DESCRIPTION
## Fixes
* Fixes #16956

## Purpose / Description
This fixes the issue where the error message "Not at top of the queue" appears when a review is in progress and the user opens another deck through the deck picker widget or a deck shortcut. The message appears when attempting to review a card after using the back button on the first deck which takes the user to a deck 'underneath' it. There should not be multiple review activity instances and so restricting there to be only a single review instance on the activity stack removes the possiblity of the "Not at top of the queue" error message occuring.

[Intent.FLAG_ACTIVITY_CLEAR_TOP docs:](https://developer.android.com/reference/android/content/Intent#FLAG_ACTIVITY_CLEAR_TOP)

> If set, and the activity being launched is already running in the current task, then instead of launching a new instance of that activity, all of the other activities on top of it will be closed and this Intent will be delivered to the (now on top) old activity as a new Intent.
> 
> For example, consider a task consisting of the activities: A, B, C, D. If D calls startActivity() with an Intent that resolves to the component of activity B, then C and D will be finished and B receive the given Intent, resulting in the stack now being: A, B.
> 

[deck-shortcut-single-activity.webm](https://github.com/user-attachments/assets/8f7683c0-9eb6-4005-beeb-9807e1e5d55e)