### PR TITLE
fix: multimedia options opening more than once

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -170,6 +170,7 @@ import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.ichi2.widget.WidgetStatus
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import org.json.JSONArray
@@ -200,6 +201,8 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
     private var changed = false
     private var isTagsEdited = false
     private var isFieldEdited = false
+
+    private var multimediaActionJob: Job? = null
 
     /**
      * Flag which forces the calling activity to rebuild it's definition of current card from scratch
@@ -1741,8 +1744,11 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
      * @param fieldIndex the index of the field in the note where the multimedia content should be added
      */
     private fun handleMultimediaActions(fieldIndex: Int) {
+        // Cancel any existing subscription to avoid duplicate listeners
+        multimediaActionJob?.cancel()
+
         // Based on the type of multimedia action received, perform the corresponding operation
-        lifecycleScope.launch {
+        multimediaActionJob = lifecycleScope.launch {
             val note: MultimediaEditableNote = getCurrentMultimediaEditableNote()
             if (note.isEmpty) return@launch
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -74,13 +74,14 @@ class MultimediaActivity : AnkiActivity(), BaseSnackbarBuilderProvider {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_multimedia)
         setTransparentStatusBar()
+
+        val toolbar: MaterialToolbar = findViewById(R.id.toolbar)
+        setSupportActionBar(toolbar)
+
         // avoid recreating the fragment on configuration changes
         if (savedInstanceState != null) {
             return
         }
-
-        val toolbar: MaterialToolbar = findViewById(R.id.toolbar)
-        setSupportActionBar(toolbar)
 
         val fragmentClassName =
             requireNotNull(intent.getStringExtra(MULTIMEDIA_FRAGMENT_NAME_EXTRA)) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Root Cause of the issue was:
- Persistent Flow Subscription: Each time handleMultimediaActions is called, a new subscription to the multimediaAction flow is created, leading to multiple active observers.
- Race Condition: When an action is emitted, all active subscriptions are notified, causing the action to be handled multiple times.

## Fixes
* Fixes #17453

## Approach
Keep track of the job 

## How Has This Been Tested?
Tested on Google emulator API35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
