### PR TITLE
refactor(libanki): convert Consts to enums

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -32,13 +32,13 @@ import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
 import com.ichi2.anki.testutil.grantPermissions
 import com.ichi2.libanki.Card
-import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.addNotetypeLegacy
 import com.ichi2.libanki.backend.BackendUtils
@@ -1102,7 +1102,7 @@ class ContentProviderTest : InstrumentedTest() {
         val cardId = card!!.id
 
         // the card starts out being new
-        assertEquals("card is initial new", 0, card.queue)
+        assertEquals("card is initial new", QueueType.New, card.queue)
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
         val noteId = card.nid
@@ -1132,7 +1132,7 @@ class ContentProviderTest : InstrumentedTest() {
 
         // lookup the card after update, ensure it's not new anymore
         val cardAfterReview = col.getCard(cardId)
-        assertEquals("card is now type rev", Consts.QUEUE_TYPE_REV, cardAfterReview.queue)
+        assertEquals("card is now type rev", QueueType.Rev, cardAfterReview.queue)
     }
 
     /**
@@ -1147,7 +1147,7 @@ class ContentProviderTest : InstrumentedTest() {
         // verify that the card is not already user-buried
         assertNotEquals(
             "Card is not user-buried before test",
-            Consts.QUEUE_TYPE_SIBLING_BURIED,
+            QueueType.SiblingBuried,
             card!!.queue,
         )
 
@@ -1173,10 +1173,10 @@ class ContentProviderTest : InstrumentedTest() {
         // verify that it did get buried
         // -----------------------------
         val cardAfterUpdate = col.getCard(cardId)
-        // QUEUE_TYPE_MANUALLY_BURIED was also used for SIBLING_BURIED in sched v1
+        // QueueType.MANUALLY_BURIED was also used for SIBLING_BURIED in sched v1
         assertEquals(
             "Card is user-buried",
-            Consts.QUEUE_TYPE_MANUALLY_BURIED,
+            QueueType.ManuallyBuried,
             cardAfterUpdate.queue,
         )
 
@@ -1197,7 +1197,7 @@ class ContentProviderTest : InstrumentedTest() {
         // verify that the card is not already suspended
         assertNotEquals(
             "Card is not suspended before test",
-            Consts.QUEUE_TYPE_SUSPENDED,
+            QueueType.Suspended,
             card!!.queue,
         )
 
@@ -1223,7 +1223,7 @@ class ContentProviderTest : InstrumentedTest() {
         // verify that it did get suspended
         // --------------------------------
         val cardAfterUpdate = col.getCard(cardId)
-        assertEquals("Card is suspended", Consts.QUEUE_TYPE_SUSPENDED, cardAfterUpdate.queue)
+        assertEquals("Card is suspended", QueueType.Suspended, cardAfterUpdate.queue)
 
         // cleanup, unsuspend card and reschedule
         // --------------------------------------

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1102,7 +1102,7 @@ class ContentProviderTest : InstrumentedTest() {
         val cardId = card!!.id
 
         // the card starts out being new
-        assertEquals("card is initial new", Consts.CARD_TYPE_NEW, card.queue)
+        assertEquals("card is initial new", 0, card.queue)
         val cr = contentResolver
         val reviewInfoUri = FlashCardsContract.ReviewInfo.CONTENT_URI
         val noteId = card.nid
@@ -1132,7 +1132,7 @@ class ContentProviderTest : InstrumentedTest() {
 
         // lookup the card after update, ensure it's not new anymore
         val cardAfterReview = col.getCard(cardId)
-        assertEquals("card is now type rev", Card.TYPE_REV, cardAfterReview.queue)
+        assertEquals("card is now type rev", Consts.QUEUE_TYPE_REV, cardAfterReview.queue)
     }
 
     /**

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -28,9 +28,10 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import com.ichi2.annotations.DuplicatedCode
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.common.IgnoreFlakyTestsInCIRule
 import kotlinx.coroutines.runBlocking
@@ -149,8 +150,8 @@ abstract class InstrumentedTest {
 
     @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
     protected fun Card.moveToReviewQueue() {
-        this.queue = Consts.QUEUE_TYPE_REV
-        this.type = CardType.REV
+        this.queue = QueueType.Rev
+        this.type = CardType.Rev
         this.due = 0
         col.updateCard(this, true)
     }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -150,7 +150,7 @@ abstract class InstrumentedTest {
     @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
     protected fun Card.moveToReviewQueue() {
         this.queue = Consts.QUEUE_TYPE_REV
-        this.type = Consts.CARD_TYPE_REV
+        this.type = CardType.REV
         this.due = 0
         col.updateCard(this, true)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -271,7 +271,7 @@ open class AnkiDroidJsAPI(
             "cardMod" -> convertToByteArray(apiContract, currentCard.mod)
             "cardId" -> convertToByteArray(apiContract, currentCard.id)
             "cardNid" -> convertToByteArray(apiContract, currentCard.nid)
-            "cardType" -> convertToByteArray(apiContract, currentCard.type)
+            "cardType" -> convertToByteArray(apiContract, currentCard.type.code)
             "cardDid" -> convertToByteArray(apiContract, currentCard.did)
             "cardLeft" -> convertToByteArray(apiContract, currentCard.left)
             "cardODid" -> convertToByteArray(apiContract, currentCard.oDid)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -276,7 +276,7 @@ open class AnkiDroidJsAPI(
             "cardLeft" -> convertToByteArray(apiContract, currentCard.left)
             "cardODid" -> convertToByteArray(apiContract, currentCard.oDid)
             "cardODue" -> convertToByteArray(apiContract, currentCard.oDue)
-            "cardQueue" -> convertToByteArray(apiContract, currentCard.queue)
+            "cardQueue" -> convertToByteArray(apiContract, currentCard.queue.code)
             "cardLapses" -> convertToByteArray(apiContract, currentCard.lapses)
             "cardDue" -> convertToByteArray(apiContract, currentCard.due)
             "deckName" -> convertToByteArray(apiContract, Decks.basename(activity.getColUnsafe.decks.name(currentCard.did)))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -99,8 +99,7 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Consts.QUEUE_TYPE_NEW
-import com.ichi2.libanki.Consts.QUEUE_TYPE_SUSPENDED
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.CurrentQueueState
 import com.ichi2.libanki.undoableOp
@@ -1088,10 +1087,10 @@ open class Reviewer :
             if (ease == Ease.AGAIN && wasLeech) {
                 state.topCard.load(getColUnsafe)
                 val leechMessage: String =
-                    if (state.topCard.queue < 0) {
-                        resources.getString(R.string.leech_suspend_notification)
-                    } else {
+                    if (state.topCard.queue.buriedOrSuspended()) {
                         resources.getString(R.string.leech_notification)
+                    } else {
+                        resources.getString(R.string.leech_suspend_notification)
                     }
                 showSnackbar(leechMessage, Snackbar.LENGTH_SHORT)
             }
@@ -1615,7 +1614,7 @@ open class Reviewer :
             false
         } else {
             getColUnsafe.db.queryScalar(
-                "select 1 from cards where nid = ? and id != ? and queue != $QUEUE_TYPE_SUSPENDED limit 1",
+                "select 1 from cards where nid = ? and id != ? and queue != ${QueueType.Suspended.code} limit 1",
                 currentCard!!.nid,
                 currentCard!!.id,
             ) == 1
@@ -1628,7 +1627,7 @@ open class Reviewer :
             false
         } else {
             getColUnsafe.db.queryScalar(
-                "select 1 from cards where nid = ? and id != ? and queue >=  $QUEUE_TYPE_NEW limit 1",
+                "select 1 from cards where nid = ? and id != ? and queue >=  ${QueueType.New.code} limit 1",
                 currentCard!!.nid,
                 currentCard!!.id,
             ) == 1

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -46,11 +46,11 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.ChangeManager
-import com.ichi2.libanki.Consts
-import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
-import com.ichi2.libanki.Consts.QUEUE_TYPE_SIBLING_BURIED
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.NoteId
+import com.ichi2.libanki.QueueType
+import com.ichi2.libanki.QueueType.ManuallyBuried
+import com.ichi2.libanki.QueueType.SiblingBuried
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -539,7 +539,7 @@ class CardBrowserViewModel(
             val cardIds = queryAllSelectedCardIds()
 
             undoableOp<OpChanges> {
-                val wantUnsuspend = cardIds.all { getCard(it).queue == Consts.QUEUE_TYPE_SUSPENDED }
+                val wantUnsuspend = cardIds.all { getCard(it).queue == QueueType.Suspended }
                 if (wantUnsuspend) {
                     sched.unsuspendCards(cardIds)
                 } else {
@@ -566,7 +566,7 @@ class CardBrowserViewModel(
         }
 
         // https://github.com/ankitects/anki/blob/074becc0cee1e9ae59be701ad6c26787f74b4594/qt/aqt/browser/browser.py#L896-L902
-        fun Card.isBuried(): Boolean = queue == QUEUE_TYPE_MANUALLY_BURIED || queue == QUEUE_TYPE_SIBLING_BURIED
+        fun Card.isBuried(): Boolean = queue == ManuallyBuried || queue == SiblingBuried
 
         val cardIds = queryAllSelectedCardIds()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.multimediacard.fields.TextField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
@@ -227,12 +228,8 @@ object NoteService {
      * returns the average ease of all the non-new cards in the note,
      * or if all the cards in the note are new, returns null
      */
-    fun avgEase(
-        col: Collection,
-        note: Note,
-    ): Int? {
-        val nonNewCards = note.cards(col).filter { it.type != Consts.CARD_TYPE_NEW }
-
+    fun avgEase(col: Collection, note: Note): Int? {
+        val nonNewCards = note.cards(col).filter { it.type != CardType.NEW }
         return nonNewCards.average { it.factor }?.let { it / 10 }?.toInt()
     }
 
@@ -251,12 +248,8 @@ object NoteService {
      * Returns the average interval of all the non-new and non-learning cards in the note,
      * or if all the cards in the note are new or learning, returns null
      */
-    fun avgInterval(
-        col: Collection,
-        note: Note,
-    ): Int? {
-        val nonNewOrLearningCards = note.cards(col).filter { it.type != Consts.CARD_TYPE_NEW && it.type != Consts.CARD_TYPE_LRN }
-
+    fun avgInterval(col: Collection, note: Note): Int? {
+        val nonNewOrLearningCards = note.cards(col).filter { it.type != CardType.NEW && it.type != CardType.LRN }
         return nonNewOrLearningCards.average { it.ivl }?.toInt()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -36,10 +36,10 @@ import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.NotetypeJson
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.CollectionUtils.average
@@ -228,8 +228,11 @@ object NoteService {
      * returns the average ease of all the non-new cards in the note,
      * or if all the cards in the note are new, returns null
      */
-    fun avgEase(col: Collection, note: Note): Int? {
-        val nonNewCards = note.cards(col).filter { it.type != CardType.NEW }
+    fun avgEase(
+        col: Collection,
+        note: Note,
+    ): Int? {
+        val nonNewCards = note.cards(col).filter { it.type != CardType.New }
         return nonNewCards.average { it.factor }?.let { it / 10 }?.toInt()
     }
 
@@ -248,8 +251,11 @@ object NoteService {
      * Returns the average interval of all the non-new and non-learning cards in the note,
      * or if all the cards in the note are new or learning, returns null
      */
-    fun avgInterval(col: Collection, note: Note): Int? {
-        val nonNewOrLearningCards = note.cards(col).filter { it.type != CardType.NEW && it.type != CardType.LRN }
+    fun avgInterval(
+        col: Collection,
+        note: Note,
+    ): Int? {
+        val nonNewOrLearningCards = note.cards(col).filter { it.type != CardType.New && it.type != CardType.Lrn }
         return nonNewOrLearningCards.average { it.ivl }?.toInt()
     }
 
@@ -272,7 +278,7 @@ fun Card.avgIntervalOfNote(col: Collection) = NoteService.avgInterval(col, note(
 suspend fun isBuryNoteAvailable(card: Card): Boolean =
     withCol {
         db.queryScalar(
-            "select 1 from cards where nid = ? and id != ? and queue >=  " + Consts.QUEUE_TYPE_NEW + " limit 1",
+            "select 1 from cards where nid = ? and id != ? and queue >=  " + QueueType.New.code + " limit 1",
             card.nid,
             card.id,
         ) == 1
@@ -281,7 +287,7 @@ suspend fun isBuryNoteAvailable(card: Card): Boolean =
 suspend fun isSuspendNoteAvailable(card: Card): Boolean =
     withCol {
         db.queryScalar(
-            "select 1 from cards where nid = ? and id != ? and queue != " + Consts.QUEUE_TYPE_SUSPENDED + " limit 1",
+            "select 1 from cards where nid = ? and id != ? and queue != " + QueueType.Suspended.code + " limit 1",
             card.nid,
             card.id,
         ) == 1

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -24,7 +24,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.utils.ext.ifZero
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Consts.CardQueue
-import com.ichi2.libanki.Consts.CardType
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
@@ -75,9 +75,7 @@ open class Card : Cloneable {
     var mod: Long = 0
     private var usn = 0
 
-    @get:CardType
-    @CardType
-    var type = 0
+    var type: CardType = CardType.NEW
 
     @get:CardQueue
     @CardQueue
@@ -130,7 +128,7 @@ open class Card : Cloneable {
         ord = card.templateIdx
         mod = card.mtimeSecs
         usn = card.usn
-        type = card.ctype
+        type = CardType.fromCode(card.ctype)
         queue = card.queue
         due = card.due
         ivl = card.interval
@@ -154,7 +152,7 @@ open class Card : Cloneable {
             noteId = nid
             deckId = did
             templateIdx = ord
-            ctype = type
+            ctype = type.code
             queue = this@Card.queue
             due = this@Card.due
             interval = ivl
@@ -444,8 +442,6 @@ open class Card : Cloneable {
     }
 
     companion object {
-        const val TYPE_REV = 2
-
         // A list of class members to skip in the toString() representation
         val SKIP_PRINT: Set<String> =
             HashSet(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -19,12 +19,9 @@ package com.ichi2.libanki
 
 import androidx.annotation.VisibleForTesting
 import anki.cards.FsrsMemoryState
-import anki.decks.deckId
 import com.ichi2.anki.Flag
 import com.ichi2.anki.utils.ext.ifZero
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.libanki.Consts.CardQueue
-import com.ichi2.libanki.CardType
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
@@ -75,11 +72,9 @@ open class Card : Cloneable {
     var mod: Long = 0
     private var usn = 0
 
-    var type: CardType = CardType.NEW
+    var type: CardType = CardType.New
 
-    @get:CardQueue
-    @CardQueue
-    var queue = 0
+    var queue: QueueType = QueueType.New
     var due: Int = 0
     var ivl = 0
     var factor = 0
@@ -129,7 +124,7 @@ open class Card : Cloneable {
         mod = card.mtimeSecs
         usn = card.usn
         type = CardType.fromCode(card.ctype)
-        queue = card.queue
+        queue = QueueType.fromCode(card.queue)
         due = card.due
         ivl = card.interval
         factor = card.easeFactor
@@ -153,7 +148,7 @@ open class Card : Cloneable {
             deckId = did
             templateIdx = ord
             ctype = type.code
-            queue = this@Card.queue
+            queue = this@Card.queue.code
             due = this@Card.due
             interval = ivl
             easeFactor = factor

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -94,6 +94,28 @@ sealed class QueueType(
     }
 }
 
+// model types
+sealed class NoteTypeKind(
+    val code: Int,
+) {
+    object Std : NoteTypeKind(0)
+
+    object Cloze : NoteTypeKind(1)
+
+    class Unknown(
+        code: Int,
+    ) : NoteTypeKind(code)
+
+    companion object {
+        fun fromCode(code: Int) =
+            when (code) {
+                0 -> Std
+                1 -> Cloze
+                else -> Unknown(code)
+            }
+    }
+}
+
 object Consts {
     // dynamic deck order
     const val DYN_OLDEST = 0
@@ -110,14 +132,6 @@ object Consts {
     @Retention(AnnotationRetention.SOURCE)
     @IntDef(DYN_OLDEST, DYN_RANDOM, DYN_SMALLINT, DYN_BIGINT, DYN_LAPSES, DYN_ADDED, DYN_DUE, DYN_REVADDED, DYN_DUEPRIORITY)
     annotation class DynPriority
-
-    // model types
-    const val MODEL_STD = 0
-    const val MODEL_CLOZE = 1
-
-    @Retention(AnnotationRetention.SOURCE)
-    @IntDef(MODEL_STD, MODEL_CLOZE)
-    annotation class ModelType
 
     const val STARTING_FACTOR = 2500
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -18,52 +18,83 @@ package com.ichi2.libanki
 import androidx.annotation.IntDef
 import kotlin.annotation.Retention
 
-
-
 // Card types
-sealed class CardType(val code: Int) {
-    object NEW: CardType(0)
-    object LRN: CardType(1)
-    object REV: CardType(2)
-    object RELEARNING: CardType(3)
-    class UNKNOWN(code: Int): CardType(code)
+sealed class CardType(
+    val code: Int,
+) {
+    object New : CardType(0)
+
+    object Lrn : CardType(1)
+
+    object Rev : CardType(2)
+
+    object Relearning : CardType(3)
+
+    class Unknown(
+        code: Int,
+    ) : CardType(code)
 
     companion object {
         fun fromCode(code: Int) =
-            when(code) {
-                0 -> NEW
-                1 -> LRN
-                2 -> REV
-                3 -> RELEARNING
-                else -> UNKNOWN(code)
+            when (code) {
+                0 -> New
+                1 -> Lrn
+                2 -> Rev
+                3 -> Relearning
+                else -> Unknown(code)
+            }
+    }
+}
+
+sealed class QueueType(
+    val code: Int,
+) {
+    object ManuallyBuried : QueueType(-3)
+
+    object SiblingBuried : QueueType(-2)
+
+    object Suspended : QueueType(-1)
+
+    object New : QueueType(0)
+
+    object Lrn : QueueType(1)
+
+    object Rev : QueueType(2)
+
+    object DayLearnRelearn : QueueType(3)
+
+    object Preview : QueueType(4)
+
+    class Unknown(
+        code: Int,
+    ) : QueueType(code)
+
+    /**
+     * Whether this card can be reviewed.
+     */
+    fun buriedOrSuspended() =
+        when (this) {
+            ManuallyBuried, SiblingBuried, Suspended -> true
+            New, Lrn, Rev, DayLearnRelearn, Preview -> false
+            is Unknown -> this.code < 0
+        }
+
+    companion object {
+        fun fromCode(code: Int): QueueType =
+            when (code) {
+                -3 -> ManuallyBuried
+                -2 -> SiblingBuried
+                -1 -> Suspended
+                0 -> New
+                1 -> Lrn
+                2 -> Rev
+                3 -> DayLearnRelearn
+                else -> Unknown(code)
             }
     }
 }
 
 object Consts {
-    // Queue types
-    const val QUEUE_TYPE_MANUALLY_BURIED = -3
-    const val QUEUE_TYPE_SIBLING_BURIED = -2
-    const val QUEUE_TYPE_SUSPENDED = -1
-    const val QUEUE_TYPE_NEW = 0
-    const val QUEUE_TYPE_LRN = 1
-    const val QUEUE_TYPE_REV = 2
-    const val QUEUE_TYPE_DAY_LEARN_RELEARN = 3
-    const val QUEUE_TYPE_PREVIEW = 4
-
-    @Retention(AnnotationRetention.SOURCE)
-    @IntDef(
-        QUEUE_TYPE_MANUALLY_BURIED,
-        QUEUE_TYPE_SIBLING_BURIED,
-        QUEUE_TYPE_SUSPENDED,
-        QUEUE_TYPE_NEW,
-        QUEUE_TYPE_LRN,
-        QUEUE_TYPE_REV,
-        QUEUE_TYPE_DAY_LEARN_RELEARN,
-        QUEUE_TYPE_PREVIEW,
-    )
-    annotation class CardQueue
-
     // dynamic deck order
     const val DYN_OLDEST = 0
     const val DYN_RANDOM = 1

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -18,6 +18,28 @@ package com.ichi2.libanki
 import androidx.annotation.IntDef
 import kotlin.annotation.Retention
 
+
+
+// Card types
+sealed class CardType(val code: Int) {
+    object NEW: CardType(0)
+    object LRN: CardType(1)
+    object REV: CardType(2)
+    object RELEARNING: CardType(3)
+    class UNKNOWN(code: Int): CardType(code)
+
+    companion object {
+        fun fromCode(code: Int) =
+            when(code) {
+                0 -> NEW
+                1 -> LRN
+                2 -> REV
+                3 -> RELEARNING
+                else -> UNKNOWN(code)
+            }
+    }
+}
+
 object Consts {
     // Queue types
     const val QUEUE_TYPE_MANUALLY_BURIED = -3
@@ -41,16 +63,6 @@ object Consts {
         QUEUE_TYPE_PREVIEW,
     )
     annotation class CardQueue
-
-    // Card types
-    const val CARD_TYPE_NEW = 0
-    const val CARD_TYPE_LRN = 1
-    const val CARD_TYPE_REV = 2
-    const val CARD_TYPE_RELEARNING = 3
-
-    @Retention(AnnotationRetention.SOURCE)
-    @IntDef(CARD_TYPE_NEW, CARD_TYPE_LRN, CARD_TYPE_REV, CARD_TYPE_RELEARNING)
-    annotation class CardType
 
     // dynamic deck order
     const val DYN_OLDEST = 0

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -21,7 +21,6 @@ import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import anki.notes.NoteFieldsCheckResponse
 import com.ichi2.libanki.Consts.DEFAULT_DECK_ID
-import com.ichi2.libanki.Consts.MODEL_STD
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.set
@@ -116,7 +115,7 @@ class Note : Cloneable {
             if (customTemplate != null) {
                 customTemplate.deepClone()
             } else {
-                val index = if (model.type == MODEL_STD) ord else 0
+                val index = if (model.isStd) ord else 0
                 model.tmpls[index]
             }
         // may differ in cloze case

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -71,9 +71,9 @@ class NotetypeJson : JSONObject {
     val templatesNames: List<String>
         get() = getJSONArray("tmpls").toStringList("name")
     val isStd: Boolean
-        get() = getInt("type") == Consts.MODEL_STD
+        get() = type == NoteTypeKind.Std
     val isCloze: Boolean
-        get() = getInt("type") == Consts.MODEL_CLOZE
+        get() = type == NoteTypeKind.Cloze
 
     /**
      * @param sfld Fields of a note of this note type
@@ -129,12 +129,10 @@ class NotetypeJson : JSONObject {
             put("sortf", value)
         }
 
-    // TODO: Not constrained
-    @Consts.ModelType
-    var type: Int
-        get() = getInt("type")
+    var type: NoteTypeKind
+        get() = NoteTypeKind.fromCode(getInt("type"))
         set(value) {
-            put("type", value)
+            put("type", value.code)
         }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -43,7 +43,6 @@ import anki.notetypes.restoreNotetypeToStockRequest
 import com.google.protobuf.ByteString
 import com.ichi2.anki.CrashReportService
 import com.ichi2.annotations.NeedsTest
-import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.BackendUtils.fromJsonBytes
@@ -600,7 +599,7 @@ class Notetypes(
     ): OpChanges {
         val fieldMap = convertLegacyMap(fmap, newModel.fieldsNames.size)
         val templateMap =
-            if (cmap.isEmpty() || noteType.type == MODEL_CLOZE || newModel.type == MODEL_CLOZE) {
+            if (cmap.isEmpty() || noteType.isCloze || newModel.isCloze) {
                 listOf()
             } else {
                 convertLegacyMap(cmap, newModel.templatesNames.size)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -44,11 +44,8 @@ import com.ichi2.anki.Ease
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Consts.CARD_TYPE_LRN
-import com.ichi2.libanki.Consts.CARD_TYPE_NEW
-import com.ichi2.libanki.Consts.CARD_TYPE_RELEARNING
-import com.ichi2.libanki.Consts.CARD_TYPE_REV
 import com.ichi2.libanki.Consts.QUEUE_TYPE_NEW
 import com.ichi2.libanki.Consts.QUEUE_TYPE_REV
 import com.ichi2.libanki.DeckConfig
@@ -566,12 +563,12 @@ open class Scheduler(
                 .db
                 .query(
                     """select
-                          avg(case when type = $CARD_TYPE_NEW then case when ease > 1 then 1.0 else 0.0 end else null end) as newRate,
-                          avg(case when type = $CARD_TYPE_NEW then time else null end) as newTime,
-                          avg(case when type in ($CARD_TYPE_LRN, $CARD_TYPE_RELEARNING) then case when ease > 1 then 1.0 else 0.0 end else null end) as revRate,
-                          avg(case when type in ($CARD_TYPE_LRN, $CARD_TYPE_RELEARNING) then time else null end) as revTime,
-                          avg(case when type = $CARD_TYPE_REV then case when ease > 1 then 1.0 else 0.0 end else null end) as relrnRate,
-                          avg(case when type = $CARD_TYPE_REV then time else null end) as relrnTime
+                          avg(case when type = ${CardType.NEW.code} then case when ease > 1 then 1.0 else 0.0 end else null end) as newRate,
+                          avg(case when type = ${CardType.NEW.code} then time else null end) as newTime,
+                          avg(case when type in (${CardType.LRN.code}, ${CardType.RELEARNING.code}) then case when ease > 1 then 1.0 else 0.0 end else null end) as revRate,
+                          avg(case when type in (${CardType.LRN.code}, ${CardType.RELEARNING.code}) then time else null end) as revTime,
+                          avg(case when type = ${CardType.REV.code} then case when ease > 1 then 1.0 else 0.0 end else null end) as relrnRate,
+                          avg(case when type = ${CardType.REV.code} then time else null end) as relrnTime
                         from revlog where id > ?""",
                     (col.sched.dayCutoff - (10 * SECONDS_PER_DAY)) * 1000,
                 ).use { cur ->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -21,7 +21,7 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.SUCCESS_KEY
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.VALUE_KEY
-import com.ichi2.libanki.Consts
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.BASIC_MODEL_NAME
 import net.ankiweb.rsdroid.withoutUnicodeIsolation
@@ -109,7 +109,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             // Card Type
             assertThat(
                 getDataFromRequest("cardType", jsapi),
-                equalTo(formatApiResult(currentCard.type)),
+                equalTo(formatApiResult(currentCard.type.code)),
             )
             // Card ODue
             assertThat(
@@ -389,7 +389,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             val c = n.firstCard()
 
             // Make card review with 28L due and 280% ease
-            c.type = Consts.CARD_TYPE_REV
+            c.type = CardType.REV
             c.due = 28
             c.factor = 2800
             c.ivl = 8
@@ -398,7 +398,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             assertEquals(28, c.due, "Card due before reset")
             assertEquals(8, c.ivl, "Card interval before reset")
             assertEquals(2800, c.factor, "Card ease before reset")
-            assertEquals(Consts.CARD_TYPE_REV, c.type, "Card type before reset")
+            assertEquals(CardType.REV, c.type, "Card type before reset")
 
             val reviewer: Reviewer = startReviewer()
             waitForAsyncTasksToComplete()
@@ -414,7 +414,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             val cardAfterReset = col.getCard(reviewer.currentCard!!.id)
             assertEquals(2, cardAfterReset.due, "Card due after reset")
             assertEquals(0, cardAfterReset.ivl, "Card interval after reset")
-            assertEquals(Consts.CARD_TYPE_NEW, cardAfterReset.type, "Card type after reset")
+            assertEquals(CardType.NEW, cardAfterReset.type, "Card type after reset")
         }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -144,7 +144,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             // Card Queue
             assertThat(
                 getDataFromRequest("cardQueue", jsapi),
-                equalTo(formatApiResult(currentCard.queue)),
+                equalTo(formatApiResult(currentCard.queue.code)),
             )
             // Card Reps
             assertThat(
@@ -389,7 +389,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             val c = n.firstCard()
 
             // Make card review with 28L due and 280% ease
-            c.type = CardType.REV
+            c.type = CardType.Rev
             c.due = 28
             c.factor = 2800
             c.ivl = 8
@@ -398,7 +398,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             assertEquals(28, c.due, "Card due before reset")
             assertEquals(8, c.ivl, "Card interval before reset")
             assertEquals(2800, c.factor, "Card ease before reset")
-            assertEquals(CardType.REV, c.type, "Card type before reset")
+            assertEquals(CardType.Rev, c.type, "Card type before reset")
 
             val reviewer: Reviewer = startReviewer()
             waitForAsyncTasksToComplete()
@@ -414,7 +414,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             val cardAfterReset = col.getCard(reviewer.currentCard!!.id)
             assertEquals(2, cardAfterReset.due, "Card due after reset")
             assertEquals(0, cardAfterReset.ivl, "Card interval after reset")
-            assertEquals(CardType.NEW, cardAfterReset.type, "Card type after reset")
+            assertEquals(CardType.New, cardAfterReset.type, "Card type after reset")
         }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -51,6 +51,7 @@ import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.BrowserConfig
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
@@ -560,7 +561,7 @@ class CardBrowserTest : RobolectricTest() {
             addNoteUsingBasicModel("Hello", "World").firstCard().update {
                 due = 5
                 queue = Consts.QUEUE_TYPE_REV
-                type = Consts.CARD_TYPE_REV
+                type = CardType.REV
             }
             val cal = Calendar.getInstance()
             cal.add(Calendar.DATE, 5)
@@ -1147,7 +1148,7 @@ class CardBrowserTest : RobolectricTest() {
         cal.add(Calendar.DATE, 27)
 
         // Not filtered
-        c.type = Consts.CARD_TYPE_NEW
+        c.type = CardType.NEW
         c.due = 27
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         Assert.assertEquals("27", nextDue(col, c))
@@ -1165,7 +1166,7 @@ class CardBrowserTest : RobolectricTest() {
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("27", dueString(col, c))
-        c.type = Consts.CARD_TYPE_LRN
+        c.type = CardType.LRN
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         Assert.assertEquals("", nextDue(col, c))
@@ -1182,7 +1183,7 @@ class CardBrowserTest : RobolectricTest() {
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("", dueString(col, c))
-        c.type = Consts.CARD_TYPE_REV
+        c.type = CardType.REV
 
         val cal2 = Calendar.getInstance()
         cal2.add(Calendar.DATE, 20)
@@ -1203,7 +1204,7 @@ class CardBrowserTest : RobolectricTest() {
         c.queue = Consts.QUEUE_TYPE_PREVIEW
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("", dueString(col, c))
-        c.type = Consts.CARD_TYPE_RELEARNING
+        c.type = CardType.RELEARNING
         c.due = id
         c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
         Assert.assertEquals("", nextDue(col, c))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -52,9 +52,9 @@ import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.BrowserConfig
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.CardType
-import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrowSuspend
@@ -560,8 +560,8 @@ class CardBrowserTest : RobolectricTest() {
             TimeManager.reset()
             addNoteUsingBasicModel("Hello", "World").firstCard().update {
                 due = 5
-                queue = Consts.QUEUE_TYPE_REV
-                type = CardType.REV
+                queue = QueueType.Rev
+                type = CardType.Rev
             }
             val cal = Calendar.getInstance()
             cal.add(Calendar.DATE, 5)
@@ -1148,78 +1148,78 @@ class CardBrowserTest : RobolectricTest() {
         cal.add(Calendar.DATE, 27)
 
         // Not filtered
-        c.type = CardType.NEW
+        c.type = CardType.New
         c.due = 27
-        c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
+        c.queue = QueueType.ManuallyBuried
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("(27)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
+        c.queue = QueueType.SiblingBuried
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("(27)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SUSPENDED
+        c.queue = QueueType.Suspended
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("(27)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_NEW
+        c.queue = QueueType.New
         c.due = 27
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("27", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_PREVIEW
+        c.queue = QueueType.Preview
         Assert.assertEquals("27", nextDue(col, c))
         Assert.assertEquals("27", dueString(col, c))
-        c.type = CardType.LRN
+        c.type = CardType.Lrn
         c.due = id
-        c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
+        c.queue = QueueType.ManuallyBuried
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
+        c.queue = QueueType.SiblingBuried
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SUSPENDED
+        c.queue = QueueType.Suspended
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_LRN
+        c.queue = QueueType.Lrn
         Assert.assertEquals(expectedDate, nextDue(col, c))
         Assert.assertEquals(expectedDate, dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_PREVIEW
+        c.queue = QueueType.Preview
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("", dueString(col, c))
-        c.type = CardType.REV
+        c.type = CardType.Rev
 
         val cal2 = Calendar.getInstance()
         cal2.add(Calendar.DATE, 20)
         val expectedDate2 = LanguageUtil.getShortDateFormatFromMs(cal2.timeInMillis)
         c.due = 20
-        c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
+        c.queue = QueueType.ManuallyBuried
         Assert.assertEquals(expectedDate2, nextDue(col, c))
         Assert.assertEquals("($expectedDate2)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
+        c.queue = QueueType.SiblingBuried
         Assert.assertEquals(expectedDate2, nextDue(col, c))
         Assert.assertEquals("($expectedDate2)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SUSPENDED
+        c.queue = QueueType.Suspended
         Assert.assertEquals(expectedDate2, nextDue(col, c))
         Assert.assertEquals("($expectedDate2)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_REV
+        c.queue = QueueType.Rev
         Assert.assertEquals(expectedDate2, nextDue(col, c))
         Assert.assertEquals(expectedDate2, dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_PREVIEW
+        c.queue = QueueType.Preview
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("", dueString(col, c))
-        c.type = CardType.RELEARNING
+        c.type = CardType.Relearning
         c.due = id
-        c.queue = Consts.QUEUE_TYPE_MANUALLY_BURIED
+        c.queue = QueueType.ManuallyBuried
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
+        c.queue = QueueType.SiblingBuried
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SUSPENDED
+        c.queue = QueueType.Suspended
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("()", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_LRN
+        c.queue = QueueType.Lrn
         c.due = id
         Assert.assertEquals(expectedDate, nextDue(col, c))
         Assert.assertEquals(expectedDate, dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_PREVIEW
+        c.queue = QueueType.Preview
         Assert.assertEquals("", nextDue(col, c))
         Assert.assertEquals("", dueString(col, c))
 
@@ -1229,7 +1229,7 @@ class CardBrowserTest : RobolectricTest() {
         c.did = dyn
         Assert.assertEquals("(filtered)", nextDue(col, c))
         Assert.assertEquals("(filtered)", dueString(col, c))
-        c.queue = Consts.QUEUE_TYPE_SIBLING_BURIED
+        c.queue = QueueType.SiblingBuried
         Assert.assertEquals("(filtered)", nextDue(col, c))
         Assert.assertEquals("((filtered))", dueString(col, c))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.preferences.PreferenceTestUtils
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ActionButtonStatus
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
@@ -509,7 +510,7 @@ class ReviewerTest : RobolectricTest() {
     private fun Card.moveToReviewQueue() {
         update {
             queue = Consts.QUEUE_TYPE_REV
-            type = Consts.CARD_TYPE_REV
+            type = CardType.REV
             due = 0
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -38,9 +38,9 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.ActionButtonStatus
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardType
-import com.ichi2.libanki.Consts
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.undoableOp
 import com.ichi2.libanki.utils.TimeManager
@@ -509,8 +509,8 @@ class ReviewerTest : RobolectricTest() {
 
     private fun Card.moveToReviewQueue() {
         update {
-            queue = Consts.QUEUE_TYPE_REV
-            type = CardType.REV
+            queue = QueueType.Rev
+            type = CardType.Rev
             due = 0
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -43,11 +43,11 @@ import com.ichi2.anki.model.SortType.SORT_FIELD
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.utils.ext.ifNotZero
-import com.ichi2.libanki.Consts.QUEUE_TYPE_MANUALLY_BURIED
-import com.ichi2.libanki.Consts.QUEUE_TYPE_NEW
-import com.ichi2.libanki.Consts.QUEUE_TYPE_SUSPENDED
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Note
+import com.ichi2.libanki.QueueType
+import com.ichi2.libanki.QueueType.ManuallyBuried
+import com.ichi2.libanki.QueueType.New
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.TestClass
@@ -220,15 +220,15 @@ class CardBrowserViewModelTest : JvmTest() {
 
             suspend fun getQueue() = col.getCard(queryAllSelectedCardIds().single()).queue
 
-            assertThat("initial queue = NEW", getQueue(), equalTo(QUEUE_TYPE_NEW))
+            assertThat("initial queue = NEW", getQueue(), equalTo(New))
 
             toggleBury()
 
-            assertThat("bury: queue -> MANUALLY_BURIED", getQueue(), equalTo(QUEUE_TYPE_MANUALLY_BURIED))
+            assertThat("bury: queue -> MANUALLY_BURIED", getQueue(), equalTo(ManuallyBuried))
 
             toggleBury()
 
-            assertThat("unbury: queue -> NEW", getQueue(), equalTo(QUEUE_TYPE_NEW))
+            assertThat("unbury: queue -> NEW", getQueue(), equalTo(New))
         }
 
     @Test
@@ -877,7 +877,7 @@ private fun TestClass.assertAllSuspended(context: String) {
         assertThat(
             "$context: all cards are unsuspended",
             card.queue,
-            equalTo(QUEUE_TYPE_SUSPENDED),
+            equalTo(QueueType.Suspended),
         )
     }
 }
@@ -890,7 +890,7 @@ private fun TestClass.assertAllUnsuspended(context: String) {
         assertThat(
             "$context: all cards unsuspended",
             card.queue,
-            not(equalTo(QUEUE_TYPE_SUSPENDED)),
+            not(equalTo(QueueType.Suspended)),
         )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.ImageField
 import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.servicelayer.NoteService
-import com.ichi2.libanki.Consts
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.testutils.createTransientFile
@@ -283,7 +283,7 @@ class NoteServiceTest : RobolectricTest() {
         // factor for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {
             card.update {
-                type = Consts.CARD_TYPE_REV
+                type = CardType.REV
                 factor = 3000 / (i + 1)
             }
         }
@@ -292,13 +292,13 @@ class NoteServiceTest : RobolectricTest() {
 
         // test case: one card is new
         note.cards()[2].update {
-            type = Consts.CARD_TYPE_NEW
+            type = CardType.NEW
         }
         // avg ease = (3000/10 + 1500/10 + 750/10) / 3 = [175] = 175
         assertEquals(175, NoteService.avgEase(col, note))
 
         // test case: all cards are new
-        note.updateCards { type = Consts.CARD_TYPE_NEW }
+        note.updateCards { type = CardType.NEW }
         // no cards are rev, so avg ease cannot be calculated
         assertEquals(null, NoteService.avgEase(col, note))
     }
@@ -307,8 +307,8 @@ class NoteServiceTest : RobolectricTest() {
     fun testAvgInterval() {
         // basic case: all cards are relearning or review
         val note = addNoteUsingModelName("Cloze", "{{c1::Hello}}{{c2::World}}{{c3::foo}}{{c4::bar}}", "extra")
-        val reviewOrRelearningList = listOf(Consts.CARD_TYPE_REV, Consts.CARD_TYPE_RELEARNING)
-        val newOrLearningList = listOf(Consts.CARD_TYPE_NEW, Consts.CARD_TYPE_LRN)
+        val reviewOrRelearningList = listOf(CardType.REV, CardType.RELEARNING)
+        val newOrLearningList = listOf(CardType.NEW, CardType.LRN)
 
         // interval for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -283,7 +283,7 @@ class NoteServiceTest : RobolectricTest() {
         // factor for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {
             card.update {
-                type = CardType.REV
+                type = CardType.Rev
                 factor = 3000 / (i + 1)
             }
         }
@@ -292,13 +292,13 @@ class NoteServiceTest : RobolectricTest() {
 
         // test case: one card is new
         note.cards()[2].update {
-            type = CardType.NEW
+            type = CardType.New
         }
         // avg ease = (3000/10 + 1500/10 + 750/10) / 3 = [175] = 175
         assertEquals(175, NoteService.avgEase(col, note))
 
         // test case: all cards are new
-        note.updateCards { type = CardType.NEW }
+        note.updateCards { type = CardType.New }
         // no cards are rev, so avg ease cannot be calculated
         assertEquals(null, NoteService.avgEase(col, note))
     }
@@ -307,8 +307,8 @@ class NoteServiceTest : RobolectricTest() {
     fun testAvgInterval() {
         // basic case: all cards are relearning or review
         val note = addNoteUsingModelName("Cloze", "{{c1::Hello}}{{c2::World}}{{c3::foo}}{{c4::bar}}", "extra")
-        val reviewOrRelearningList = listOf(CardType.REV, CardType.RELEARNING)
-        val newOrLearningList = listOf(CardType.NEW, CardType.LRN)
+        val reviewOrRelearningList = listOf(CardType.Rev, CardType.Relearning)
+        val newOrLearningList = listOf(CardType.New, CardType.Lrn)
 
         // interval for cards: 3000, 1500, 1000, 750
         for ((i, card) in note.cards().withIndex()) {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -17,9 +17,7 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Ease
-import com.ichi2.libanki.CardType.REV
-import com.ichi2.libanki.Consts.QUEUE_TYPE_REV
-import com.ichi2.libanki.Consts.QUEUE_TYPE_SUSPENDED
+import com.ichi2.libanki.QueueType.Suspended
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.TimeManager
@@ -89,7 +87,7 @@ class FinderTest : JvmTest() {
     ): Card {
         sched.answerCard(toManuallyBury, Ease.AGAIN)
         val siblingBuried = Note(col, toManuallyBury.nid).cards()[1]
-        assertThat(siblingBuried.queue, equalTo(Consts.QUEUE_TYPE_SIBLING_BURIED))
+        assertThat(siblingBuried.queue, equalTo(QueueType.SiblingBuried))
         return siblingBuried
     }
 
@@ -101,7 +99,7 @@ class FinderTest : JvmTest() {
         val manuallyBuriedCard = Card(col, id)
         assertThat(
             manuallyBuriedCard.queue,
-            equalTo(Consts.QUEUE_TYPE_MANUALLY_BURIED),
+            equalTo(QueueType.ManuallyBuried),
         )
         return manuallyBuriedCard
     }
@@ -184,8 +182,8 @@ class FinderTest : JvmTest() {
         var c =
             note.cards()[0].apply {
                 due = 999999
-                queue = QUEUE_TYPE_REV
-                type = REV
+                queue = QueueType.Rev
+                type = CardType.Rev
             }
         assertEquals(0, col.findCards("is:review").size)
         col.updateCard(c, skipUndoEntry = true)
@@ -193,12 +191,12 @@ class FinderTest : JvmTest() {
         assertEquals(0, col.findCards("is:due").size)
         c.update {
             due = 0
-            queue = QUEUE_TYPE_REV
+            queue = QueueType.Rev
         }
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:due"))
         assertEquals(4, col.findCards("-is:due").size)
         // ensure this card gets a later mod time
-        c.update { queue = QUEUE_TYPE_SUSPENDED }
+        c.update { queue = Suspended }
         col.db.execute("update cards set mod = mod + 1 where id = ?", c.id)
         AnkiAssert.assertEqualsArrayList(arrayOf(c.id), col.findCards("is:suspended"))
         // nids

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -17,7 +17,7 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Ease
-import com.ichi2.libanki.Consts.CARD_TYPE_REV
+import com.ichi2.libanki.CardType.REV
 import com.ichi2.libanki.Consts.QUEUE_TYPE_REV
 import com.ichi2.libanki.Consts.QUEUE_TYPE_SUSPENDED
 import com.ichi2.libanki.exception.ConfirmModSchemaException
@@ -185,7 +185,7 @@ class FinderTest : JvmTest() {
             note.cards()[0].apply {
                 due = 999999
                 queue = QUEUE_TYPE_REV
-                type = CARD_TYPE_REV
+                type = REV
             }
         assertEquals(0, col.findCards("is:review").size)
         col.updateCard(c, skipUndoEntry = true)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -19,10 +19,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.scheduler.UnburyDeckRequest
 import com.ichi2.anki.Ease
 import com.ichi2.anki.utils.SECONDS_PER_DAY
-import com.ichi2.libanki.Consts.CARD_TYPE_LRN
-import com.ichi2.libanki.Consts.CARD_TYPE_NEW
-import com.ichi2.libanki.Consts.CARD_TYPE_RELEARNING
-import com.ichi2.libanki.Consts.CARD_TYPE_REV
+import com.ichi2.libanki.CardType.LRN
+import com.ichi2.libanki.CardType.NEW
+import com.ichi2.libanki.CardType.RELEARNING
+import com.ichi2.libanki.CardType.REV
 import com.ichi2.libanki.Consts.LEECH_SUSPEND
 import com.ichi2.libanki.Consts.QUEUE_TYPE_DAY_LEARN_RELEARN
 import com.ichi2.libanki.Consts.QUEUE_TYPE_LRN
@@ -92,12 +92,12 @@ open class SchedulerTest : JvmTest() {
         val c = col.sched.card!!
         assertNotNull(c)
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
-        Assert.assertEquals(CARD_TYPE_NEW, c.type)
+        Assert.assertEquals(NEW, c.type)
         // if we answer it, it should become a learn card
         val t = time.intTime().toInt()
         col.sched.answerCard(c, Ease.AGAIN)
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
-        Assert.assertEquals(CARD_TYPE_LRN, c.type)
+        Assert.assertEquals(LRN, c.type)
         MatcherAssert.assertThat(c.due, Matchers.greaterThanOrEqualTo(t))
 
         // disabled for now, as the learn fudging makes this randomly fail
@@ -238,20 +238,20 @@ open class SchedulerTest : JvmTest() {
         Assert.assertEquals(1, (c.left % 1000).toLong())
         // the next pass should graduate the card
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
-        Assert.assertEquals(CARD_TYPE_LRN, c.type)
+        Assert.assertEquals(LRN, c.type)
         col.sched.answerCard(c, Ease.GOOD)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
-        Assert.assertEquals(CARD_TYPE_REV, c.type)
+        Assert.assertEquals(REV, c.type)
         // should be due tomorrow, with an interval of 1
         Assert.assertEquals((col.sched.today + 1), c.due)
         Assert.assertEquals(1, c.ivl)
         // or normal removal
         c.update {
-            type = CARD_TYPE_NEW
+            type = NEW
             queue = QUEUE_TYPE_LRN
         }
         col.sched.answerCard(c, Ease.EASY)
-        Assert.assertEquals(CARD_TYPE_REV, c.type)
+        Assert.assertEquals(REV, c.type)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         Assert.assertTrue(AnkiAssert.checkRevIvl(c, 4))
         // revlog should have been updated each time
@@ -273,7 +273,7 @@ open class SchedulerTest : JvmTest() {
                 ivl = 100
                 due = col.sched.today
                 queue = QUEUE_TYPE_REV
-                type = CARD_TYPE_REV
+                type = REV
             }
         col.updateCard(c, skipUndoEntry = true)
 
@@ -281,12 +281,12 @@ open class SchedulerTest : JvmTest() {
         c = col.sched.card!!
         col.sched.answerCard(c, Ease.AGAIN)
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
-        Assert.assertEquals(CARD_TYPE_RELEARNING, c.type)
+        Assert.assertEquals(RELEARNING, c.type)
         Assert.assertEquals(1, c.ivl)
 
         // immediately graduate it
         col.sched.answerCard(c, Ease.EASY)
-        Assert.assertEquals(CARD_TYPE_REV, c.type)
+        Assert.assertEquals(REV, c.type)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         Assert.assertEquals(2, c.ivl)
         Assert.assertEquals((col.sched.today + c.ivl), c.due)
@@ -303,7 +303,7 @@ open class SchedulerTest : JvmTest() {
                 ivl = 100
                 due = col.sched.today
                 queue = QUEUE_TYPE_REV
-                type = CARD_TYPE_REV
+                type = REV
             }
         col.updateCard(c, skipUndoEntry = true)
         val conf = col.decks.configDictForDeckId(1)
@@ -313,7 +313,7 @@ open class SchedulerTest : JvmTest() {
         // fail the card
         c = col.sched.card!!
         col.sched.answerCard(c, Ease.AGAIN)
-        Assert.assertEquals(CARD_TYPE_REV, c.type)
+        Assert.assertEquals(REV, c.type)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
     }
 
@@ -385,7 +385,7 @@ open class SchedulerTest : JvmTest() {
         // the last pass should graduate it into a review card
         Assert.assertEquals(SECONDS_PER_DAY, col.sched.nextIvl(c, Ease.GOOD))
         col.sched.answerCard(c, Ease.GOOD)
-        Assert.assertEquals(CARD_TYPE_REV, c.type)
+        Assert.assertEquals(REV, c.type)
         Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         // if the lapse step is tomorrow, failing it should handle the counts
         // correctly
@@ -412,7 +412,7 @@ open class SchedulerTest : JvmTest() {
         // set the card up as a review card, due 8 days ago
         var c =
             note.cards()[0].apply {
-                type = CARD_TYPE_REV
+                type = REV
                 queue = QUEUE_TYPE_REV
                 due = (col.sched.today - 8)
                 factor = STARTING_FACTOR
@@ -489,7 +489,7 @@ open class SchedulerTest : JvmTest() {
         // 1 day ivl review card due now
         val c =
             note.cards()[0].update {
-                type = CARD_TYPE_REV
+                type = REV
                 queue = QUEUE_TYPE_REV
                 due = col.sched.today
                 reps = 1
@@ -606,7 +606,7 @@ open class SchedulerTest : JvmTest() {
         // lapsed cards
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c.update {
-            type = CARD_TYPE_RELEARNING
+            type = RELEARNING
             ivl = 100
             factor = STARTING_FACTOR
         }
@@ -616,7 +616,7 @@ open class SchedulerTest : JvmTest() {
         // review cards
         // //////////////////////////////////////////////////////////////////////////////////////////////////
         c.update {
-            type = CARD_TYPE_REV
+            type = REV
             queue = QUEUE_TYPE_REV
             ivl = 100
             factor = STARTING_FACTOR
@@ -695,7 +695,7 @@ open class SchedulerTest : JvmTest() {
         c.update {
             due = 0
             ivl = 100
-            type = CARD_TYPE_REV
+            type = REV
             queue = QUEUE_TYPE_REV
         }
         c = col.sched.card!!
@@ -706,12 +706,12 @@ open class SchedulerTest : JvmTest() {
         )
         val due = c.due
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
-        Assert.assertEquals(CARD_TYPE_RELEARNING, c.type)
+        Assert.assertEquals(RELEARNING, c.type)
         col.sched.suspendCards(listOf(c.id))
         col.sched.unsuspendCards(listOf(c.id))
         c.load()
         Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
-        Assert.assertEquals(CARD_TYPE_RELEARNING, c.type)
+        Assert.assertEquals(RELEARNING, c.type)
         Assert.assertEquals(due, c.due)
         // should cope with cards in cram decks
         c.update { this.due = 1 }
@@ -738,7 +738,7 @@ open class SchedulerTest : JvmTest() {
             note.cards()[0].update {
                 ivl = 100
                 queue = QUEUE_TYPE_REV
-                type = CARD_TYPE_REV
+                type = REV
                 // due in 25 days, so it's been waiting 75 days
                 due = (col.sched.today + 25)
                 mod = 1
@@ -813,12 +813,12 @@ open class SchedulerTest : JvmTest() {
         conf.getJSONObject("new").put("delays", JSONArray(doubleArrayOf(1.0, 10.0, 61.0)))
         col.decks.save(conf)
         col.sched.answerCard(c, Ease.AGAIN)
-        Assert.assertEquals(CARD_TYPE_LRN, c.queue)
-        Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
+        Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
+        Assert.assertEquals(LRN, c.type)
         Assert.assertEquals(3, c.left % 1000)
         col.sched.answerCard(c, Ease.GOOD)
-        Assert.assertEquals(CARD_TYPE_LRN, c.queue)
-        Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
+        Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
+        Assert.assertEquals(LRN, c.type)
 
         // create a dynamic deck and refresh it
         val did = addDynamicDeck("Cram")
@@ -826,8 +826,8 @@ open class SchedulerTest : JvmTest() {
 
         // card should still be in learning state
         c.load()
-        Assert.assertEquals(CARD_TYPE_LRN, c.queue)
-        Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
+        Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
+        Assert.assertEquals(LRN, c.type)
         Assert.assertEquals(2, c.left % 1000)
 
         // should be able to advance learning steps
@@ -841,8 +841,8 @@ open class SchedulerTest : JvmTest() {
         // emptying the deck preserves learning state
         col.sched.emptyDyn(did)
         c.load()
-        Assert.assertEquals(CARD_TYPE_LRN, c.queue)
-        Assert.assertEquals(QUEUE_TYPE_LRN, c.type)
+        Assert.assertEquals(QUEUE_TYPE_LRN, c.queue)
+        Assert.assertEquals(LRN, c.type)
         Assert.assertEquals(1, c.left % 1000)
         MatcherAssert.assertThat(
             c.due - time.intTime(),
@@ -883,14 +883,14 @@ open class SchedulerTest : JvmTest() {
         col.sched.answerCard(c2, Ease.EASY)
         Assert.assertEquals(QUEUE_TYPE_NEW, c2.queue)
         Assert.assertEquals(0, c2.reps)
-        Assert.assertEquals(CARD_TYPE_NEW, c2.type)
+        Assert.assertEquals(NEW, c2.type)
 
         // emptying the filtered deck should restore card
         col.sched.emptyDyn(did)
         c.load()
         Assert.assertEquals(QUEUE_TYPE_NEW, c.queue)
         Assert.assertEquals(0, c.reps)
-        Assert.assertEquals(CARD_TYPE_NEW, c.type)
+        Assert.assertEquals(NEW, c.type)
     }
 
     @Test
@@ -1005,7 +1005,7 @@ open class SchedulerTest : JvmTest() {
         note.setItem("Front", "three")
         col.addNote(note)
         note.cards()[0].update {
-            type = CARD_TYPE_REV
+            type = REV
             queue = QUEUE_TYPE_REV
             due = col.sched.today
         }
@@ -1023,7 +1023,7 @@ open class SchedulerTest : JvmTest() {
             note.setItem("Front", "num$i")
             col.addNote(note)
             note.cards()[0].update {
-                type = CARD_TYPE_REV
+                type = REV
                 queue = QUEUE_TYPE_REV
                 due = 0
             }
@@ -1202,7 +1202,7 @@ open class SchedulerTest : JvmTest() {
         val c =
             note.cards()[0].update {
                 queue = QUEUE_TYPE_REV
-                type = CARD_TYPE_REV
+                type = REV
                 ivl = 100
                 due = 0
             }
@@ -1224,8 +1224,8 @@ open class SchedulerTest : JvmTest() {
         c.load()
         Assert.assertEquals(col.sched.today, c.due)
         Assert.assertEquals(1, c.ivl)
-        Assert.assertEquals(QUEUE_TYPE_REV, c.type)
-        Assert.assertEquals(CARD_TYPE_REV, c.queue)
+        Assert.assertEquals(REV, c.type)
+        Assert.assertEquals(QUEUE_TYPE_REV, c.queue)
         col.sched.reschedCards(listOf(c.id), 1, 1)
         c.load()
         Assert.assertEquals((col.sched.today + 1), c.due)
@@ -1241,7 +1241,7 @@ open class SchedulerTest : JvmTest() {
         col.addNote(note)
         val c =
             note.cards()[0].update {
-                type = CARD_TYPE_REV
+                type = REV
                 queue = QUEUE_TYPE_REV
                 due = 0
                 factor = STARTING_FACTOR
@@ -1267,7 +1267,7 @@ open class SchedulerTest : JvmTest() {
         col.addNote(note)
         var c =
             note.cards()[0].update {
-                type = CARD_TYPE_REV
+                type = REV
                 queue = QUEUE_TYPE_REV
                 ivl = 100
                 due = (col.sched.today - ivl)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -28,6 +28,7 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
+import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.set
 import kotlinx.coroutines.Dispatchers
@@ -59,8 +60,8 @@ interface TestClass {
     ): Note {
         val note = addNoteUsingBasicModel(front, back)
         val card = note.firstCard()
-        card.queue = Consts.QUEUE_TYPE_REV
-        card.type = CardType.REV
+        card.queue = QueueType.Rev
+        card.type = CardType.Rev
         card.due = col.sched.today
         return note
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -20,6 +20,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.ioDispatcher
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckConfig
@@ -59,7 +60,7 @@ interface TestClass {
         val note = addNoteUsingBasicModel(front, back)
         val card = note.firstCard()
         card.queue = Consts.QUEUE_TYPE_REV
-        card.type = Consts.CARD_TYPE_REV
+        card.type = CardType.REV
         card.due = col.sched.today
         return note
     }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/CollectionAssert.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/libanki/CollectionAssert.kt
@@ -17,7 +17,7 @@ package com.ichi2.testutils.libanki
 
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.Consts
+import com.ichi2.libanki.QueueType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 
@@ -26,6 +26,6 @@ object CollectionAssert {
         collection: Collection,
         cardId: CardId,
     ) {
-        assertThat("Card should be suspended", collection.getCard(cardId).queue, equalTo(Consts.QUEUE_TYPE_SUSPENDED))
+        assertThat("Card should be suspended", collection.getCard(cardId).queue, equalTo(QueueType.Suspended))
     }
 }


### PR DESCRIPTION
This PR should be merged after #17430. It contains #17430 and removing #17430 would create a ton of merge conflict.

It transforms IntDef of Consts.kt into enum

* https://github.com/ankidroid/Anki-Android/labels/Blocked%20by%20dependency https://github.com/ankidroid/Anki-Android/pull/17430