### PR TITLE
fix: multimedia bottomsheet nav bar color transparency

### DIFF
--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -243,4 +243,8 @@
         <item name="android:alertDialogStyle">@style/AlertDialogStyle</item>
     </style>
 
+    <style name="ThemeOverlay.App.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
+        <item name="android:navigationBarColor" tools:ignore="NewApi">@android:color/transparent</item>
+    </style>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -149,6 +149,8 @@
         <!-- AlertDialogTheme-->
         <item name="alertDialogTheme">@style/ThemeOverlay.AnkiDroid.AlertDialog</item>
         <item name="tabStyle">@style/Widget.MaterialComponents.TabLayout</item>
+
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
     </style>
 
     <style name="Theme_Dark" parent="Base.Theme.Dark"/>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -138,6 +138,8 @@
         <item name="checkMediaListForeground">@color/material_grey_700</item>
         <item name="progressDialogButtonTextColor">@color/material_light_blue_500</item>
         <item name="tabStyle">@style/Widget.MaterialComponents.TabLayout</item>
+
+        <item name="bottomSheetDialogTheme">@style/ThemeOverlay.App.BottomSheetDialog</item>
     </style>
 
     <style name="Theme_Light" parent="Base.Theme.Light"/>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It was pointed out by @david-allison when the bottom sheet code was merged as non blocker, hence I am resolving it now, this PR makes the nav bar color transparent.

## How Has This Been Tested?
Google emulator API 35:
![image](https://github.com/user-attachments/assets/ad3d427b-e7ee-427d-a997-49d9840fea1a)


## Learning (optional, can help others)
Resources used: Google M3 [docs](https://github.com/material-components/material-components-android/blob/master/docs/components/BottomSheet.md)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
