### PR TITLE
Enable searching for backups related settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -125,6 +125,8 @@ class HeaderFragment : PreferenceFragmentCompat() {
                     .addBreadcrumb(R.string.pref_cat_appearance)
                 index(R.xml.preferences_controls)
                 index(R.xml.preferences_accessibility)
+                index(R.xml.preferences_backup_limits)
+                ignorePreference(activity.getString(R.string.pref_backups_help_key))
             }
 
             // Some preferences and categories are only shown conditionally,

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -191,6 +191,7 @@
     <string name="about_screen_key">aboutScreen</string>
 
     <!-- Backup limits -->
+    <string name="pref_backups_screen_key">backupsScreen</string>
     <string name="pref_backups_help_key">backups_help</string>
     <string name="pref_minutes_between_automatic_backups_key">minutes_between_automatic_backups</string>
     <string name="pref_daily_backups_to_keep_key">daily_backups_to_keep</string>

--- a/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
@@ -2,7 +2,8 @@
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-    android:title="@string/button_backup">
+    android:title="@string/button_backup"
+    android:key="@string/pref_backups_screen_key">
     <!-- Includes modified text from `TR.preferencesBackupExplanation()`
          and `TR.preferencesNoteMediaIsNotBackedUp()`. -->
     <com.ichi2.preferences.HtmlHelpPreference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -49,6 +49,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
         "customSyncServerScreen",
         "appBarButtonsScreen",
         "pref_screen_advanced",
+        "backupsScreen",
         "backups_help",
         // Categories: don't have a value
         "appearance_preference_group",


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

I didn't make the backups settings searchable when I created them. Added the proper calls for our SearchConfiguration. One of the backups setting that was used purely as a helper text was removed from the search results.

## Fixes
* Fixes #17123

## How Has This Been Tested?

Search settings for the term "backup".

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
