### PR TITLE
fix: check media dialog not dismissed by touch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -584,6 +584,11 @@ open class AnkiActivity : AppCompatActivity, SimpleMessageDialogListener, Shortc
             DIALOG_FRAGMENT_TAG,
             FragmentManager.POP_BACK_STACK_INCLUSIVE
         )
+        supportFragmentManager.fragments.forEach { fragment ->
+            if (fragment is DialogFragment) {
+                fragment.dismissAllowingStateLoss()
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Dismisses the dialog in case dismiss interface is called i.e. clears the stack so that the dialog is not shown again 

## Fixes
* Fixes #17491

## How Has This Been Tested?
Tested on Google Emulator API35
[Screen_recording_20241124_215823.webm](https://github.com/user-attachments/assets/716c357f-f850-44a8-be26-7fdbf71aeace)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
