### PR TITLE
Fixed a weak warning of "The argument can be converted to 'Set' to improve performance" in MediaTest.kt file in Line 131.

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -128,7 +128,7 @@ class MediaTest : InstrumentedTest() {
         assertEquals(expected.size, actual.size)
         expected = listOf("foo.jpg")
         actual = ret.unusedFileNames.toMutableList()
-        actual.retainAll(expected)
+        actual.retainAll(expected.toSet())
         assertEquals(expected.size, actual.size)
     }
 


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
The MediaTest.kt contained actual.retainAll(expected). Its performance was bit slower.
## Fixes
It improved by using actual.retainAll(expected.toSet()).