### PR TITLE
test(coverage): only fail CI on main repo

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -197,4 +197,4 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           verbose: true
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)

--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -180,4 +180,4 @@ jobs:
       - uses: codecov/codecov-action@v5
         with:
           verbose: true
-          fail_ci_if_error: true # optional (default = false)
+          fail_ci_if_error: ${{ github.repository == 'ankidroid/Anki-Android' }} # optional (default = false)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

with the move to codecov action v5, upload tokens are either strictly required, *or* you have to have a public repository *and* go into your codecov settings on their website and allow uploads with no tokens

We allow uploads with no token on the main repository, but that was a specific setting change and there is no expectation that forks will do this, so uploads will fail for folks in the general case

We want the coverage fail signal on the main repo so I had set coverage upload failures to fail the build, but that's not a great experience for forks.

So now we only fail the build on coverage uploads if you are in the main repo

## Fixes

* Related #17443
* Build failures like https://github.com/mikehardy/Anki-Android/actions/runs/12394439234/job/34597894494#step:16:323

## Approach

use workflow templating and default-included variables to fail only on main repo

## How Has This Been Tested?

workflows aren't easily testable but if this succeeds on my fork then at least it isn't failing there anymore, so pending the outcome of that:

- https://github.com/mikehardy/Anki-Android/actions/runs/12395576762/job/34601626281

## Learning (optional, can help others)

Testing, false positives, false negatives - any time you increase testing you have to deal with both, and you'll get them...

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
