### PR TITLE
Fix webview version fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -181,6 +181,7 @@ import com.ichi2.utils.SyncStatus
 import com.ichi2.utils.VersionUtils
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.checkBoxPrompt
+import com.ichi2.utils.checkWebviewVersion
 import com.ichi2.utils.configureView
 import com.ichi2.utils.customView
 import com.ichi2.utils.message
@@ -200,8 +201,6 @@ import net.ankiweb.rsdroid.Translations
 import org.json.JSONException
 import timber.log.Timber
 import java.io.File
-
-const val OLDEST_WORKING_WEBVIEW_VERSION = 77
 
 /**
  * The current entry point for AnkiDroid. Displays decks, allowing users to study. Many other functions.
@@ -572,7 +571,7 @@ open class DeckPicker :
 
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
-        InitialActivity.checkWebviewVersion(packageManager, this)
+        checkWebviewVersion(packageManager, this)
 
         supportFragmentManager.setFragmentResultListener(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU, this) { requestKey, arguments ->
             when (requestKey) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -571,7 +571,7 @@ open class DeckPicker :
 
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
-        checkWebviewVersion(packageManager, this)
+        checkWebviewVersion(this)
 
         supportFragmentManager.setFragmentResultListener(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU, this) { requestKey, arguments ->
             when (requestKey) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -18,17 +18,13 @@ package com.ichi2.anki
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.content.pm.PackageInfo
-import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteFullException
 import android.os.Build
 import android.os.Environment
 import android.os.Parcelable
 import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
-import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
-import androidx.core.content.pm.PackageInfoCompat
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
@@ -37,11 +33,8 @@ import com.ichi2.anki.ui.windows.permissions.Full30and31PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsUntil29Fragment
 import com.ichi2.anki.ui.windows.permissions.TiramisuPermissionsFragment
-import com.ichi2.utils.OLDEST_WORKING_WEBVIEW_VERSION_CODE
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils.pkgVersionName
-import com.ichi2.utils.getAndroidSystemWebViewPackageInfo
-import com.ichi2.utils.show
 import kotlinx.parcelize.Parcelize
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
@@ -145,57 +138,6 @@ object InitialActivity {
     enum class StartupFailure {
         SD_CARD_NOT_MOUNTED, DIRECTORY_NOT_ACCESSIBLE, FUTURE_ANKIDROID_VERSION,
         DB_ERROR, DATABASE_LOCKED, WEBVIEW_FAILED, DISK_FULL
-    }
-
-    /**
-     * Shows a dialog if the current WebView version is older than the last supported version.
-     */
-    fun checkWebviewVersion(packageManager: PackageManager, activity: AnkiActivity) {
-        val webviewPackageInfo = getAndroidSystemWebViewPackageInfo(packageManager) ?: return
-        val webviewVersion = webviewPackageInfo.versionName ?: run {
-            Timber.w("Failed to obtain WebView version")
-            return
-        }
-        val versionCode = PackageInfoCompat.getLongVersionCode(webviewPackageInfo)
-        // TODO modify the alert dialog text to handle the usage of developer builds for system WebView
-        val userVisibleCode = runCatching {
-            webviewVersion.split(".")[0].toInt()
-        }.getOrNull() ?: 0
-        if (versionCode >= OLDEST_WORKING_WEBVIEW_VERSION_CODE) {
-            Timber.d(
-                "WebView is up to date. %s: %s(%s)",
-                webviewPackageInfo.packageName,
-                webviewVersion,
-                versionCode.toString()
-            )
-            return
-        }
-
-        val legacyWebViewPackageInfo = getLegacyWebViewPackageInfo(packageManager)
-        if (legacyWebViewPackageInfo != null) {
-            Timber.w("WebView is outdated. %s: %s", legacyWebViewPackageInfo.packageName, legacyWebViewPackageInfo.versionName)
-            showOutdatedWebViewDialog(activity, userVisibleCode, activity.getString(R.string.link_legacy_webview_update))
-        } else {
-            Timber.w("WebView is outdated. %s: %s", webviewPackageInfo.packageName, webviewPackageInfo.versionName)
-            showOutdatedWebViewDialog(activity, userVisibleCode, activity.getString(R.string.link_webview_update))
-        }
-    }
-
-    private fun showOutdatedWebViewDialog(activity: AnkiActivity, installedVersion: Int, learnMoreUrl: String) {
-        AlertDialog.Builder(activity).show {
-            setMessage(activity.getString(R.string.webview_update_message, installedVersion, OLDEST_WORKING_WEBVIEW_VERSION))
-            setPositiveButton(R.string.scoped_storage_learn_more) { _, _ ->
-                activity.openUrl(learnMoreUrl)
-            }
-        }
-    }
-
-    private fun getLegacyWebViewPackageInfo(packageManager: PackageManager): PackageInfo? {
-        return try {
-            packageManager.getPackageInfo("com.android.webview", 0)
-        } catch (e: PackageManager.NameNotFoundException) {
-            null
-        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -18,12 +18,11 @@ package com.ichi2.anki.servicelayer
 
 import android.content.Context
 import android.os.Build
-import android.webkit.WebView
-import androidx.annotation.MainThread
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.utils.VersionUtils.pkgVersionName
+import com.ichi2.utils.getWebviewUserAgent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.acra.util.Installation
@@ -64,16 +63,6 @@ object DebugInfoService {
                
                Crash Reports Enabled = ${isSendingCrashReports(info)}
         """.trimIndent()
-    }
-
-    @MainThread
-    private fun getWebviewUserAgent(context: Context): String? {
-        try {
-            return WebView(context).settings.userAgentString
-        } catch (e: Throwable) {
-            CrashReportService.sendExceptionReport(e, "Info::copyDebugInfo()", "some issue occurred while extracting webview user agent")
-        }
-        return null
     }
 
     private fun isSendingCrashReports(context: Context): Boolean {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2024 Mike Hardy <github@mikehardy.net>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual.equalTo
+import org.junit.Test
+
+class WebViewUtilsTest {
+
+    @Test
+    fun testWebviewVersionCodes() {
+        assertThat(
+            "Known old webview determined correctly",
+            checkWebViewVersionComponents("com.google.android.webview", "53.0.2785.124", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1),
+            equalTo(53)
+        )
+
+        assertThat(
+            "Known good webview determined correctly",
+            checkWebViewVersionComponents("com.google.android.webview", "131.0.6778.39", 677803933L),
+            equalTo(null)
+        )
+
+        assertThat(
+            "Known confusing webview determined incorrectly",
+            checkWebViewVersionComponents("com.google.android.webview", "130.0.0.1", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1),
+            equalTo(130)
+        )
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
@@ -25,20 +25,20 @@ class WebViewUtilsTest {
     fun testWebviewVersionCodes() {
         assertThat(
             "Known old webview determined correctly",
-            checkWebViewVersionComponents("com.google.android.webview", "53.0.2785.124", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1),
+            checkWebViewVersionComponents("com.google.android.webview", "53.0.2785.124", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1, "Mozilla/5.0 (Linux; Android 7.0; Android SDK built for arm64 Build/NYC; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36"),
             equalTo(53)
         )
 
         assertThat(
             "Known good webview determined correctly",
-            checkWebViewVersionComponents("com.google.android.webview", "131.0.6778.39", 677803933L),
+            checkWebViewVersionComponents("com.google.android.webview", "131.0.6778.39", 677803933L, "Mozilla/5.0 (Linux; Android 14; sdk_gphone64_arm64 Build/UE1A.230829.036.A4; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.39 Mobile Safari/537.36"),
             equalTo(null)
         )
 
         assertThat(
-            "Known confusing webview determined incorrectly",
-            checkWebViewVersionComponents("com.google.android.webview", "130.0.0.1", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1),
-            equalTo(130)
+            "Known confusing webview determined correctly",
+            checkWebViewVersionComponents("com.google.android.webview", "74.0.0.0", OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1, "Mozilla/5.0 (Linux; Android 9; SM-A730F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.102 Mobile Safari/537.36"),
+            equalTo(null)
         )
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Apparently the webview package on some devices can have a version code and version name that indicate they will not be compatible, but they work fine.

Inspection of the User-Agent string from the WebView indicates it advertises a Chrome version that is more than adequate.

This PR adds a fallback WebView version detection mode that will believe the User-Agent if it says it's compatible, even if the versionCode says it isn't

## Fixes
* Fixes #17498

## Approach

Most of the work: refactoring and adding a test:

- Start by refactoring all the WebView stuff in to one spot
- Continue by refactoring the gathering of information from the processing of information, so it is testable
- Add some test cases that behave how 2.19.2 currently behaves

Actual work:
Add logic to check User-Agent and verify that our confusing test cases from real world examples now work fine

## How Has This Been Tested?

- Extensively with unit tests - User-Agent from #17498 has a test case and passes
- Verified on my API24 emulator it still warns me
- Verified on my API34 emulator it is fine

## Learning (optional, can help others)

Learned some Kotlin regex

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
