### PR TITLE
feat(forget-cards): Add link to manual 

### DIFF
--- a/AnkiDroid/src/main/java/androidx/appcompat/widget/DialogTitleView.kt
+++ b/AnkiDroid/src/main/java/androidx/appcompat/widget/DialogTitleView.kt
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This file incorporates work covered by the following copyright and
+ *  permission notice:
+ *
+ *     Copyright (C) 2015 Google Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ * Changes:
+ * * Converted to Kotlin
+ * * Removed @RestrictTo(LIBRARY_GROUP_PREFIX)
+ * * renamed: `DialogTitle` -> `DialogTitleView`
+ * * Inherit from FixedTextView
+ */
+package androidx.appcompat.widget
+
+import android.content.Context
+import android.util.AttributeSet
+import android.util.TypedValue
+import androidx.appcompat.R
+import com.ichi2.ui.FixedTextView
+
+/**
+ * Used by dialogs to change the font size and number of lines to try to fit the text to the available space.
+ *
+ * Renamed from `DialogTitle` to avoid a conflict
+ */
+class DialogTitleView : FixedTextView {
+    constructor(context: Context, attrs: AttributeSet, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+
+    constructor(context: Context) : super(context)
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+
+        val layout = layout ?: return
+        val lineCount = layout.lineCount
+        if (lineCount <= 0) return
+
+        val ellipsisCount = layout.getEllipsisCount(lineCount - 1)
+        if (ellipsisCount == 0) return
+
+        setSingleLine(false)
+        setMaxLines(2)
+
+        val a = context.obtainStyledAttributes(
+            null,
+            R.styleable.TextAppearance,
+            android.R.attr.textAppearanceMedium,
+            android.R.style.TextAppearance_Medium
+        )
+        val textSize = a.getDimensionPixelSize(R.styleable.TextAppearance_android_textSize, 0)
+        if (textSize != 0) {
+            // textSize is already expressed in pixels
+            setTextSize(TypedValue.COMPLEX_UNIT_PX, textSize.toFloat())
+        }
+        a.recycle()
+
+        super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.scheduling
 
 import android.app.Dialog
+import android.net.Uri
 import android.os.Bundle
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
@@ -28,6 +29,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.CardId
@@ -36,7 +38,7 @@ import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.create
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
-import com.ichi2.utils.title
+import com.ichi2.utils.titleWithHelpIcon
 import timber.log.Timber
 
 /**
@@ -102,7 +104,9 @@ class ForgetCardsDialog : DialogFragment() {
             // BUG: this is 'Reset Card'/'Forget Card' in Anki Desktop (24.04)
             // title(text = TR.actionsForgetCard().toSentenceCase(R.string.sentence_forget_cards))
             // "Reset card progress" is less explicit on the singular/plural dimension
-            title(text = getString(R.string.reset_card_dialog_title))
+            titleWithHelpIcon(stringRes = R.string.reset_card_dialog_title) {
+                requireActivity().openUrl(Uri.parse(getString(R.string.link_help_forget_cards)))
+            }
             positiveButton(R.string.dialog_ok) {
                 parentFragmentManager.setFragmentResult(
                     REQUEST_KEY_FORGET,

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedTextView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedTextView.kt
@@ -48,7 +48,7 @@ import android.view.MotionEvent
 import androidx.appcompat.widget.AppCompatTextView
 import timber.log.Timber
 
-class FixedTextView : AppCompatTextView {
+open class FixedTextView : AppCompatTextView {
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -29,7 +29,9 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.FrameLayout
+import android.widget.ImageView
 import android.widget.ListView
+import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -41,6 +43,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 import com.ichi2.ui.FixedTextView
+import timber.log.Timber
 
 /** Wraps [DialogInterface.OnClickListener] as we don't need the `which` parameter */
 typealias DialogInterfaceListener = (DialogInterface) -> Unit
@@ -356,4 +359,44 @@ fun AlertDialog.Builder.listItemsAndMessage(message: String?, items: List<CharSe
         onClick(dialog, index)
     }
     return this.setView(dialogView)
+}
+
+/**
+ * Adds a custom title view to the dialog with a 'help' icon. Typically used to open the Anki Manual
+ *
+ * **Example:**
+ * ```kotlin
+ * MaterialAlertDialogBuilder(context).create {
+ *     titleWithHelpIcon(stringRes = R.string.reset_card_dialog_title) {
+ *         requireActivity().openUrl(Uri.parse(getString(R.string.link_manual)))
+ *     }
+ * }
+ * ```
+ *
+ * @param block action executed when the help icon is clicked
+ *
+ */
+fun AlertDialog.Builder.titleWithHelpIcon(
+    @StringRes stringRes: Int? = null,
+    text: String? = null,
+    block: View.OnClickListener
+) {
+    // setup the view for the dialog
+    val customTitleView = LayoutInflater.from(context).inflate(R.layout.alert_dialog_title_with_help, null, false)
+    setCustomTitle(customTitleView)
+
+    // apply a custom title
+    val titleTextView = customTitleView.findViewById<TextView>(android.R.id.title)
+
+    if (stringRes != null) {
+        titleTextView.setText(stringRes)
+    } else if (text != null) {
+        titleTextView.text = text
+    }
+
+    // set the action when clicking the help icon
+    customTitleView.findViewById<ImageView>(R.id.help_icon).setOnClickListener { v ->
+        Timber.i("dialog help icon click")
+        block.onClick(v)
+    }
 }

--- a/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
+++ b/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="?attr/materialAlertDialogTitlePanelStyle"
+    android:orientation="horizontal"
+    android:paddingStart="24dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="24dp"
+    android:paddingBottom="8dp">
+
+    <androidx.appcompat.widget.DialogTitleView
+        android:id="@android:id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceHeadlineSmall"
+        android:textColor="?attr/colorOnSurface"
+        app:layout_constraintEnd_toStartOf="@+id/help_icon"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:text="Reset Card Progress" />
+
+    <ImageView
+        android:id="@+id/help_icon"
+        style="?attr/materialAlertDialogTitleIconStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
+        android:background="?attr/selectableItemBackground"
+        android:padding="8dp"
+        android:src="@drawable/ic_help_black_24dp"
+        android:contentDescription="@string/help"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="@android:id/title"
+        app:layout_constraintTop_toTopOf="@android:id/title" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -154,6 +154,7 @@
     <string name="link_custom_sync_server_help_learn_more_en">https://docs.ankidroid.org/#_custom_sync_server</string>
     <string name="link_set_due_date_help">https://docs.ankiweb.net/browsing.html#cards</string>
     <string name="link_full_storage_access">https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access</string>
+    <string name="link_help_forget_cards">https://docs.ankiweb.net/studying.html#editing-and-more</string>
 
     <string-array name="cram_deck_conf_order_values">
         <item>0</item>


### PR DESCRIPTION
## Purpose / Description
A user was confused about what the dialog did

## Fixes
* Fixes #17530

## Approach
Adds a custom title View for dialogs, which includes a 'help' button. 

I wanted the button on the end, rather than on the start, and this was not supported

Includes a ripple effect for the help icon

## How Has This Been Tested?

<img width="384" alt="Screenshot 2024-12-02 at 00 59 32" src="https://github.com/user-attachments/assets/bd5e9b1a-c8bc-44ed-943c-25d435a043ed">
<img width="388" alt="Screenshot 2024-12-02 at 00 59 52" src="https://github.com/user-attachments/assets/d15aceae-2faa-4bfc-9d1d-ca02a03ca07b">
<img width="617" alt="Screenshot 2024-12-02 at 01 01 01" src="https://github.com/user-attachments/assets/a583d42c-6eec-4b58-aebf-04293437019d">
<img width="616" alt="Screenshot 2024-12-02 at 01 02 23" src="https://github.com/user-attachments/assets/a94f1035-49b8-4cb9-925f-0195163e13af">


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] ⚠️ UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
  - I am explicitly ignoring this. We have a 40x40 icon, it should be 48x48.
  - Increasing the size moves the sample dialog title over two lines, which looks bad
  - There are no other clickable elements in the vicinity, and there is a decent margin between the button and the edge of the dialog
