### PR TITLE
Fix: Enable multi-line support for the deck picker footer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -58,6 +58,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import androidx.core.content.edit
@@ -69,6 +70,7 @@ import androidx.core.util.component1
 import androidx.core.util.component2
 import androidx.core.view.MenuItemCompat
 import androidx.core.view.OnReceiveContentListener
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.draganddrop.DropHelper
 import androidx.fragment.app.commit
@@ -2207,12 +2209,21 @@ open class DeckPicker :
         dueTree = result
         launchCatchingTask { renderPage(collectionHasNoCards) }
         // Update the mini statistics bar as well
-        reviewSummaryTextView.setSingleLine()
         launchCatchingTask {
             reviewSummaryTextView.text =
                 withCol {
-                    sched.studiedToday()
+                    // Backend returns studiedToday() with newlines for HTML formatting,so we replace them with spaces.
+                    sched.studiedToday().replace("\n", " ")
                 }
+            val fabLinearLayout = findViewById<LinearLayout>(R.id.fabLinearLayout)
+            // Adjust bottom margin of fabLinearLayout based on reviewSummaryTextView height
+            reviewSummaryTextView.doOnLayout {
+                if (reviewSummaryTextView.lineCount > 1) {
+                    val layoutParams = fabLinearLayout.layoutParams as CoordinatorLayout.LayoutParams
+                    layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
+                    fabLinearLayout.layoutParams = layoutParams
+                }
+            }
         }
         Timber.d("Startup - Deck List UI Completed")
     }

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -46,6 +46,10 @@
                     <com.ichi2.ui.FixedTextView
                         android:id="@+id/today_stats_text_view"
                         android:layout_width="match_parent"
+                        android:layout_marginLeft="8dp"
+                        android:layout_marginRight="8dp"
+                        android:layout_alignParentEnd="true"
+                        android:layout_alignParentStart="true"
                         android:layout_height="wrap_content"
                         android:layout_alignParentBottom="true"
                         android:layout_marginBottom="4dp"

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -14,6 +14,7 @@
         />
 
     <LinearLayout
+        android:id="@+id/fabLinearLayout"
         android:layout_width="wrap_content"
         android:orientation="vertical"
         android:padding="12dp"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The purpose of this change is to allow the footer of the deck picker to display multiple lines of text.

## Fixes
* Part of #17100
* Maybe a fix for https://github.com/ankidroid/Anki-Android/issues/14641

## Approach
The `setSingleLine` method has been removed from the `DeckPicker.kt` file to allow the footer text to display across multiple lines. Additionally, a `.replace` function was implemented to ensure that newline characters in the text from `sched.studiedToday()` are replaced with spaces, preventing any text from being hidden.

## How Has This Been Tested?
This change has been tested using different font sizes and languages.

## Screenshot
![multiline_footer](https://github.com/user-attachments/assets/b5cd6296-c248-45e7-84a1-2d8a43bebb65)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
