### PR TITLE
NF: rename `files` to `decks`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -70,7 +70,7 @@ class DeckPickerTest : InstrumentedTest() {
         createDeckWithCard(testString)
 
         // Go to RecyclerView item having "Test Deck" and click on the counts layout
-        onView(withId(R.id.files)).perform(
+        onView(withId(R.id.decks)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(withText("TestDeck$testString")),
                 clickChildViewWithId(R.id.counts_layout)
@@ -114,7 +114,7 @@ class DeckPickerTest : InstrumentedTest() {
         onView(withText(R.string.dialog_ok)).perform(click())
 
         // The deck is currently empty, so if we tap on it, it becomes the selected deck but doesn't enter
-        onView(withId(R.id.files)).perform(
+        onView(withId(R.id.decks)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(withText("TestDeck$testString")),
                 clickChildViewWithId(R.id.counts_layout)

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -122,8 +122,8 @@ class ReviewerFragmentTest : InstrumentedTest() {
     }
 
     private fun clickOnDeckWithName(deckName: String) {
-        onView(withId(R.id.files)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
-        onView(withId(R.id.files)).perform(
+        onView(withId(R.id.decks)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
+        onView(withId(R.id.decks)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(withText(deckName)),
                 click()

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -124,8 +124,8 @@ class ReviewerTest : InstrumentedTest() {
     }
 
     private fun clickOnDeckWithName(deckName: String) {
-        onView(withId(R.id.files)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
-        onView(withId(R.id.files)).perform(
+        onView(withId(R.id.decks)).checkWithTimeout(matches(hasDescendant(withText(deckName))))
+        onView(withId(R.id.decks)).perform(
             RecyclerViewActions.actionOnItem<RecyclerView.ViewHolder>(
                 hasDescendant(withText(deckName)),
                 click()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -507,7 +507,7 @@ open class DeckPicker :
         title = resources.getString(R.string.app_name)
 
         deckPickerContent = findViewById(R.id.deck_picker_content)
-        recyclerView = findViewById(R.id.files)
+        recyclerView = findViewById(R.id.decks)
         noDecksPlaceholder = findViewById(R.id.no_decks_placeholder)
 
         deckPickerContent.visibility = View.GONE

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -34,7 +34,7 @@
                     android:orientation="vertical">
 
                     <androidx.recyclerview.widget.RecyclerView
-                        android:id="@+id/files"
+                        android:id="@+id/decks"
                         android:layout_width="match_parent"
                         android:layout_height="match_parent"
                         android:clipToPadding="false"


### PR DESCRIPTION
I suspect that long ago `files` name made sense, maybe when there was a single deck. That's clearer for today's implementation
