### PR TITLE
Revert lint rule changes

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -22,14 +22,12 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
-<!--    At the time of writing, ankidroid minSdk is 23. This library requires API 24.-->
-<!--    In order to use it, we use <uses-sdk tools:overrideLibrary instead of-->
-<!--    <uses-feature android:name. We must ensure this is never called when running on API 23.-->
-    <uses-sdk tools:overrideLibrary="androidx.draganddrop"/>
 
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />
     <uses-feature android:name="android.software.app_widgets" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <!--    <uses-feature android:name. We must ensure this is never called when running on API 23.-->
+    <uses-feature android:name="androidx.draganddrop" android:required="false"/>
     <!-- `ScopedStorage` lint error is ignored:
         the recommended change is setting maxSDkVersion
          but this means preserveLegacyExternalStorage is inactive, and users do not have access to

--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -26,7 +26,6 @@
     <uses-feature android:name="android.hardware.audio.output" android:required="false" />
     <uses-feature android:name="android.software.app_widgets" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
-    <!--    <uses-feature android:name. We must ensure this is never called when running on API 23.-->
     <uses-feature android:name="androidx.draganddrop" android:required="false"/>
     <!-- `ScopedStorage` lint error is ignored:
         the recommended change is setting maxSDkVersion

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -159,8 +159,9 @@
 
     <issue id="ExpiredTargetSdkVersion" severity="fatal" />
     <issue id="ObsoleteLintCustomCheck" severity="fatal" />
-    <issue id="UnusedQuantity" severity="fatal" />
-    <issue id="MissingQuantity" severity="fatal" />
+    <!--          Revert lint rule changes [UnusedQuantity, MissingQuantity] from fatal to ignore             -->
+    <issue id="UnusedQuantity" severity="ignore" />
+    <issue id="MissingQuantity" severity="ignore" />
     <issue id="ExportedPreferenceActivity" severity="fatal" />
     <issue id="PrivateApi" severity="fatal" />
     <issue id="ProguardSplit" severity="fatal" />

--- a/testlib/src/main/AndroidManifest.xml
+++ b/testlib/src/main/AndroidManifest.xml
@@ -1,15 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:tools="http://schemas.android.com/tools">
-    <!--
-    Testlib's manifest should implicitly imports everything from `AnkiDroid/src/main/AndroidManifest.xml`,
-    except the imports done with `overrideLibrary` it seems. So we repeat the overridden imports below.
-    Otherwise, here is the error message we receive:
-
-    /Users/davidallison/StudioProjects/Anki-Android/testlib/build/intermediates/tmp/manifest/test/amazon/debug/tempFile1ProcessTestManifest12107165475509574808.xml:5:5-74 Error:
-        uses-sdk:minSdkVersion 23 cannot be smaller than version 24 declared in library [androidx.draganddrop:draganddrop:1.0.0] /Users/davidallison/.gradle/caches/8.9/transforms/20ebe1ae2c541e0d36502b025cdb232b/transformed/draganddrop-1.0.0/AndroidManifest.xml as the library might be using APIs not available in 23
-        Suggestion: use a compatible library with a minSdk of at most 23,
-            or increase this project's minSdk version to at least 24,
-            or use tools:overrideLibrary="androidx.draganddrop" to force usage (may lead to runtime failures)
-    -->
-    <uses-sdk tools:overrideLibrary="androidx.draganddrop"/>
-</manifest>
+<manifest />


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
*   #17425
The lint build fails with the following error: "Error: For locale "ca" (Catalan) the following quantity should also be defined: many "[MissingQuantity] to solve this error I Revert lint rule changes [UnusedQuantity, MissingQuantity] from fatal to ignore 
## Fixes
*  Fixes #17425 

## Approach
I made modifications to two AndroidManifest.xml
*AnkiDroid/src/main/AndroidManifest.xml
*testlib/src/main/AndroidManifest.xml
in lint-release.xml I changed thes two line from
```xml
<issue id="UnusedQuantity" severity="fatal" />
<issue id="MissingQuantity" severity="fatal" />
```
to
```xml
<issue id="UnusedQuantity" severity="ignore" />
<issue id="MissingQuantity" severity="ignore" />

```
These changes fix the lint build failure, making the build successful
## How Has This Been Tested?

tested on emulator Google HPE device

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
