### PR TITLE
fix(custom-buttons): revert custom button name to 'Reschedule'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/CustomButtonsSettingsFragment.kt
@@ -20,11 +20,8 @@ import android.content.Intent
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
-import androidx.preference.ListPreference
 import androidx.preference.Preference
-import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
-import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
@@ -55,15 +52,6 @@ class CustomButtonsSettingsFragment : SettingsFragment() {
                 negativeButton(R.string.dialog_cancel)
             }
             true
-        }
-        setDynamicTitle()
-    }
-
-    private fun setDynamicTitle() {
-        findPreference<ListPreference>(getString(R.string.custom_button_schedule_card_key))?.let {
-            val preferenceTitle = TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date)
-            it.title = preferenceTitle
-            it.dialogTitle = preferenceTitle
         }
     }
 

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -27,7 +27,6 @@ TODO: Add a unit test
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:title="@string/custom_buttons"
     android:key="@string/pref_app_bar_buttons_screen_key">
     <Preference
@@ -53,7 +52,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_schedule_card_key"
-            tools:title="Set due date"
+            android:title="@string/card_editor_reschedule_card"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="2"


### PR DESCRIPTION
## Purpose / Description
Partial revert of b0de535d4c760072807120f1b99662c0f71ff3cf

In the above commit, "Reschedule" was renamed to "Set Due Date" but the affected menu item in the Reviewer is "Reschedule": offering "Set Due Date" and "Reset progress"

## Fixes
* Fixes #16598

## Approach
Partial revert of b0de535d4c760072807120f1b99662c0f71ff3cf

Rename the Custom Button: "Set due date" back to "Reschedule"

## How Has This Been Tested?
<img width="657" alt="Screenshot 2024-10-10 at 01 43 43" src="https://github.com/user-attachments/assets/42c43af9-59f5-4334-97ff-7bb266ab770a">

<img width="1277" alt="Screenshot 2024-10-10 at 01 44 07" src="https://github.com/user-attachments/assets/7a9673ac-ebda-44bb-a546-ebfd21850d3d">

<img width="684" alt="Screenshot 2024-10-10 at 01 44 16" src="https://github.com/user-attachments/assets/817756cf-c9c9-413d-8244-77fc867ac045">

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
