### PR TITLE
Add fsrs version to debug info

### DIFF
--- a/.idea/dictionaries/anki.xml
+++ b/.idea/dictionaries/anki.xml
@@ -47,6 +47,7 @@
       <w>fname</w>
       <w>fnames</w>
       <w>frac</w>
+      <w>fsrs</w>
       <w>fullsync</w>
       <w>gendeck</w>
       <w>genrem</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -62,6 +62,9 @@ class AboutFragment : Fragment(R.layout.about_layout) {
         view.findViewById<TextView>(R.id.about_backend).text =
             "(anki " + BackendBuildConfig.ANKI_DESKTOP_VERSION + " / " + BackendBuildConfig.ANKI_COMMIT_HASH.subSequence(0, 8) + ")"
 
+        // FSRS version text
+        view.findViewById<TextView>(R.id.about_fsrs).text = "(FSRS ${BackendBuildConfig.FSRS_VERSION})"
+
         // Logo secret
         view.findViewById<ImageView>(R.id.about_app_logo)
             .setOnClickListener(DevOptionsSecretClickListener(requireActivity() as Preferences))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -60,7 +60,7 @@ object DebugInfoService {
                
                ACRA UUID = ${Installation.id(info)}
                
-               FSRS Enabled = $isFSRSEnabled
+               FSRS = ${BackendBuildConfig.FSRS_VERSION} (Enabled: $isFSRSEnabled)
                
                Crash Reports Enabled = ${isSendingCrashReports(info)}
         """.trimIndent()

--- a/AnkiDroid/src/main/res/layout/about_layout.xml
+++ b/AnkiDroid/src/main/res/layout/about_layout.xml
@@ -63,8 +63,15 @@
         style="?android:textAppearanceSmall"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="14dp"
         tools:text="(anki 23.10.1 / be74babb0)" />
+
+    <TextView
+        android:id="@+id/about_fsrs"
+        style="?android:textAppearanceSmall"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="14dp"
+        tools:text="(FSRS 0.6.4)" />
 
     <TextView
         android:id="@+id/about_contributors_title"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Adds the fsrs version to the debug info. In a separate commit I also added the version to the about settings screen so it can be removed if not wanted(or maybe combine the backend and fsrs info):
![s1](https://github.com/user-attachments/assets/6368193b-8d2d-4863-a44c-ed74e26a36e7)


## Fixes
Towards #17236

## How Has This Been Tested?

Looked at the debug info, looked at the settings screen

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
