### PR TITLE
fix: match tag control label to actual action

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -167,7 +167,7 @@
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/tag_command_key"
-            android:title="@string/add_tag"
+            android:title="@string/menu_edit_tags"
             android:icon="@drawable/ic_tag"
             />
         <com.ichi2.preferences.ControlPreference


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
Match the label for tag control to the actual action (opening "Tags" dialog box, not "Add tag" dialog box)


[Current label]
`Add tag`
<img src="https://github.com/user-attachments/assets/fbb83c68-7301-41cf-a0a8-65461d56a972" width="320px">

[Action]
Opening "Tags" dialog box. It is the same result of selecting "Edit tags" in the menu of Reviewer screen:
<img src="https://github.com/user-attachments/assets/ba4ea4bf-b3ab-42ac-b174-2bd0656fc5d5" width="320px">

<img src="https://github.com/user-attachments/assets/6536d551-bbec-4f78-a97d-705b4e19f16f" width="200px">




## Fixes
N/A

## Approach
Replace the string with another existing string

## How Has This Been Tested?
Checked in physical device (Android 11):
![image](https://github.com/user-attachments/assets/56ce79f2-cdec-4289-8891-0223451d90e7)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
