### PR TITLE
dev(github): use 'Bug' type for new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: File a bug
-title: "[BUG]: "
-labels:  [Bug, "Needs Triage"]
+type: "Bug"
+labels:  ["Needs Triage"]
 
 body:
 


### PR DESCRIPTION
This is part of the 'GitHub Issue Types' beta

**Implementation** 
https://redirect.github.com/orgs/community/discussions/139933#:~:text=Issue%20form%20with%20%60type%60%20field

**Announcement**
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-beta/

**Before**
<img width="752" alt="Screenshot 2024-12-18 at 05 39 34" src="https://github.com/user-attachments/assets/8e38ab95-5cfc-4e25-80cd-c8c6df6c4459" />

**After (expected)**
<img width="497" alt="Screenshot 2024-12-18 at 05 39 56" src="https://github.com/user-attachments/assets/1590a3fc-d5ed-40a4-903e-349b8276ca8e" />

⚠️ Untested