### PR TITLE
NF: remove "Delete card" string

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1085,17 +1085,10 @@ open class CardBrowser :
             }
         }
         actionBarMenu.findItem(R.id.action_delete_card).apply {
-            this.title = if (viewModel.cardsOrNotes == CARDS) {
-                resources.getQuantityString(
-                    R.plurals.card_browser_delete_cards,
-                    viewModel.selectedRowCount()
-                )
-            } else {
-                resources.getQuantityString(
-                    R.plurals.card_browser_delete_notes,
-                    viewModel.selectedRowCount()
-                )
-            }
+            this.title = resources.getQuantityString(
+                R.plurals.card_browser_delete_notes,
+                viewModel.selectedNoteCount()
+            )
         }
         actionBarMenu.findItem(R.id.action_select_all).isVisible = !hasSelectedAllCards()
         // Note: Theoretically should not happen, as this should kick us back to the menu

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -462,6 +462,13 @@ class CardBrowserViewModel(
 
     fun selectedRowCount(): Int = selectedRows.size
 
+    fun selectedNoteCount() = if (cardsOrNotes == NOTES) {
+        selectedRowCount()
+    } else {
+        // Selected cards should still be loaded, so this should be doable without any database access to reload card.
+        selectedRows.map { it.card.nid }.toSet().size
+    }
+
     suspend fun changeCardOrder(which: SortType): Job? {
         val changeType = when {
             which != order -> ChangeCardOrder.OrderChange(which)

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -30,10 +30,6 @@
     </plurals>
 
     <string name="card_browser_all_decks">All decks</string>
-    <plurals name="card_browser_delete_cards">
-        <item quantity="one">Delete card</item>
-        <item quantity="other">Delete cards</item>
-    </plurals>
     <plurals name="card_browser_delete_notes">
         <item quantity="one">Delete note</item>
         <item quantity="other">Delete notes</item>


### PR DESCRIPTION
This string is misleading, and I'd even state, dangerous. A card can't be removed. That's a question users often ask, how to delete a single card. We must NOTE make them believe this is possible.

Using this, if they want to delete a card, they'll end up deleting the note instead and losing data.

Admittedly, this is not perfect, as the user selected card and not notes. So it should be "Delete card's note" or "Delete cards' notes" but that's too long.