### PR TITLE
Remove Automatic Display Answer global setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1233,8 +1233,7 @@ abstract class AbstractFlashcardViewer :
         // These are preferences we pull out of the collection instead of SharedPreferences
         try {
             showNextReviewTime = col.config.get("estTimes") ?: true
-            val preferences = baseContext.sharedPrefs()
-            automaticAnswer = AutomaticAnswer.createInstance(this, preferences, col)
+            automaticAnswer = AutomaticAnswer.createInstance(this, col)
         } catch (ex: Exception) {
             Timber.w(ex)
             onCollectionLoadError()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -457,7 +457,6 @@ object UsageAnalytics {
         "dayOffset", // Start of next day
         "learnCutoff", // Learn ahead limit
         "timeLimit", // Timebox time limit
-        "timeoutAnswer", // Automatic display answer
         "keepScreenOn", // Disable screen timeout
         "doubleTapTimeInterval", // Double tap time interval (milliseconds)
         // Sync

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -128,8 +128,6 @@
     <string name="notification_minimum_cards_due">More than %d cards due</string>
     <string name="notification_minimum_cards_due_vibrate" maxLength="41">Vibrate</string>
     <string name="notification_minimum_cards_due_blink" maxLength="41">Blink light</string>
-    <string name="timeout_answer_text" maxLength="41">Automatic display answer</string>
-    <string name="timeout_answer_summ2">Show answer automatically without user input. Configure from deck options.</string>
     <string name="select_locale_title">Select language</string>
     <string name="software_render" maxLength="41">Disable card hardware render</string>
     <string name="software_render_summ">Hardware render is faster but may have problems, specifically on Android 8/8.1. If you cannot see parts of the card review user interface, try this setting.</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -249,7 +249,7 @@
 
     <string-array name="reviewing_summary_entries">
         <item>@string/pref_cat_scheduling</item>
-        <item>@string/timeout_answer_text</item>
+        <item>@string/pref_keep_screen_on</item>
     </string-array>
 
     <string-array name="sync_summary_entries">

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -13,7 +13,6 @@
     <string name="day_offset_preference">dayOffset</string>
     <string name="learn_cutoff_preference">learnCutoff</string>
     <string name="time_limit_preference">timeLimit</string>
-    <string name="timeout_answer_preference">timeoutAnswer</string>
     <string name="keep_screen_on_preference">keepScreenOn</string>
     <string name="double_tap_time_interval_preference">doubleTapTimeInterval</string>
     <!-- Sync -->

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -49,14 +49,6 @@
             app:min="0"
             app1:summaryFormat="@plurals/pref_summ_minutes"/>
     </PreferenceCategory>
-    <PreferenceCategory android:title="@string/timeout_answer_text" >
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
-            android:disableDependentsState="false"
-            android:key="@string/timeout_answer_preference"
-            android:summary="@string/timeout_answer_summ2"
-            android:title="@string/timeout_answer_text" />
-    </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
         <SwitchPreferenceCompat
             android:defaultValue="false"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -277,7 +277,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     fun noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632() = runTest {
         val controller = getViewerController(addCard = true, startedWithShortcut = false)
         val viewer = controller.get()
-        viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, true, 5.0, 5.0))
+        viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, 5.0, 5.0))
         viewer.executeCommand(ViewerCommand.SHOW_ANSWER)
         assertThat("messages after flipping card", viewer.hasAutomaticAnswerQueued(), equalTo(true))
         controller.pause()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerAndroidTest.kt
@@ -69,5 +69,5 @@ class AutomaticAnswerAndroidTest : RobolectricTest() {
     }
 
     private fun createInstance() =
-        AutomaticAnswer.createInstance(mock(), super.getPreferences(), super.col)
+        AutomaticAnswer.createInstance(mock(), super.col)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
@@ -53,7 +53,6 @@ class AutomaticAnswerTest : JvmTest() {
         val answer = AutomaticAnswer(
             target = automaticallyAnsweredMock(),
             settings = AutomaticAnswerSettings(
-                useTimer = true,
                 secondsToShowQuestionFor = 0.0,
                 secondsToShowAnswerFor = 0.0
             )
@@ -136,7 +135,6 @@ class AutomaticAnswerTest : JvmTest() {
         return AutomaticAnswer(
             target = automaticAnswerHandler,
             settings = AutomaticAnswerSettings(
-                useTimer = true,
                 secondsToShowQuestionFor = 10.0,
                 secondsToShowAnswerFor = 10.0
             )


### PR DESCRIPTION
People get confused when they enable Auto Advance but it doesn't work. The preference had an use when Anki didn't have Auto advance, but now it doesn't have a purpose because everything can be configured from deck options

Example: https://forums.ankiweb.net/t/auto-advance-in-deck-options/51898

## Fixes
* Fixes #17463

## Approach
Removed the global setting

## How Has This Been Tested?

Tested if auto advance still works

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
