### PR TITLE
NF: Add `.attach_pid*` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ Thumbs.db
 *.iws
 /.idea/*
 /captures
+# File that should be deleted by java's test but sometime is not
+AnkiDroid/.attach_pid*
 
 # IDEA/Android Studio Ignore exceptions - this lets you share things you specifically want all team members to use
 !/.idea/codeStyles/


### PR DESCRIPTION
At least on my device, I get plenty of warning that files are created. It seems to be generated by bug in tests system.
As I don't expect it'll be useful to anyone, I allow myself to request a change in gitignore