### PR TITLE
Fix image occlusion cards being added to wrong deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2464,7 +2464,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             kind = "edit"
             id = editorNote?.id!!
         }
-        val intent = ImageOcclusion.getIntent(requireContext(), kind, id, imagePath)
+        val intent = ImageOcclusion.getIntent(requireContext(), kind, id, imagePath, deckId)
         requestIOEditorCloser.launch(intent)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -22,11 +22,16 @@ import android.view.View
 import android.webkit.WebView
 import androidx.activity.addCallback
 import androidx.core.os.bundleOf
+import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.dialogs.DiscardChangesDialog
+import com.ichi2.annotations.NeedsTest
+import com.ichi2.libanki.DeckId
 import com.ichi2.themes.setTransparentStatusBar
+import kotlinx.coroutines.launch
 import org.json.JSONObject
 import timber.log.Timber
 
@@ -43,10 +48,34 @@ class ImageOcclusion : PageFragment(R.layout.image_occlusion) {
             }
         }
 
+        @NeedsTest("#17393 verify that the added image occlusion cards are put in the correct deck")
         view.findViewById<MaterialToolbar>(R.id.toolbar).setOnMenuItemClickListener {
+            val editorWorkingDeckId = requireArguments().getLong(ARG_KEY_EDITOR_DECK_ID)
             if (it.itemId == R.id.action_save) {
                 Timber.i("save item selected")
-                webView.evaluateJavascript("anki.imageOcclusion.save()", null)
+                // TODO desktop code doesn't allow a deck change from the reviewer, if we would do
+                //  the same then NoteEditor could simply set the deck as selected and this hack
+                //  could be removed
+                // because NoteEditor doesn't update the selected deck in Collection.decks when
+                // there's a deck change and keeps its own deckId reference, we need to use that
+                // deck id reference as the target deck in this fragment(backend code simply uses
+                // the current selected deck it sees as the target deck for adding)
+                lifecycleScope.launch {
+                    val previousDeckId = withCol {
+                        val current = backend.getCurrentDeck().id
+                        backend.setCurrentDeck(editorWorkingDeckId)
+                        current
+                    }
+                    webView.evaluateJavascript("anki.imageOcclusion.save()") {
+                        // reset to the previous deck that the backend "saw" as selected, this
+                        // avoids other screens unexpectedly having their working decks modified(
+                        // most important being the Reviewer where the user would find itself
+                        // studying another deck after editing a note with changing the deck)
+                        lifecycleScope.launch {
+                            withCol { backend.setCurrentDeck(previousDeckId) }
+                        }
+                    }
+                }
             }
             return@setOnMenuItemClickListener true
         }
@@ -81,8 +110,18 @@ class ImageOcclusion : PageFragment(R.layout.image_occlusion) {
         private const val ARG_KEY_KIND = "kind"
         private const val ARG_KEY_ID = "id"
         private const val ARG_KEY_PATH = "imagePath"
+        private const val ARG_KEY_EDITOR_DECK_ID = "arg_key_editor_deck_id"
 
-        fun getIntent(context: Context, kind: String, noteOrNotetypeId: Long, imagePath: String?): Intent {
+        /**
+         * @param editorWorkingDeckId the current deck id that [com.ichi2.anki.NoteEditor] is using
+         */
+        fun getIntent(
+            context: Context,
+            kind: String,
+            noteOrNotetypeId: Long,
+            imagePath: String?,
+            editorWorkingDeckId: DeckId
+        ): Intent {
             val suffix = if (kind == "edit") {
                 "/$noteOrNotetypeId"
             } else {
@@ -92,7 +131,8 @@ class ImageOcclusion : PageFragment(R.layout.image_occlusion) {
                 ARG_KEY_KIND to kind,
                 ARG_KEY_ID to noteOrNotetypeId,
                 ARG_KEY_PATH to imagePath,
-                PATH_ARG_KEY to "image-occlusion$suffix"
+                PATH_ARG_KEY to "image-occlusion$suffix",
+                ARG_KEY_EDITOR_DECK_ID to editorWorkingDeckId
             )
             return SingleFragmentActivity.getIntent(context, ImageOcclusion::class, arguments)
         }


### PR DESCRIPTION
## Purpose / Description

_NoteEditor_ keeps its own reference to the selected deck through _deckId_, see the _onDeckSelected()_ method where on deck change the code doesn't update the deck selected in the backend:

https://github.com/ankidroid/Anki-Android/blob/1107816ffc5c1a9395d70a48a62a3ccf1c64746d/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt#L392-L396

The problem for image occlusion cards is we use the backend page which will use as a target for the new cards the deck that the backend currently sees as selected, see:

https://github.com/ankitects/anki/blob/763712c69697cbfca6f758ec0602714e2c90c2a8/rslib/src/image_occlusion/imagedata.rs#L49

So image occlusion cards will always be added to the deck that was selected when NoteEditor was created. The fix I used passes the deckId from NoteEditor and then updates/restore the backend's selected deck when it's time to create the image occlusion cards.

A much simpler fix would be to just use _true_ for _deckSpinnerSelection!!.selectDeckById(deckId, false)_ in _NoteEditor.ondeckSelected()_. I didn't use this because it will modify the current behavior where changing the deck in NoteEditor doesn't update the selected deck for other screens. This could be problematic for the reviewer(user will find himself reviewing another deck) and I think there will be people making bug reports about this.

At reviewer discretion if this should go in 2.19.x branches.

## Fixes
* Fixes  #17393

## How Has This Been Tested?

Check the bug reproduction steps, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
