### PR TITLE
fix: CardTemplateEditor restores wrong editor view

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -494,7 +494,8 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 true
             }
             // set saved or default view
-            bottomNavigation.selectedItemId = requireArguments().getInt(EDITOR_VIEW_ID_KEY)
+            bottomNavigation.selectedItemId =
+                templateEditor.tabToViewId[cardIndex] ?: requireArguments().getInt(EDITOR_VIEW_ID_KEY)
 
             // Set text change listeners
             val templateEditorWatcher: TextWatcher = object : TextWatcher {


### PR DESCRIPTION
## Purpose
Fixes the bug where activity recreation causes `CardTemplateEditor` to set the view to `front` regardless of the previous state.

## Fixes
* Fixes #14086

## Approach
### Bug Lore 🔬:
<details><summary>This decides what would be view (front/back/style) of the template editor initially (or after activity restart)</summary>
<p>

https://github.com/ankidroid/Anki-Android/blob/8d626d1593b4364f1fb29b21925447d305b83bf2/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt#L497

</p>
</details> 

<details><summary>But <code>EDITOR_VIEW_ID_KEY</code> is always <code>R.id.front_edit</code>,</summary>
<p>

https://github.com/ankidroid/Anki-Android/blob/8d626d1593b4364f1fb29b21925447d305b83bf2/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt#L410

</p>
</details> 

<details><summary>as this is the initial value for <code>tabToViewId[0]</code> in absence of any saved instance,</summary>
<p>

https://github.com/ankidroid/Anki-Android/blob/8d626d1593b4364f1fb29b21925447d305b83bf2/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt#L159

</p>
</details> 

and if there are more than one card (e.g. Basic and Reversed), for Reversed i.e. 1, that would be null initially, so `R.id.front_edit` would be set as the value regardless.

This works fine normally because initial view of the editor is always front, but after an activity restart (e.g. changing system theme, or any other thing that will force that), it may not be the case that editor was on the front before that event.

This causes the problem of "text being copied from back to front", as after recreation, regardless of whatever the view was before, it will now be set to `front`, but the text still remains of whichever view that previously was before the activity recreation, which triggers the `TextWatcher` which now updates the value of `front` to the text to the view that was previously present.

This explains why the bug only happens for `front` and only when the editor before the activity recreation is at either `back` or `style`,
because if it is at `front` at activity recreation, problem doesn't arises, as the view will still be `front` after recreation which doesn't causes any "copying"

Due to the same reason it doesn't happens with `back` or `style`, as their text remains unmodified, because the view is being considered as `front` after recreation.

### Fix 👾
When setting the intitial view (front/back/style) at first load or after activity recreation,
set it to the `tabToView` for associated Card number if it is not null (which it will not if being loaded from saved state after recreation), else apply the default `front` view.

## How Has This Been Tested?
Device (Physical): Pixel 6a, Android 14, SDK 34

### Testing Instructions:
**Location:** Add Card -> `Cards: Card 1, ...`
| Action ⛏️ | After Fix ✨ | Before Fix 🐞 |
|--------|--------|--------|
| -> Back -> Theme Change | View says `Back template` | View says `Front template` |
| -> Front | Contents of `Front` | Contents of `Back` |
| -> Styling -> Theme Change | View says `Styling` | View says `Front template` |
| -> Front | Contents of `Front` | Contents of `Styling` |

### Video:

<details><summary>After Fix ✨</summary>
<p>

https://github.com/user-attachments/assets/969207b0-0dc2-49c8-bd27-e8bd53b5859e

</p>
</details> 

<details><summary>Before Fix 🐞</summary>
<p>

https://github.com/user-attachments/assets/e57c54d4-1289-4730-8067-e1fedd999228

</p>
</details> 

## Learning
- Vertical orientation can sometimes be quite pleasing
