### PR TITLE
fix: image preview was not shown after taking picture

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -385,12 +385,16 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     }
 
     private fun handleTakePictureResult(imagePath: String?) {
-        Timber.d("handleTakePictureResult")
+        Timber.d("handleTakePictureResult, imagePath: %s", imagePath)
         if (imagePath == null) {
             Timber.i("handleTakePictureResult appears to have an invalid picture")
             return
         }
 
+        val imageFile = File(imagePath)
+        viewModel.updateCurrentMultimediaPath(imagePath)
+        viewModel.updateCurrentMultimediaUri(getUriForFile(imageFile))
+        imagePreview.setImageURI(getUriForFile(imageFile))
         updateAndDisplayImageSize(imagePath)
 
         showCropDialog(getString(R.string.crop_image))


### PR DESCRIPTION

## Purpose / Description

Not sure what happened here but after the changes to use the WebView for preview images, it was no longer possible to preview images from the camera

## Fixes

Nothing logged but reproduction was done on an Android 14 emulator

- add new card
- click paperclip
- choose camera
- snap picture
- click check mark to accept the picture

Actual: a default graphic indicating that the image was not loaded into preview, and a toast

Expected: image loaded into preview and dialog to crop or not

## Approach

Look at other places where the multimedia loads image information for viewing and do what those other places did

## How Has This Been Tested?

After making the change I follow my reproduction steps and I see my camera photo in the preview

## Learning (optional, can help others)

No issue reproduction is so small that you won't find some other issue you need to fix before you can get back to your original fix. Warning: This is recursive.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
