### PR TITLE
feat: create and upload un-minified release during publish

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -143,7 +143,7 @@ android {
         }
         named('release') {
             testCoverageEnabled = testReleaseBuild
-            minifyEnabled true
+            minifyEnabled System.getenv("MINIFY_ENABLED") ? System.getenv("MINIFY_ENABLED") != "false" : true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             testProguardFile 'proguard-test-rules.pro'
             splits.abi.universalApk = universalApkEnabled // Build universal APK for release with `-Duniversal-apk=true`

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -144,6 +144,17 @@ done
 # Pack up our proguard mapping file for debugging in case needed
 tar -zcf proguard-mappings.tar.gz AnkiDroid/build/outputs/mapping
 
+# Create a full universal build that disables minify, to help diagnose proguard issues
+./gradlew --stop
+echo Running assembleFullRelease target with universal APK flag and MINIFY_ENABLED=false
+if ! MINIFY_ENABLED=false ./gradlew assembleFullRelease -Duniversal-apk=true
+then
+  echo "unable to build full unminified APKs"
+  exit 1
+fi
+# Copy our unminified full universal release out
+cp AnkiDroid/build/outputs/apk/full/release/AnkiDroid-full-universal-release.apk AnkiDroid-"$VERSION"-full-universal-nominify.apk
+
 # Push to Github Releases.
 GITHUB_TOKEN=$(cat ~/src/my-github-personal-access-token)
 export GITHUB_TOKEN
@@ -181,6 +192,8 @@ for FLAVOR in $FLAVORS; do
   echo "Adding universal APK for $FLAVOR to Github release"
   github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk --file AnkiDroid-"$VERSION"-"$FLAVOR"-universal.apk
 done
+echo "Adding un-minified full universal APK to GitHub release"
+github-release upload --tag v"$VERSION" --name AnkiDroid-"$VERSION"-full-universal-nominify.apk --file AnkiDroid-"$VERSION"-full-universal-nominify.apk
 echo "Adding proguard mappings file to Github release"
 github-release upload --tag v"$VERSION" --name proguard-mappings.tar.gz --file proguard-mappings.tar.gz
 


### PR DESCRIPTION
## Purpose / Description

Now that we are minifying release builds, we may have problems. A quick way to tell for sure if it is related to minification is to have a user try a non-minified build. This is very difficult unless you have one already available for the same commit the minified builds are on, so build them and upload them at the same time

This will also provide a way for users to self-help if it was a minification problem, as they can run unminified until fixed

## Fixes

Does not fix, but may help focus effort for a fix on:

* Related #17256

## Approach

There is no way to control the `minifyEnabled` gradle buildType DSL property except in the block - it isn't possible to use gradle build config logic to do it in any other place dynamically

But you can operate conditionally right in the property assignment, and you can work of environment variables while doing that

In that way we may toggle minification on or off dynamically

## How Has This Been Tested?

I created release builds locally using `./gradlew assembleFullRelease -Duniversal-apk=true` both with the environment variable `MINIFY_ENABLED` unset, set to `false` and set to anything else, until I was satisfied that it would minify if unset, and would only run with `minifyEnabled false` in the DSL if it was `MINIFY_ENABLED=false` in the shell environment

It is not possible to test the release workflow script unless you run it, so that is via visual inspection after careful edit

## Learning (optional, can help others)

The gradle build DSL combination of variants and flavors etc is not terribly useful in my opinion

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
