### PR TITLE
test: close Scenarios after use to reduce memory pressure

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
@@ -36,9 +36,11 @@ class FilteredDeckOptionsTest : InstrumentedTest() {
 
     @Test
     fun canOpenDeckOptions() {
-        ActivityScenario.launch(DeckPicker::class.java).onActivity { deckPicker ->
-            val deckId = col.decks.newFiltered("Filtered Testing")
-            deckPicker.showContextMenuDeckOptions(deckId)
-        }.close()
+        ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
+            scenario.onActivity { deckPicker ->
+                val deckId = col.decks.newFiltered("Filtered Testing")
+                deckPicker.showContextMenuDeckOptions(deckId)
+            }
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -622,9 +622,10 @@ class TagsDialogTest : RobolectricTest() {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { Timber.d("Dialog successfully opened") }
+        FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory).use { scenario ->
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.onFragment { Timber.d("Dialog successfully opened") }
+        }
     }
 
     @Test
@@ -637,20 +638,21 @@ class TagsDialogTest : RobolectricTest() {
             .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
-        val scenario = FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory)
-        scenario.moveToState(Lifecycle.State.STARTED)
-        scenario.onFragment { f ->
-            val tagsFile = requireNotNull(
-                BundleCompat.getParcelable(
-                    f.requireArguments(),
-                    "tagsFile",
-                    TagsFile::class.java
+        FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory).use { scenario ->
+            scenario.moveToState(Lifecycle.State.STARTED)
+            scenario.onFragment { f ->
+                val tagsFile = requireNotNull(
+                    BundleCompat.getParcelable(
+                        f.requireArguments(),
+                        "tagsFile",
+                        TagsFile::class.java
+                    )
                 )
-            )
 
-            val dataFromArguments = tagsFile.getData()
+                val dataFromArguments = tagsFile.getData()
 
-            assertThat(dataFromArguments.allTags, containsInAnyOrder(allTags))
+                assertThat(dataFromArguments.allTags, containsInAnyOrder(allTags))
+            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -39,18 +39,19 @@ class DeckOptionsTest : RobolectricTest() {
         // Launch deck options
         val intent = DeckOptions.getIntent(targetContext, col.decks.selected())
 
-        val scenario = ActivityScenario.launch<SingleFragmentActivity>(intent)
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity { activity ->
-            assertThat("Activity should not be finishing", !activity.isFinishing)
+        ActivityScenario.launch<SingleFragmentActivity>(intent).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                assertThat("Activity should not be finishing", !activity.isFinishing)
 
-            // Perform system-level back press
-            pressBack()
+                // Perform system-level back press
+                pressBack()
 
-            // Discard on modal
-            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+                // Discard on modal
+                clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
 
-            assertThat("Activity should be finishing", activity.isFinishing)
+                assertThat("Activity should be finishing", activity.isFinishing)
+            }
         }
     }
 
@@ -59,24 +60,25 @@ class DeckOptionsTest : RobolectricTest() {
         // Launch deck options
         val intent = DeckOptions.getIntent(targetContext, col.decks.selected())
 
-        val scenario = ActivityScenario.launch<SingleFragmentActivity>(intent)
-        scenario.moveToState(Lifecycle.State.RESUMED)
-        scenario.onActivity { activity ->
-            assertThat("Activity should not be finishing", !activity.isFinishing)
-        }
+        ActivityScenario.launch<SingleFragmentActivity>(intent).use { scenario ->
+            scenario.moveToState(Lifecycle.State.RESUMED)
+            scenario.onActivity { activity ->
+                assertThat("Activity should not be finishing", !activity.isFinishing)
+            }
 
-        // Perform toolbar up button press
-        try {
-            onView(withContentDescription("Navigate up")).perform(click())
-        } catch (ex: NoMatchingViewException) {
-            Timber.d("Toolbar UP button not found. Is english locale being used?")
-            return // Abort
-        }
+            // Perform toolbar up button press
+            try {
+                onView(withContentDescription("Navigate up")).perform(click())
+            } catch (ex: NoMatchingViewException) {
+                Timber.d("Toolbar UP button not found. Is english locale being used?")
+                return // Abort
+            }
 
-        scenario.onActivity { activity ->
-            // Discard on modal
-            clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
-            assertThat("Activity should be finishing", activity.isFinishing)
+            scenario.onActivity { activity ->
+                // Discard on modal
+                clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
+                assertThat("Activity should be finishing", activity.isFinishing)
+            }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PreferencesTest.kt
@@ -72,12 +72,12 @@ class PreferencesTest : RobolectricTest() {
     /** checks if any of the Preferences fragments throws while being created */
     @Test
     fun fragmentsDoNotThrowOnCreation() {
-        val activityScenario = ActivityScenario.launch(Preferences::class.java)
-
-        activityScenario.onActivity { activity ->
-            PreferenceTestUtils.getAllPreferencesFragments(activity).forEach {
-                activity.supportFragmentManager.commitNow {
-                    add(R.id.settings_container, it)
+        ActivityScenario.launch(Preferences::class.java).use { activityScenario ->
+            activityScenario.onActivity { activity ->
+                PreferenceTestUtils.getAllPreferencesFragments(activity).forEach {
+                    activity.supportFragmentManager.commitNow {
+                        add(R.id.settings_container, it)
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -71,8 +71,10 @@ class PermissionsActivityTest : RobolectricTest() {
             ApplicationProvider.getApplicationContext(),
             permissionSet
         )
-        ActivityScenario.launch<PermissionsActivity>(intent).onActivity { activity ->
-            action.perform(activity)
+        ActivityScenario.launch<PermissionsActivity>(intent).use { scenario ->
+            scenario.onActivity { activity ->
+                action.perform(activity)
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

* https://github.com/ankidroid/Anki-Android/pull/17495 failed with

```
CreateDeckDialogTest > searchDecksIconVisibilityDeckCreationTest FAILED
    java.lang.OutOfMemoryError: Java heap space
        at org.robolectric.res.android.CppAssetManager2$Theme.SetTo(CppAssetManager2.java:1700)
        at org.robolectric.shadows.ShadowArscAssetManager10.nativeThemeCopy(ShadowArscAssetManager10.java:1657)
        ...
```

This is similar to: https://github.com/ankidroid/Anki-Android/commit/1113858df6a6b8c8c93afac0e1f788942db70c9f. We likely have a few more leaks, but this is a quick one to scan for and fix

*  https://github.com/ankidroid/Anki-Android/pull/15532

## Approach

Call `.use { }`

## How Has This Been Tested?
Ran tests and they continued to pass

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
