### PR TITLE
Fix: Maintain scroll position when entering/exiting fullscreen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -19,6 +19,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import android.view.ViewTreeObserver
 import android.webkit.CookieManager
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceError
@@ -51,6 +52,7 @@ import timber.log.Timber
 abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
     abstract val viewModel: CardViewerViewModel
     protected abstract val webView: WebView
+    private var scrollPosition: Pair<Int, Int> = Pair(0, 0)
 
     @CallSuper
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -224,6 +226,8 @@ abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
                     systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
                     hide(WindowInsetsCompat.Type.systemBars())
                 }
+                // Save the scroll position before going to fullscreen video
+                scrollPosition = Pair(webView.scrollX, webView.scrollY)
             }
 
             override fun onHideCustomView() {
@@ -234,6 +238,13 @@ abstract class CardViewerFragment(@LayoutRes layout: Int) : Fragment(layout) {
                     systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
                     show(WindowInsetsCompat.Type.systemBars())
                 }
+                // Ensure WebView is rendered before restoring scroll position
+                webView.viewTreeObserver.addOnGlobalLayoutListener(object : ViewTreeObserver.OnGlobalLayoutListener {
+                    override fun onGlobalLayout() {
+                        webView.scrollTo(scrollPosition.first, scrollPosition.second)
+                        webView.viewTreeObserver.removeOnGlobalLayoutListener(this)
+                    }
+                })
             }
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR ensures that the WebView maintains its scroll position when entering and exiting fullscreen mode.

## Fixes
* Fixes #17306 

## Approach
Save the WebView scroll position before entering fullscreen and restore it after exiting

## How Has This Been Tested?
Physical Device ( Oppo Reno f21 )
https://github.com/user-attachments/assets/8fdbb4c7-8e80-4563-b266-ed6f20f082c3

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)