### PR TITLE
Enable filtered decks in widget

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -304,7 +304,7 @@ class DeckPickerWidgetConfig : AnkiActivity(), DeckSelectionListener, BaseSnackb
     /** Returns the list of standard deck. */
     private suspend fun fetchDecks(): List<SelectableDeck> {
         return withContext(Dispatchers.IO) {
-            SelectableDeck.fromCollection(includeFiltered = false)
+            SelectableDeck.fromCollection(includeFiltered = true)
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This change allows users to access filtered decks directly from the homescreen widget, enhancing usability and quick access to specific decks.

## Fixes
* Fixes #17323

## Approach
The change involves modifying the `DeckPickerWidgetConfig.kt` file by updating the `SelectableDeck.fromCollection()` function. Specifically, the `includeFiltered` parameter was changed from `false` to `true`, allowing filtered decks to be included in the widget selection options.

## How Has This Been Tested?
Tested by adding filtered decks to the widget and confirming they appear correctly.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
