### PR TITLE
Limit Card Deck TextView to 30% width and support multiline.

### DIFF
--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -36,8 +36,9 @@
                     android:orientation="horizontal" >
                     <com.ichi2.ui.FixedTextView
                         android:id="@+id/CardEditorModelText"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_weight="0.3"
                         android:layout_gravity="center"
                         android:layout_marginLeft="8dip"
                         android:layout_marginRight="8dip"
@@ -47,8 +48,9 @@
                         android:text="@string/CardEditorModel" />
                     <Spinner
                         android:id="@+id/note_type_spinner"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="@dimen/touch_target"
+                        android:layout_weight="0.7"
                         />
                 </LinearLayout>
 
@@ -59,19 +61,23 @@
                     android:orientation="horizontal" >
                     <com.ichi2.ui.FixedTextView
                         android:id="@+id/CardEditorDeckText"
-                        android:layout_width="wrap_content"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:layout_weight="0.3"
                         android:layout_gravity="center"
                         android:layout_marginLeft="8dip"
                         android:layout_marginRight="8dip"
                         android:clickable="false"
+                        android:singleLine="false"
                         android:gravity="start|center_vertical"
                         android:textStyle="bold"
                         android:text="@string/CardEditorNoteDeck" />
                     <Spinner
                         android:id="@+id/note_deck_spinner"
-                        android:layout_width="match_parent"
+                        android:layout_width="0dp"
                         android:layout_height="wrap_content"
+                        android:minHeight="@dimen/touch_target"
+                        android:layout_weight="0.7"
                         app:popupTheme="@style/ActionBar.Popup"/>
                 </LinearLayout>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this PR is to improve the layout of the FixedTextView (Deck - Paquet de cartes). Currently, the TextView takes up more space than necessary, leading to a cluttered UI. This change ensures that the TextView will occupy a maximum of 30% of the screen width while supporting multiline text for better readability and overall layout consistency.

## Fixes
* Fixes #17100

## Approach
The width of the `FixedTextView` and `Spinner` is set using `layout_weight`, with the `FixedTextView` taking 30% (`layout_weight="0.3"`) and the `Spinner` taking 70% (`layout_weight="0.7"`).

## How Has This Been Tested?
The changes have been tested across various font sizes and screen sizes

## Screenshot
![WhatsApp Image 2024-10-11 at 16 16 32](https://github.com/user-attachments/assets/a273ac7d-9c24-41f8-85f5-3e7da606d5c9)


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
