### PR TITLE
Gradle lintage

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -267,7 +267,11 @@ play {
 tasks.register('installGitHook', Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
     into { new File(rootProject.rootDir, '.git/hooks') }
-    fileMode 0755
+    filePermissions {
+        user {
+            read = write = execute = true
+        }
+    }
 }
 // to run manually: `./gradlew installGitHook`
 tasks.named('preBuild').configure { dependsOn('installGitHook') }

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -108,7 +108,7 @@ def testReport = tasks.register('jacocoTestReport', JacocoReport) {
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def kotlinClasses = fileTree(dir: project.layout.buildDirectory.dir(classDir), excludes: fileFilter)
@@ -136,7 +136,7 @@ def unitTestReport = tasks.register('jacocoUnitTestReport', JacocoReport) {
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def kotlinClasses = fileTree(dir: project.layout.buildDirectory.dir(classDir), excludes: fileFilter)
@@ -161,7 +161,7 @@ def androidTestReport = tasks.register('jacocoAndroidTestReport', JacocoReport) 
 
     reports {
         xml.required = true
-        html.destination htmlOutDir
+        html.outputLocation = htmlOutDir
     }
 
     def kotlinClasses = fileTree(dir: project.layout.buildDirectory.dir(classDir), excludes: fileFilter)

--- a/AnkiDroid/src/amazon/AndroidManifest.xml
+++ b/AnkiDroid/src/amazon/AndroidManifest.xml
@@ -1,9 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
-
-    <!-- This camera permission will be removed in the merged manifest due to node removal -->
-    <uses-permission
-        android:name="android.permission.CAMERA"
-        tools:node="remove" />
 </manifest> 


### PR DESCRIPTION
## Purpose / Description

When there's too much noise I can't see the signal, so took a pass at quieting our build down

Also, we're ready for gradle 9 now

## Fixes

Nothing logged - but the final result is that there are zero gradle warnings except about tools:replace not replacing anything

## Approach

Ran all the main build targets with --warning-mode=all and fixed them, also looked at the manifest merger warnings

## How Has This Been Tested?

By re-running the tasks, and checking file perms on pre-commit hook

## Learning (optional, can help others)

It is not possible to quiet the build warning from a `tools:replace` manifest merger when there was nothing to replace

It seems that the merger happens in priority order, and since it comes from a library, my attempt to define a dummy entry in our app manifest (that would be replaced, quietly) did not work as the replace warning already happened when the library attempted to do it first, without getting to the app manifest yet

the only thing I think could be done is make a tiny dummy library that defines the replaced items but that's a lot of work for little gain

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
