### PR TITLE
lint: better link to Crowdin

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -101,7 +101,7 @@ class TranslationTypo : ResourceXmlDetector(), XmlScanner {
         fun Element.reportIssue(message: String) {
             val elementToReport = this
             val crowdinEditUrl = crowdinContext?.getEditUrl(elementToReport)
-                ?.let { url -> "; $url" } ?: ""
+                ?.let { url -> "\n$url" } ?: ""
             context.report(
                 issue = ISSUE,
                 location = context.getElementLocation(elementToReport),


### PR DESCRIPTION
A url was added in ad847571f6612eb428f33c0ae31244fbccbbb6e7

The URL is the most important aspect, but it's inconveniently placed due to the line length

So put it on a newline

```diff
- values-bn/01-core.xml:124: Error: should be 'JavaScript'; https://crowdin.com/editor/ankidroid/7290/en-bn#q=create_subdeck [TranslationTypo from com.ichi2.anki:lint-rules]
+ values-bn/01-core.xml:124: Error: should be 'JavaScript'
+ https://crowdin.com/editor/ankidroid/7290/en-bn#q=create_subdeck [TranslationTypo from com.ichi2.anki:lint-rules]
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
