### PR TITLE
Fix: DeckPicker-NullPointerException in onQueryTextChange

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -928,8 +928,21 @@ open class DeckPicker :
                 }
 
                 override fun onQueryTextChange(newText: String): Boolean {
-                    val adapter = recyclerView.adapter as Filterable?
-                    adapter!!.filter.filter(newText)
+                    val adapter = recyclerView.adapter as? Filterable
+                    if (adapter == null || adapter.filter == null) {
+                        Timber.w(
+                            "DeckPicker.onQueryTextChange: adapter is null: %s, filter is null: %s, adapter type: %s",
+                            adapter == null,
+                            adapter?.filter == null,
+                            adapter?.javaClass?.simpleName ?: "Unknown"
+                        )
+                        CrashReportService.sendExceptionReport(
+                            Exception("DeckPicker.onQueryTextChanged with unexpected null adapter or filter. Carefully examine logcat"),
+                            "DeckPicker"
+                        )
+                        return true
+                    }
+                    adapter.filter.filter(newText)
                     return true
                 }
             })


### PR DESCRIPTION
## Purpose / Description
Fixes NullPointerException in onQueryTextChange by safely casting the adapter to Filterable before calling the filter method, preventing crashes when the adapter is null or not of the correct type.

## Fixes
* Fixes #17391 

## How Has This Been Tested?
Realme 6 and Emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
