### PR TITLE
IntentHandler decides which reviewer is used.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -97,6 +97,7 @@ import com.ichi2.anki.InitialActivity.StartupFailure.DISK_FULL
 import com.ichi2.anki.InitialActivity.StartupFailure.FUTURE_ANKIDROID_VERSION
 import com.ichi2.anki.InitialActivity.StartupFailure.SD_CARD_NOT_MOUNTED
 import com.ichi2.anki.InitialActivity.StartupFailure.WEBVIEW_FAILED
+import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShorcuts
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
@@ -2202,10 +2203,7 @@ open class DeckPicker :
         // This code should not be reachable with lower versions
         val shortcut = ShortcutInfoCompat.Builder(this, did.toString())
             .setIntent(
-                Intent(context, Reviewer::class.java)
-                    .setAction(Intent.ACTION_VIEW)
-                    .putExtra("deckId", did)
-                    .addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                intentToReviewDeckFromShorcuts(context, did)
             )
             .setIcon(IconCompat.createWithResource(context, R.mipmap.ic_launcher))
             .setShortLabel(Decks.basename(getColUnsafe.decks.name(did)))

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -26,8 +26,8 @@ import android.view.View
 import android.widget.RemoteViews
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
+import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShorcuts
 import com.ichi2.anki.R
-import com.ichi2.anki.Reviewer
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.pages.DeckOptions
@@ -181,11 +181,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
             val isEmptyDeck = deckData.newCount == 0 && deckData.reviewCount == 0 && deckData.learnCount == 0
 
             val intent = if (!isEmptyDeck) {
-                Intent(context, Reviewer::class.java).apply {
-                    action = Intent.ACTION_VIEW
-                    putExtra("deckId", deckData.deckId)
-                    addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                }
+                intentToReviewDeckFromShorcuts(context, deckData.deckId)
             } else {
                 DeckOptions.getIntent(context, deckData.deckId)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -27,8 +27,8 @@ import android.widget.RemoteViews
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportService
+import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShorcuts
 import com.ichi2.anki.R
-import com.ichi2.anki.Reviewer
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.pages.DeckOptions
@@ -141,11 +141,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
                 val isEmptyDeck = deck.newCount == 0 && deck.reviewCount == 0 && deck.learnCount == 0
 
                 val intent = if (!isEmptyDeck) {
-                    Intent(context, Reviewer::class.java).apply {
-                        action = Intent.ACTION_VIEW
-                        putExtra("deckId", deck.deckId)
-                        addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
-                    }
+                    intentToReviewDeckFromShorcuts(context, deck.deckId)
                 } else {
                     DeckOptions.getIntent(context, deck.deckId)
                 }


### PR DESCRIPTION
This also cause shortcuts, reminder and widget to use the IntentHandler instead of directly opening the Reviewer.

I should note that the reminders that were created before this commit will break when the Reviewer class will be removed. Unless we specifically keep the Reviewer to cause it to redirect to the new Reviewer.

Given that the reminder is quite broken anyway, must be redone from scratch, at this point, I think it's an acceptable loss. Trying to correct it while the reminder does not work properly will be a nightmare.

There are still plenty of places in the code that use the previous reviewer inconditionally. I'm not touching them, because I don't need them to unblock my sync in reviewer issue

Test: I tested shortcut and deck picker widget. I've not tested notification as they are quite harder to use

* Fixes #17420