### PR TITLE
Fix TabLayoutMediator attached before adapter initialization in CardT…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -263,6 +263,9 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         fieldNames = tempModel!!.notetype.fieldsNames
         // Set up the ViewPager with the sections adapter.
         viewPager.adapter = TemplatePagerAdapter(this@CardTemplateEditor)
+        TabLayoutMediator(slidingTabLayout!!, viewPager) { tab: TabLayout.Tab, position: Int ->
+            tab.text = tempModel!!.getTemplate(position).getString("name")
+        }.apply { attach() }
 
         // Set activity title
         supportActionBar?.let {
@@ -456,7 +459,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         private var cursorPosition = 0
 
         private lateinit var templateEditor: CardTemplateEditor
-        private var tabLayoutMediator: TabLayoutMediator? = null
         lateinit var tempModel: CardTemplateNotetype
         lateinit var bottomNavigation: BottomNavigationView
 
@@ -649,7 +651,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
         }
 
         override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-            initTabLayoutMediator()
             templateEditor.slidingTabLayout?.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
                 override fun onTabSelected(p0: TabLayout.Tab?) {
                     templateEditor.loadTemplatePreviewerFragmentIfFragmented()
@@ -666,16 +667,6 @@ open class CardTemplateEditor : AnkiActivity(), DeckSelectionListener {
                 }
             }
             setupMenu()
-        }
-
-        private fun initTabLayoutMediator() {
-            if (tabLayoutMediator != null) {
-                tabLayoutMediator!!.detach()
-            }
-            tabLayoutMediator = TabLayoutMediator(templateEditor.slidingTabLayout!!, templateEditor.viewPager) { tab: TabLayout.Tab, position: Int ->
-                tab.text = templateEditor.tempModel!!.getTemplate(position).getString("name")
-            }
-            tabLayoutMediator!!.attach()
         }
 
         /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixed the bug by moving the TabLayoutMediator setup code in onCollectionLoaded() after the adapter is set on the ViewPager. Besides the fragment not using the TabLayoutMediator reference that it was setting up, that code doesn't belong in the fragment.

The issue appeared when the activity was killed in the background and then brought back to foreground and the collection was not available before the system recreated the fragments.

How to reproduce the bug:
- enable developer setting "Don't keep activities"
- to simulate the collection not being available right away in CardTemplateEditor follow the next steps:
   - Change AnkiActivity.startLoadingCollection() to remove:
       ```
        if (colIsOpenUnsafe()) {
            Timber.d("Synchronously calling onCollectionLoaded")
            onCollectionLoaded(getColUnsafe)
            return
        }
      ```
   - Modify the coroutine in CollectionLoader to add a delay before withContext {}
- Go to Manage notetypes -> Edit cards -> Press home to send the app to background and to be killed -> Use the recent activities and bring the app back  -> Crash with TabLayoutMediator attached before adapter


## Fixes
* Fixes #17384

## How Has This Been Tested?

Reproduce the bug and check that is fixed, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
