### PR TITLE
Update milestone targets to 2.20

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -20,7 +20,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: ${{ github.event.pull_request.number }},
-            milestone: 59
+            milestone: 64
           });
 
           // graphql query to get referenced issues to merged pull request
@@ -51,7 +51,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              milestone: 59
+              milestone: 64
             });
           }
 


### PR DESCRIPTION
## Purpose / Description
2.19.1 is released and I think it makes sense now to update the milestone targets to [2.20 ](https://github.com/ankidroid/Anki-Android/milestone/64)

## How Has This Been Tested?

No tests for this.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)