### PR TITLE
fix: audio recorder UI init twice

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
@@ -114,6 +114,8 @@ class AudioRecordingFragment : MultimediaFragment(R.layout.fragment_audio_record
 
     @NeedsTest("AudioRecordingController is correctly initialized")
     private fun initializeAudioRecorder() {
+        if (audioRecordingController != null) return
+        Timber.d("Initialising AudioRecordingController")
         try {
             audioRecordingController = AudioRecordingController(
                 context = requireActivity(),


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The audio recorder UI was initialised twice at times, this PR fixes the behaviour 

## Fixes
* Fixes #17201


## How Has This Been Tested?
Tested locally on Google emulator API35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
