### PR TITLE
Handle failures to parse system WebView version

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
@@ -19,6 +19,8 @@ package com.ichi2.utils
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 
+internal const val OLDEST_WORKING_WEBVIEW_VERSION_CODE = 386507305L
+
 /**
  * Returns a [PackageInfo] from the current system WebView, or `null` if unavailable
  */


### PR DESCRIPTION
## Purpose / Description

There are several reports in acra about crashes in _checkWebviewVersion()_ when parsing the system WebView version. It seems some of those versions appear as _"Developer Build"_ and not a simple number like we expect.

https://ankidroid.org/acra/app/1/bug/256775/report/e8bb99dc-2cb8-4a73-ab66-3491c1e2752f
https://ankidroid.org/acra/app/1/bug/253230/report/6d761065-e7d6-498a-9323-84a68f7fbfd4

Stacktrace:

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.DeckPicker}: java.lang.NumberFormatException: For input string: "Developer Build"
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2683)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2744)
	at android.app.ActivityThread.-wrap12(ActivityThread.java)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1495)
	at android.os.Handler.dispatchMessage(Handler.java:102)
	at android.os.Looper.loop(Looper.java:154)
	at android.app.ActivityThread.main(ActivityThread.java:6181)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:893)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:783)
Caused by: java.lang.NumberFormatException: For input string: "Developer Build"
	at java.lang.Integer.parseInt(Integer.java:521)
	at java.lang.Integer.parseInt(Integer.java:556)
	at com.ichi2.anki.InitialActivity.checkWebviewVersion(InitialActivity.java:147)
	at com.ichi2.anki.DeckPicker.onCreate(DeckPicker.kt:573)
	at android.app.Activity.performCreate(Activity.java:6785)
```


The fix consists in catching exceptions from version parsing and displaying a dialog about the minimum WebView version. I also added a checkbox to this dialog to hide the dialog on future runs, if the users have a developer build it seems reasonable to expect it's above our minimum WebView version requirements.

The dialog:
![zz](https://github.com/user-attachments/assets/b7fdc98b-2867-47ff-bf69-7bfedc28a75e)



I added the _Review High Priority_ label because I think these users can't access the DeckPicker.

## How Has This Been Tested?

Not tested, just opened the dialog to see how it looks.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
