### PR TITLE
refactor: build.gradle.kts => use build.versions.toml & improve JVM error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,12 +26,14 @@ if (project.rootProject.file("local.properties").exists()) {
 }
 val fatalWarnings = !(localProperties["fatal_warnings"] == "false")
 
+// can't be obtained inside 'subprojects'
+val ktlintVersion = libs.versions.ktlint.get()
+
 // Here we extract per-module "best practices" settings to a single top-level evaluation
 subprojects {
-    // TODO: should be able to use libs.versions.toml here
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
     configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
-        version.set("1.5.0")
+        version.set(ktlintVersion)
     }
 
     afterEvaluate {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,16 +101,17 @@ subprojects {
 }
 
 val jvmVersion = Jvm.current().javaVersion?.majorVersion
+val minSdk = libs.versions.compileSdk.get()
 if (jvmVersion != "17" && jvmVersion != "21") {
     println("\n\n\n")
     println("**************************************************************************************************************")
     println("\n\n\n")
     println("ERROR: AnkiDroid builds with JVM version 17 or 21.")
-    println("  Incompatible major version detected: '" + jvmVersion + "'")
+    println("  Incompatible major version detected: '$jvmVersion'")
     println("\n\n\n")
     println("  If you receive this error because you want to use a newer JDK, we may accept PRs to support new versions.")
     println("  Edit the main build.gradle file, find this message in the file, and add support for the new version.")
-    println("  Please make sure the `jacocoTestReport` target works on an emulator with our minSdkVersion (currently 23).")
+    println("  Please make sure the `jacocoTestReport` target works on an emulator with our minSdk (currently $minSdk).")
     println("\n\n\n")
     println("**************************************************************************************************************")
     println("\n\n\n")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,7 @@
 
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.api.extension.impl.AndroidComponentsExtensionImpl
+import com.android.ide.common.util.parseIntOrDefault
 import com.slack.keeper.optInToKeeper
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.internal.jvm.Jvm
@@ -110,10 +111,12 @@ if (jvmVersion != "17" && jvmVersion != "21") {
     println("\n\n\n")
     println("ERROR: AnkiDroid builds with JVM version 17 or 21.")
     println("  Incompatible major version detected: '$jvmVersion'")
-    println("\n\n\n")
-    println("  If you receive this error because you want to use a newer JDK, we may accept PRs to support new versions.")
-    println("  Edit the main build.gradle file, find this message in the file, and add support for the new version.")
-    println("  Please make sure the `jacocoTestReport` target works on an emulator with our minSdk (currently $minSdk).")
+    if (jvmVersion.parseIntOrDefault(defaultValue = 0) > 21) {
+        println("\n\n\n")
+        println("  If you receive this error because you want to use a newer JDK, we may accept PRs to support new versions.")
+        println("  Edit the main build.gradle file, find this message in the file, and add support for the new version.")
+        println("  Please make sure the `jacocoTestReport` target works on an emulator with our minSdk (currently $minSdk).")
+    }
     println("\n\n\n")
     println("**************************************************************************************************************")
     println("\n\n\n")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ compileSdk = "35"
 minSdk = "24"  # also in testlib/build.gradle.kts
 targetSdk = "34"  # also in  ../robolectricDownloader.gradle
 acra = '5.12.0'
+ktlint = '1.5.0'
 # AGP is included in Android Studio and changelogs are not well maintained/at a stable URL
 # Open https://developer.android.com/build/releases/gradle-plugin#patch-releases
 # Maybe select a "bug fixes" link ->


### PR DESCRIPTION
Fixes a TODO and bumps `minSdk` to the correct version

After this, I noticed that some of the 'JDK' error was shown when it wasn't relevant

As this message is a common onboarding snag, I felt it was worthwhile to reduce the bulk of the error message

Especially as most new users won't be interested in such an involved change as their first issue