### PR TITLE
Use ID for getting input box in statistics

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -147,7 +147,7 @@ class Statistics :
      **/
     private fun changeDeck(selectedDeckName: String) {
         val javascriptCode = """
-        var textBox = [].slice.call(document.getElementsByTagName('input'), 0).filter(x => x.type == "text")[0];
+        var textBox = document.getElementById("statisticsSearchText");
         textBox.value = "deck:\"$selectedDeckName\"";
         textBox.dispatchEvent(new Event("input", { bubbles: true }));
         textBox.dispatchEvent(new Event("change"));


### PR DESCRIPTION
## Fixes
* Fixes #17075

## Approach
Get the input box with its new ID

## How Has This Been Tested?

By changing the deck in statistics with its deck spinner

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
