### PR TITLE
test: android test for MultimediaFragment intents

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
@@ -52,7 +52,7 @@ class MultimediaTest : InstrumentedTest() {
 
     @Test
     fun testFragmentTitle() {
-        ActivityScenario.launch<MultimediaActivity>(intentBuilder(testContext)).use { scenario ->
+        withMultimediaActivityScenario { scenario ->
             scenario.onActivity { activity ->
                 val fragment = activity.supportFragmentManager.findFragmentById(R.id.fragment_container) as MultimediaFragment
                 val titleString = title?.let { testContext.getString(it) }
@@ -102,16 +102,16 @@ class MultimediaTest : InstrumentedTest() {
         get() = this.supportFragmentManager.findFragmentById(R.id.fragment_container)!!
 
     companion object {
-        @Parameterized.Parameters(name = "{2}")
+        @Parameterized.Parameters(name = "{index}: {1}")
         @JvmStatic
         fun initParameters(): Collection<Array<out Any>> {
             return listOf(
-                arrayOf({ context: Context -> getCameraFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Camera)"),
-                arrayOf({ context: Context -> getGalleryFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Gallery)"),
-                arrayOf({ context: Context -> getDrawingFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Drawing)"),
-                arrayOf({ context: Context -> getAudioFragment(context) }, R.string.multimedia_editor_popup_audio_clip, "Add audio clip"),
-                arrayOf({ context: Context -> getVideoFragment(context) }, R.string.multimedia_editor_popup_video_clip, "Add video clip"),
-                arrayOf({ context: Context -> getAudioRecordingFragment(context) }, R.string.multimedia_editor_field_editing_audio, "Record audio")
+                arrayOf({ context: Context -> getCameraFragment(context) }, R.string.multimedia_editor_popup_image),
+                arrayOf({ context: Context -> getGalleryFragment(context) }, R.string.multimedia_editor_popup_image),
+                arrayOf({ context: Context -> getDrawingFragment(context) }, R.string.multimedia_editor_popup_image),
+                arrayOf({ context: Context -> getAudioFragment(context) }, R.string.multimedia_editor_popup_audio_clip),
+                arrayOf({ context: Context -> getVideoFragment(context) }, R.string.multimedia_editor_popup_video_clip),
+                arrayOf({ context: Context -> getAudioRecordingFragment(context) }, R.string.multimedia_editor_field_editing_audio)
             )
         }
 

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
@@ -48,24 +48,15 @@ class MultimediaTest : InstrumentedTest() {
     @Parameterized.Parameter(0)
     var intentBuilder: (Context) -> Intent? = { null }
 
-    @JvmField
-    @Parameterized.Parameter(1)
-    var expectedTitleRes: Int? = null
-
-    @Suppress("unused") // used by "{2}"
-    @JvmField
-    @Parameterized.Parameter(2)
-    var testName: String = ""
-
-    private val expectedTitle
-        get() = testContext.getString(expectedTitleRes!!)
+    private var title: Int? = null
 
     @Test
     fun testFragmentTitle() {
-        withMultimediaActivityScenario { scenario ->
+        ActivityScenario.launch<MultimediaActivity>(intentBuilder(testContext)).use { scenario ->
             scenario.onActivity { activity ->
-                val actualFragmentTitle = (activity.fragmentContainer as MultimediaFragment).title
-                assertEquals(expectedTitle, actualFragmentTitle, message = "title")
+                val fragment = activity.supportFragmentManager.findFragmentById(R.id.fragment_container) as MultimediaFragment
+                val titleString = title?.let { testContext.getString(it) }
+                assertEquals(titleString, fragment.title)
             }
         }
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
@@ -48,7 +48,9 @@ class MultimediaTest : InstrumentedTest() {
     @Parameterized.Parameter(0)
     var intentBuilder: (Context) -> Intent? = { null }
 
-    private var title: Int? = null
+    @JvmField
+    @Parameterized.Parameter(1)
+    var title: Int? = null
 
     @Test
     fun testFragmentTitle() {

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/MultimediaTest.kt
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.content.Context
+import android.content.Intent
+import androidx.fragment.app.Fragment
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.ichi2.anki.multimedia.AudioRecordingFragment
+import com.ichi2.anki.multimedia.AudioVideoFragment
+import com.ichi2.anki.multimedia.MultimediaActivity
+import com.ichi2.anki.multimedia.MultimediaActivityExtra
+import com.ichi2.anki.multimedia.MultimediaFragment
+import com.ichi2.anki.multimedia.MultimediaImageFragment
+import com.ichi2.anki.multimediacard.fields.ImageField
+import com.ichi2.anki.multimediacard.fields.TextField
+import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
+import com.ichi2.anki.tests.InstrumentedTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class MultimediaTest : InstrumentedTest() {
+
+    @JvmField
+    @Parameterized.Parameter(0)
+    var intentBuilder: (Context) -> Intent? = { null }
+
+    @JvmField
+    @Parameterized.Parameter(1)
+    var expectedTitleRes: Int? = null
+
+    @Suppress("unused") // used by "{2}"
+    @JvmField
+    @Parameterized.Parameter(2)
+    var testName: String = ""
+
+    private val expectedTitle
+        get() = testContext.getString(expectedTitleRes!!)
+
+    @Test
+    fun testFragmentTitle() {
+        withMultimediaActivityScenario { scenario ->
+            scenario.onActivity { activity ->
+                val actualFragmentTitle = (activity.fragmentContainer as MultimediaFragment).title
+                assertEquals(expectedTitle, actualFragmentTitle, message = "title")
+            }
+        }
+    }
+
+    @Test
+    fun testImageFragmentDiscardDialogShown() {
+        val validIntentBuilders = setOf(
+            { context: Context -> getCameraFragment(context) },
+            { context: Context -> getGalleryFragment(context) },
+            { context: Context -> getDrawingFragment(context) }
+        )
+
+        if (intentBuilder !in validIntentBuilders) {
+            return
+        }
+
+        withMultimediaActivityScenario { scenario ->
+            scenario.onActivity { activity ->
+                (activity.fragmentContainer as MultimediaImageFragment).apply {
+                    viewModel.updateCurrentMultimediaPath("test/path")
+                    requireActivity().onBackPressedDispatcher.onBackPressed()
+                }
+            }
+
+            onView(withText(CollectionManager.TR.addingDiscardCurrentInput()))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+
+            onView(withText(R.string.discard))
+                .check(matches(isDisplayed()))
+
+            onView(withText(CollectionManager.TR.addingKeepEditing()))
+                .check(matches(isDisplayed()))
+        }
+    }
+
+    /** Runs [ActivityScenario.launch] with the result of the [intentBuilder] */
+    private fun withMultimediaActivityScenario(block: (ActivityScenario<MultimediaActivity>) -> Unit) {
+        ActivityScenario.launch<MultimediaActivity>(intentBuilder(testContext)).use { block(it) }
+    }
+
+    private val MultimediaActivity.fragmentContainer: Fragment
+        get() = this.supportFragmentManager.findFragmentById(R.id.fragment_container)!!
+
+    companion object {
+        @Parameterized.Parameters(name = "{2}")
+        @JvmStatic
+        fun initParameters(): Collection<Array<out Any>> {
+            return listOf(
+                arrayOf({ context: Context -> getCameraFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Camera)"),
+                arrayOf({ context: Context -> getGalleryFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Gallery)"),
+                arrayOf({ context: Context -> getDrawingFragment(context) }, R.string.multimedia_editor_popup_image, "Add image (Drawing)"),
+                arrayOf({ context: Context -> getAudioFragment(context) }, R.string.multimedia_editor_popup_audio_clip, "Add audio clip"),
+                arrayOf({ context: Context -> getVideoFragment(context) }, R.string.multimedia_editor_popup_video_clip, "Add video clip"),
+                arrayOf({ context: Context -> getAudioRecordingFragment(context) }, R.string.multimedia_editor_field_editing_audio, "Record audio")
+            )
+        }
+
+        private val multimediaActivityExtra = MultimediaActivityExtra(0, ImageField(), getTestMultimediaNote())
+
+        private fun getCameraFragment(context: Context): Intent {
+            return MultimediaImageFragment.getIntent(
+                context,
+                multimediaActivityExtra,
+                MultimediaImageFragment.ImageOptions.CAMERA
+            )
+        }
+
+        private fun getGalleryFragment(context: Context): Intent {
+            return MultimediaImageFragment.getIntent(
+                context,
+                multimediaActivityExtra,
+                MultimediaImageFragment.ImageOptions.GALLERY
+            )
+        }
+
+        private fun getDrawingFragment(context: Context): Intent {
+            return MultimediaImageFragment.getIntent(
+                context,
+                multimediaActivityExtra,
+                MultimediaImageFragment.ImageOptions.DRAWING
+            )
+        }
+
+        private fun getVideoFragment(context: Context): Intent {
+            return AudioVideoFragment.getIntent(
+                context,
+                multimediaActivityExtra,
+                AudioVideoFragment.MediaOption.VIDEO_CLIP
+            )
+        }
+
+        private fun getAudioFragment(context: Context): Intent {
+            return AudioVideoFragment.getIntent(
+                context,
+                multimediaActivityExtra,
+                AudioVideoFragment.MediaOption.AUDIO_CLIP
+            )
+        }
+
+        private fun getAudioRecordingFragment(context: Context): Intent {
+            return AudioRecordingFragment.getIntent(
+                context,
+                multimediaActivityExtra
+            )
+        }
+
+        private fun getTestMultimediaNote(): MultimediaEditableNote {
+            val note = MultimediaEditableNote()
+            note.setNumFields(1)
+            note.setField(0, TextField())
+            note.freezeInitialFieldValues()
+            return note
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Test for multimedia activity intents i.e. camera, gallery & drawing 

## Approach
Use `libs.androidx.espresso.intents` to check if the intents are there or not, this will be useful to test other components too I.e cropper, audio recorder, etc

## How Has This Been Tested?
Tested locally using `./gradlew connectedplayDebugAndroidTest`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
