### PR TITLE
Resolves issue #17520 -ensures testlib is built

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -279,6 +279,13 @@ tasks.register('copyTestLibIntoAndroidTest', Copy) {
     }
 }
 tasks.named('preBuild').configure { dependsOn('copyTestLibIntoAndroidTest') }
+
+//Issue 17520 -ensures testlib is built
+tasks.named("assemble") {
+    dependsOn(":testlib:assemblePlayDebugAndroidTest")
+}
+
+
 tasks.named('runKtlintCheckOverAndroidTestSourceSet').configure { mustRunAfter('copyTestLibIntoAndroidTest') }
 
 // Issue 11078 - some emulators run, but run zero tests, and still report success


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Ensures that GitHub Actions runs ./gradlew :testlib:assemblePlayDebugAndroidTest at some point to ensure that testlib compiles.

## Fixes
* Fixes #17520 

## Approach
By adding a dependency on this task from AnkiDroid's androidTest in build.gradle

## How Has This Been Tested?

Tried building the changes locally and did not get any error.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
