### PR TITLE
Update robolectric downloads

### DIFF
--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -12,6 +12,7 @@ import java.nio.file.Files
 
 // List from: https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/plugins/DefaultSdkProvider.java
 // This list will need to be updated for new Android SDK versions that come out.
+// Note: the PREINSTRUMENTED_VERSION constant is what you put on the end of the artifact
 
 // Only the versions currently used in AnkiDroid Robolectric tests are active, the rest are commented out
 // To update these versions, open a terminal in the Anki-Android directory and perform the following steps:
@@ -43,6 +44,7 @@ tasks.register('robolectricSdkDownload') {
 
 // Generate the configuration and actual copy tasks.
 robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
+    // the final part of this `-i<number>` comes from PREINSTRUMENTED_VERSION in upstream DefaultSdkProvider
     def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i7"
 
     // Creating a configuration with a dependency allows Gradle to manage the actual resolution of

--- a/AnkiDroid/robolectricDownloader.gradle
+++ b/AnkiDroid/robolectricDownloader.gradle
@@ -32,6 +32,7 @@ def robolectricAndroidSdkVersions = [
 //        [androidVersion: "12.1", frameworkSdkBuildVersion:  "8229987"],
 //        [androidVersion: "13", frameworkSdkBuildVersion:  "9030017"],
         [androidVersion: "14", frameworkSdkBuildVersion: "10818077"],
+        [androidVersion: "15", frameworkSdkBuildVersion: "12650502"],
 ]
 
 // Base, public task - will be displayed in ./gradlew robolectricDownloader:tasks
@@ -42,7 +43,7 @@ tasks.register('robolectricSdkDownload') {
 
 // Generate the configuration and actual copy tasks.
 robolectricAndroidSdkVersions.forEach { robolectricSdkVersion ->
-    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i6"
+    def version = "${robolectricSdkVersion['androidVersion']}-robolectric-${robolectricSdkVersion['frameworkSdkBuildVersion']}-i7"
 
     // Creating a configuration with a dependency allows Gradle to manage the actual resolution of
     // the jar file

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,6 +92,7 @@ nanohttpd = "2.3.1"
 okhttp = "4.12.0"
 # https://github.com/protocolbuffers/protobuf/releases
 protobufKotlinLite = "4.28.3"
+# ../AnkiDroid/robolectricDownload.gradle may need changes - read instructions in that file
 robolectric = "4.14"
 searchpreference = "2.5.1"
 seismic = "1.0.3"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

#17445 contained new robolectric and I suspected we'd need the android 15 artifact

Turns out the artifact build number had changed, as had the preinstrumented number (which I documented this time)

Updated both

## Fixes

Nothing logged but without this, we're sure to get random unit test flakes

## Approach

Follow the directions in the file (and update the directions where a chunk was missing)

## How Has This Been Tested?

This is what it looks like after `\rm -fr ~/.m2` before this patch when you run `./gradlew jacocoUnitTestReport` then:

```
mike@isabela:~/work/ankidroid/Anki-Android (dependency-updates *) % find ~/.m2 -type d -name '*-robolectric-*'
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/14-robolectric-10818077-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/15-robolectric-12650502-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/9-robolectric-4913185-2-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i7
```

Re-ran the `rm -fr ~/.m2`, ran:

```
mike@isabela:~/work/ankidroid/Anki-Android (dependency-updates *) % ./gradlew robolectricSdkDownload

BUILD SUCCESSFUL in 1m 7s
5 actionable tasks: 5 executed
mike@isabela:~/work/ankidroid/Anki-Android (dependency-updates *) % find ~/.m2 -type d -name '*-robolectric-*'
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/14-robolectric-10818077-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/15-robolectric-12650502-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/9-robolectric-4913185-2-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/10-robolectric-5803371-i7
/Users/mike/.m2/repository/org/robolectric/android-all-instrumented/11-robolectric-6757853-i7
```

same output

✅ 

## Learning (optional, can help others)

the only constant is change

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
