### PR TITLE
build(deps): adopt anki24.11 release plus deck options z-index fix

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.0"
-ankiBackend = '0.1.47-anki24.11rc2'
+ankiBackend = '0.1.48-anki24.11'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

Won't build until Maven Central has it:

https://mvnrepository.com/artifact/io.github.david-allison/anki-android-backend