### PR TITLE
refactor: remove context from `InstantEditorViewModel`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1160,7 +1160,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             lifecycleScope.launch {
                 val noteFieldsCheck = checkNoteFieldsResponse(editorNote!!)
                 if (noteFieldsCheck is NoteFieldsCheckResult.Failure) {
-                    addNoteErrorMessage = noteFieldsCheck.getLocalizedMessage(requireContext())
+                    addNoteErrorMessage = noteFieldsCheck.localizedMessage ?: getString(R.string.something_wrong)
                     displayErrorSavingNote()
                     return@launch
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteFieldsCheckResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteFieldsCheckResult.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki
 
-import android.content.Context
 import anki.notes.NoteFieldsCheckResponse
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
@@ -38,9 +37,7 @@ sealed interface NoteFieldsCheckResult {
     data object Success : NoteFieldsCheckResult
 
     /** @property localizedMessage user-readable error message */
-    data class Failure(private val localizedMessage: String?) : NoteFieldsCheckResult {
-        fun getLocalizedMessage(context: Context) = localizedMessage ?: context.getString(R.string.something_wrong)
-    }
+    data class Failure(val localizedMessage: String?) : NoteFieldsCheckResult
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki.instantnoteeditor
 
-import android.content.Context
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -26,7 +25,6 @@ import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NoteFieldsCheckResult
 import com.ichi2.anki.OnErrorListener
-import com.ichi2.anki.R
 import com.ichi2.anki.checkNoteFieldsResponse
 import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity.DialogType
 import com.ichi2.anki.utils.ext.getAllClozeTextFields
@@ -136,13 +134,10 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
      * Checks the note fields and calls [saveNote] if all fields are valid.
      * If [skipClozeCheck] is set to true, the cloze field check is skipped.
      *
-     * @param context The context used to retrieve localized error messages.
      * @param skipClozeCheck Indicates whether to skip the cloze field check.
      * @return A [SaveNoteResult] indicating the outcome of the operation.
      */
-    // TODO: remove context from here
     suspend fun checkAndSaveNote(
-        context: Context,
         skipClozeCheck: Boolean = false
     ): SaveNoteResult {
         if (skipClozeCheck) {
@@ -152,8 +147,7 @@ class InstantEditorViewModel : ViewModel(), OnErrorListener {
         val note = editorNote
         val result = checkNoteFieldsResponse(note)
         if (result is NoteFieldsCheckResult.Failure) {
-            val errorMessage = result.getLocalizedMessage(context)
-            return SaveNoteResult.Warning(errorMessage)
+            return SaveNoteResult.Warning(result.localizedMessage)
         }
         Timber.d("Note fields check successful, saving note")
         instantEditorError.emit(null)
@@ -414,20 +408,7 @@ sealed class SaveNoteResult {
      *
      * @property message An optional message describing the reason for the failure.
      */
-    data class Failure(val message: String? = null) : SaveNoteResult() {
-
-        /**
-         * Retrieves the error message associated with this failure.
-         *
-         * If a message is provided, it returns that message. Otherwise, it returns a default
-         * error message from the context's resources.
-         *
-         * @param context The context used to retrieve the default error message string.
-         * @return The error message.
-         */
-        fun getErrorMessage(context: Context) =
-            message ?: context.getString(R.string.something_wrong)
-    }
+    data class Failure(val message: String? = null) : SaveNoteResult()
 
     /**
      * Indicates that the save note operation completed with a warning.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -373,7 +373,7 @@ class InstantNoteEditorActivity : AnkiActivity(), DeckSelectionDialog.DeckSelect
         when (result) {
             is SaveNoteResult.Failure -> {
                 Timber.d("Failed to save note")
-                savingErrorDialog(result.getErrorMessage(this))
+                savingErrorDialog(result.message ?: getString(R.string.something_wrong))
             }
 
             SaveNoteResult.Success -> {
@@ -384,7 +384,7 @@ class InstantNoteEditorActivity : AnkiActivity(), DeckSelectionDialog.DeckSelect
 
             is SaveNoteResult.Warning -> {
                 Timber.d("Showing warning to the user")
-                viewModel.setWarningMessage(result.message)
+                viewModel.setWarningMessage(result.message ?: getString(R.string.something_wrong))
             }
         }
     }
@@ -497,7 +497,7 @@ class InstantNoteEditorActivity : AnkiActivity(), DeckSelectionDialog.DeckSelect
     private fun saveNoteWithProgress(skipClozeCheck: Boolean) {
         lifecycleScope.launch {
             val result = withProgress(resources.getString(R.string.saving_facts)) {
-                viewModel.checkAndSaveNote(this@InstantNoteEditorActivity, skipClozeCheck = skipClozeCheck)
+                viewModel.checkAndSaveNote(skipClozeCheck = skipClozeCheck)
             }
             handleSaveNoteResult(result)
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -90,7 +90,7 @@ class InstantEditorViewModelTest : RobolectricTest() {
     @Test
     fun testSavingNoteWithNoCloze() = runViewModelTest {
         editorNote.setField(0, "Hello")
-        val result = checkAndSaveNote(targetContext)
+        val result = checkAndSaveNote()
 
         assertEquals(CollectionManager.TR.addingYouHaveAClozeDeletionNote(), saveNoteResult(result))
     }
@@ -99,21 +99,21 @@ class InstantEditorViewModelTest : RobolectricTest() {
     fun testSavingNoteWithEmptyFields() = runViewModelTest {
         editorNote.setField(0, "{{c1::Hello}}")
 
-        val result = checkAndSaveNote(targetContext)
+        val result = checkAndSaveNote()
 
         assertEquals("Success", saveNoteResult(result))
     }
 
     @Test
     fun testSavingNoteWithClozeFields() = runViewModelTest {
-        val result = checkAndSaveNote(targetContext)
+        val result = checkAndSaveNote()
 
         assertEquals(CollectionManager.TR.addingTheFirstFieldIsEmpty(), saveNoteResult(result))
     }
 
     @Test
     fun testCheckAndSaveNote_NullEditorNote_ReturnsFailure() = runViewModelTest {
-        val result = checkAndSaveNote(targetContext)
+        val result = checkAndSaveNote()
 
         assertTrue(result is SaveNoteResult.Warning)
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Completes a TODO to keep ViewModel context free


## How Has This Been Tested?
Locally Google emulator API35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
