### PR TITLE
fix: use default constructor / factory + Arguments init style

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1562,7 +1562,7 @@ open class CardBrowser :
     }
 
     private fun showOptionsDialog() {
-        val dialog = BrowserOptionsDialog(viewModel.cardsOrNotes, viewModel.isTruncated)
+        val dialog = BrowserOptionsDialog.newInstance(viewModel.cardsOrNotes, viewModel.isTruncated)
         dialog.show(supportFragmentManager, "browserOptionsDialog")
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -26,6 +26,7 @@ import android.widget.RadioButton
 import android.widget.RadioGroup
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.R
@@ -33,14 +34,16 @@ import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.model.CardsOrNotes
 import timber.log.Timber
 
-class BrowserOptionsDialog(private val cardsOrNotes: CardsOrNotes, private val isTruncated: Boolean) : AppCompatDialogFragment() {
+class BrowserOptionsDialog : AppCompatDialogFragment() {
     private lateinit var dialogView: View
 
     private val viewModel: CardBrowserViewModel by activityViewModels()
 
     private val positiveButtonClick = { _: DialogInterface, _: Int ->
-        @IdRes val selectedButtonId = dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
-        val newCardsOrNotes = if (selectedButtonId == R.id.select_cards_mode) CardsOrNotes.CARDS else CardsOrNotes.NOTES
+        @IdRes val selectedButtonId =
+            dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
+        val newCardsOrNotes =
+            if (selectedButtonId == R.id.select_cards_mode) CardsOrNotes.CARDS else CardsOrNotes.NOTES
         if (cardsOrNotes != newCardsOrNotes) {
             viewModel.setCardsOrNotes(newCardsOrNotes)
         }
@@ -48,6 +51,25 @@ class BrowserOptionsDialog(private val cardsOrNotes: CardsOrNotes, private val i
 
         if (newTruncate != isTruncated) {
             viewModel.setTruncated(newTruncate)
+        }
+    }
+
+    private val cardsOrNotes by lazy {
+        when (arguments?.getBoolean(CARDS_OR_NOTES_KEY)) {
+            true -> CardsOrNotes.CARDS
+            false -> CardsOrNotes.NOTES
+            null -> {
+                // Default case, and what we'll do if there were no arguments supplied
+                Timber.w("BrowserOptionsDialog instantiated without configuration.")
+                CardsOrNotes.CARDS
+            }
+        }
+    }
+
+    private val isTruncated by lazy {
+        arguments?.getBoolean(IS_TRUNCATED_KEY) ?: run {
+            Timber.w("BrowserOptionsDialog instantiated without configuration.")
+            false
         }
     }
 
@@ -78,6 +100,21 @@ class BrowserOptionsDialog(private val cardsOrNotes: CardsOrNotes, private val i
             }
             this.setPositiveButton(getString(R.string.dialog_ok), DialogInterface.OnClickListener(function = positiveButtonClick))
             this.create()
+        }
+    }
+
+    companion object {
+        private const val CARDS_OR_NOTES_KEY = "cardsOrNotes"
+        private const val IS_TRUNCATED_KEY = "isTruncated"
+
+        fun newInstance(cardsOrNotes: CardsOrNotes, isTruncated: Boolean): BrowserOptionsDialog {
+            Timber.i("BrowserOptionsDialog::newInstance")
+            return BrowserOptionsDialog().apply {
+                arguments = bundleOf(
+                    CARDS_OR_NOTES_KEY to (cardsOrNotes == CardsOrNotes.CARDS),
+                    IS_TRUNCATED_KEY to isTruncated
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description

this allows Fragment lifecycle save/restore to work seemlessly and that fixes crashes on Activity restarts

~~**NOTE THAT IF THIS STYLE IS OKAY - A FEW OTHER DIALOGS NEED FIXES IN SAME STYLE**~~

[edit: turns out this was the only easy one like this - so just one commit]

## Fixes

* Fixes #17381

## Approach

Used the approach mentioned here https://stackoverflow.com/a/51831137/9910298

- Stop providing params to constructor, so there is a default constructor as required by default Fragment factory
- Start providing params as a Bundle set in to Fragment.arguments via a static newInstance method
- Access all params via Fragment.arguments
- Handle optionally missing arguments with warnings+defaults

## How Has This Been Tested?

- Enable developer option Don't Keep Activities
- Go to Card Browser, open Actions Menu "Options"
- Background AnkiDroid, resume AnkiDroid --> crash without patch
- With patch check all toggles + background/foreground permutations

Everything seems to work

[browser-options-crashfix.webm](https://github.com/user-attachments/assets/d7d9441e-fd7a-41ee-af9f-79452ecf8a85)

## Learning (optional, can help others)

Now we don't just have Activity lifecycle problems, we have Fragment lifecycle problems. Great

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
