### PR TITLE
fix: export option dialog have text overlapping issue and last checkbox is not visible in landscope mode

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_export_options.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_export_options.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:padding="16dp">
@@ -29,20 +34,16 @@
             tools:text="Include media" />
     </LinearLayout>
 
-    <ScrollView
-        android:id="@+id/export_extras_apkg"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:fillViewport="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/decks_selected_barrier">
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:id="@+id/export_extras_apkg"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/decks_selected_barrier"
             android:orientation="vertical">
 
             <CheckBox
@@ -63,23 +64,18 @@
                 android:layout_height="wrap_content"
                 android:checked="true" />
         </LinearLayout>
-    </ScrollView>
 
-    <ScrollView
-        android:id="@+id/export_extras_notes"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:visibility="gone"
-        android:fillViewport="true"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/decks_selected_barrier">
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:id="@+id/export_extras_notes"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:visibility="gone"
+            android:orientation="vertical"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/decks_selected_barrier">
 
             <CheckBox
                 android:id="@+id/notes_include_html"
@@ -104,7 +100,6 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content" />
         </LinearLayout>
-    </ScrollView>
 
     <LinearLayout
         android:id="@+id/export_extras_cards"
@@ -182,3 +177,4 @@
             android:indeterminate="true" />
     </FrameLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
export option dialog have text overlapping issue and last checkbox is not visible in landscope mode

## Fixes
* Fixes #17060 

## Approach
make layout scrollview

## How Has This Been Tested?
physical android device

## Screenshot
![WhatsApp Image 2024-09-12 at 8 26 06 PM](https://github.com/user-attachments/assets/8f5277fb-dc29-4315-b99e-9aa85158c008)
![WhatsApp Image 2024-09-12 at 8 26 08 PM](https://github.com/user-attachments/assets/518ef18d-b411-4a21-ab73-5533a693cf77)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
