### PR TITLE
Fix inconsistent Toolbar background color

### DIFF
--- a/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/locale_selection_dialog.xml
@@ -28,7 +28,7 @@
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/ActionBarStyle"
-        android:background="?attr/colorPrimary"
+        android:background="?attr/appBarColor"
         android:layout_alignParentTop="true"
         app:title="@string/locale_selection_dialog_title_new"
         app:popupTheme="@style/ActionBar.Popup"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The toolbar background color should not be blue, it should be black in Black/Dark theme

## Fixes
* Fixes #17145 

## Approach
Fix inconsistent Toolbar background by replacing `colorPrimary` with `appBarColor`

## How Has This Been Tested?
![WhatsApp Image 2024-09-27 at 5 40 20 PM](https://github.com/user-attachments/assets/072c0218-d94f-4547-96c6-bffc891bc6b8)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
