### PR TITLE
fix controls layout in landscape

### DIFF
--- a/AnkiDroid/src/main/res/layout/gesture_picker.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_picker.xml
@@ -18,8 +18,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
-    tools:layout_height="500dp"
-    tools:layout_width="400dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -42,6 +40,7 @@
         android:gravity="center_horizontal"
         android:spinnerMode="dropdown"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/gestureDisplay"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintBottom_toTopOf="@id/warning"/>
 
@@ -55,7 +54,7 @@
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/spinner_gesture"
+        app:layout_constraintBottom_toBottomOf="parent"
         android:drawableStart="@drawable/ic_warning"
         android:drawableTint="?attr/colorError"
         android:drawablePadding="4dp"


### PR DESCRIPTION
the warning wasn't well positioned

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #17158

## Approach

Position the warning correctly. The picker can get smaller if there is a warning. The only way that I see to fix that is to put the spinner aligned with the buttons or make the picker smaller, but I wanted to just fix the issue for now.

## How Has This Been Tested?

[a.webm](https://github.com/user-attachments/assets/cb8ebaa5-328f-446a-83eb-05422f17dfa1)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
