### PR TITLE
fix: stop reporting storage access exceptions to acrarium

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -32,6 +32,7 @@ import androidx.lifecycle.viewModelScope
 import anki.collection.Progress
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.message
@@ -169,8 +170,9 @@ suspend fun <T> FragmentActivity.runCatching(
                 Timber.w(exc, errorMessage)
                 exc.localizedMessage?.let { showSnackbar(it) }
             }
-            is BackendNetworkException, is BackendSyncException -> {
+            is BackendNetworkException, is BackendSyncException, is StorageAccessException -> {
                 // these exceptions do not generate worthwhile crash reports
+                Timber.i("Showing error dialog but not sending a crash report.")
                 showError(this, exc.localizedMessage!!, exc, false)
             }
             is BackendException -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -29,6 +29,7 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.core.content.pm.PackageInfoCompat
+import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
@@ -68,6 +69,11 @@ object InitialActivity {
         } catch (e: SQLiteFullException) {
             Timber.w(e)
             StartupFailure.DISK_FULL
+        } catch (e: StorageAccessException) {
+            // Same handling as the fall through, but without the exception report
+            // These are now handled with a dialog and don't generate actionable reports
+            Timber.w(e)
+            StartupFailure.DB_ERROR
         } catch (e: Exception) {
             Timber.w(e)
             CrashReportService.sendExceptionReport(e, "InitialActivity::getStartupFailureType")


### PR DESCRIPTION

## Purpose / Description

these no longer generate useful reports


## Fixes

* Fixes #17373

## Approach

This stops reporting one specific error in coroutine handler and in startup

## How Has This Been Tested?

Ran it manually and watched logcat, using the test-trigger-patch from linked issue

```

11-20 20:21:36.137 15236 15236 D DeckPicker: handleStartup: Continuing after permission granted
11-20 20:21:36.143  1595  9078 E MediaProvider: Creating or writing to a non-default top level directory is not allowed!
11-20 20:21:36.144  1595 12530 E MediaProvider: Creating or writing to a non-default top level directory is not allowed!
11-20 20:21:36.146 15236 15236 W InitialActivity: com.ichi2.anki.exception.StorageAccessException: Failed to create AnkiDroid directory /storage/emulated/0/AnkiDroid
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionHelper.initializeAnkiDroidDirectory(CollectionHelper.kt:88)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager.collectionPathInValidFolder(CollectionManager.kt:264)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager.ensureOpenInner(CollectionManager.kt:243)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager.getColUnsafe$lambda$11$lambda$10(CollectionManager.kt:299)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager.$r8$lambda$1xvLXT2AdUAF2dT9vOLsddKVcWo(Unknown Source:0)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager$$ExternalSyntheticLambda2.invoke(D8$$SyntheticClass:0)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at com.ichi2.anki.CollectionManager$withQueue$3.invokeSuspend(CollectionManager.kt:103)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:111)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
11-20 20:21:36.146 15236 15236 W InitialActivity: 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
11-20 20:21:36.148  1595  8611 E MediaProvider: Creating or writing to a non-default top level directory is not allowed!
11-20 20:21:36.150  1595  9078 E MediaProvider: Creating or writing to a non-default top level directory is not allowed!
11-20 20:21:36.151 15236 15236 W CollectionHelper: com.ichi2.anki.exception.StorageAccessException: Failed to create AnkiDroid directory /storage/emulated/0/AnkiDroid
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.ichi2.anki.CollectionHelper.initializeAnkiDroidDirectory(CollectionHelper.kt:88)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.ichi2.anki.CollectionHelper.isCurrentAnkiDroidDirAccessible(CollectionHelper.kt:111)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.ichi2.anki.InitialActivity.getStartupFailureType(InitialActivity.kt:85)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.ichi2.anki.DeckPicker.handleStartup(DeckPicker.kt:717)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.ichi2.anki.DeckPicker.onCreate(DeckPicker.kt:497)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.Activity.performCreate(Activity.java:8595)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.Activity.performCreate(Activity.java:8573)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1456)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3764)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3922)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2443)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.os.Handler.dispatchMessage(Handler.java:106)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.os.Looper.loopOnce(Looper.java:205)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.os.Looper.loop(Looper.java:294)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at android.app.ActivityThread.main(ActivityThread.java:8177)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at java.lang.reflect.Method.invoke(Native Method)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:552)
11-20 20:21:36.151 15236 15236 W CollectionHelper: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:971)
11-20 20:21:36.151 15236 15236 I DeckPicker: AnkiDroid directory inaccessible
11-20 20:21:36.154   798   941 D EGL_emulation: app_time_stats: avg=4366.66ms min=4366.66ms max=4366.66ms count=1
11-20 20:21:36.161 15236 15236 I FragmentLifecycleLogger: DeckPicker::DatabaseErrorDialog::onAttach
11-20 20:21:36.162 15236 15236 I FragmentLifecycleLogger: DeckPicker::DatabaseErrorDialog::onCreate
11-20 20:21:36.169 15236 15236 I ScopedStorageService: isLegacyStorage(): current dir: /storage/emulated/0/AnkiDroid
11-20 20:21:36.169 15236 15236 I ScopedStorageService: scoped external dirs: /storage/emulated/0/Android/data/com.ichi2.anki.debug/files
11-20 20:21:36.169 15236 15236 I ScopedStorageService: scoped internal dir: /data/user/0/com.ichi2.anki.debug/files
11-20 20:21:36.170 15236 15236 I ScopedStorageService: isLegacyStorage(): true
11-20 20:21:36.171 15236 15236 W NavigationDrawerActivity$Companion: No storage access, not enabling shortcuts
11-20 20:21:36.173 15236 15236 D DeckPicker: No DeckPicker background preference
11-20 20:21:36.174 15236 15236 D InitialActivity: WebView is up to date. com.google.android.webview: 113.0.5672.136(567263634)
11-20 20:21:36.176 15236 15236 I AnkiDroidApp$onCreate: DeckPicker::onStart
11-20 20:21:36.211 15236 15236 W WindowOnBackDispatcher: OnBackInvokedCallback is not enabled for the application.
11-20 20:21:36.211 15236 15236 W WindowOnBackDispatcher: Set 'android:enableOnBackInvokedCallback="true"' in the application manifest.
11-20 20:21:36.211 15236 15236 I FragmentLifecycleLogger: DeckPicker::DatabaseErrorDialog::onStart
11-20 20:21:36.215 15236 15236 I AnkiDroidApp$onCreate: DeckPicker::onResume
11-20 20:21:36.216 15236 15236 D UsageAnalytics: sendAnalyticsScreenView(): DeckPicker
11-20 20:21:36.216 15236 15236 D UsageAnalytics: getOptIn() status: false
11-20 20:21:36.223 15236 15236 D UsageAnalytics: sendAnalyticsScreenView(): DatabaseErrorDialog
11-20 20:21:36.223 15236 15236 D UsageAnalytics: getOptIn() status: false
11-20 20:21:36.223 15236 15236 I FragmentLifecycleLogger: DeckPicker::DatabaseErrorDialog::onResume

```

No more exception report

## Learning (optional, can help others)

Our startup logic is a tangle!
Our coroutine error handling logic is a tangle!

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
