### PR TITLE
Restore info related to cards counts in study options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -84,6 +84,8 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, MenuProvider 
     private lateinit var learningBuryText: TextView
     private lateinit var reviewCountText: TextView
     private lateinit var reviewBuryText: TextView
+    private lateinit var totalNewCardsCount: TextView
+    private lateinit var totalCardsCount: TextView
 
     private var retryMenuRefreshJob: Job? = null
 
@@ -227,6 +229,8 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, MenuProvider 
         buttonStart = studyOptionsView.findViewById<Button?>(R.id.studyoptions_start).apply {
             setOnClickListener(buttonClickListener)
         }
+        totalNewCardsCount = studyOptionsView.findViewById(R.id.studyoptions_total_new_count)
+        totalCardsCount = studyOptionsView.findViewById(R.id.studyoptions_total_count)
     }
 
     /**
@@ -448,7 +452,7 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, MenuProvider 
         val buriedNew: Int,
         val buriedLearning: Int,
         val buriedReview: Int,
-
+        val totalNewCards: Int,
         /**
          * Number of cards in this decks and its subdecks.
          */
@@ -582,6 +586,8 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, MenuProvider 
             learningBuryText.isVisible = result.buriedLearning != 0
             reviewBuryText.text = requireContext().resources.getQuantityString(R.plurals.studyoptions_buried_count, result.buriedReview, result.buriedReview)
             reviewBuryText.isVisible = result.buriedReview != 0
+            totalNewCardsCount.text = result.totalNewCards.toString()
+            totalCardsCount.text = result.numberOfCardsInDeck.toString()
             // Rebuild the options menu
             configureToolbar()
         }
@@ -614,6 +620,7 @@ class StudyOptionsFragment : Fragment(), ChangeManager.Subscriber, MenuProvider 
             buriedNew = buriedNew,
             buriedLearning = buriedLearning,
             buriedReview = buriedReview,
+            totalNewCards = sched.totalNewForCurrentDeck(),
             numberOfCardsInDeck = decks.cardCount(deckId, includeSubdecks = true)
         )
     }

--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -175,9 +175,49 @@
                         android:textColor="?attr/buryCountColor"
                         tools:text="+105"/>
 
+                    <TextView
+                        android:id="@+id/studyoptions_total_new_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_review_count_label"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/barrier_labels"
+                        app:layout_constraintHorizontal_bias="0"
+                        android:text="@string/studyoptions_total_new_label"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_total_new_count"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_review_count"
+                        app:layout_constraintStart_toEndOf="@id/barrier_labels"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_total_new_label"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        tools:text="2341"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_total_label"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_total_new_label"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintEnd_toStartOf="@id/barrier_labels"
+                        app:layout_constraintHorizontal_bias="0"
+                        android:text="@string/studyoptions_total_label"/>
+
+                    <TextView
+                        android:id="@+id/studyoptions_total_count"
+                        android:layout_width="wrap_content"
+                        app:layout_constraintTop_toBottomOf="@id/studyoptions_total_new_count"
+                        app:layout_constraintStart_toEndOf="@id/barrier_labels"
+                        app:layout_constraintBottom_toBottomOf="@id/studyoptions_total_label"
+                        android:layout_marginStart="8dp"
+                        android:layout_height="wrap_content"
+                        tools:text="781"/>
+
                     <androidx.constraintlayout.widget.Group
                         android:id="@+id/group_counts"
-                        app:constraint_referenced_ids="studyoptions_new_count,studyoptions_new_count_label,studyoptions_new_bury,studyoptions_learning_count,studyoptions_learning_count_label,studyoptions_learning_bury,studyoptions_review_count,studyoptions_review_count_label,studyoptions_review_bury"
+                        app:constraint_referenced_ids="studyoptions_new_count,studyoptions_new_count_label,studyoptions_new_bury,studyoptions_learning_count,studyoptions_learning_count_label,studyoptions_learning_bury,studyoptions_review_count,studyoptions_review_count_label,studyoptions_review_bury,studyoptions_total_new_label,studyoptions_total_new_count,studyoptions_total_label,studyoptions_total_count"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
                 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -72,6 +72,8 @@
     <plurals name="studyoptions_buried_count">
         <item quantity="other">+%d buried</item>
     </plurals>
+    <string name="studyoptions_total_new_label">Total new cards</string>
+    <string name="studyoptions_total_label">Total cards</string>
 
     <!-- Card editor -->
     <string name="cardeditor_title_edit_card" maxLength="28">Edit note</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Shows again the total number of cards and the total new cards in the study options screen by switching to the old code. See images:

![s1](https://github.com/user-attachments/assets/4ab6c9aa-8175-47fb-9a1f-56868df68dd7)
![s2](https://github.com/user-attachments/assets/1d592d42-c93e-467f-99b4-275927a78bb7)


## Fixes
* Fixes #17489

## How Has This Been Tested?

Ran the tests, checked the study options screen.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
