### PR TITLE
fix(deck-download): handle "Daily limit exceeded; please try again tomorrow." correctly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -122,7 +122,7 @@ class SharedDecksActivity : AnkiActivity() {
         ) {
             super.onReceivedHttpError(view, request, errorResponse)
 
-            if (errorResponse?.statusCode != 429) return
+            if (errorResponse?.statusCode != HTTP_STATUS_TOO_MANY_REQUESTS) return
 
             // If a user is logged in, they see: "Daily limit exceeded; please try again tomorrow."
             // We have nothing we can do here
@@ -131,22 +131,7 @@ class SharedDecksActivity : AnkiActivity() {
             // The following cases are handled below:
             // "Please log in to download more decks." - on clicking "Download"
             // "Please log in to perform more searches" - on searching
-
-            // TODO: the result of login is typically redirecting the user to their decks
-            // this should be improved
-
-            showSnackbar(R.string.shared_decks_login_required, LENGTH_INDEFINITE) {
-                if (isLoggedIn()) return@showSnackbar
-                setAction(R.string.sign_up) {
-                    webView.loadUrl(getString(R.string.shared_decks_sign_up_url))
-                }
-            }
-            if (redirectTimes++ < 3) {
-                Timber.i("HTTP 429, redirecting to login")
-                webView.loadUrl(getString(R.string.shared_decks_login_url))
-            } else {
-                Timber.w("HTTP 429 redirect limit exceeded, only displaying message")
-            }
+            redirectUserToSignUpOrLogin()
         }
 
         override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
@@ -154,11 +139,48 @@ class SharedDecksActivity : AnkiActivity() {
             shouldHistoryBeCleared = false
             super.onReceivedError(view, request, error)
         }
+
+        /**
+         * Redirects the user to a login page
+         *
+         * A message is shown informing the user they need to log in to download more decks
+         *
+         * If the user has not logged in **inside AnkiDroid** then the message provides
+         * the user with an action to sign up
+         *
+         * The redirect is not performed if [redirectTimes] is 3 or more
+         */
+        private fun redirectUserToSignUpOrLogin() {
+            // inform the user they need to log in as they've hit a rate limit
+            showSnackbar(R.string.shared_decks_login_required, LENGTH_INDEFINITE) {
+                if (isLoggedIn()) return@showSnackbar
+
+                // If a user is not logged in inside AnkiDroid, assume they have no AnkiWeb account
+                // and give them the option to sign up
+                setAction(R.string.sign_up) {
+                    webView.loadUrl(getString(R.string.shared_decks_sign_up_url))
+                }
+            }
+
+            // redirect user to /account/login
+            // TODO: the result of login is typically redirecting the user to their decks
+            // this should be improved
+
+            if (redirectTimes++ < 3) {
+                val url = getString(R.string.shared_decks_login_url)
+                Timber.i("HTTP 429, redirecting to login: '$url'")
+                webView.loadUrl(url)
+            } else {
+                // Ensure that we do not have an infinite redirect
+                Timber.w("HTTP 429 redirect limit exceeded, only displaying message")
+            }
+        }
     }
 
     companion object {
         const val SHARED_DECKS_DOWNLOAD_FRAGMENT = "SharedDecksDownloadFragment"
         const val DOWNLOAD_FILE = "DownloadFile"
+        private const val HTTP_STATUS_TOO_MANY_REQUESTS = 429
     }
 
     // Show WebView with AnkiWeb shared decks with the functionality to capture downloads and import decks.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.webkit.CookieManager
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
@@ -34,6 +35,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.ui.AccessibleSearchView
 import timber.log.Timber
 import java.io.Serializable
@@ -93,6 +95,26 @@ class SharedDecksActivity : AnkiActivity() {
             return true
         }
 
+        private val cookieManager: CookieManager by lazy {
+            CookieManager.getInstance()
+        }
+
+        private val isLoggedInToAnkiWeb: Boolean
+            get() {
+                try {
+                    // cookies are null after the user logs out, or if the site is first visited
+                    val cookies = cookieManager.getCookie("https://ankiweb.net") ?: return false
+                    // ankiweb currently (2024-09-25) sets two cookies:
+                    // * `ankiweb`, which is base64-encoded JSON
+                    // * `has_auth`, which is 1
+                    return cookies.contains("has_auth=1")
+                } catch (e: Exception) {
+                    Timber.w(e, "Could not determine login status")
+                    return false
+                }
+            }
+
+        @NeedsTest("A user is not redirected to login/signup if they are logged in to AnkiWeb")
         override fun onReceivedHttpError(
             view: WebView?,
             request: WebResourceRequest?,
@@ -101,6 +123,12 @@ class SharedDecksActivity : AnkiActivity() {
             super.onReceivedHttpError(view, request, errorResponse)
 
             if (errorResponse?.statusCode != 429) return
+
+            // If a user is logged in, they see: "Daily limit exceeded; please try again tomorrow."
+            // We have nothing we can do here
+            if (isLoggedInToAnkiWeb) return
+
+            // The following cases are handled below:
             // "Please log in to download more decks." - on clicking "Download"
             // "Please log in to perform more searches" - on searching
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Previously all 429 errors redirected a user to the login page, even if they were already logged in

Now it shows "Daily limit exceeded, please try again tomorrow"


## Fixes
* Fixes #17135

## Approach
* Determine the cookies which AnkiWeb uses for login
* Check to see if the user is logged into AnkIWeb
* If they are, skip the code to handle "user is not logged in" rate limits
* Refactors/documentation

## How Has This Been Tested?

* A non-logged in user is still redirected to signup/login
* A logged in user is no longer redirected

<img width="426" alt="Screenshot 2024-09-25 at 16 59 53" src="https://github.com/user-attachments/assets/e1877c31-1346-4722-a750-2ceb9c1ab8e4">


## Learning (optional, can help others)
* AnkiWeb has two cookies:
   *  `ankiweb` (base64 encoded JSON, not quite a JWT)
   * `has_auth=1`


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
