### PR TITLE
chore: add triage information for unexplained startup crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -221,8 +221,20 @@ object CollectionHelper {
      * @param context Used to get the External App-Specific directory for AnkiDroid
      * @return Returns the absolute path to the App-Specific External AnkiDroid directory
      */
-    private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String {
-        return context.getExternalFilesDir(null)!!.absolutePath
+    private fun getAppSpecificExternalAnkiDroidDirectory(context: Context): String? {
+        val externalFilesDir = context.getExternalFilesDir(null)
+
+        // This value *may* be null but we strictly require it. This has caused NullPointerException
+        // in previous releases as we dereference. We can't recover but for purposes of triage,
+        // we will now check for null and if so try to log more information about why.
+        if (externalFilesDir == null) {
+            Timber.e("Attempting to determine collection path, but no valid external storage?")
+            throw IllegalStateException(
+                "getExternalFilesDir unexpectedly returned null. Media state: " +
+                    Environment.getExternalStorageState()
+            )
+        }
+        return externalFilesDir.absolutePath
     }
 
     /**


### PR DESCRIPTION

## Purpose / Description

Looking at acrarium, there was a pretty odd crash with a NullPointerException.
Those are usually pretty easy to fix but I couldn't really figure out why on this one:

https://ankidroid.org/acra/app/1/bug/260065/report/ec131296-dcf2-44e3-bd7f-3aa8f34678f6

```
11-22 07:38:50.977 W/AnkiDroid( 7692): Activity/ java.lang.NullPointerException
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionHelper.getAppSpecificExternalAnkiDroidDirectory(CollectionHelper.kt:225)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionHelper.getDefaultAnkiDroidDirectory(CollectionHelper.kt:189)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext$lambda$2(CollectionHelper.kt:295)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.preferences.PreferenceExtensionsKt.getOrSetString(PreferenceExtensions.kt:36)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext$AnkiDroid_playRelease(CollectionHelper.kt:294)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionManager.getCollectionDirectory(CollectionManager.kt:258)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionManager.collectionPathInValidFolder(CollectionManager.kt:263)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionManager.ensureOpenInner(CollectionManager.kt:243)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionManager.getColUnsafe$lambda$11$lambda$10(CollectionManager.kt:299)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at com.ichi2.anki.CollectionManager$withQueue$3.invokeSuspend(CollectionManager.kt:103)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:104)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.java:111)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:99)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:584)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:811)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:715)
11-22 07:38:50.977 W/AnkiDroid( 7692): 	at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:702)
```

But external storage appears to be mounted ? So not sure how this returned null.
Maybe there was a race condition between us attempting to access it (while it was still unmounted?) and ACRA attempting to log it and seeing it was mounted by then?

So I don't think we can recover from this but we can provide a custom exception with more information maybe, and can try again later


## Fixes

Doesn't fix anything, but shouldn't regress.

## Approach

Check for unexpected error condition vs just `!!`ing the value, and try to log useful information

## How Has This Been Tested?

`./gradlew jacocoTestReport` and the app still runs on my emulator

## Learning (optional, can help others)

Reading lots of API docs

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
