### PR TITLE
fix(record-audio): saving audio snackbar obscured 'done'  

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -24,10 +24,13 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.commit
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
+import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.getSerializableExtraCompat
 import com.ichi2.themes.setTransparentStatusBar
@@ -56,7 +59,7 @@ data class MultimediaActivityExtra(
 /**
  * Multimedia activity that allows users to attach media files to an input field in NoteEditor.
  */
-class MultimediaActivity : AnkiActivity() {
+class MultimediaActivity : AnkiActivity(), BaseSnackbarBuilderProvider {
 
     private val Intent.multimediaArgsExtra: MultimediaActivityExtra?
         get() = extras?.getSerializableCompat(MULTIMEDIA_ARGS_EXTRA)
@@ -99,6 +102,17 @@ class MultimediaActivity : AnkiActivity() {
             Timber.d("MultimediaActivity:: Back pressed")
             onBackPressedDispatcher.onBackPressed()
         }
+    }
+
+    override val baseSnackbarBuilder: SnackbarBuilder = {
+        // if action_done exists in a fragment, use that as the anchor view
+
+        // This is a minor hack architecturally: AudioRecordingController should request that
+        // the host fragment/activity opens a snackbar, so the activity doesn't need knowledge
+        // of the layout of its hosted fragments
+
+        // If this doesn't work, anchorView remains null
+        anchorView = findViewById<MaterialButton>(R.id.action_done)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -24,7 +24,6 @@ import android.text.format.Formatter
 import android.view.MenuItem
 import android.view.View
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.addCallback
 import androidx.annotation.DrawableRes
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AlertDialog
@@ -57,6 +56,8 @@ import java.io.File
  * including caching directories, managing fields and notes, and setting toolbar titles.
  *
  * @param layout The layout resource ID to be inflated by this fragment.
+ *
+ * @see MultimediaActivity
  */
 abstract class MultimediaFragment(@LayoutRes layout: Int) : Fragment(layout) {
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
@@ -36,6 +36,8 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.imageview.ShapeableImageView
 import com.google.android.material.progressindicator.LinearProgressIndicator
 import com.ichi2.anki.R
+import com.ichi2.anki.Reviewer
+import com.ichi2.anki.multimedia.AudioVideoFragment
 import com.ichi2.anki.multimedia.MultimediaViewModel
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.RecordingState.AppendToRecording
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.RecordingState.ImmediatePlayback
@@ -60,6 +62,9 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 // TODO : stop audio time view flickering
+/**
+ * This may be hosted in the [Reviewer], or in a [AudioVideoFragment]
+ */
 class AudioRecordingController(
     val context: Context,
     val linearLayout: LinearLayout? = null,


### PR DESCRIPTION
## Fixes
* Fixes #17227

## Approach
Set `anchorView`

## How Has This Been Tested?
**Before**
![image](https://github.com/user-attachments/assets/5a37d8be-eb3b-4374-aae3-d90938f3563a)


**After**
<img width="394" alt="Screenshot 2024-10-11 at 03 37 43" src="https://github.com/user-attachments/assets/6887f4dd-eac0-4fa9-b407-2605e0b19d62">

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
