### PR TITLE
NF: Remove `else ->` when possible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -12,7 +12,7 @@ import kotlinx.parcelize.Parcelize
 
 object ActivityTransitionAnimation {
     @Suppress("DEPRECATION", "deprecated in API34 for predictive back, must plumb through new open/close parameter")
-    fun slide(activity: Activity, direction: Direction?) {
+    fun slide(activity: Activity, direction: Direction) {
         when (direction) {
             Direction.START -> if (isRightToLeft(activity)) {
                 activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
@@ -31,8 +31,6 @@ object ActivityTransitionAnimation {
             Direction.DOWN -> activity.overridePendingTransition(R.anim.slide_down_in, R.anim.slide_down_out)
             Direction.NONE -> activity.overridePendingTransition(R.anim.none, R.anim.none)
             Direction.DEFAULT -> {
-            }
-            else -> {
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1730,8 +1730,29 @@ abstract class AbstractFlashcardViewer :
                 loadUrlInViewer("javascript: showAllHints();")
                 true
             }
-
-            else -> {
+            ViewerCommand.REDO,
+            ViewerCommand.MARK,
+            ViewerCommand.TOGGLE_FLAG_RED,
+            ViewerCommand.TOGGLE_FLAG_ORANGE,
+            ViewerCommand.TOGGLE_FLAG_GREEN,
+            ViewerCommand.TOGGLE_FLAG_BLUE,
+            ViewerCommand.TOGGLE_FLAG_PINK,
+            ViewerCommand.TOGGLE_FLAG_TURQUOISE,
+            ViewerCommand.TOGGLE_FLAG_PURPLE,
+            ViewerCommand.UNSET_FLAG,
+            ViewerCommand.CARD_INFO,
+            ViewerCommand.ADD_NOTE,
+            ViewerCommand.RESCHEDULE_NOTE,
+            ViewerCommand.TOGGLE_AUTO_ADVANCE,
+            ViewerCommand.USER_ACTION_1,
+            ViewerCommand.USER_ACTION_2,
+            ViewerCommand.USER_ACTION_3,
+            ViewerCommand.USER_ACTION_4,
+            ViewerCommand.USER_ACTION_5,
+            ViewerCommand.USER_ACTION_6,
+            ViewerCommand.USER_ACTION_7,
+            ViewerCommand.USER_ACTION_8,
+            ViewerCommand.USER_ACTION_9 -> {
                 Timber.w("Unknown command requested: %s", which)
                 false
             }
@@ -2508,7 +2529,7 @@ abstract class AbstractFlashcardViewer :
                 is SoundOrVideoTag -> tag
                 is TTSTag -> tag
                 // not currently supported
-                else -> return
+                null -> return
             }
             cardMediaPlayer.playOneSound(avTag)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2176,7 +2176,7 @@ open class CardBrowser :
             return Themes.getColorFromAttr(context, colorAttr)
         }
 
-        fun getColumnHeaderText(key: CardBrowserColumn?): String? {
+        fun getColumnHeaderText(key: CardBrowserColumn): String? {
             return when (key) {
                 CardBrowserColumn.SFLD -> card.note(col).sFld(col)
                 CardBrowserColumn.DECK -> col.decks.name(card.did)
@@ -2200,7 +2200,9 @@ open class CardBrowser :
                     updateSearchItemQA()
                     qa!!.second
                 }
-                else -> null
+                CardBrowserColumn.FSRS_DIFFICULTY,
+                CardBrowserColumn.FSRS_RETRIEVABILITY,
+                CardBrowserColumn.FSRS_STABILITY -> null
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -728,7 +728,7 @@ open class DeckPicker :
     }
 
     @VisibleForTesting
-    fun handleStartupFailure(failure: StartupFailure?) {
+    fun handleStartupFailure(failure: StartupFailure) {
         when (failure) {
             is SDCardNotMounted -> {
                 Timber.i("SD card not mounted")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -341,7 +341,7 @@ open class Reviewer :
         return when (fullscreenMode) {
             FullScreenMode.BUTTONS_ONLY -> R.layout.reviewer_fullscreen
             FullScreenMode.FULLSCREEN_ALL_GONE -> R.layout.reviewer_fullscreen_noanswers
-            else -> R.layout.reviewer
+            FullScreenMode.BUTTONS_AND_MENU -> R.layout.reviewer
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -286,7 +286,6 @@ class CardMediaPlayer : Closeable {
                         soundErrorListener?.onTtsError(it, isAutomaticPlayback)
                     }
                 }
-                else -> Timber.w("unknown audio: ${tag.javaClass}")
             }
             ensureActive()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -107,11 +107,11 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
     }
 
     private fun execute(gesture: Gesture?): Boolean? {
-        val command = mapGestureToCommand(gesture) ?: return false
+        val command = gesture?.let { mapGestureToCommand(it) } ?: return false
         return processor?.executeCommand(command, gesture)
     }
 
-    private fun mapGestureToCommand(gesture: Gesture?): ViewerCommand? {
+    private fun mapGestureToCommand(gesture: Gesture): ViewerCommand? {
         return when (gesture) {
             Gesture.SWIPE_UP -> gestureSwipeUp
             Gesture.SWIPE_DOWN -> gestureSwipeDown
@@ -129,7 +129,6 @@ class GestureProcessor(private val processor: ViewerCommand.CommandProcessor?) {
             Gesture.DOUBLE_TAP -> gestureDoubleTap
             Gesture.LONG_TAP -> gestureLongclick
             Gesture.SHAKE -> gestureShake
-            else -> null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -192,7 +192,28 @@ enum class ViewerCommand(val resourceId: Int) {
                 SHOW_HINT -> listOf(keyCode(KeyEvent.KEYCODE_H, CardSide.BOTH))
                 SHOW_ALL_HINTS -> listOf(keyCode(KeyEvent.KEYCODE_G, CardSide.BOTH))
                 ADD_NOTE -> listOf(keyCode(KeyEvent.KEYCODE_A, CardSide.BOTH))
-                else -> emptyList()
+                SHOW_ANSWER,
+                DELETE,
+                EXIT,
+                UNSET_FLAG,
+                PAGE_UP,
+                PAGE_DOWN,
+                TAG,
+                CARD_INFO,
+                ABORT_AND_SYNC,
+                TOGGLE_WHITEBOARD,
+                CLEAR_WHITEBOARD,
+                CHANGE_WHITEBOARD_PEN_COLOR,
+                RESCHEDULE_NOTE,
+                USER_ACTION_1,
+                USER_ACTION_2,
+                USER_ACTION_3,
+                USER_ACTION_4,
+                USER_ACTION_5,
+                USER_ACTION_6,
+                USER_ACTION_7,
+                USER_ACTION_8,
+                USER_ACTION_9 -> emptyList()
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -567,7 +567,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     ?: res().getString(R.string.card_browser_unknown_deck_name)
                 res().getString(R.string.directory_inaccessible_after_uninstall_summary, directory)
             }
-            else -> requireArguments().getString("dialogMessage")
+            DIALOG_ERROR_HANDLING -> requireArguments().getString("dialogMessage")
         }
     private val title: String
         get() = when (requireDialogType()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -144,7 +144,12 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                         )
                         requireActivity().showDialogFragment(dialogFragment)
                     }
-                    else -> {
+                    STUDY_NEW,
+                    STUDY_REV,
+                    STUDY_FORGOT,
+                    STUDY_AHEAD,
+                    STUDY_RANDOM,
+                    STUDY_PREVIEW -> {
                         // User asked for a standard custom study option
                         val d = CustomStudyDialog(collection, customStudyListener)
                             .withArguments(
@@ -337,7 +342,12 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
             return when (getOption()) {
                 STUDY_NEW -> res.getString(R.string.custom_study_new_total_new, collection.sched.totalNewForCurrentDeck())
                 STUDY_REV -> res.getString(R.string.custom_study_rev_total_rev, collection.sched.totalRevForCurrentDeck())
-                else -> ""
+                STUDY_FORGOT,
+                STUDY_AHEAD,
+                STUDY_RANDOM,
+                STUDY_PREVIEW,
+                STUDY_TAGS,
+                null -> ""
             }
         }
     private val text2: String
@@ -350,7 +360,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 STUDY_AHEAD -> res.getString(R.string.custom_study_ahead)
                 STUDY_RANDOM -> res.getString(R.string.custom_study_random)
                 STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
-                else -> ""
+                STUDY_TAGS,
+                null -> ""
             }
         }
     private val defaultValue: String
@@ -363,7 +374,8 @@ class CustomStudyDialog(private val collection: Collection, private val customSt
                 STUDY_AHEAD -> prefs.getInt("aheadDays", 1).toString()
                 STUDY_RANDOM -> prefs.getInt("randomCards", 100).toString()
                 STUDY_PREVIEW -> prefs.getInt("previewDays", 1).toString()
-                else -> ""
+                STUDY_TAGS,
+                null -> ""
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/MediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/MediaPlayer.kt
@@ -126,7 +126,8 @@ class MediaPlayer :
         when (state) {
             IDLE, INITIALIZED, PREPARED, STARTED, PAUSED, STOPPED, PLAYBACK_COMPLETE, ERROR ->
                 state = IDLE
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            PREPARING,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -139,7 +140,14 @@ class MediaPlayer :
         super.prepareAsync()
         when (state) {
             INITIALIZED, STOPPED -> state = PREPARING
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            PREPARING,
+            PREPARED,
+            STARTED,
+            PAUSED,
+            PLAYBACK_COMPLETE,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -147,7 +155,14 @@ class MediaPlayer :
         super.prepare()
         when (state) {
             INITIALIZED, STOPPED -> state = PREPARED
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            PREPARING,
+            PREPARED,
+            STARTED,
+            PAUSED,
+            PLAYBACK_COMPLETE,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -155,7 +170,12 @@ class MediaPlayer :
         super.seekTo(msec)
         when (state) {
             PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETE -> {}
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            INITIALIZED,
+            PREPARING,
+            STOPPED,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -163,7 +183,12 @@ class MediaPlayer :
         super.seekTo(msec, mode)
         when (state) {
             PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETE -> {}
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            INITIALIZED,
+            PREPARING,
+            STOPPED,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -171,7 +196,11 @@ class MediaPlayer :
         super.stop()
         when (state) {
             PREPARED, STARTED, STOPPED, PAUSED, PLAYBACK_COMPLETE -> state = STOPPED
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            INITIALIZED,
+            PREPARING,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -179,7 +208,12 @@ class MediaPlayer :
         super.start()
         when (state) {
             PREPARED, STARTED, PAUSED, PLAYBACK_COMPLETE -> state = STARTED
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            INITIALIZED,
+            PREPARING,
+            STOPPED,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 
@@ -187,7 +221,13 @@ class MediaPlayer :
         super.pause()
         when (state) {
             STARTED, PAUSED, PLAYBACK_COMPLETE -> state = PAUSED
-            else -> throw IllegalStateException("Invalid MediaPlayerState $state")
+            ERROR,
+            IDLE,
+            INITIALIZED,
+            PREPARING,
+            PREPARED,
+            STOPPED,
+            END -> throw IllegalStateException("Invalid MediaPlayerState $state")
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -322,7 +322,7 @@ enum class AutomaticAnswerAction(private val configValue: Int) {
             ANSWER_AGAIN -> AGAIN.toViewerCommand()
             ANSWER_HARD -> HARD.toViewerCommand()
             ANSWER_GOOD -> GOOD.toViewerCommand()
-            else -> null
+            SHOW_REMINDER -> null
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -118,7 +118,7 @@ class MappableBinding(val binding: Binding, val screen: Screen) {
                 val formatString = when (side) {
                     CardSide.QUESTION -> context.getString(R.string.display_binding_card_side_question)
                     CardSide.ANSWER -> context.getString(R.string.display_binding_card_side_answer)
-                    else -> context.getString(R.string.display_binding_card_side_both) // intentionally no prefix
+                    CardSide.BOTH -> context.getString(R.string.display_binding_card_side_both) // intentionally no prefix
                 }
                 return String.format(formatString, binding.toDisplayString(context))
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -146,8 +146,7 @@ object NoteService {
                     }
                     when (field.type) {
                         EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> field.mediaPath = outFile.absolutePath
-                        else -> {
-                        }
+                        EFieldType.TEXT -> {}
                     }
                 }
             } catch (e: IOException) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -84,13 +84,13 @@ data class SoundOrVideoTag(val filename: String) : AvTag() {
     }
 }
 
-/** In python, this is a union of [TTSTag] and [SoundOrVideoTag] */
-open class AvTag
-
 /**
  * [Regex] used to identify the markers for sound files
  */
 val SOUND_RE = Pattern.compile("\\[sound:([^\\[\\]]*)]").toRegex()
+
+/** In python, this is a union of [TTSTag] and [SoundOrVideoTag] */
+sealed class AvTag
 
 fun stripAvRefs(text: String, replacement: String = "") = AvRef.REGEX.replace(text, replacement)
 

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -167,7 +167,7 @@ class CheckBoxTriStates : AppCompatCheckBox {
         val btnDrawable: Int = when (_state) {
             State.UNCHECKED -> R.drawable.ic_baseline_check_box_outline_blank_24_inset
             State.CHECKED -> R.drawable.ic_baseline_check_box_24_inset
-            else -> R.drawable.ic_baseline_indeterminate_check_box_24_inset
+            State.INDETERMINATE -> R.drawable.ic_baseline_indeterminate_check_box_24_inset
         }
         setButtonDrawable(btnDrawable)
     }


### PR DESCRIPTION
#17352 duplicated. For some reason I can't re-open it

When `when` is used on an enum, the `else ->` can always be transformed into a complete enumeration of the enum's entries.

This ensure that each time a new entry is added, there is a warning and the developer must decide whether or not a change is needed. While the `else` may hide some required change.

So, for the sake of future developement, I removed `else ->` when it makes sense.

I should note that I kept some `else ->` when the `when` consider only a very small part of all possible enum value, in order to reduce the size of the code.