### PR TITLE
Some cleaning of Database error dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -84,6 +84,8 @@ import java.io.IOException
 class DatabaseErrorDialog : AsyncDialogFragment() {
     private lateinit var backups: Array<File>
 
+    private fun requireDeckPicker() = activity as DeckPicker
+
     @SuppressLint("CheckResult")
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreateDialog(savedInstanceState)
@@ -131,7 +133,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                     }
                     negativeButton(R.string.answering_error_report) {
-                        (activity as DeckPicker).sendErrorReport()
+                        requireDeckPicker().sendErrorReport()
                         activity?.dismissAllDialogFragments()
                     }
                     neutralButton(R.string.close) {
@@ -139,7 +141,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     }
                 }.apply {
                     show()
-                    getButton(Dialog.BUTTON_NEGATIVE).isEnabled = (activity as DeckPicker).hasErrorFiles()
+                    getButton(Dialog.BUTTON_NEGATIVE).isEnabled = requireDeckPicker().hasErrorFiles()
                 }
             }
             DIALOG_ERROR_HANDLING -> {
@@ -179,23 +181,23 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     listItems(items = options) { _, index ->
                         when (values[index]) {
                             ErrorHandlingEntries.RETRY -> {
-                                ActivityCompat.recreate(activity as DeckPicker)
+                                ActivityCompat.recreate(requireDeckPicker())
                                 return@listItems
                             }
                             ErrorHandlingEntries.REPAIR -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION, exceptionData)
+                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.RESTORE -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
+                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.ONE_WAY -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER, exceptionData)
+                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER, exceptionData)
                                 return@listItems
                             }
                             ErrorHandlingEntries.NEW -> {
-                                (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_NEW_COLLECTION, exceptionData)
+                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_NEW_COLLECTION, exceptionData)
                                 return@listItems
                             }
 
@@ -219,7 +221,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.dialog_positive_repair) {
-                        (activity as DeckPicker).repairCollection()
+                        requireDeckPicker().repairCollection()
                         activity?.dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -290,9 +292,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         CollectionManager.closeCollectionBlocking()
                         val path1 = CollectionHelper.getCollectionPath(requireActivity())
                         if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
-                            ActivityCompat.recreate(activity as DeckPicker)
+                            ActivityCompat.recreate(requireDeckPicker())
                         } else {
-                            (activity as DeckPicker).showDatabaseErrorDialog(DIALOG_LOAD_FAILED, exceptionData)
+                            requireDeckPicker().showDatabaseErrorDialog(DIALOG_LOAD_FAILED, exceptionData)
                         }
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -304,7 +306,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.check_db_title)
                     message(text = message)
                     positiveButton(R.string.dialog_ok) {
-                        (activity as DeckPicker).integrityCheck()
+                        requireDeckPicker().integrityCheck()
                         activity?.dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -328,7 +330,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.backup_one_way_sync_from_server)
                     message(text = message)
                     positiveButton(R.string.dialog_positive_overwrite) {
-                        (activity as DeckPicker).sync(ConflictResolution.FULL_DOWNLOAD)
+                        requireDeckPicker().sync(ConflictResolution.FULL_DOWNLOAD)
                         activity?.dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -363,11 +365,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     }
                     listItemsAndMessage(message = message, items = options) { _, index: Int ->
                         when (values[index]) {
-                            IncompatibleDbVersionEntries.RESTORE -> (activity as DeckPicker).showDatabaseErrorDialog(
+                            IncompatibleDbVersionEntries.RESTORE -> requireDeckPicker().showDatabaseErrorDialog(
                                 DIALOG_RESTORE_BACKUP,
                                 exceptionData
                             )
-                            IncompatibleDbVersionEntries.ONE_WAY -> (activity as DeckPicker).showDatabaseErrorDialog(
+                            IncompatibleDbVersionEntries.ONE_WAY -> requireDeckPicker().showDatabaseErrorDialog(
                                 DIALOG_ONE_WAY_SYNC_FROM_SERVER,
                                 exceptionData
                             )
@@ -390,7 +392,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.directory_inaccessible_after_uninstall)
                     listItemsAndMessage(message = message, items = listItems.map { getString(it.stringRes) }) { _, index: Int ->
                         val listItem = listItems[index]
-                        listItem.onClick(activity as DeckPicker)
+                        listItem.onClick(requireDeckPicker())
                         if (listItem.dismissesDialog) {
                             dismiss()
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -56,6 +56,7 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.INCOMP
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.isLoggedIn
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.showImportDialog
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -112,7 +113,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
-                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                        showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
                     }
                     negativeButton(R.string.close) {
                         closeCollectionAndFinish()
@@ -128,11 +129,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
-                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                        showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
                     }
                     negativeButton(R.string.answering_error_report) {
                         requireDeckPicker().sendErrorReport()
-                        activity?.dismissAllDialogFragments()
+                        requireActivity().dismissAllDialogFragments()
                     }
                     neutralButton(R.string.close) {
                         closeCollectionAndFinish()
@@ -179,23 +180,23 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     listItems(items = options) { _, index ->
                         when (values[index]) {
                             ErrorHandlingEntries.RETRY -> {
-                                ActivityCompat.recreate(requireDeckPicker())
+                                ActivityCompat.recreate(requireActivity())
                                 return@listItems
                             }
                             ErrorHandlingEntries.REPAIR -> {
-                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION, exceptionData)
+                                showDatabaseErrorDialog(DIALOG_REPAIR_COLLECTION)
                                 return@listItems
                             }
                             ErrorHandlingEntries.RESTORE -> {
-                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
+                                showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
                                 return@listItems
                             }
                             ErrorHandlingEntries.ONE_WAY -> {
-                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER, exceptionData)
+                                showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER)
                                 return@listItems
                             }
                             ErrorHandlingEntries.NEW -> {
-                                requireDeckPicker().showDatabaseErrorDialog(DIALOG_NEW_COLLECTION, exceptionData)
+                                showDatabaseErrorDialog(DIALOG_NEW_COLLECTION)
                                 return@listItems
                             }
 
@@ -220,7 +221,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.dialog_positive_repair) {
                         requireDeckPicker().repairCollection()
-                        activity?.dismissAllDialogFragments()
+                        requireActivity().dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
                 }
@@ -233,7 +234,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     alertDialog.title(R.string.backup_restore)
                         .title(text = message)
                         .positiveButton(R.string.dialog_ok) {
-                            requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                            showDatabaseErrorDialog(DIALOG_ERROR_HANDLING)
                         }
                 } else {
                     // Show backups sorted with latest on top
@@ -254,7 +255,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                                 requireDeckPicker().restoreFromBackup(
                                     backups[index].path
                                 )
-                                activity?.dismissAllDialogFragments()
+                                requireActivity().dismissAllDialogFragments()
                             } else {
                                 // otherwise show an error dialog
                                 AlertDialog.Builder(requireActivity()).show {
@@ -268,7 +269,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 alertDialog.setOnKeyListener { _: DialogInterface?, keyCode: Int, _: KeyEvent? ->
                     if (keyCode == KeyEvent.KEYCODE_BACK) {
                         Timber.i("DIALOG_RESTORE_BACKUP caught hardware back button")
-                        activity?.dismissAllDialogFragments()
+                        requireActivity().dismissAllDialogFragments()
                         return@setOnKeyListener true
                     }
                     false
@@ -290,7 +291,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         if (BackupManager.moveDatabaseToBrokenDirectory(path1, false, time)) {
                             ActivityCompat.recreate(requireDeckPicker())
                         } else {
-                            requireDeckPicker().showDatabaseErrorDialog(DIALOG_LOAD_FAILED, exceptionData)
+                            showDatabaseErrorDialog(DIALOG_LOAD_FAILED)
                         }
                     }
                     negativeButton(R.string.dialog_cancel)
@@ -303,7 +304,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     positiveButton(R.string.dialog_ok) {
                         requireDeckPicker().integrityCheck()
-                        activity?.dismissAllDialogFragments()
+                        requireActivity().dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
                 }
@@ -314,7 +315,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.restore_backup_title)
                     message(text = message)
                     positiveButton(R.string.dialog_continue) {
-                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
+                        showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP)
                     }
                     negativeButton(R.string.dialog_cancel)
                 }
@@ -326,7 +327,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     positiveButton(R.string.dialog_positive_overwrite) {
                         requireDeckPicker().sync(ConflictResolution.FULL_DOWNLOAD)
-                        activity?.dismissAllDialogFragments()
+                        requireActivity().dismissAllDialogFragments()
                     }
                     negativeButton(R.string.dialog_cancel)
                 }
@@ -360,13 +361,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     }
                     listItemsAndMessage(message = message, items = options) { _, index: Int ->
                         when (values[index]) {
-                            IncompatibleDbVersionEntries.RESTORE -> requireDeckPicker().showDatabaseErrorDialog(
-                                DIALOG_RESTORE_BACKUP,
-                                exceptionData
+                            IncompatibleDbVersionEntries.RESTORE -> showDatabaseErrorDialog(
+                                DIALOG_RESTORE_BACKUP
                             )
-                            IncompatibleDbVersionEntries.ONE_WAY -> requireDeckPicker().showDatabaseErrorDialog(
-                                DIALOG_ONE_WAY_SYNC_FROM_SERVER,
-                                exceptionData
+                            IncompatibleDbVersionEntries.ONE_WAY -> showDatabaseErrorDialog(
+                                DIALOG_ONE_WAY_SYNC_FROM_SERVER
                             )
                         }
                     }
@@ -387,7 +386,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.directory_inaccessible_after_uninstall)
                     listItemsAndMessage(message = message, items = listItems.map { getString(it.stringRes) }) { _, index: Int ->
                         val listItem = listItems[index]
-                        listItem.onClick(requireDeckPicker())
+                        listItem.onClick(requireAnkiActivity())
                         if (listItem.dismissesDialog) {
                             dismiss()
                         }
@@ -396,6 +395,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                 }
             }
         }
+    }
+
+    /** @see DeckPicker.showDatabaseErrorDialog */
+    private fun showDatabaseErrorDialog(errorDialogType: DatabaseErrorDialogType) {
+        requireDeckPicker().showDatabaseErrorDialog(errorDialogType, exceptionData)
     }
 
     /**
@@ -521,7 +525,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
     }
 
     private fun closeCollectionAndFinish() {
-        (activity as AnkiActivity).closeCollectionAndFinish()
+        (requireActivity() as AnkiActivity).closeCollectionAndFinish()
     } // Generic message shown when a libanki task failed
 
     // The sqlite database has been corrupted (DatabaseErrorHandler.onCorrupt() was called)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -112,8 +112,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
-                        (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                     }
                     negativeButton(R.string.close) {
                         closeCollectionAndFinish()
@@ -129,8 +128,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     message(text = message)
                     setIcon(R.drawable.ic_warning)
                     positiveButton(R.string.error_handling_options) {
-                        (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                     }
                     negativeButton(R.string.answering_error_report) {
                         requireDeckPicker().sendErrorReport()
@@ -235,8 +233,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     alertDialog.title(R.string.backup_restore)
                         .title(text = message)
                         .positiveButton(R.string.dialog_ok) {
-                            (activity as DeckPicker?)
-                                ?.showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
+                            requireDeckPicker().showDatabaseErrorDialog(DIALOG_ERROR_HANDLING, exceptionData)
                         }
                 } else {
                     // Show backups sorted with latest on top
@@ -254,10 +251,9 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                         .setSingleChoiceItems(dates.toTypedArray(), -1) { _, index: Int ->
                             if (backups[index].length() > 0) {
                                 // restore the backup if it's valid
-                                (activity as DeckPicker?)
-                                    ?.restoreFromBackup(
-                                        backups[index].path
-                                    )
+                                requireDeckPicker().restoreFromBackup(
+                                    backups[index].path
+                                )
                                 activity?.dismissAllDialogFragments()
                             } else {
                                 // otherwise show an error dialog
@@ -318,8 +314,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     title(R.string.restore_backup_title)
                     message(text = message)
                     positiveButton(R.string.dialog_continue) {
-                        (activity as DeckPicker?)
-                            ?.showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
+                        requireDeckPicker().showDatabaseErrorDialog(DIALOG_RESTORE_BACKUP, exceptionData)
                     }
                     negativeButton(R.string.dialog_cancel)
                 }


### PR DESCRIPTION
While working on #17399 I realized that similar cleaning could occur to the nullable deck picker that can't actually be null.