### PR TITLE
docs(bug-report): improve link to issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -9,7 +9,7 @@ body:
     id: contact
     attributes:
       label: Checked for duplicates?
-      description: Quickly search our [open issues](https://github.com/ankidroid/Anki-Android/issues) to see if a similar issue exists
+      description: Quickly search our [issues](https://github.com/ankidroid/Anki-Android/issues?q=is%3Aissue) to see if a similar issue exists
       options:
         - label: This issue is not a duplicate
           required: true


### PR DESCRIPTION
A user only searched open issues
We also want them to check the closed issues

See comment:

* https://github.com/ankidroid/Anki-Android/issues/17040#issuecomment-2336790319

Sample link: https://github.com/ankidroid/Anki-Android/issues?q=is%3Aissue