### PR TITLE
Expose exceptions thrown during caching of imported files

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -122,9 +122,9 @@ class ImportUtilsTest : RobolectricTest() {
         lateinit var cacheFileName: String
             private set
 
-        override fun copyFileToCache(context: Context, data: Uri?, tempPath: String): Boolean {
+        override fun copyFileToCache(context: Context, data: Uri?, tempPath: String): Pair<Boolean, String?> {
             cacheFileName = tempPath
-            return true
+            return Pair(true, null)
         }
 
         override fun getFileNameFromContentProvider(context: Context, data: Uri): String? {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

We have a lot of reports in the form of:

```
java.lang.RuntimeException: Error importing apkg file
	at com.ichi2.utils.ImportUtils$FileImporter.handleContentProviderFile(ImportUtils.java:211)
	at com.ichi2.utils.ImportUtils$FileImporter.handleFileImportInternal(ImportUtils.java:128)
	at com.ichi2.utils.ImportUtils$FileImporter.handleFileImport(ImportUtils.java:117)
	at com.ichi2.utils.ImportUtils.handleFileImport(ImportUtils.java:61)
```

coming from:

https://github.com/ankidroid/Anki-Android/blob/f4b08261418fca31293629a55d341b861c0fbb73/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt#L203-L211

which are a front for problems in the ImportUtils.copyToCache() method:

https://github.com/ankidroid/Anki-Android/blob/f4b08261418fca31293629a55d341b861c0fbb73/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt#L306-L327

This PR "extracts" any exception happening in that method and sends it to acra instead of the current useless RuntimeException we are sending. Having the real exceptions could helps us to see what's really happening.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
