### PR TITLE
Update Anki to 24.11rc1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.0"
-ankiBackend = '0.1.43-anki24.10rc2'
+ankiBackend = '0.1.47-anki24.11rc1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION
Need the new `SYNC_SERVER_MESSAGE` for an upcoming PR.
See: https://github.com/ankidroid/Anki-Android-Backend/pull/439