### PR TITLE
fix: ignore shared deck download and dialog dismissal at inappropriate lifecycle states

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -580,10 +580,13 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Shortc
 
     // Dismiss whatever dialog is showing
     fun dismissAllDialogFragments() {
-        supportFragmentManager.popBackStack(
-            DIALOG_FRAGMENT_TAG,
-            FragmentManager.POP_BACK_STACK_INCLUSIVE
-        )
+        // trying to pop fragment manager back state crashes if state already saved
+        if (!supportFragmentManager.isStateSaved) {
+            supportFragmentManager.popBackStack(
+                DIALOG_FRAGMENT_TAG,
+                FragmentManager.POP_BACK_STACK_INCLUSIVE
+            )
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -211,11 +211,14 @@ class SharedDecksActivity : AnkiActivity() {
         webView.loadUrl(resources.getString(R.string.shared_decks_url))
         webView.webViewClient = WebViewClient()
         webView.setDownloadListener { url, userAgent, contentDisposition, mimetype, _ ->
-            val sharedDecksDownloadFragment = SharedDecksDownloadFragment()
-            sharedDecksDownloadFragment.arguments = bundleOf(DOWNLOAD_FILE to DownloadFile(url, userAgent, contentDisposition, mimetype))
-
-            supportFragmentManager.commit {
-                add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT).addToBackStack(null)
+            // If the activity/fragment lifecycle has already begun teardown process,
+            // avoid handling the download, as FragmentManager.commit will throw
+            if (!supportFragmentManager.isStateSaved) {
+                val sharedDecksDownloadFragment = SharedDecksDownloadFragment()
+                sharedDecksDownloadFragment.arguments = bundleOf(DOWNLOAD_FILE to DownloadFile(url, userAgent, contentDisposition, mimetype))
+                supportFragmentManager.commit {
+                    add(R.id.shared_decks_fragment_container, sharedDecksDownloadFragment, SHARED_DECKS_DOWNLOAD_FRAGMENT).addToBackStack(null)
+                }
             }
         }
 


### PR DESCRIPTION

## Purpose / Description

Fix a crash where the shared deck download state is such that the WebView is attempting to instantiate our shared fragment download listener, but activity/fragment lifecycle state is already saved during teardown process

## Fixes

ACRA crash https://ankidroid.org/acra/app/1/bug/260938/report/667f6607-e575-4499-8860-2bb61b5db51b

```
java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
	at androidx.fragment.app.FragmentManager.checkStateLoss(FragmentManager.java:1861)
	at androidx.fragment.app.FragmentManager.enqueueAction(FragmentManager.java:1901)
	at androidx.fragment.app.BackStackRecord.commitInternal(BackStackRecord.java:342)
	at androidx.fragment.app.BackStackRecord.commit(BackStackRecord.java:306)
	at com.ichi2.anki.SharedDecksActivity.onCreate$lambda$1(SharedDecksActivity.kt:328)
	at WV.h7.handleMessage(chromium-TrichromeWebViewGoogle6432.aab-stable-672310733:483)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loopOnce(Looper.java:232)
	at android.os.Looper.loop(Looper.java:317)
	at android.app.ActivityThread.main(ActivityThread.java:8705)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)

```

Second commit also fixes a bunch of other crashes where dialog dismissal is attempted but state is already saved

## Approach

Read up on lifecycle stuff for Fragments, think about how to most-correctly just cut out of the download if for some reason state is saved but the download listener is still called

Couldn't directly reproduce the issue but my reasoning is that we should ignore a download completely if the activity is already in teardown?

Also saw a bunch of others were dialog dismissal was attempted but the exceptions in the crashes were clearly indicating it just wasn't possible, and just cut that attempted dismissal out if state wouldn't permit it

## How Has This Been Tested?

Verified shared deck downloads still work with this change in place, so no regression

I tried to alter emulator network settings to open up possibility of triggering the race condition that caused this while simulating a slower / crappier network but couldn't trigger it

## Learning (optional, can help others)

Race conditions are fierce

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
