### PR TITLE
[Bug]: Set due date setting is  cannot be searched

### DIFF
--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -181,6 +181,8 @@
     <string name="pref_cat_reviewer" maxLength="41">Reviewer</string>
     <string name="show_deck_title" maxLength="41">Show deck title</string>
     <string name="accessibility" maxLength="41">Accessibility</string>
+    <string name="set_due_date" maxLength="41">Set due date</string>
+
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -130,6 +130,7 @@
         <com.ichi2.preferences.ControlPreference
             android:key="@string/reschedule_command_key"
             tools:title="Set due date"
+            android:title="@string/set_due_date"
             android:icon="@drawable/ic_reschedule"
             />
         <com.ichi2.preferences.ControlPreference

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -54,6 +54,7 @@ TODO: Add a unit test
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_schedule_card_key"
             tools:title="Set due date"
+            android:title="@string/set_due_date"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="2"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Set due date setting is  cannot be searched

## Fixes
* Fixes #16603 


## How Has This Been Tested?

physical device SDK 34

##Screenshot
![WhatsApp Image 2024-10-07 at 10 02 12 PM](https://github.com/user-attachments/assets/d2571c05-615a-4879-a34a-b71136850a2b)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
