### PR TITLE
partial fix for flaky test: `testLoadSavedPreferences`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -153,7 +153,7 @@ class CardAnalysisWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnac
             showDeckSelectionDialog()
         }
 
-        updateViewWithSavedPreferences()
+        lifecycleScope.launch { updateViewWithSavedPreferences() }
 
         // Update the visibility of the "no decks" placeholder and the widget configuration container
         updateViewVisibility()
@@ -234,16 +234,15 @@ class CardAnalysisWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnac
     }
 
     /** Updates the view according to the saved preference for appWidgetId.*/
-    fun updateViewWithSavedPreferences() {
+    suspend fun updateViewWithSavedPreferences() {
         val selectedDeckId = cardAnalysisWidgetPreferences.getSelectedDeckIdFromPreferences(appWidgetId) ?: return
-        lifecycleScope.launch {
-            val decks = fetchDecks()
-            val selectedDecks = decks.filter { it.deckId == selectedDeckId }
-            selectedDecks.forEach { deckAdapter.addDeck(it) }
-            updateViewVisibility()
-            updateFabVisibility()
-            updateSubmitButtonText()
-        }
+
+        val decks = fetchDecks()
+        val selectedDecks = decks.filter { it.deckId == selectedDeckId }
+        selectedDecks.forEach { deckAdapter.addDeck(it) }
+        updateViewVisibility()
+        updateFabVisibility()
+        updateSubmitButtonText()
     }
 
     /** Asynchronously displays the list of deck in the selection dialog. */

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -96,6 +96,7 @@ class CardAnalysisWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnac
         // Check if the collection is empty before proceeding and if the collection is empty, show a toast instead of the configuration view.
         lifecycleScope.launch {
             if (isCollectionEmpty()) {
+                Timber.w("Closing: Collection is empty")
                 showThemedToast(
                     this@CardAnalysisWidgetConfig,
                     R.string.app_not_initialized_new,

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -222,16 +222,14 @@ class CardAnalysisWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnac
 
     /** Updates the visibility of the FloatingActionButton based on the number of selected decks */
     private fun updateFabVisibility() {
-        lifecycleScope.launch {
-            // Directly check if there's exactly one deck selected
-            val selectedDeckCount = deckAdapter.itemCount
+        // Directly check if there's exactly one deck selected
+        val selectedDeckCount = deckAdapter.itemCount
 
-            // Find the FloatingActionButton by its ID
-            val fab = findViewById<FloatingActionButton>(R.id.fabWidgetDeckPicker)
+        // Find the FloatingActionButton by its ID
+        val fab = findViewById<FloatingActionButton>(R.id.fabWidgetDeckPicker)
 
-            // Make the FAB visible only if no deck is selected (allow adding one deck)
-            fab.isVisible = selectedDeckCount == 0
-        }
+        // Make the FAB visible only if no deck is selected (allow adding one deck)
+        fab.isVisible = selectedDeckCount == 0
     }
 
     /** Updates the view according to the saved preference for appWidgetId.*/

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -151,7 +151,7 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
             showDeckSelectionDialog()
         }
 
-        updateViewWithSavedPreferences()
+        lifecycleScope.launch { updateViewWithSavedPreferences() }
 
         // Update the visibility of the "no decks" placeholder and the widget configuration container
         updateViewVisibility()
@@ -282,17 +282,15 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
     }
 
     /** Updates the view according to the saved preference for appWidgetId.*/
-    fun updateViewWithSavedPreferences() {
+    suspend fun updateViewWithSavedPreferences() {
         val selectedDeckIds = deckPickerWidgetPreferences.getSelectedDeckIdsFromPreferences(appWidgetId)
         if (selectedDeckIds.isNotEmpty()) {
-            lifecycleScope.launch {
-                val decks = fetchDecks()
-                val selectedDecks = decks.filter { it.deckId in selectedDeckIds }
-                selectedDecks.forEach { deckAdapter.addDeck(it) }
-                updateViewVisibility()
-                updateFabVisibility()
-                setupDoneButton()
-            }
+            val decks = fetchDecks()
+            val selectedDecks = decks.filter { it.deckId in selectedDeckIds }
+            selectedDecks.forEach { deckAdapter.addDeck(it) }
+            updateViewVisibility()
+            updateFabVisibility()
+            setupDoneButton()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -100,6 +100,7 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
         // Check if the collection is empty before proceeding and if the collection is empty, show a toast instead of the configuration view.
         lifecycleScope.launch {
             if (isCollectionEmpty()) {
+                Timber.w("Closing: Collection is empty")
                 showThemedToast(
                     this@DeckPickerWidgetConfig,
                     R.string.app_not_initialized_new,

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -26,6 +26,7 @@ import android.os.Bundle
 import android.view.View
 import android.widget.Button
 import androidx.activity.OnBackPressedCallback
+import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
@@ -47,6 +48,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.widget.WidgetConfigScreenAdapter
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import timber.log.Timber
@@ -70,6 +72,10 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
     private var hasUnsavedChanges = false
     private var isAdapterObserverRegistered = false
     private lateinit var onBackPressedCallback: OnBackPressedCallback
+
+    /** Tracks coroutine running [initializeUIComponents]: must be run on a non-empty collection */
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    internal lateinit var initTask: Job
 
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
@@ -98,7 +104,7 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
         }
 
         // Check if the collection is empty before proceeding and if the collection is empty, show a toast instead of the configuration view.
-        lifecycleScope.launch {
+        this.initTask = lifecycleScope.launch {
             if (isCollectionEmpty()) {
                 Timber.w("Closing: Collection is empty")
                 showThemedToast(
@@ -125,7 +131,7 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
         showSnackbar(getString(messageResId))
     }
 
-    fun initializeUIComponents() {
+    private fun initializeUIComponents() {
         deckAdapter = WidgetConfigScreenAdapter { deck, position ->
             deckAdapter.removeDeck(deck.deckId)
             showSnackbar(R.string.deck_removed_from_widget)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
@@ -31,7 +31,6 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class CardAnalysisWidgetConfigTest : RobolectricTest() {
@@ -85,16 +84,13 @@ class CardAnalysisWidgetConfigTest : RobolectricTest() {
      * `RecyclerView` displays the correct number of items based on the saved preferences.
      */
     @Test
-    fun testLoadSavedPreferences() {
+    fun testLoadSavedPreferences() = runTest {
         // Save decks to preferences
         val deckId = 1L
         widgetPreferences.saveSelectedDeck(1, deckId)
 
         // Load preferences
         activity.updateViewWithSavedPreferences()
-
-        // Ensure all tasks on the UI thread are completed
-        Robolectric.flushForegroundThreadScheduler()
 
         // Get the RecyclerView and its adapter
         val recyclerView = activity.findViewById<RecyclerView>(R.id.recyclerViewSelectedDecks)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
@@ -28,7 +28,6 @@ import com.ichi2.widget.cardanalysis.CardAnalysisWidgetConfig
 import com.ichi2.widget.cardanalysis.CardAnalysisWidgetPreferences
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -53,20 +52,10 @@ class CardAnalysisWidgetConfigTest : RobolectricTest() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 1)
         }
 
-        activity = Robolectric.buildActivity(CardAnalysisWidgetConfig::class.java, intent)
-            .create()
-            .start()
-            .resume()
-            .get()
+        activity = startActivityNormallyOpenCollectionWithIntent(CardAnalysisWidgetConfig::class.java, intent)
 
         // Ensure deckAdapter is initialized
         activity.initializeUIComponents()
-    }
-
-    @After
-    override fun tearDown() {
-        super.tearDown()
-        activity.finish()
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/cardanalysis/CardAnalysisWidgetConfigTest.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.widget.cardanalysis.CardAnalysisWidgetConfig
 import com.ichi2.widget.cardanalysis.CardAnalysisWidgetPreferences
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Before
@@ -47,6 +48,8 @@ class CardAnalysisWidgetConfigTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
+        ensureNonEmptyCollection()
+
         val intent = Intent(targetContext, CardAnalysisWidgetConfig::class.java).apply {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 1)
         }
@@ -54,7 +57,7 @@ class CardAnalysisWidgetConfigTest : RobolectricTest() {
         activity = startActivityNormallyOpenCollectionWithIntent(CardAnalysisWidgetConfig::class.java, intent)
 
         // Ensure deckAdapter is initialized
-        activity.initializeUIComponents()
+        runBlocking { activity.initTask.join() }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
@@ -31,7 +31,6 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 
 @RunWith(AndroidJUnit4::class)
 class DeckPickerWidgetConfigTest : RobolectricTest() {
@@ -85,16 +84,13 @@ class DeckPickerWidgetConfigTest : RobolectricTest() {
      * `RecyclerView` displays the correct number of items based on the saved preferences.
      */
     @Test
-    fun testLoadSavedPreferences() {
+    fun testLoadSavedPreferences() = runTest {
         // Save decks to preferences
         val deckIds = listOf(1L)
         widgetPreferences.saveSelectedDecks(1, deckIds.map { it.toString() })
 
         // Load preferences
         activity.updateViewWithSavedPreferences()
-
-        // Ensure all tasks on the UI thread are completed
-        Robolectric.flushForegroundThreadScheduler()
 
         // Get the RecyclerView and its adapter
         val recyclerView = activity.findViewById<RecyclerView>(R.id.recyclerViewSelectedDecks)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
@@ -52,11 +52,7 @@ class DeckPickerWidgetConfigTest : RobolectricTest() {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 1)
         }
 
-        activity = Robolectric.buildActivity(DeckPickerWidgetConfig::class.java, intent)
-            .create()
-            .start()
-            .resume()
-            .get()
+        activity = startActivityNormallyOpenCollectionWithIntent(DeckPickerWidgetConfig::class.java, intent)
 
         // Ensure deckAdapter is initialized
         activity.initializeUIComponents()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/deckpicker/DeckPickerWidgetConfigTest.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.widget.deckpicker.DeckPickerWidgetConfig
 import com.ichi2.widget.deckpicker.DeckPickerWidgetPreferences
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Before
@@ -47,6 +48,8 @@ class DeckPickerWidgetConfigTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
+        ensureNonEmptyCollection()
+
         val intent = Intent(targetContext, DeckPickerWidgetConfig::class.java).apply {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, 1)
         }
@@ -54,7 +57,7 @@ class DeckPickerWidgetConfigTest : RobolectricTest() {
         activity = startActivityNormallyOpenCollectionWithIntent(DeckPickerWidgetConfig::class.java, intent)
 
         // Ensure deckAdapter is initialized
-        activity.initializeUIComponents()
+        runBlocking { activity.initTask.join() }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -18,6 +18,7 @@ package com.ichi2.testutils
 
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.ioDispatcher
+import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
@@ -142,6 +143,11 @@ interface TestClass {
         } catch (filteredAncestor: BackendDeckIsFilteredException) {
             throw RuntimeException(filteredAncestor)
         }
+    }
+
+    /** Ensures [isCollectionEmpty] returns `false` */
+    fun ensureNonEmptyCollection() {
+        addNotes(1)
     }
 
     fun selectDefaultDeck() {


### PR DESCRIPTION
## Fixes
* Fixes #17010

This may not completely fix the issue, there is still an 'uncompleted' task run inside `lifecycleScope`.

This may or may not be fixed by calling `finish()` on the activity (step 1)

EDIT: I ran 15x3 unit tests and none failed. marking the above issue as fixed

## Approach

1. Fix activity cleanup - didn't happen in `DeckPickerWidgetConfigTest`
2. Add logs
3. Wait for `updateViewWithSavedPreferences` properly, make it `suspend`
4. ensure the collection is set up before performing tests
  * `finish()` is no longer called 


## How Has This Been Tested?

Unit tested, ran the widgets in an emulator and they continued to function

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
