### PR TITLE
Create copy of `Ease` constants in `api` module and Update `FlashCardsContract` docs

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/EaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/EaseTest.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *  Copyright (c) 2024 Ben Wicks <benjaminlwicks@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -13,14 +13,19 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 package com.ichi2.anki
 
-/**
- * [value] should be kept in sync with the [com.ichi2.anki.api.Ease] enum.
- */
-enum class Ease(val value: Int) {
-    AGAIN(1),
-    HARD(2),
-    GOOD(3),
-    EASY(4);
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class EaseTest {
+    @Test
+    fun `Ease enum values match api module`() {
+        assertEquals(Ease.AGAIN.value, com.ichi2.anki.api.Ease.EASE_1.value)
+        assertEquals(Ease.HARD.value, com.ichi2.anki.api.Ease.EASE_2.value)
+        assertEquals(Ease.GOOD.value, com.ichi2.anki.api.Ease.EASE_3.value)
+        assertEquals(Ease.EASY.value, com.ichi2.anki.api.Ease.EASE_4.value)
+        assertEquals(Ease.entries.size, com.ichi2.anki.api.Ease.entries.size)
+    }
 }

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -8,6 +8,7 @@ package com.ichi2.anki
 
 import android.net.Uri
 import com.ichi2.anki.api.BuildConfig
+import com.ichi2.anki.api.Ease
 
 /**
  * The contract between AnkiDroid and applications. Contains definitions for the supported URIs and
@@ -688,10 +689,10 @@ public object FlashCardsContract {
      * JSONArray  | MEDIA_FILES       | read-only  | The media files, like images and sound files, contained in the cards.
      * --------------------------------------------------------------------------------------------------------------------
      * String     | EASE              | write-only | The ease of the card. Used when answering the card. One of:
-     *            |                   |            | com.ichi2.anki.AbstractFlashcardViewer.EASE_1
-     *            |                   |            | com.ichi2.anki.AbstractFlashcardViewer.EASE_2
-     *            |                   |            | com.ichi2.anki.AbstractFlashcardViewer.EASE_3
-     *            |                   |            | com.ichi2.anki.AbstractFlashcardViewer.EASE_4
+     *            |                   |            | com.ichi2.anki.api.Ease.EASE_1.value
+     *            |                   |            | com.ichi2.anki.api.Ease.EASE_2.value
+     *            |                   |            | com.ichi2.anki.api.Ease.EASE_3.value
+     *            |                   |            | com.ichi2.anki.api.Ease.EASE_4.value
      * --------------------------------------------------------------------------------------------------------------------
      * String     | TIME_TAKEN        | write_only | The it took to answer the card (in milliseconds). Used when answering the card.
      * --------------------------------------------------------------------------------------------------------------------
@@ -710,7 +711,7 @@ public object FlashCardsContract {
      *      ContentValues values = new ContentValues();
      *      long noteId = 123456789; //<-- insert real note id here
      *      int cardOrd = 0;   //<-- insert real card ord here
-     *      int ease = AbstractFlashcardViewer.EASE_3; //<-- insert real ease here
+     *      int ease = Ease.EASE_3.value; //<-- insert real ease here
      *      long timeTaken = System.currentTimeMillis() - cardStartTime; //<-- insert real time taken here
      *
      *      values.put(FlashCardsContract.ReviewInfo.NOTE_ID, noteId);
@@ -772,9 +773,9 @@ public object FlashCardsContract {
          */
         public const val MEDIA_FILES: String = "media_files"
 
-        /*
+        /**
          * Ease of an answer. Is not set when requesting the scheduled cards.
-         * Can take values of AbstractFlashcardViewer e.g. EASE_1
+         * Can take values from the [Ease] enum e.g. [Ease.EASE_1.value].
          */
         public const val EASE: String = "answer_ease"
 

--- a/api/src/main/java/com/ichi2/anki/api/Ease.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Ease.kt
@@ -1,0 +1,24 @@
+/*
+ *  Copyright (c) 2024 Ben Wicks <benjaminlwicks@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.api
+
+public enum class Ease(public val value: Int) {
+    EASE_1(1),
+    EASE_2(2),
+    EASE_3(3),
+    EASE_4(4);
+}


### PR DESCRIPTION
## Purpose / Description
Updates the documentation in `api/src/main/java/com/ichi2/anki/FlashCardsContract.kt` that referenced `AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt` which is not accessible from maven API package. The references were to the 4 `Ease` constants which are now copied into a new enum class in the `api` module.

## Fixes
* Fixes #17021

## Approach
This change copies the existing 4 Ease constants into the `api` module as a new `Ease` enum class and add a comment in the previously existing `Ease` enum as a reminder that the 2 should stay in sync if either is modified.

## How Has This Been Tested?

I added a unit test to assert that the constants in this new `Ease` enum match the previously existing `Ease` enum class's values.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] ~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~
- [ ] ~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~
