### PR TITLE
Fix Android Studio lint errors in `AudioRecordingController.kt`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
@@ -302,7 +302,7 @@ class AudioRecordingController(
                 audioPlayer!!.reset()
             }
         } catch (e: IllegalStateException) {
-            Timber.w("Media Player couldn't be reset or already reset", e)
+            Timber.w(e, "Media Player couldn't be reset or already reset")
         }
     }
 
@@ -663,7 +663,7 @@ class AudioRecordingController(
         try {
             setupForNewRecording()
         } catch (e: Exception) {
-            Timber.d("Unable to reset the audio recorder", e)
+            Timber.d(e, "Unable to reset the audio recorder")
         }
     }
 
@@ -700,7 +700,7 @@ class AudioRecordingController(
                 audioWaveform.addAmplitude(maxAmplitude.toFloat())
             }
         } catch (e: IllegalStateException) {
-            Timber.d("Audio recorder interrupted")
+            Timber.d(e, "Audio recorder interrupted")
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
There were 2 Android Lint errors and 1 warning in `AudioRecordingController.kt` that are fixed in this PR.

## Fixes
* Addresses #13282

## Approach
I just picked the first errors after a code inspection and fixed the warning in the file too.

## How Has This Been Tested?
No testing is necessary for the changes to parameter ordering.
I added the exception parameter to the one `Timber.d` call where it was missing. I believe this call will be a no-op for non-debug builds.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] ~~You have commented your code, particularly in hard-to-understand areas~~
- [x] You have performed a self-review of your own code
- [ ] ~~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~~
- [ ] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~
