### PR TITLE
Revert "fix: preserve debuggability even in minimized release mode"

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -16,8 +16,12 @@
 # debugging stack traces.
 -keepattributes SourceFile,LineNumberTable
 
+# #17256: `-dontobfuscate` caused crashes in SDK 26 (release mode):
+# java.lang.NoSuchMethodError: No direct method <init>(II)V in class Lorg/apache/http/protocol/HttpRequestExecutor; or its super classes (declaration of 'org.apache.http.protocol.HttpRequestExecutor' appears in /system/framework/org.apache.http.legacy.boot.jar)
+# The underlying cause has not been investigated, reinstate this line when fixed
+
 # We do not have commercial interests to protect, so optimize for easier debugging
--dontobfuscate
+# -dontobfuscate
 
 # Used through Reflection
 -keep class com.ichi2.anki.**.*Fragment { *; }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This reverts commit aa271f93d3ce9d399da8983c849650261c696477.

`-dontobfuscate` appears to cause problems, and there were crashes in 2.19beta4-6 that appear to be related to it

It should work, and the failure has not been characterized yet

## Fixes
* Fixes #17256

## Approach

A lot of detailed investigation and reading on my part, but really it was just a bisect and then a one-line change on an alternate release pathway (#17259) that allowed me to zero in on the `-dontobfuscate` change to proguard config

## How Has This Been Tested?

Diff indicated that proguard was only thing between beta3 and beta4 that should have caused this, and disabling it worked for user. So I *assume* that reverting that change will then work.

There is a slight chance it will not work.

## Learning (optional, can help others)

`-dontobfuscate` must have some interaction between app code and library code but I couldn't pin it down

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
