### PR TITLE
add controls icons

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_double_arrow_down.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_double_arrow_down.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M18,6.41l-1.41,-1.41l-4.59,4.58l-4.59,-4.58l-1.41,1.41l6,6z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M18,13l-1.41,-1.41l-4.59,4.58l-4.59,-4.58l-1.41,1.41l6,6z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_double_arrow_up.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_double_arrow_up.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,17.59l1.41,1.41l4.59,-4.58l4.59,4.58l1.41,-1.41l-6,-6z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M6,11l1.41,1.41l4.59,-4.58l4.59,4.58l1.41,-1.41l-6,-6z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_fast_forward.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_fast_forward.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M5.58,16.89l5.77,-4.07c0.56,-0.4 0.56,-1.24 0,-1.63L5.58,7.11C4.91,6.65 4,7.12 4,7.93v8.14c0,0.81 0.91,1.28 1.58,0.82zM13,7.93v8.14c0,0.81 0.91,1.28 1.58,0.82l5.77,-4.07c0.56,-0.4 0.56,-1.24 0,-1.63l-5.77,-4.07c-0.67,-0.47 -1.58,0 -1.58,0.81z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_lightbulb.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_lightbulb.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,22c1.1,0 2,-0.9 2,-2h-4C10,21.1 10.9,22 12,22z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M8,17h8v2h-8z"/>
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,2C7.86,2 4.5,5.36 4.5,9.5c0,3.82 2.66,5.86 3.77,6.5h7.46c1.11,-0.64 3.77,-2.68 3.77,-6.5C19.5,5.36 16.14,2 12,2z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_lightbulb_stars.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_lightbulb_stars.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M7,20h4c0,1.1 -0.9,2 -2,2S7,21.1 7,20zM5,19h8v-2H5V19zM16.5,9.5c0,3.82 -2.66,5.86 -3.77,6.5H5.27C4.16,15.36 1.5,13.32 1.5,9.5C1.5,5.36 4.86,2 9,2S16.5,5.36 16.5,9.5zM21.37,7.37L20,8l1.37,0.63L22,10l0.63,-1.37L24,8l-1.37,-0.63L22,6L21.37,7.37zM19,6l0.94,-2.06L22,3l-2.06,-0.94L19,0l-0.94,2.06L16,3l2.06,0.94L19,6z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -181,18 +181,22 @@
         <com.ichi2.preferences.ControlPreference
             android:key="@string/page_up_command_key"
             android:title="@string/gesture_page_up"
+            android:icon="@drawable/ic_double_arrow_up"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/page_down_command_key"
             android:title="@string/gesture_page_down"
+            android:icon="@drawable/ic_double_arrow_down"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/abort_command_key"
             android:title="@string/gesture_abort_learning"
+            android:icon="@drawable/close_icon"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/abort_and_sync_command_key"
             android:title="@string/gesture_abort_sync"
+            android:icon="@drawable/ic_sync"
             />
     </PreferenceCategory>
 
@@ -250,14 +254,17 @@
         <com.ichi2.preferences.ControlPreference
             android:key="@string/toggle_auto_advance_command_key"
             android:title="@string/toggle_auto_advance"
+            android:icon="@drawable/ic_fast_forward"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/show_hint_command_key"
             android:title="@string/gesture_show_hint"
+            android:icon="@drawable/ic_lightbulb"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/show_all_hints_command_key"
             android:title="@string/gesture_show_all_hints"
+            android:icon="@drawable/ic_lightbulb_stars"
             />
     </PreferenceCategory>
 
@@ -270,38 +277,47 @@
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_1_key"
             android:title="@string/user_action_1"
+            android:icon="@drawable/user_action_1"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_2_key"
             android:title="@string/user_action_2"
+            android:icon="@drawable/user_action_2"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_3_key"
             android:title="@string/user_action_3"
+            android:icon="@drawable/user_action_3"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_4_key"
             android:title="@string/user_action_4"
+            android:icon="@drawable/user_action_4"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_5_key"
             android:title="@string/user_action_5"
+            android:icon="@drawable/user_action_5"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_6_key"
             android:title="@string/user_action_6"
+            android:icon="@drawable/user_action_6"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_7_key"
             android:title="@string/user_action_7"
+            android:icon="@drawable/user_action_7"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_8_key"
             android:title="@string/user_action_8"
+            android:icon="@drawable/user_action_8"
             />
         <com.ichi2.preferences.ControlPreference
             android:key="@string/user_action_9_key"
             android:title="@string/user_action_9"
+            android:icon="@drawable/user_action_9"
             />
     </com.ichi2.anki.preferences.ExtendedPreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Fixes
* Fixes most of #14243. The only pending icons are Show answer and the Answer button 1/2/3/4

## Approach
Got the icons from [material icons](https://fonts.google.com/icons) and set them.

Some of them were already in the app resources

## How Has This Been Tested?

https://github.com/user-attachments/assets/d49a8423-a2ae-4017-8141-35b4dbbdc4fe


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
