### PR TITLE
Improve Manage note type with big text

### DIFF
--- a/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
@@ -33,7 +33,7 @@
                 tools:text="912 notes"/>
         </LinearLayout>
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <androidx.appcompat.widget.ButtonBarLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content" >
             <Button
@@ -60,7 +60,16 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintStart_toEndOf="@id/note_edit_cards"
-                app:layout_constraintEnd_toStartOf="@id/note_delete" />
+                app:layout_constraintEnd_toStartOf="@id/spacer" />
+
+            <android.widget.Space
+                android:id="@+id/spacer"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                app:layout_constraintStart_toEndOf="@id/note_rename"
+                app:layout_constraintEnd_toStartOf="@id/note_delete"
+                />
 
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/note_delete"
@@ -72,6 +81,6 @@
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent" />
-        </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.appcompat.widget.ButtonBarLayout>
     </LinearLayout>
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
Currently, when text is big for accessibility, and text is long, such as French localization, some button overlaps.

This commit correct it by ensuring that text follow the Material Dialog. It stay horizontal normally. But can become vertical when there is not enough horizontal room.

Thanks to @david-allison for the tip of using the material dialog implementation.

I admit I'm not a fan of the result. This is a lot of real estate and will require to scroll potentially a lot.
Also, it's really not clear how to:
* copy a note type (you should tap on the plus symbol)
* edit the list of fiels (tap anywhere on the note type except on the buttons)

So in my opinion, it'd be better to just remove all buttons, and when a user tap on a card, we open a standard menu that allows to do:
* Edit cards
* Edit fields
* Rename
* Copy
* Delete

But, given that this is already an improvement (for the broken case) and should not change anything for the not broken case, I believe it's still worth merging it.

I'm quite sorry @Aditya13s for the work it seems you did, that was also solving the problem but in a way that is less standard in Android.

* Bug: #17100


Here are the results:
![manage_note_type_small_english](https://github.com/user-attachments/assets/d7a710e6-629c-49b5-a38a-344bf277beb9)
![manage_note_type_big_french](https://github.com/user-attachments/assets/bc9b4ca4-baa4-428c-bb27-834dc1e848ec)
