### PR TITLE
build(deps): remove dokka, no longer in use

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -3,7 +3,6 @@ import com.android.build.gradle.internal.tasks.factory.dependsOn
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.dokka)
     id("maven-publish")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ktlint.gradle.plugin) apply false
-    alias(libs.plugins.dokka) apply false
     alias(libs.plugins.keeper) apply false
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,7 +66,6 @@ commonsIo = "2.18.0"
 coroutines = '1.9.0'
 desugar-jdk-libs-nio = "2.1.3"
 drawer = "1.0.3"
-dokka = "1.9.20"
 espresso = '3.6.1'
 mikehardyGoogleAnalyticsJava7 = "2.0.13"
 hamcrest = "3.0"
@@ -209,7 +208,6 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 ktlint-gradle-plugin = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintGradlePlugin" }
 
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

It doesn't appear that we actually *use* dokka anymore, remove the dependency

## Fixes

- Closes #17612 

## Approach

Remove all references to dokka in our build files

## How Has This Been Tested?

We use jitpack.io to publish the API artifacts, and in our `jitpack.yml` we run `./gradlew :api:publishToMavenLocal`

https://github.com/ankidroid/Anki-Android/blob/ff607b3f4411e47f403f671861435ab29eca4327/jitpack.yml#L15

So I ran that then checked the javadoc artifact (attached) - it does generate (which is job number one) and it appears fine.

To be clear though, I'm not that interested in the output, it's mainly generated at all because some publishers (maven at least, jitpack unknown) require you to have a javadoc jar.

But we also publish the *actual sources* of the API module since we are open source, and most (all?) IDEs will auto-pull those and cross-link everything up and let you just open things and look. Which is 100 times more useful than javadoc and the primary reason why I haven't actually looked at anyone's javadoc in ages.

[api-2.0.0-javadoc.zip](https://github.com/user-attachments/files/18183642/api-2.0.0-javadoc.zip)

## Learning (optional, can help others)

I'd almost forgotten that javadoc existed, but then I don't work much with closed-source products.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
