### PR TITLE
fix filtered decks not appearing in browser deck selection dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -202,7 +202,7 @@ class DeckSpinnerSelection(
      * Displays a [DeckSelectionDialog]
      */
     suspend fun displayDeckSelectionDialog() {
-        val decks = fromCollection(includeFiltered = false).toMutableList()
+        val decks = fromCollection(includeFiltered = showFilteredDecks).toMutableList()
         if (showAllDecks) {
             decks.add(SelectableDeck(ALL_DECKS_ID, context.resources.getString(R.string.card_browser_all_decks)))
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Filtered decks did not appear in the browser

## Fixes
* Fixes filtered decks not appearing in the card browser deck selection dialog

## Approach

Respect the `showFilteredDecks` parameter that was removed in 7a65160e0e23e20080091a30abdd4c05fc610e06

## How Has This Been Tested?

In an Android 15 emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
