### PR TITLE
test: deck options on back press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -38,7 +38,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-@NeedsTest("pressing back: icon + button should go to the previous screen")
 @NeedsTest("15130: pressing back: icon + button should return to options if the manual is open")
 class DeckOptions : PageFragment() {
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2024 Chen Shanhan <c.shanhan3@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import android.content.DialogInterface
+import androidx.lifecycle.Lifecycle
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.NoMatchingViewException
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.matcher.ViewMatchers.withContentDescription
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.SingleFragmentActivity
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import timber.log.Timber
+
+@RunWith(AndroidJUnit4::class)
+class DeckOptionsTest : RobolectricTest() {
+    @Test
+    fun `When pressing the back button, the activity should finish`() {
+        // Launch deck options
+        val intent = DeckOptions.getIntent(targetContext, col.decks.selected())
+
+        val scenario = ActivityScenario.launch<SingleFragmentActivity>(intent)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity { activity ->
+            assertThat("Activity should not be finishing", !activity.isFinishing)
+
+            // Perform system-level back press
+            pressBack()
+
+            // Discard on modal
+            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+
+            assertThat("Activity should be finishing", activity.isFinishing)
+        }
+    }
+
+    @Test
+    fun `When pressing the toolbar up button, the activity should finish`() {
+        // Launch deck options
+        val intent = DeckOptions.getIntent(targetContext, col.decks.selected())
+
+        val scenario = ActivityScenario.launch<SingleFragmentActivity>(intent)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+        scenario.onActivity { activity ->
+            assertThat("Activity should not be finishing", !activity.isFinishing)
+        }
+
+        // Perform toolbar up button press
+        try {
+            onView(withContentDescription("Navigate up")).perform(click())
+        } catch (ex: NoMatchingViewException) {
+            Timber.d("Toolbar UP button not found. Is english locale being used?")
+            return // Abort
+        }
+
+        scenario.onActivity { activity ->
+            // Discard on modal
+            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+            assertThat("Activity should be finishing", activity.isFinishing)
+        }
+    }
+}


### PR DESCRIPTION
Hello, I'm mostly a TypeScript dev who is really rusty with Android and trying to get back into Android development. Forgive my Android newbie-ness.

<!--- Please fill the necessary details below -->
## Purpose / Description
Implemented test case for `DeckOptions`, ensures that on pressing the system-level back button and back navigation icon finishes the activity. 

## Fixes
* Fixes part of #13283

## Approach
2 tests have been written: 1 that does a system-level back press and 1 that simulates the icon button back press. For both tests, it passes as long as the deck options fragment activity is finishing.

I understand that the test annotation description was to verify that it returned to the previous screen, does checking if the activity is finishing sufficient in determining that going back works as intended?
I assume it's related to this other test case: `@NeedsTest("15130: pressing back: icon + button should return to options if the manual is open")`, then doing this check would make sense.

## How Has This Been Tested?

Ran `./gradlew jacocoUnitTestReport`

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
