### PR TITLE
feat: use Backend for Custom Study Dialog & a few bugfixes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.description
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.ChangeManager
@@ -583,7 +584,7 @@ class StudyOptionsFragment :
                 if (!isDynamic) {
                     deckInfoLayout.visibility = View.GONE
                     buttonStart.visibility = View.VISIBLE
-                    buttonStart.setText(R.string.custom_study)
+                    buttonStart.text = TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study)
                 } else {
                     buttonStart.visibility = View.GONE
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -386,7 +386,11 @@ class CustomStudyDialog(
      */
     private fun getListIds(): List<ContextMenuOption> {
         // Standard context menu
-        return mutableListOf(STUDY_REV, STUDY_FORGOT, STUDY_AHEAD, STUDY_RANDOM, STUDY_PREVIEW, STUDY_TAGS).apply {
+        return mutableListOf(STUDY_FORGOT, STUDY_AHEAD, STUDY_RANDOM, STUDY_PREVIEW, STUDY_TAGS).apply {
+            if (defaults.extendReview.isUsable) {
+                this.add(0, STUDY_REV)
+            }
+            // We want 'Extend new' above 'Extend review' if both appear
             if (defaults.extendNew.isUsable) {
                 this.add(0, STUDY_NEW)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -1,5 +1,6 @@
 /****************************************************************************************
  * Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>                          *
+ * Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>                      *
  *                                                                                      *
  * This program is free software; you can redistribute it and/or modify it under        *
  * the terms of the GNU General Public License as published by the Free Software        *
@@ -28,6 +29,8 @@ import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
+import anki.scheduler.CustomStudyDefaultsResponse
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
@@ -40,6 +43,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.ST
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_RANDOM
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_REV
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_TAGS
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.Companion.toDomainModel
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.launchCatchingTask
@@ -124,6 +128,9 @@ class CustomStudyDialog(
     private val selectedSubDialog: ContextMenuOption?
         get() = requireArguments().getNullableInt(ARG_SUB_DIALOG_ID)?.let { ContextMenuOption.entries[it] }
 
+    /** @see CustomStudyDefaults */
+    private lateinit var defaults: CustomStudyDefaults
+
     fun withArguments(
         did: DeckId,
         contextMenuAttribute: ContextMenuOption? = null,
@@ -147,6 +154,7 @@ class CustomStudyDialog(
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val option = selectedSubDialog
+        this.defaults = collection.sched.customStudyDefaults(dialogDeckId).toDomainModel()
         return if (option == null) {
             Timber.i("Showing Custom Study main menu")
             // Select the specified deck
@@ -378,19 +386,18 @@ class CustomStudyDialog(
     private fun getListIds(): List<ContextMenuOption> {
         // Standard context menu
         return mutableListOf(STUDY_REV, STUDY_FORGOT, STUDY_AHEAD, STUDY_RANDOM, STUDY_PREVIEW, STUDY_TAGS).apply {
-            if (collection.sched.totalNewForCurrentDeck() != 0) {
-                // If no new cards we won't show STUDY_NEW
+            if (defaults.extendNew.isUsable) {
                 this.add(0, STUDY_NEW)
             }
         }
     }
 
+    /** Line 1 of the number entry dialog */
     private val text1: String
-        get() {
-            val res = resources
-            return when (selectedSubDialog) {
-                STUDY_NEW -> res.getString(R.string.custom_study_new_total_new, collection.sched.totalNewForCurrentDeck())
-                STUDY_REV -> res.getString(R.string.custom_study_rev_total_rev, collection.sched.totalRevForCurrentDeck())
+        get() =
+            when (selectedSubDialog) {
+                STUDY_NEW -> defaults.labelForNewQueueAvailable()
+                STUDY_REV -> defaults.labelForReviewQueueAvailable()
                 STUDY_FORGOT,
                 STUDY_AHEAD,
                 STUDY_RANDOM,
@@ -399,7 +406,7 @@ class CustomStudyDialog(
                 null,
                 -> ""
             }
-        }
+
     private val text2: String
         get() {
             val res = resources
@@ -419,8 +426,8 @@ class CustomStudyDialog(
         get() {
             val prefs = requireActivity().sharedPrefs()
             return when (selectedSubDialog) {
-                STUDY_NEW -> prefs.getInt("extendNew", 10).toString()
-                STUDY_REV -> prefs.getInt("extendRev", 50).toString()
+                STUDY_NEW -> defaults.extendNew.initialValue.toString()
+                STUDY_REV -> defaults.extendReview.initialValue.toString()
                 STUDY_FORGOT -> prefs.getInt("forgottenDays", 1).toString()
                 STUDY_AHEAD -> prefs.getInt("aheadDays", 1).toString()
                 STUDY_RANDOM -> prefs.getInt("randomCards", 100).toString()
@@ -530,6 +537,110 @@ class CustomStudyDialog(
         STUDY_RANDOM(R.string.custom_study_random_selection),
         STUDY_PREVIEW(R.string.custom_study_preview_new),
         STUDY_TAGS(R.string.custom_study_limit_tags),
+    }
+
+    /**
+     * Default values for extending deck limits, and default tag selection
+     *
+     * Adapter which documents [anki.scheduler.CustomStudyDefaultsResponse]
+     *
+     * Upstream: [sched.proto: CustomStudyDefaultsResponse](https://github.com/search?q=repo%3Aankitects%2Fanki+CustomStudyDefaultsResponse+language%3A%22Protocol+Buffer%22&type=code&l=Protocol+Buffer)
+     */
+    private class CustomStudyDefaults(
+        val extendNew: ExtendLimits,
+        val extendReview: ExtendLimits,
+        @Suppress("unused")
+        val tags: List<CustomStudyDefaultsResponse.Tag>,
+    ) {
+        /** Available new cards: 1 (2 in subdecks) */
+        fun labelForNewQueueAvailable(): String = TR.customStudyAvailableNewCards2(extendNew.labelForCountWithChildren())
+
+        /** Available review cards: 1 (2 in subdecks) */
+        fun labelForReviewQueueAvailable(): String = TR.customStudyAvailableReviewCards2(extendReview.labelForCountWithChildren())
+
+        /**
+         * Data displayed to a user wanting to temporarily extend the daily limits of
+         * either new/review cards for a deck
+         *
+         * Displays `Available new cards: 1 (2 in subdecks)` when a limit is reached with remaining cards:
+         * ```
+         * Deck (1)
+         *   Deck::Child1 (1)
+         *   Deck::Child2 (1)
+         * ```
+         */
+        class ExtendLimits(
+            /** The initial value to display in the input dialog */
+            val initialValue: Int,
+            /**
+             * The number of pending cards in only the parent deck
+             *
+             * **Example**
+             * Returns **1** when a limit is reached with remaining cards:
+             * ```
+             * Deck (1)
+             *   Deck::Child1 (1)
+             *   Deck::Child2 (1)
+             * ```
+             */
+            val available: Int,
+            /**
+             * The sum of cards in only the child decks
+             *
+             * **Example**
+             * * Returns **2** when a limit is reached  with remaining cards:
+             * ```
+             * Deck (1)
+             *   Deck::Child1 (1)
+             *   Deck::Child2 (1)
+             * ```
+             */
+            val availableInChildren: Int,
+        ) {
+            /**
+             * "Extend" only has an effect if there are pending cards in the target deck
+             *
+             * The number of pending cards in child decks is only informative
+             */
+            val isUsable
+                get() = available > 0
+
+            /**
+             * A string representing the count of cards which have exceeded a deck limit
+             *
+             * `123 (456 in subdecks)` or `123`
+             *
+             * For use in either
+             * [net.ankiweb.rsdroid.Translations.customStudyAvailableReviewCards2] or
+             * [net.ankiweb.rsdroid.Translations.customStudyAvailableNewCards2]
+             *
+             */
+            fun labelForCountWithChildren(): String =
+                if (availableInChildren == 0) {
+                    available.toString()
+                } else {
+                    "$available ${TR.customStudyAvailableChildCount(availableInChildren)}"
+                }
+        }
+
+        companion object {
+            fun CustomStudyDefaultsResponse.toDomainModel(): CustomStudyDefaults =
+                CustomStudyDefaults(
+                    extendNew =
+                        ExtendLimits(
+                            initialValue = extendNew,
+                            available = availableNew,
+                            availableInChildren = availableNewInChildren,
+                        ),
+                    extendReview =
+                        ExtendLimits(
+                            initialValue = extendReview,
+                            available = availableReview,
+                            availableInChildren = availableReviewInChildren,
+                        ),
+                    tags = this.tagsList,
+                )
+        }
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.dialogs.customstudy
 
 import android.annotation.SuppressLint
 import android.app.Dialog
+import android.content.res.Resources
 import android.os.Bundle
 import android.text.Editable
 import android.text.TextWatcher
@@ -50,6 +51,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.showThemedToast
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.withProgress
@@ -168,13 +170,12 @@ class CustomStudyDialog(
 
     private fun buildContextMenu(): AlertDialog {
         val listIds = getListIds()
-        val titles = listIds.map { resources.getString(it.stringResource) }
 
         return AlertDialog
             .Builder(requireActivity())
-            .title(R.string.custom_study)
+            .title(text = TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study))
             .cancelable(true)
-            .listItems(items = titles) { _, index ->
+            .listItems(items = listIds.map { it.getTitle(resources) }) { _, index ->
                 when (listIds[index]) {
                     STUDY_TAGS -> {
                         /*
@@ -528,15 +529,27 @@ class CustomStudyDialog(
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     enum class ContextMenuOption(
-        val stringResource: Int,
+        val getTitle: Resources.() -> String,
     ) {
-        STUDY_NEW(R.string.custom_study_increase_new_limit),
-        STUDY_REV(R.string.custom_study_increase_review_limit),
-        STUDY_FORGOT(R.string.custom_study_review_forgotten),
-        STUDY_AHEAD(R.string.custom_study_review_ahead),
-        STUDY_RANDOM(R.string.custom_study_random_selection),
-        STUDY_PREVIEW(R.string.custom_study_preview_new),
-        STUDY_TAGS(R.string.custom_study_limit_tags),
+        /** Increase today's new card limit */
+        STUDY_NEW({ TR.customStudyIncreaseTodaysNewCardLimit() }),
+
+        /** Increase today's review card limit */
+        STUDY_REV({ TR.customStudyIncreaseTodaysReviewCardLimit() }),
+
+        /** Review forgotten cards */
+        STUDY_FORGOT({ TR.customStudyReviewForgottenCards() }),
+
+        /** Review ahead */
+        STUDY_AHEAD({ TR.customStudyReviewAhead() }),
+
+        STUDY_RANDOM({ getString(R.string.custom_study_random_selection) }),
+
+        /** Preview new cards */
+        STUDY_PREVIEW({ TR.customStudyPreviewNewCards() }),
+
+        /** Limit to particular tags */
+        STUDY_TAGS({ getString(R.string.custom_study_limit_tags) }),
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -520,7 +520,8 @@ class CustomStudyDialog(
      *
      * Upstream: [sched.proto: CustomStudyDefaultsResponse](https://github.com/search?q=repo%3Aankitects%2Fanki+CustomStudyDefaultsResponse+language%3A%22Protocol+Buffer%22&type=code&l=Protocol+Buffer)
      */
-    private class CustomStudyDefaults(
+    @VisibleForTesting
+    class CustomStudyDefaults(
         val extendNew: ExtendLimits,
         val extendReview: ExtendLimits,
         @Suppress("unused")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -35,7 +35,6 @@ import anki.scheduler.CustomStudyRequestKt
 import anki.scheduler.customStudyRequest
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
@@ -461,15 +460,6 @@ class CustomStudyDialog(
                     showThemedToast(requireActivity(), ex.localizedMessage ?: ex.message ?: "", true)
                     return
                 }
-        }
-        if (!dyn.has("terms")) {
-            // #5959 - temp code to diagnose why terms doesn't exist.
-            // normally we wouldn't want to log this much, but we need to know how deep the corruption is to fix the
-            // issue
-            Timber.w("Invalid Dynamic Deck: %s", dyn)
-            CrashReportService.sendExceptionReport("Custom Study Deck had no terms", "CustomStudyDialog - createCustomStudySession")
-            showThemedToast(requireContext(), getString(R.string.custom_study_rebuild_deck_corrupt), false)
-            return
         }
         // and then set various options
         dyn.put("delays", JSONObject.NULL)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -487,6 +487,7 @@ open class Scheduler(
     @CheckResult
     fun customStudy(request: CustomStudyRequest): OpChanges = col.backend.customStudy(request)
 
+    @CheckResult
     fun customStudyDefaults(deckId: DeckId): CustomStudyDefaultsResponse = col.backend.customStudyDefaults(deckId)
 
     /**
@@ -496,16 +497,6 @@ open class Scheduler(
     fun totalNewForCurrentDeck(): Int =
         col.db.queryScalar(
             "SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN ${deckLimit()} AND queue = $QUEUE_TYPE_NEW LIMIT ?)",
-            REPORT_LIMIT,
-        )
-
-    /** @return Number of review cards in current deck.
-     */
-    @Suppress("ktlint:standard:max-line-length")
-    fun totalRevForCurrentDeck(): Int =
-        col.db.queryScalar(
-            "SELECT count() FROM cards WHERE id IN (SELECT id FROM cards WHERE did IN ${deckLimit()} AND queue = $QUEUE_TYPE_REV AND due <= ? LIMIT ?)",
-            today,
             REPORT_LIMIT,
         )
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/EditTextUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/EditTextUtils.kt
@@ -20,3 +20,11 @@ import android.widget.EditText
 
 /** Moves the cursor to the end of the [EditText] */
 fun EditText.moveCursorToEnd() = setSelection(text?.length ?: 0)
+
+/**
+ * Parses the [text][EditText.text] as an [Int] and returns the result, or `null` if the
+ * string is not a valid representation of an [Int].
+ *
+ * note: "1.0" returns `null`
+ */
+fun EditText.textAsIntOrNull() = this.text.toString().toIntOrNull()

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -62,7 +62,6 @@
     <string name="filter_by_flags" maxLength="41">Flags</string>
 
     <!-- Custom study options -->
-    <string name="custom_study_random_selection">Study a random selection of cards</string>
     <string name="custom_study_limit_tags">Limit to particular tags</string>
     <plurals name="studyoptions_buried_count">
         <item quantity="other">+%d buried</item>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -62,12 +62,7 @@
     <string name="filter_by_flags" maxLength="41">Flags</string>
 
     <!-- Custom study options -->
-    <string name="custom_study_increase_new_limit">Modify today’s new card limit</string>
-    <string name="custom_study_increase_review_limit">Modify today’s review card limit</string>
-    <string name="custom_study_review_forgotten">Review forgotten cards</string>
-    <string name="custom_study_review_ahead">Review ahead</string>
     <string name="custom_study_random_selection">Study a random selection of cards</string>
-    <string name="custom_study_preview_new">Preview new cards</string>
     <string name="custom_study_limit_tags">Limit to particular tags</string>
     <plurals name="studyoptions_buried_count">
         <item quantity="other">+%d buried</item>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -52,8 +52,6 @@
     <string name="repair_deck_dialog">Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.</string>
     <string name="intent_aedict_empty">Category “default” is empty</string>
     <string name="intent_aedict_category">To add cards to AnkiDroid remove all Notepad categories or add one named “default”</string>
-    <string name="custom_study_new_total_new">New cards in deck: %d</string>
-    <string name="custom_study_rev_total_rev">Reviews due in deck: %d</string>
     <string name="custom_study_new_extend">Increase/decrease (“-3”) today’s new card limit by</string>
     <string name="custom_study_rev_extend">Increase/decrease (“-3”) today’s review limit by</string>
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -56,7 +56,6 @@
     <string name="custom_study_rev_extend">Increase/decrease (“-3”) today’s review limit by</string>
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead">Review ahead by x days:</string>
-    <string name="custom_study_random">Select x cards randomly from the deck:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
     <string name="custom_study_rebuild_deck_corrupt">Could not rebuild custom study deck</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -57,7 +57,6 @@
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead">Review ahead by x days:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
-    <string name="custom_study_rebuild_deck_corrupt">Could not rebuild custom study deck</string>
 
     <string name="storage_full_title">Storage full</string>
     <string name="storage_almost_full_title">Storage almost full</string>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -40,5 +40,6 @@ undoActionUndone()
     <string name="sentence_gesture_flag_remove">Remove flag</string>
     <string name="sentence_gesture_abort_sync">Abort learning and sync</string>
     <string name="sentence_gesture_toggle_whiteboard">Toggle whiteboard</string>
+    <string name="sentence_custom_study">Custom study</string>
 
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -45,6 +45,7 @@ import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.TaskSchedulerRule
+import com.ichi2.testutils.TestClass
 import com.ichi2.testutils.common.FailOnUnhandledExceptionRule
 import com.ichi2.testutils.common.IgnoreFlakyTestsInCIRule
 import com.ichi2.testutils.filter
@@ -75,7 +76,9 @@ import org.robolectric.shadows.ShadowMediaPlayer
 import timber.log.Timber
 import kotlin.test.assertNotNull
 
-open class RobolectricTest : AndroidTest {
+open class RobolectricTest :
+    TestClass,
+    AndroidTest {
     @Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
     private fun Any.wait(timeMs: Long) = (this as Object).wait(timeMs)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -27,7 +27,7 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.scheduler.CustomStudyDefaultsResponse
 import anki.scheduler.customStudyDefaultsResponse
-import com.ichi2.anki.R
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
@@ -124,7 +124,7 @@ class CustomStudyDialogTest : RobolectricTest() {
             factory = dialogFactory(col = mockCollectionWithSchedulerReturning(studyDefaults)),
         ) { dialogFragment: CustomStudyDialog ->
             assertNotNull(dialogFragment.dialog as? AlertDialog?, "dialog")
-            onView(withText(R.string.custom_study_increase_new_limit))
+            onView(withText(TR.customStudyIncreaseTodaysNewCardLimit()))
                 .inRoot(isDialog())
                 .check(matches(isDisplayed()))
         }
@@ -140,7 +140,7 @@ class CustomStudyDialogTest : RobolectricTest() {
             factory = dialogFactory(col = mockCollectionWithSchedulerReturning(studyDefaults)),
         ) { dialogFragment: CustomStudyDialog ->
             assertNotNull(dialogFragment.dialog as? AlertDialog?, "dialog")
-            onView(withText(R.string.custom_study_increase_new_limit))
+            onView(withText(TR.customStudyIncreaseTodaysNewCardLimit()))
                 .inRoot(isDialog())
                 .check(doesNotExist())
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -146,6 +146,36 @@ class CustomStudyDialogTest : RobolectricTest() {
         }
     }
 
+    @Test
+    @Config(qualifiers = "en")
+    fun `'increase review limit' is shown when there are new cards`() {
+        val studyDefaults = customStudyDefaultsResponse { availableReview = 1 }
+
+        withCustomStudyFragment(
+            args = argumentsDisplayingMainScreen(),
+            factory = dialogFactory(col = mockCollectionWithSchedulerReturning(studyDefaults)),
+        ) { dialogFragment: CustomStudyDialog ->
+            onView(withText(TR.customStudyIncreaseTodaysReviewCardLimit()))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+        }
+    }
+
+    @Test
+    @Config(qualifiers = "en")
+    fun `'increase review limit' is not shown when there are no new cards`() {
+        val studyDefaults = customStudyDefaultsResponse { availableReview = 0 }
+
+        withCustomStudyFragment(
+            args = argumentsDisplayingMainScreen(),
+            factory = dialogFactory(col = mockCollectionWithSchedulerReturning(studyDefaults)),
+        ) { dialogFragment: CustomStudyDialog ->
+            onView(withText(TR.customStudyIncreaseTodaysReviewCardLimit()))
+                .inRoot(isDialog())
+                .check(doesNotExist())
+        }
+    }
+
     /**
      * Runs [block] on a [CustomStudyDialog]
      */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
@@ -42,7 +42,7 @@ fun AlertDialog.performPositiveClick() {
     // This exists as callOnClick did not call the listener
     val positiveButton = assertNotNull(getButton(DialogInterface.BUTTON_POSITIVE), message = "positive button")
     assertThat("button is visible", positiveButton.isVisible)
-    assertThat("button is enalbed", positiveButton.isEnabled)
+    assertThat("button is enabled", positiveButton.isEnabled)
     executeFunctionUsingHandler { positiveButton.callOnClick() }
     InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -37,6 +37,7 @@ class SentenceCaseTest : RobolectricTest() {
             assertThat(TR.browsingToggleSuspend().toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
             assertThat(TR.browsingToggleBury().toSentenceCase(this, R.string.sentence_toggle_bury), equalTo("Toggle bury"))
             assertThat(TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date), equalTo("Set due date"))
+            assertThat(TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study), equalTo("Custom study"))
 
             assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
             assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/AndroidTest.kt
@@ -20,10 +20,21 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
+import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.preferences.sharedPrefs
 
-/** Marker interface for classes annotated with `@RunWith(AndroidJUnit4.class)` */
-interface AndroidTest : TestClass
+/**
+ * Marker interface for classes annotated with `@RunWith(AndroidJUnit4.class)` which do
+ * not need access to the collection
+ *
+ * Classes should also be marked with `@Config(application = EmptyApplication::class)` for
+ * performance improvements
+ *
+ * Use [JvmTest] if a reference to Android is not necessary but the collection is required
+ *
+ * Use [RobolectricTest] if access the collection is necessary
+ */
+interface AndroidTest
 
 val AndroidTest.targetContext: Context
     get() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/EditTextUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/EditTextUtilsTest.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.utils
+
+import android.widget.EditText
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.AndroidTest
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.targetContext
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class EditTextUtilsTest : AndroidTest {
+    @Test
+    fun `textAsIntOrNull test`() {
+        fun textAsIntOrNull(value: String) =
+            EditText(targetContext)
+                .apply { setText(value) }
+                .textAsIntOrNull()
+
+        fun textAsIntOrNull(value: Long) = textAsIntOrNull(value.toString())
+
+        fun textAsIntOrNull(value: Int) = textAsIntOrNull(value.toString())
+
+        assertThat("1", textAsIntOrNull("1"), equalTo(1))
+        assertThat("1.0 => null", textAsIntOrNull("1.0"), nullValue())
+        assertThat("1.1 => null", textAsIntOrNull("1.1"), nullValue())
+        assertThat("-1", textAsIntOrNull("-1"), equalTo(-1))
+        assertThat("2147483647", textAsIntOrNull(Int.MAX_VALUE), equalTo(2147483647))
+        assertThat("-2147483648", textAsIntOrNull(Int.MIN_VALUE), equalTo(-2147483648))
+
+        assertThat("MIN_VALUE - 1 => null", textAsIntOrNull(Int.MIN_VALUE - 1L), nullValue())
+        assertThat("MAX_VALUE + 1 => null", textAsIntOrNull(Int.MAX_VALUE + 1L), nullValue())
+
+        assertThat("empty string => null", textAsIntOrNull(""), nullValue())
+        assertThat("text => null", textAsIntOrNull("non-int text"), nullValue())
+        assertThat("too long => null", textAsIntOrNull(Long.MAX_VALUE), nullValue())
+    }
+}


### PR DESCRIPTION
## Purpose / Description
This removes some custom business logic, and instead uses the Anki Backend for the default values in Custom Study

It then goes to fix a bug: we could 'increase review limits' of a deck with no pending reviews

## Approach
See commits

## How Has This Been Tested?
Unit tests fixed up & written

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
