### PR TITLE
Refactored `CardAnalysisWidget` to handle empty state visibility in similar way to `DeckPickerWidget`.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -114,10 +114,22 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
             appWidgetId: Int,
             remoteViews: RemoteViews
         ) {
-            remoteViews.setTextViewText(R.id.empty_widget, context.getString(R.string.app_not_initialized_new))
+            remoteViews.setTextViewText(R.id.empty_widget, context.getString(R.string.empty_collection_state_in_widget))
             remoteViews.setViewVisibility(R.id.empty_widget, View.VISIBLE)
             remoteViews.setViewVisibility(R.id.cardAnalysisDataHolder, View.GONE)
             remoteViews.setViewVisibility(R.id.deckNameCardAnalysis, View.GONE)
+
+            val configIntent = Intent(context, CardAnalysisWidgetConfig::class.java).apply {
+                putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId)
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            val configPendingIntent = PendingIntent.getActivity(
+                context,
+                appWidgetId,
+                configIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+            remoteViews.setOnClickPendingIntent(R.id.empty_widget, configPendingIntent)
 
             appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
         }
@@ -129,6 +141,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
             remoteViews: RemoteViews
         ) {
             // Show empty_widget and set click listener to open configuration
+            remoteViews.setTextViewText(R.id.empty_widget, context.getString(R.string.empty_widget_state))
             remoteViews.setViewVisibility(R.id.empty_widget, View.VISIBLE)
             remoteViews.setViewVisibility(R.id.cardAnalysisDataHolder, View.GONE)
             remoteViews.setViewVisibility(R.id.deckNameCardAnalysis, View.GONE)

--- a/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
+++ b/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
@@ -16,6 +16,7 @@
         android:layout_marginBottom="8dp"
         android:layout_marginStart="7dp"
         android:gravity="center"
+        android:layout_centerInParent="true"
         android:padding="30dp"
         android:text="@string/empty_widget_state"
         android:visibility="gone" />/>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Aligned empty state visibility logic with `DeckPickerWidget` for a more unified behavior across widgets.

## Fixes
Enabled the widget to reconfigure by a direct tap, when the collection transit from a state of being empty collection to a non-empty collection.

## How Has This Been Tested?
![365466193-9abd501a-694d-44fd-b537-fec8c3d49c0a](https://github.com/user-attachments/assets/26725ec6-c61e-47b0-a501-9e9695ac35d2)

https://github.com/user-attachments/assets/2eb8f92a-d615-425b-a487-fb3f4acf0e55



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
