### PR TITLE
Upper case to "cards selected by"

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -221,7 +221,7 @@
     <string name="deck_conf_cram_filter" maxLength="41">Filter</string>
     <string name="deck_conf_cram_search" maxLength="41" comment = "Label of a text field that contains a search query. It is also used outside fo the card filtered deck menu.">Search</string>
     <string name="deck_conf_cram_limit" maxLength="41">Limit to</string>
-    <string name="deck_conf_cram_order" maxLength="41">cards selected by</string>
+    <string name="deck_conf_cram_order" maxLength="41">Cards selected by</string>
     <string name="deck_conf_cram_reschedule"  maxLength="41" comment="Title of the box labelled by deck_conf_cram_reschedule_summ">Reschedule</string>
     <string name="deck_conf_cram_reschedule_summ">Reschedule cards based on my answers in this deck</string>
     <string name="deck_conf_cram_filter_2_check">Enable second filter</string>


### PR DESCRIPTION
The way the menu looked was wrong. With all options with upper case except for the title.
![Screenshot_20240921_192722](https://github.com/user-attachments/assets/bd54ba3b-4be6-46be-97c3-1fe6aa88649b)
