### PR TITLE
Enable Tooltip on ActionBar Subtitle for Overflow Text Visibility

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -55,6 +55,8 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.Toolbar
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import androidx.core.content.edit
@@ -2135,6 +2137,9 @@ open class DeckPicker :
                     res.getQuantityString(R.plurals.widget_cards_due, due, due)
                 }
                 supportActionBar!!.subtitle = subTitle
+
+                val toolbar = findViewById<Toolbar>(R.id.toolbar)
+                TooltipCompat.setTooltipText(toolbar, toolbar.subtitle)
             }
         } catch (e: RuntimeException) {
             Timber.e(e, "RuntimeException setting time remaining")


### PR DESCRIPTION

## Purpose / Description
This pull request adds tooltip functionality to the supportActionBar subtitle in the application. By utilizing TooltipCompat, users can now easily view the full subtitle text when it exceeds the visible space. 

## Fixes
* Referencing #17100 

## How Has This Been Tested?
Realme 6 (API-30) and Emulator

## Screen Recording
https://github.com/user-attachments/assets/ff418ffb-507a-42c2-9305-1db0f2736b6e

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
