### PR TITLE
fix(deck-options): close any open modals on back button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -127,6 +127,7 @@ class DeckOptions : PageFragment() {
                 view: WebView?,
                 request: WebResourceRequest?
             ): Boolean {
+                // #16715: ensure that the fragment can't be used for general web browsing
                 val host = request?.url?.host ?: return shouldOverrideUrlLoading(view, request)
                 return if (ankiManualHostRegex.matches(host)) {
                     super.shouldOverrideUrlLoading(view, request)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -54,6 +54,8 @@ open class PageFragment(@LayoutRes contentLayoutId: Int = R.layout.page_fragment
      */
     protected open fun onCreateWebViewClient(savedInstanceState: Bundle?) = PageWebViewClient()
 
+    protected open fun onWebViewCreated(webView: WebView) { }
+
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         webView = view.findViewById<WebView>(R.id.webview).apply {
@@ -66,6 +68,7 @@ open class PageFragment(@LayoutRes contentLayoutId: Int = R.layout.page_fragment
             webViewClient = onCreateWebViewClient(savedInstanceState)
             webChromeClient = PageChromeClient()
         }
+        onWebViewCreated(webView)
         requireActivity().setTransparentStatusBar()
         val arguments = requireArguments()
         val path = requireNotNull(arguments.getString(PATH_ARG_KEY)) { "'$PATH_ARG_KEY' missing" }


### PR DESCRIPTION
Previously the back button only handled navigation to the manual

Now it also closes any modals which are open and requires another back press to close

* Fixes #17196

## Approach
* Add a JavaScriptInterface
* Test for Bootstrap open & close commands

## How Has This Been Tested?

* Pressing 'back' with no modal open -> "save changes"
* Pressing 'back' with modal open -> modal closes

⚠️ I was unable to test on API 23 due to an outdated WebView

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
