### PR TITLE
disable fragment animation in safe display mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -39,6 +39,7 @@ import com.google.android.material.appbar.CollapsingToolbarLayout
 import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.utils.FragmentFactoryUtils
 import timber.log.Timber
@@ -113,7 +114,7 @@ class PreferencesFragment :
         fragment.arguments = pref.extras
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment::class.jvmName)
-            setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+            setOpenTransition(this)
             addToBackStack(null)
         }
         return true
@@ -125,7 +126,7 @@ class PreferencesFragment :
         parentFragmentManager.popBackStack() // clear the search fragment from the backstack
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment.javaClass.name)
-            setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+            setOpenTransition(this)
             addToBackStack(fragment.javaClass.name)
         }
 
@@ -138,6 +139,12 @@ class PreferencesFragment :
 
         view?.findViewById<CollapsingToolbarLayout>(R.id.collapsingToolbarLayout)?.title = title
         view?.findViewById<MaterialToolbar>(R.id.toolbar)?.title = title
+    }
+
+    private fun setOpenTransition(fragmentTransaction: FragmentTransaction) {
+        if (!sharedPrefs().getBoolean("safeDisplay", false)) {
+            fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+        }
     }
 
     /**


### PR DESCRIPTION
## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/pull/17584#discussion_r1878868490

## Approach
Check if display mode is active

## How Has This Been Tested?

I enabled the setting then tested if the animation showed up and it didn't

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
