### PR TITLE
Clarify the reviewer window title

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -43,8 +43,8 @@
         <item quantity="other">%1$d hours %2$d left</item>
     </plurals>
     <plurals name="reviewer_window_title_days_new">
-        <item quantity="one">%1$d day %2$d left</item>
-        <item quantity="other">%1$d days %2$d left</item>
+        <item quantity="one">%1$d day %2$dh left</item>
+        <item quantity="other">%1$d days %2$dh left</item>
     </plurals>
     <string name="no_cards_placeholder_title">Collection is empty</string>
     <string name="no_cards_placeholder_description">Start adding cards\nusing the + icon.</string>


### PR DESCRIPTION
"1 day 2" seems really strange to me. "1 day 2 hours" would be too long for most smartphone. But "1 day 2h" seems reasonable to me

Also, "plural" does not allow for two parameters, and it would have been complex to consider both words if they are singular or plural.

Regarding "1 hour 5" I preferred to not change it. "1 hour 5 min" woud add far too many character. "1 hour 5m" sounds strange. And stating "1 hour 5" is far more standard than "1 day 5".

It seems I was the one who introduced this string in 2020. I have no idea why I had not put the "h" at the time. And I can't easily find the PR to see whether it was discussed at the time