### PR TITLE
improvement(lint): 'TranslationTypo' - link to Crowdin 

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -27,6 +27,7 @@ import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
+import com.ichi2.anki.lint.utils.CrowdinContext.Companion.toCrowdinContext
 import com.ichi2.anki.lint.utils.ext.isRightToLeftLanguage
 import org.w3c.dom.Element
 
@@ -94,13 +95,17 @@ class TranslationTypo : ResourceXmlDetector(), XmlScanner {
             return
         }
 
+        val crowdinContext = context.toCrowdinContext()
+
         /** Helper function to report 'TranslationTypo' issues */
         fun Element.reportIssue(message: String) {
             val elementToReport = this
+            val crowdinEditUrl = crowdinContext?.getEditUrl(elementToReport)
+                ?.let { url -> "; $url" } ?: ""
             context.report(
                 issue = ISSUE,
                 location = context.getElementLocation(elementToReport),
-                message = message
+                message = message + crowdinEditUrl
             )
         }
 

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -38,16 +38,16 @@ import org.w3c.dom.Element
 class TranslationTypo : ResourceXmlDetector(), XmlScanner {
     companion object {
         @VisibleForTesting
-        val ID_TITLE_LENGTH = "TranslationTypo"
+        val ID_TRANSLATION_TYPO = "TranslationTypo"
 
         @VisibleForTesting
-        val EXPLANATION_TITLE_LENGTH = "Typo in translation"
+        val EXPLANATION_TRANSLATION_TYPO = "Typo in translation"
 
         private val implementation = Implementation(TranslationTypo::class.java, Scope.RESOURCE_FILE_SCOPE)
         val ISSUE: Issue = Issue.create(
-            ID_TITLE_LENGTH,
-            EXPLANATION_TITLE_LENGTH,
-            EXPLANATION_TITLE_LENGTH,
+            ID_TRANSLATION_TYPO,
+            EXPLANATION_TRANSLATION_TYPO,
+            EXPLANATION_TRANSLATION_TYPO,
             Constants.ANKI_XML_CATEGORY,
             Constants.ANKI_XML_PRIORITY,
             Constants.ANKI_XML_SEVERITY,
@@ -94,20 +94,30 @@ class TranslationTypo : ResourceXmlDetector(), XmlScanner {
             return
         }
 
+        /** Helper function to report 'TranslationTypo' issues */
+        fun Element.reportIssue(message: String) {
+            val elementToReport = this
+            context.report(
+                issue = ISSUE,
+                location = context.getElementLocation(elementToReport),
+                message = message
+            )
+        }
+
         // use the unicode character instead of three dots for ellipsis
         // ignore RTL to reduce maintenance: GitHub incorrectly displays ellipsis, so hard to review
         if (element.textContent.contains("...") && !context.isRightToLeftLanguage()) {
-            context.report(ISSUE, context.getElementLocation(element), "should use unicode '&#8230;' instead of three dots for ellipsis")
+            element.reportIssue("should use unicode '&#8230;' instead of three dots for ellipsis")
         }
 
         // casing of 'JavaScript'
         if (element.textContent.lowercase().contains("javascript") && !element.textContent.contains("JavaScript")) {
-            context.report(ISSUE, context.getElementLocation(element), "should be 'JavaScript'")
+            element.reportIssue("should be 'JavaScript'")
         }
 
         // remove empty strings
         if (element.textContent.isEmpty() && element.getAttribute("name") != "empty_string") {
-            context.report(ISSUE, context.getElementLocation(element), "should not be empty")
+            element.reportIssue("should not be empty")
         }
     }
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.utils
+
+import com.android.tools.lint.detector.api.ResourceContext
+import org.w3c.dom.Element
+import java.io.File
+import java.util.Locale
+
+/**
+ * Identifier of an XML file in a Crowdin URL.
+ * 8236 -> `20-search-preference.xml` in the URL https://crowdin.com/editor/ankidroid/8236/en-yu
+ */
+@JvmInline
+value class CrowdinFileIdentifier(private val value: Long) {
+    override fun toString(): String = value.toString()
+
+    companion object {
+        private val fileNameToIdentifier = mapOf(
+            "01-core" to 7290,
+            "02-strings" to 7291,
+            "03-dialogs" to 7303,
+            "04-network" to 8167,
+            "05-feedback" to 8168,
+            "06-statistics" to 8169,
+            "07-cardbrowser" to 8170,
+            "08-widget" to 8171,
+            "09-backup" to 8172,
+            "10-preferences" to 8173,
+            "11-arrays" to 8174,
+            "16-multimedia-editor" to 8229,
+            "17-model-manager" to 8230,
+            "19-standard-models" to 8232,
+            "20-search-preference" to 8236
+        ).mapValues { CrowdinFileIdentifier(it.value.toLong()) }
+
+        fun fromFile(file: File): CrowdinFileIdentifier? =
+            fileNameToIdentifier[file.nameWithoutExtension]
+    }
+}
+
+/**
+ * The language key which Crowdin uses to represent the language: `yu`, NOT `yue`
+ */
+@JvmInline
+value class CrowdinLanguageTag(private val tag: String) {
+    override fun toString() = tag
+
+    companion object {
+        private val customMappings = mapOf(
+            /* from tools/localization/src/update.ts */
+            "yue" to "yu",
+            "heb" to "he",
+            "iw" to "he",
+            "ind" to "id",
+            "tgl" to "tl",
+
+            /* Other weirdness */
+
+            /* Malayalam */
+            "ml" to "mlin",
+            /* Punjabi */
+            "pa" to "pain",
+            // Norwegian Nynorsk
+            "nn" to "nnno",
+
+            /* Tatar (Russia) */
+            "tt" to "ttru",
+
+            /* Urdu (Pakistan) */
+            "ur" to "urpk",
+
+            // Crowdin does not handle 'Spanish (Spain)' as 'eses', it needs 'es'
+            "eses" to "es",
+            "ptpt" to "pt"
+        )
+
+        fun fromFolderName(folderName: String): CrowdinLanguageTag? {
+            if (!folderName.startsWith("values-")) return null
+
+            val language = folderName.substring("values-".length)
+                .replace("-r", "") // es-rAR -> esAR
+                .lowercase(Locale.ROOT) // esAR -> esar
+
+            val crowdinLanguage = customMappings[language] ?: language
+
+            return CrowdinLanguageTag(crowdinLanguage)
+        }
+
+        fun fromFolder(folder: File): CrowdinLanguageTag? = fromFolderName(folder.name)
+    }
+}
+
+/**
+ * How Crowdin represents the Android path of `values-yue/01-core.xml`
+ * @param languageTag How 'values-zh-rCN' is represented. See [CrowdinLanguageTag]
+ * @param fileIdentifier How `01-core` is represented. See [CrowdinFileIdentifier]
+ */
+data class CrowdinContext(val languageTag: CrowdinLanguageTag, val fileIdentifier: CrowdinFileIdentifier) {
+    private fun getStringName(element: Element): String? =
+        if (element.hasAttribute("name")) element.getAttribute("name") else null
+
+    fun getEditUrl(element: Element): String? {
+        val stringName = getStringName(element) ?: return null
+        return getEditUrl(stringName)
+    }
+
+    /** Example: [https://crowdin.com/editor/ankidroid/7290/en-af#q=create_subdeck](https://crowdin.com/editor/ankidroid/7290/en-af#q=create_subdeck) */
+    fun getEditUrl(string: String): String =
+        "https://crowdin.com/editor/ankidroid/$fileIdentifier/en-$languageTag#q=$string"
+
+    companion object {
+        fun ResourceContext.toCrowdinContext(): CrowdinContext? {
+            return CrowdinContext(
+                languageTag = CrowdinLanguageTag.fromFolder(file.parentFile) ?: return null,
+                fileIdentifier = CrowdinFileIdentifier.fromFile(file) ?: return null
+            )
+        }
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -69,4 +69,67 @@ class TranslationTypoTest {
 
         TranslationTypo.ISSUE.assertXmlStringsNoIssues(stringRemoved)
     }
+
+    /** A link to the string on Crowdin should be provided */
+    @Test
+    fun crowdinEditLinkIsProvided() {
+        // Use links in the form: https://crowdin.com/editor/ankidroid/7290/en-af#q=create_subdeck
+        // where 7290 is 01-core.xml, `en-af` is Afrikaans, and `create_subdeck` is the key
+
+        // The actual link is https://crowdin.com/editor/ankidroid/7290/en-af#6534818, but
+        // we don't have context to map from `create_subdeck` to `6534818`
+
+        // We do not use '...', as this is not checked for RTL languages
+        val xmlWithIssue = """<resources>
+           <string name="create_subdeck">javascript</string>
+        </resources>"""
+
+        // 'standard' test
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7290/en-af#q=create_subdeck",
+            fileName = "01-core",
+            androidLanguageFolder = "af"
+        )
+
+        // 02-strings -> 7291
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7291/en-af#q=create_subdeck",
+            fileName = "02-strings",
+            androidLanguageFolder = "af"
+        )
+
+        // custom mapping: yue -> yu
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7290/en-yu#q=create_subdeck",
+            fileName = "01-core",
+            androidLanguageFolder = "yue"
+        )
+
+        // Used region specifier: Chinese
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7290/en-zhcn#q=create_subdeck",
+            fileName = "01-core",
+            androidLanguageFolder = "zh-rCN"
+        )
+
+        // no -> nnno
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7290/en-nnno#q=create_subdeck",
+            fileName = "01-core",
+            androidLanguageFolder = "nn"
+        )
+
+        // ur -> urpa
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlWithIssue,
+            expectedError = "https://crowdin.com/editor/ankidroid/7290/en-urpk#q=create_subdeck",
+            fileName = "01-core",
+            androidLanguageFolder = "ur"
+        )
+    }
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
@@ -43,17 +43,29 @@ fun Issue.assertXmlStringsHasErrorCount(@Language("XML") xmlFile: String, expect
         .expectErrorCount(expectedErrorCount)
 }
 
-fun Issue.assertXmlStringsHasError(@Language("XML") xmlFile: String, expectedError: String) {
+/**
+ * @param androidLanguageFolder the code used in the Android `values-XX` folder.
+ *  Cantonese: `yue`, not `yu`
+ * @param fileName The name of the xml file without extension: `01-core` etc...
+ */
+fun Issue.assertXmlStringsHasError(
+    @Language("XML") xmlFile: String,
+    expectedError: String,
+    androidLanguageFolder: String? = null,
+    fileName: String? = null
+) {
+    val languageQualifier = if (androidLanguageFolder != null) "-$androidLanguageFolder" else ""
+    val resourceFileName = fileName ?: "constants"
     TestLintTask.lint()
         .allowMissingSdk()
         .allowCompilationErrors()
-        .files(TestFiles.xml("res/values/constants.xml", xmlFile))
+        .files(TestFiles.xml("res/values$languageQualifier/$resourceFileName.xml", xmlFile))
         .issues(this)
         .run()
         .expectErrorCount(1)
         .check({ output: String ->
             assertTrue(
-                "check should fail wth '$expectedError', but was '$output'",
+                "check should fail with '$expectedError', but was '$output'",
                 output.contains(expectedError)
             )
         })

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/utils/CrowdinLanguageTagTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/utils/CrowdinLanguageTagTest.kt
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Test
+
+typealias ManuallyVerifiedString = String?
+
+class CrowdinLanguageTagTest {
+
+    @Test
+    fun manuallyTestLinks() {
+        // when adding a new string, define it as 'null' and this test will
+        // provide a URL for you to manually test:
+        // example: "values-xx" to null
+        // Once the URL works, replace 'null' with the language Crowdin uses
+
+        // manually verified by David (2024-09-30)
+        val folderNames = mapOf<String, ManuallyVerifiedString>(
+            "values-af" to "af",
+            "values-am" to "am",
+            "values-ar" to "ar",
+            "values-az" to "az",
+            "values-be" to "be",
+            "values-bg" to "bg",
+            "values-bn" to "bn",
+            "values-ca" to "ca",
+            "values-ckb" to "ckb",
+            "values-cs" to "cs",
+            "values-da" to "da",
+            "values-de" to "de",
+            "values-el" to "el",
+            "values-en" to "en",
+            "values-eo" to "eo",
+            "values-es-rAR" to "esar",
+            "values-es-rES" to "es",
+            "values-et" to "et",
+            "values-eu" to "eu",
+            "values-fa" to "fa",
+            "values-fi" to "fi",
+            "values-fil" to "fil",
+            "values-fr" to "fr",
+            "values-fy" to "fy",
+            "values-ga" to "ga",
+            "values-gl" to "gl",
+            "values-got" to "got",
+            "values-gu" to "gu",
+            "values-heb" to "he",
+            "values-hi" to "hi",
+            "values-hr" to "hr",
+            "values-hu" to "hu",
+            "values-hy" to "hy",
+            "values-ind" to "id",
+            "values-is" to "is",
+            "values-it" to "it",
+            "values-iw" to "he",
+            "values-ja" to "ja",
+            "values-jv" to "jv",
+            "values-ka" to "ka",
+            "values-kk" to "kk",
+            "values-km" to "km",
+            "values-kn" to "kn",
+            "values-ko" to "ko",
+            "values-ku" to "ku",
+            "values-ky" to "ky",
+            "values-lt" to "lt",
+            "values-lv" to "lv",
+            "values-mk" to "mk",
+            "values-ml" to "mlin",
+            "values-mn" to "mn",
+            "values-mr" to "mr",
+            "values-ms" to "ms",
+            "values-my" to "my",
+            "values-nl" to "nl",
+            "values-nn" to "nnno",
+            "values-no" to "no",
+            "values-or" to "or",
+            "values-pa" to "pain",
+            "values-pl" to "pl",
+            "values-pt-rBR" to "ptbr",
+            "values-pt-rPT" to "pt",
+            "values-ro" to "ro",
+            "values-ru" to "ru",
+            "values-sat" to "sat",
+            "values-sc" to "sc",
+            "values-sk" to "sk",
+            "values-sl" to "sl",
+            "values-sq" to "sq",
+            "values-sr" to "sr",
+            "values-ss" to "ss",
+            "values-sv" to "sv",
+            "values-ta" to "ta",
+            "values-te" to "te",
+            "values-tg" to "tg",
+            "values-tgl" to "tl",
+            "values-th" to "th",
+            "values-ti" to "ti",
+            "values-tn" to "tn",
+            "values-tr" to "tr",
+            "values-ts" to "ts",
+            "values-tt" to "ttru",
+            "values-uk" to "uk",
+            "values-ur" to "urpk",
+            "values-uz" to "uz",
+            "values-ve" to "ve",
+            "values-vi" to "vi",
+            "values-wo" to "wo",
+            "values-xh" to "xh",
+            "values-yue" to "yu",
+            "values-zh-rCN" to "zhcn",
+            "values-zh-rTW" to "zhtw",
+            "values-zu" to "zu"
+        )
+
+        val fileIdentifier = CrowdinFileIdentifier(7290)
+
+        val stringsToTest = mutableListOf<String>()
+        for ((folderName, expected) in folderNames) {
+            val languageTag = CrowdinLanguageTag.fromFolderName(folderName)!!
+
+            if (expected != null) {
+                assertThat(languageTag.toString(), equalTo(expected))
+                continue
+            }
+
+            val context = CrowdinContext(languageTag, fileIdentifier)
+
+            // the '_' in the name ensures the strings only match names, and not the English
+            val actual = context.getEditUrl("send_feedback")
+
+            stringsToTest.add(actual)
+        }
+
+        // display a list of the languages to test (if any)
+        println(stringsToTest.joinToString(separator = "\n"))
+        assertThat(
+            "all values should be manually tested, test the links printed above",
+            stringsToTest,
+            hasSize(0)
+        )
+    }
+}

--- a/tools/localization/src/update.ts
+++ b/tools/localization/src/update.ts
@@ -171,6 +171,7 @@ export async function updateI18nFiles() {
             androidLanguages = [language.split("-", 1)[0]]; // Example: es-ES becomes es
         }
 
+        // Also update mappings for CrowdinLanguageTag in Crowdin.kt.
         switch (language) {
             case "yu":
                 androidLanguages = ["yue"];


### PR DESCRIPTION
## Purpose / Description

A discussion on https://github.com/ankidroid/Anki-Android/pull/17160 prompted the fact that we can save time by linking directly to Crowdin if errors occur

Sample link: https://crowdin.com/editor/ankidroid/7290/en-af#q=create_subdeck

## Approach
* obtain a 'file' on Crowdin:
  * map from `01-core.xml` to `7290`
  * map languages: `zh-rCN` to `zhcn`
* query the string in the file: `#search_string` in the URL fragment works


## How Has This Been Tested?
Manual/unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
