### PR TITLE
fix(note-editor): restore instance state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.noteeditor
 import android.content.Context
 import android.os.Bundle
 import android.view.View
-import androidx.core.os.BundleCompat
 import com.ichi2.anki.FieldEditLine
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
@@ -37,19 +36,20 @@ import kotlin.math.min
 class FieldState private constructor(
     private val editor: NoteEditor,
 ) {
-    private var savedFieldData: List<View.BaseSavedState>? = null
+    private var customViewIds: List<Int>? = null
 
     fun loadFieldEditLines(type: FieldChangeType): List<FieldEditLine> {
-        val fieldEditLines: List<FieldEditLine>
-        if (type.type == Type.INIT && savedFieldData != null) {
-            fieldEditLines = recreateFieldsFromState()
-            savedFieldData = null
-        } else {
-            fieldEditLines = createFields(type)
-        }
-        for (l in fieldEditLines) {
-            l.id = View.generateViewId()
-        }
+        val fieldEditLines: List<FieldEditLine> =
+            if (type.type == Type.INIT && customViewIds != null) {
+                recreateFields(customViewIds!!)
+            } else {
+                createFields(type).also { fields ->
+                    for (field in fields) {
+                        field.id = View.generateViewId()
+                    }
+                }
+            }
+
         if (type.type == Type.CLEAR_KEEP_STICKY) {
             // we use the UI values here as the model will post-processing steps (newline -> br).
             val currentFieldStrings = editor.currentFieldStrings
@@ -69,18 +69,12 @@ class FieldState private constructor(
         return fieldEditLines
     }
 
-    private fun recreateFieldsFromState(): List<FieldEditLine> {
-        val editLines: MutableList<FieldEditLine> = ArrayList(savedFieldData!!.size)
-        for (state in savedFieldData!!) {
-            val editLineView = FieldEditLine(editor.requireContext())
-            if (editLineView.id == 0) {
-                editLineView.id = View.generateViewId()
-            }
-            editLineView.loadState(state)
-            editLines.add(editLineView)
-        }
-        return editLines
-    }
+    /**
+     * Given a list of [viewIds]: create the fields, assign the IDs and let Android
+     * restore the state via [FieldEditLine.onRestoreInstanceState]
+     */
+    private fun recreateFields(viewIds: List<Int>): List<FieldEditLine> =
+        viewIds.map { id -> FieldEditLine(editor.requireContext()).also { field -> field.id = id } }
 
     private fun createFields(type: FieldChangeType): List<FieldEditLine> {
         val fields = getFields(type)
@@ -105,28 +99,7 @@ class FieldState private constructor(
     }
 
     fun setInstanceState(savedInstanceState: Bundle?) {
-        if (savedInstanceState == null) {
-            return
-        }
-        if (!savedInstanceState.containsKey("customViewIds") || !savedInstanceState.containsKey("android:viewHierarchyState")) {
-            return
-        }
-        val customViewIds = savedInstanceState.getIntegerArrayList("customViewIds")
-        val viewHierarchyState = savedInstanceState.getBundle("android:viewHierarchyState")
-        if (customViewIds == null || viewHierarchyState == null) {
-            return
-        }
-        val views =
-            BundleCompat.getSparseParcelableArray(
-                viewHierarchyState,
-                "android:views",
-                View.BaseSavedState::class.java,
-            ) ?: return
-        val important: MutableList<View.BaseSavedState> = ArrayList(customViewIds.size)
-        for (i in customViewIds) {
-            important.add(views[i!!] as View.BaseSavedState)
-        }
-        savedFieldData = important
+        customViewIds = savedInstanceState?.getIntegerArrayList("customViewIds")
     }
 
     /** How fields should be changed when the UI is rebuilt  */


### PR DESCRIPTION
Now Note Editor is a fragment, it no longer receives `android:viewHierarchyState`. This is now handled by the Activity

But, we did not need to handle this manually. Recreating the fields, with the same `id` value restores the text

Note: I could have done a lot more refactoring here, but since this is being cherry-picked, I wanted a minimal line change

## Fixes
* Fixes #17521
* Maybe #17476 (couldn't reproduce)

## Approach
* Assign the Ids
* Don't clobber the Ids with new values

## How Has This Been Tested?
Samsung S21 with "Don't keep activities"
* Add Card
* Edit Card
* Change Card Type


This fix does not handle the loss of focus for dynamic elements

During testing, this lack of focus coming back from 'Drawing' was jarring. In Production this will have minimal impact as the user will have lost context by the time the activity is restored (a user will not have 'Don't keep activities" on).

## Learning

I like our new linter

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
