### PR TITLE
Make browser options scrollable for larger text size.

### DIFF
--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical">
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -110,6 +114,8 @@
                 android:layout_height="wrap_content"/>
         </LinearLayout>
 
+      </LinearLayout>
+
     </LinearLayout>
 
-</LinearLayout>
+</ScrollView>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR ensures the browser options remain accessible and user-friendly when larger text sizes are used by making the layout scrollable. This enhances usability, particularly for users with accessibility needs or custom font settings.

## Fixes
* Fixes #17100

## How Has This Been Tested?
Realme 6 (API-30) and Emulator

## Screen Recording
https://github.com/user-attachments/assets/03d681cc-facb-430b-ae24-1298dab7d2a8

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
