### PR TITLE
fix: unable to crop shared images

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -274,9 +274,13 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     }
 
     private fun handleImageUri() {
+        fun processExternalImage(uri: Uri): Uri? = internalizeUri(uri)?.let { Uri.fromFile(it) }
+
         if (imageUri != null) {
             view?.findViewById<TextView>(R.id.no_image_textview)?.visibility = View.GONE
-            handleSelectImageIntent(imageUri)
+
+            val internalUri = imageUri?.let { processExternalImage(it) }
+            handleSelectImageIntent(internalUri)
         } else {
             handleSelectedImageOptions()
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- https://github.com/ankidroid/Anki-Android/issues/17361
The image when shared to AnkiDroid directly doesn't grant Uri permission as the photo is coming from other app, so we internalise the URI and then use the image, hence fixing the crop issue as it needs Uri with correct permission to edit it

## Fixes
* Fixes #17361


## How Has This Been Tested?
Tested on Google Emulator API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
