### PR TITLE
fix(shared-decks): can't download decks on Android 15

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DownloadFileTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DownloadFileTest.kt
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.tests.InstrumentedTest
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Test of [DownloadFile] */
+@RunWith(AndroidJUnit4::class)
+class DownloadFileTest : InstrumentedTest() {
+    @Test
+    fun guessFileName_Issue17573() {
+        // broken on API 35
+        // https://github.com/ankidroid/Anki-Android/issues/17573
+        // https://issuetracker.google.com/issues/382864232
+
+        val downloadFile = DownloadFile(
+            url = "https://ankiweb.net/svc/shared/download-deck/293204297?t=token",
+            userAgent = "unused",
+            contentDisposition = "attachment; filename=Goethe_Institute_A1_Wordlist.apkg",
+            mimeType = "application/octet-stream"
+        )
+
+        assertThat(
+            downloadFile.toFileName(extension = "apkg"),
+            equalTo("Goethe_Institute_A1_Wordlist.apkg")
+        )
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -30,7 +30,6 @@ import android.os.Handler
 import android.os.Looper
 import android.view.View
 import android.webkit.CookieManager
-import android.webkit.URLUtil
 import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -163,11 +162,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
             ContextCompat.RECEIVER_EXPORTED
         )
 
-        val currentFileName = URLUtil.guessFileName(
-            fileToBeDownloaded.url,
-            fileToBeDownloaded.contentDisposition,
-            fileToBeDownloaded.mimeType
-        )
+        val currentFileName = fileToBeDownloaded.toFileName(extension = "apkg")
 
         val downloadRequest = generateDeckDownloadRequest(fileToBeDownloaded, currentFileName)
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -26,7 +26,6 @@ import timber.log.Timber
 import java.io.File
 import java.io.IOException
 import java.io.InputStream
-import java.util.AbstractMap
 
 object FileUtil {
 
@@ -107,21 +106,6 @@ object FileUtil {
     }
 
     /**
-     * @return Key: Filename; Value: extension including dot
-     */
-    fun getFileNameAndExtension(fileName: String?): Map.Entry<String, String>? {
-        if (fileName == null) {
-            return null
-        }
-        val index = fileName.lastIndexOf(".")
-        return if (index < 1) {
-            null
-        } else {
-            AbstractMap.SimpleEntry(fileName.substring(0, index), fileName.substring(index))
-        }
-    }
-
-    /**
      * Wraps [File.listFiles] and throws an exception instead of returning `null` if dir does not
      * denote an actual directory.
      *
@@ -149,4 +133,38 @@ object FileUtil {
     }
 
     fun File.isDescendantOf(ancestor: File) = this.getParentsAndSelfRecursive().drop(1).contains(ancestor)
+}
+
+/**
+ * A filename without a path (e.g `collection.apkg`)
+ *
+ * @param fileName name of the file, before the '.'
+ * @param extensionWithDot extension of the file, with a '.'
+ */
+data class FileNameAndExtension(val fileName: String, val extensionWithDot: String) {
+    /**
+     * Ensures the filename is valid for [File.createTempFile], which requires `name.length() >= 3`
+     */
+    fun renameForCreateTempFile(): FileNameAndExtension =
+        if (fileName.length >= 3) this else this.copy(fileName = "$fileName-name")
+
+    override fun toString() = "$fileName$extensionWithDot"
+
+    companion object {
+
+        /**
+         * @return a valid [FileNameAndExtension]. `null` if [fileName] does not contain '.'
+         */
+        fun fromString(fileName: String): FileNameAndExtension? {
+            val index = fileName.lastIndexOf(".")
+            return if (index < 1) {
+                null
+            } else {
+                FileNameAndExtension(
+                    fileName = fileName.substring(0, index),
+                    extensionWithDot = fileName.substring(index)
+                )
+            }
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -141,12 +141,28 @@ object FileUtil {
  * @param fileName name of the file, before the '.'
  * @param extensionWithDot extension of the file, with a '.'
  */
-data class FileNameAndExtension(val fileName: String, val extensionWithDot: String) {
+@ConsistentCopyVisibility
+data class FileNameAndExtension private constructor(
+    val fileName: String,
+    val extensionWithDot: String
+) {
+    init {
+        require(extensionWithDot.startsWith('.')) { "extension must start with '.'" }
+    }
+
     /**
      * Ensures the filename is valid for [File.createTempFile], which requires `name.length() >= 3`
      */
     fun renameForCreateTempFile(): FileNameAndExtension =
         if (fileName.length >= 3) this else this.copy(fileName = "$fileName-name")
+
+    /**
+     * Returns a [FileNameAndExtension] with a custom extension
+     */
+    fun replaceExtension(extension: String): FileNameAndExtension {
+        val withDot = if (extension.startsWith(".")) extension else ".$extension"
+        return copy(extensionWithDot = withDot)
+    }
 
     override fun toString() = "$fileName$extensionWithDot"
 

--- a/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/FileUtilTest.kt
@@ -115,7 +115,7 @@ class FileUtilTest {
 
     @Test
     fun `test create temp file - too short`() {
-        // createTempFile fails with a 2-character prefix
+        // createTempFile fails with a 2-character filename
         val invalidTempFile = getValidFileNameAndExtension("ok.computer")
         assertThrows<IllegalArgumentException> {
             File.createTempFile(invalidTempFile.fileName, invalidTempFile.extensionWithDot)
@@ -128,6 +128,17 @@ class FileUtilTest {
     fun `string representation is unchanged`() {
         val underTest = getValidFileNameAndExtension("file.ext")
         assertThat("toString()", underTest.toString(), equalTo("file.ext"))
+    }
+
+    @Test
+    fun `extension replacement dot handling`() {
+        // I felt that requiring the '.' prefix was unintuitive and would lead to errors
+        // so both the missing and valid cases are handled
+
+        val underTest = getValidFileNameAndExtension("file.ext")
+
+        assertThat("replace extension, no .", underTest.replaceExtension(extension = "file").toString(), equalTo("file.file"))
+        assertThat("replace extension, with .", underTest.replaceExtension(extension = ".file").toString(), equalTo("file.file"))
     }
 
     /**


### PR DESCRIPTION
[API 35] `URLUtil.guessFileName`: regression guessing file extension [selects '.bin' when better alternatives exist] - https://issuetracker.google.com/issues/382864232

AnkiDroid fails to open `Goethe_Institute_A1_Wordlist.bin`

## Fixes
* Fixes #17573

## Approach
* repurpose `getFileNameAndExtension` to return a class
* Use this to handle updating the extension of the file to `apkg`

## How Has This Been Tested?
* Unit tests
* Instrumented tests:
  * API 35 emulator
  * API 34 emulator 

## Learning (optional, can help others)
https://issuetracker.google.com/issues/382864232

Android 15 is out

@thedroiddiv is awesome (I knew this already, so I guess this wasn't learning and I just wanted to say thank you!)
 
* `File.createTempFile("ok", ".computer")` fails: the length of the first string must be `>= 3`
  * ⚠️ this is now a URL, maybe we want another test value?

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
