### PR TITLE
feat(error-dialog): copy stack trace & debug info

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.CustomExceptionData
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.dialogs.SimpleMessageDialog
@@ -594,8 +595,8 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Shortc
     }
 
     // Show dialogs to deal with database loading issues etc
-    open fun showDatabaseErrorDialog(errorDialogType: DatabaseErrorDialogType) {
-        val newFragment: AsyncDialogFragment = DatabaseErrorDialog.newInstance(errorDialogType)
+    open fun showDatabaseErrorDialog(errorDialogType: DatabaseErrorDialogType, exceptionData: CustomExceptionData? = null) {
+        val newFragment: AsyncDialogFragment = DatabaseErrorDialog.newInstance(errorDialogType, exceptionData)
         showAsyncDialogFragment(newFragment)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -90,13 +90,13 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.InitialActivity.StartupFailure
-import com.ichi2.anki.InitialActivity.StartupFailure.DATABASE_LOCKED
-import com.ichi2.anki.InitialActivity.StartupFailure.DB_ERROR
-import com.ichi2.anki.InitialActivity.StartupFailure.DIRECTORY_NOT_ACCESSIBLE
-import com.ichi2.anki.InitialActivity.StartupFailure.DISK_FULL
-import com.ichi2.anki.InitialActivity.StartupFailure.FUTURE_ANKIDROID_VERSION
-import com.ichi2.anki.InitialActivity.StartupFailure.SD_CARD_NOT_MOUNTED
-import com.ichi2.anki.InitialActivity.StartupFailure.WEBVIEW_FAILED
+import com.ichi2.anki.InitialActivity.StartupFailure.DBError
+import com.ichi2.anki.InitialActivity.StartupFailure.DatabaseLocked
+import com.ichi2.anki.InitialActivity.StartupFailure.DirectoryNotAccessible
+import com.ichi2.anki.InitialActivity.StartupFailure.DiskFull
+import com.ichi2.anki.InitialActivity.StartupFailure.FutureAnkidroidVersion
+import com.ichi2.anki.InitialActivity.StartupFailure.SDCardNotMounted
+import com.ichi2.anki.InitialActivity.StartupFailure.WebviewFailed
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShorcuts
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -108,6 +108,7 @@ import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.BackupPromptDialog
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.CreateDeckDialog
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.CustomExceptionData
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerAnalyticsOptInDialog
 import com.ichi2.anki.dialogs.DeckPickerBackupNoSpaceLeftDialog
@@ -727,11 +728,11 @@ open class DeckPicker :
     @VisibleForTesting
     fun handleStartupFailure(failure: StartupFailure?) {
         when (failure) {
-            SD_CARD_NOT_MOUNTED -> {
+            is SDCardNotMounted -> {
                 Timber.i("SD card not mounted")
                 onSdCardNotMounted()
             }
-            DIRECTORY_NOT_ACCESSIBLE -> {
+            is DirectoryNotAccessible -> {
                 Timber.i("AnkiDroid directory inaccessible")
                 if (ScopedStorageService.collectionWasMadeInaccessibleAfterUninstall(this)) {
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL)
@@ -739,15 +740,15 @@ open class DeckPicker :
                     showDirectoryNotAccessibleDialog()
                 }
             }
-            FUTURE_ANKIDROID_VERSION -> {
+            is FutureAnkidroidVersion -> {
                 Timber.i("Displaying database versioning")
                 showDatabaseErrorDialog(DatabaseErrorDialogType.INCOMPATIBLE_DB_VERSION)
             }
-            DATABASE_LOCKED -> {
+            is DatabaseLocked -> {
                 Timber.i("Displaying database locked error")
                 showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_LOCKED)
             }
-            WEBVIEW_FAILED -> AlertDialog.Builder(this).show {
+            is WebviewFailed -> AlertDialog.Builder(this).show {
                 title(R.string.ankidroid_init_failed_webview_title)
                 message(
                     text = getString(
@@ -760,8 +761,8 @@ open class DeckPicker :
                 }
                 cancelable(false)
             }
-            DISK_FULL -> displayNoStorageError()
-            DB_ERROR -> displayDatabaseFailure()
+            is DiskFull -> displayNoStorageError()
+            is DBError -> displayDatabaseFailure(CustomExceptionData.fromException(failure.exception))
             else -> displayDatabaseFailure()
         }
     }
@@ -791,10 +792,11 @@ open class DeckPicker :
         }
     }
 
-    private fun displayDatabaseFailure() {
+    private fun displayDatabaseFailure(exceptionData: CustomExceptionData? = null) {
         Timber.i("Displaying database failure")
-        showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_LOAD_FAILED)
+        showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_LOAD_FAILED, exceptionData)
     }
+
     private fun displayNoStorageError() {
         Timber.i("Displaying no storage error")
         showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DISK_FULL)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -30,6 +30,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
+import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.CollectionHelper
@@ -55,11 +56,13 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.INCOMP
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.isLoggedIn
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.showImportDialog
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.UiUtil.makeBold
 import com.ichi2.utils.cancelable
+import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.create
 import com.ichi2.utils.listItems
 import com.ichi2.utils.listItemsAndMessage
@@ -69,6 +72,9 @@ import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.io.File
@@ -104,7 +110,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
                         (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
+                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                     }
                     negativeButton(R.string.close) {
                         closeCollectionAndFinish()
@@ -121,7 +127,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
                         (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
+                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                     }
                     negativeButton(R.string.answering_error_report) {
                         (activity as DeckPicker).sendErrorReport()
@@ -138,8 +144,8 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             DIALOG_ERROR_HANDLING -> {
                 // The user has asked to see repair options; allow them to choose one of the repair options or go back
                 // to the previous dialog
-                val options = ArrayList<String>(6)
-                val values = ArrayList<ErrorHandlingEntries>(6)
+                val options = ArrayList<String>(7)
+                val values = ArrayList<ErrorHandlingEntries>(7)
                 if (!(activity as AnkiActivity).colIsOpenUnsafe()) {
                     // retry
                     options.add(res.getString(R.string.backup_retry_opening))
@@ -161,6 +167,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 // delete old collection and build new one
                 options.add(res.getString(R.string.backup_del_collection))
                 values.add(ErrorHandlingEntries.NEW)
+                // copy stack trace and debug info
+                options.add(res.getString(R.string.feedback_copy_debug))
+                values.add(ErrorHandlingEntries.DEBUG_INFO)
+
                 alertDialog.show {
                     title(R.string.error_handling_title)
                     setIcon(R.drawable.ic_warning)
@@ -172,19 +182,29 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 return@listItems
                             }
                             ErrorHandlingEntries.REPAIR -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION)
+                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.RESTORE -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
+                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.ONE_WAY -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER)
+                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.NEW -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_NEW_COLLECTION)
+                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_NEW_COLLECTION, exceptionData)
+                                return@listItems
+                            }
+
+                            ErrorHandlingEntries.DEBUG_INFO -> {
+                                lifecycleScope.launch {
+                                    /* Using NonCancellable to ensure that debug information collection completes even if the coroutine is canceled */
+                                    withContext(NonCancellable) {
+                                        copyStackTraceAndDebugInfo()
+                                    }
+                                }
                                 return@listItems
                             }
                         }
@@ -213,7 +233,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         .title(text = message)
                         .positiveButton(R.string.dialog_ok) {
                             (activity as DeckPicker?)
-                                ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
+                                ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                         }
                 } else {
                     // Show backups sorted with latest on top
@@ -271,7 +291,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
                             ActivityCompat.recreate(activity as DeckPicker)
                         } else {
-                            (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_LOAD_FAILED)
+                            (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_LOAD_FAILED, exceptionData)
                         }
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -296,7 +316,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     positiveButton(R.string.dialog_continue) {
                         (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
+                            ?.showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
                     }
                     negativeButton(R.string.dialog_cancel)
                 }
@@ -343,10 +363,12 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     listItemsAndMessage(message = message, items = options) { _, index: Int ->
                         when (values[index]) {
                             IncompatibleDbVersionEntries.RESTORE -> (activity as DeckPicker).showDatabaseErrorDialog(
-                                DIALOG_RESTORE_BACKUP
+                                DIALOG_RESTORE_BACKUP,
+                                exceptionData
                             )
                             IncompatibleDbVersionEntries.ONE_WAY -> (activity as DeckPicker).showDatabaseErrorDialog(
-                                DIALOG_ONE_WAY_SYNC_FROM_SERVER
+                                DIALOG_ONE_WAY_SYNC_FROM_SERVER,
+                                exceptionData
                             )
                         }
                     }
@@ -376,6 +398,24 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
         }
+    }
+
+    /**
+     * Collects the current exception's stack trace and debug information,
+     * and copies the combines information to the Android clipboard.
+     */
+    private suspend fun copyStackTraceAndDebugInfo() {
+        val combinedInfo = listOf(
+            exceptionData?.toHumanReadableString(),
+            DebugInfoService.getDebugInfo(requireContext())
+        )
+            .filterNotNull()
+            .joinToString(separator = "\n")
+
+        requireContext().copyToClipboard(
+            combinedInfo,
+            failureMessageId = R.string.about_ankidroid_error_copy_debug_info
+        )
     }
 
     /** List items for [DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL] */
@@ -551,7 +591,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     override val dialogHandlerMessage
         get() = ShowDatabaseErrorDialog(requireDialogType())
 
-    private fun requireDialogType() = BundleCompat.getParcelable(requireArguments(), "dialog", DatabaseErrorDialogType::class.java)!!
+    private fun requireDialogType() = BundleCompat.getParcelable(requireArguments(), DIALOG_KEY, DatabaseErrorDialogType::class.java)!!
+
+    private val exceptionData: CustomExceptionData? by lazy {
+        BundleCompat.getParcelable(requireArguments(), EXCEPTION_KEY, CustomExceptionData::class.java)
+    }
 
     fun dismissAllDialogFragments() {
         (activity as AnkiActivity).dismissAllDialogFragments()
@@ -588,15 +632,27 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         var databaseCorruptFlag = false
 
         /**
+         * Key for passing a CustomExceptionData object in a Bundle,
+         * contains error message and stack trace.
+         *
+         * @see CustomExceptionData
+         */
+        private const val EXCEPTION_KEY = "exception"
+
+        // Key for the dialog type in the Bundle, indicating which dialog to show
+        private const val DIALOG_KEY = "dialog"
+
+        /**
          * A set of dialogs which deal with problems with the database when it can't load
          *
          * @param dialogType the sub-dialog to show
          */
         @CheckResult
-        fun newInstance(dialogType: DatabaseErrorDialogType): DatabaseErrorDialog {
+        fun newInstance(dialogType: DatabaseErrorDialogType, exceptionData: CustomExceptionData? = null): DatabaseErrorDialog {
             val f = DatabaseErrorDialog()
             val args = Bundle()
-            args.putParcelable("dialog", dialogType)
+            args.putParcelable(DIALOG_KEY, dialogType)
+            exceptionData?.let { args.putParcelable(EXCEPTION_KEY, it) }
             f.arguments = args
             return f
         }
@@ -614,21 +670,44 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
         override fun toMessage(): Message = Message.obtain().apply {
             what = this@ShowDatabaseErrorDialog.what
             data = bundleOf(
-                "dialog" to dialogType
+                DIALOG_KEY to dialogType
             )
         }
 
         companion object {
             fun fromMessage(message: Message): ShowDatabaseErrorDialog {
-                val dialogType = BundleCompat.getParcelable(message.data, "dialog", DatabaseErrorDialogType::class.java)!!
+                val dialogType = BundleCompat.getParcelable(message.data, DIALOG_KEY, DatabaseErrorDialogType::class.java)!!
                 return ShowDatabaseErrorDialog(dialogType)
+            }
+        }
+    }
+
+    @Parcelize
+    class CustomExceptionData(
+        val stackTrace: String
+    ) : Parcelable {
+        fun toHumanReadableString() = stackTrace
+
+        companion object {
+            private const val MAX_STACKTRACE_LINES = 2000
+
+            @CheckResult
+            fun fromException(exception: Exception): CustomExceptionData {
+                val stackTraceLines = exception.stackTraceToString().lines()
+                val truncatedStackTrace = if (stackTraceLines.size > MAX_STACKTRACE_LINES) {
+                    stackTraceLines.take(MAX_STACKTRACE_LINES).joinToString("\n") + "\n...<stack trace truncated>...\n"
+                } else {
+                    stackTraceLines.joinToString("\n")
+                }
+
+                return CustomExceptionData(truncatedStackTrace)
             }
         }
     }
 }
 
 private enum class ErrorHandlingEntries {
-    RETRY, REPAIR, RESTORE, ONE_WAY, NEW,
+    RETRY, REPAIR, RESTORE, ONE_WAY, NEW, DEBUG_INFO
 }
 
 private enum class IncompatibleDbVersionEntries {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -13,6 +13,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerContextMenu
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
@@ -209,7 +210,7 @@ class DeckPickerTest : RobolectricTest() {
     fun databaseLockedTest() {
         // don't call .onCreate
         val deckPicker = Robolectric.buildActivity(DeckPickerEx::class.java, Intent()).get()
-        deckPicker.handleStartupFailure(InitialActivity.StartupFailure.DATABASE_LOCKED)
+        deckPicker.handleStartupFailure(InitialActivity.StartupFailure.DatabaseLocked)
         assertThat(
             deckPicker.databaseErrorDialog,
             equalTo(DatabaseErrorDialogType.DIALOG_DB_LOCKED)
@@ -745,7 +746,7 @@ class DeckPickerTest : RobolectricTest() {
         var displayedAnalyticsOptIn = false
         var optionsMenu: Menu? = null
 
-        override fun showDatabaseErrorDialog(errorDialogType: DatabaseErrorDialogType) {
+        override fun showDatabaseErrorDialog(errorDialogType: DatabaseErrorDialogType, exceptionData: DatabaseErrorDialog.CustomExceptionData?) {
             databaseErrorDialog = errorDialogType
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityWithConflictTest.kt
@@ -52,7 +52,7 @@ class InitialActivityWithConflictTest : RobolectricTest() {
 
             val f = getStartupFailureType(targetContext)
 
-            assertThat("A conflict should be returned", f, equalTo(StartupFailure.DATABASE_LOCKED))
+            assertThat("A conflict should be returned", f, equalTo(StartupFailure.DatabaseLocked))
         } finally {
             setupForDefault()
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomExceptionDataTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomExceptionDataTest.kt
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.CustomExceptionData
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.arrayWithSize
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.Test
+
+class CustomExceptionDataTest {
+
+    @Test
+    fun `exception type and message is printed`() {
+        val exception = IllegalStateException("Java heap space")
+        assertThat("stack trace should exist", exception.stackTrace, not(arrayWithSize(0)))
+
+        val exceptionData = CustomExceptionData.fromException(exception)
+
+        val outputString = exceptionData.toHumanReadableString()
+
+        assertThat(outputString, containsString("IllegalStateException: Java heap space"))
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this pr is to add a button in Error Dialog to copy stack track and debug info.

## Fixes
* Fixes #17232

## Approach
The approach is to first pass the exception from `InitialActivity` to `DeckPicker` by converting the `StartupFailure` enum into a sealed class and adding an exception parameter to each class inside the `StartupFailure` sealed class. Then, in the `DeckPicker` class, a companion object is created to store the exception. Finally, in the `DatabaseErrorDialog`, the companion object is accessed and used in the `copyStackTraceAndDebugInfo` function.

## How Has This Been Tested?
This change has been tested for database errors.

## Screenshots
![ErrorDialog](https://github.com/user-attachments/assets/963ec842-929e-492f-aa27-0a3e80956fd3)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
