### PR TITLE
Remove legacy collection loading code from AnkiFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiFragment.kt
@@ -28,7 +28,6 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.android.input.ShortcutGroup
-import com.ichi2.async.CollectionLoader
 import com.ichi2.libanki.Collection
 import com.ichi2.themes.Themes
 import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
@@ -60,13 +59,6 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout), AnkiActivity
         get() = requireView().findViewById(R.id.toolbar)
 
     // Open function: These can be overridden to react to specific parts of the lifecycle
-
-    /**
-     * Callback for [startLoadingCollection], executed once the collection is available.
-     */
-    protected open fun onCollectionLoaded(col: Collection) {
-        hideProgressBar()
-    }
 
     @Suppress("deprecation", "API35 properly handle edge-to-edge")
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -112,16 +104,6 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout), AnkiActivity
     }
 
     /**
-     * Hides progress bar.
-     */
-    private fun hideProgressBar() = ankiActivity.hideProgressBar()
-
-    /**
-     * Shows progress bar.
-     */
-    private fun showProgressBar() = ankiActivity.showProgressBar()
-
-    /**
      * Unregisters a previously registered broadcast receiver.
      *
      * @param unmountReceiver The BroadcastReceiver instance to unregister.
@@ -161,32 +143,6 @@ open class AnkiFragment(@LayoutRes layout: Int) : Fragment(layout), AnkiActivity
      */
     protected fun setTitle(@StringRes title: Int) {
         mainToolbar.setTitle(title)
-    }
-
-    /**
-     * Starts loading the Anki collection asynchronously if it hasn't been opened yet.
-     * If the collection is already open, calls `onCollectionLoaded` synchronously.
-     * Shows a progress bar during loading.
-     */
-    protected fun startLoadingCollection() {
-        Timber.d("AnkiFragment.startLoadingCollection()")
-        if (CollectionManager.isOpenUnsafe()) {
-            Timber.d("Synchronously calling onCollectionLoaded")
-            onCollectionLoaded(getColUnsafe)
-            return
-        }
-        // Open collection asynchronously if it hasn't already been opened
-        showProgressBar()
-        CollectionLoader.load(
-            this
-        ) { col: Collection? ->
-            if (col != null) {
-                Timber.d("Asynchronously calling onCollectionLoaded")
-                onCollectionLoaded(col)
-            } else {
-                ankiActivity.onCollectionLoadError()
-            }
-        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -495,7 +495,12 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
             )
             setIconColor(MaterialColors.getColor(requireContext(), R.attr.toolbarIconColor, 0))
         }
-        startLoadingCollection()
+        try {
+            setupEditor(getColUnsafe)
+        } catch (ex: RuntimeException) {
+            ankiActivity.onCollectionLoadError()
+            return
+        }
         // TODO this callback doesn't handle predictive back navigation!
         // see #14678, added to temporarily fix for a bug
         requireActivity().onBackPressedDispatcher.addCallback(this) {
@@ -574,8 +579,7 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
         get() = NoteService.getFieldsAsBundleForPreview(editFields, shouldReplaceNewlines())
 
     // Finish initializing the fragment after the collection has been correctly loaded
-    override fun onCollectionLoaded(col: Collection) {
-        super.onCollectionLoaded(col)
+    private fun setupEditor(col: Collection) {
         val intent = requireActivity().intent
         Timber.d("NoteEditor() onCollectionLoaded: caller: %d", caller)
         ankiActivity.registerReceiver()

--- a/AnkiDroid/src/main/res/layout/note_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_editor.xml
@@ -148,6 +148,4 @@
         android:id="@+id/editor_toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
-
-    <include layout="@layout/anki_progress"/>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Purpose / Description

_AnkiFragment_ was using _CollectionManager.getColUnsafe()_ and also set up a loading mechanism similar with the _CollectionLoader_ used by _AnkiActivity_ returning the same _CollectionManager.getColUnsafe()_. This PR removes the loading mechanism and lets NoteEditor to only use _CollectionManager.getColUnsafe()_. This way, the setup that was done in onCollectionLoaded() is inserted in the fragment lifecycle and should prevent bugs from the bad timing around onCollectionLoaded().

The progress bar in the layout was removed because it was only used for the collection loading mechanism.
I was kind of able to reproduce the error in #17380 by using the same steps from #17407(modify the collection loading in ANkiFragment) and opening NoteEditor -> attach image. I said kind of because there's a bug in the multimedia image selection(see #17455) where the return to NoteEditor doesn't work quite right with _Don't keep activities_ enabled. IMO both bugs in #17380 and #17407 are happening because there's bad timing between the code expecting the collection to be available and the collection not being yet available( meaning onCollectionLoaded() executed).

At reviewers discretion if this should go in 2.19.x.

## Fixes
* Probably  fixes #17380

## How Has This Been Tested?

Tried to add things, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
