### PR TITLE
Change undo default shortcut to Ctrl+Z

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -179,7 +179,7 @@ enum class ViewerCommand(val resourceId: Int) {
                 REPLAY_VOICE -> listOf(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH))
                 RECORD_VOICE -> listOf(keyCode(KeyEvent.KEYCODE_V, CardSide.BOTH, shift()))
                 SAVE_VOICE -> listOf(keyCode(KeyEvent.KEYCODE_S, CardSide.BOTH, shift()))
-                UNDO -> listOf(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH))
+                UNDO -> listOf(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH, ctrl()))
                 REDO -> listOf(keyCode(KeyEvent.KEYCODE_Z, CardSide.BOTH, ModifierKeys(shift = true, ctrl = true, alt = false)))
                 TOGGLE_FLAG_RED -> listOf(keyCode(KeyEvent.KEYCODE_1, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_1, CardSide.BOTH, ctrl()))
                 TOGGLE_FLAG_ORANGE -> listOf(keyCode(KeyEvent.KEYCODE_2, CardSide.BOTH, ctrl()), keyCode(KeyEvent.KEYCODE_NUMPAD_2, CardSide.BOTH, ctrl()))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -38,7 +38,14 @@ import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_1
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_2
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_3
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.EASE_4
+import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.reviewer.Binding.Companion.keyCode
+import com.ichi2.anki.reviewer.Binding.ModifierKeys
+import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.libanki.Card
 import kotlinx.coroutines.Job
 import org.hamcrest.MatcherAssert.assertThat
@@ -174,6 +181,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
 
     @Test
     fun pressingZShouldUndoIfAvailable() {
+        ViewerCommand.UNDO.addBinding(sharedPrefs(), MappableBinding(keyCode(KEYCODE_Z, ModifierKeys.none()), MappableBinding.Screen.Reviewer(CardSide.BOTH)))
         val underTest = KeyboardInputTestReviewer.displayingAnswer().withUndoAvailable(true)
         underTest.handleAndroidKeyPress(KEYCODE_Z)
         assertThat("Undo should be called", underTest.undoCalled)
@@ -181,6 +189,7 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
 
     @Test
     fun pressingZShouldNotUndoIfNotAvailable() {
+        ViewerCommand.UNDO.addBinding(sharedPrefs(), MappableBinding(keyCode(KEYCODE_Z, ModifierKeys.none()), MappableBinding.Screen.Reviewer(CardSide.BOTH)))
         val underTest = KeyboardInputTestReviewer.displayingAnswer().withUndoAvailable(false)
         underTest.handleUnicodeKeyPress('z')
         assertThat("Undo is not available so should not be called", !underTest.undoCalled)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

I noticed that the Undo control default shortcut is just Z, not Ctrl+Z like other apps, so I tried to fix it. I don't know if there is a reason to use just Z, but I can close this if there is one.

## Approach
Add a Ctrl modificer

## How Has This Been Tested?

I reinstalled the app to see the new shortcut

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
