### PR TITLE
fix: Prevent deck creation on 'Enter' key when deck name already exists

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -97,7 +97,17 @@ class CreateDeckDialog(
             val inputField = dialog.getInputField()
             inputField.setOnEditorActionListener { _, actionId, event ->
                 if (actionId == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
-                    onPositiveButtonClicked()
+                    when {
+                        dialog.positiveButton.isEnabled -> {
+                            onPositiveButtonClicked()
+                        }
+                        text.isBlank() -> {
+                            dialog.getInputTextLayout().showSnackbar(context.getString(R.string.empty_deck_name), Snackbar.LENGTH_SHORT)
+                        }
+                        else -> {
+                            dialog.getInputTextLayout().showSnackbar(context.getString(R.string.deck_already_exists), Snackbar.LENGTH_SHORT)
+                        }
+                    }
                     true
                 } else {
                     false

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -247,6 +247,7 @@
     </string>
 
     <string name="deck_already_exists">Deck already exists</string>
+    <string name="empty_deck_name">Deck name cannot be empty</string>
 
     <string name="create_deck_numeric_hint">If you have deck ordering issues (e.g. ‘10’ appears before ‘2’), replace ‘2’ with ‘02’</string>
 


### PR DESCRIPTION
## Purpose / Description
Ensure that pressing the "Enter" key does not create a deck when the deck name already exists, providing a snackbar notification and keeping the dialog open for user correction.

## Fixes
* Fixes #17044 

## How Has This Been Tested?
Realme 6 (API-30) and Emulator

## Screen Recording
https://github.com/user-attachments/assets/cc83a20c-6def-4a39-90bd-a185c37b6e27

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
