### PR TITLE
fix: avoid crash if intent sent with no extras

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler2.kt
@@ -30,13 +30,22 @@ import timber.log.Timber
 class IntentHandler2 : AbstractIntentHandler() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Timber.v(intent.toString())
         if (NoteEditor.intentLaunchedWithImage(intent)) {
             Timber.i("Intent contained an image")
             intent.putExtra(NoteEditor.EXTRA_CALLER, NoteEditor.CALLER_ADD_IMAGE)
         }
-        val noteEditorIntent = NoteEditorLauncher.PassArguments(intent.extras!!).getIntent(this, intent.action)
-        noteEditorIntent.setDataAndType(intent.data, intent.type)
-        startActivity(noteEditorIntent)
-        finish()
+        if (intent.extras == null) {
+            Timber.w("Intent unexpectedly has no extras. Notifying user, defaulting to add note.")
+            showThemedToast(this, getString(R.string.something_wrong), false)
+            startActivity(NoteEditorLauncher.AddNote().getIntent(this))
+            finish()
+        } else {
+            val noteEditorIntent =
+                NoteEditorLauncher.PassArguments(intent.extras!!).getIntent(this, intent.action)
+            noteEditorIntent.setDataAndType(intent.data, intent.type)
+            startActivity(noteEditorIntent)
+            finish()
+        }
     }
 }


### PR DESCRIPTION

## Purpose / Description

Avoid a crash seen in Acrarium when user sent bad data into AnkiDroid via Intent

## Fixes

https://ankidroid.org/acra/app/1/bug/258530/report/9c451938-ee66-4852-b2ff-2b1c2204d51b

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.IntentHandler2}: java.lang.NullPointerException
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4169)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4325)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2574)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8762)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:604)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1067)
Caused by: java.lang.NullPointerException
	at com.ichi2.anki.IntentHandler2.onCreate(IntentHandler2.kt:37)
	at android.app.Activity.performCreate(Activity.java:8591)
	at android.app.Activity.performCreate(Activity.java:8570)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1384)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4150)

```

## Approach

STOPS USING `!!`

When will we learn?

## How Has This Been Tested?

You can trigger the original crash (and see the new behavior) with:

> adb shell am start -a android.intent.action.MAIN -c android.intent.category.LAUNCHER -n com.ichi2.anki.debug/com.ichi2.anki.IntentHandler2

[bad-intent-crash-fix.webm](https://github.com/user-attachments/assets/08a885df-c199-4c77-afa0-403776670b8e)


## Learning (optional, can help others)

If we keep accepting `!!` we'll keep getting crashes.

## Checklist
_Please, go through these checks before submitting the PR._

- [ x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
