### PR TITLE
fix: SingleFragmentActivity: fragment has not been initialized 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -19,8 +19,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
-import android.view.KeyboardShortcutGroup
-import android.view.Menu
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
@@ -107,15 +105,4 @@ open class SingleFragmentActivity : AnkiActivity() {
 
 interface DispatchKeyEventListener {
     fun dispatchKeyEvent(event: KeyEvent): Boolean
-}
-
-interface KeyboardShortcutEventListener {
-    /**
-     * @see AnkiActivity.onProvideKeyboardShortcuts
-     */
-    fun onProvideKeyboardShortcuts(
-        data: MutableList<KeyboardShortcutGroup>,
-        menu: Menu?,
-        deviceId: Int
-    )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -41,7 +41,7 @@ import kotlin.reflect.jvm.jvmName
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
 open class SingleFragmentActivity : AnkiActivity() {
-    // The displayed fragment.
+    /** The displayed fragment. */
     lateinit var fragment: Fragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -57,8 +57,12 @@ open class SingleFragmentActivity : AnkiActivity() {
         // avoid recreating the fragment on configuration changes
         // the fragment should handle state restoration
         if (savedInstanceState != null) {
-            Timber.d("not recreating fragment due to config changes")
-            return
+            Timber.d("restoring fragment due to config changes")
+            supportFragmentManager.findFragmentById(R.id.fragment_container)?.let { fragment ->
+                this.fragment = fragment
+                return
+            }
+            Timber.w("Fragment not found after config change. Recreating it")
         }
 
         val fragmentClassName = requireNotNull(intent.getStringExtra(FRAGMENT_NAME_EXTRA)) {


### PR DESCRIPTION
## Fixes
* Fixes #17246

## Approach
Fixed by re-initializing `fragment`

## How Has This Been Tested?
* On an API 34 tablet, the app no longer crashes after a user types

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
