### PR TITLE
fix: revert workaround for broken AGP [8.6.1]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/PackageManagerCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/PackageManagerCompat.kt
@@ -129,7 +129,6 @@ const val GET_ATTRIBUTIONS = -0x80000000 // API 31
 
 @LongDef(
     flag = true,
-    open = true, // HACK: AGP 8.6.1 broke .toLong(): https://issuetracker.google.com/issues/367752734
     // prefix = ["GET_", "MATCH_"],
     value = [
         AndroidPackageManager.GET_ACTIVITIES.toLong(),

--- a/AnkiDroid/src/main/java/com/ichi2/compat/ResolveInfoCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/ResolveInfoCompat.kt
@@ -152,7 +152,6 @@ const val MATCH_DIRECT_BOOT_UNAWARE = 0x00040000
 
 @LongDef(
     flag = true,
-    open = true, // HACK: AGP 8.6.1 broke .toLong(): https://issuetracker.google.com/issues/367752734
     // prefix = ["GET_", "MATCH_"],
     value = [
         GET_META_DATA.toLong(),

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.kt
@@ -22,6 +22,7 @@ import androidx.browser.customtabs.CustomTabsService
 import com.ichi2.compat.CompatHelper.Companion.queryIntentActivitiesCompat
 import com.ichi2.compat.CompatHelper.Companion.resolveActivityCompat
 import com.ichi2.compat.CompatHelper.Companion.resolveServiceCompat
+import com.ichi2.compat.GET_RESOLVED_FILTER
 import com.ichi2.compat.ResolveInfoFlagsCompat
 import timber.log.Timber
 
@@ -110,7 +111,7 @@ object CustomTabsHelper {
             val pm = context.packageManager
             val handlers = pm.queryIntentActivitiesCompat(
                 intent,
-                ResolveInfoFlagsCompat.of(PackageManager.GET_RESOLVED_FILTER.toLong())
+                ResolveInfoFlagsCompat.of(GET_RESOLVED_FILTER.toLong())
             )
             if (handlers.isEmpty()) {
                 return false

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -28,6 +28,7 @@ import android.provider.Settings
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.CompatHelper.Companion.queryIntentActivitiesCompat
+import com.ichi2.compat.MATCH_DEFAULT_ONLY
 import com.ichi2.compat.PackageInfoFlagsCompat
 import com.ichi2.compat.ResolveInfoFlagsCompat
 import timber.log.Timber
@@ -74,7 +75,7 @@ object AdaptionUtil {
         }
         val intent = Intent(Intent.ACTION_VIEW, Uri.parse("http://www.google.com"))
         val pm = context.packageManager
-        val list = pm.queryIntentActivitiesCompat(intent, ResolveInfoFlagsCompat.of(PackageManager.MATCH_DEFAULT_ONLY.toLong()))
+        val list = pm.queryIntentActivitiesCompat(intent, ResolveInfoFlagsCompat.of(MATCH_DEFAULT_ONLY.toLong()))
         for (ri in list) {
             if (!isValidBrowser(ri)) {
                 continue


### PR DESCRIPTION
We're now on AGP 8.7.1 and this is fixed:
https://issuetracker.google.com/issues/367752734

* remove `open = true`
* fix error

Reverts part of 7db4ea983b127812fcb9c6a34f0cd325a0f9f91d

* androidGradlePlugin 8.6.1 broke lint if using `.toLong()` in a `@LongDef`

https://issuetracker.google.com/issues/367752734 was been raised and `open = true` was temporarily added on broken `@LongDef` instances

## Fixes
* Broken/added in #17086
* Fixed in #17263
* Fixes #17265

## How Has This Been Tested?
`./gradlew lint` now passes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
