### PR TITLE
Remove leech() method in Scheduler to avoid Android usages in libanki

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1070,7 +1070,7 @@ open class Reviewer :
         var wasLeech = false
         undoableOp(this) {
             sched.answerCard(state, ease).also {
-                wasLeech = sched.againIsLeech(state)
+                wasLeech = sched.stateIsLeech(state.states.again)
             }
         }.also {
             if (ease == Consts.BUTTON_ONE && wasLeech) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.libanki.sched
 
-import android.app.Activity
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
@@ -41,9 +40,6 @@ import anki.scheduler.SchedulingStates
 import anki.scheduler.UnburyDeckRequest
 import anki.scheduler.cardAnswer
 import anki.scheduler.scheduleCardsAsNewRequest
-import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anki.R
-import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
@@ -699,25 +695,6 @@ open class Scheduler(val col: Collection) {
 
     fun timeboxSecs(): Int {
         return col.config.get("timeLim") ?: 0
-    }
-}
-
-/**
- * Tell the user the current card has leeched and whether it was suspended. Timber if no activity.
- * @param card A card that just became a leech
- * @param activity An activity on which a message can be shown
- */
-fun leech(card: Card, activity: Activity?) {
-    if (activity != null) {
-        val res = activity.resources
-        val leechMessage: String = if (card.queue < 0) {
-            res.getString(R.string.leech_suspend_notification)
-        } else {
-            res.getString(R.string.leech_notification)
-        }
-        activity.showSnackbar(leechMessage, Snackbar.LENGTH_SHORT)
-    } else {
-        Timber.w("LeechHook :: could not show leech snackbar as activity was null")
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -152,8 +152,10 @@ open class Scheduler(val col: Collection) {
         card.load(col)
     }
 
-    fun againIsLeech(info: CurrentQueueState): Boolean {
-        return col.backend.stateIsLeech(info.states.again)
+    /** True if new state marks the card as a leech. */
+    @LibAnkiAlias("state_is_leech")
+    fun stateIsLeech(state: SchedulingState): Boolean {
+        return col.backend.stateIsLeech(state)
     }
 
     fun buildAnswer(card: Card, states: SchedulingStates, ease: Int): CardAnswer {


### PR DESCRIPTION
## Fixes
* Fixes part of #14320

## Approach

I did the first commit because I thought that was necessary to properly remove the leech() method

But then I noticed that leech() wasn't used at all. I left the first commit there because it's still an useful update to libanki

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
