### PR TITLE
Remove manual broadcasts for DeckPickerWidget and CardAnalysisWidget

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidgetConfig.kt
@@ -311,9 +311,6 @@ class CardAnalysisWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnac
 
             val resultValue = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             setResult(RESULT_OK, resultValue)
-
-            sendBroadcast(Intent(this, CardAnalysisWidget::class.java))
-
             finish()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -239,9 +239,6 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
 
             val resultValue = Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
             setResult(RESULT_OK, resultValue)
-
-            sendBroadcast(Intent(this, DeckPickerWidget::class.java))
-
             finish()
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The widgets are updated after the UIs are built asynchronously so there's no need for those sendBroadcast calls.

## Fixes
* Fixes #17157

## How Has This Been Tested?

The widgets function as before the removals.

