### PR TITLE
Fix FixedPreferencesTitleLength

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -20,11 +20,11 @@
 -->
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Navigation drawer items-->
-    <string name="decks">Decks</string>
-    <string name="card_browser" maxLength="41" comment="The usage of card browser inside the app (note the casing)">Card browser</string>
-    <string name="statistics">Statistics</string>
-    <string name="settings">Settings</string>
-    <string name="help">Help</string>
+    <string name="decks" maxLength="28">Decks</string>
+    <string name="card_browser" maxLength="28" comment="The usage of card browser inside the app (note the casing)">Card browser</string>
+    <string name="statistics" maxLength="28">Statistics</string>
+    <string name="settings" maxLength="28">Settings</string>
+    <string name="help" maxLength="28">Help</string>
     <string name="drawing">Drawing</string>
     <string name="send_feedback">Send feedback</string>
 
@@ -59,36 +59,36 @@
     <string name="ease_button_hard" maxLength="41">Hard</string>
     <string name="ease_button_good" maxLength="41">Good</string>
     <string name="ease_button_easy">Easy</string>
-    <string name="menu_import">Import</string>
-    <string name="undo"  maxLength="29" comment="When tapping on this text, the last action is undone.">Undo</string>
-    <string name="redo" maxLength="41">Redo</string>
-    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
+    <string name="menu_import" maxLength="28">Import</string>
+    <string name="undo" maxLength="28" comment="When tapping on this text, the last action is undone.">Undo</string>
+    <string name="redo" maxLength="28">Redo</string>
+    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)" maxLength="28">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
-    <string name="unbury">Unbury</string>
-    <string name="rename_deck">Rename deck</string>
+    <string name="unbury" maxLength="28">Unbury</string>
+    <string name="rename_deck" maxLength="28">Rename deck</string>
     <string name="create_shortcut">Create shortcut</string>
     <string name="browse_cards">Browse cards</string>
     <string name="edit_deck_description" comment="edit the deck description">Edit description</string>
-    <string name="menu_add" comment="A generic add button. Please inform us if you need more specific strings" maxLength="29">Add</string>
-    <string name="menu_add_note" maxLength="41">Add note</string>
+    <string name="menu_add" comment="A generic add button. Please inform us if you need more specific strings" maxLength="28">Add</string>
+    <string name="menu_add_note" maxLength="28">Add note</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
-    <string name="menu_dismiss_note" maxLength="41">Hide / delete</string>
-    <string name="menu_bury_card" maxLength="41">Bury card</string>
-    <string name="menu_bury_note" maxLength="41">Bury note</string>
-    <string name="menu_suspend_card" maxLength="41">Suspend card</string>
-    <string name="menu_suspend_note" maxLength="41">Suspend note</string>
-    <string name="menu_bury" maxLength="41">Bury</string>
-    <string name="menu_suspend" maxLength="41">Suspend</string>
-    <string name="menu_delete_note" maxLength="41">Delete note</string>
+    <string name="menu_dismiss_note" maxLength="41" >Hide / delete</string>
+    <string name="menu_bury_card" maxLength="28">Bury card</string>
+    <string name="menu_bury_note" maxLength="28">Bury note</string>
+    <string name="menu_suspend_card" maxLength="28">Suspend card</string>
+    <string name="menu_suspend_note" maxLength="28">Suspend note</string>
+    <string name="menu_bury" maxLength="28">Bury</string>
+    <string name="menu_suspend" maxLength="28">Suspend</string>
+    <string name="menu_delete_note" maxLength="28">Delete note</string>
     <string name="menu_flag" maxLength="41">Flag</string>
     <string name="rename_flag">Rename flags</string>
-    <string name="menu_flag_card">Flag card</string>
-    <string name="menu_edit_tags" maxLength="41">Edit tags</string>
+    <string name="menu_flag_card" maxLength="28">Flag card</string>
+    <string name="menu_edit_tags" maxLength="28">Edit tags</string>
     <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
-    <string name="menu_search">Lookup in %1$s</string>
-    <string name="menu_mark_note" maxLength="41">Mark note</string>
+    <string name="menu_search" maxLength="28">Lookup in %1$s</string>
+    <string name="menu_mark_note" maxLength="28">Mark note</string>
     <string name="menu_unmark_note">Unmark note</string>
-    <string name="menu_enable_voice_playback" maxLength="41">Enable voice playback</string>
+    <string name="menu_enable_voice_playback" maxLength="28">Enable voice playback</string>
     <string name="menu_disable_voice_playback">Disable voice playback</string>
     <string name="new_deck">Create deck</string>
     <string name="new_dynamic_deck">Create filtered deck</string>
@@ -99,28 +99,28 @@
     of the permissions/app info screen will differ between devices. -->
     <string name="startup_no_storage_permission">Please grant AnkiDroid the ‘Storage’ permission to continue</string>
     <string name="rebuild_filtered_deck">Rebuilding filtered deck…</string>
-    <string name="rebuild_cram_label">Rebuild</string>
-    <string name="empty_cram_label">Empty</string>
+    <string name="rebuild_cram_label" maxLength="28">Rebuild</string>
+    <string name="empty_cram_label" maxLength="28">Empty</string>
     <string name="create_subdeck">Create subdeck</string>
     <string name="empty_filtered_deck">Emptying filtered deck…</string>
     <string name="custom_study_deck_name">Custom study session</string>
     <string name="custom_study_deck_exists">Rename the existing custom study deck first</string>
     <string name="search_deck" comment="Deck search for selecting it">Deck Search</string>
     <string name="empty_deck">This deck is empty</string>
-    <string name="search_for_download_deck" comment="Deck search value for downloading deck">Deck Search</string>
+    <string name="search_for_download_deck" comment="Deck search value for downloading deck" maxLength="28">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
     <string name="studyoptions_congrats_next_due_in" comment="The param will be replaced with 'The next card will be ready in X time'">Deck finished for now! %s</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
 
     <string name="sd_card_not_mounted">Device storage not mounted</string>
-    <string name="button_sync" comment="Text of the sync button">Sync</string>
+    <string name="button_sync" comment="Text of the sync button" maxLength="28">Sync</string>
     <string name="cancel_sync_confirm" tools:ignore="UnusedResources">Do you want to cancel the sync?</string>
     <string name="continue_sync" tools:ignore="UnusedResources">Continue sync</string>
     <string name="sync_cancelled" tools:ignore="UnusedResources">Sync cancelled</string>
     <string name="sync_cancel_message" tools:ignore="UnusedResources">Cancelling…\nThis may take some time.</string>
     <string name="syncing_media">Syncing media</string>
-    <string name="export_deck">Export deck</string>
+    <string name="export_deck" maxLength="28">Export deck</string>
     <string name="export_collection">Export collection</string>
     <string name="nothing">Nothing</string>
 
@@ -128,10 +128,10 @@
     <string name="title_activity_template_editor">Card types</string>
     <string name="card_template_editor_front">Front template</string>
     <string name="card_template_editor_back">Back template</string>
-    <string name="card_template_editor_styling">Styling</string>
-    <string name="card_template_editor_menu_card_browser_appearance">Card Browser Appearance</string>
-    <string name="card_template_editor_deck_override">Deck override</string>
-    <string name="card_template_editor_insert_field">Insert field</string>
+    <string name="card_template_editor_styling" maxLength="28">Styling</string>
+    <string name="card_template_editor_menu_card_browser_appearance" maxLength="28">Card Browser Appearance</string>
+    <string name="card_template_editor_deck_override" maxLength="28">Deck override</string>
+    <string name="card_template_editor_insert_field" maxLength="28">Insert field</string>
     <string name="card_template_editor_select_field">Select field</string>
     <string name="card_template_editor_cant_delete">At least one card type is required</string>
     <plurals name="card_template_editor_confirm_add">
@@ -149,7 +149,7 @@
     <string name="card_template_browser_appearance_title">Browser appearance</string>
 
     <!-- card Info -->
-    <string name="card_info_title" maxLength="41">Card info</string>
+    <string name="card_info_title" maxLength="28">Card info</string>
 
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -21,7 +21,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Navigation drawer items-->
     <string name="decks">Decks</string>
-    <string name="card_browser" comment="The usage of card browser inside the app (note the casing)">Card browser</string>
+    <string name="card_browser" maxLength="41" comment="The usage of card browser inside the app (note the casing)">Card browser</string>
     <string name="statistics">Statistics</string>
     <string name="settings">Settings</string>
     <string name="help">Help</string>
@@ -53,15 +53,15 @@
 
     <!-- flashcard_portrait.xml -->
     <string name="type_answer_hint">Type answer</string>
-    <string name="show_answer">Show answer</string>
+    <string name="show_answer" maxLength="41">Show answer</string>
     <string name="hide_answer">Hide answer</string>
-    <string name="ease_button_again">Again</string>
-    <string name="ease_button_hard">Hard</string>
-    <string name="ease_button_good">Good</string>
+    <string name="ease_button_again" maxLength="41">Again</string>
+    <string name="ease_button_hard" maxLength="41">Hard</string>
+    <string name="ease_button_good" maxLength="41">Good</string>
     <string name="ease_button_easy">Easy</string>
     <string name="menu_import">Import</string>
     <string name="undo"  maxLength="29" comment="When tapping on this text, the last action is undone.">Undo</string>
-    <string name="redo">Redo</string>
+    <string name="redo" maxLength="41">Redo</string>
     <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury">Unbury</string>
@@ -70,25 +70,25 @@
     <string name="browse_cards">Browse cards</string>
     <string name="edit_deck_description" comment="edit the deck description">Edit description</string>
     <string name="menu_add" comment="A generic add button. Please inform us if you need more specific strings" maxLength="29">Add</string>
-    <string name="menu_add_note">Add note</string>
+    <string name="menu_add_note" maxLength="41">Add note</string>
     <string name="menu_my_account" comment="Label of the window in which the user should enter their account. This text can't be found in AnkiDroid directly.">Sync account</string>
-    <string name="menu_dismiss_note">Hide / delete</string>
-    <string name="menu_bury_card">Bury card</string>
-    <string name="menu_bury_note">Bury note</string>
-    <string name="menu_suspend_card">Suspend card</string>
-    <string name="menu_suspend_note">Suspend note</string>
-    <string name="menu_bury">Bury</string>
-    <string name="menu_suspend">Suspend</string>
-    <string name="menu_delete_note">Delete note</string>
-    <string name="menu_flag">Flag</string>
+    <string name="menu_dismiss_note" maxLength="41">Hide / delete</string>
+    <string name="menu_bury_card" maxLength="41">Bury card</string>
+    <string name="menu_bury_note" maxLength="41">Bury note</string>
+    <string name="menu_suspend_card" maxLength="41">Suspend card</string>
+    <string name="menu_suspend_note" maxLength="41">Suspend note</string>
+    <string name="menu_bury" maxLength="41">Bury</string>
+    <string name="menu_suspend" maxLength="41">Suspend</string>
+    <string name="menu_delete_note" maxLength="41">Delete note</string>
+    <string name="menu_flag" maxLength="41">Flag</string>
     <string name="rename_flag">Rename flags</string>
     <string name="menu_flag_card">Flag card</string>
-    <string name="menu_edit_tags">Edit tags</string>
+    <string name="menu_edit_tags" maxLength="41">Edit tags</string>
     <string name="delete_note_message">Really delete this note and all its cards?\n%s</string>
     <string name="menu_search">Lookup in %1$s</string>
-    <string name="menu_mark_note">Mark note</string>
+    <string name="menu_mark_note" maxLength="41">Mark note</string>
     <string name="menu_unmark_note">Unmark note</string>
-    <string name="menu_enable_voice_playback">Enable voice playback</string>
+    <string name="menu_enable_voice_playback" maxLength="41">Enable voice playback</string>
     <string name="menu_disable_voice_playback">Disable voice playback</string>
     <string name="new_deck">Create deck</string>
     <string name="new_dynamic_deck">Create filtered deck</string>
@@ -149,7 +149,7 @@
     <string name="card_template_browser_appearance_title">Browser appearance</string>
 
     <!-- card Info -->
-    <string name="card_info_title">Card info</string>
+    <string name="card_info_title" maxLength="41">Card info</string>
 
     <!-- Permissions -->
     <string name="read_write_permission_label">Read and write to the AnkiDroid database</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -32,22 +32,22 @@
 
     <string name="tag_name">Tag name</string>
     <string name="add_new_filter_tags">Add/filter tags</string>
-    <string name="add_tag">Add tag</string>
-    <string name="check_all_tags">Check/uncheck all tags</string>
-    <string name="filter_tags">Filter tags</string>
+    <string name="add_tag" maxLength="28">Add tag</string>
+    <string name="check_all_tags" maxLength="28">Check/uncheck all tags</string>
+    <string name="filter_tags" maxLength="28">Filter tags</string>
     <string name="no_tags">You haven’t added any tags yet</string>
     <string name="updated_version">Updated to version %s</string>
 
     <!-- Reviewer.kt -->
-    <string name="save_whiteboard" maxLength="41">Save whiteboard</string>
-    <string name="enable_stylus" maxLength="41">Enable stylus writing</string>
+    <string name="save_whiteboard" maxLength="28">Save whiteboard</string>
+    <string name="enable_stylus" maxLength="28">Enable stylus writing</string>
     <string name="disable_stylus">Disable stylus writing</string>
-    <string name="enable_whiteboard" maxLength="41">Enable whiteboard</string>
+    <string name="enable_whiteboard" maxLength="28">Enable whiteboard</string>
     <string name="disable_whiteboard">Disable whiteboard</string>
     <string name="show_whiteboard">Show whiteboard</string>
-    <string name="hide_whiteboard" maxLength="41">Hide whiteboard</string>
-    <string name="clear_whiteboard" maxLength="41">Clear whiteboard</string>
-    <string name="replay_audio" maxLength="41">Replay audio</string>
+    <string name="hide_whiteboard" maxLength="28">Hide whiteboard</string>
+    <string name="clear_whiteboard" maxLength="28">Clear whiteboard</string>
+    <string name="replay_audio" maxLength="28">Replay audio</string>
     <string name="leech_suspend_notification">Card marked as leech and suspended</string>
     <string name="leech_notification">Card marked as leech</string>
     <string name="webview_crash_unknown">Unknown error</string>
@@ -74,14 +74,14 @@
     </plurals>
 
     <!-- Card editor -->
-    <string name="cardeditor_title_edit_card" maxLength="41">Edit note</string>
+    <string name="cardeditor_title_edit_card" maxLength="28">Edit note</string>
     <string name="discard">Discard</string>
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
     <string name="note_editor_insert_cloze_no_cloze_note_type">Cloze deletions will only work on a Cloze note type</string>
     <string name="saving_facts">Saving note</string>
     <string name="saving_model">Saving note type</string>
-    <string name="save">Save</string>
+    <string name="save" maxLength="28">Save</string>
     <string name="close">Close</string>
     <string name="select">Select</string>
     <string name="field_remapping">%1$s (from “%2$s”)</string>
@@ -102,19 +102,19 @@
     </plurals>
 
     <string name="fact_adder_intent_title" comment="Label of the 'Add Note' window. This title can't be seen in AnkiDroid directly.">AnkiDroid card</string>
-    <string name="note_editor_copy_note">Copy note</string>
-    <string name="card_editor_reposition_card" comment="reposition a card in the new queue">Reposition</string>
-    <string name="card_editor_reset_card">Reset progress</string>
-    <string name="card_editor_reschedule_card" comment="Action to reschedule a card">Reschedule</string>
-    <string name="card_editor_preview_card" comment="Button offering to preview some card(s)" maxLength="29">Preview</string>
-    <string name="copy_as_markdown" comment="Copies text to the clipboard as Markdown">Copy as Markdown</string>
+    <string name="note_editor_copy_note" maxLength="28">Copy note</string>
+    <string name="card_editor_reposition_card" comment="reposition a card in the new queue" maxLength="28">Reposition</string>
+    <string name="card_editor_reset_card" maxLength="28">Reset progress</string>
+    <string name="card_editor_reschedule_card" comment="Action to reschedule a card" maxLength="28">Reschedule</string>
+    <string name="card_editor_preview_card" comment="Button offering to preview some card(s)" maxLength="28">Preview</string>
+    <string name="copy_as_markdown" comment="Copies text to the clipboard as Markdown" maxLength="28">Copy as Markdown</string>
     <string name="preview_progress_bar_text" comment="What card we are on out of how many in card previewer progress bar">%1$d of %2$d</string>
-    <string name="rename" comment="Confirm that the renaming action should be processed.">Rename</string>
+    <string name="rename" comment="Confirm that the renaming action should be processed." maxLength="28">Rename</string>
 
-    <string name="checks_action">Check</string>
-    <string name="check_db">Check database</string>
-    <string name="check_media">Check media</string>
-    <string name="empty_cards">Empty cards</string>
+    <string name="checks_action" maxLength="28">Check</string>
+    <string name="check_db" maxLength="28">Check database</string>
+    <string name="check_media" maxLength="28">Check media</string>
+    <string name="empty_cards" maxLength="28">Empty cards</string>
     <string name="unknown_type_field_warning">Type answer: unknown field %s</string>
     <string name="delete_deck">Deleting deck…</string>
 
@@ -152,11 +152,11 @@
     <string name="export_choice_share">Share</string>
     <string name="export_choice_save_to">Save to</string>
     <string name="export_saving_exported_collection">Saving exported file&#8230;</string>
-    <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options" maxLength="29">Options</string>
-    <string name="menu__deck_options" maxLength="41">Deck options</string>
+    <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options" maxLength="28">Options</string>
+    <string name="menu__deck_options" maxLength="28">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
-    <string name="select_tts" maxLength="41">Set TTS language</string>
-    <string name="custom_study">Custom study</string>
+    <string name="select_tts" maxLength="28">Set TTS language</string>
+    <string name="custom_study" maxLength="28">Custom study</string>
     <string name="more_options">More</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
     <string name="steps_error">Steps must be numbers greater than 0</string>
@@ -183,7 +183,7 @@
     <string name="choose_an_image" maxLength="41">Select image</string>
     <string name="remove_background_image">Remove background?</string>
     <!-- Card Template Browser Appearance -->
-    <string name="restore_default">Restore Default</string>
+    <string name="restore_default" maxLength="28">Restore Default</string>
 
     <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
 
@@ -192,7 +192,7 @@
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>
 
     <string name="title_whiteboard_pen_color" maxLength="41">Whiteboard pen color</string>
-    <string name="title_whiteboard_editor" maxLength="41">Whiteboard editor</string>
+    <string name="title_whiteboard_editor" maxLength="28">Whiteboard editor</string>
 
     <string name="user_is_a_robot">Detected automated test. If you are a human, contact AnkiDroid support</string>
 
@@ -212,14 +212,14 @@
     <string name="card_viewer_could_not_find_image">Card Content Error: Failed to load ‘%s’</string>
 
     <!-- Deck Picker -->
-    <string name="search_decks">Search decks</string>
+    <string name="search_decks" maxLength="28">Search decks</string>
     <string name="ankidroid_init_failed_webview_title">Fatal Error</string>
     <string name="ankidroid_init_failed_webview">AnkiDroid relies on the System WebView which is unavailable. This can happen if the system is installing updates. Please try again in a few minutes.\n\n%s</string>
 
     <!-- A Menu item to change the Font Size (currently in the Note Editor) -->
-    <string name="menu_font_size">Font size</string>
+    <string name="menu_font_size" maxLength="28">Font size</string>
 
-    <string name="menu_show_toolbar" comment="Checkable item stating whether the note editor toolbar should be shown">Show toolbar</string>
+    <string name="menu_show_toolbar" comment="Checkable item stating whether the note editor toolbar should be shown" maxLength="28">Show toolbar</string>
 
     <string name="format_insert_bold">Format as Bold</string>
     <string name="format_insert_italic">Format as Italic</string>
@@ -249,8 +249,8 @@
     <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
-    <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled">Capitalize sentences</string>
-    <string name="menu_scroll_toolbar" comment="Checkbox stating whether note editor toolbar is scrollable or stacked. Checked: Scroll">Scroll toolbar</string>
+    <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled" maxLength="28">Capitalize sentences</string>
+    <string name="menu_scroll_toolbar" comment="Checkbox stating whether note editor toolbar is scrollable or stacked. Checked: Scroll" maxLength="28">Scroll toolbar</string>
 
 
     <!-- Symbols used as Button text in IncrementNumberRangePreference -->
@@ -279,7 +279,7 @@
     <string name="check_network">Please check your network connection</string>
     <string name="search_using_deck_name">Search using deck name</string>
     <string name="external_storage_unavailable">Download aborted, the external storage is not available</string>
-    <string name="home">Home</string>
+    <string name="home" maxLength="28">Home</string>
 
     <!-- Reviewer actions 
     Each of these strings ends with a period, following the notation of Anki Desktop -->
@@ -393,7 +393,7 @@ opening the system text to speech settings fails">
         <item quantity="other">%d cards unburied</item>
     </plurals>
 
-    <string name="card_template_reposition_template" comment="move a card template to a new position">Reposition</string>
+    <string name="card_template_reposition_template" comment="move a card template to a new position" maxLength="28">Reposition</string>
 
     <string name="start_recording">Record</string>
     <string name="stop_recording">Stop</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -39,15 +39,15 @@
     <string name="updated_version">Updated to version %s</string>
 
     <!-- Reviewer.kt -->
-    <string name="save_whiteboard">Save whiteboard</string>
-    <string name="enable_stylus">Enable stylus writing</string>
+    <string name="save_whiteboard" maxLength="41">Save whiteboard</string>
+    <string name="enable_stylus" maxLength="41">Enable stylus writing</string>
     <string name="disable_stylus">Disable stylus writing</string>
-    <string name="enable_whiteboard">Enable whiteboard</string>
+    <string name="enable_whiteboard" maxLength="41">Enable whiteboard</string>
     <string name="disable_whiteboard">Disable whiteboard</string>
     <string name="show_whiteboard">Show whiteboard</string>
-    <string name="hide_whiteboard">Hide whiteboard</string>
-    <string name="clear_whiteboard">Clear whiteboard</string>
-    <string name="replay_audio">Replay audio</string>
+    <string name="hide_whiteboard" maxLength="41">Hide whiteboard</string>
+    <string name="clear_whiteboard" maxLength="41">Clear whiteboard</string>
+    <string name="replay_audio" maxLength="41">Replay audio</string>
     <string name="leech_suspend_notification">Card marked as leech and suspended</string>
     <string name="leech_notification">Card marked as leech</string>
     <string name="webview_crash_unknown">Unknown error</string>
@@ -59,7 +59,7 @@
     <string name="webview_crash_loop_dialog_title">System WebView Rendering Failure</string>
     <string name="webview_crash_loop_dialog_content">System WebView failed to render card \'%1$s\'.\n %2$s</string>
 
-    <string name="filter_by_flags">Flags</string>
+    <string name="filter_by_flags" maxLength="41">Flags</string>
 
     <!-- Custom study options -->
     <string name="custom_study_increase_new_limit">Modify today’s new card limit</string>
@@ -74,7 +74,7 @@
     </plurals>
 
     <!-- Card editor -->
-    <string name="cardeditor_title_edit_card">Edit note</string>
+    <string name="cardeditor_title_edit_card" maxLength="41">Edit note</string>
     <string name="discard">Discard</string>
     <string name="note_editor_no_cards_created">No cards created. Please fill in more fields</string>
     <string name="note_editor_no_cards_created_all_fields">The current note type did not produce any cards.\nPlease choose another note type, or click ‘Cards’ and add a field substitution</string>
@@ -153,9 +153,9 @@
     <string name="export_choice_save_to">Save to</string>
     <string name="export_saving_exported_collection">Saving exported file&#8230;</string>
     <string name="study_options" comment="Name for a preference category in Filtered deck (aka Cram deck, aka Custom study) options" maxLength="29">Options</string>
-    <string name="menu__deck_options">Deck options</string>
+    <string name="menu__deck_options" maxLength="41">Deck options</string>
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
-    <string name="select_tts">Set TTS language</string>
+    <string name="select_tts" maxLength="41">Set TTS language</string>
     <string name="custom_study">Custom study</string>
     <string name="more_options">More</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
@@ -179,8 +179,8 @@
     <string name="web_page_error">Error loading page: %s</string>
     <!-- The name of the deck which corrupt cards will be moved to -->
     <!-- Deckpicker Background -->
-    <string name="background_image_title">Background</string>
-    <string name="choose_an_image">Select image</string>
+    <string name="background_image_title" maxLength="41">Background</string>
+    <string name="choose_an_image" maxLength="41">Select image</string>
     <string name="remove_background_image">Remove background?</string>
     <!-- Card Template Browser Appearance -->
     <string name="restore_default">Restore Default</string>
@@ -191,8 +191,8 @@
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>
 
-    <string name="title_whiteboard_pen_color">Whiteboard pen color</string>
-    <string name="title_whiteboard_editor">Whiteboard editor</string>
+    <string name="title_whiteboard_pen_color" maxLength="41">Whiteboard pen color</string>
+    <string name="title_whiteboard_editor" maxLength="41">Whiteboard editor</string>
 
     <string name="user_is_a_robot">Detected automated test. If you are a human, contact AnkiDroid support</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -232,7 +232,7 @@
     <!-- scoped storage -->
     <string name="backup_your_collection">Backup your collection</string>
     <string name="backup_collection_message">You haven\'t backed up your collection in a while. You should do this now to prevent data loss</string>
-    <string name="button_backup">Backup</string>
+    <string name="button_backup" maxLength="41">Backup</string>
     <string name="button_disable_reminder">Disable reminder</string>
     <string name="button_backup_later" comment="dismiss the 'Backup' dialog for around 2 weeks">Later</string>
     <string name="button_do_not_show_again" comment="permanently dismisses a dialog">Don\'t show again</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -20,7 +20,7 @@
 --><resources xmlns:tools="http://schemas.android.com/tools">
     <string name="check_db_title">Check database?</string>
     <string name="check_db_warning">This may take a long time</string>
-    <string name="contextmenu_deckpicker_delete_deck">Delete deck</string>
+    <string name="contextmenu_deckpicker_delete_deck" maxLength="28">Delete deck</string>
     <string name="delete_deck_title">Delete deck?</string>
     <plurals name="delete_deck_message">
         <item quantity="one">Delete all cards in %1$s? It contains %2$d card</item>
@@ -81,7 +81,7 @@
     <string name="dialog_continue">Continue</string>
     <string name="dialog_processing">Processing…</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>
-    <string name="dialog_positive_delete">Delete</string>
+    <string name="dialog_positive_delete" maxLength="28">Delete</string>
     <!-- Currently unsued, should be useful in the future -->
     <string name="dialog_positive_disable" tools:ignore="UnusedResources">Disable</string>
     <string name="dialog_positive_overwrite">Overwrite</string>
@@ -188,7 +188,7 @@
     <string name="help_item_reddit">Reddit</string>
     <string name="help_item_report_bug">Report a Bug</string>
 
-    <string name="help_title_support_ankidroid">Support AnkiDroid</string>
+    <string name="help_title_support_ankidroid" maxLength="28">Support AnkiDroid</string>
     <string name="help_item_support_opencollective_donate">Donate</string>
     <string name="help_item_support_develop_ankidroid">Develop</string>
     <string name="help_item_support_rate_ankidroid">Rate</string>

--- a/AnkiDroid/src/main/res/values/04-network.xml
+++ b/AnkiDroid/src/main/res/values/04-network.xml
@@ -53,7 +53,7 @@
     <!-- Please run ‘Check database’ before syncing -->
     <string name="sync_sanity_local">Local</string>
     <string name="sync_sanity_remote">Remote</string>
-    <string name="one_way_sync_title">One-way sync</string>
+    <string name="one_way_sync_title" maxLength="41">One-way sync</string>
     <string name="one_way_sync_confirmation">One way sync requested</string>
     <string name="full_sync_confirmation">The requested change will require a full upload of the database when you next synchronize your collection. If you have reviews or other changes waiting on another device that haven’t been synchronized here yet, they will be lost. Continue?</string>
     <string name="full_sync_confirmation_upgrade">Due to a bug in the previously installed version of AnkiDroid, it’s recommended to force a full sync.</string>

--- a/AnkiDroid/src/main/res/values/05-feedback.xml
+++ b/AnkiDroid/src/main/res/values/05-feedback.xml
@@ -22,7 +22,7 @@
 <resources>
     <!-- Feedback.java -->
     <string name="empty_string"/>
-    <string name="error_reporting_choice">Error reporting mode</string>
+    <string name="error_reporting_choice" maxLength="41">Error reporting mode</string>
     <string name="feedback_disclaimer">Disclaimer: We don’t collect any personal information such as your email address, phone number, or your phone IMEI. We do collect some information about your device such as the manufacturer, model and version of Android, as well as the nature of reported errors themselves and the steps which led up to them occurring.</string>
     <string name="feedback_title">AnkiDroid Feedback</string>
     <string name="feedback_default_text">Enter your feedback or information about the nature of any errors you’re reporting.</string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -34,23 +34,23 @@
         <item quantity="one">Delete note</item>
         <item quantity="other">Delete notes</item>
     </plurals>
-    <string name="card_browser_change_deck">Change deck</string>
+    <string name="card_browser_change_deck" maxLength="28">Change deck</string>
     <string name="delete_card_title">Delete note?</string>
-    <string name="card_browser_show_marked" maxLength="29">Filter marked</string>
-    <string name="card_browser_show_suspended" maxLength="29">Filter suspended</string>
-    <string name="card_browser_search_by_tag" maxLength="29">Filter by tag</string>
-    <string name="card_browser_search_by_flag" maxLength="29">Filter by flag</string>
-    <string name="card_browser_list_my_searches" maxLength="29">My searches</string>
-    <string name="card_browser_list_my_searches_save" maxLength="29">Save search</string>
+    <string name="card_browser_show_marked" maxLength="28">Filter marked</string>
+    <string name="card_browser_show_suspended" maxLength="28">Filter suspended</string>
+    <string name="card_browser_search_by_tag" maxLength="28">Filter by tag</string>
+    <string name="card_browser_search_by_flag" maxLength="28">Filter by flag</string>
+    <string name="card_browser_list_my_searches" maxLength="28">My searches</string>
+    <string name="card_browser_list_my_searches_save" maxLength="28">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>
     <string name="card_browser_list_my_searches_new_name">Name for the current search</string>
     <string name="card_browser_list_my_searches_new_search_error_empty_name">You can’t save a search without a name</string>
     <string name="card_browser_list_my_searches_new_search_error_dup">Name exists</string>
     <string name="no_note_to_edit">No note to edit</string>
     <string name="card_browser_list_my_searches_remove_content">Delete “%1$s”?</string>
-    <string name="card_browser_change_display_order" maxLength="29">Change display order</string>
+    <string name="card_browser_change_display_order" maxLength="28">Change display order</string>
     <string name="card_browser_search_hint" comment="Message displayed in the search text field in the card browser.">Search</string>
-    <string name="card_browser_cram_search" maxLength="29" comment = "Menu entry to start a search.">Search</string>
+    <string name="card_browser_cram_search" maxLength="28" comment = "Menu entry to start a search.">Search</string>
     <string name="card_browser_change_display_order_title">Choose display order</string>
     <string name="card_details_tags">Tags</string>
     <string-array name="card_browser_order_labels">
@@ -65,8 +65,8 @@
         <item>By reviews</item>
         <item>By lapses</item>
     </string-array>
-    <string name="card_browser_select_all" maxLength="29">Select all</string>
-    <string name="card_browser_select_none">Select none</string>
+    <string name="card_browser_select_all" maxLength="28">Select all</string>
+    <string name="card_browser_select_none" maxLength="28">Select none</string>
     <string name="card_browser_interval_new_card" comment="Message indicating that a card is currently new, and so has no interval/ease.">(new)</string>
     <string name="card_browser_due_filtered_card">(filtered)</string>
     <string name="card_browser_interval_learning_card">(learning)</string>

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -21,7 +21,7 @@
 
     <string name="backup_deck_no_storage_left">Backup not saved. Not enough space left on your storage. Lower the backup depth or remove some other files.</string>
     <string name="storage_warning">Less than %d MB space on your storage left.\nFree some space to avoid data loss.</string>
-    <string name="backup_restore">Restore from backup</string>
+    <string name="backup_restore" maxLength="28">Restore from backup</string>
     <string name="backup_new_collection">New collection</string>
     <string name="backup_del_collection">Delete collection and create new one</string>
     <string name="backup_del_collection_question">Delete the collection and create a new one? This will drop all your learning progress and delete all cards.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -314,14 +314,10 @@ this formatter is used if the bind only applies to both the question and the ans
         <br><br>
         You can restore from a backup and export your collection in the deck list menu.
     ]]></string>
-    <string name="pref__minutes_between_automatic_backups__title" maxLength="41"
-        >Minutes between automatic backups</string>
-    <string name="pref__daily_backups_to_keep__title" maxLength="41"
-        >Daily backups to keep</string>
-    <string name="pref__weekly_backups_to_keep__title" maxLength="41"
-        >Weekly backups to keep</string>
-    <string name="pref__monthly_backups_to_keep__title" maxLength="41"
-        >Monthly backups to keep</string>
+    <string name="pref__minutes_between_automatic_backups__title" maxLength="41">Minutes between automatic backups</string>
+    <string name="pref__daily_backups_to_keep__title" maxLength="41">Daily backups to keep</string>
+    <string name="pref__weekly_backups_to_keep__title" maxLength="41">Weekly backups to keep</string>
+    <string name="pref__monthly_backups_to_keep__title" maxLength="41">Monthly backups to keep</string>
 
     <!-- #######################################################################################
          ################################# Manage space activity ###############################

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -222,7 +222,7 @@
     <string name="deck_conf_cram_search" maxLength="41" comment = "Label of a text field that contains a search query.">Search</string>
     <string name="deck_conf_cram_limit" maxLength="41">Limit to</string>
     <string name="deck_conf_cram_order" maxLength="41">Cards selected by</string>
-    <string name="deck_conf_cram_reschedule"  maxLength="41" comment="Title of the box labelled by deck_conf_cram_reschedule_summ">Reschedule</string>
+    <string name="deck_conf_cram_reschedule" maxLength="41" comment="Title of the box labelled by deck_conf_cram_reschedule_summ">Reschedule</string>
     <string name="deck_conf_cram_reschedule_summ">Reschedule cards based on my answers in this deck</string>
     <string name="deck_conf_cram_filter_2_check">Enable second filter</string>
     <string name="deck_conf_cram_steps_summ" maxLength="41">Define custom steps</string>
@@ -260,22 +260,22 @@
     <string name="axis_picker_move_joystick">Move a joystick/motion controller</string>
     <string name="user_actions" maxLength="41">User actions</string>
     <string name="user_actions_summary" maxLength="41">Trigger JavaScript from the review screen</string>
-    <string name="user_action_1" maxLength="41">User action 1</string>
-    <string name="user_action_2" maxLength="41">User action 2</string>
-    <string name="user_action_3" maxLength="41">User action 3</string>
-    <string name="user_action_4" maxLength="41">User action 4</string>
-    <string name="user_action_5" maxLength="41">User action 5</string>
-    <string name="user_action_6" maxLength="41">User action 6</string>
-    <string name="user_action_7" maxLength="41">User action 7</string>
-    <string name="user_action_8" maxLength="41">User action 8</string>
-    <string name="user_action_9" maxLength="41">User action 9</string>
+    <string name="user_action_1" maxLength="28">User action 1</string>
+    <string name="user_action_2" maxLength="28">User action 2</string>
+    <string name="user_action_3" maxLength="28">User action 3</string>
+    <string name="user_action_4" maxLength="28">User action 4</string>
+    <string name="user_action_5" maxLength="28">User action 5</string>
+    <string name="user_action_6" maxLength="28">User action 6</string>
+    <string name="user_action_7" maxLength="28">User action 7</string>
+    <string name="user_action_8" maxLength="28">User action 8</string>
+    <string name="user_action_9" maxLength="28">User action 9</string>
     <string name="toggle_auto_advance" maxLength="41">Toggle auto advance</string>
 
     <!-- Select card side -->
     <string name="card_side_selection_title">Select card side</string>
     <string name="card_side_question">Question</string>
     <string name="card_side_answer">Answer</string>
-    <string name="card_side_both">Question &amp; Answer</string>
+    <string name="card_side_both" maxLength="28">Question &amp; Answer</string>
     <string name="display_binding_card_side_question" comment="When displaying a key bind on a preference
 this formatter is used if the bind only applies to the question">Q: %s</string>
     <string name="display_binding_card_side_answer" comment="When displaying a key bind on a preference

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -65,28 +65,28 @@
     <string name="html_size_code_xx_large">xx-large</string>
 
     <!-- gestures_labels -->
-    <string name="answer_again">Answer again</string>
-    <string name="answer_hard">Answer hard</string>
-    <string name="answer_good">Answer good</string>
-    <string name="answer_easy">Answer easy</string>
-    <string name="gesture_play">Play media</string>
-    <string name="gesture_abort_learning">Close reviewer</string>
-    <string name="gesture_flag_red">Toggle Red Flag</string>
-    <string name="gesture_flag_orange">Toggle Orange Flag</string>
-    <string name="gesture_flag_green">Toggle Green Flag</string>
-    <string name="gesture_flag_blue">Toggle Blue Flag</string>
-    <string name="gesture_flag_pink">Toggle Pink Flag</string>
-    <string name="gesture_flag_turquoise">Toggle Turquoise Flag</string>
-    <string name="gesture_flag_purple">Toggle Purple Flag</string>
-    <string name="gesture_flag_remove">Remove Flag</string>
-    <string name="gesture_page_up">Page Up</string>
-    <string name="gesture_page_down">Page Down</string>
-    <string name="gesture_abort_sync">Close reviewer and Sync</string>
-    <string name="gesture_toggle_whiteboard">Toggle Whiteboard</string>
-    <string name="gesture_show_hint">Show Hint</string>
-    <string name="gesture_show_all_hints">Show All Hints</string>
-    <string name="record_voice">Record Voice</string>
-    <string name="replay_voice">Replay Voice</string>
-    <string name="save_voice">Save Recording</string>
+    <string name="answer_again" maxLength="41">Answer again</string>
+    <string name="answer_hard" maxLength="41">Answer hard</string>
+    <string name="answer_good" maxLength="41">Answer good</string>
+    <string name="answer_easy" maxLength="41">Answer easy</string>
+    <string name="gesture_play" maxLength="41">Play media</string>
+    <string name="gesture_abort_learning" maxLength="41">Close reviewer</string>
+    <string name="gesture_flag_red" maxLength="41">Toggle Red Flag</string>
+    <string name="gesture_flag_orange" maxLength="41">Toggle Orange Flag</string>
+    <string name="gesture_flag_green" maxLength="41">Toggle Green Flag</string>
+    <string name="gesture_flag_blue" maxLength="41">Toggle Blue Flag</string>
+    <string name="gesture_flag_pink" maxLength="41">Toggle Pink Flag</string>
+    <string name="gesture_flag_turquoise" maxLength="41">Toggle Turquoise Flag</string>
+    <string name="gesture_flag_purple" maxLength="41">Toggle Purple Flag</string>
+    <string name="gesture_flag_remove" maxLength="41">Remove Flag</string>
+    <string name="gesture_page_up" maxLength="41">Page Up</string>
+    <string name="gesture_page_down" maxLength="41">Page Down</string>
+    <string name="gesture_abort_sync" maxLength="41">Close reviewer and Sync</string>
+    <string name="gesture_toggle_whiteboard" maxLength="41">Toggle Whiteboard</string>
+    <string name="gesture_show_hint" maxLength="41">Show Hint</string>
+    <string name="gesture_show_all_hints" maxLength="41">Show All Hints</string>
+    <string name="record_voice" maxLength="41">Record Voice</string>
+    <string name="replay_voice" maxLength="41">Replay Voice</string>
+    <string name="save_voice" maxLength="41">Save Recording</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -49,12 +49,12 @@
 
     <!-- Crop function-->
     <string name="crop_image">Do you want to crop this image?</string>
-    <string name="crop_button">Crop image</string>
+    <string name="crop_button" maxLength="28">Crop image</string>
     <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to compress it?</string>
     <string name="select_image_failed">"Select image failed, Please retry"</string>
     <string name="activity_result_unexpected">App returned an unexpected value. You may need to use a different app</string>
     <string name="audio_recording_field_list" comment="Displays a list of the field data in the note editor while audio recording is taking place">Field Contents</string>
 
-    <string name="reselect">Reselect</string>
+    <string name="reselect" maxLength="28">Reselect</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -2,7 +2,7 @@
 <resources>
 
     <!--Menu Labels-->
-    <string name="model_browser_label" comment="Label of the browser of note types. The text can't be found in AnkiDroid directly.">Manage note types</string>
+    <string name="model_browser_label" comment="Label of the browser of note types. The text can't be found in AnkiDroid directly." maxLength="28">Manage note types</string>
     <string name="model_editor_label" comment="Label of the window to edit the fields of a note type. This text can't be found in Ankidroid directly">Manage fields</string>
 
 
@@ -41,7 +41,7 @@
 
     <!--Field Editing-->
     <string name="model_field_editor_title">Edit fields</string>.
-    <string name="model_field_editor_add">Add field</string>
+    <string name="model_field_editor_add" maxLength="28">Add field</string>
     <string name="model_field_editor_delete">Delete field</string>
     <string name="model_field_editor_rename">Rename field</string>
     <string name="model_field_editor_language_hint">Set keyboard language hint</string>
@@ -74,7 +74,7 @@
     <string name="model_manager_deck_override_added_message">Set ‘%1$s’ default deck to ‘%2$s’</string>
     <string name="model_manager_deck_override_removed_message">Removed default deck for ‘%s’</string>
     <string name="deck_override_explanation">Select deck to place new ‘%s’ cards into</string>
-    <string name="deck_picker_dialog_filter_decks">Filter decks</string>
+    <string name="deck_picker_dialog_filter_decks" maxLength="28">Filter decks</string>
 
 
 </resources>

--- a/AnkiDroid/src/main/res/values/18-standard-models.xml
+++ b/AnkiDroid/src/main/res/values/18-standard-models.xml
@@ -2,6 +2,6 @@
 <resources>
 
     <!--Fields-->
-    <string name="front_field_name">Front</string>
-    <string name="back_field_name">Back</string>
+    <string name="front_field_name" maxLength="28">Front</string>
+    <string name="back_field_name" maxLength="28">Back</string>
 </resources>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -61,7 +61,9 @@ class IssueRegistry : IssueRegistry() {
                 NonPositionalFormatSubstitutions.ISSUE,
                 TranslationTypo.ISSUE,
                 FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH,
+                FixedPreferencesTitleLength.MENU_ISSUE_MAX_LENGTH,
                 FixedPreferencesTitleLength.PREFERENCES_ISSUE_TITLE_LENGTH,
+                FixedPreferencesTitleLength.MENU_ISSUE_TITLE_LENGTH,
                 VariableNamingDetector.ISSUE,
                 InvalidStringFormatDetector.ISSUE,
                 AvoidAlertDialogUsage.ISSUE

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -60,8 +60,8 @@ class IssueRegistry : IssueRegistry() {
                 PrintStackTraceUsage.ISSUE,
                 NonPositionalFormatSubstitutions.ISSUE,
                 TranslationTypo.ISSUE,
-                FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
-                FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH,
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_TITLE_LENGTH,
                 VariableNamingDetector.ISSUE,
                 InvalidStringFormatDetector.ISSUE,
                 AvoidAlertDialogUsage.ISSUE

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -27,48 +27,52 @@ import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
-import com.android.utils.Pair
-import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import org.w3c.dom.Element
+import java.lang.IllegalArgumentException
 import java.util.Locale
 
+/**
+ * Detector for preference's title whose length may be bigger than 41 character.
+ * There is an error for each string which is longer than 41 character in English.
+ * There is also an error for each string which does not have `maxLength` set to at most 41.
+ *
+ * Recall that `title` here is not the title of the preference screen, but the title of the preference entry. That is the text in bold that appears on a single line.
+ */
 class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     companion object {
-        @VisibleForTesting
-        val ID_TITLE_LENGTH = "FixedPreferencesTitleLength"
+        private const val PREFERENCES_ID_TITLE_LENGTH = "FixedPreferencesTitleLength"
 
-        @VisibleForTesting
-        val ID_MAX_LENGTH = "PreferencesTitleMaxLengthAttr"
-        private const val PREFERENCE_TITLE_MAX_LENGTH = 41
+        private const val PREFERENCES_ID_MAX_LENGTH = "PreferencesTitleMaxLengthAttr"
 
-        @VisibleForTesting
-        val DESCRIPTION_TITLE_LENGTH = "Preference titles should be less than $PREFERENCE_TITLE_MAX_LENGTH characters"
+        private const val PREFERENCES_TITLE_MAX_LENGTH = 41
 
-        @VisibleForTesting
-        val DESCRIPTION_MAX_LENGTH = """Preference titles should contain maxLength="$PREFERENCE_TITLE_MAX_LENGTH" attribute"""
+        private const val PREFERENCES_DESCRIPTION_TITLE_LENGTH = "Preference titles should be less than $PREFERENCES_TITLE_MAX_LENGTH characters"
+
+        private const val PREFERENCES_DESCRIPTION_MAX_LENGTH = """Preference titles should contain maxLength="$PREFERENCES_TITLE_MAX_LENGTH" attribute"""
 
         // Around 42 is a hard max on emulators, likely smaller in reality, so use a buffer
-        private const val EXPLANATION_TITLE_LENGTH =
-            "A title with more than $PREFERENCE_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
+        private const val PREFERENCES_EXPLANATION_TITLE_LENGTH =
+            "A title with more than $PREFERENCES_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
 
         // Read More: https://support.crowdin.com/file-formats/android-xml/
-        private const val EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute " +
+        private const val PREFERENCES_EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute " +
             "because it fixes translated string length"
+
         private val implementation = Implementation(FixedPreferencesTitleLength::class.java, Scope.RESOURCE_FILE_SCOPE)
-        val ISSUE_TITLE_LENGTH: Issue = Issue.create(
-            ID_TITLE_LENGTH,
-            DESCRIPTION_TITLE_LENGTH,
-            EXPLANATION_TITLE_LENGTH,
+        val PREFERENCES_ISSUE_TITLE_LENGTH: Issue = Issue.create(
+            PREFERENCES_ID_TITLE_LENGTH,
+            PREFERENCES_DESCRIPTION_TITLE_LENGTH,
+            PREFERENCES_EXPLANATION_TITLE_LENGTH,
             Constants.ANKI_XML_CATEGORY,
             Constants.ANKI_XML_PRIORITY,
             Constants.ANKI_XML_SEVERITY,
             implementation
         )
-        val ISSUE_MAX_LENGTH: Issue = Issue.create(
-            ID_MAX_LENGTH,
-            DESCRIPTION_MAX_LENGTH,
-            EXPLANATION_MAX_LENGTH,
+        val PREFERENCES_ISSUE_MAX_LENGTH: Issue = Issue.create(
+            PREFERENCES_ID_MAX_LENGTH,
+            PREFERENCES_DESCRIPTION_MAX_LENGTH,
+            PREFERENCES_EXPLANATION_MAX_LENGTH,
             Constants.ANKI_XML_CATEGORY,
             Constants.ANKI_XML_PRIORITY,
             Constants.ANKI_XML_SEVERITY,
@@ -79,34 +83,44 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
         private const val ATTR_MAX_LENGTH = "maxLength"
     }
 
-    private val xmlData: MutableSet<String> = HashSet()
-    private val valuesData: MutableMap<String, Pair<Element, Handle>> = HashMap<String, Pair<Element, Handle>>()
+    /**
+     * Titles of the resources in the xml/ folder.
+     * I.e. after the end of [visitElement], it contains
+     * "pref__delete_unused_media_files__title" from src/main/res/xml/manage_space
+     */
+    private val titlesOfPreferenceScreens: MutableSet<String> = HashSet()
+
+    /**
+     * String resources.
+     * I.e. after the end of [visitElement], it'll map "pref__delete_unused_media_files__title" to the element
+     * ```
+     *     <string name="pref__delete_unused_media_files__title" maxLength="41" comment="Preference title"
+     *         >Delete unused media files</string>
+     * ```
+     * of src/main/res/values/10-preferences.xml, and its handle.
+     */
+    private val stringResources: MutableMap<String, Handle> = HashMap()
     override fun getApplicableElements(): Collection<String>? {
         return ALL
     }
 
     override fun visitElement(context: XmlContext, element: Element) {
-        /* 1. This condition checks that current file has xml as a parent file.
-           2. Checks that element contains title attribute or not.
-           If both of conditions are true then set the value in xmlSet.
-         */
         if ("xml" == context.file.parentFile.name && element.hasAttribute(ATTR_TITLE)) {
-            val stringName = element.getAttribute(ATTR_TITLE).substring(8)
-            xmlData.add(stringName)
+            /* Add the `android:title`'s resource name (without "@string/") to [stringResources] if the element has this attribute and the file belongs to src/main/res/xml.
+             */
+            // Removing the "@string/" part.
+            val titleAttribute = element.getAttribute(ATTR_TITLE)
+            val stringName = titleAttribute.substringAfter("@string/", "").ifEmpty { return }
+            // the entry `stringName` may already exists. Losing the first entry is not an issue, as it won't actually hide that there are issues.
+            titlesOfPreferenceScreens.add(stringName)
             return
         }
-        if ("values" != context.file.parentFile.name) {
-            return
+        if ("values" == context.file.parentFile.name &&
+            "string" == element.tagName
+        ) {
+            // Let's consider the `string`s tag of "src/main/res/values/*.xml"
+            stringResources[element.getAttribute(ATTR_NAME)] = context.createLocationHandle(element).apply { clientData = element }
         }
-        if ("10-preferences.xml" != context.file.name) {
-            return
-        }
-        if ("resources" == element.tagName) {
-            return
-        }
-        val handle: Handle = context.createLocationHandle(element)
-        handle.clientData = element
-        valuesData[element.getAttribute(ATTR_NAME)] = Pair.of(element, handle)
     }
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean {
@@ -114,22 +128,19 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     }
 
     override fun afterCheckEachProject(context: Context) {
-        for (title in xmlData) {
-            if (!valuesData.containsKey(title)) {
-                continue
+        for (title in titlesOfPreferenceScreens) {
+            val stringHandle = stringResources[title] ?: throw IllegalArgumentException(title)
+            val stringElement: Element = stringHandle.clientData as Element
+            if (!stringElement.hasAttribute(ATTR_MAX_LENGTH)) {
+                val message = String.format(Locale.ENGLISH, "Preference title '%s' is missing maxLength=\"%d\" attribute.", title, PREFERENCES_TITLE_MAX_LENGTH)
+                context.report(PREFERENCES_ISSUE_MAX_LENGTH, stringHandle.resolve(), message)
+            } else if (stringElement.getAttribute(ATTR_MAX_LENGTH).toInt() > PREFERENCES_TITLE_MAX_LENGTH) {
+                val message = String.format(Locale.ENGLISH, "Preference title '%s' has maxLength=\"%s\". Its max length should be at most %d.", title, stringElement.getAttribute(ATTR_MAX_LENGTH), PREFERENCES_TITLE_MAX_LENGTH)
+                context.report(PREFERENCES_ISSUE_MAX_LENGTH, stringHandle.resolve(), message)
             }
-            val stringData: Pair<Element, Handle> = valuesData[title]!!
-            val element = stringData.first
-            if (!element.hasAttribute(ATTR_MAX_LENGTH)) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' is missing \"maxLength=%d\" attribute", title, PREFERENCE_TITLE_MAX_LENGTH)
-                context.report(ISSUE_MAX_LENGTH, stringData.second.resolve(), message)
-            } else if (element.getAttribute(ATTR_MAX_LENGTH) != PREFERENCE_TITLE_MAX_LENGTH.toString()) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' is having maxLength=%s it should contain maxLength=%d", title, element.getAttribute(ATTR_MAX_LENGTH), PREFERENCE_TITLE_MAX_LENGTH)
-                context.report(ISSUE_MAX_LENGTH, stringData.second.resolve(), message)
-            }
-            if (element.textContent.length > PREFERENCE_TITLE_MAX_LENGTH) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' must be less than %d characters (currently %d)", title, PREFERENCE_TITLE_MAX_LENGTH, element.textContent.length)
-                context.report(ISSUE_TITLE_LENGTH, stringData.second.resolve(), message)
+            if (stringElement.textContent.length > PREFERENCES_TITLE_MAX_LENGTH) {
+                val message = String.format(Locale.ENGLISH, "Preference title '%s' must be less than %d characters (currently %d).", title, PREFERENCES_TITLE_MAX_LENGTH, stringElement.textContent.length)
+                context.report(PREFERENCES_ISSUE_TITLE_LENGTH, stringHandle.resolve(), message)
             }
         }
     }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLength.kt
@@ -33,7 +33,7 @@ import java.lang.IllegalArgumentException
 import java.util.Locale
 
 /**
- * Detector for preference's title whose length may be bigger than 41 character.
+ * Detector for preference's title whose length may be bigger than 41 character and for menu's title whose length may be bigger than 29 characters.
  * There is an error for each string which is longer than 41 character in English.
  * There is also an error for each string which does not have `maxLength` set to at most 41.
  *
@@ -42,22 +42,27 @@ import java.util.Locale
 class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     companion object {
         private const val PREFERENCES_ID_TITLE_LENGTH = "FixedPreferencesTitleLength"
+        private const val MENU_ID_TITLE_LENGTH = "FixedMenuTitleLength"
 
         private const val PREFERENCES_ID_MAX_LENGTH = "PreferencesTitleMaxLengthAttr"
+        private const val MENU_ID_MAX_LENGTH = "MenuTitleMaxLengthAttr"
 
         private const val PREFERENCES_TITLE_MAX_LENGTH = 41
+        private const val MENU_TITLE_MAX_LENGTH = 28
 
         private const val PREFERENCES_DESCRIPTION_TITLE_LENGTH = "Preference titles should be less than $PREFERENCES_TITLE_MAX_LENGTH characters"
+        private const val MENU_DESCRIPTION_TITLE_LENGTH = "Preference titles should be less than $MENU_TITLE_MAX_LENGTH characters"
 
         private const val PREFERENCES_DESCRIPTION_MAX_LENGTH = """Preference titles should contain maxLength="$PREFERENCES_TITLE_MAX_LENGTH" attribute"""
+        private const val MENU_DESCRIPTION_MAX_LENGTH = """Preference titles should contain maxLength="$MENU_TITLE_MAX_LENGTH" attribute"""
 
-        // Around 42 is a hard max on emulators, likely smaller in reality, so use a buffer
-        private const val PREFERENCES_EXPLANATION_TITLE_LENGTH =
-            "A title with more than $PREFERENCES_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
+        // Around 42 (resp. 29) characters is a hard max on emulators in preferences (resp. menu), likely smaller in reality, so use a buffer
+        private const val PREFERENCES_EXPLANATION_TITLE_LENGTH = "A preference title with more than $PREFERENCES_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
+        private const val MENU_EXPLANATION_TITLE_LENGTH = "A menu title with more than $MENU_TITLE_MAX_LENGTH characters may fail to display on smaller screens"
 
         // Read More: https://support.crowdin.com/file-formats/android-xml/
-        private const val PREFERENCES_EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute " +
-            "because it fixes translated string length"
+        private const val PREFERENCES_EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute because it fixes translated string length"
+        private const val MENU_EXPLANATION_MAX_LENGTH = "Preference Title should contain maxLength attribute because it fixes translated string length"
 
         private val implementation = Implementation(FixedPreferencesTitleLength::class.java, Scope.RESOURCE_FILE_SCOPE)
         val PREFERENCES_ISSUE_TITLE_LENGTH: Issue = Issue.create(
@@ -69,10 +74,29 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
             Constants.ANKI_XML_SEVERITY,
             implementation
         )
+        val MENU_ISSUE_TITLE_LENGTH: Issue = Issue.create(
+            MENU_ID_TITLE_LENGTH,
+            MENU_DESCRIPTION_TITLE_LENGTH,
+            MENU_EXPLANATION_TITLE_LENGTH,
+            Constants.ANKI_XML_CATEGORY,
+            Constants.ANKI_XML_PRIORITY,
+            Constants.ANKI_XML_SEVERITY,
+            implementation
+        )
+
         val PREFERENCES_ISSUE_MAX_LENGTH: Issue = Issue.create(
             PREFERENCES_ID_MAX_LENGTH,
             PREFERENCES_DESCRIPTION_MAX_LENGTH,
             PREFERENCES_EXPLANATION_MAX_LENGTH,
+            Constants.ANKI_XML_CATEGORY,
+            Constants.ANKI_XML_PRIORITY,
+            Constants.ANKI_XML_SEVERITY,
+            implementation
+        )
+        val MENU_ISSUE_MAX_LENGTH: Issue = Issue.create(
+            MENU_ID_MAX_LENGTH,
+            MENU_DESCRIPTION_MAX_LENGTH,
+            MENU_EXPLANATION_MAX_LENGTH,
             Constants.ANKI_XML_CATEGORY,
             Constants.ANKI_XML_PRIORITY,
             Constants.ANKI_XML_SEVERITY,
@@ -91,6 +115,11 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     private val titlesOfPreferenceScreens: MutableSet<String> = HashSet()
 
     /**
+     * Titles of the resources in the menu/ folder.
+     */
+    private val titlesOfMenuScreens: MutableSet<String> = HashSet()
+
+    /**
      * String resources.
      * I.e. after the end of [visitElement], it'll map "pref__delete_unused_media_files__title" to the element
      * ```
@@ -105,14 +134,21 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     }
 
     override fun visitElement(context: XmlContext, element: Element) {
-        if ("xml" == context.file.parentFile.name && element.hasAttribute(ATTR_TITLE)) {
+        if (element.hasAttribute(ATTR_TITLE)) {
+            val folderName = context.file.parentFile.name
+            val titlesToHandle =
+                when (folderName) {
+                    "xml" -> titlesOfPreferenceScreens
+                    "menu" -> titlesOfMenuScreens
+                    else -> return
+                }
             /* Add the `android:title`'s resource name (without "@string/") to [stringResources] if the element has this attribute and the file belongs to src/main/res/xml.
              */
             // Removing the "@string/" part.
             val titleAttribute = element.getAttribute(ATTR_TITLE)
             val stringName = titleAttribute.substringAfter("@string/", "").ifEmpty { return }
             // the entry `stringName` may already exists. Losing the first entry is not an issue, as it won't actually hide that there are issues.
-            titlesOfPreferenceScreens.add(stringName)
+            titlesToHandle.add(stringName)
             return
         }
         if ("values" == context.file.parentFile.name &&
@@ -124,23 +160,28 @@ class FixedPreferencesTitleLength : ResourceXmlDetector(), XmlScanner {
     }
 
     override fun appliesTo(folderType: ResourceFolderType): Boolean {
-        return folderType == ResourceFolderType.XML || folderType == ResourceFolderType.VALUES
+        return folderType == ResourceFolderType.XML || folderType == ResourceFolderType.VALUES || folderType == ResourceFolderType.MENU
     }
 
     override fun afterCheckEachProject(context: Context) {
-        for (title in titlesOfPreferenceScreens) {
+        checkFolder(context, titlesOfPreferenceScreens, PREFERENCES_ISSUE_MAX_LENGTH, PREFERENCES_ISSUE_MAX_LENGTH, PREFERENCES_ISSUE_TITLE_LENGTH, "Preference", PREFERENCES_TITLE_MAX_LENGTH)
+        checkFolder(context, titlesOfMenuScreens, MENU_ISSUE_MAX_LENGTH, MENU_ISSUE_MAX_LENGTH, MENU_ISSUE_TITLE_LENGTH, "Menu", MENU_TITLE_MAX_LENGTH)
+    }
+
+    fun checkFolder(context: Context, titles: Set<String>, missingMaxLengthIssueIssue: Issue, wrongMaxLengthIssue: Issue, stringTooLongIssue: Issue, folder: String, maxLength: Int) {
+        for (title in titles) {
             val stringHandle = stringResources[title] ?: throw IllegalArgumentException(title)
             val stringElement: Element = stringHandle.clientData as Element
             if (!stringElement.hasAttribute(ATTR_MAX_LENGTH)) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' is missing maxLength=\"%d\" attribute.", title, PREFERENCES_TITLE_MAX_LENGTH)
-                context.report(PREFERENCES_ISSUE_MAX_LENGTH, stringHandle.resolve(), message)
-            } else if (stringElement.getAttribute(ATTR_MAX_LENGTH).toInt() > PREFERENCES_TITLE_MAX_LENGTH) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' has maxLength=\"%s\". Its max length should be at most %d.", title, stringElement.getAttribute(ATTR_MAX_LENGTH), PREFERENCES_TITLE_MAX_LENGTH)
-                context.report(PREFERENCES_ISSUE_MAX_LENGTH, stringHandle.resolve(), message)
+                val message = String.format(Locale.ENGLISH, "$folder title '%s' is missing maxLength=\"%d\" attribute.", title, maxLength)
+                context.report(missingMaxLengthIssueIssue, stringHandle.resolve(), message)
+            } else if (stringElement.getAttribute(ATTR_MAX_LENGTH).toInt() > maxLength) {
+                val message = String.format(Locale.ENGLISH, "$folder title '%s' has maxLength=\"%s\". Its max length should be at most %d.", title, stringElement.getAttribute(ATTR_MAX_LENGTH), maxLength)
+                context.report(wrongMaxLengthIssue, stringHandle.resolve(), message)
             }
-            if (stringElement.textContent.length > PREFERENCES_TITLE_MAX_LENGTH) {
-                val message = String.format(Locale.ENGLISH, "Preference title '%s' must be less than %d characters (currently %d).", title, PREFERENCES_TITLE_MAX_LENGTH, stringElement.textContent.length)
-                context.report(PREFERENCES_ISSUE_TITLE_LENGTH, stringHandle.resolve(), message)
+            if (stringElement.textContent.length > maxLength) {
+                val message = String.format(Locale.ENGLISH, "$folder title '%s' must be less than %d characters (currently %d).", title, maxLength, stringElement.textContent.length)
+                context.report(stringTooLongIssue, stringHandle.resolve(), message)
             }
         }
     }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/FixedPreferencesTitleLengthTest.kt
@@ -24,55 +24,44 @@ class FixedPreferencesTitleLengthTest {
 
     companion object {
         @Language("XML")
-        val stringsXmlValid = """<resources>
+        val strings1XmlValid = """<resources>
     <string name="app_name" maxLength="41">app_name</string>
     <string name="pref_cat_general_summ">pref_cat_general_summ</string>
-    <string name="button_sync" maxLength="41">button_sync</string>
+    <string name="button_sync" maxLength="28">button_sync</string>
     <string name="sync_account" maxLength="41">sync_account</string>
-    <string name="sync_account_summ_logged_out">sync_account_summ</string>
-    <string name="sync_fetch_missing_media_summ">sync_fetch_missing</string>
-    <string name="less_characters_than_limit" maxLength="41">Less than limit</string></resources>"""
-
-        @Language("XML")
-        val stringsXmlInvalid = """<resources>
-<!--Not contains maxLength=41 attribute-->
-    <string name="app_name">app_name</string>
-    <string name="pref_cat_general_summ">pref_cat_general_summ</string>
-<!--Not contains maxLength attribute but having value 55-->
-    <string name="button_sync" maxLength="55">button_sync</string>
-<!--This is correct because it contains maxLength=41 and character length is less than 42-->
-    <string name="sync_account" maxLength="41">sync_account</string>
-    <string name="sync_account_summ_logged_out">sync_account_summ</string>
-    <string name="sync_fetch_missing_media_summ">sync_fetch_missing</string>
-<!--Not contains maxLength=41 attribute but character length is greater than 32 and contains UTF-8 character-->
-    <string name="more_characters_than_limit"  maxLength="41">This String contains character more than limit £</string>
 </resources>"""
 
         @Language("XML")
-        val invalidString =
-            """<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-                    android:title="@string/app_name"
-                    android:summary="@string/pref_cat_general_summ" >
-                    <PreferenceCategory android:title="@string/button_sync" >
-                        <Preference
-                            android:dialogTitle="@string/sync_account"
-                            android:key="syncAccount"
-                            android:summary="@string/sync_account_summ_logged_out"
-                            android:title="@string/sync_account" >
-                            <intent
-                                android:targetClass="com.ichi2.anki.MyAccount"
-                                android:targetPackage="com.ichi2.anki" />
-                        </Preference>
-                        <CheckBoxPreference
-                            android:defaultValue="true"
-                            android:key="syncFetchesMedia"
-                            android:summary="@string/sync_fetch_missing_media_summ"
-                            android:title = "@string/more_characters_than_limit" />   
-                     </PreferenceCategory>
-                </PreferenceScreen>"""
+        val strings10XmlValid = """<resources>
+    <string name="sync_account_summ_logged_out">sync_account_summ</string>
+    <string name="sync_fetch_missing_media_summ">sync_fetch_missing</string>
+    <string name="checkbox_title" maxLength="41">Less than limit</string>
+    <string name="number_title" maxLength="41">number_title</string>
+</resources>"""
 
         @Language("XML")
-        val validString =
+        val strings10XmlInvalid = """<resources>
+<!--This preference's title should have a maxLength attribute-->
+    <string name="app_name">app_name</string>
+    <string name="pref_cat_general_summ">pref_cat_general_summ</string>
+<!--Its maxLength attribute is greater than 41-->
+    <string name="button_sync" maxLength="55">button_sync</string>
+<!--This is correct because it contains maxLength=41 and character length is less than 42-->
+    <string name="sync_account" maxLength="41">sync_account</string>
+</resources>"""
+
+        @Language("XML")
+        val strings1XmlInvalid = """<resources>
+    <string name="sync_account_summ_logged_out">sync_account_summ</string>
+    <string name="sync_fetch_missing_media_summ">sync_fetch_missing</string>
+<!--The string is 44 characters long, more than 41.-->
+    <string name="checkbox_title" maxLength="41">This String contains character more than limit</string>
+<!--The string contains unicode character -->
+    <string name="number_title" maxLength="41">This String contains a £.</string>
+</resources>"""
+
+        @Language("XML")
+        val preferenceString =
             """<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     android:title="@string/app_name"
     android:summary="@string/pref_cat_general_summ" >
@@ -86,35 +75,54 @@ class FixedPreferencesTitleLengthTest {
                 android:targetClass="com.ichi2.anki.MyAccount"
                 android:targetPackage="com.ichi2.anki" />
         </Preference>
+        <com.ichi2.preferences.IncrementerNumberRangePreference
+            android:defaultValue="true"
+            android:key="unicode"
+            android:summary="@string/unicode"
+            android:title = "@string/number_title" />
         <CheckBoxPreference
             android:defaultValue="true"
             android:key="syncFetchesMedia"
             android:summary="@string/sync_fetch_missing_media_summ"
-            android:title="@string/less_characters_than_limit" />   </PreferenceCategory></PreferenceScreen>"""
+            android:title = "@string/checkbox_title" />
+    </PreferenceCategory>
+</PreferenceScreen>"""
     }
+
+    @Language("XML")
+    val preferenceWithHardcodedTitle = """
+        <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+            android:title="Dev options"
+            android:key="@string/pref_dev_options_screen_key">
+            <SwitchPreferenceCompat
+                android:title="New congrats screen"
+                android:key="@string/new_congrats_screen_pref_key"
+                android:defaultValue="false"/>
+        </PreferenceScreen>"""
 
     @Test
     fun showsErrorForInvalidFile() {
         TestLintTask.lint().allowMissingSdk()
             .allowCompilationErrors()
             .files(
-                TestFiles.xml("res/xml/preference_general_invalid.xml", invalidString),
-                TestFiles.xml("res/values/10-preferences.xml", stringsXmlInvalid)
+                TestFiles.xml("res/xml/preference_general_invalid.xml", preferenceString),
+                TestFiles.xml("res/values/10-preferences.xml", strings10XmlInvalid),
+                TestFiles.xml("res/values/01-core.xml", strings1XmlInvalid)
             )
             .issues(
-                FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH,
-                FixedPreferencesTitleLength.ISSUE_MAX_LENGTH
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_TITLE_LENGTH,
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH
             )
             .run()
             .expectErrorCount(3)
             .expect(
-                """res/values/10-preferences.xml:12: Error: Preference title 'more_characters_than_limit' must be less than 41 characters (currently 48) [FixedPreferencesTitleLength]
-    <string name="more_characters_than_limit"  maxLength="41">This String contains character more than limit £</string>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-res/values/10-preferences.xml:3: Error: Preference title 'app_name' is missing "maxLength=41" attribute [PreferencesTitleMaxLengthAttr]
+                """res/values/01-core.xml:5: Error: Preference title 'checkbox_title' must be less than 41 characters (currently 46). [FixedPreferencesTitleLength]
+    <string name="checkbox_title" maxLength="41">This String contains character more than limit</string>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+res/values/10-preferences.xml:3: Error: Preference title 'app_name' is missing maxLength="41" attribute. [PreferencesTitleMaxLengthAttr]
     <string name="app_name">app_name</string>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-res/values/10-preferences.xml:6: Error: Preference title 'button_sync' is having maxLength=55 it should contain maxLength=41 [PreferencesTitleMaxLengthAttr]
+res/values/10-preferences.xml:6: Error: Preference title 'button_sync' has maxLength="55". Its max length should be at most 41. [PreferencesTitleMaxLengthAttr]
     <string name="button_sync" maxLength="55">button_sync</string>
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 3 errors, 0 warnings"""
@@ -126,12 +134,29 @@ res/values/10-preferences.xml:6: Error: Preference title 'button_sync' is having
         TestLintTask.lint().allowMissingSdk()
             .allowCompilationErrors()
             .files(
-                TestFiles.xml("res/xml/preference_general_valid.xml", validString),
-                TestFiles.xml("res/values/10-preferences.xml", stringsXmlValid)
+                TestFiles.xml("res/xml/preference_general_valid.xml", preferenceString),
+                TestFiles.xml("res/values/10-preferences.xml", strings10XmlValid),
+                TestFiles.xml("res/values/01-core.xml", strings1XmlValid)
             )
             .issues(
-                FixedPreferencesTitleLength.ISSUE_MAX_LENGTH,
-                FixedPreferencesTitleLength.ISSUE_TITLE_LENGTH
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH,
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_TITLE_LENGTH
+            )
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun hardcodedTitleIsNotFlagged() {
+        TestLintTask.lint().allowMissingSdk()
+            .allowCompilationErrors()
+            .files(
+                TestFiles.xml("res/xml/preference_general_valid.xml", preferenceWithHardcodedTitle),
+                TestFiles.xml("res/values/01-core.xml", strings1XmlValid)
+            )
+            .issues(
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH,
+                FixedPreferencesTitleLength.PREFERENCES_ISSUE_TITLE_LENGTH
             )
             .run()
             .expectClean()


### PR DESCRIPTION
I tried to remove a `maxLength="41"` and lint was still succesful.

I finally took the time to learn how the linter works, after having years where it is a mystery.

Given that the code was not very clear to me, I added comments, and rewrote part of it.

I then realized that the issue was that, if the string was not found, no error was recorded. Strings may be missing either:
* because the string is hard coded in English (developer options), in which case I explicitly decided to ignore the strings, or
* because the string is defined outside of 10-preferences.xml

As far as I can tell, even if the string is not purely a preference, the max length constraint should still be present outside of preferences.

I also updated the string so that, with maxLength less than 41, the lint still works. This is important because some strings are being used in Menu, where the maxLength is even shorter. A future PR should reuse this same code for menus.

I also rewrote slightly the error message, hopefully improving them. Admittedly, given that only developers will see the errors, it was not that important a change.

Finally, of course, I added the maxLength to every strings that were found by the linter.