### PR TITLE
Fix more potential ActivityNotFoundExceptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2498,7 +2498,8 @@ abstract class AbstractFlashcardViewer :
             try {
                 startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                Timber.w(e) // Don't crash if the intent is not handled
+                Timber.w("No app found to handle open external url from AbstractFlashcardViewer")
+                showSnackbar(R.string.activity_start_failed)
             }
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -21,6 +21,7 @@ package com.ichi2.anki
 import android.annotation.SuppressLint
 import android.app.Activity
 import android.app.Activity.RESULT_CANCELED
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.ClipDescription
 import android.content.ClipboardManager
@@ -653,7 +654,12 @@ class NoteEditor : AnkiFragment(R.layout.note_editor), DeckSelectionListener, Su
                         }
 
                         override fun onGalleryClicked() {
-                            ioEditorLauncher.launch("image/*")
+                            try {
+                                ioEditorLauncher.launch("image/*")
+                            } catch (ex: ActivityNotFoundException) {
+                                Timber.w("No app found to handle onGalleryClicked request")
+                                activity?.showSnackbar(R.string.activity_start_failed)
+                            }
                         }
                     }
                 imageOcclusionBottomSheet.show(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.export
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.ClipData
 import android.content.Intent
 import android.net.Uri
@@ -132,7 +133,12 @@ class ActivityExportingDelegate(private val activity: AnkiActivity, private val 
             putExtra("android.content.extra.FANCY", true)
             putExtra("android.content.extra.SHOW_FILESIZE", true)
         }
-        saveFileLauncher.launch(saveIntent)
+        try {
+            saveFileLauncher.launch(saveIntent)
+        } catch (ex: ActivityNotFoundException) {
+            Timber.w("No activity found to handle saveExportFile request")
+            activity.showSnackbar(R.string.activity_start_failed)
+        }
     }
 
     fun onSaveInstanceState(outState: Bundle) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.preferences
 
+import android.content.ActivityNotFoundException
 import android.os.Build
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
@@ -55,8 +56,9 @@ class AppearanceSettingsFragment : SettingsFragment() {
         backgroundImage!!.onPreferenceClickListener = Preference.OnPreferenceClickListener {
             try {
                 backgroundImageResultLauncher.launch("image/*")
-            } catch (ex: Exception) {
-                Timber.w(ex)
+            } catch (ex: ActivityNotFoundException) {
+                Timber.w("No app found to handle background preference change request")
+                activity?.showSnackbar(R.string.activity_start_failed)
             }
             true
         }


### PR DESCRIPTION
## Purpose / Description

Fixes one more acra crash report about an app not being available to handle a _Intent.ACTION_CREATE_DOCUMENT_ request. To avoid these in the future I went and verified other places where an _ActivityNotFoundException_ might be thrown and handled those as well. Can squash if asked.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
