### PR TITLE
Refactored `DeckPickerWidget` to handle empty state visibility.

### DIFF
--- a/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
+++ b/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
@@ -17,7 +17,7 @@
         android:layout_marginStart="7dp"
         android:gravity="center"
         android:padding="30dp"
-        android:text="@string/empty_widget"
+        android:text="@string/empty_widget_state"
         android:visibility="gone" />/>
 
     <LinearLayout

--- a/AnkiDroid/src/main/res/layout/widget_deck_picker_large.xml
+++ b/AnkiDroid/src/main/res/layout/widget_deck_picker_large.xml
@@ -8,6 +8,17 @@
     android:focusable="false"
     android:theme="@style/Theme.Material3.DynamicColors.DayNight">
 
+    <TextView
+        android:id="@+id/empty_widget"
+        style="@style/TextAppearance.AppCompat.Medium"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="7dp"
+        android:gravity="center"
+        android:padding="20dp"
+        android:text="@string/empty_widget"
+        android:visibility="gone" />
+
     <LinearLayout
         android:id="@+id/deckCollection"
         android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/widget_deck_picker_large.xml
+++ b/AnkiDroid/src/main/res/layout/widget_deck_picker_large.xml
@@ -13,10 +13,11 @@
         style="@style/TextAppearance.AppCompat.Medium"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="7dp"
+        android:layout_marginStart="8dp"
         android:gravity="center"
+        android:layout_centerInParent="true"
         android:padding="20dp"
-        android:text="@string/empty_widget"
+        android:text="@string/empty_widget_state"
         android:visibility="gone" />
 
     <LinearLayout

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -51,6 +51,7 @@
         <item quantity="one">You can select up to %d deck.</item>
         <item quantity="other">You can select up to %d decks.</item>
     </plurals>
-    <string name="empty_widget" comment="To denote the widget is empty">Missing deck. Please reconfigure</string>
+    <string name="empty_widget_state" comment="To denote the widget is empty">Missing deck. Tap to reconfigure.</string>
+    <string name="empty_collection_state_in_widget" comment="To denote the collection is empty">Collection is empty, use app to add decks then reconfigure</string>"
 
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Handle empty state visibility, allowing users to reconfigure the widget by clicking the empty state message in the Deck Picker Widget.

## Approach
Handled similar to that Card Analysis Widget.

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/9abd501a-694d-44fd-b537-fec8c3d49c0a)


https://github.com/user-attachments/assets/862c78ec-868c-4831-8272-0f5d6a492ffe




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
