### PR TITLE
Improve info shown when collection directory is not accessible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -36,6 +36,7 @@ import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Message
+import android.text.util.Linkify
 import android.util.TypedValue
 import android.view.KeyEvent
 import android.view.Menu
@@ -180,6 +181,7 @@ import com.ichi2.utils.SyncStatus
 import com.ichi2.utils.VersionUtils
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.checkBoxPrompt
+import com.ichi2.utils.customView
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
@@ -736,9 +738,7 @@ open class DeckPicker :
                 if (ScopedStorageService.collectionWasMadeInaccessibleAfterUninstall(this)) {
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL)
                 } else {
-                    val i = AdvancedSettingsFragment.getSubscreenIntent(this)
-                    requestPathUpdateLauncher.launch(i)
-                    showThemedToast(this, R.string.directory_inaccessible, false)
+                    showDirectoryNotAccessibleDialog()
                 }
             }
             FUTURE_ANKIDROID_VERSION -> {
@@ -765,6 +765,31 @@ open class DeckPicker :
             DISK_FULL -> displayNoStorageError()
             DB_ERROR -> displayDatabaseFailure()
             else -> displayDatabaseFailure()
+        }
+    }
+
+    private fun showDirectoryNotAccessibleDialog() {
+        val contentView = TextView(this).apply {
+            autoLinkMask = Linkify.WEB_URLS
+            linksClickable = true
+            text = getString(
+                R.string.directory_inaccessible_info,
+                getString(R.string.link_full_storage_access)
+            )
+        }
+        AlertDialog.Builder(this).show {
+            title(R.string.directory_inaccessible)
+            customView(
+                contentView,
+                convertDpToPixel(16F, this@DeckPicker).toInt(),
+                0,
+                convertDpToPixel(32F, this@DeckPicker).toInt(),
+                convertDpToPixel(32F, this@DeckPicker).toInt()
+            )
+            positiveButton(R.string.open_settings) {
+                val settingsIntent = AdvancedSettingsFragment.getSubscreenIntent(this@DeckPicker)
+                requestPathUpdateLauncher.launch(settingsIntent)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -423,4 +423,6 @@ opening the system text to speech settings fails">
 
     <string name="show_shortcuts_message">Press Alt+K to show keyboard shortcuts</string>
     <string name="missing_user_action_dialog_message" comment="%s is the user action number">User action %s is not set in this notetype. Please configure it</string>
+
+    <string name="directory_inaccessible_info">Learn more about how to restore access here %s or go to settings to update collection folder.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -153,6 +153,7 @@
     <string name="link_install_non_play_store_install">https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access</string>
     <string name="link_custom_sync_server_help_learn_more_en">https://docs.ankidroid.org/#_custom_sync_server</string>
     <string name="link_set_due_date_help">https://docs.ankiweb.net/browsing.html#cards</string>
+    <string name="link_full_storage_access">https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access</string>
 
     <string-array name="cram_deck_conf_order_values">
         <item>0</item>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Instead of the previous toast plus going automatically to settings, the code now shows a dialog with an action to go to settings plus a link to the wiki related to full storage access. Of course suggest changes to the actual info text, additional link etc

![screen](https://github.com/user-attachments/assets/d4356494-9d4d-4893-b087-2162f18643e6)


## Fixes
* Fixes #16987

## How Has This Been Tested?

Checked how the dialog is looking, couldn't reproduce the actual situation when the dialog is being shown.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
