### PR TITLE
fix(boot-service): execute on later Android versions 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -188,7 +188,7 @@ open class AnkiDroidApp : Application(), Configuration.Provider, ChangeManager.S
         LanguageUtil.setDefaultBackendLanguages()
 
         // Create the AnkiDroid directory if missing. Send exception report if inaccessible.
-        if (Permissions.hasStorageAccessPermission(this)) {
+        if (Permissions.hasLegacyStorageAccessPermission(this)) {
             try {
                 val dir = CollectionHelper.getCurrentAnkiDroidDirectory(this)
                 CollectionHelper.initializeAnkiDroidDirectory(dir)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -40,7 +40,7 @@ import com.ichi2.utils.ImportUtils.showImportUnsuccessfulDialog
 import com.ichi2.utils.IntentUtil.resolveMimeType
 import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.Permissions
-import com.ichi2.utils.Permissions.hasStorageAccessPermission
+import com.ichi2.utils.Permissions.hasLegacyStorageAccessPermission
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.trimToLength
 import timber.log.Timber
@@ -272,7 +272,7 @@ class IntentHandler : AbstractIntentHandler() {
          *  @return `true`: if granted, otherwise `false` and shows a missing permission toast
          */
         fun grantedStoragePermissions(context: Context, showToast: Boolean): Boolean {
-            val granted = !ScopedStorageService.isLegacyStorage(context) || hasStorageAccessPermission(context) || Permissions.isExternalStorageManagerCompat()
+            val granted = !ScopedStorageService.isLegacyStorage(context) || hasLegacyStorageAccessPermission(context) || Permissions.isExternalStorageManagerCompat()
 
             if (!granted && showToast) {
                 showThemedToast(context, context.getString(R.string.intent_handler_failed_no_storage_permission), false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -7,17 +7,19 @@ import android.content.Context
 import android.content.Intent
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.Preferences
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.showThemedToast
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.Permissions.hasLegacyStorageAccessPermission
 import timber.log.Timber
 import java.util.Calendar
 
+@NeedsTest("Check on various Android versions that this can execute")
 class BootService : BroadcastReceiver() {
     private var failedToShowNotifications = false
     override fun onReceive(context: Context, intent: Intent) {
@@ -25,7 +27,7 @@ class BootService : BroadcastReceiver() {
             Timber.d("BootService - Already run")
             return
         }
-        if (!hasLegacyStorageAccessPermission(context)) {
+        if (!grantedStoragePermissions(context, showToast = false)) {
             Timber.w("Boot Service did not execute - no permissions")
             return
         }
@@ -67,7 +69,7 @@ class BootService : BroadcastReceiver() {
         // getInstance().getColSafe
         return try {
             CollectionManager.getColUnsafe()
-        } catch (e: Exception) {
+        } catch (e: Error) { // java.lang.UnsatisfiedLinkError occurs in tests
             Timber.e(e, "Failed to get collection for boot service - possibly media ejecting")
             null
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -14,7 +14,7 @@ import com.ichi2.anki.showThemedToast
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.utils.Time
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.Permissions.hasStorageAccessPermission
+import com.ichi2.utils.Permissions.hasLegacyStorageAccessPermission
 import timber.log.Timber
 import java.util.Calendar
 
@@ -25,7 +25,7 @@ class BootService : BroadcastReceiver() {
             Timber.d("BootService - Already run")
             return
         }
-        if (!hasStorageAccessPermission(context)) {
+        if (!hasLegacyStorageAccessPermission(context)) {
             Timber.w("Boot Service did not execute - no permissions")
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -26,6 +26,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
@@ -116,11 +117,13 @@ object Permissions {
     /**
      * Check if we have read and write access permission to the external storage
      * Note: This can return true >= R on a debug build or if storage is preserved
+     *
+     * @see IntentHandler.grantedStoragePermissions
+     *
      * @param context
-     * @return
      */
     @JvmStatic // unit tests were flaky - maybe remove later
-    fun hasStorageAccessPermission(context: Context): Boolean {
+    fun hasLegacyStorageAccessPermission(context: Context): Boolean {
         return hasStorageReadAccessPermission(context) && hasStorageWriteAccessPermission(context)
     }
 


### PR DESCRIPTION
## Fixes
* Fixes #17153

## Approach
Don't use a legacy check

## How Has This Been Tested?

On my S21 (Android 14), logs now show the Boot Service executing

## Learning (optional, can help others)
Need more tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
