### PR TITLE
Fetching correct DeckID at EditNote

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2239,7 +2239,11 @@ class NoteEditor :
         fun calculateDeckId(): DeckId {
             if (deckId != 0L) return deckId
             if (note != null && !addNote && currentEditedCard != null) {
-                return currentEditedCard!!.currentDeckId().did
+                val deckId = currentEditedCard!!.currentDeckId().did
+                if (deckId == 0L && note.notetype.did != 0L) {
+                    return note.notetype.did
+                }
+                return deckId
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -140,7 +140,7 @@ open class Card : Cloneable {
         lapses = card.lapses
         left = card.remainingSteps
         oDue = card.originalDue
-        oDid = card.deckId
+        oDid = card.originalDeckId
         flags = card.flags
         originalPosition = if (card.hasOriginalPosition()) card.originalPosition else null
         customData = card.customData
@@ -233,7 +233,7 @@ open class Card : Cloneable {
     }
 
     @LibAnkiAlias("current_deck_id")
-    fun currentDeckId() = deckId { did = oDid.ifZero { did } }
+    fun currentDeckId() = deckId { did = oDid.ifZero { this@Card.toBackendCard().deckId } }
 
     /**
      * Time limit for answering in milliseconds.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -140,7 +140,7 @@ open class Card : Cloneable {
         lapses = card.lapses
         left = card.remainingSteps
         oDue = card.originalDue
-        oDid = card.originalDeckId
+        oDid = card.deckId
         flags = card.flags
         originalPosition = if (card.hasOriginalPosition()) card.originalPosition else null
         customData = card.customData

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -233,7 +233,7 @@ open class Card : Cloneable {
     }
 
     @LibAnkiAlias("current_deck_id")
-    fun currentDeckId() = deckId { did = oDid.ifZero { this@Card.toBackendCard().deckId } }
+    fun currentDeckId() = deckId { did = oDid.ifZero { this@Card.did } }
 
     /**
      * Time limit for answering in milliseconds.


### PR DESCRIPTION
## Purpose / Description
Note editor shows Default deck for all cards 


## Fixes
* Fixes #17604

## How Has This Been Tested?

https://github.com/user-attachments/assets/2d106940-d8d1-45fb-b47c-9caf05cc8e8a

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
