### PR TITLE
add transitions to preferences fragments

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -27,6 +27,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.XmlRes
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.commit
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
@@ -112,6 +113,7 @@ class PreferencesFragment :
         fragment.arguments = pref.extras
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment::class.jvmName)
+            setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
             addToBackStack(null)
         }
         return true
@@ -123,6 +125,7 @@ class PreferencesFragment :
         parentFragmentManager.popBackStack() // clear the search fragment from the backstack
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment.javaClass.name)
+            setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
             addToBackStack(fragment.javaClass.name)
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I noticed that other apps had animation in their settings but AnkiDroid didn't. So I researched how to add animations

## Approach

In the learning secion below

## How Has This Been Tested?

[transition.webm](https://github.com/user-attachments/assets/25380db6-9468-4fd1-a022-9d532932d298)

## Learning (optional, can help others)

I initially thought that I had to create a custom animation with [setCustomAnimation](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction.html#setCustomAnimations(int,int)) so I created some animations and experimented with them and making reverse animations

After some time, I didn't manage to look like Android's default animations, so I researched more and found [setTransition](https://developer.android.com/reference/androidx/fragment/app/FragmentTransaction.html#setTransition(int)), which made things a lot simpler and solved the issue

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
