### PR TITLE
[BUG]:The Set Due Date dialog box is missing its title 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -45,7 +45,9 @@ class ControlsSettingsFragment : SettingsFragment() {
 
     private fun setDynamicTitle() {
         findPreference<ControlPreference>(getString(R.string.reschedule_command_key))?.let {
-            it.title = TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+            val preferenceTitle = TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+            it.title = preferenceTitle
+            it.dialogTitle = preferenceTitle
         }
         findPreference<ControlPreference>(getString(R.string.toggle_whiteboard_command_key))?.let {
             it.title = getString(R.string.gesture_toggle_whiteboard).toSentenceCase(R.string.sentence_gesture_toggle_whiteboard)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
@@ -59,8 +60,10 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
     }
 
     private fun setDynamicTitle() {
-        findPreference<Preference>(getString(R.string.custom_button_schedule_card_key))?.let {
-            it.title = TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date)
+        findPreference<ListPreference>(getString(R.string.custom_button_schedule_card_key))?.let {
+            val preferenceTitle = TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date)
+            it.title = preferenceTitle
+            it.dialogTitle = preferenceTitle
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The Set Due Date dialog box is missing its title .
## Fixes
* Fixes #17124 

##Screenshot
settings-> controls->set due date
![WhatsApp Image 2024-09-26 at 4 27 46 PM](https://github.com/user-attachments/assets/240e36e9-bd47-4ea3-9264-4de3999247b0)

settings-> appearance->app bar button-> set due date
![WhatsApp Image 2024-09-26 at 4 27 45 PM](https://github.com/user-attachments/assets/db53fb10-36ca-4ab8-9d00-825625295c36)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
