### PR TITLE
Fix workflow failure when (Has Conflicts) label is already removed

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -104,7 +104,16 @@ jobs:
                                 // if PR has no conflicts, remove the label
                                 if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
                                     console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
-                                    await removeLabel(['Has Conflicts'], prNumber);
+                                    try {
+                                        await removeLabel(['Has Conflicts'], prNumber);
+                                    } catch(err) {
+                                        if (err.status === 404) {
+                                            console.warn("(Has Conflicts) label no longer found when trying to remove it");
+                                        } else {
+                                            console.log("Unexpected error while removing (Has Conflicts) label: " + err);
+                                            throw err;
+                                        }
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Looked at other workflows where we catch api calls errors and added a try-catch for 404 failures while still failing for any other errors.

## Fixes
* Fixes #17548

## How Has This Been Tested?

Not really testable.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
