### PR TITLE
Fix android studio warnings - AdvancedSettingsFragment.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -125,7 +125,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
 
     private fun removeUnnecessaryAdvancedPrefs() {
         /** These preferences should be searchable or not based
-         * on this same condition at [Preferences.configureSearchBar] */
+         * on this same condition at [HeaderFragment.configureSearchBar] */
         // Disable the double scroll preference if no scrolling keys
         if (!CompatHelper.hasScrollKeys()) {
             val doubleScrolling = findPreference<SwitchPreferenceCompat>("double_scrolling")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Reducing the amount of warnings given within android studio.

## Fixes
Contributes towards #13282 `[Cleanup]: Fix Android Studio Warnings`

## Approach
There was a broken reference in one of the comments. The configureSearchBar function had previously been moved from the HeaderFragment class to the Preferences class, but recently it was moved back and the comments describing it had not been updated.

## How Has This Been Tested?

Only comments have been changed so testing does not apply.

## Learning (optional, can help others)

I looked back in previous commits to see when that comment came to be, and investigated where the broken reference was meant to be pointing to.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
