### PR TITLE
chore: forward-port to compileSdk 35

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -620,6 +620,7 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Shortc
         )
 
     /** @see Window.setNavigationBarColor */
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     fun setNavigationBarColor(@AttrRes attr: Int) {
         window.navigationBarColor = Themes.getColorFromAttr(this, attr)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
@@ -68,6 +68,7 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout), AnkiActivity
         hideProgressBar()
     }
 
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         requireActivity().window.statusBarColor = Themes.getColorFromAttr(requireContext(), R.attr.appBarColor)
         super.onViewCreated(view, savedInstanceState)
@@ -96,6 +97,7 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout), AnkiActivity
      */
     protected suspend fun userAcceptsSchemaChange() = ankiActivity.userAcceptsSchemaChange()
 
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     fun setNavigationBarColor(@AttrRes attr: Int) {
         requireActivity().window.navigationBarColor =
             Themes.getColorFromAttr(requireContext(), attr)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -248,7 +248,7 @@ object CrashReportService {
                 Timber.w("Could not get WebView package information")
                 return webViewInfo
             }
-            webViewInfo[WEBVIEW_VER_NAME] = pi.versionName
+            pi.versionName?.let { webViewInfo[WEBVIEW_VER_NAME] = it }
             webViewInfo["WEBVIEW_VER_CODE"] = PackageInfoCompat.getLongVersionCode(pi).toString()
         } catch (e: Throwable) {
             Timber.w(e)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -144,7 +144,11 @@ object InitialActivity {
      */
     fun checkWebviewVersion(packageManager: PackageManager, activity: AnkiActivity) {
         val webviewPackageInfo = getAndroidSystemWebViewPackageInfo(packageManager) ?: return
-        val versionCode = webviewPackageInfo.versionName.split(".")[0].toInt()
+        val webviewVersion = webviewPackageInfo.versionName ?: run {
+            Timber.w("Failed to obtain WebView version")
+            return
+        }
+        val versionCode = webviewVersion.split(".")[0].toInt()
         if (versionCode >= OLDEST_WORKING_WEBVIEW_VERSION) {
             Timber.d("WebView is up to date. %s: %s", webviewPackageInfo.packageName, webviewPackageInfo.versionName)
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -112,6 +112,7 @@ abstract class NavigationDrawerActivity :
     }
 
     // Navigation drawer initialisation
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     protected fun initNavigationDrawer(mainView: View) {
         // Create inherited navigation drawer layout here so that it can be used by parent class
         drawerLayout = mainView.findViewById(R.id.drawer_layout)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -459,6 +459,7 @@ class Whiteboard(activity: AnkiActivity, private val handleMultiTouch: Boolean, 
             invalidate()
         }
 
+        @Suppress("deprecation", "API35 computeBounds - maybe compat, but...new API is Flagged?")
         fun erase(x: Int, y: Int): Boolean {
             var didErase = false
             val clip = Region(0, 0, displayDimensions.x, displayDimensions.y)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -47,6 +47,7 @@ class Statistics :
     private lateinit var deckSpinnerSelection: DeckSpinnerSelection
     private lateinit var spinner: Spinner
 
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         webView.isNestedScrollingEnabled = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerActivity.kt
@@ -32,6 +32,7 @@ import kotlin.reflect.jvm.jvmName
  * @see TemplatePreviewerFragment
  */
 class CardViewerActivity : SingleFragmentActivity() {
+    @Suppress("deprecation", "API35 properly handle edge-to-edge")
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge() // TODO assess moving this to SingleFragmentActivity
         super.onCreate(savedInstanceState)

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -139,6 +139,7 @@ object Themes {
     }
 }
 
+@Suppress("deprecation", "API35 properly handle edge-to-edge")
 fun FragmentActivity.setTransparentStatusBar() {
     WindowInsetsControllerCompat(window, window.decorView).isAppearanceLightStatusBars =
         !Themes.currentTheme.isNightMode

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -103,8 +103,8 @@ object AdaptionUtil {
         return if (packageName != null) {
             try {
                 val info = pm.getPackageInfoCompat(packageName, PackageInfoFlagsCompat.EMPTY) ?: return false
-                info.applicationInfo != null &&
-                    info.applicationInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
+                val appInfo = info.applicationInfo ?: return false
+                appInfo.flags and ApplicationInfo.FLAG_SYSTEM != 0
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.w(e)
                 false

--- a/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/VersionUtils.kt
@@ -43,7 +43,9 @@ object VersionUtils {
                     Timber.w("Couldn't find package named %s", context.packageName)
                     return pkgName
                 }
-                pkgName = context.getString(pInfo.applicationInfo.labelRes)
+                pInfo.applicationInfo?.let {
+                    pkgName = context.getString(it.labelRes)
+                }
             } catch (e: PackageManager.NameNotFoundException) {
                 Timber.e(e, "Couldn't find package named %s", context.packageName)
             }
@@ -59,9 +61,9 @@ object VersionUtils {
             val context: Context = applicationInstance ?: return pkgVersion
             try {
                 val pInfo = context.getPackageInfoCompat(context.packageName, PackageInfoFlagsCompat.EMPTY) ?: return pkgVersion
-                pkgVersion = pInfo.versionName
+                return pInfo.versionName ?: pkgVersion
             } catch (e: PackageManager.NameNotFoundException) {
-                Timber.e(e, "Couldn't find package named %s", context.packageName)
+                Timber.w(e, "Couldn't find package named %s", context.packageName)
             }
             return pkgVersion
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -33,7 +33,7 @@ class ActivityStartupMetaTest : RobolectricTest() {
 
         // we can't access this in a static context
         val packageInfo = targetContext.getPackageInfoCompat(targetContext.packageName, PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong())) ?: throw IllegalStateException("getPackageInfo failed")
-        val manifestActivities = packageInfo.activities
+        val manifestActivities = packageInfo.activities ?: throw IllegalStateException("activity list")
         val testedActivityClassNames = ActivityList.allActivitiesAndIntents().map { it.className }.toSet()
         val manifestActivityNames = manifestActivities
             .map { it.name }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compileSdk = "34"
+compileSdk = "35"
 minSdk = "23"  # also in testlib/build.gradle.kts
 targetSdk = "34"  # also in  ../robolectricDownloader.gradle
 acra = '5.11.4'


### PR DESCRIPTION
## Purpose / Description

Unblock new dependencies that rely on compileSdk 35

most of the changes performed at same time are nullability-related

there are two specific things deferred via suppression annotation:
- all the targetSdk 35 edge-to-edge behavior changes - this is a big one
- one compute bounds thing for graphics, minor but API change is confusing

## Fixes

No fixes but:
- Related: #17327 
- Related: #17329 

## Approach

Nullability stuff was easy to handle as the null case was already contemplated in the codepaths as either "okay" or already an error. So that was just syntactic chore

Suppression of two other things was different and related issues have been logged:
- #17334 
- #17335 

## How Has This Been Tested?

Ran the lint gradle command line locally as well as `./gradlew jacocoTestReport` until everything compiled well and tested okay

## Learning (optional, can help others)

Same ol' same ol' - relentless march of progress imposes background carry-cost load

I will be curious to see what the flagged API thing is for the computeBounds Path API deprecation

The edge-to-edge stuff will be a legitimate effort in this repository, it is a non-trivial UI update

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
