### PR TITLE
Fix saving changes in NoteEditor after CardTemplateEditor visit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -312,6 +312,10 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                 Timber.d("onActivityResult() template edit return - current card exists")
                 // reload current card - the template ordinals are possibly different post-edit
                 currentEditedCard = getColUnsafe.getCard(currentEditedCard!!.id)
+                @NeedsTest("#17282 returning from template editor saves further made changes")
+                // make sure the card's note is available going forward
+                currentEditedCard!!.note(getColUnsafe)
+                editorNote = currentEditedCard!!.note // update the NoteEditor's working note reference
                 updateCards(editorNote!!.notetype)
             }
         }


### PR DESCRIPTION
## Purpose / Description
After going to CardTemplateEditor the current card being edited is fetched again from the collection(this makes the card to have a null Note). After making changes and attempting to save, in the saveNote() method the card's note is being accessed and because it's null a call to note(collection) is done. This call fetches the previous stored fields values and those values end up being saved instead of the changed ones. 

## Fixes
* Fixes #17282

## How Has This Been Tested?

Ran the tests, manually verified the bug behavior. Also verified the normal save.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
