### PR TITLE
refactor: remove 'sched.totalCards'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1455,7 +1455,7 @@ open class DeckPicker :
         val (deckName, totalCards, isFilteredDeck) = withCol {
             Triple(
                 decks.name(focusedDeck),
-                sched.cardCount(),
+                decks.cardCount(focusedDeck, includeSubdecks = true),
                 decks.isFiltered(focusedDeck)
             )
         }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -549,13 +549,6 @@ open class Scheduler(val col: Collection) {
         return col.db.queryScalar("SELECT 1 FROM cards WHERE did IN " + deckLimit() + " AND queue = " + Consts.QUEUE_TYPE_NEW + " LIMIT 1") != 0
     }
 
-    /** @return Number of cards in the current deck and its descendants.
-     */
-    fun cardCount(): Int {
-        val dids = deckLimit()
-        return col.db.queryScalar("SELECT count() FROM cards WHERE did IN $dids")
-    }
-
     private val etaCache: DoubleArray = doubleArrayOf(-1.0, -1.0, -1.0, -1.0, -1.0, -1.0)
 
     /**


### PR DESCRIPTION
No longer exists

Part of a goal to eliminate `deckLimit()` -> `decks.active()`