### PR TITLE
Fix study options related menus

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -275,7 +275,6 @@
             />
         <activity
             android:name="com.ichi2.anki.StudyOptionsActivity"
-            android:label="StudyOptions"
             android:exported="false"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:parentActivityName=".DeckPicker"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -15,17 +15,33 @@
  ****************************************************************************************/
 package com.ichi2.anki
 
+import android.content.Intent
 import android.os.Bundle
+import android.view.Menu
 import android.view.MenuItem
+import androidx.core.view.MenuItemCompat
 import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
+import anki.collection.OpChanges
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
+import com.ichi2.libanki.ChangeManager
+import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.widget.WidgetStatus
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
-class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyListener {
+class StudyOptionsActivity :
+    AnkiActivity(),
+    StudyOptionsListener,
+    CustomStudyListener,
+    ChangeManager.Subscriber {
+
+    private var undoState = UndoState()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -34,6 +50,7 @@ class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyLi
         customStudyDialogFactory.attachToActivity<ExtendedFragmentFactory>(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.studyoptions)
+        enableToolbar().apply { title = "" }
         if (savedInstanceState == null) {
             loadStudyOptionsFragment()
         }
@@ -53,12 +70,36 @@ class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyLi
     private val currentFragment: StudyOptionsFragment?
         get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame) as StudyOptionsFragment?
 
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        menuInflater.inflate(R.menu.activity_study_options, menu)
+        val undoMenuItem = menu.findItem(R.id.action_undo)
+        val undoActionProvider = MenuItemCompat.getActionProvider(undoMenuItem) as? RtlCompliantActionProvider
+        // Set the proper click target for the undo button's ActionProvider
+        undoActionProvider?.clickHandler = { _, menuItem -> onOptionsItemSelected(menuItem) }
+        undoMenuItem.isVisible = undoState.hasAction
+        undoMenuItem.title = undoState.label
+        return true
+    }
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (item.itemId == android.R.id.home) {
-            closeStudyOptions()
-            return true
+        return when (item.itemId) {
+            android.R.id.home -> {
+                closeStudyOptions()
+                true
+            }
+            R.id.action_undo -> {
+                launchCatchingTask {
+                    undoAndShowSnackbar()
+                    // TODO why are we going to the Reviewer from here? Desktop doesn't do this
+                    Intent(this@StudyOptionsActivity, Reviewer::class.java)
+                        .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
+                        .also { startActivity(it) }
+                    finish()
+                }
+                true
+            }
+            else -> return super.onOptionsItemSelected(item)
         }
-        return super.onOptionsItemSelected(item)
     }
 
     private fun closeStudyOptions(result: Int = RESULT_OK) {
@@ -73,6 +114,11 @@ class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyLi
         closeStudyOptions()
         @Suppress("DEPRECATION")
         super.onBackPressed()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        refreshUndoState()
     }
 
     public override fun onStop() {
@@ -98,4 +144,28 @@ class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyLi
         // Sched needs to be reset so provide true argument
         currentFragment!!.refreshInterface()
     }
+
+    override fun opExecuted(changes: OpChanges, handler: Any?) {
+        refreshUndoState()
+    }
+
+    private fun refreshUndoState() {
+        lifecycleScope.launch {
+            val newUndoState = withCol {
+                UndoState(
+                    hasAction = undoAvailable(),
+                    label = undoLabel()
+                )
+            }
+            if (undoState != newUndoState) {
+                undoState = newUndoState
+                invalidateOptionsMenu()
+            }
+        }
+    }
+
+    private data class UndoState(
+        val hasAction: Boolean = false,
+        val label: String? = null
+    )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -25,7 +25,7 @@ import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.widget.WidgetStatus
 import timber.log.Timber
 
-class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, CustomStudyListener {
+class StudyOptionsActivity : AnkiActivity(), StudyOptionsListener, CustomStudyListener {
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -34,8 +34,6 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
         customStudyDialogFactory.attachToActivity<ExtendedFragmentFactory>(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.studyoptions)
-        // create inherited navigation drawer layout here so that it can be used by parent class
-        initNavigationDrawer(findViewById(android.R.id.content))
         if (savedInstanceState == null) {
             loadStudyOptionsFragment()
         }
@@ -56,9 +54,6 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
         get() = supportFragmentManager.findFragmentById(R.id.studyoptions_frame) as StudyOptionsFragment?
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        if (drawerToggle.onOptionsItemSelected(item)) {
-            return true
-        }
         if (item.itemId == android.R.id.home) {
             closeStudyOptions()
             return true
@@ -74,13 +69,10 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
 
     @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
-        if (isDrawerOpen) {
-            @Suppress("DEPRECATION")
-            super.onBackPressed()
-        } else {
-            Timber.i("Back key pressed")
-            closeStudyOptions()
-        }
+        Timber.i("Back key pressed")
+        closeStudyOptions()
+        @Suppress("DEPRECATION")
+        super.onBackPressed()
     }
 
     public override fun onStop() {
@@ -88,11 +80,6 @@ class StudyOptionsActivity : NavigationDrawerActivity(), StudyOptionsListener, C
         if (colIsOpenUnsafe()) {
             WidgetStatus.updateInBackground(this)
         }
-    }
-
-    public override fun onResume() {
-        super.onResume()
-        selectNavigationItem(-1)
     }
 
     override fun onRequireDeckListUpdate() {

--- a/AnkiDroid/src/main/res/drawable/ic_arrow_back_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_arrow_back_white.xml
@@ -1,5 +1,0 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
-</vector>

--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -2,6 +2,13 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include layout="@layout/toolbar" />
+
         <LinearLayout
             android:id="@+id/deckpicker_xl_view"
             android:layout_width="match_parent"
@@ -18,5 +25,6 @@
                 android:layout_width="1dip"
                 android:layout_height="match_parent"/>
         </LinearLayout>
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
 

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -16,8 +16,6 @@
         android:layout_height="match_parent"
         android:orientation="vertical" >
 
-        <include layout="@layout/toolbar" />
-
         <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
             android:id="@+id/pull_to_sync_wrapper"
             android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout/homescreen.xml
@@ -2,5 +2,13 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
-    <include layout="@layout/deck_picker" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include layout="@layout/toolbar" />
+
+        <include layout="@layout/deck_picker" />
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/studyoptions.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions.xml
@@ -7,6 +7,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:orientation="vertical">
+
+                <include layout="@layout/toolbar" />
+
                 <FrameLayout
                     android:id="@+id/studyoptions_frame"
                     android:layout_width="match_parent"

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -8,24 +8,11 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <androidx.appcompat.widget.Toolbar
-            android:id="@+id/studyOptionsToolbar"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:minHeight="?attr/actionBarSize"
-            android:theme="@style/ActionBarStyle"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            android:background="?attr/appBarColor"
-            app:popupTheme="@style/ActionBar.Popup"
-            app:navigationContentDescription="@string/abc_action_bar_up_description"
-            app:navigationIcon="?attr/homeAsUpIndicator"/>
         <View
             android:id="@+id/studyoptions_gradient"
             android:layout_width="15dp"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/studyOptionsToolbar"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             android:background="@drawable/shadow_left"
             android:visibility="gone"/>
@@ -46,7 +33,7 @@
             android:layout_above="@id/bottom_area_layout"
             android:layout_width="0dp"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/studyOptionsToolbar"
+            app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintStart_toEndOf="@id/studyoptions_gradient"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintBottom_toTopOf="@id/studyoptions_start"

--- a/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
@@ -1,29 +1,39 @@
 <menu xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/deck_picker_action_filter"
         android:icon="@drawable/ic_search_white"
         android:title="@string/search_decks"
         android:visible="false"
-        ankidroid:actionViewClass="com.ichi2.ui.AccessibleSearchView"
-        ankidroid:showAsAction="always|collapseActionView"/>
+        app:actionViewClass="com.ichi2.ui.AccessibleSearchView"
+        app:showAsAction="always|collapseActionView"/>
     <item
         android:id="@+id/action_sync"
         android:icon="@drawable/ic_sync"
         android:title="@string/button_sync"
-        ankidroid:actionProviderClass="com.ichi2.anki.SyncActionProvider"
-        ankidroid:showAsAction="always"/>
+        app:actionProviderClass="com.ichi2.anki.SyncActionProvider"
+        app:showAsAction="always"/>
+    <item
+        android:id="@+id/action_deck_rename"
+        android:icon="@drawable/ic_popup_menu_item_editor"
+        android:title="@string/rename_deck"
+        app:showAsAction="always"/>
+    <item
+        android:id="@+id/action_deck_delete"
+        android:icon="@drawable/ic_delete_white"
+        android:title="@string/delete_deck"
+        app:showAsAction="always"/>
     <item
         android:id="@+id/action_undo"
-        ankidroid:showAsAction="never"
+        android:icon="@drawable/ic_undo_white"
+        app:showAsAction="never"
         android:visible="false"
         tools:title="Undo X"/>
     <item
         android:id="@+id/checks"
         android:title="@string/checks_action"
-        ankidroid:showAsAction="never">
+        app:showAsAction="never">
         <menu>
             <item
                 android:id="@+id/action_check_database"

--- a/AnkiDroid/src/main/res/menu/activity_study_options.xml
+++ b/AnkiDroid/src/main/res/menu/activity_study_options.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_undo"
+        android:icon="@drawable/ic_undo_white"
+        android:title="@string/undo"
+        app:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
+        app:showAsAction="always"/>
+</menu>

--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -1,13 +1,5 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:ankidroid="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
-    <item
-        android:id="@+id/action_undo_study_options"
-        android:enabled="true"
-        android:icon="@drawable/ic_undo_white"
-        android:title="@string/undo"
-        ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
-        ankidroid:showAsAction="always"/>
+    xmlns:ankidroid="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_rebuild"
         android:title="@string/rebuild_cram_label"
@@ -25,31 +17,12 @@
         android:title="@string/custom_study"
         android:icon="@drawable/ic_build_white"
         ankidroid:showAsAction="ifRoom"/>
-    <item
-        android:id="@+id/action_rename"
-        android:title="@string/rename_deck"
-        android:visibility = "gone"/>
     <!-- the title for the following option will be set dynamically -->
     <item
         android:id="@+id/action_deck_or_study_options"
         android:title="@string/menu__deck_options"
         android:icon="@drawable/ic_tune_white"
         ankidroid:showAsAction="always"/>
-    <item
-        android:id="@+id/action_delete"
-        android:title="@string/contextmenu_deckpicker_delete_deck"
-        android:visibility = "gone"/>
-    <item
-        android:id="@+id/action_export"
-        tools:text="Export"
-        android:visibility="gone">
-        <menu>
-            <item
-                android:id="@+id/action_export_deck"
-                android:menuCategory="secondary"
-                android:title="@string/export_deck" />
-        </menu>
-    </item>
     <item
         android:id="@+id/action_unbury"
         android:title="@string/unbury"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Introduces changes to improve the handling of menus around StudyOptionsFragment which is used both in single and multi pane layouts in multiple activities. More info in the commits details.

Other notes:
- the undo menu item was moved out of StudyOptionsFragment, I think this is a global action and shouldn't be handled manually at fragment level
- the previous code used an option on tablets to export the current selected deck. I don't feel this is a menu option that should be present as we already have a menu item that does this at the cost of an extra touch. Also doesn't seem this would have the use frequency to have its own menu item.
- as the second commit introduces breaking changes(fixed later) the last 4 commits should probably be squashed.
- the label _"StudyOptions"_ was deleted from the manifest for _StudyOptionsActivity_ to show a toolbar without title like the previous code did(the fragment's toolbar didn't set a title). Maybe we should add a title here?

Some images:
<img src="https://github.com/user-attachments/assets/74e64993-06b0-4805-91f8-714dc153a32e" width="240px" height="520px" /><img src="https://github.com/user-attachments/assets/2215a924-8a94-4976-81f1-46facce9ed73" width="240px" height="520px" /><img src="https://github.com/user-attachments/assets/947339ab-b90d-4a75-b0cf-41e532b4888e" width="240px" height="520px" />

![tablet_normal_deck](https://github.com/user-attachments/assets/8fe0cc77-e93b-4ea2-892f-41e2361f6b74)
![tablet_normal_expanded_menu](https://github.com/user-attachments/assets/a411dcb6-dd40-4c01-acb3-fbee12f14dc7)

## Fixes
* Fixes #17284
* Fixes #17077
* Supersedes and closes  #17099 

## How Has This Been Tested?

Ran the tests, looked at the menus in phone/tablet mode.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
