### PR TITLE
Manual-Download-link

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -34,12 +34,14 @@ import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.openUrl
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.utils.ImportUtils
@@ -70,6 +72,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
     private lateinit var downloadPercentageText: TextView
     private lateinit var downloadProgressBar: ProgressBar
     private lateinit var checkNetworkInfoText: TextView
+    private lateinit var openInBrowserButton: Button
 
     /**
      * Android's DownloadManager - Used here to manage the functionality of downloading decks, one
@@ -106,6 +109,37 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
          * so our FileProvider can actually serve the file!
          */
         const val SHARED_DECKS_DOWNLOAD_FOLDER = "shared_decks"
+
+        private val deckIdRegex = "download-deck/(\\d+)".toRegex()
+
+        /**
+         * Given the URI of a deck's download URL such as
+         * https://ankiweb.net/svc/shared/download-deck/1104981491?t=eyJvcCI6InNkZCIsImlhdCI6MTc0MTUyNjQ0OSwianYiOjF9.hr4a_G-LAqMVBAp5_95l60_2lEtYxodGl4DrJ6dT2WI
+         * returns the deck's id, in this case "1104981491" if it can be found.
+         */
+        @VisibleForTesting
+        fun getDeckIdFromDownloadURL(downloadUrl: String) =
+            deckIdRegex
+                .find(downloadUrl)
+                ?.groups
+                ?.get(1)
+                ?.value
+
+        /**
+         * Given the URI of a deck's download URL such as
+         * https://ankiweb.net/svc/shared/download-deck/1104981491?t=eyJvcCI6InNkZCIsImlhdCI6MTc0MTUyNjQ0OSwianYiOjF9.hr4a_G-LAqMVBAp5_95l60_2lEtYxodGl4DrJ6dT2WI
+         * returns the deck's page URL such as https://ankiweb.net/shared/info/1104981491
+         * If the deck id can't be found, returns the ankiweb's shared deck's main page.
+         */
+        @VisibleForTesting
+        fun Context.getDeckPageUri(deckDownloadURL: String): String {
+            val deckId = getDeckIdFromDownloadURL(deckDownloadURL)
+            return if (deckId != null) {
+                getString(R.string.shared_deck_info) + deckId
+            } else {
+                getString(R.string.shared_decks_url)
+            }
+        }
     }
 
     override fun onViewCreated(
@@ -120,6 +154,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
         importDeckButton = view.findViewById(R.id.import_shared_deck_button)
         tryAgainButton = view.findViewById(R.id.try_again_deck_download)
         checkNetworkInfoText = view.findViewById(R.id.check_network_info_text)
+        openInBrowserButton = view.findViewById(R.id.download_shared_deck_from_browser)
 
         val fileToBeDownloaded = arguments?.getSerializableCompat<DownloadFile>(DOWNLOAD_FILE)!!
         downloadManager = (activity as SharedDecksActivity).downloadManager
@@ -136,14 +171,21 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
             openDownloadedDeck(context)
         }
 
+        openInBrowserButton.setOnClickListener {
+            Timber.i("'Open in Browser' clicked")
+            downloadManager.remove(downloadId)
+            openUrl(Uri.parse(requireContext().getDeckPageUri(fileToBeDownloaded.url)))
+            parentFragmentManager.popBackStack()
+        }
+
         tryAgainButton.setOnClickListener {
             Timber.i("Try again button clicked, retry downloading of deck")
             downloadManager.remove(downloadId)
             downloadFile(fileToBeDownloaded)
             cancelButton.visibility = View.VISIBLE
             tryAgainButton.visibility = View.GONE
+            openInBrowserButton.visibility = View.GONE
         }
-        requireActivity().onBackPressedDispatcher.addCallback(onBackPressedCallback)
     }
 
     /**
@@ -487,6 +529,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
                 context?.let { showThemedToast(it, R.string.something_wrong, false) }
                 // Update UI if download could not be successful
                 tryAgainButton.visibility = View.VISIBLE
+                openInBrowserButton.visibility = View.VISIBLE
                 cancelButton.visibility = View.GONE
                 downloadPercentageText.text = getString(R.string.download_failed)
                 downloadProgressBar.progress = DOWNLOAD_STARTED_PROGRESS_PERCENTAGE.toInt()

--- a/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_shared_decks_download.xml
@@ -77,6 +77,22 @@
         android:visibility="gone" />
 
     <android.widget.Button
+        android:id="@+id/download_shared_deck_from_browser"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/open_in_browser"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:textColor="@color/material_blue_500"
+        android:padding="8dp"
+        android:layout_marginBottom="24dp"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/try_again_deck_download"
+        android:visibility="gone" />
+
+    <android.widget.Button
         android:id="@+id/cancel_shared_decks_download"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -261,6 +261,7 @@
     <!-- %% is required to display % symbol. Reference: https://stackoverflow.com/a/16834358 -->
     <string name="percentage">%s%%</string>
     <string name="download_deck">Download deck</string>
+    <string name="open_in_browser" comment="Label of a button inviting to open ankiweb's shared deck page if automated download failed">Open in Browser</string>
     <string name="try_again">Try Again</string>
     <string name="cancel_download">Cancel download</string>
     <string name="cancel_download_question_title">Cancel download?</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -130,6 +130,7 @@
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>
     <string name="link_third_party_api_apps">https://github.com/ankidroid/Anki-Android/wiki/Third-Party-Apps</string>
     <string name="shared_decks_url">https://ankiweb.net/shared/decks/</string>
+    <string name="shared_deck_info">https://ankiweb.net/shared/info/</string>
     <string name="shared_decks_login_url">https://ankiweb.net/account/login</string>
     <string name="shared_decks_sign_up_url">https://ankiweb.net/account/signup</string>
     <string name="repair_deck">https://docs.ankiweb.net/#/files?id=corrupt-collections</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SharedDecksDownloadFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SharedDecksDownloadFragmentTest.kt
@@ -1,0 +1,43 @@
+// noinspection MissingCopyrightHeader #17351
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.SharedDecksDownloadFragment.Companion.getDeckPageUri
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class SharedDecksDownloadFragmentTest : RobolectricTest() {
+    @Test
+    fun `test getDeckIdFromDownloadURL with valid URL`() {
+        val url = "https://ankiweb.net/svc/shared/download-deck/1104981491?t=some-token"
+        assertEquals("1104981491", SharedDecksDownloadFragment.getDeckIdFromDownloadURL(url))
+    }
+
+    @Test
+    fun `test getDeckIdFromDownloadURL without Query Parameter`() {
+        val url = "https://ankiweb.net/svc/shared/download-deck/1104981491"
+        assertEquals("1104981491", SharedDecksDownloadFragment.getDeckIdFromDownloadURL(url))
+    }
+
+    @Test
+    fun `test getDeckIdFromDownloadURL with invalid URL`() {
+        val url = "https://ankiweb.net/svc/shared/download-deck/"
+        assertNull(SharedDecksDownloadFragment.getDeckIdFromDownloadURL(url), "Expected deckId to be null")
+    }
+
+    @Test
+    fun `test getDeckPageUri with valid deck URL`() {
+        val url = "https://ankiweb.net/svc/shared/download-deck/1104981491?t=some-token"
+        assertEquals("https://ankiweb.net/shared/info/1104981491", targetContext.getDeckPageUri(url))
+    }
+
+    @Test
+    fun `test getDeckPageUri with invalid deck URL`() {
+        val url = "https://ankiweb.net/svc/shared/download-deck/"
+        assertEquals("https://ankiweb.net/shared/decks/", targetContext.getDeckPageUri(url))
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The user can download the deck manually if  download fails.

## Fixes
* Fixes #17178 

## Approach
This change allows users to manually download decks from AnkiWeb through an external browser if the download fails in the in-app WebView. By using an Intent, we redirect users to their preferred browser.

Once the download is initiated, the app pops the fragment stack.

![Screen_Recording_20241105_184749_AnkiDroid](https://github.com/user-attachments/assets/7c892833-f312-49a5-97a0-a25601482168)


## Steps to reproduce the download failed error.

1 : Comment out the downloadFile() function call in the onViewCreated method.
2 : Instead, call checkDownloadStatusAndUnregisterReceiver(false, false).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]
(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


