### PR TITLE
Solves a few little issues with tooltip

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -964,7 +964,7 @@ open class CardBrowser :
                 }
             })
             searchView = (searchItem!!.actionView as CardBrowserSearchView).apply {
-                queryHint = resources.getString(R.string.deck_conf_cram_search)
+                queryHint = resources.getString(R.string.card_browser_search_hint)
                 setMaxWidth(Integer.MAX_VALUE)
                 setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                     override fun onQueryTextChange(newText: String): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -968,7 +968,7 @@ open class CardBrowser :
                 setMaxWidth(Integer.MAX_VALUE)
                 setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                     override fun onQueryTextChange(newText: String): Boolean {
-                        if (this@apply.shouldIgnoreValueChange()) {
+                        if (this@apply.ignoreValueChange) {
                             return true
                         }
                         viewModel.updateQueryText(newText)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -957,9 +957,7 @@ open class DeckPicker :
             SyncIconState.OneWay -> R.string.sync_menu_title_one_way_sync
             SyncIconState.NotLoggedIn -> R.string.sync_menu_title_no_account
         }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            provider.setTooltipText(getString(tooltipText))
-        }
+        provider.setTooltipText(getString(tooltipText))
         when (state.syncIcon) {
             SyncIconState.Normal -> {
                 BadgeDrawableBuilder.removeBadge(provider)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -165,6 +165,7 @@ import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.DeckNode
 import com.ichi2.libanki.undoableOp
 import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.ui.BadgeDrawableBuilder
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ClipboardUtil.IMPORT_MIME_TYPES
@@ -322,7 +323,7 @@ open class DeckPicker :
     var importColpkgListener: ImportColpkgListener? = null
 
     private var toolbarSearchItem: MenuItem? = null
-    private var toolbarSearchView: SearchView? = null
+    private var toolbarSearchView: AccessibleSearchView? = null
     private lateinit var customStudyDialogFactory: CustomStudyDialogFactory
 
     override val permissionScreenLauncher = recreateActivityResultLauncher()
@@ -823,7 +824,7 @@ open class DeckPicker :
         menu.findItem(R.id.deck_picker_action_filter)?.let {
             toolbarSearchItem = it
             setupSearchIcon(it)
-            toolbarSearchView = it.actionView as SearchView
+            toolbarSearchView = it.actionView as AccessibleSearchView
         }
         toolbarSearchView?.maxWidth = Integer.MAX_VALUE
 
@@ -894,7 +895,7 @@ open class DeckPicker :
             }
         })
 
-        (menuItem.actionView as SearchView).run {
+        (menuItem.actionView as AccessibleSearchView).run {
             queryHint = getString(R.string.search_decks)
             setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                 override fun onQueryTextSubmit(query: String): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -62,7 +62,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.PopupMenu
-import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
@@ -137,6 +136,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
+import com.ichi2.compat.setTooltipTextCompat
 import com.ichi2.imagecropper.ImageCropper
 import com.ichi2.imagecropper.ImageCropper.Companion.CROP_IMAGE_RESULT
 import com.ichi2.imagecropper.ImageCropperLauncher
@@ -2198,7 +2198,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         val button = toolbar.insertItem(0, drawable) { insertCloze(type) }.apply {
             contentDescription = description
         }
-        TooltipCompat.setTooltipText(button, description)
+        button.setTooltipTextCompat(description)
     }
 
     private fun updateToolbar() {
@@ -2258,7 +2258,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         drawable!!.setTint(MaterialColors.getColor(requireContext(), R.attr.toolbarIconColor, 0))
         val addButton = toolbar.insertItem(0, drawable) { displayAddToolbarDialog() }
         addButton.contentDescription = resources.getString(R.string.add_toolbar_item)
-        TooltipCompat.setTooltipText(addButton, resources.getString(R.string.add_toolbar_item))
+        addButton.setTooltipTextCompat(resources.getString(R.string.add_toolbar_item))
     }
 
     private val toolbarButtons: ArrayList<CustomToolbarButton>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -34,6 +34,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.ui.AccessibleSearchView
 import timber.log.Timber
 import java.io.Serializable
 
@@ -217,7 +218,7 @@ class SharedDecksActivity : AnkiActivity() {
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.download_shared_decks_menu, menu)
 
-        val searchView = menu.findItem(R.id.search)?.actionView as SearchView
+        val searchView = menu.findItem(R.id.search)?.actionView as AccessibleSearchView
         searchView.queryHint = getString(R.string.search_using_deck_name)
         searchView.setMaxWidth(Integer.MAX_VALUE)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SyncActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SyncActionProvider.kt
@@ -18,14 +18,13 @@ package com.ichi2.anki
 import android.app.Activity
 import android.content.Context
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
-import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.view.isVisible
 import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.ichi2.compat.setTooltipTextCompat
 import com.ichi2.ui.RtlCompliantActionProvider.Companion.unwrapContext
 
 class SyncActionProvider(context: Context) : ActionProviderCompat(context) {
@@ -60,8 +59,7 @@ class SyncActionProvider(context: Context) : ActionProviderCompat(context) {
         return view
     }
 
-    @RequiresApi(Build.VERSION_CODES.O)
     fun setTooltipText(value: CharSequence) {
-        syncButton?.tooltipText = value
+        syncButton?.setTooltipTextCompat(value)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -50,6 +50,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
 import com.ichi2.libanki.sched.DeckNode
+import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.TypedFilter
 import com.ichi2.utils.create
@@ -159,7 +160,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         toolbar.title = title
         toolbar.inflateMenu(R.menu.deck_picker_dialog_menu)
         val searchItem = toolbar.menu.findItem(R.id.deck_picker_dialog_action_filter)
-        val searchView = searchItem.actionView as SearchView
+        val searchView = searchItem.actionView as AccessibleSearchView
         searchView.queryHint = getString(R.string.deck_picker_dialog_filter_decks)
         searchView.setOnQueryTextListener(object : SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -33,6 +33,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.LocaleSelectionDialog.LocaleListAdapter.TextViewHolder
+import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.ui.RecyclerSingleTouchAdapter
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TypedFilter
@@ -98,7 +99,7 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
         tagsDialogView.findViewById<Toolbar>(R.id.locale_dialog_selection_toolbar).apply {
             inflateMenu(R.menu.locale_dialog_search_bar)
             setNavigationOnClickListener { dialogHandler!!.onLocaleSelectionCancelled() }
-            (menu.findItem(R.id.locale_dialog_action_search).actionView as SearchView).apply {
+            (menu.findItem(R.id.locale_dialog_action_search).actionView as AccessibleSearchView).apply {
                 imeOptions = EditorInfo.IME_ACTION_DONE
                 setOnQueryTextListener(object : SearchView.OnQueryTextListener {
                     override fun onQueryTextSubmit(query: String): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.annotations.NeedsTest
+import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.TagsUtil
 import com.ichi2.utils.customView
@@ -76,7 +77,7 @@ class TagsDialog : AnalyticsDialogFragment {
     private var positiveText: String? = null
     private var dialogTitle: String? = null
     private var tagsArrayAdapter: TagsArrayAdapter? = null
-    private var toolbarSearchView: SearchView? = null
+    private var toolbarSearchView: AccessibleSearchView? = null
     private var toolbarSearchItem: MenuItem? = null
     private var noTagsTextView: TextView? = null
     private var tagsListRecyclerView: RecyclerView? = null
@@ -254,7 +255,7 @@ class TagsDialog : AnalyticsDialogFragment {
         }
         toolbarSearchItem = toolbar.menu.findItem(R.id.tags_dialog_action_filter)
         val toolbarSearchItem: MenuItem? = toolbarSearchItem
-        toolbarSearchView = toolbarSearchItem?.actionView as SearchView
+        toolbarSearchView = toolbarSearchItem?.actionView as AccessibleSearchView
         val queryET = toolbarSearchView!!.findViewById<EditText>(com.google.android.material.R.id.search_src_text)
         queryET.filters = arrayOf(addTagFilter)
         toolbarSearchView!!.queryHint = getString(R.string.filter_tags)
@@ -343,7 +344,7 @@ class TagsDialog : AnalyticsDialogFragment {
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    internal fun getSearchView(): SearchView? {
+    internal fun getSearchView(): AccessibleSearchView? {
         return toolbarSearchView
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -43,6 +43,7 @@ import com.ichi2.libanki.getNotetypeNameIdUseCount
 import com.ichi2.libanki.getNotetypeNames
 import com.ichi2.libanki.removeNotetype
 import com.ichi2.libanki.updateNotetype
+import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.getInputField
 import com.ichi2.utils.input
 import com.ichi2.utils.message
@@ -104,7 +105,7 @@ class ManageNotetypes : AnkiActivity() {
 
         val searchItem = menu.findItem(R.id.search_item)
         val searchManager = getSystemService(Context.SEARCH_SERVICE) as SearchManager
-        val searchView = searchItem?.actionView as? SearchView
+        val searchView = searchItem?.actionView as? AccessibleSearchView
         searchView?.maxWidth = Integer.MAX_VALUE
         searchView?.setSearchableInfo(searchManager.getSearchableInfo(componentName))
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatHelper.kt
@@ -29,6 +29,8 @@ import android.os.Bundle
 import android.view.KeyCharacterMap.deviceHasKey
 import android.view.KeyEvent.KEYCODE_PAGE_DOWN
 import android.view.KeyEvent.KEYCODE_PAGE_UP
+import android.view.View
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.content.ContextCompat
 import com.ichi2.compat.CompatHelper.Companion.compat
 import java.io.Serializable
@@ -195,3 +197,18 @@ class CompatHelper private constructor() {
             ContextCompat.registerReceiver(this, receiver, filter, flags)
     }
 }
+
+/**
+ * Sets the tooltip text for the view.
+ *
+ * On API 26 and later, this method calls through to {@link View#setTooltipText(CharSequence)}.
+ *
+ * Prior to API 26, this method sets or clears (when tooltipText is {@code null}) the view's
+ * {@code OnLongClickListener} and {@code OnHoverListener}. A tooltip-like sub-panel will be
+ * created on long-click or mouse hover.
+ *
+ * @receiver the view on which to set the tooltip text
+ * @param tooltipText the tooltip text
+ */
+fun View.setTooltipTextCompat(tooltipText: CharSequence?) =
+    TooltipCompat.setTooltipText(this, tooltipText)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AccessibleSearchView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AccessibleSearchView.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2024 Arthur Milchior <Arthur@Milchior.fr>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -18,38 +18,24 @@ package com.ichi2.ui
 
 import android.content.Context
 import android.util.AttributeSet
+import android.widget.ImageView
+import com.ichi2.anki.R
+import com.ichi2.compat.setTooltipTextCompat
 
-class CardBrowserSearchView : AccessibleSearchView {
+/**
+ * Same as androidx's SearchView, with an extra tooltip.
+ * Use this class instead of [androidx.appcompat.widget.SearchView].
+ * @see androidx.appcompat.widget.SearchView
+ */
+open class AccessibleSearchView : androidx.appcompat.widget.SearchView {
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-
-    /** Whether an action to set text should be ignored  */
-    var ignoreValueChange = false
-        private set
-
-    override fun onActionViewCollapsed() {
-        try {
-            ignoreValueChange = true
-            super.onActionViewCollapsed()
-        } finally {
-            ignoreValueChange = false
-        }
+    init {
+        // close_btn is the cross that deletes the search field content. It does not close the search view.
+        findViewById<ImageView>(androidx.appcompat.R.id.search_close_btn)
+            ?.setTooltipTextCompat(context.getString(R.string.discard))
     }
-
-    override fun onActionViewExpanded() {
-        try {
-            ignoreValueChange = true
-            super.onActionViewExpanded()
-        } finally {
-            ignoreValueChange = false
-        }
-    }
-
-    override fun setQuery(query: CharSequence, submit: Boolean) {
-        if (ignoreValueChange) {
-            return
-        }
-        super.setQuery(query, submit)
-    }
+    // SearchView contains four buttons. The three others seems never to appear in ankidroid.
+    // there is also an arrow to the trailing side, that should get a tooltip. Alas, I fail to see the id of this button, so I can't add it.
 }

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CardBrowserSearchView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CardBrowserSearchView.kt
@@ -26,12 +26,8 @@ class CardBrowserSearchView : SearchView {
     constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
     /** Whether an action to set text should be ignored  */
-    private var ignoreValueChange = false
-
-    /** Whether an action to set text should be ignored  */
-    fun shouldIgnoreValueChange(): Boolean {
-        return ignoreValueChange
-    }
+    var ignoreValueChange = false
+        private set
 
     override fun onActionViewCollapsed() {
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -19,8 +19,8 @@ import android.view.MenuItem
 import android.view.View
 import android.widget.ImageButton
 import androidx.annotation.VisibleForTesting
-import androidx.appcompat.widget.TooltipCompat
 import com.ichi2.anki.ActionProviderCompat
+import com.ichi2.compat.setTooltipTextCompat
 
 /**
  * An Rtl version of a normal action view, where the drawable is mirrored
@@ -40,7 +40,7 @@ class RtlCompliantActionProvider(context: Context) : ActionProviderCompat(contex
 
     override fun onCreateActionView(forItem: MenuItem): View {
         val actionView = ImageButton(context, null, android.R.attr.actionButtonStyle)
-        TooltipCompat.setTooltipText(actionView, forItem.title)
+        actionView.setTooltipTextCompat(forItem.title)
         forItem.icon?.let {
             it.isAutoMirrored = true
             actionView.setImageDrawable(it)

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -7,7 +7,7 @@
         android:icon="@drawable/ic_search_white"
         android:title="@string/search_decks"
         android:visible="false"
-        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
     <group android:id="@+id/commonItems">
         <item

--- a/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
@@ -21,7 +21,7 @@
         android:id="@+id/deck_picker_dialog_action_filter"
         android:icon="@drawable/ic_search_white"
         android:title="@string/deck_picker_dialog_filter_decks"
-        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
     <item
         android:id="@+id/deck_picker_dialog_action_add_deck"

--- a/AnkiDroid/src/main/res/menu/download_shared_decks_menu.xml
+++ b/AnkiDroid/src/main/res/menu/download_shared_decks_menu.xml
@@ -13,5 +13,5 @@
         android:title="@string/search_for_download_deck"
         android:icon="@drawable/ic_search_white"
         app:showAsAction="ifRoom|collapseActionView"
-        app:actionViewClass="androidx.appcompat.widget.SearchView" />
+        app:actionViewClass="com.ichi2.ui.AccessibleSearchView" />
 </menu>

--- a/AnkiDroid/src/main/res/menu/locale_dialog_search_bar.xml
+++ b/AnkiDroid/src/main/res/menu/locale_dialog_search_bar.xml
@@ -22,7 +22,7 @@
         android:id="@+id/locale_dialog_action_search"
         android:title="@string/menu_search"
         android:icon="@drawable/ic_search_white"
-        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:actionViewClass="com.ichi2.ui.AccessibleSearchView"
         app:showAsAction="ifRoom|collapseActionView"
         />
 </menu>

--- a/AnkiDroid/src/main/res/menu/search.xml
+++ b/AnkiDroid/src/main/res/menu/search.xml
@@ -18,7 +18,7 @@
         android:id="@+id/search_item"
         android:title="@android:string/search_go"
         android:icon="@drawable/ic_search_white"
-        app:actionViewClass="androidx.appcompat.widget.SearchView"
+        app:actionViewClass="com.ichi2.ui.AccessibleSearchView"
         app:showAsAction="ifRoom|collapseActionView"
         />
 </menu>

--- a/AnkiDroid/src/main/res/menu/tags_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/tags_dialog_menu.xml
@@ -6,7 +6,7 @@
         android:id="@+id/tags_dialog_action_filter"
         android:icon="@drawable/ic_search_white"
         android:title="@string/filter_tags"
-        ankidroid:actionViewClass="androidx.appcompat.widget.SearchView"
+        ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
         ankidroid:showAsAction="always|collapseActionView"/>
 
     <item

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -53,6 +53,7 @@
     <string name="no_note_to_edit">No note to edit</string>
     <string name="card_browser_list_my_searches_remove_content">Delete “%1$s”?</string>
     <string name="card_browser_change_display_order">Change display order</string>
+    <string name="card_browser_search_hint" comment="Message displayed in the search text field in the card browser.">Search</string>
     <string name="card_browser_change_display_order_title">Choose display order</string>
     <string name="card_details_tags">Tags</string>
     <string-array name="card_browser_order_labels">

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -219,7 +219,7 @@
     <string name="deck_conf_general" maxLength="41" comment="Label of the submenu for the general options of new deck">General</string>
     <string name="deck_conf_reminders" maxLength="41">Reminders</string>
     <string name="deck_conf_cram_filter" maxLength="41">Filter</string>
-    <string name="deck_conf_cram_search" maxLength="41">Search</string>
+    <string name="deck_conf_cram_search" maxLength="41" comment = "Label of a text field that contains a search query. It is also used outside fo the card filtered deck menu.">Search</string>
     <string name="deck_conf_cram_limit" maxLength="41">Limit to</string>
     <string name="deck_conf_cram_order" maxLength="41">cards selected by</string>
     <string name="deck_conf_cram_reschedule"  maxLength="41" comment="Title of the box labelled by deck_conf_cram_reschedule_summ">Reschedule</string>


### PR DESCRIPTION
Fixed: #15308

The first commit clean some code, using TooltipCompats when possible, instead of checking the API version in code

The second does some more cleaning.

The third split a string in two strings, because it should not be the same in French, and probably not in other languages too. In English, the noun and the verb "search" are the same. Not in French at least.

The fourth add a "Discard" tooltip on the "x" button near the search view that discard the content of the search field.