### PR TITLE
Add card browser chip filtering for flags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1321,14 +1321,16 @@ open class CardBrowser :
 
     private fun openSaveSearchView() {
         val searchTerms = viewModel.searchTerms.copy(userInput = searchView!!.query.toString())
-        showDialogFragment(
-            newInstance(
-                null,
-                mySearchesDialogListener,
-                searchTerms.toQuery(),
-                CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE,
-            ),
-        )
+        launchCatchingTask {
+            showDialogFragment(
+                newInstance(
+                    null,
+                    mySearchesDialogListener,
+                    searchTerms.toQuery(),
+                    CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE,
+                ),
+            )
+        }
     }
 
     private fun repositionSelectedCards(): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -40,6 +40,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
 import androidx.core.content.ContextCompat
+import androidx.core.os.BundleCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.DividerItemDecoration
@@ -63,9 +64,11 @@ import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardOrNoteId
 import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.browser.SaveSearchResult
+import com.ichi2.anki.browser.SearchParameters
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.getLabel
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
+import com.ichi2.anki.browser.toQuery
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
@@ -137,9 +140,7 @@ open class CardBrowser :
     ChangeManager.Subscriber,
     ExportDialogsFactoryProvider {
     override fun onDeckSelected(deck: SelectableDeck?) {
-        deck?.let {
-            launchCatchingTask { selectDeckAndSave(deck.deckId) }
-        }
+        deck?.let { selectDeckAndSave(deck.deckId) }
     }
 
     private enum class TagsDialogListenerAction {
@@ -461,10 +462,10 @@ open class CardBrowser :
                 .setSelection(COLUMN2_KEYS.indexOf(column))
         }
 
-        fun onFilterQueryChanged(filterQuery: String) {
+        fun onFilterQueryChanged(filterQuery: SearchParameters) {
             // setQuery before expand does not set the view's value
             searchItem!!.expandActionView()
-            searchView!!.setQuery(filterQuery, submit = false)
+            searchView!!.setQuery(filterQuery.userInput, submit = false)
         }
 
         suspend fun onDeckIdChanged(deckId: DeckId?) {
@@ -503,8 +504,8 @@ open class CardBrowser :
             when (searchState) {
                 SearchState.Initializing -> { }
                 SearchState.Searching -> {
-                    if ("" != viewModel.searchTerms && searchView != null) {
-                        searchView!!.setQuery(viewModel.searchTerms, false)
+                    if (viewModel.searchTerms.userInput.isNotEmpty() && searchView != null) {
+                        searchView!!.setQuery(viewModel.searchTerms.userInput, false)
                         searchItem!!.expandActionView()
                     }
                 }
@@ -603,7 +604,7 @@ open class CardBrowser :
         }
     }
 
-    suspend fun selectDeckAndSave(deckId: DeckId) {
+    fun selectDeckAndSave(deckId: DeckId) {
         viewModel.setDeckId(deckId)
     }
 
@@ -931,7 +932,7 @@ open class CardBrowser :
                         viewModel.setSearchQueryExpanded(false)
                         // SearchView doesn't support empty queries so we always reset the search when collapsing
                         searchView!!.setQuery("", false)
-                        searchCards("")
+                        searchCards(viewModel.searchTerms.copy(userInput = ""))
                         return true
                     }
                 },
@@ -951,7 +952,7 @@ open class CardBrowser :
                             }
 
                             override fun onQueryTextSubmit(query: String): Boolean {
-                                searchCards(query)
+                                searchCards(viewModel.searchTerms.copy(userInput = query))
                                 searchView!!.clearFocus()
                                 return true
                             }
@@ -960,14 +961,14 @@ open class CardBrowser :
                 }
             // Fixes #6500 - keep the search consistent if coming back from note editor
             // Fixes #9010 - consistent search after drawer change calls invalidateOptionsMenu
-            if (!viewModel.tempSearchQuery.isNullOrEmpty() || viewModel.searchTerms.isNotEmpty()) {
-                searchItem!!.expandActionView() // This calls mSearchView.setOnSearchClickListener
-                val toUse = if (!viewModel.tempSearchQuery.isNullOrEmpty()) viewModel.tempSearchQuery else viewModel.searchTerms
+            if (!viewModel.tempSearchQuery.isNullOrEmpty() || viewModel.searchTerms.userInput.isNotEmpty()) {
+                searchItem!!.expandActionView() // This calls searchView.setOnSearchClickListener
+                val toUse = if (!viewModel.tempSearchQuery.isNullOrEmpty()) viewModel.tempSearchQuery else viewModel.searchTerms.userInput
                 searchView!!.setQuery(toUse!!, false)
             }
             searchView!!.setOnSearchClickListener {
                 // Provide SearchView with the previous search terms
-                searchView!!.setQuery(viewModel.searchTerms, false)
+                searchView!!.setQuery(viewModel.searchTerms.userInput, false)
             }
         } else {
             // multi-select mode
@@ -1319,12 +1320,12 @@ open class CardBrowser :
     }
 
     private fun openSaveSearchView() {
-        val searchTerms = searchView!!.query.toString()
+        val searchTerms = viewModel.searchTerms.copy(userInput = searchView!!.query.toString())
         showDialogFragment(
             newInstance(
                 null,
                 mySearchesDialogListener,
-                searchTerms,
+                searchTerms.toQuery(),
                 CardBrowserMySearchesDialog.CARD_BROWSER_MY_SEARCHES_TYPE_SAVE,
             ),
         )
@@ -1581,19 +1582,25 @@ open class CardBrowser :
 
     public override fun onSaveInstanceState(outState: Bundle) {
         // Save current search terms
-        outState.putString("mSearchTerms", viewModel.searchTerms)
+        outState.putParcelable("mSearchTerms", viewModel.searchTerms)
         exportingDelegate.onSaveInstanceState(outState)
         super.onSaveInstanceState(outState)
     }
 
     public override fun onRestoreInstanceState(savedInstanceState: Bundle) {
         super.onRestoreInstanceState(savedInstanceState)
-        searchCards(savedInstanceState.getString("mSearchTerms", ""))
+        val savedSearchTerms =
+            BundleCompat.getParcelable(
+                savedInstanceState,
+                "mSearchTerms",
+                SearchParameters::class.java,
+            ) ?: return
+        searchCards(savedSearchTerms)
     }
 
     private fun forceRefreshSearch(useSearchTextValue: Boolean = false) {
         if (useSearchTextValue && searchView != null) {
-            searchCards(searchView!!.query.toString())
+            searchCards(viewModel.searchTerms.copy(userInput = searchView!!.query.toString()))
         } else {
             searchCards()
         }
@@ -1829,7 +1836,7 @@ open class CardBrowser :
     }
 
     @VisibleForTesting
-    fun searchCards(searchQuery: String) =
+    fun searchCards(searchQuery: SearchParameters) =
         launchCatchingTask {
             withProgress { viewModel.launchSearchForCards(searchQuery)?.join() }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -100,6 +100,11 @@ enum class Flag(
         fun fromCode(code: Int) = Flag.entries.first { it.code == code }
 
         /**
+         * Usage:
+         * ```kotlin
+         * Flag.queryDisplayNames().map { (flag, displayName) -> ... }
+         * ```
+         *
          * @return A mapping from each [Flag] to its display name (optionally user-defined)
          */
         suspend fun queryDisplayNames(): Map<Flag, String> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserFlagsFilteringFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserFlagsFilteringFragment.kt
@@ -1,0 +1,129 @@
+/*
+* This program is free software; you can redistribute it and/or modify it under
+* the terms of the GNU General Public License as published by the Free Software
+* Foundation; either version 3 of the License, or (at your option) any later
+* version.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package com.ichi2.anki.browser
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CheckBox
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.view.children
+import androidx.core.view.isVisible
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.Flag
+import com.ichi2.anki.R
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.workarounds.BottomSheetDialogFragmentFix
+import kotlinx.coroutines.launch
+
+class BrowserFlagsFilteringFragment : BottomSheetDialogFragmentFix() {
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View? {
+        val content = inflater.inflate(R.layout.fragment_flags_filter_sheet, container, false)
+        content
+            .findViewById<LinearLayout>(R.id.clear_filter_container)
+            .setOnClickListener {
+                searchFor(emptySet())
+                dismiss()
+            }
+        return content
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        val container = view.findViewById<LinearLayout>(R.id.flags_container)
+        val currentSelection =
+            if (savedInstanceState != null) {
+                savedInstanceState
+                    .getString(KEY_SELECTED_FLAGS)
+                    ?.split("|")
+                    ?.map { Flag.fromCode(it.toInt()) }
+                    ?.toSet() ?: viewModel.searchTerms.flags
+            } else {
+                viewModel.searchTerms.flags
+            }
+        val clearContainer = view.findViewById<LinearLayout>(R.id.clear_filter_container)
+        clearContainer.isVisible = currentSelection.isNotEmpty()
+        viewLifecycleOwner.lifecycleScope.launch {
+            Flag.queryDisplayNames().forEach { (flag, displayName) ->
+                buildFlagFilterView(container, clearContainer, flag, displayName, currentSelection.contains(flag))
+            }
+        }
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(
+            KEY_SELECTED_FLAGS,
+            viewModel.searchTerms.flags
+                .map { it.code }
+                .joinToString("|"),
+        )
+    }
+
+    private fun buildFlagFilterView(
+        container: LinearLayout,
+        clearContainer: LinearLayout,
+        flag: Flag,
+        displayName: String,
+        isAlreadySelected: Boolean,
+    ) {
+        val view =
+            requireActivity().layoutInflater.inflate(R.layout.item_browser_flag_filter, container, false).apply {
+                findViewById<ImageView>(R.id.icon).setImageResource(flag.drawableRes)
+                findViewById<TextView>(R.id.text).text = displayName
+                setOnClickListener {
+                    searchFor(setOf(flag))
+                    dismiss() // direct selection clears everything and closes the filter
+                }
+            }
+        view.findViewById<CheckBox>(R.id.checkbox).apply {
+            setChecked(isAlreadySelected)
+            setOnCheckedChangeListener { _, isChecked ->
+                val newSelection =
+                    viewModel.searchTerms.flags.toMutableSet().apply {
+                        if (isChecked) add(flag) else remove(flag)
+                    }
+                clearContainer.isVisible = container.children.any { it.findViewById<CheckBox>(R.id.checkbox).isChecked }
+                searchFor(newSelection)
+            }
+        }
+        container.addView(view)
+    }
+
+    private fun searchFor(flagsSelection: Set<Flag>) {
+        requireActivity().launchCatchingTask {
+            viewModel.launchSearchForCards(
+                viewModel.searchTerms.copy(flags = flagsSelection),
+            )
+        }
+    }
+
+    companion object {
+        const val TAG = "BrowserFlagsFilteringFragment"
+        private const val KEY_SELECTED_FLAGS = "key_selected_flags"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -695,19 +695,6 @@ class CardBrowserViewModel(
         launchSearchForCards(searchTerms.copy(userInput = "is:suspended"))
     }
 
-    suspend fun setFlagFilter(flag: Flag) {
-        Timber.i("filtering to flag: %s", flag)
-        val flagSearchTerm = "flag:${flag.code}"
-        val userInput = searchTerms.userInput
-        val updatedInput =
-            when {
-                userInput.contains("flag:") -> userInput.replaceFirst("flag:.".toRegex(), flagSearchTerm)
-                userInput.isNotEmpty() -> "$flagSearchTerm $userInput"
-                else -> flagSearchTerm
-            }
-        launchSearchForCards(searchTerms.copy(userInput = updatedInput))
-    }
-
     suspend fun filterByTags(
         selectedTags: List<String>,
         cardState: CardStateFilter,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -17,27 +17,46 @@ package com.ichi2.anki.browser
 import com.google.android.material.chip.Chip
 import com.google.android.material.chip.ChipGroup
 import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 
-@Suppress("UnusedReceiverParameter")
-fun CardBrowser.setupChips(
-    @Suppress("UNUSED_PARAMETER") chips: ChipGroup,
-) {
-    // TODO add here code to initialize each of the filtering chips
+// move to context parameters when available
+fun CardBrowser.setupChips(chips: ChipGroup) {
+    chips.findViewById<Chip>(R.id.chip_flag).apply {
+        text = TR.browsingSidebarFlags()
+        setOnClickListener { chip ->
+            (chip as Chip).isChecked = !chip.isChecked
+            BrowserFlagsFilteringFragment().show(
+                supportFragmentManager,
+                BrowserFlagsFilteringFragment.TAG,
+            )
+        }
+    }
 }
 
-@Suppress("RedundantSuspendModifier", "UnusedReceiverParameter")
+@Suppress("UnusedReceiverParameter")
+// move to context parameters when available
 suspend fun CardBrowser.updateChips(
-    @Suppress("UNUSED_PARAMETER") chips: ChipGroup,
+    chips: ChipGroup,
     oldSearchParameters: SearchParameters,
     newSearchParameters: SearchParameters,
 ) {
     if (oldSearchParameters.flags != newSearchParameters.flags) {
-        // TODO add code for each chip to update its status
+        val flagNames = Flag.queryDisplayNames()
+        chips.findViewById<Chip>(R.id.chip_flag).let { chip ->
+            chip.update(
+                activeItems = newSearchParameters.flags,
+                inactiveText = TR.browsingSidebarFlags(),
+                activeTextGetter = { flag -> flagNames[flag]!! },
+            )
+            // text shows "Red + 1" if there are multiple flags, so show the first flag icon
+            val firstFlagOrDefault = newSearchParameters.flags.firstOrNull() ?: Flag.NONE
+            chip.setChipIconResource(firstFlagOrDefault.drawableRes)
+        }
     }
 }
 
-@Suppress("unused")
 private fun <T> Chip.update(
     activeItems: Collection<T>,
     inactiveText: String,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/Chips.kt
@@ -1,0 +1,61 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import com.google.android.material.chip.Chip
+import com.google.android.material.chip.ChipGroup
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.R
+
+@Suppress("UnusedReceiverParameter")
+fun CardBrowser.setupChips(
+    @Suppress("UNUSED_PARAMETER") chips: ChipGroup,
+) {
+    // TODO add here code to initialize each of the filtering chips
+}
+
+@Suppress("RedundantSuspendModifier", "UnusedReceiverParameter")
+suspend fun CardBrowser.updateChips(
+    @Suppress("UNUSED_PARAMETER") chips: ChipGroup,
+    oldSearchParameters: SearchParameters,
+    newSearchParameters: SearchParameters,
+) {
+    if (oldSearchParameters.flags != newSearchParameters.flags) {
+        // TODO add code for each chip to update its status
+    }
+}
+
+@Suppress("unused")
+private fun <T> Chip.update(
+    activeItems: Collection<T>,
+    inactiveText: String,
+    activeTextGetter: (T) -> String,
+) {
+    if (activeItems.isEmpty()) {
+        isChecked = false
+        text = inactiveText
+    } else {
+        isChecked = true
+        val firstSelectedItemName = activeTextGetter(activeItems.first())
+        text =
+            if (activeItems.size == 1) {
+                firstSelectedItemName
+            } else {
+                // Display the first filter, along with the count of additional applied filters:
+                // e.g. ["Tag1", "Tag2", "Tag3"] -> "Tag1 +2"
+                context.getString(R.string.chip_filter_multiple_selections, firstSelectedItemName, (activeItems.size - 1))
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
@@ -15,6 +15,7 @@
 package com.ichi2.anki.browser
 
 import android.os.Parcelable
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.libanki.DeckId
 import kotlinx.parcelize.Parcelize
@@ -34,11 +35,16 @@ data class SearchParameters(
     }
 }
 
-fun SearchParameters.toQuery() =
-    listOf(
+suspend fun SearchParameters.toQuery(): String {
+    val targetDecksNames =
+        withCol {
+            deckIds.map { deckId -> decks.name(deckId) }
+        }
+    return listOf(
         userInput,
-        deckIds.joinToString(" OR ") { "did:$it" },
+        targetDecksNames.joinToString(" OR ") { "deck:\"$it\"" },
         tags.joinToString(" OR ") { """"tag:$it"""" },
         flags.joinToString(" OR ") { "flag:${it.code}" },
     ).filter { it.isNotEmpty() }
         .joinToString(" ") { "($it)" }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchParameters.kt
@@ -1,0 +1,44 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.os.Parcelable
+import com.ichi2.anki.Flag
+import com.ichi2.libanki.DeckId
+import kotlinx.parcelize.Parcelize
+
+@Parcelize
+data class SearchParameters(
+    val userInput: String,
+    val deckIds: Set<DeckId>,
+    val tags: Set<String>,
+    val flags: Set<Flag>,
+) : Parcelable {
+    val isEmpty get() = userInput.isEmpty() && deckIds.isEmpty() && tags.isEmpty() && flags.isEmpty()
+    val isNotEmpty get() = !isEmpty
+
+    companion object {
+        val EMPTY = SearchParameters("", emptySet(), emptySet(), emptySet())
+    }
+}
+
+fun SearchParameters.toQuery() =
+    listOf(
+        userInput,
+        deckIds.joinToString(" OR ") { "did:$it" },
+        tags.joinToString(" OR ") { """"tag:$it"""" },
+        flags.joinToString(" OR ") { "flag:${it.code}" },
+    ).filter { it.isNotEmpty() }
+        .joinToString(" ") { "($it)" }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/BottomSheetDialogFragmentFix.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/BottomSheetDialogFragmentFix.kt
@@ -1,0 +1,47 @@
+/*
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.workarounds
+
+import android.content.Context
+import android.content.res.Configuration
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.bottomsheet.BottomSheetDialog
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.ichi2.anki.convertDpToPixel
+
+// https://stackoverflow.com/questions/41591733
+open class BottomSheetDialogFragmentFix : BottomSheetDialogFragment() {
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        fixBottomSheetPeekHeight() // After device rotation
+    }
+
+    override fun onResume() {
+        super.onResume()
+        fixBottomSheetPeekHeight() // When showing for the first time
+    }
+
+    private fun fixBottomSheetPeekHeight() {
+        (dialog as? BottomSheetDialog)?.behavior?.peekHeight =
+            if (requireContext().isLandscape) {
+                convertDpToPixel(512f, requireContext()).toInt()
+            } else {
+                BottomSheetBehavior.PEEK_HEIGHT_AUTO
+            }
+    }
+}
+
+private val Context.isLandscape get() =
+    resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -14,6 +14,27 @@
 
         <include layout="@layout/toolbar" />
 
+        <HorizontalScrollView
+            android:id="@+id/browser_chips"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/colorBackground"
+            android:paddingHorizontal="8dp"
+            android:clipToPadding="false"
+            android:scrollbars="none"
+            app:layout_behavior="com.google.android.material.search.SearchBar$ScrollingViewBehavior">
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/filtering_chips_group"
+                style="@style/Widget.Material3.ChipGroup"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:elevation="0dp"
+                app:singleLine="true">
+
+            </com.google.android.material.chip.ChipGroup>
+        </HorizontalScrollView>
+
         <LinearLayout
             android:layout_width="match_parent"
             android:background="?android:attr/colorBackground"

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -31,7 +31,13 @@
                 android:layout_height="wrap_content"
                 android:elevation="0dp"
                 app:singleLine="true">
-
+                <com.google.android.material.chip.Chip
+                    android:id="@+id/chip_flag"
+                    style="@style/Chip.WithIcon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:chipIcon="@drawable/ic_flag_transparent"
+                    app:chipIconTint="@null" />
             </com.google.android.material.chip.ChipGroup>
         </HorizontalScrollView>
 

--- a/AnkiDroid/src/main/res/layout/fragment_flags_filter_sheet.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_flags_filter_sheet.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingVertical="12dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:id="@+id/clear_filter_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center_vertical"
+            android:visibility="gone"
+            android:minHeight="?attr/listPreferredItemHeightSmall"
+            android:background="?attr/selectableItemBackground"
+            tools:visibility="visible">
+
+            <ImageView
+                android:id="@+id/clear_icon"
+                android:layout_width="24dp"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:layout_marginStart="16dp"
+                android:layout_marginEnd="12dp"
+                app:srcCompat="@drawable/ic_clear_white" />
+
+            <com.ichi2.ui.FixedTextView
+                android:id="@+id/clear_selection"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/clear_filter"
+                android:textAppearance="?attr/textAppearanceBodyMedium"
+                tools:text="Clear filter"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/flags_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical" />
+    </LinearLayout>
+</ScrollView>

--- a/AnkiDroid/src/main/res/layout/item_browser_flag_filter.xml
+++ b/AnkiDroid/src/main/res/layout/item_browser_flag_filter.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:background="?attr/selectableItemBackground"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall"
+    android:focusable="true"
+    android:clickable="true"
+    android:layoutDirection="locale"
+    tools:ignore="UnusedResources">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="24dp"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="8dp"
+        tools:src="@drawable/ic_flag_green" />
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
+        android:gravity="start|center_vertical"
+        android:textAppearance="?android:textAppearanceMedium"
+        android:textDirection="locale"
+        android:textAlignment="gravity"
+        android:layout_marginEnd="16dp"
+        tools:text="Green flag"/>
+
+    <CheckBox
+        android:id="@+id/checkbox"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="16dp" />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout/item_browser_flag_filter.xml
+++ b/AnkiDroid/src/main/res/layout/item_browser_flag_filter.xml
@@ -22,8 +22,7 @@
     android:minHeight="?android:attr/listPreferredItemHeightSmall"
     android:focusable="true"
     android:clickable="true"
-    android:layoutDirection="locale"
-    tools:ignore="UnusedResources">
+    android:layoutDirection="locale">
 
     <ImageView
         android:id="@+id/icon"
@@ -31,7 +30,7 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:layout_marginStart="16dp"
-        android:layout_marginEnd="8dp"
+        android:layout_marginEnd="12dp"
         tools:src="@drawable/ic_flag_green" />
 
     <com.ichi2.ui.FixedTextView
@@ -40,7 +39,7 @@
         android:layout_height="match_parent"
         android:layout_weight="1"
         android:gravity="start|center_vertical"
-        android:textAppearance="?android:textAppearanceMedium"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
         android:textDirection="locale"
         android:textAlignment="gravity"
         android:layout_marginEnd="16dp"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -35,15 +35,6 @@
         android:title="@string/card_browser_search_by_tag"/>
 
     <item
-        ankidroid:showAsAction="never"
-        android:id="@+id/action_search_by_flag"
-        android:title="@string/card_browser_search_by_flag">
-        <menu>
-            <!-- flags are dynamically added -->
-        </menu>
-    </item>
-
-    <item
         ankidroid:showAsAction="ifRoom"
         android:id="@+id/action_undo"
         android:title="@string/undo"

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -39,7 +39,6 @@
     <string name="card_browser_show_marked" maxLength="28">Filter marked</string>
     <string name="card_browser_show_suspended" maxLength="28">Filter suspended</string>
     <string name="card_browser_search_by_tag" maxLength="28">Filter by tag</string>
-    <string name="card_browser_search_by_flag" maxLength="28">Filter by flag</string>
     <string name="card_browser_list_my_searches" maxLength="28">My searches</string>
     <string name="card_browser_list_my_searches_save" maxLength="28">Save search</string>
     <string name="card_browser_list_my_searches_title">Choose a saved search</string>
@@ -95,4 +94,5 @@
     Example shown to use: 'Red +2'
     When displaying a chip control for a filter, if one element is selected, we display it
     If more than one element is selected, we also show the count of extra filters">%1$s +%2$d</string>
+    <string name="clear_filter">Clear filter</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -89,4 +89,10 @@
     <!--Keyboard shortcuts dialog-->
     <string name="edit_tags_dialog" comment="Description of the shortcut that opens the edit tags dialog">Edit tags dialog</string>
     <string name="show_order_dialog" comment="Description of the shortcut that shows the order dialog">Show order dialog</string>
+
+    <string name="chip_filter_multiple_selections" comment="Arg 1: Selected filter ('Red Flag')
+    Arg 2: Number of additional selected filters (2: Green and Blue Flags)
+    Example shown to use: 'Red +2'
+    When displaying a chip control for a filter, if one element is selected, we display it
+    If more than one element is selected, we also show the count of extra filters">%1$s +%2$d</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -179,4 +179,12 @@
     <attr name="checkMediaListForeground" format="color" />
 
     <attr name="progressDialogButtonTextColor" format="color"/>
+
+    <attr name="bottomSheetFilterBackgroundColor" format="color|reference"/>
+
+    <attr name="chipInactiveStrokeColor" format="color"/>
+    <attr name="chipInactiveTextAndIconColor" format="color"/>
+    <attr name="chipActiveBackgroundColor" format="color"/>
+    <attr name="chipActiveTextAndIconColor" format="color"/>
+
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -157,6 +157,23 @@
         <item name="android:tint">@color/black</item>
     </style>
 
+    <style name="Chip.WithIcon" parent="Widget.Material3.Chip.Suggestion">
+        <item name="materialThemeOverlay">@style/ThemeOverlay.App.Chip</item>
+        <item name="chipIconVisible">true</item>
+        <item name="chipIconTint">@color/m3_chip_text_color</item>
+        <item name="android:ellipsize">middle</item>
+        <item name="android:maxWidth">200dp</item>
+    </style>
+    <style name="ThemeOverlay.App.Chip" parent="">
+        <item name="colorOutline">?attr/chipInactiveStrokeColor</item>
+        <item name="colorOnSurfaceVariant">?attr/chipInactiveTextAndIconColor</item>
+        <item name="colorSecondaryContainer">?attr/chipActiveBackgroundColor</item>
+        <item name="colorOnSecondaryContainer">?attr/chipActiveTextAndIconColor</item>
+        <item name="colorSurface">@color/transparent</item> <!-- Container background -->
+        <item name="textAppearanceTitleSmall">@style/TextAppearance.Material3.TitleSmall</item>
+        <item name="textAppearanceLabelLarge">@style/TextAppearance.Material3.LabelLarge</item>
+    </style>
+
     <style name="reviewer_whiteboard_editor_button_style">
         <item name="android:layout_height">40dp</item>
         <item name="android:layout_width">40dp</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -123,6 +123,17 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">false</item>
         <item name="android:navigationBarColor">@color/black</item>
 
+        <item name="chipInactiveStrokeColor">#6fff</item>
+        <item name="chipInactiveTextAndIconColor">#9fff</item>
+        <item name="chipActiveBackgroundColor">#4fff</item>
+        <item name="chipActiveTextAndIconColor">#fff</item>
+
+        <item name="bottomSheetFilterBackgroundColor">#606060</item>
+        <item name="chipInactiveStrokeColor">#6fff</item>
+        <item name="chipInactiveTextAndIconColor">#9fff</item>
+        <item name="chipActiveBackgroundColor">#4fff</item>
+        <item name="chipActiveTextAndIconColor">#fff</item>
+
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -114,6 +114,12 @@
         <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
         <item name="editTextDisabled">@color/material_grey_500</item>
 
+        <item name="bottomSheetFilterBackgroundColor">#eee</item>
+        <item name="chipInactiveStrokeColor">#ddd</item>
+        <item name="chipInactiveTextAndIconColor">#444</item>
+        <item name="chipActiveBackgroundColor">#cef</item>
+        <item name="chipActiveTextAndIconColor">#023</item>
+
         <!-- Snackbar. Attributes snackbarStyle, snackbarTextViewStyle and snackbarButtonStyle
              must be *all* present in a theme (or its parent) in order for the snackbar
              to pick up the proper layout that uses these attributes. -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -747,14 +747,18 @@ class CardBrowserTest : RobolectricTest() {
             }
 
             val cardBrowser = browserWithNoNewCards
-            cardBrowser.searchCards("Hello").join()
+            cardBrowser.searchCards(cardBrowser.viewModel.searchTerms.copy(userInput = "Hello")).join()
             waitForAsyncTasksToComplete()
             assertThat(
                 "Card browser should have Test Deck as the selected deck",
                 cardBrowser.selectedDeckNameForUi,
                 equalTo("Test Deck"),
             )
-            assertThat("Result should be empty", cardBrowser.viewModel.rowCount, equalTo(0))
+            assertThat(
+                "Result should be empty",
+                cardBrowser.viewModel.rowCount,
+                equalTo(0),
+            )
 
             cardBrowser.searchAllDecks().join()
             waitForAsyncTasksToComplete()
@@ -1240,7 +1244,7 @@ val CardBrowser.validDecksForChangeDeck
     get() = runBlocking { getValidDecksForChangeDeck() }
 
 suspend fun CardBrowser.searchCardsSync(query: String) {
-    searchCards(query)
+    searchCards(viewModel.searchTerms.copy(userInput = query))
     viewModel.searchJob?.join()
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -237,7 +237,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `default init`() =
         runTest {
             viewModel().apply {
-                assertThat(searchTerms, equalTo(""))
+                assertThat(searchTerms.userInput, equalTo(""))
             }
         }
 
@@ -245,7 +245,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `Card Browser menu init`() =
         runTest {
             viewModel(intent = SystemContextMenu("Hello")).apply {
-                assertThat(searchTerms, equalTo("Hello"))
+                assertThat(searchTerms.userInput, equalTo("Hello"))
             }
         }
 
@@ -253,7 +253,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `Deep Link init`() =
         runTest {
             viewModel(intent = DeepLink("Hello")).apply {
-                assertThat(searchTerms, equalTo("Hello"))
+                assertThat(searchTerms.userInput, equalTo("Hello"))
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -42,7 +42,6 @@ import com.ichi2.anki.model.SortType.EASE
 import com.ichi2.anki.model.SortType.NO_SORTING
 import com.ichi2.anki.model.SortType.SORT_FIELD
 import com.ichi2.anki.servicelayer.NoteService
-import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.DeckId
@@ -157,7 +156,7 @@ class CardBrowserViewModelTest : JvmTest() {
             val anotherCardWithRedFlag = addBasicNote("Second card with red flag", "Reverse")
             flagCardForNote(anotherCardWithRedFlag, Flag.RED)
 
-            setFlagFilterSync(Flag.RED)
+            launchSearchForCards(searchTerms.copy(flags = setOf(Flag.RED)))?.join()
 
             assertThat("Flagged cards should be returned", rowCount, equalTo(2))
         }


### PR DESCRIPTION
## Purpose / Description
Adds a part of the CardBrowser new chip filtering, targeting flags. The PR uses code from the original attempt at  #16859  where possible. See more info in the messages of commits.

UI note: I think it would be better if we just show _Flags +x_ instead of _FlagName +1_:
- I find it confusing to have a chip checked and its text to read _"No flag"_
- while for single flag selection having the name makes sense, this loses its advantage when you also have +x because you don't have any info about the other flags so you're forced to open the sheet again anyway
- makes it easier to keep all filtering chips on screen. If we have a longer tag name + flag name it's easy to push the last filtering chip(state) outside of the screen
- would have a more consistent UI if all chip filtering would use the same system: _Tags +2 Flags +2 Card state +2_

Some images:

<img src="https://github.com/user-attachments/assets/5eeafc21-fb71-49ff-9eeb-0d16bd067c84" width="300px" height="640px"/>
<img src="https://github.com/user-attachments/assets/7a6787fa-97cf-41ba-a765-2f17d74c61f7" width="300px" height="640px"/>
<img src="https://github.com/user-attachments/assets/fad1e760-b303-42a2-839a-9013a11c43e1" width="300px" height="640px"/>


## Fixes
* Towards  #12554

## How Has This Been Tested?

Ran the tests and filtered by flag.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
