### PR TITLE
fix: invalid file issue on pasting file

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -33,6 +33,7 @@ import androidx.annotation.VisibleForTesting
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.ui.FixedEditText
 import com.ichi2.utils.ClipboardUtil.getDescription
 import com.ichi2.utils.ClipboardUtil.getPlainText
@@ -171,7 +172,13 @@ class FieldEditText : FixedEditText, NoteService.NoteField {
         return if (mediaUri == null) {
             false
         } else {
-            pasteListener!!.onPaste(this, mediaUri, description)
+            try {
+                pasteListener!!.onPaste(this, mediaUri, description)
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to paste media")
+                showSnackbar(context.getString(R.string.multimedia_editor_something_wrong))
+                false
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- https://github.com/ankidroid/Anki-Android/issues/17388
When some invalid or corrupted file is being pasted in the field then it might cause the issue, though I tried to reproduce it with various types of  files such as pdf but can not get it, so putting a try catch and send report to ACRA

## Fixes
* Fixes #17388


## How Has This Been Tested?
Local build, try-catch should do the work

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
