### PR TITLE
build(ci): ensure `testlib` is built

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -281,6 +281,11 @@ tasks.register('copyTestLibIntoAndroidTest', Copy) {
 tasks.named('preBuild').configure { dependsOn('copyTestLibIntoAndroidTest') }
 tasks.named('runKtlintCheckOverAndroidTestSourceSet').configure { mustRunAfter('copyTestLibIntoAndroidTest') }
 
+// to run manually: `./gradlew :testlib:assemblePlayDebugAndroidTest`
+tasks.named("assemblePlayDebugAndroidTest") {
+    dependsOn(":testlib:assemblePlayDebugAndroidTest")
+}
+
 // Issue 11078 - some emulators run, but run zero tests, and still report success
 tasks.register('assertNonzeroAndroidTests') {
     doLast {


### PR DESCRIPTION
Added a dependency on the assemblePlayDebugAndroidTest task from AnkiDroid's androidTest in build.gradle.

<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the issue #17520 by adding  a dependency on the assemblePlayDebugAndroidTest task from AnkiDroid's androidTest in build.gradle.

## Fixes
* Fixes #17520 


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
