### PR TITLE
Anki24.10beta1 Test Integration - be very very careful

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ androidxWebkit = "1.12.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.9.1"
 annotations = "25.0.0"
-ankiBackend = '0.1.40-anki24.06.3'
+ankiBackend = '0.1.40-anki24.10beta1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

This is a test integration only.

It comes with a big warning that the new FSRS params will cause cross-device sync to fail unless *all* your clients are using the new underlying 24.10beta1 anki code

And it would be shocking if they were

So do not use this on collections you care about unless you know exactly what you are doing