### PR TITLE
fix: Settings highlight does not follow 'back button'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -24,7 +24,6 @@ import androidx.preference.PreferenceFragmentCompat
 import com.bytehamster.lib.preferencesearch.SearchConfiguration
 import com.bytehamster.lib.preferencesearch.SearchPreference
 import com.ichi2.anki.BuildConfig
-import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.ui.internationalization.toSentenceCase
@@ -43,7 +42,7 @@ class HeaderFragment : PreferenceFragmentCompat() {
         highlightHeaderPreference(requirePreference<HeaderPreference>(selectedHeaderPreferenceKey))
 
         requirePreference<HeaderPreference>(R.string.pref_backup_limits_screen_key)
-            .title = CollectionManager.TR.preferencesBackups()
+            .title = TR.preferencesBackups()
 
         requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
             if (AdaptionUtil.isXiaomiRestrictedLearningDevice) {
@@ -103,6 +102,10 @@ class HeaderFragment : PreferenceFragmentCompat() {
 
     fun setDevOptionsVisibility(isVisible: Boolean) {
         requirePreference<Preference>(R.string.pref_dev_options_screen_key).isVisible = isVisible
+    }
+
+    fun handelHighlightHeaderPreferenceOnBack(key: String) {
+        highlightHeaderPreference(requirePreference<HeaderPreference>(key))
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -192,6 +192,14 @@ class Preferences :
         result.highlight(fragment as PreferenceFragmentCompat)
     }
 
+    fun handleHighlightPreferenceOnBack(key: String?) {
+        val fragmentManager = supportFragmentManager
+        if (key != null) {
+            val headerFragment = (fragmentManager.findFragmentById(R.id.lateral_nav_container) as? HeaderFragment)
+            headerFragment?.handelHighlightHeaderPreferenceOnBack(key)
+        }
+    }
+
     companion object {
 
         /* Only enable AnkiDroid notifications unrelated to due reminders */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -100,6 +100,15 @@ abstract class SettingsFragment :
         dialogFragment.show(parentFragmentManager, "androidx.preference.PreferenceFragment.DIALOG")
     }
 
+    override fun onResume() {
+        super.onResume()
+        preferenceScreen?.key?.let {
+            (requireActivity() as Preferences).handleHighlightPreferenceOnBack(
+                it
+            )
+        }
+    }
+
     override fun onStart() {
         super.onStart()
         requireActivity().title = preferenceScreen.title


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

### Approach

- When the back button is pressed, the current fragment is popped from the back stack, and the previous fragment is displayed.

- The `onResume` method of the newly visible fragment is triggered.

- In the `onResume` method, the current fragment passes its unique key to the associated `Preferences` activity.

- The `Preferences` activity locates the `HeaderFragment` using the fragment manager and passes the received key to it.

- The `HeaderFragment` uses the key to identify the appropriate header and highlights it.


### Description of Changes

#### **HeaderFragment.kt**
- **Added a New Function**: `handleHighlightHeaderPreferenceOnBack`
  - **Purpose**: Highlights a specific header preference when the back button is pressed.

#### **Preferences.kt**
- **Introduced a New Function**: `handleHighlightPreferenceOnBack`
    - **Details**: 
    - Fetches the `HeaderFragment` instance.
    - Calls the `handleHighlightHeaderPreferenceOnBack` method on the `HeaderFragment`.

#### **SettingsFragment.kt**
- **Overridden the `onResume` Method**:
  - **Purpose**: Ensures the highlighting logic is triggered when the fragment resumes.
  - **Details**: 
    - Calls the `handleHighlightPreferenceOnBack` method from `Preferences` to handle the highlighting logic.


## Fixes
* Fixes #17414

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

[Screen_recording_20241115_173821.webm](https://github.com/user-attachments/assets/8271b875-b66c-4b8d-b76f-795bbab8df0f)

