### PR TITLE
fix(manage-space): crash if `getPackageSizeInfo` fails

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/FileUtils.kt
@@ -38,6 +38,7 @@ import kotlin.coroutines.resume
 /**
  * Get the size of user data and cache for the current package, in bytes.
  * This should amount to the sum of User data and Cache in App info -> Storage and cache.
+ * @throws NoSuchMethodException occasionally on some phones < [Build.VERSION_CODES.O] (#17387)
  */
 suspend fun Context.getUserDataAndCacheSize(): Long =
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -107,6 +108,9 @@ private fun Context.getUserDataAndCacheSizeUsingStorageStatsManager(): Long {
  * The logic was taken from this SO question: https://stackoverflow.com/q/36944194#36983630
  * Asked by Chris Sherlock: https://stackoverflow.com/users/2992462/chris-sherlock
  * Answered by Mattia Maestrini: https://stackoverflow.com/users/2837959/mattia-maestrini
+ */
+/**
+ * @throws NoSuchMethodException on some API 25 phones (#17387)
  */
 private suspend fun Context.getUserDataAndCacheSizeUsingGetPackageSizeInfo(): Long {
     lateinit var continuation: Continuation<Long>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
@@ -152,7 +152,13 @@ class ManageSpaceViewModel(val app: Application) : AndroidViewModel(app), Collec
         flowOfDeleteEverythingSize.emit(Size.Calculating)
         flowOfDeleteEverythingSize.emit(
             withContext(Dispatchers.IO) {
-                Size.Bytes(app.getUserDataAndCacheSize())
+                try {
+                    Size.Bytes(app.getUserDataAndCacheSize())
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Size.Error(e)
+                }
             }
         )
     }


### PR DESCRIPTION
On a (knockoff?) API 25 phone, `getPackageSizeInfo` failed with

```
java.lang.NoSuchMethodException: getPackageSizeInfo [class java.lang.String, interface b.a]
	at java.lang.Class.getMethod(Class.java:1981)
	at java.lang.Class.getMethod(Class.java:1637)
	at com.ichi2.anki.ui.windows.managespace.FileUtilsKt.getUserDataAndCacheSizeUsingGetPackageSizeInfo(FileUtils.kt:115)
```

## Fixes
* Fixes #17387

## Approach

* handling the exception
* documenting the exception

## How Has This Been Tested?

I modified the code to throw an exception

<img width="407" alt="Screenshot 2024-11-10 at 17 14 48" src="https://github.com/user-attachments/assets/a2a78835-ad1a-4168-805e-5266831c73fc">

* button still worked

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
