### PR TITLE
Apk size isolated analysis

### DIFF
--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -9,7 +9,7 @@ on:
         type: number
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.inputs.prNumber }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -66,10 +66,10 @@ jobs:
       - name: Get PR APK size
         run: echo NEWSIZE=`ls -lrt AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-arm64-v8a-release.apk | awk '{print $5}'` >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 1
+      - name: Checkout Baseline for PR
+        # we want to checkout the base for this PR on main, not just main - as main moves over time
+        # and we want to know the isolated affect of this PR regardless of when the workflow executes
+        run: git checkout `git merge-base main HEAD`
 
       - name: Assemble Baseline APK
         # This makes sure we fetch gradle network resources with a retry


### PR DESCRIPTION

I wanted to see the size effect of the upstream jquery/mathjax usage from #17233 and tried it here:

https://github.com/ankidroid/Anki-Android/pull/17233#issuecomment-2409081070

That's insufficient now though: after the PR is merged. And in fact it was always unstable. Because the previous workflow always compared against "current main", instead of "main before the PR started adding commits"

I did a fair bit of learning on git and after looking at cat-file, rev-parse, `gh pr view --json commits,baseRefName |jq -r '.commits | length'` and a few other styles that worked or didn't work, this is the best way to find the base SHA I think

idea from https://stackoverflow.com/a/64510906/9910298