### PR TITLE
Handle locale name being empty in preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
@@ -40,11 +40,15 @@ object LanguageUtils {
     }
 
     /**
-     * @return if app is using a RTL language
+     * @return true if the app is using a RTL language, false otherwise or if there's any error when
+     *  querying the [Locale]
      */
     fun appLanguageIsRTL(): Boolean {
-        val directionality = Character.getDirectionality(Locale.getDefault().displayName[0])
-        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT || directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC
+        val localeName = Locale.getDefault().displayName
+        if (localeName.isEmpty()) return false
+        val directionality = Character.getDirectionality(localeName[0])
+        return directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT ||
+            directionality == Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC
     }
 
     private fun stripScriptAndExtensions(localeCodeStr: String): String {


### PR DESCRIPTION
## Purpose / Description

Fixes a recent [acra report](https://ankidroid.org/acra/app/1/bug/259385/report/f8483a5e-4e0f-438a-9630-e1720e7aa380) where the device locale was not available. This crashes the preferences code because we query the displayName of the locale to determine if the app language is rtl or not:

```
Caused by: java.lang.StringIndexOutOfBoundsException: length=0; index=0
	at java.lang.String.charAt(Native Method)
	at com.ichi2.anki.LanguageUtils.appLanguageIsRTL(LanguageUtils.java:46)
	at com.ichi2.preferences.HeaderPreference$Companion.buildHeaderSummary(HeaderPreference.kt:69)
	at com.ichi2.preferences.HeaderPreference.<init>(HeaderPreference.kt:45)
	at com.ichi2.preferences.HeaderPreference.<init>(HeaderPreference.kt:31)
	at com.ichi2.preferences.HeaderPreference.<init>(HeaderPreference.kt)
	... 35 more
```

I've modified the problematic method to handle an empty _locale.displayName_ and to default to false(not rtl language) when that happens.


## How Has This Been Tested?

Ran the related test, tried using rtl vs non rtl in preferences. I don't know how to test a no locale displayName.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
