### PR TITLE
Fix notetype name being reverted when going to CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -248,6 +248,9 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
      */
     override fun onCollectionLoaded(col: Collection) {
         super.onCollectionLoaded(col)
+        // without this call the editor doesn't see the latest changes to notetypes, see #16630
+        @NeedsTest("Add test to check that renaming notetypes in ManageNotetypes is seen in CardTemplateEditor(#16630)")
+        col.notetypes.clearCache()
         // The first time the activity loads it has a model id but no edits yet, so no edited model
         // take the passed model id load it up for editing
         if (tempModel == null) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Due to how CardTemplateEditor accesses the collection it seems it doesn't "see" the renames done in ManageNotetypes so when it saves any changes to the template it also saves the last name it "saw". I just called load() on the collection to initialize again the components, especially _Notetypes_. This should be ok, I don't think there are other side effects on calling load().

There's a warning for worker method being called on the main thread but I think it's safe as that method just initializes again several objects, it doesn't seem to do anything heavy.

We should probably move CardTemplateEditor to use CollectionManager.

## Fixes
* Fixes #16630

## How Has This Been Tested?

Ran the tests, manually tried(and failed) to replicate the issue again.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
