### PR TITLE
Fix more onBackPressed() deprecations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -24,6 +24,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
@@ -143,6 +144,13 @@ abstract class NavigationDrawerActivity :
             // Decide which action to take when the navigation button is tapped.
             toolbar.setNavigationOnClickListener { onNavigationPressed() }
         }
+        val drawerBackCallback =
+            object : OnBackPressedCallback(isDrawerOpen) {
+                override fun handleOnBackPressed() {
+                    closeDrawer()
+                }
+            }
+        onBackPressedDispatcher.addCallback(drawerBackCallback)
         // ActionBarDrawerToggle ties together the the proper interactions
         // between the sliding drawer and the action bar app icon
         drawerToggle =
@@ -155,7 +163,7 @@ abstract class NavigationDrawerActivity :
                 override fun onDrawerClosed(drawerView: View) {
                     super.onDrawerClosed(drawerView)
                     invalidateOptionsMenu()
-
+                    drawerBackCallback.isEnabled = false
                     // If animations are disabled, this is executed before onNavigationItemSelected is called
                     // PERF: May be able to reduce this delay
                     HandlerUtils.postDelayedOnNewHandler({
@@ -169,6 +177,7 @@ abstract class NavigationDrawerActivity :
                 override fun onDrawerOpened(drawerView: View) {
                     super.onDrawerOpened(drawerView)
                     invalidateOptionsMenu()
+                    drawerBackCallback.isEnabled = true
                 }
             }
         if (drawerLayout is ClosableDrawerLayout) {
@@ -265,17 +274,6 @@ abstract class NavigationDrawerActivity :
                 ActivityCompat.recreate(this)
             }
         }
-
-    @Suppress("deprecation") // onBackPressed
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        if (isDrawerOpen) {
-            Timber.i("Back key pressed")
-            closeDrawer()
-        } else {
-            super.onBackPressed()
-        }
-    }
 
     /**
      * Called, when navigation button of the action bar is pressed.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -259,44 +259,6 @@ class SharedDecksActivity : AnkiActivity() {
         onBackPressedDispatcher.addCallback(onBackPressedCallback)
     }
 
-    /**
-     * If download screen is open:
-     *      If download is in progress: Show download cancellation dialog
-     *      If download is not in progress: Close the download screen
-     * Otherwise, close the WebView.
-     */
-    @Deprecated("Deprecated in Java")
-    @Suppress("deprecation") // onBackPressed
-    override fun onBackPressed() {
-        when {
-            sharedDecksDownloadFragmentExists() -> {
-                supportFragmentManager.findFragmentByTag(SHARED_DECKS_DOWNLOAD_FRAGMENT)?.let {
-                    if ((it as SharedDecksDownloadFragment).isDownloadInProgress) {
-                        Timber.i("Back pressed when download is in progress, show cancellation confirmation dialog")
-                        // Show cancel confirmation dialog if download is in progress
-                        it.showCancelConfirmationDialog()
-                    } else {
-                        Timber.i("Back pressed when download is not in progress but download screen is open, close fragment")
-                        // Remove fragment
-                        supportFragmentManager.commit {
-                            remove(it)
-                        }
-                    }
-                }
-                supportFragmentManager.popBackStackImmediate()
-            }
-            else -> {
-                Timber.i("Back pressed which would lead to closing of the WebView")
-                super.onBackPressed()
-            }
-        }
-    }
-
-    private fun sharedDecksDownloadFragmentExists(): Boolean {
-        val sharedDecksDownloadFragment = supportFragmentManager.findFragmentByTag(SHARED_DECKS_DOWNLOAD_FRAGMENT)
-        return sharedDecksDownloadFragment != null && sharedDecksDownloadFragment.isAdded
-    }
-
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.download_shared_decks_menu, menu)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -32,7 +32,6 @@ import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 class StudyOptionsActivity :
     AnkiActivity(),
@@ -53,6 +52,7 @@ class StudyOptionsActivity :
         if (savedInstanceState == null) {
             loadStudyOptionsFragment()
         }
+        setResult(RESULT_OK)
     }
 
     private fun loadStudyOptionsFragment() {
@@ -83,7 +83,7 @@ class StudyOptionsActivity :
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         return when (item.itemId) {
             android.R.id.home -> {
-                closeStudyOptions()
+                onBackPressedDispatcher.onBackPressed()
                 true
             }
             R.id.action_undo -> {
@@ -99,20 +99,6 @@ class StudyOptionsActivity :
             }
             else -> return super.onOptionsItemSelected(item)
         }
-    }
-
-    private fun closeStudyOptions(result: Int = RESULT_OK) {
-        // mCompat.invalidateOptionsMenu(this);
-        setResult(result)
-        finish()
-    }
-
-    @Deprecated("Deprecated in Java")
-    override fun onBackPressed() {
-        Timber.i("Back key pressed")
-        closeStudyOptions()
-        @Suppress("DEPRECATION")
-        super.onBackPressed()
     }
 
     override fun onResume() {


### PR DESCRIPTION
## Purpose / Description
Replace some usages of onBackPressed() with specific OnBackPressedCallbacks that are enabled/disabled ahead of time(of BACK action). More info in the commits messages. Four more usages of onBackPressed() left but those are more difficult to fix. See some videos with the new behavior(must add _android:enableOnBackInvokedCallback="true"_ for the _application_ tag in the manifest):

https://github.com/user-attachments/assets/2fb01930-7629-41ca-b065-c5cea7ea5ec9


https://github.com/user-attachments/assets/5abb8642-1aa7-497e-aa07-dff581fc86d5


https://github.com/user-attachments/assets/96f048be-feb8-4ca1-a8d4-caccdc1ac915


https://github.com/user-attachments/assets/d276cc57-732d-42b6-9801-e21917b97428


https://github.com/user-attachments/assets/52294cab-007a-4e69-ab15-5e5b1f59fc30







## Fixes
* For #14558

## How Has This Been Tested?

Used the app screens, less for shared decks(because I went there too many times I'm seeing 429 responses:( ).

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
