### PR TITLE
fix: attach custom study dialog fragment factory in SinglePageActivity to avoid crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -19,11 +19,15 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
+import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
+import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.utils.getInstanceFromClassName
 import timber.log.Timber
 import kotlin.reflect.KClass
@@ -38,7 +42,7 @@ import kotlin.reflect.jvm.jvmName
  *
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
-open class SingleFragmentActivity : AnkiActivity() {
+open class SingleFragmentActivity : AnkiActivity(), CustomStudyDialog.CustomStudyListener {
     /** The displayed fragment. */
     lateinit var fragment: Fragment
 
@@ -46,6 +50,13 @@ open class SingleFragmentActivity : AnkiActivity() {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
+
+        // This page *may* host the CustomStudyDialog (CongratsPage)
+        // CustomStudyDialog requires a custom factory install during lifecycle or it can
+        // crash during lifecycle resume after background kill
+        val customStudyDialogFactory = CustomStudyDialogFactory({ this.getColUnsafe }, this)
+        customStudyDialogFactory.attachToActivity<ExtendedFragmentFactory>(this)
+
         super.onCreate(savedInstanceState)
         if (!ensureStoragePermissions()) {
             return
@@ -101,6 +112,41 @@ open class SingleFragmentActivity : AnkiActivity() {
 
     override val shortcuts: ShortcutGroup?
         get() = (fragment as? ShortcutGroupProvider)?.shortcuts
+
+    // Begin - implementation of CustomStudyListener methods here for crash fix
+    // TODO - refactor https://github.com/ankidroid/Anki-Android/pull/17508#pullrequestreview-2465561993
+    private fun openStudyOptionsAndFinish() {
+        val intent = Intent(this, StudyOptionsActivity::class.java).apply {
+            putExtra("withDeckOptions", false)
+        }
+        startActivity(intent, null)
+        this.finish()
+    }
+
+    override fun onExtendStudyLimits() {
+        Timber.v("CustomStudyListener::hideProgressBar() - not handled")
+        openStudyOptionsAndFinish()
+    }
+
+    override fun showDialogFragment(newFragment: DialogFragment) {
+        Timber.v("CustomStudyListener::showDialogFragment()")
+        newFragment.show(supportFragmentManager, null)
+    }
+
+    override fun startActivity(intent: Intent) {
+        Timber.v("CustomStudyListener::startActivity() - not handled")
+    }
+
+    override fun onCreateCustomStudySession() {
+        Timber.v("CustomStudyListener::onCreateCustomStudySession()")
+        openStudyOptionsAndFinish()
+    }
+
+    override fun hideProgressBar() {
+        Timber.v("CustomStudyListener::hideProgressBar() - not handled")
+    }
+
+    // END CustomStudyListener temporary implementation - should refactor out
 }
 
 interface DispatchKeyEventListener {


### PR DESCRIPTION
There were two Activities that attached the custom factory for custom study dialog in onCreate, but there were *three* that needed it (SinglePageActivity hosting CongratsPage fragment hosting study options was missing)

If you didn't attach in onCreate then you would crash if the fragment/activity lifecycle had done a cycle on you due to background kill or don't keep activities on

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes

https://ankidroid.org/acra/app/1/bug/237277/report/ecbf20ba-e077-4952-ae40-14d56647ad99

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.SingleFragmentActivity}: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.ichi2.anki.dialogs.customstudy.CustomStudyDialog: could not find Fragment constructor
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4164)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4322)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:139)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:96)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2685)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:230)
	at android.os.Looper.loop(Looper.java:319)
	at android.app.ActivityThread.main(ActivityThread.java:8919)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:578)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1103)
Caused by: androidx.fragment.app.Fragment$InstantiationException: Unable to instantiate fragment com.ichi2.anki.dialogs.customstudy.CustomStudyDialog: could not find Fragment constructor
	at androidx.fragment.app.Fragment.instantiate(SourceFile:9)
	at androidx.fragment.app.FragmentContainer.instantiate(SourceFile:1)
	at androidx.fragment.app.FragmentManager$3.instantiate(SourceFile:18)
	at androidx.fragment.app.FragmentState.instantiate(SourceFile:3)
	at androidx.fragment.app.FragmentStateManager.<init>(SourceFile:13)
	at androidx.fragment.app.FragmentManager.restoreSaveStateInternal(SourceFile:253)
	at androidx.fragment.app.Fragment.restoreChildFragmentState(SourceFile:15)
	at androidx.fragment.app.Fragment.onCreate(SourceFile:4)
	at androidx.fragment.app.Fragment.performCreate(SourceFile:22)
	at androidx.fragment.app.FragmentStateManager.create(SourceFile:60)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(SourceFile:133)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(SourceFile:31)
	at androidx.fragment.app.FragmentManager.moveToState(SourceFile:28)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(SourceFile:10)
	at androidx.fragment.app.FragmentManager.dispatchCreate(SourceFile:12)
	at androidx.fragment.app.FragmentController.dispatchCreate(SourceFile:5)
	at androidx.fragment.app.FragmentActivity.onCreate(SourceFile:13)
	at com.ichi2.anki.AnkiActivity.onCreate(SourceFile:13)
	at com.ichi2.anki.SingleFragmentActivity.onCreate(SourceFile:8)
	at android.app.Activity.performCreate(Activity.java:8975)
	at android.app.Activity.performCreate(Activity.java:8944)
```

Combined with this logcat showing the offender:

```

LOGCAT
--------- beginning of main
11-22 23:50:34.728 I/AnkiDroid(20104): Timber config: PRODUCTION
11-22 23:50:34.728 I/AnkiDroid(20104): initialize()
11-22 23:50:34.956 I/AnkiDroid(20104): Participating in analytics sample (sample percentage vs random: 10 1)
11-22 23:50:34.956 I/AnkiDroid(20104): setOptIn(): from false to true
11-22 23:50:34.956 I/AnkiDroid(20104): Not participating in analytics sample (sample percentage vs random: 10 99)
11-22 23:50:35.028 I/AnkiDroid(20104): Creating notification channel with id/name: General Notifications/AnkiDroid
11-22 23:50:35.028 I/AnkiDroid(20104): Creating notification channel with id/name: Synchronization/Synchronization
11-22 23:50:35.029 I/AnkiDroid(20104): Creating notification channel with id/name: Global Reminders/Cards due
11-22 23:50:35.029 I/AnkiDroid(20104): Creating notification channel with id/name: Deck Reminders/Reminders
11-22 23:50:35.029 I/AnkiDroid(20104): Creating notification channel with id/name: Scoped Storage/Storage migration
11-22 23:50:35.033 I/AnkiDroid(20104): AnkiDroidApp: Starting Services
11-22 23:50:35.052 I/AnkiDroid(20104): (Re)opening Database: /storage/emulated/0/Android/data/com.ichi2.anki/files/AnkiDroid/collection.anki2
11-22 23:50:35.078 I/AnkiDroid(20104): Executing Boot Service
11-22 23:50:35.089 I/AnkiDroid(20104): Setting theme to LIGHT
11-22 23:50:35.108 I/AnkiDroid(20104): SingleFragmentActivity::onCreate
11-22 23:50:35.109 I/AnkiDroid(20104): SingleFragmentActivity::CongratsPage::onAttach
```

## Approach

Implement CustomStudyListener in SinglePageActivity as a temporary solution to fix this crash, before a better refactoring that fixes the area

## How Has This Been Tested?

1- turn on developer options -> don't keep activities so we trigger lifecycle changes when app backgrounds
2- create new deck with one card, review the card, see the congrats page
3- tap the link for custom study to open the dialog
4- background the app, foreground the app
5- see crash without patch, no crash with patch

I also tested other pathways that I knew use other fragment factories like the BrowserOptions one (card browser -> actions bar menu -> options -> change stuff / do lifecycle transitions) and this did not break those, so our fragment factory delegation is working correctly 

## Learning (optional, can help others)

Our fragment factory here is pretty complicated but...I guess it works.

Fragment lifecycle requires that we attach that fragment factory in Activity.onCreate if there is no default constructor though, otherwise the default fragment factory *will* crash while trying to call the default constructor

(similar to #17488 but here it is not feasible to make a default constructor - tried that, ugly change)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
