### PR TITLE
feat: show discard dialog in case multimedia changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
@@ -24,7 +24,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
 import com.ichi2.anki.CrashReportService
@@ -41,8 +40,6 @@ import timber.log.Timber
 class AudioRecordingFragment : MultimediaFragment(R.layout.fragment_audio_recording) {
     override val title: String
         get() = resources.getString(R.string.multimedia_editor_field_editing_audio)
-
-    private val viewModel: MultimediaViewModel by viewModels()
 
     private var audioRecordingController: AudioRecordingController? = null
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
@@ -30,7 +30,6 @@ import androidx.annotation.OptIn
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
-import androidx.fragment.app.viewModels
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
@@ -61,8 +60,6 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
 
     override val title: String
         get() = getTitleForFragment(selectedMediaOptions, requireContext())
-
-    private val viewModel: MultimediaViewModel by viewModels()
 
     /**
      * Launches an activity to pick audio or video file from the device

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -33,7 +33,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
-import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.canhub.cropper.CropException
 import com.google.android.material.button.MaterialButton
@@ -76,8 +75,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
 
     private lateinit var imagePreview: ImageView
     private lateinit var imageFileSize: TextView
-
-    private val viewModel: MultimediaViewModel by viewModels()
 
     private lateinit var selectedImageOptions: ImageOptions
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR completes a `TODO` shows a discard dialog in case there are changes i.e. user selects a media file

## How Has This Been Tested?
Google emulator 
![image](https://github.com/user-attachments/assets/d7afdf7a-b129-4b52-87cd-65de6835b98f)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
