### PR TITLE
Multi-Line Support in NavigationDrawer Added

### DIFF
--- a/AnkiDroid/src/main/res/layout/navigation_drawer.xml
+++ b/AnkiDroid/src/main/res/layout/navigation_drawer.xml
@@ -10,5 +10,6 @@
     app:headerLayout="@layout/navdrawer_header"
     app:itemIconTint="?attr/navDrawerItemColor"
     app:itemTextColor="?attr/navDrawerItemColor"
+    app:itemMaxLines="2"
     app:itemBackground="?attr/navDrawerItemBackgroundColor"
     app:menu="@menu/navigation_drawer" />


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To Purpose of this PR is to fix the issue in which long text is not fully show in navigation drawer.

## Fixes
* Fixes #17100

## Approach
The Approach is to add property named `itemMaxLines`  with value `2` in `NavigationView`.

## How Has This Been Tested?
This change has been tested using different font size and languages.

## Screenshot
![WhatsApp Image 2024-10-07 at 17 43 43 (1)](https://github.com/user-attachments/assets/3a29bafd-b427-4bb9-a5ed-0154a4d56878)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
