### PR TITLE
Fix notetype field not being used as sort field

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ModelFieldEditor.kt
@@ -434,6 +434,7 @@ class ModelFieldEditor : AnkiActivity(), LocaleSelectionDialogHandler {
             withCol {
                 Timber.d("doInBackgroundChangeSortField")
                 notetypes.setSortIndex(notetype, idx)
+                notetypes.save(notetype)
             }
         }
         initialize()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added missing call to save() to register the change in sort field.

## Fixes
* Fixes #16649

## How Has This Been Tested?

Ran the tests, manually checked the behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
