### PR TITLE
Added multiselect delete in manageNotesType 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypeCallbacks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypeCallbacks.kt
@@ -1,0 +1,24 @@
+/****************************************************************************************
+ * Copyright (c) 2022 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.notetype
+
+interface ManageNoteTypeCallbacks {
+    fun enableMultiSelectMode()
+    fun addInToDeleteList(id: Long, position: Int)
+    fun isToDeleteListContains(id: Long): Boolean
+    fun removeIdFromToDeleteList(id: Long, position: Int)
+    fun toggleCheckBoxSelection(id: Long, position: Int)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/NotetypeAdapter.kt
@@ -20,6 +20,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.CheckBox
 import android.widget.TextView
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -46,6 +47,8 @@ internal class NotetypesAdapter(
     private val onShowFields: (ManageNoteTypeUiModel) -> Unit,
     private val onEditCards: (ManageNoteTypeUiModel) -> Unit,
     private val onRename: (ManageNoteTypeUiModel) -> Unit,
+    private val callback: ManageNoteTypeCallbacks,
+    private val getIsInMultiSelectMode: () -> Boolean,
     private val onDelete: (ManageNoteTypeUiModel) -> Unit
 ) : ListAdapter<ManageNoteTypeUiModel, NotetypeViewHolder>(notetypeNamesAndCountDiff) {
     private val layoutInflater = LayoutInflater.from(context)
@@ -56,6 +59,8 @@ internal class NotetypesAdapter(
             onDelete = onDelete,
             onRename = onRename,
             onEditCards = onEditCards,
+            callback = callback,
+            getIsInMultiSelectMode = getIsInMultiSelectMode,
             onShowFields = onShowFields
         )
     }
@@ -63,31 +68,61 @@ internal class NotetypesAdapter(
     override fun onBindViewHolder(holder: NotetypeViewHolder, position: Int) {
         holder.bind(getItem(position))
     }
+
+    override fun onBindViewHolder(holder: NotetypeViewHolder, position: Int, payloads: List<Any>) {
+        if (payloads.isEmpty()) {
+            onBindViewHolder(holder, position)
+        } else {
+            for (payload in payloads) {
+                when (payload) {
+                    "payload_checkbox_selection" -> {
+                        holder.setCheckBoxSelection(getItem(position))
+                    }
+                    "payload_checkbox_visibility" -> {
+                        holder.handleMultiselectMode(getItem(position))
+                    }
+                }
+            }
+        }
+    }
 }
 
 internal class NotetypeViewHolder(
     rowView: View,
-    onShowFields: (ManageNoteTypeUiModel) -> Unit,
+    private val onShowFields: (ManageNoteTypeUiModel) -> Unit,
+    private val callback: ManageNoteTypeCallbacks,
     onEditCards: (ManageNoteTypeUiModel) -> Unit,
     onRename: (ManageNoteTypeUiModel) -> Unit,
+    getIsInMultiSelectMode: () -> Boolean,
     onDelete: (ManageNoteTypeUiModel) -> Unit
 ) : RecyclerView.ViewHolder(rowView) {
     val name: TextView = rowView.findViewById(R.id.note_name)
-    val useCount: TextView = rowView.findViewById(R.id.note_use_count)
+    private val useCount: TextView = rowView.findViewById(R.id.note_use_count)
     private val btnDelete: Button = rowView.findViewById(R.id.note_delete)
     private val btnRename: Button = rowView.findViewById(R.id.note_rename)
     private val btnEditCards: Button = rowView.findViewById(R.id.note_edit_cards)
     private var mManageNoteTypeUiModel: ManageNoteTypeUiModel? = null
     private val resources = rowView.context.resources
+    private val isInMultiSelectMode = getIsInMultiSelectMode
+    private val selectedItemCheckbox: CheckBox = rowView.findViewById(R.id.selected_item_checkbox)
 
     init {
-        rowView.setOnClickListener { mManageNoteTypeUiModel?.let(onShowFields) }
         btnEditCards.setOnClickListener { mManageNoteTypeUiModel?.let(onEditCards) }
         btnDelete.setOnClickListener { mManageNoteTypeUiModel?.let(onDelete) }
         btnRename.setOnClickListener { mManageNoteTypeUiModel?.let(onRename) }
     }
 
     fun bind(manageNoteTypeUiModel: ManageNoteTypeUiModel) {
+        if (isInMultiSelectMode()) {
+            showCheckBox(selectedItemCheckbox)
+            itemView.setOnClickListener {
+                toggleCheckBoxSelection(manageNoteTypeUiModel.id, bindingAdapterPosition)
+            }
+        } else {
+            hideCheckBox(selectedItemCheckbox)
+            itemView.setOnClickListener { mManageNoteTypeUiModel?.let(onShowFields) }
+        }
+
         this.mManageNoteTypeUiModel = manageNoteTypeUiModel
         name.text = manageNoteTypeUiModel.name
         useCount.text = resources.getQuantityString(
@@ -95,5 +130,45 @@ internal class NotetypeViewHolder(
             manageNoteTypeUiModel.useCount,
             manageNoteTypeUiModel.useCount
         )
+        itemView.setOnLongClickListener {
+            if (!isInMultiSelectMode()) {
+                callback.enableMultiSelectMode()
+            }
+            callback.addInToDeleteList(manageNoteTypeUiModel.id, bindingAdapterPosition)
+            true
+        }
+    }
+
+    fun handleMultiselectMode(manageNoteTypeUiModel: ManageNoteTypeUiModel) {
+        if (isInMultiSelectMode()) {
+            applyMultiSelectMode(manageNoteTypeUiModel)
+        } else {
+            removeMultiSelectMode(manageNoteTypeUiModel)
+        }
+    }
+    fun setCheckBoxSelection(manageNoteTypeUiModel: ManageNoteTypeUiModel) {
+        val isSelectedToDelete = callback.isToDeleteListContains(manageNoteTypeUiModel.id)
+        selectedItemCheckbox.isChecked = isSelectedToDelete
+    }
+    private fun toggleCheckBoxSelection(id: Long, bindingAdapterPosition: Int) {
+        callback.toggleCheckBoxSelection(id, bindingAdapterPosition)
+    }
+
+    private fun removeMultiSelectMode(manageNoteTypeUiModel: ManageNoteTypeUiModel) {
+        hideCheckBox(selectedItemCheckbox)
+        callback.removeIdFromToDeleteList(manageNoteTypeUiModel.id, bindingAdapterPosition)
+        itemView.setOnClickListener { mManageNoteTypeUiModel?.let(onShowFields) }
+    }
+    private fun applyMultiSelectMode(manageNoteTypeUiModel: ManageNoteTypeUiModel) {
+        showCheckBox(selectedItemCheckbox)
+        itemView.setOnClickListener {
+            toggleCheckBoxSelection(manageNoteTypeUiModel.id, bindingAdapterPosition)
+        }
+    }
+    private fun hideCheckBox(checkBox: CheckBox) {
+        checkBox.visibility = View.GONE
+    }
+    private fun showCheckBox(checkBox: CheckBox) {
+        checkBox.visibility = View.VISIBLE
     }
 }

--- a/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
@@ -14,23 +14,41 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
+            android:orientation="horizontal"
             android:padding="16dp">
 
-            <TextView
-                android:id="@+id/note_name"
-                tools:text="Basic (and reversed card)"
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:orientation="vertical">
+
+                <TextView
+                    android:id="@+id/note_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?attr/textAppearanceHeadline6"
+                    tools:text="Basic (and reversed card)" />
+
+             <TextView
+                    android:id="@+id/note_use_count"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:textAppearance="?attr/textAppearanceBody2"
+                    android:textColor="?android:attr/textColorSecondary"
+                    tools:text="912 notes"/>
+            </LinearLayout>
+            <CheckBox
+                android:id="@+id/selected_item_checkbox"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textAppearance="?attr/textAppearanceHeadline6" />
-            <TextView
-                android:id="@+id/note_use_count"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="8dp"
-                android:textAppearance="?attr/textAppearanceBody2"
-                android:textColor="?android:attr/textColorSecondary"
-                tools:text="912 notes"/>
+                android:checked="false"
+                android:focusable="false"
+                android:focusableInTouchMode="false"
+                android:visibility="gone"
+                tools:visibility="visible" />
+
         </LinearLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout

--- a/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
+++ b/AnkiDroid/src/main/res/menu/menu_manage_notes.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context=".DeckPicker">
+    <item
+        android:id="@+id/action_delete_notes"
+        android:icon="@drawable/ic_delete_white"
+        android:title="@string/dialog_positive_delete"
+        android:visible="false"
+        ankidroid:showAsAction="always"/>
+</menu>


### PR DESCRIPTION

## Fixes
* Fixes #15885 


 
## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


Video

Working of Multiple selection and allowing to delete:
[Screencast from 2024-09-16 23-23-52.webm](https://github.com/user-attachments/assets/b9b97ffc-ee4b-468f-8840-92e93decf32a)



