### PR TITLE
NF: Use enum for flag everywhere possible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -239,7 +239,7 @@ open class AnkiDroidJsAPI(private val activity: AbstractFlashcardViewer) {
                 convertToByteArray(apiContract, true)
             }
             "cardMark" -> convertToByteArray(apiContract, currentCard.note(getColUnsafe).hasTag(getColUnsafe, "marked"))
-            "cardFlag" -> convertToByteArray(apiContract, currentCard.userFlag())
+            "cardFlag" -> convertToByteArray(apiContract, currentCard.userFlag().code)
             "cardReps" -> convertToByteArray(apiContract, currentCard.reps)
             "cardInterval" -> convertToByteArray(apiContract, currentCard.ivl)
             "cardFactor" -> convertToByteArray(apiContract, currentCard.factor)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1029,7 +1029,7 @@ open class CardBrowser :
             }
 
             for ((flag, displayName) in Flag.queryDisplayNames()) {
-                subMenu.add(groupId, flag.ordinal, Menu.NONE, displayName)
+                subMenu.add(groupId, flag.code, Menu.NONE, displayName)
                     .setIcon(flag.drawableRes)
             }
         }
@@ -2161,7 +2161,7 @@ open class CardBrowser :
          */
         @ColorInt
         fun getBackgroundColor(context: Context): Int {
-            val flagColor = Flag.fromCode(card.userFlag()).browserColorRes
+            val flagColor = card.userFlag().browserColorRes
             if (flagColor != null) {
                 return context.getColor(flagColor)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -21,26 +21,56 @@ import androidx.annotation.IdRes
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.utils.ext.getStringOrNull
-import com.ichi2.libanki.Card
-import com.ichi2.libanki.CardId
-import com.ichi2.libanki.Collection
 import org.json.JSONObject
-import timber.log.Timber
 
 enum class Flag(
     val code: Int,
+    /**
+     * A Unique ID representing this flag in a menu.
+     */
     @IdRes val id: Int,
+    /**
+     * Flag drawn to represents this flag.
+     */
     @DrawableRes val drawableRes: Int,
-    @ColorRes val browserColorRes: Int?
+    /**
+     * Color for the background of cards with this flag in the card browser.
+     */
+    @ColorRes val browserColorRes: Int?,
+    /**
+     * Flag drawn to represents this flagInTheReviewer if it differs from [drawableRes].
+     * @TODO: Checks whether we can use colorControlNormal everywhere.
+     */
+    @DrawableRes val drawableReviewerRes: Int? = null
 ) {
-    NONE(0, R.id.flag_none, R.drawable.ic_flag_lightgrey, null),
+    NONE(0, R.id.flag_none, R.drawable.ic_flag_lightgrey, null, R.drawable.ic_flag_transparent),
     RED(1, R.id.flag_red, R.drawable.ic_flag_red, R.color.flag_red),
-    ORANGE(2, R.id.flag_orange, R.drawable.ic_flag_orange, R.color.flag_orange),
+    ORANGE(
+        2,
+        R.id.flag_orange,
+        R.drawable.ic_flag_orange,
+        R.color.flag_orange
+    ),
     GREEN(3, R.id.flag_green, R.drawable.ic_flag_green, R.color.flag_green),
     BLUE(4, R.id.flag_blue, R.drawable.ic_flag_blue, R.color.flag_blue),
     PINK(5, R.id.flag_pink, R.drawable.ic_flag_pink, R.color.flag_pink),
-    TURQUOISE(6, R.id.flag_turquoise, R.drawable.ic_flag_turquoise, R.color.flag_turquoise),
-    PURPLE(7, R.id.flag_purple, R.drawable.ic_flag_purple, R.color.flag_purple);
+    TURQUOISE(
+        6,
+        R.id.flag_turquoise,
+        R.drawable.ic_flag_turquoise,
+        R.color.flag_turquoise
+    ),
+    PURPLE(
+        7,
+        R.id.flag_purple,
+        R.drawable.ic_flag_purple,
+        R.color.flag_purple
+    );
+
+    /**
+     * Flag drawn to represents this flagInTheReviewer.
+     */
+    @DrawableRes fun drawableReviewerRes() = drawableReviewerRes ?: drawableRes
 
     /**
      * Retrieves the name associated with the flag. This may be user-defined
@@ -75,9 +105,7 @@ enum class Flag(
     }
 
     companion object {
-        fun fromCode(code: Int): Flag {
-            return entries.first { it.code == code }
-        }
+        fun fromCode(code: Int) = Flag.entries.first { it.code == code }
 
         /**
          * @return A mapping from each [Flag] to its display name (optionally user-defined)
@@ -103,7 +131,7 @@ private value class FlagLabels(val value: JSONObject) {
      */
     fun getLabel(flag: Flag): String? = value.getStringOrNull(flag.code.toString())
     suspend fun updateName(flag: Flag, newName: String) {
-        value.put(flag.ordinal.toString(), newName)
+        value.put(flag.code.toString(), newName)
         withCol {
             config.set("flagLabels", value)
         }
@@ -114,9 +142,3 @@ private value class FlagLabels(val value: JSONObject) {
             FlagLabels(withCol { config.getObject("flagLabels", JSONObject()) })
     }
 }
-
-fun Collection.setUserFlag(flag: Flag, cids: List<CardId>) {
-    Timber.d("Flagging %d card(s) as %s", cids.size, flag)
-    this.setUserFlag(flag.code, cids)
-}
-fun Card.setUserFlag(flag: Flag) = this.setUserFlag(flag.code)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FlagToDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FlagToDisplay.kt
@@ -16,16 +16,16 @@
 package com.ichi2.anki
 
 class FlagToDisplay(
-    private val actualFlag: Int,
+    private val actualFlag: Flag,
     private val isOnAppBar: Boolean,
     private val isFullscreen: Boolean
 ) {
 
-    fun get(): Int {
+    fun get(): Flag {
         return when {
             !isOnAppBar -> actualFlag
             isFullscreen -> actualFlag
-            else -> Flag.NONE.code
+            else -> Flag.NONE
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -251,7 +251,7 @@ open class Reviewer :
         server.stop()
     }
 
-    protected val flagToDisplay: Int
+    protected val flagToDisplay: Flag
         get() {
             return FlagToDisplay(
                 currentCard!!.userFlag(),
@@ -302,9 +302,9 @@ open class Reviewer :
             return
         }
         launchCatchingTask {
-            card.setUserFlag(flag.code)
+            card.setUserFlag(flag)
             undoableOp(this@Reviewer) {
-                setUserFlagForCards(listOf(card.id), flag.code)
+                setUserFlagForCards(listOf(card.id), flag)
             }
             refreshActionBar()
             onFlagChanged()
@@ -315,7 +315,7 @@ open class Reviewer :
         if (currentCard == null) {
             return
         }
-        cardMarker!!.displayFlag(Flag.fromCode(flagToDisplay))
+        cardMarker!!.displayFlag(flagToDisplay)
     }
 
     private fun selectDeckFromExtra() {
@@ -726,16 +726,7 @@ open class Reviewer :
         val flagIcon = menu.findItem(R.id.action_flag)
         if (flagIcon != null) {
             if (currentCard != null) {
-                when (currentCard!!.userFlag()) {
-                    1 -> flagIcon.setIcon(R.drawable.ic_flag_red)
-                    2 -> flagIcon.setIcon(R.drawable.ic_flag_orange)
-                    3 -> flagIcon.setIcon(R.drawable.ic_flag_green)
-                    4 -> flagIcon.setIcon(R.drawable.ic_flag_blue)
-                    5 -> flagIcon.setIcon(R.drawable.ic_flag_pink)
-                    6 -> flagIcon.setIcon(R.drawable.ic_flag_turquoise)
-                    7 -> flagIcon.setIcon(R.drawable.ic_flag_purple)
-                    else -> flagIcon.setIcon(R.drawable.ic_flag_transparent)
-                }
+                flagIcon.setIcon(currentCard!!.userFlag().drawableReviewerRes())
             }
             flagIcon.iconAlpha = alpha
         }
@@ -873,7 +864,7 @@ open class Reviewer :
     private fun setupFlags(subMenu: SubMenu) {
         lifecycleScope.launch {
             for ((flag, displayName) in Flag.queryDisplayNames()) {
-                val menuItem = subMenu.add(Menu.NONE, flag.ordinal, Menu.NONE, displayName)
+                val menuItem = subMenu.add(Menu.NONE, flag.code, Menu.NONE, displayName)
                     .setIcon(flag.drawableRes)
                 flagItemIds.add(menuItem.itemId)
             }
@@ -1312,7 +1303,7 @@ open class Reviewer :
     }
 
     private fun toggleFlag(flag: Flag) {
-        if (currentCard!!.userFlag() == flag.code) {
+        if (currentCard!!.userFlag() == flag) {
             Timber.i("Toggle flag: unsetting flag")
             onFlag(currentCard, Flag.NONE)
         } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -42,7 +42,6 @@ import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.SortType
 import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.preferences.SharedPreferencesProvider
-import com.ichi2.anki.setUserFlag
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
@@ -104,7 +104,7 @@ class FlagAdapter(private val lifecycleScope: CoroutineScope) :
 
     class FlagItemDiffCallback : DiffUtil.ItemCallback<FlagItem>() {
         override fun areItemsTheSame(oldItem: FlagItem, newItem: FlagItem): Boolean {
-            return oldItem.ordinal == newItem.ordinal
+            return oldItem.flag == newItem.flag
         }
 
         override fun areContentsTheSame(oldItem: FlagItem, newItem: FlagItem): Boolean {
@@ -116,13 +116,13 @@ class FlagAdapter(private val lifecycleScope: CoroutineScope) :
 /**
  * Data class representing a flag item.
  *
- * @property ordinal The ordinal value of the flag.
+ * @property flag The ordinal value of the flag.
  * @property title The title or name of the flag.
  * @property icon The icon resource ID of the flag.
  * @property isInEditMode Whether the flag is being edited.
  */
 data class FlagItem(
-    val ordinal: Int,
+    val flag: Flag,
     val title: String,
     val icon: Int,
     var isInEditMode: Boolean = false
@@ -132,5 +132,5 @@ data class FlagItem(
      *
      * @param newName The new name for the flag.
      */
-    suspend fun renameTo(newName: String) = Flag.fromCode(ordinal).rename(newName)
+    suspend fun renameTo(newName: String) = flag.rename(newName)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagRenameDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagRenameDialog.kt
@@ -80,7 +80,7 @@ class FlagRenameDialog : DialogFragment() {
             .filter { it.key != Flag.NONE }
             .map { (flag, displayName) ->
                 FlagItem(
-                    ordinal = flag.code,
+                    flag = flag,
                     title = displayName,
                     icon = flag.drawableRes
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -123,10 +123,10 @@ class PreviewerFragment :
 
         // handle selection of a new flag
         lifecycleScope.launch {
-            viewModel.flagCode
+            viewModel.flag
                 .flowWithLifecycle(lifecycle)
-                .collectLatest { flagCode ->
-                    menu.findItem(R.id.action_flag).setIcon(Flag.fromCode(flagCode).drawableRes)
+                .collectLatest { flag ->
+                    menu.findItem(R.id.action_flag).setIcon(flag.drawableRes)
                 }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -52,7 +52,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
     val currentIndex = MutableStateFlow(firstIndex)
     val backSideOnly = MutableStateFlow(false)
     val isMarked = MutableStateFlow(false)
-    val flagCode: MutableStateFlow<Int> = MutableStateFlow(Flag.NONE.code)
+    val flag: MutableStateFlow<Flag> = MutableStateFlow(Flag.NONE)
     private val selectedCardIds: List<Long> = previewerIdsFile.getCardIds()
     val isBackButtonEnabled =
         combine(currentIndex, showingAnswer, backSideOnly) { index, showingAnswer, isBackSideOnly ->
@@ -124,14 +124,14 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
         launchCatchingIO {
             val card = currentCard.await()
             undoableOp {
-                setUserFlagForCards(listOf(card.id), flag.code)
+                setUserFlagForCards(listOf(card.id), flag)
             }
-            flagCode.emit(flag.code)
+            this.flag.emit(flag)
         }
     }
 
     fun toggleFlag(flag: Flag) {
-        if (flagCode.value == flag.code) {
+        if (this@PreviewerViewModel.flag.value == flag) {
             setFlag(Flag.NONE)
         } else {
             setFlag(flag)
@@ -210,7 +210,7 @@ class PreviewerViewModel(previewerIdsFile: PreviewerIdsFile, firstIndex: Int, ca
     }
 
     private suspend fun updateFlagIcon() {
-        flagCode.emit(currentCard.await().userFlag())
+        flag.emit(currentCard.await().userFlag())
     }
 
     private suspend fun updateMarkIcon() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -245,9 +245,9 @@ class ReviewerFragment :
             }
         }
 
-        viewModel.flagCodeFlow.flowWithLifecycle(lifecycle)
+        viewModel.flagFlow.flowWithLifecycle(lifecycle)
             .collectLatestIn(lifecycleScope) { flagCode ->
-                menu.findItem(R.id.action_flag).setIcon(Flag.fromCode(flagCode).drawableRes)
+                menu.findItem(R.id.action_flag).setIcon(flagCode.drawableRes)
             }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -69,7 +69,7 @@ class ReviewerViewModel(cardMediaPlayer: CardMediaPlayer) :
     }
     var isQueueFinishedFlow = MutableSharedFlow<Boolean>()
     val isMarkedFlow = MutableStateFlow(false)
-    val flagCodeFlow = MutableStateFlow(Flag.NONE.code)
+    val flagFlow = MutableStateFlow(Flag.NONE)
     val actionFeedbackFlow = MutableSharedFlow<String>()
     val canBuryNoteFlow = MutableStateFlow(true)
     val canSuspendNoteFlow = MutableStateFlow(true)
@@ -170,9 +170,9 @@ class ReviewerViewModel(cardMediaPlayer: CardMediaPlayer) :
         launchCatchingIO {
             val card = currentCard.await()
             undoableOp {
-                setUserFlagForCards(listOf(card.id), flag.code)
+                setUserFlagForCards(listOf(card.id), flag)
             }
-            flagCodeFlow.emit(flag.code)
+            flagFlow.emit(flag)
         }
     }
 
@@ -392,7 +392,7 @@ class ReviewerViewModel(cardMediaPlayer: CardMediaPlayer) :
         showQuestion()
         loadAndPlaySounds(CardSide.QUESTION)
         updateMarkedStatus()
-        flagCodeFlow.emit(card.userFlag())
+        flagFlow.emit(card.userFlag())
         canBuryNoteFlow.emit(isBuryNoteAvailable(card))
         canSuspendNoteFlow.emit(isSuspendNoteAvailable(card))
         countsFlow.emit(state.counts to state.countsIndex)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,6 +40,7 @@ import anki.search.BrowserRow
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
+import com.ichi2.anki.Flag
 import com.ichi2.libanki.Utils.ids2str
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.backend.model.toProtoBuf
@@ -632,14 +633,13 @@ class Collection(
     /**
      * Card Flags *****************************************************************************************************
      */
-    fun setUserFlag(flag: Int, cids: List<Long>) {
-        assert(flag in (0..7))
+    fun setUserFlag(flag: Flag, cids: List<Long>) {
         db.execute(
             "update cards set flags = (flags & ~?) | ?, usn=?, mod=? where id in " + ids2str(
                 cids
             ),
             7,
-            flag,
+            flag.code,
             usn(),
             TimeManager.time.intTime()
         )
@@ -683,8 +683,8 @@ class Collection(
 
     /** Change the flag color of the specified cards. flag=0 removes flag. */
     @CheckResult
-    fun setUserFlagForCards(cids: Iterable<Long>, flag: Int): OpChangesWithCount {
-        return backend.setFlag(cardIds = cids, flag = flag)
+    fun setUserFlagForCards(cids: Iterable<Long>, flag: Flag): OpChangesWithCount {
+        return backend.setFlag(cardIds = cids, flag = flag.code)
     }
 
     fun getEmptyCards(): EmptyCardsReport {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerCommandTest.kt
@@ -33,10 +33,11 @@ import org.hamcrest.Matchers.notNullValue
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
 import org.mockito.invocation.InvocationOnMock
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.whenever
 import org.robolectric.Robolectric
 
@@ -48,7 +49,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         viewer.executeCommand(TOGGLE_FLAG_RED)
         viewer.executeCommand(TOGGLE_FLAG_RED)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.NONE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.NONE))
     }
 
     @Test
@@ -57,7 +58,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(UNSET_FLAG)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.NONE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.NONE))
     }
 
     @Test
@@ -67,7 +68,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         viewer.executeCommand(UNSET_FLAG)
         viewer.executeCommand(UNSET_FLAG)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.NONE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.NONE))
     }
 
     @Test
@@ -77,7 +78,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         viewer.executeCommand(TOGGLE_FLAG_RED)
         viewer.executeCommand(TOGGLE_FLAG_BLUE)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.BLUE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.BLUE))
     }
 
     @Test
@@ -87,7 +88,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         viewer.executeCommand(TOGGLE_FLAG_RED)
         viewer.executeCommand(UNSET_FLAG)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.NONE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.NONE))
     }
 
     @Test
@@ -96,7 +97,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_RED)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.RED.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.RED))
     }
 
     @Test
@@ -105,7 +106,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_ORANGE)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.ORANGE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.ORANGE))
     }
 
     companion object {
@@ -151,7 +152,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_GREEN)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.GREEN.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.GREEN))
     }
 
     @Test
@@ -160,7 +161,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_BLUE)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.BLUE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.BLUE))
     }
 
     @Test
@@ -169,7 +170,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_PINK)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.PINK.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.PINK))
     }
 
     @Test
@@ -178,7 +179,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_TURQUOISE)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.TURQUOISE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.TURQUOISE))
     }
 
     @Test
@@ -187,7 +188,7 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
 
         viewer.executeCommand(TOGGLE_FLAG_PURPLE)
 
-        assertThat(viewer.lastFlag, equalTo(Flag.PURPLE.code))
+        assertThat(viewer.lastFlag, equalTo(Flag.PURPLE))
     }
 
     @Test
@@ -207,26 +208,25 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         viewer.executeCommand(command)
         viewer.executeCommand(command)
 
-        assertThat(command.toString(), viewer.lastFlag, equalTo(Flag.NONE.code))
+        assertThat(command.toString(), viewer.lastFlag, equalTo(Flag.NONE))
     }
 
     private fun createViewer(): CommandTestCardViewer {
-        return CommandTestCardViewer(cardWith(Flag.NONE.code))
+        return CommandTestCardViewer(cardWith(Flag.NONE))
     }
 
-    private fun cardWith(@Suppress("SameParameterValue") flag: Int): Card {
+    private fun cardWith(@Suppress("SameParameterValue") flag: Flag): Card {
         val c = mock(Card::class.java)
-        val flags = intArrayOf(flag)
+        val flags = arrayOf<Flag>(flag)
         whenever(c.userFlag()).then { flags[0] }
         doAnswer { invocation: InvocationOnMock ->
             flags[0] = invocation.getArgument(0)
-            null
-        }.whenever(c).setUserFlag(anyInt())
+        }.whenever(c).setUserFlag(anyOrNull())
         return c
     }
 
     private class CommandTestCardViewer(private var currentCardOverride: Card?) : Reviewer() {
-        var lastFlag = 0
+        var lastFlag = Flag.NONE
             private set
 
         override var currentCard: Card?
@@ -241,8 +241,8 @@ class AbstractFlashcardViewerCommandTest : RobolectricTest() {
         }
 
         override fun onFlag(card: Card?, flag: Flag) {
-            lastFlag = flag.code
-            currentCard!!.setUserFlag(flag.code)
+            lastFlag = flag
+            currentCard!!.setUserFlag(flag)
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -159,7 +159,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             getDataFromRequest("cardFlag", jsapi),
             equalTo(formatApiResult(0))
         )
-        reviewer.currentCard!!.setFlag(1)
+        reviewer.currentCard!!.setFlag(Flag.RED.ordinal)
         assertThat(
             getDataFromRequest("cardFlag", jsapi),
             equalTo(formatApiResult(1))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -360,7 +360,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(
             "Card should be flagged",
             getCheckedCard(cardBrowser).card.userFlag(),
-            equalTo(Flag.RED.code)
+            equalTo(Flag.RED)
         )
 
         // unflag the selected card
@@ -369,7 +369,7 @@ class CardBrowserTest : RobolectricTest() {
         assertThat(
             "Card flag should be removed",
             getCheckedCard(cardBrowser).card.userFlag(),
-            equalTo(Flag.NONE.code)
+            equalTo(Flag.NONE)
         )
 
         // deselect and select all cards
@@ -382,7 +382,7 @@ class CardBrowserTest : RobolectricTest() {
             "All cards should be flagged",
             cardBrowser.viewModel.queryAllCardIds()
                 .map { cardId -> getCardFlagAfterFlagChangeDone(cardBrowser, cardId) }
-                .all { flag1 -> flag1 == Flag.GREEN.code }
+                .all { flag1 -> flag1 == Flag.GREEN }
         )
     }
 
@@ -397,10 +397,10 @@ class CardBrowserTest : RobolectricTest() {
 
         val actualFlag = getCardFlagAfterFlagChangeDone(b, cardId)
 
-        assertThat("The card flag value should be reflected in the UI", actualFlag, equalTo(1))
+        assertThat("The card flag value should be reflected in the UI", actualFlag, equalTo(Flag.RED))
     }
 
-    private fun getCardFlagAfterFlagChangeDone(cardBrowser: CardBrowser, cardId: CardId): Int {
+    private fun getCardFlagAfterFlagChangeDone(cardBrowser: CardBrowser, cardId: CardId): Flag {
         return cardBrowser.getPropertiesForCardId(cardId).card.userFlag()
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/FlagToDisplayTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/FlagToDisplayTest.kt
@@ -10,24 +10,24 @@ class FlagToDisplayTest {
     @ParameterizedTest
     @EnumSource(value = Flag::class)
     fun `is hidden if flag is on app bar and fullscreen is disabled`(actualFlag: Flag) {
-        assertEquals(Flag.NONE.code, FlagToDisplay(actualFlag.code, isOnAppBar = true, isFullscreen = false).get())
+        assertEquals(Flag.NONE, FlagToDisplay(actualFlag, isOnAppBar = true, isFullscreen = false).get())
     }
 
     @ParameterizedTest
     @EnumSource(value = Flag::class)
     fun `is not hidden if flag is not on app bar and fullscreen is disabled`(actualFlag: Flag) {
-        assertEquals(actualFlag.code, FlagToDisplay(actualFlag.code, isOnAppBar = false, isFullscreen = false).get())
+        assertEquals(actualFlag, FlagToDisplay(actualFlag, isOnAppBar = false, isFullscreen = false).get())
     }
 
     @ParameterizedTest
     @EnumSource(value = Flag::class)
     fun `is not hidden if flag is not on app bar and fullscreen is enabled`(actualFlag: Flag) {
-        assertEquals(actualFlag.code, FlagToDisplay(actualFlag.code, isOnAppBar = false, isFullscreen = true).get())
+        assertEquals(actualFlag, FlagToDisplay(actualFlag, isOnAppBar = false, isFullscreen = true).get())
     }
 
     @ParameterizedTest
     @EnumSource(value = Flag::class)
     fun `is not hidden if flag is on app bar and fullscreen is enabled`(actualFlag: Flag) {
-        assertEquals(actualFlag.code, FlagToDisplay(actualFlag.code, isOnAppBar = true, isFullscreen = true).get())
+        assertEquals(actualFlag, FlagToDisplay(actualFlag, isOnAppBar = true, isFullscreen = true).get())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FlagTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.Flag
 import com.ichi2.testutils.JvmTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -38,36 +39,36 @@ class FlagTest : JvmTest() {
         val origBits = 0b101 shl 3
         c.update { setFlag(origBits) }
         // no flags to start with
-        assertEquals(0, c.userFlag())
+        assertEquals(Flag.NONE, c.userFlag())
         assertEquals(1, col.findCards("flag:0").size)
         assertEquals(0, col.findCards("flag:1").size)
         // set flag 2
-        col.setUserFlag(2, listOf(c.id))
+        col.setUserFlag(Flag.ORANGE, listOf(c.id))
         c.load()
-        assertEquals(2, c.userFlag())
+        assertEquals(Flag.ORANGE, c.userFlag())
         // assertEquals(origBits, c.flags & origBits);TODO: create direct access to real flag value
         assertEquals(0, col.findCards("flag:0").size)
         assertEquals(1, col.findCards("flag:2").size)
         assertEquals(0, col.findCards("flag:3").size)
         // change to 3
-        col.setUserFlag(3, listOf(c.id))
+        col.setUserFlag(Flag.GREEN, listOf(c.id))
         c.load()
-        assertEquals(3, c.userFlag())
+        assertEquals(Flag.GREEN, c.userFlag())
         // unset
-        col.setUserFlag(0, listOf(c.id))
+        col.setUserFlag(Flag.NONE, listOf(c.id))
         c.load()
-        assertEquals(0, c.userFlag())
+        assertEquals(Flag.NONE, c.userFlag())
 
         // should work with Cards method as well
-        c.setUserFlag(2)
-        assertEquals(2, c.userFlag())
-        c.setUserFlag(3)
-        assertEquals(3, c.userFlag())
-        c.setUserFlag(0)
-        assertEquals(0, c.userFlag())
+        c.setUserFlag(Flag.ORANGE)
+        assertEquals(Flag.ORANGE, c.userFlag())
+        c.setUserFlag(Flag.GREEN)
+        assertEquals(Flag.GREEN, c.userFlag())
+        c.setUserFlag(Flag.NONE)
+        assertEquals(Flag.NONE, c.userFlag())
 
         // test new flags
-        col.setUserFlag(7, listOf(c.id))
+        col.setUserFlag(Flag.PURPLE, listOf(c.id))
         assertEquals(1, col.findCards("flag:7").size)
     }
 }


### PR DESCRIPTION
It should be added that there is some ambiguity for the value of the flag. A flag could be either between 0 and 7, or an arbitrary int whose first 3 digits are the displayed flags.

Actually, the only time a number greater than 7 is generated, it's stored into the card's `flags` field, and never leave this object. So it's okay to use `Flag` object everywhere else.