### PR TITLE
Test that all TS backend functions are handled

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -20,6 +20,7 @@
       <w>contextmenu</w>
       <w>customtabs</w>
       <w>fileprovider</w>
+      <w>funcs</w>
       <w>greylist</w>
       <w>greylisted</w>
       <w>gtxt</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -1,5 +1,7 @@
 /*
  *  Copyright (c) 2023 Brayan Oliveira <brayandso.dev@gmail.com>
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2024 voczi <dev@voczi.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -16,18 +18,19 @@
 package com.ichi2.anki.pages
 
 import android.app.Activity
+import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
-import com.ichi2.anki.CollectionManager.getBackend
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.importAnkiPackageUndoable
 import com.ichi2.anki.importCsvRaw
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.searchInBrowser
+import com.ichi2.libanki.Collection
 import com.ichi2.libanki.completeTagRaw
 import com.ichi2.libanki.getCsvMetadataRaw
-import com.ichi2.libanki.getDeckConfigRaw
 import com.ichi2.libanki.getDeckConfigsForUpdateRaw
 import com.ichi2.libanki.getDeckNamesRaw
 import com.ichi2.libanki.getFieldNamesRaw
@@ -42,6 +45,8 @@ import com.ichi2.libanki.stats.getGraphPreferencesRaw
 import com.ichi2.libanki.stats.graphsRaw
 import com.ichi2.libanki.stats.setGraphPreferencesRaw
 import com.ichi2.libanki.undoableOp
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import timber.log.Timber
 
@@ -49,48 +54,87 @@ interface PostRequestHandler {
     suspend fun handlePostRequest(uri: String, bytes: ByteArray): ByteArray
 }
 
-suspend fun handleCollectionPostRequest(methodName: String, bytes: ByteArray): ByteArray? {
-    return when (methodName) {
-        "i18nResources" -> withCol { i18nResourcesRaw(bytes) }
-        "getGraphPreferences" -> withCol { getGraphPreferencesRaw() }
-        "setGraphPreferences" -> withCol { setGraphPreferencesRaw(bytes) }
-        "graphs" -> withCol { graphsRaw(bytes) }
-        "getNotetypeNames" -> withCol { getNotetypeNamesRaw(bytes) }
-        "getDeckNames" -> withCol { getDeckNamesRaw(bytes) }
-        "getCsvMetadata" -> withCol { getCsvMetadataRaw(bytes) }
-        "importCsv" -> importCsvRaw(bytes)
-        "importAnkiPackage" -> importAnkiPackageUndoable(bytes)
-        "importDone" -> bytes
-        "getImportAnkiPackagePresets" -> withCol { getImportAnkiPackagePresetsRaw(bytes) }
-        "completeTag" -> withCol { completeTagRaw(bytes) }
-        "getFieldNames" -> withCol { getFieldNamesRaw(bytes) }
-        "cardStats" -> withCol { cardStatsRaw(bytes) }
-        "getDeckConfig" -> withCol { getDeckConfigRaw(bytes) }
-        "getDeckConfigsForUpdate" -> withCol { getDeckConfigsForUpdateRaw(bytes) }
-        "computeFsrsParams" -> withCol { computeFsrsParamsRaw(bytes) }
-        "computeOptimalRetention" -> withCol { computeOptimalRetentionRaw(bytes) }
-        "evaluateParams" -> withCol { evaluateParamsRaw(bytes) }
-        "simulateFsrsReview" -> withCol { simulateFsrsReviewRaw(bytes) }
-        "getImageForOcclusion" -> withCol { getImageForOcclusionRaw(bytes) }
-        "getImageOcclusionNote" -> withCol { getImageOcclusionNoteRaw(bytes) }
-        "getImageForOcclusionFields" -> withCol { getImageOcclusionFieldsRaw(bytes) }
-        "setWantsAbort" -> getBackend().setWantsAbortRaw(bytes)
-        "latestProgress" -> getBackend().latestProgressRaw(bytes)
-        "congratsInfo" -> withCol { congratsInfoRaw(bytes) }
-        else -> null
+fun <ByteArray> backendIdentity(bytes: ByteArray): ByteArray = bytes
+
+typealias CollectionBackendInterface = Collection.(bytes: ByteArray) -> ByteArray
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+val collectionMethods = hashMapOf<String, CollectionBackendInterface>(
+    "i18nResources" to { bytes -> i18nResourcesRaw(bytes) },
+    "getGraphPreferences" to { _ -> getGraphPreferencesRaw() },
+    "setGraphPreferences" to { bytes -> setGraphPreferencesRaw(bytes) },
+    "graphs" to { bytes -> graphsRaw(bytes) },
+    "getNotetypeNames" to { bytes -> getNotetypeNamesRaw(bytes) },
+    "getDeckNames" to { bytes -> getDeckNamesRaw(bytes) },
+    "getCsvMetadata" to { bytes -> getCsvMetadataRaw(bytes) },
+    "importDone" to { bytes -> backendIdentity(bytes) },
+    "getImportAnkiPackagePresets" to { bytes -> getImportAnkiPackagePresetsRaw(bytes) },
+    "completeTag" to { bytes -> completeTagRaw(bytes) },
+    "getFieldNames" to { bytes -> getFieldNamesRaw(bytes) },
+    "cardStats" to { bytes -> cardStatsRaw(bytes) },
+    "getDeckConfigsForUpdate" to { bytes -> getDeckConfigsForUpdateRaw(bytes) },
+    "computeFsrsParams" to { bytes -> computeFsrsParamsRaw(bytes) },
+    "computeOptimalRetention" to { bytes -> computeOptimalRetentionRaw(bytes) },
+    "evaluateParams" to { bytes -> evaluateParamsRaw(bytes) },
+    "simulateFsrsReview" to { bytes -> simulateFsrsReviewRaw(bytes) },
+    "getImageForOcclusion" to { bytes -> getImageForOcclusionRaw(bytes) },
+    "getImageOcclusionNote" to { bytes -> getImageOcclusionNoteRaw(bytes) },
+    "setWantsAbort" to { bytes -> setWantsAbortRaw(bytes) },
+    "latestProgress" to { bytes -> latestProgressRaw(bytes) },
+    "getSchedulingStatesWithContext" to { bytes -> getSchedulingStatesWithContextRaw(bytes) },
+    "setSchedulingStates" to { bytes -> setSchedulingStatesRaw(bytes) },
+    "getChangeNotetypeInfo" to { bytes -> getChangeNotetypeInfoRaw(bytes) },
+    "changeNotetype" to { bytes -> changeNotetypeRaw(bytes) },
+    "importJsonString" to { bytes -> importJsonStringRaw(bytes) },
+    "importJsonFile" to { bytes -> importJsonFileRaw(bytes) },
+    "congratsInfo" to { bytes -> congratsInfoRaw(bytes) },
+    "getImageOcclusionFields" to { bytes -> getImageOcclusionFieldsRaw(bytes) }
+)
+
+fun handleCollectionPostRequest(methodName: String, bytes: ByteArray): ByteArray? {
+    return collectionMethods[methodName]?.let { bytes } ?: run {
+        Timber.w("Unknown TS method called.")
+        Timber.d("handleCollectionPostRequest could not resolve TS method %s", methodName)
+        null
     }
 }
 
-suspend fun FragmentActivity?.handleUiPostRequest(methodName: String, bytes: ByteArray): ByteArray? {
+typealias UIBackendInterface = FragmentActivity.(bytes: ByteArray) -> Deferred<ByteArray>
+
+@VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+val uiMethods = hashMapOf<String, UIBackendInterface>(
+    "searchInBrowser" to { bytes -> lifecycleScope.async { searchInBrowser(bytes) } },
+    "updateDeckConfigs" to { bytes -> lifecycleScope.async { updateDeckConfigsRaw(bytes) } },
+    "importCsv" to { bytes -> lifecycleScope.async { importCsvRaw(bytes) } },
+    "importAnkiPackage" to { bytes -> lifecycleScope.async { importAnkiPackageUndoable(bytes) } },
+    "addImageOcclusionNote" to { bytes ->
+        lifecycleScope.async {
+            withCol { addImageOcclusionNoteRaw(bytes) }
+        }
+    },
+    "updateImageOcclusionNote" to { bytes ->
+        lifecycleScope.async {
+            withCol { updateImageOcclusionNoteRaw(bytes) }
+        }
+    }
+)
+
+suspend fun FragmentActivity?.handleUiPostRequest(
+    methodName: String,
+    bytes: ByteArray
+): ByteArray? {
     if (this == null) {
         Timber.w("ignored UI request '%s' due to screen/app being backgrounded", methodName)
         return null
     }
-    return when (methodName) {
-        "searchInBrowser" -> searchInBrowser(bytes)
-        "updateDeckConfigs" -> updateDeckConfigsRaw(bytes)
+
+    val data = uiMethods[methodName]?.let { bytes } ?: run {
+        Timber.w("Unknown TS method called.")
+        Timber.d("handleUiPostRequest could not resolve TS method %s", methodName)
+        return null
+    }
+    when (methodName) {
         "addImageOcclusionNote" -> {
-            val data = withCol { addImageOcclusionNoteRaw(bytes) }
             undoableOp { OpChanges.parseFrom(data) }
             launchCatchingTask {
                 // Allow time for toast message to appear before closing editor
@@ -98,12 +142,9 @@ suspend fun FragmentActivity?.handleUiPostRequest(methodName: String, bytes: Byt
                 setResult(Activity.RESULT_OK)
                 finish()
             }
-            data
         }
+
         "updateImageOcclusionNote" -> {
-            val data = withCol {
-                updateImageOcclusionNoteRaw(bytes)
-            }
             undoableOp { OpChanges.parseFrom(data) }
             launchCatchingTask {
                 // Allow time for toast message to appear before closing editor
@@ -111,8 +152,7 @@ suspend fun FragmentActivity?.handleUiPostRequest(methodName: String, bytes: Byt
                 setResult(NoteEditor.RESULT_UPDATED_IO_NOTE)
                 finish()
             }
-            data
         }
-        else -> null
     }
+    return data
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendDeckOptions.kt
@@ -15,10 +15,6 @@
  ****************************************************************************************/
 package com.ichi2.libanki
 
-fun Collection.getDeckConfigRaw(input: ByteArray): ByteArray {
-    return backend.getDeckConfigRaw(input)
-}
-
 fun Collection.getDeckConfigsForUpdateRaw(input: ByteArray): ByteArray {
     return backend.getDeckConfigsForUpdateRaw(input)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -743,6 +743,38 @@ class Collection(
         return backend.congratsInfoRaw(input = input)
     }
 
+    fun setWantsAbortRaw(input: ByteArray): ByteArray {
+        return backend.setWantsAbortRaw(input = input)
+    }
+
+    fun latestProgressRaw(input: ByteArray): ByteArray {
+        return backend.latestProgressRaw(input = input)
+    }
+
+    fun getSchedulingStatesWithContextRaw(input: ByteArray): ByteArray {
+        return backend.getSchedulingStatesWithContextRaw(input = input)
+    }
+
+    fun setSchedulingStatesRaw(input: ByteArray): ByteArray {
+        return backend.setSchedulingStatesRaw(input = input)
+    }
+
+    fun getChangeNotetypeInfoRaw(input: ByteArray): ByteArray {
+        return backend.getChangeNotetypeInfoRaw(input = input)
+    }
+
+    fun changeNotetypeRaw(input: ByteArray): ByteArray {
+        return backend.changeNotetypeRaw(input = input)
+    }
+
+    fun importJsonStringRaw(input: ByteArray): ByteArray {
+        return backend.importJsonStringRaw(input = input)
+    }
+
+    fun importJsonFileRaw(input: ByteArray): ByteArray {
+        return backend.importJsonFileRaw(input = input)
+    }
+
     fun compareAnswer(expected: String, provided: String, combining: Boolean = true): String {
         return backend.compareAnswer(expected = expected, provided = provided, combining = combining)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/PostRequestHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/PostRequestHandlerTest.kt
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2024 voczi <dev@voczi.com>
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.InputStreamReader
+
+@RunWith(AndroidJUnit4::class)
+class PostRequestHandlerTest : RobolectricTest() {
+    @Test
+    fun `All backend typescript functions should be handled`() {
+        assertThat(
+            "Mapping exists for every TS backend function call",
+            typescriptFunctionsUsedByBackend,
+            // this matcher asserts equality in everything but order, no extras, nothing missing
+            containsInAnyOrder((collectionMethods + uiMethods).keys)
+        )
+    }
+
+    /**
+     * Auto-generated list of all typescript funcs created & packaged during backend build
+     */
+    private val typescriptFunctionsUsedByBackend: List<String> =
+        InputStreamReader(targetContext.assets.open("backend/ts_funcs.txt")).use {
+            it.readLines().also { lines ->
+                assertThat("Stored Typescript functions", lines, not(empty()))
+            }
+        }
+}


### PR DESCRIPTION
## Purpose / Description
Make sure that we do not update to newer Anki backend versions where the names of TS functions do not correlate to the mappings we have set in PostRequestHandler. Otherwise, we would have to manually go and check for any such change in the Anki repo. If we don't do this, then functionality in some of the Svelte pages might be straight up unsupported, and we wouldn't know about this until we actually test the affected component.

## Fixes
N/A.

## Approach
Refactor PostRequestHandler so the switch-statement takes the form of a hash map instead. Then, in PostRequestHandlerTest, use list of TS functions generated from the AnkiDroid backend (https://github.com/ankidroid/Anki-Android-Backend/pull/434) to find out what function mappings we are supposed to have.

## How Has This Been Tested?
Just made sure that the tests passed and made sure we have mappings for all the backend functions.
For the first few lists of backend functions, I found some inconsistencies with my parsing code in the AnkiDroid backend and subsequently fixed this (https://github.com/ankidroid/Anki-Android-Backend/pull/437).

## Learning (optional, can help others)
Tree-sitter is some interesting stuff.
https://github.com/tree-sitter/tree-sitter
https://tree-sitter.github.io/tree-sitter/playground

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
