### PR TITLE
Simplify Custom Study Dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -640,7 +640,7 @@ open class DeckPicker :
             DeckPickerContextMenuOption.CUSTOM_STUDY -> {
                 Timber.i("ContextMenu: Custom study option selected")
                 val d = FragmentFactoryUtils.instantiate(this, CustomStudyDialog::class.java)
-                d.withArguments(CustomStudyDialog.ContextMenuConfiguration.STANDARD, deckId)
+                d.withArguments(deckId)
                 showDialogFragment(d)
             }
             DeckPickerContextMenuOption.CREATE_SHORTCUT -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -241,7 +241,7 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, Toolbar.OnMen
     private fun showCustomStudyContextMenu() {
         val ankiActivity = requireActivity() as AnkiActivity
         val contextMenu = instantiate(ankiActivity, CustomStudyDialog::class.java)
-        contextMenu.withArguments(CustomStudyDialog.ContextMenuConfiguration.STANDARD, col!!.decks.selected())
+        contextMenu.withArguments(col!!.decks.selected())
         ankiActivity.showDialogFragment(contextMenu)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.dialogs.customstudy
 import android.annotation.SuppressLint
 import android.app.Dialog
 import android.content.Intent
-import android.content.res.Resources
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -58,7 +57,6 @@ import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Consts.DynPriority
 import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
-import com.ichi2.utils.HashUtil.hashMapInit
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.customView
@@ -110,15 +108,15 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
     }
 
     private fun buildContextMenu(): AlertDialog {
-        val listIds = getListIds().map { it.value }.toIntArray()
+        val listIds = getListIds()
         val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
-        val items = getValuesFromKeys(keyValueMap, listIds).toList().map { it as CharSequence }
+        val titles = listIds.map { resources.getString(it.stringResource) }
 
         return AlertDialog.Builder(requireActivity())
             .title(R.string.custom_study)
             .cancelable(true)
-            .listItems(items = items) { _, index ->
-                when (ContextMenuOption.fromString(resources, items[index].toString())) {
+            .listItems(items = titles) { _, index ->
+                when (listIds[index]) {
                     DECK_OPTIONS -> {
                         // User asked to permanently change the deck options
                         val deckId = requireArguments().getLong("did")
@@ -155,7 +153,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         // User asked for a standard custom study option
                         val d = CustomStudyDialog(collection, customStudyListener)
                             .withArguments(
-                                ContextMenuOption.fromString(resources, items[index].toString()),
+                                listIds[index],
                                 requireArguments().getLong("did"),
                                 jumpToReviewer
                             )
@@ -307,23 +305,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_VISIBLE)
         return dialog
     }
-
-    private val keyValueMap: HashMap<Int, String>
-        get() {
-            val res = resources
-            val keyValueMap = hashMapInit<Int, String>(10)
-            keyValueMap[STANDARD.value] = res.getString(R.string.custom_study)
-            keyValueMap[STUDY_NEW.value] = res.getString(R.string.custom_study_increase_new_limit)
-            keyValueMap[STUDY_REV.value] = res.getString(R.string.custom_study_increase_review_limit)
-            keyValueMap[STUDY_FORGOT.value] = res.getString(R.string.custom_study_review_forgotten)
-            keyValueMap[STUDY_AHEAD.value] = res.getString(R.string.custom_study_review_ahead)
-            keyValueMap[STUDY_RANDOM.value] = res.getString(R.string.custom_study_random_selection)
-            keyValueMap[STUDY_PREVIEW.value] = res.getString(R.string.custom_study_preview_new)
-            keyValueMap[STUDY_TAGS.value] = res.getString(R.string.custom_study_limit_tags)
-            keyValueMap[DECK_OPTIONS.value] = res.getString(R.string.menu__deck_options)
-            keyValueMap[MORE_OPTIONS.value] = res.getString(R.string.more_options)
-            return keyValueMap
-        }
 
     /**
      * Gathers the final selection of tags and type of cards,
@@ -516,7 +497,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
 
         companion object {
             fun fromInt(value: Int): ContextMenuOption = entries.first { it.value == value }
-            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = entries.first { resources.getString(it.stringResource) == stringValue }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -352,25 +352,16 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
 
     /**
      * Retrieve the list of ids to put in the context menu list
-     * @param dialogId option to specify which tasks are shown in the list
      * @return the ids of which values to show
      */
     private fun getListIds(): List<ContextMenuOption> {
         // Standard context menu
-        val dialogOptions = mutableListOf<ContextMenuOption>().apply {
-            add(STUDY_NEW)
-            add(STUDY_REV)
-            add(STUDY_FORGOT)
-            add(STUDY_AHEAD)
-            add(STUDY_RANDOM)
-            add(STUDY_PREVIEW)
-            add(STUDY_TAGS)
+        return mutableListOf(STUDY_REV, STUDY_FORGOT, STUDY_AHEAD, STUDY_RANDOM, STUDY_PREVIEW, STUDY_TAGS).apply {
+            if (collection.sched.totalNewForCurrentDeck() != 0) {
+                // If no new cards we won't show STUDY_NEW
+                this.add(0, STUDY_NEW)
+            }
         }
-        if (collection.sched.totalNewForCurrentDeck() == 0) {
-            // If no new cards we wont show CUSTOM_STUDY_NEW
-            dialogOptions.remove(STUDY_NEW)
-        }
-        return dialogOptions.toList()
     }
 
     private val text1: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -35,8 +35,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.DECK_OPTIONS
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.MORE_OPTIONS
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_AHEAD
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_FORGOT
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_NEW
@@ -136,21 +134,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
             .cancelable(true)
             .listItems(items = titles) { _, index ->
                 when (listIds[index]) {
-                    DECK_OPTIONS -> {
-                        // User asked to permanently change the deck options
-                        val deckId = requireArguments().getLong(DID)
-                        val i = com.ichi2.anki.pages.DeckOptions.getIntent(requireContext(), deckId)
-                        requireActivity().startActivity(i)
-                    }
-                    MORE_OPTIONS -> {
-                        // User asked to see all custom study options
-                        val d = CustomStudyDialog(collection, customStudyListener)
-                            .withArguments(
-                                requireArguments().getLong(DID),
-                                jumpToReviewer
-                            )
-                        customStudyListener?.showDialogFragment(d)
-                    }
                     STUDY_TAGS -> {
                         /*
                          * This is a special Dialog for CUSTOM STUDY, where instead of only collecting a
@@ -287,9 +270,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                             false
                         )
                     }
-                    STUDY_TAGS,
-                    DECK_OPTIONS,
-                    MORE_OPTIONS -> TODO("This branch has not been covered before")
+                    STUDY_TAGS -> TODO("This branch has not been covered before")
                 }
             }
             .negativeButton(R.string.dialog_cancel) {
@@ -482,8 +463,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         STUDY_AHEAD(R.string.custom_study_review_ahead),
         STUDY_RANDOM(R.string.custom_study_random_selection),
         STUDY_PREVIEW(R.string.custom_study_preview_new),
-        STUDY_TAGS(R.string.custom_study_limit_tags),
-        DECK_OPTIONS(R.string.menu__deck_options),
-        MORE_OPTIONS(R.string.more_options);
+        STUDY_TAGS(R.string.custom_study_limit_tags)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -110,7 +110,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
     }
 
     private fun buildContextMenu(): AlertDialog {
-        val listIds = getListIds(STANDARD).map { it.value }.toIntArray()
+        val listIds = getListIds().map { it.value }.toIntArray()
         val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
         val items = getValuesFromKeys(keyValueMap, listIds).toList().map { it as CharSequence }
 
@@ -355,26 +355,22 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
      * @param dialogId option to specify which tasks are shown in the list
      * @return the ids of which values to show
      */
-    private fun getListIds(dialogId: ContextMenuConfiguration): List<ContextMenuOption> {
-        when (dialogId) {
-            STANDARD -> {
-                // Standard context menu
-                val dialogOptions = mutableListOf<ContextMenuOption>().apply {
-                    add(STUDY_NEW)
-                    add(STUDY_REV)
-                    add(STUDY_FORGOT)
-                    add(STUDY_AHEAD)
-                    add(STUDY_RANDOM)
-                    add(STUDY_PREVIEW)
-                    add(STUDY_TAGS)
-                }
-                if (collection.sched.totalNewForCurrentDeck() == 0) {
-                    // If no new cards we wont show CUSTOM_STUDY_NEW
-                    dialogOptions.remove(STUDY_NEW)
-                }
-                return dialogOptions.toList()
-            }
+    private fun getListIds(): List<ContextMenuOption> {
+        // Standard context menu
+        val dialogOptions = mutableListOf<ContextMenuOption>().apply {
+            add(STUDY_NEW)
+            add(STUDY_REV)
+            add(STUDY_FORGOT)
+            add(STUDY_AHEAD)
+            add(STUDY_RANDOM)
+            add(STUDY_PREVIEW)
+            add(STUDY_TAGS)
         }
+        if (collection.sched.totalNewForCurrentDeck() == 0) {
+            // If no new cards we wont show CUSTOM_STUDY_NEW
+            dialogOptions.remove(STUDY_NEW)
+        }
+        return dialogOptions.toList()
     }
 
     private val text1: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -547,7 +547,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
      * @see ContextMenuAttribute
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    enum class ContextMenuOption(override val value: Int, override val stringResource: Int?) : ContextMenuAttribute<ContextMenuOption> {
+    enum class ContextMenuOption(override val value: Int, override val stringResource: Int) : ContextMenuAttribute<ContextMenuOption> {
         STUDY_NEW(100, R.string.custom_study_increase_new_limit),
         STUDY_REV(101, R.string.custom_study_increase_review_limit),
         STUDY_FORGOT(102, R.string.custom_study_review_forgotten),
@@ -560,7 +560,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
 
         companion object {
             fun fromInt(value: Int): ContextMenuOption = entries.first { it.value == value }
-            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = entries.first { resources.getString(it.stringResource as Int) == stringValue }
+            fun fromString(resources: Resources, stringValue: String): ContextMenuOption = entries.first { resources.getString(it.stringResource) == stringValue }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -36,8 +36,6 @@ import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuConfiguration.EMPTY_SCHEDULE
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuConfiguration.LIMITS
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuConfiguration.STANDARD
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.DECK_OPTIONS
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.MORE_OPTIONS
@@ -105,18 +103,14 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
         return if (dialogId < 100) {
             // Select the specified deck
             collection.decks.select(requireArguments().getLong("did"))
-            buildContextMenu(dialogId)
+            buildContextMenu()
         } else {
             buildInputDialog(ContextMenuOption.fromInt(dialogId))
         }
     }
 
-    /**
-     * Build a context menu for custom study
-     * @param id the id type of the dialog
-     */
-    private fun buildContextMenu(id: Int): AlertDialog {
-        val listIds = getListIds(ContextMenuConfiguration.fromInt(id)).map { it.value }.toIntArray()
+    private fun buildContextMenu(): AlertDialog {
+        val listIds = getListIds(STANDARD).map { it.value }.toIntArray()
         val jumpToReviewer = requireArguments().getBoolean("jumpToReviewer")
         val items = getValuesFromKeys(keyValueMap, listIds).toList().map { it as CharSequence }
 
@@ -380,25 +374,6 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 }
                 return dialogOptions.toList()
             }
-            LIMITS -> // Special custom study options to show when the daily study limit has been reached
-                return if (!collection.sched.newDue() && !collection.sched.revDue()) {
-                    listOf(STUDY_NEW, STUDY_REV, DECK_OPTIONS, MORE_OPTIONS)
-                } else {
-                    if (collection.sched.newDue()) {
-                        listOf(STUDY_NEW, DECK_OPTIONS, MORE_OPTIONS)
-                    } else {
-                        listOf(STUDY_REV, DECK_OPTIONS, MORE_OPTIONS)
-                    }
-                }
-            EMPTY_SCHEDULE -> // Special custom study options to show when extending the daily study limits is not applicable
-                return listOf(
-                    STUDY_FORGOT,
-                    STUDY_AHEAD,
-                    STUDY_RANDOM,
-                    STUDY_PREVIEW,
-                    STUDY_TAGS,
-                    DECK_OPTIONS
-                )
         }
     }
 
@@ -532,13 +507,7 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
      * @see ContextMenuAttribute
      */
     enum class ContextMenuConfiguration(override val value: Int, override val stringResource: Int? = null) : ContextMenuAttribute<ContextMenuConfiguration> {
-        STANDARD(1),
-        LIMITS(2),
-        EMPTY_SCHEDULE(3);
-
-        companion object {
-            fun fromInt(value: Int): ContextMenuConfiguration = entries.first { it.value == value }
-        }
+        STANDARD(1)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -144,7 +144,6 @@ class CongratsPage :
     private fun onStudyMore() {
         val col = CollectionManager.getColUnsafe()
         val dialogFragment = CustomStudyDialog(CollectionManager.getColUnsafe(), this).withArguments(
-            CustomStudyDialog.ContextMenuConfiguration.STANDARD,
             col.decks.selected()
         )
         dialogFragment.show(childFragmentManager, null)

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -157,7 +157,6 @@
     <string name="menu__study_options" comment="Menu item that opens options for a Filtered deck (aka Cram deck, aka Custom study)">Study options</string>
     <string name="select_tts" maxLength="28">Set TTS language</string>
     <string name="custom_study" maxLength="28">Custom study</string>
-    <string name="more_options">More</string>
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
     <string name="steps_error">Steps must be numbers greater than 0</string>
     <string name="steps_min_error">At least one step is required</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -65,7 +65,10 @@ class CustomStudyDialogTest : RobolectricTest() {
     fun learnAheadCardsRegressionTest() {
         // #6289 - Regression Test
         val args = CustomStudyDialog(mock(), ParametersUtils.whatever())
-            .withArguments(CustomStudyDialog.ContextMenuOption.STUDY_AHEAD, 1)
+            .withArguments(
+                1,
+                contextMenuAttribute = CustomStudyDialog.ContextMenuOption.STUDY_AHEAD
+            )
             .arguments
         val factory = CustomStudyDialogFactory({ this.col }, mockListener)
         FragmentScenario.launch(CustomStudyDialog::class.java, args, androidx.appcompat.R.style.Theme_AppCompat, factory).use { scenario ->
@@ -107,7 +110,7 @@ class CustomStudyDialogTest : RobolectricTest() {
     fun increaseNewCardLimitRegressionTest() {
         // #8338 - Regression Test
         val args = CustomStudyDialog(mock(), ParametersUtils.whatever())
-            .withArguments(CustomStudyDialog.ContextMenuConfiguration.STANDARD, 1)
+            .withArguments(1)
             .arguments
 
         // we are using mock collection for the CustomStudyDialog but still other parts of the code


### PR DESCRIPTION
My main problem was with the typing of the ID. Using an integer seemed strange while we have `entries` that work as well.
I realized that some enum values were not used anymore. So I just remove them. This means that the dialog is either Standard or a `ContextMenuOption`.

I assume we can squash if you want. But I hope this list of commit makes reviewing simple