### PR TITLE
Fix IllegalStateException being thrown in multipanel CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -203,12 +203,11 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 tags = note.tags,
                 fillEmpty = true
             )
-            val fragment = TemplatePreviewerFragment.newInstance(args)
+            val backgroundColor = ThemeUtils.getThemeAttrColor(this@CardTemplateEditor, R.attr.alternativeBackgroundColor)
+            val fragment = TemplatePreviewerFragment.newInstance(args, backgroundColor)
             supportFragmentManager.commitNow {
                 replace(R.id.fragment_container, fragment)
             }
-            val backgroundColor = ThemeUtils.getThemeAttrColor(this@CardTemplateEditor, R.attr.alternativeBackgroundColor)
-            fragment.requireView().setBackgroundColor(backgroundColor)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.utils.ext.sharedPrefs
+import com.ichi2.utils.BundleUtils.getNullableInt
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -65,14 +66,28 @@ class TemplatePreviewerFragment :
         if (sharedPrefs().getBoolean("safeDisplay", false)) {
             view.findViewById<MaterialCardView>(R.id.webview_container).elevation = 0F
         }
+
+        arguments?.getNullableInt(ARG_BACKGROUND_OVERRIDE_COLOR)?.let { color ->
+            view.setBackgroundColor(color)
+        }
     }
 
     companion object {
         const val ARGS_KEY = "templatePreviewerArgs"
+        private const val ARG_BACKGROUND_OVERRIDE_COLOR = "arg_background_override_color"
 
-        fun newInstance(arguments: TemplatePreviewerArguments): TemplatePreviewerFragment {
+        /**
+         * @param backgroundOverrideColor optional color to be used as background on the root view
+         * of this fragment
+         */
+        fun newInstance(
+            arguments: TemplatePreviewerArguments,
+            backgroundOverrideColor: Int? = null
+        ): TemplatePreviewerFragment {
             return TemplatePreviewerFragment().apply {
-                this.arguments = bundleOf(ARGS_KEY to arguments)
+                val args = bundleOf(ARGS_KEY to arguments)
+                backgroundOverrideColor?.let { args.putInt(ARG_BACKGROUND_OVERRIDE_COLOR, backgroundOverrideColor) }
+                this.arguments = args
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -49,4 +49,19 @@ object BundleUtils {
         }
         return getLong(key)
     }
+
+    /**
+     * Retrieves a [Int] value from a [Bundle] using a key, returns null if not found
+     *
+     * can be null to support nullable bundles like [androidx.fragment.app.Fragment.getArguments]
+     * @param key the key to use
+     * @return the int value, or null if not found
+     */
+    fun Bundle.getNullableInt(key: String): Int? {
+        return if (!containsKey(key)) {
+            null
+        } else {
+            getInt(key)
+        }
+    }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This PR fixes the following bug:

_Have the emulator in an orientation that would result in a multi panel layout in CardTemplateEditor_ -> _Go to Manage notetypes screen_ -> _Click on **Edit cards** option for one of the notetypes_ -> _CardTemplateEditor is opened and a dialog is showing an IllegalStateException + there's a visual glitch(background color) for the previewer on the right part_

The fix consists of passing a background override color when creating the TemplatePreviewerFragment and then having the fragment set the background itself in one of its lifecycle methods were the view is surely available. I didn't add this color to the arguments already passed in as I didn't really consider it a part of the required data.

For consistency I also added a new helper method in BundleUtils similar to the one we already have, getNullableLong(copy pasted, just changed the type to Int).

Current behavior:

![failed_background](https://github.com/user-attachments/assets/fb214933-4011-477c-8b72-ea055e15476b)

With the code in this PR:

![success _background](https://github.com/user-attachments/assets/4f544bf7-917a-48e8-9ad6-67b2e99560f1)



## How Has This Been Tested?

Ran the tests, manually checked the steps that were triggering the bug.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
