### PR TITLE
fix: handle `BackendException$BackendFatalError` on startup

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -128,7 +128,7 @@ abstract class InstrumentedTest {
 
     /** Restore regular collection behavior  */
     private fun disableNullCollection() {
-        CollectionManager.emulateOpenFailure = false
+        CollectionManager.emulatedOpenFailure = null
     }
 
     // Instrumented tests can fail if there's a "App not responding"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -408,11 +408,16 @@ object CollectionManager {
 
     enum class CollectionOpenFailure {
         /** Raises [BackendException.BackendDbException.BackendDbLockedException] */
-        LOCKED;
+        LOCKED,
+
+        /** Raises [BackendException.BackendFatalError] */
+        FATAL_ERROR
+        ;
 
         fun triggerFailure() {
             when (this) {
                 LOCKED -> throw BackendException.BackendDbException.BackendDbLockedException(backendError {})
+                FATAL_ERROR -> throw BackendException.BackendFatalError(backendError {})
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -82,7 +82,7 @@ object DebugInfoService {
 
     private suspend fun getFSRSStatus(): Boolean? = try {
         CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs", false) }
-    } catch (e: Error) {
+    } catch (e: Throwable) { // Error and Exception paths are the same, so catch Throwable
         Timber.w(e)
         null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -69,7 +69,9 @@ class BootService : BroadcastReceiver() {
         // getInstance().getColSafe
         return try {
             CollectionManager.getColUnsafe()
-        } catch (e: Error) { // java.lang.UnsatisfiedLinkError occurs in tests
+        } catch (e: Throwable) { // Error and Exception paths are the same, so catch Throwable
+            // BackendException.BackendFatalError is a RuntimeException
+            // java.lang.UnsatisfiedLinkError occurs in tests
             Timber.e(e, "Failed to get collection for boot service - possibly media ejecting")
             null
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppFailureTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppFailureTest.kt
@@ -21,13 +21,11 @@ import com.ichi2.testutils.AnkiDroidAppWithFatalError
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
-import kotlin.test.Ignore
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = AnkiDroidAppWithFatalError::class)
 class AnkiDroidAppFailureTest : RobolectricTest() {
     @Test
-    @Ignore("#16963")
     fun `fatal error does not crash onCreate`() {
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppFailureTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidAppFailureTest.kt
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.AnkiDroidAppWithFatalError
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.Ignore
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = AnkiDroidAppWithFatalError::class)
+class AnkiDroidAppFailureTest : RobolectricTest() {
+    @Test
+    @Ignore("#16963")
+    fun `fatal error does not crash onCreate`() {
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -34,6 +34,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.work.Configuration
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
+import com.ichi2.anki.CollectionManager.CollectionOpenFailure
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.utils.FragmentTestActivity
 import com.ichi2.anki.preferences.sharedPrefs
@@ -342,12 +343,12 @@ open class RobolectricTest : AndroidTest {
     protected fun enableNullCollection() {
         CollectionManager.closeCollectionBlocking()
         CollectionManager.setColForTests(null)
-        CollectionManager.emulateOpenFailure = true
+        CollectionManager.emulatedOpenFailure = CollectionOpenFailure.LOCKED
     }
 
     /** Restore regular collection behavior  */
     protected fun disableNullCollection() {
-        CollectionManager.emulateOpenFailure = false
+        CollectionManager.emulatedOpenFailure = null
     }
 
     @Throws(JSONException::class)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiDroidAppWithFatalError.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AnkiDroidAppWithFatalError.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.CollectionOpenFailure
+
+/**
+ * AnkiDroidApp which raises [CollectionOpenFailure.FATAL_ERROR]
+ */
+class AnkiDroidAppWithFatalError : AnkiDroidApp() {
+    override fun onCreate() {
+        CollectionManager.emulatedOpenFailure = CollectionOpenFailure.FATAL_ERROR
+        super.onCreate()
+    }
+}


### PR DESCRIPTION
## Fixes
* Fixes #16963

## Approach
* catch `Throwable` rather than `Error`

## How Has This Been Tested?

Unit tested

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt	(revision dcf07cefcfff05fbe54615400a6e419b6f72c86d)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt	(date 1728647924463)
@@ -64,7 +64,7 @@
      * @see [CollectionOpenFailure]
      */
     @VisibleForTesting
-    var emulatedOpenFailure: CollectionOpenFailure? = null
+    var emulatedOpenFailure: CollectionOpenFailure? = CollectionOpenFailure.FATAL_ERROR
 
     private val testMutex = ReentrantLock()
 
```
<img width="368" alt="Screenshot 2024-10-11 at 13 02 04" src="https://github.com/user-attachments/assets/907d23ca-6779-414f-ba20-596d4217aabd">

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
