### PR TITLE
Fixing notetype to Cloze if From InstantEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -273,6 +273,9 @@ class NoteEditor :
     // Use the same HTML if the same image is pasted multiple times.
     private var pastedImageCache: HashMap<String, String> = HashMap()
 
+    // Indicate if from InstantEditor
+    private var isFromInstantEditor: Boolean = false
+
     // save field index as key and text as value when toggle sticky clicked in Field Edit Text
     private var toggleStickyText: HashMap<Int, String?> = HashMap()
 
@@ -676,6 +679,7 @@ class NoteEditor :
                     return
                 }
                 addNote = true
+                isFromInstantEditor = true
             }
             // image occlusion is handled at the end of this method, grep: CALLER_IMG_OCCLUSION
             // we need to have loaded the current note type
@@ -761,6 +765,11 @@ class NoteEditor :
         val getTextFromSearchView = requireArguments().getString(EXTRA_TEXT_FROM_SEARCH_VIEW)
         setDid(editorNote)
         setNote(editorNote, FieldChangeType.onActivityCreation(shouldReplaceNewlines()))
+        if (isFromInstantEditor) {
+            // setting notetype to cloze type if from Instant Editor
+            val notetype = col.notetypes.all().first { it.isCloze }
+            changeNoteType(notetype.id)
+        }
         if (addNote) {
             noteTypeSpinner!!.onItemSelectedListener = SetNoteTypeListener()
             setTitle(R.string.menu_add)


### PR DESCRIPTION
## Purpose / Description
whenever user creates an instant card from instant editor it is of cloze type , but when NoteEditor is opened noteType should be cloze type

## Fixes
* Fixes #16940

## How Has This Been Tested?

https://github.com/user-attachments/assets/f664c8b4-86d0-4a79-b6e1-99bc6ed613c5


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
