### PR TITLE
test: update robolectric artifact list / suffix to match current

### DIFF
--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -30,7 +30,7 @@ def robolectricAndroidSdkVersions = [
         [androidVersion: "11", frameworkSdkBuildVersion:  "6757853"],
 //        [androidVersion: "12", frameworkSdkBuildVersion:  "7732740"],
 //        [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
-        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
+//        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
         [androidVersion: "14", frameworkSdkBuildVersion: "10818077"],
 ]
 
@@ -42,7 +42,7 @@ tasks.register('robolectricSdkDownload') {
 
 // Generate the configuration and actual copy tasks.
 robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
-    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i4"
+    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i6"
 
     // Creating a configuration with a dependency allows Gradle to manage the actual resolution of
     // the jar file


### PR DESCRIPTION
## Purpose / Description

Our robolectric pre-downloader script that operates with retries in order to deflake CI when there are network failures has regressed and is not downloading the correct artifacts currently

robolectric appears to have bumped the suffix a couple times (from `-i4` through 5 and now `-i6`:

https://mvnrepository.com/artifact/org.robolectric/android-all-instrumented

...and we no longer appear to be using android 13 artifact, update list and download artifact construction to match, shown by results of following the process of clearing `~/.m2` then re-running `./gradlew jacocoUnitTestReport` then searching for the artifacts we actually use:

```
mike@isabela:~/work/ankidroid/Anki-Android (main *) % find /Users/mike/.m2/ -type d -name '*-robolectric-*'
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/14-robolectric-10818077-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/9-robolectric-4913185-2-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i6
```

## Fixes

Nothing logged, but noticed an unexpected failure in a dependency update PR that has a root cause of network reset during adhoc fetch of robolectric artifact that shouldn't have happened if the pre-download worked:

https://github.com/ankidroid/Anki-Android/actions/runs/11253125294/job/31287732561?pr=17215#step:7:189

```

InitialActivityTest > Android 11 - After reinstall (with MANAGE_EXTERNAL_STORAGE) FAILED
    java.lang.AssertionError: Failed to fetch maven artifact org.robolectric:android-all-instrumented:11-robolectric-6757853-i6
        at org.robolectric.internal.dependency.MavenArtifactFetcher.fetchArtifact(MavenArtifactFetcher.java:129)

...

        Caused by:
        java.util.concurrent.ExecutionException: java.net.ConnectException: Operation timed out
            at com.google.common.util.concurrent.AbstractFuture.getDoneValue(AbstractFuture.java:594)
            at com.google.common.util.concurrent.AbstractFuture.get(AbstractFuture.java:573)
            at com.google.common.util.concurrent.AbstractFuture$TrustedFuture.get(AbstractFuture.java:110)
            at org.robolectric.internal.dependency.MavenArtifactFetcher.fetchArtifact(MavenArtifactFetcher.java:121)
```

## Approach

The gradle file has enough comments that it just walks you through how to update the list.
Thanks previous versions of us that left those comments.

## How Has This Been Tested?

Deleted `~/.m2` again, ran `./gradlew robolectricSdkDownload` and re-ran find to verify list was identical

```
mike@isabela:~/work/ankidroid/Anki-Android (robolectric-predownload-deflake) % find /Users/mike/.m2/ -type d -name '*-robolectric-*'
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/14-robolectric-10818077-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/9-robolectric-4913185-2-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i6
/Users/mike/.m2//repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i6
```

## Learning (optional, can help others)

Old CI flakes never die

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
