### PR TITLE
fix: currentDeckId broken

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -20,9 +20,9 @@ package com.ichi2.libanki
 import androidx.annotation.VisibleForTesting
 import anki.cards.FsrsMemoryState
 import anki.decks.deckId
-import anki.notes.noteId
 import com.ichi2.anki.Flag
 import com.ichi2.anki.utils.ext.ifZero
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Consts.CardQueue
 import com.ichi2.libanki.Consts.CardType
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
@@ -233,7 +233,8 @@ open class Card : Cloneable {
     }
 
     @LibAnkiAlias("current_deck_id")
-    fun currentDeckId() = deckId { did = oDid.ifZero { did } }
+    @NeedsTest("Test functionality which calls this")
+    fun currentDeckId() = deckId { did = oDid.ifZero { this@Card.did } }
 
     /**
      * Time limit for answering in milliseconds.


### PR DESCRIPTION
## Purpose / Description
In a58b4c10ed2f1db7dab9a3b7244cbf957b6915c7, `currentDeckId` was updated to use a Kotlin-based builder, but `[this.]did` was coming from `DeckIdKt.Dsl` rather than from `[this@Card.]did`, so 0 was returned.

## Fixes
* Cause #17591
* Fixes #17604 (Note Editor issues)

## Approach
* Bisect the bad commit
* Figure out the issue
* Fix forward

## How Has This Been Tested?
API 34 emulator, editing a note now shows the correct deck

## Learning (optional, can help others)
⚠️: I also made a mistake with the implementation, I don't particularly like the Dsl


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
