### PR TITLE
Fix CardContentProvider to support parallel builds

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -137,8 +137,12 @@ class CardContentProvider : ContentProvider() {
             return sanitized.toTypedArray()
         }
 
+        // Follows the format in the manifest
+        private val sAuthority = "${BuildConfig.APPLICATION_ID}.flashcards"
+        private val sPermission = "${BuildConfig.APPLICATION_ID}.permission.READ_WRITE_DATABASE"
+
         init {
-            fun addUri(path: String, code: Int) = sUriMatcher.addURI(FlashCardsContract.AUTHORITY, path, code)
+            fun addUri(path: String, code: Int) = sUriMatcher.addURI(sAuthority, path, code)
             // Here you can see all the URIs at a glance
             addUri("notes", NOTES)
             addUri("notes_v2", NOTES_V2)
@@ -1230,16 +1234,16 @@ class CardContentProvider : ContentProvider() {
 
     private fun hasReadWritePermission(): Boolean {
         return if (BuildConfig.DEBUG) { // Allow self-calling of the provider only in debug builds (e.g. for unit tests)
-            context!!.checkCallingOrSelfPermission(FlashCardsContract.READ_WRITE_PERMISSION) == PackageManager.PERMISSION_GRANTED
+            context!!.checkCallingOrSelfPermission(sPermission) == PackageManager.PERMISSION_GRANTED
         } else {
-            context!!.checkCallingPermission(FlashCardsContract.READ_WRITE_PERMISSION) == PackageManager.PERMISSION_GRANTED
+            context!!.checkCallingPermission(sPermission) == PackageManager.PERMISSION_GRANTED
         }
     }
 
     /** Returns true if the calling package is known to be "rogue" and should be blocked.
      * Calling package might be rogue if it has not declared #READ_WRITE_PERMISSION in its manifest */
     private fun knownRogueClient(): Boolean =
-        !context!!.arePermissionsDefinedInManifest(callingPackage!!, FlashCardsContract.READ_WRITE_PERMISSION)
+        !context!!.arePermissionsDefinedInManifest(callingPackage!!, sPermission)
 }
 
 /** replaces [anki:play...] with [sound:] */


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description

CardContentProvider is currently broken for parallel builds

## Fixes
* Fixes #17309 (partially, see below)

## Approach

Makes the authority uri and permission rely on the application id, instead of being hardcoded for the release and debug builds.

Work still needs to be done to update the relevant tests, but I don't know how to get at the build config in there 🤔

## How Has This Been Tested?

Tested on the debug build

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
