### PR TITLE
add missing user action message

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/card.js
+++ b/AnkiDroid/src/main/assets/scripts/card.js
@@ -253,6 +253,8 @@ function userAction(number) {
         let userJs = globalThis[`userJs${number}`];
         if (userJs != null) {
             userJs();
+        } else {
+            window.location.href = `missing-user-action:${number}`;
         }
     } catch (e) {
         alert(e);

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2341,6 +2341,19 @@ abstract class AbstractFlashcardViewer :
                 }
                 return true
             }
+            if (url.startsWith("missing-user-action:")) {
+                val actionNumber = url.substringAfter(":")
+                val message = getString(R.string.missing_user_action_dialog_message, actionNumber)
+                AlertDialog.Builder(this@AbstractFlashcardViewer).show {
+                    setTitle(R.string.vague_error)
+                    setMessage(message)
+                    setPositiveButton(R.string.dialog_ok) { _, _ -> }
+                    setNeutralButton(R.string.help) { _, _ ->
+                        openUrl(R.string.link_user_actions_help)
+                    }
+                }
+                return true
+            }
             if (url.startsWith("videoended:")) {
                 // note: 'q:0' is provided
                 cardMediaPlayer.onVideoFinished()

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -423,4 +423,5 @@ opening the system text to speech settings fails">
     <string name="edit_browser_appearance" comment="Description of the shortcut that edits the browser appearance of card template">Edit browser appearance</string>
 
     <string name="show_shortcuts_message">Press Alt+K to show keyboard shortcuts</string>
+    <string name="missing_user_action_dialog_message" comment="%s is the user action number">User action %s is not set in this notetype. Please configure it</string>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

JS User actions don't have a feedback if the user tries to use them without setting them up first, so issues like #17171 can get reported

## Fixes
* Fixes #17171

## Approach

Add a feedback message if an user action isn't set

## How Has This Been Tested?

![Screenshot_20241011_150739](https://github.com/user-attachments/assets/1db473d9-329f-48c7-9f86-6a561857f312)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
