### PR TITLE
Menu handled by DeckPicker instead of StudyOptionsFragment

### DIFF
--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -2,6 +2,11 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <include layout="@layout/toolbar" />
         <LinearLayout
             android:id="@+id/deckpicker_xl_view"
             android:layout_width="match_parent"
@@ -18,5 +23,6 @@
                 android:layout_width="1dip"
                 android:layout_height="match_parent"/>
         </LinearLayout>
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -16,8 +16,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical" >
 
-        <include layout="@layout/toolbar" />
-
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/pull_to_sync_wrapper"
             android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -2,5 +2,11 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <include layout="@layout/deck_picker" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+        <include layout="@layout/toolbar" />
+        <include layout="@layout/deck_picker" />
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -1,15 +1,14 @@
 <menu xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
-    >
-    <item
-        android:id="@+id/deck_picker_action_filter"
-        android:icon="@drawable/ic_search_white"
-        android:title="@string/search_decks"
-        android:visible="false"
-        ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
-        ankidroid:showAsAction="always|collapseActionView"/>
-    <group android:id="@+id/commonItems">
+    tools:context=".DeckPicker">
+    <group android:id="@+id/allItems">
+        <item
+            android:id="@+id/deck_picker_action_filter"
+            android:icon="@drawable/ic_search_white"
+            android:title="@string/search_decks"
+            ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
+            ankidroid:showAsAction="always|collapseActionView"/>
         <item
             android:id="@+id/action_sync"
             android:icon="@drawable/ic_sync"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
DeckPicker should handle menu responsibility instead of StudyOptionsFramgment (Tablet)
I reverted some changes from PR #16425

* #16425

## Fixes
* Fixes #17077

## How Has This Been Tested?

Emulator

https://github.com/user-attachments/assets/33285b80-0687-4867-bd69-ab5b2a478028

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)