### PR TITLE
Changed Release order and description of releases page

### DIFF
--- a/tools/release-description.md
+++ b/tools/release-description.md
@@ -17,7 +17,7 @@ The builds with `full`, `play` and `amazon` are useful for testing our builds fo
 
 - **`full`**: F-Droid & GitHub `Parallel` apks
 - **`play`**: Google Play - does not have `MANAGE_EXTERNAL_STORAGE` permission as it is forbidden by Google, so app data is deleted on uninstall
-- **`amazon`**: Amazon - missing `CAMERA`
+- **`amazon`**: Amazon - currently same as full, historically removed `CAMERA` permission
 
 ---
 

--- a/tools/release-description.md
+++ b/tools/release-description.md
@@ -1,5 +1,3 @@
-# release-notes.md
-
 > [!IMPORTANT]
 > GitHub does not auto-update apps
 

--- a/tools/release-description.md
+++ b/tools/release-description.md
@@ -7,7 +7,7 @@
 
 Install `arm64-v8a` below. If it fails to install, use `Parallel.A`.
 
-`Parallel` builds install side-by-side with the main APK, allowing you to use different settings and profiles (via the `AnkiDroid` `directory` advanced setting & a different AnkiWeb login).
+`Parallel` builds install side-by-side with the main APK, allowing you to use different settings and profiles (via the `AnkiDroid directory` advanced setting and a different AnkiWeb login).
 
 ---
 

--- a/tools/release-description.md
+++ b/tools/release-description.md
@@ -16,7 +16,7 @@ Install `arm64-v8a` below. If it fails to install, use `Parallel.A`.
 The builds with `full`, `play` and `amazon` are useful for testing our builds for different app stores:
 
 - **`full`**: F-Droid & GitHub `Parallel` apks
-- **`play`**: Google Play - missing `MANAGE_EXTERNAL_STORAGE` [app data is deleted on uninstall]
+- **`play`**: Google Play - does not have `MANAGE_EXTERNAL_STORAGE` permission as it is forbidden by Google, so app data is deleted on uninstall
 - **`amazon`**: Amazon - missing `CAMERA`
 
 ---

--- a/tools/release-notes.md
+++ b/tools/release-notes.md
@@ -1,0 +1,28 @@
+# release-notes.md
+
+> [!IMPORTANT]
+> GitHub does not auto-update apps
+
+---
+
+## For regular users
+
+Install `arm64-v8a` below. If it fails to install, use `Parallel.A`.
+
+`Parallel` builds install side-by-side with the main APK, allowing you to use different settings and profiles (via the `AnkiDroid` `directory` advanced setting & a different AnkiWeb login).
+
+---
+
+## For testers
+
+The builds with `full`, `play` and `amazon` are useful for testing our builds for different app stores:
+
+- **`full`**: F-Droid & GitHub `Parallel` apks
+- **`play`**: Google Play - missing `MANAGE_EXTERNAL_STORAGE` [app data is deleted on uninstall]
+- **`amazon`**: Amazon - missing `CAMERA`
+
+---
+
+## ABI variants
+
+We perform ABI splits to reduce APK size. In rare cases, a phone may not be using the `arm64-v8a` ABI. You can find your phone's ABI using [kamgurgul/cpu-info](https://github.com/kamgurgul/cpu-info). If disk space isn't an issue, use the `full` apk.

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -168,14 +168,15 @@ else
 fi
 
 # Read the content of the markdown file
-RELEASE_NOTES=$(cat release-notes.md)
+RELEASE_NOTES=$(cat release-description.md)
 echo "Creating new Github release"
 github-release release --tag v"$VERSION" --name "AnkiDroid $VERSION" --description "$RELEASE_NOTES" $PRE_RELEASE
 
 echo "Sleeping 30s to make sure the release exists, see issue 11746"
 sleep 30
 
-# PREFIX is used to differentiate the ABIs
+# PREFIX is used to order the ABIs in the file list. Most users will use `arm64-v8a`.
+# variant ABIs are a source of error and confusion, so should be lower in the list
 PREFIX=""
 for ABI in $ABIS; do
   if [ "$ABI" = "arm64-v8a" ]; then
@@ -184,7 +185,7 @@ for ABI in $ABIS; do
     PREFIX="variant-abi-"
   fi
   echo "Adding full APK for $ABI to Github release"
-  github-release upload --tag v"$VERSION" --name ${PREFIX}AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
+  github-release upload --tag v"$VERSION" --name "${PREFIX}"AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
 done
 for FLAVOR in $FLAVORS; do
   if [ "$FLAVOR" = "full" ]; then
@@ -193,14 +194,14 @@ for FLAVOR in $FLAVORS; do
     PREFIX="dev-"
   fi
   echo "Adding full APK for $FLAVOR to Github release"
-  github-release upload --tag v"$VERSION" --name ${PREFIX}AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
+  github-release upload --tag v"$VERSION" --name "${PREFIX}"AnkiDroid-"$VERSION"-"$ABI".apk --file AnkiDroid-"$VERSION"-"$ABI".apk
 done
 # Set to z- for un-minified full universal APK and proguard to ensure it is at the end of the list
 PREFIX="z-"
 echo "Adding un-minified full universal APK to GitHub release"
-github-release upload --tag v"$VERSION" --name ${PREFIX}AnkiDroid-"$VERSION"-full-universal-nominify.apk --file AnkiDroid-"$VERSION"-full-universal-nominify.apk
+github-release upload --tag v"$VERSION" --name "${PREFIX}"AnkiDroid-"$VERSION"-full-universal-nominify.apk --file AnkiDroid-"$VERSION"-full-universal-nominify.apk
 echo "Adding proguard mappings file to Github release"
-github-release upload --tag v"$VERSION" --name ${PREFIX}proguard-mappings.tar.gz --file proguard-mappings.tar.gz
+github-release upload --tag v"$VERSION" --name "${PREFIX}"proguard-mappings.tar.gz --file proguard-mappings.tar.gz
 
 # Not publishing to amazon pending: https://github.com/ankidroid/Anki-Android/issues/14161
 #if [ "$PUBLIC" = "public" ]; then
@@ -226,5 +227,5 @@ fi
 for BUILD in $BUILDNAMES; do
   PREFIX=""
   echo "Adding parallel build $BUILD to Github release"
-  github-release upload --tag v"$VERSION" --name ${PREFIX}AnkiDroid-"$VERSION".parallel."$BUILD".apk --file AnkiDroid-"$VERSION".parallel."$BUILD".apk
+  github-release upload --tag v"$VERSION" --name "${PREFIX}"AnkiDroid-"$VERSION".parallel."$BUILD".apk --file AnkiDroid-"$VERSION".parallel."$BUILD".apk
 done


### PR DESCRIPTION
## Purpose / Description
Changes the order and file names in the releases page to push less used ABI variants lower down the fold, and made the description of the releases page better formatted.

## Fixes
* Fixes #15927 

## Approach
Uses basic if checks to see weather or not to use the prefix or not.

## How Has This Been Tested?

N/A

## Learning (optional, can help others)

Not much but did reference markdown formatting, and a bit about shell scripting.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
