### PR TITLE
Remove minSdk pin workaround

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -89,11 +89,6 @@ android {
         versionName="2.19beta2"
         minSdk libs.versions.minSdk.get().toInteger()
 
-        // Stays until this is in a release: https://github.com/google/desugar_jdk_libs/commit/c01a5446ca13586b801dbba4d83c6821337b3cc2
-        if (testReleaseBuild && minSdk < 24) {
-            minSdk 24
-        }
-
         // After #13695: change .tests_emulator.yml
         targetSdk libs.versions.targetSdk.get().toInteger()
         testApplicationId "com.ichi2.anki.tests"

--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -25,3 +25,5 @@
 # Ignore unused packages
 -dontwarn javax.naming.**
 -dontwarn org.ietf.jgss.**
+
+-keep class kotlin.Metadata


### PR DESCRIPTION
Problem fixed after desugar_jdk_libs_nio was updated to version 2.1.0.
https://github.com/ankidroid/Anki-Android/pull/16968
https://github.com/google/desugar_jdk_libs/commit/c7dbf2c920a29db82ebf363255265cde2ccabb5d