### PR TITLE
chore: add funding.json for FLOSS/fund

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -1,0 +1,120 @@
+{
+    "version": "v1.0.0",
+    "entity": {
+        "type": "group",
+        "role": "other",
+        "name": "AnkiDroid Open Source Team",
+        "email": "ankidroid-maintainers@googlegroups.com",
+        "description": "We are a global team of volunteers maintaining the AnkiDroid application for Android. AnkiDroid is used by millions of people worldwide, studying to be doctors, studying foreign languages, studying everything imaginable. It is an incredibly high impact open source application for Android devices.\n\nWe are seeking funding to pay for contributors and maintenance of the project, with a long-term goal of being able to support two part-time maintainers",
+        "webpageUrl": {
+            "url": "https://github.com/ankidroid"
+        }
+    },
+    "projects": [
+        {
+            "guid": "ankidroid",
+            "name": "AnkiDroid Flashcards",
+            "description": "AnkiDroid is used by ~3 million people worldwide, studying to be doctors, studying foreign languages, studying everything imaginable. It is an incredibly high impact open source application for Android devices.\n\nWe are seeking funding to pay for contributors and maintenance of the project, with a long-term goal of being able to support two part-time maintainers",
+            "webpageUrl": {
+                "url": "https://github.com/ankidroid/Anki-Android"
+            },
+            "repositoryUrl": {
+                "url": "https://github.com/ankidroid/Anki-Android"
+            },
+            "licenses": ["spdx:GPL-3.0", "spdx:AGPL-3.0"],
+            "tags": ["education", "productivity", "knowledge", "health", "mobile", "android"]
+        }
+    ],
+    "funding": {
+        "channels": [
+            {
+                "guid": "opencollective",
+                "type": "other",
+                "address": "https://opencollective.com/ankidroid",
+                "description": "You can fund us via Open Collective with your debit card, credit card or PayPal account"
+            }
+        ],
+        "plans": [
+            {
+                "guid": "oc-sponsor",
+                "status": "active",
+                "name": "Larger contribution for individuals",
+                "description": "Funds 1 hour of developer work per month.",
+                "amount": 10,
+                "currency": "USD",
+                "frequency": "monthly",
+                "channels": ["opencollective"]
+            },
+            {
+                "guid": "oc-backer",
+                "status": "active",
+                "name": "Small contribution for individuals",
+                "description": "Funds 30 minutes of developer work per month.",
+                "amount": 5,
+                "currency": "USD",
+                "frequency": "monthly",
+                "channels": ["opencollective"]
+            },
+            {
+                "guid": "oc-donation",
+                "status": "active",
+                "name": "Pay what you want: Recurring or one-time contribution",
+                "amount": 10,
+                "currency": "USD",
+                "frequency": "other",
+                "channels": ["opencollective"]
+            },
+            {
+                "guid": "oc-small-org",
+                "status": "active",
+                "name": "Sponsorship for Small Organizations",
+                "description": "Funds 10 hours of developer work per month.\n\nIf AnkiDroid benefits your students/employees, your contribution helps us continue improving the app",
+                "amount": 100,
+                "currency": "USD",
+                "frequency": "other",
+                "channels": ["opencollective"]
+            },
+            {
+                "guid": "oc-org",
+                "status": "active",
+                "name": "Sponsorship for Organizations",
+                "description": "Funds 20 hours of developer work per month.\n\nIf AnkiDroid benefits your students/employees, your contribution helps us continue improving the app",
+                "amount": 200,
+                "currency": "USD",
+                "frequency": "other",
+                "channels": ["opencollective"]
+            }
+        ],
+        "history": [
+            {
+                "year": 2023,
+                "income": 22444.29,
+                "expenses": 22064.62,
+                "currency": "USD"
+            },
+            {
+                "year": 2022,
+                "income": 16438.27,
+                "expenses": 17278.63,
+                "currency": "USD"
+            },
+            {
+                "year": 2021,
+                "income": 25839.03,
+                "expenses": 21806.01,
+                "currency": "USD"
+            },
+            {
+                "year": 2020,
+                "income": 11629.57,
+                "expenses": 605.24,
+                "currency": "USD"
+            },
+            {
+                "year": 2019,
+                "currency": "USD",
+                "description": "AnkiDroid was not seeking funding in 2019"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Initiative by Zerodha: potential funding from $10k-100k/year and a listing on https://dir.floss.fund/

**Announcement:**
https://floss.fund/blog/announcing-floss-fund/

**Manifest/schema:**
https://floss.fund/funding-manifest/

**Generated partially with**
https://vishnukvmd.github.io/funding.json/

⚠️ I am using the repo URL as ankidroid.org does not entice people to donate

I am not using the Play Store link as that did not pass the `.well-known` validation

* Part of Issue #17268

**Validated with:**
https://dir.floss.fund/validate

uri: https://github.com/ankidroid/Anki-Android/blob/main/funding.json

## Review Notes

See a sample: https://dir.floss.fund/view/funding/@ziglang.org

* ⚠️ This document proposes a 'end' goal of funding two part-time maintainers. This seems reasonable to me, but I haven't discussed it with the team
* I propose adding two 'commercial' tiers for funding at $100/mo and $200/mo as Zig is doing:
  * https://dir.floss.fund/view/funding/@ziglang.org
* I couldn't figure out how to add a custom donation
  * Maybe change to 123.45 USD 
* Open Collective links for the 'funding' may not be the right move
