### PR TITLE
fix : [Bug] The layout of the Axis Picker screen is not displaying correctly in landscape mode

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
@@ -15,38 +15,49 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    android:layout_height="match_parent">
 
-
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/axis_picker_selected_axis"
-        app:layout_constraintDimensionRatio="w,1:1"
+    <LinearLayout
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:gravity="center"
-        android:textSize="24sp"
-        android:textAlignment="center"
-        android:text="@string/axis_picker_move_joystick"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
+        android:orientation="vertical"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="w,1:1"
+        app:layout_constraintWidth_max="320dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent">
 
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/axis_picker_selected_axis"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:focusable="true"
+            android:focusableInTouchMode="true"
+            android:text="@string/axis_picker_move_joystick"
+            android:textAlignment="center"
+            android:textSize="24sp" />
+
+    </LinearLayout>
 
     <ScrollView
         android:id="@+id/axis_picker_scrollview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone"
-        >
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
         <LinearLayout
             android:id="@+id/axis_picker_available_axes"
             android:layout_width="match_parent"
-            android:orientation="vertical"
-            android:layout_height="0dp"/>
+            android:layout_height="match_parent"
+            android:orientation="vertical" />
     </ScrollView>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The layout of the Axis Picker screen is not displaying correctly in landscape mode

## Fixes
* Fixes #17026 

## Approach

## How Has This Been Tested?
Physical android device

##Screenshot

![WhatsApp Image 2024-09-14 at 3 47 58 PM](https://github.com/user-attachments/assets/26086323-f6c3-40bb-92d7-1e2bc42e73eb)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
