### PR TITLE
feat(new reviewer): type in the answer (native)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -106,12 +106,18 @@ abstract class CardViewerViewModel(
      *************************************** Internal methods ***************************************
      ********************************************************************************************* */
 
-    protected abstract suspend fun typeAnsFilter(text: String): String
+    protected abstract suspend fun typeAnsFilter(
+        text: String,
+        typedAnswer: String? = null,
+    ): String
 
     private suspend fun bodyClass(): String = bodyClassForCardOrd(currentCard.await().ord)
 
     /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L358) */
-    private suspend fun mungeQA(text: String): String = typeAnsFilter(prepareCardTextForDisplay(text))
+    private suspend fun mungeQA(
+        text: String,
+        typedAnswer: String? = null,
+    ): String = typeAnsFilter(prepareCardTextForDisplay(text), typedAnswer)
 
     private suspend fun prepareCardTextForDisplay(text: String): String =
         Sound.addPlayButtons(
@@ -140,13 +146,13 @@ abstract class CardViewerViewModel(
      *
      * @see [stdHtml]
      */
-    protected open suspend fun showAnswer() {
+    protected open suspend fun showAnswer(typedAnswer: String? = null) {
         Timber.v("showAnswer()")
         showingAnswer.emit(true)
 
         val card = currentCard.await()
         val answerData = withCol { card.answer(this) }
-        val answer = mungeQA(answerData)
+        val answer = mungeQA(answerData, typedAnswer)
 
         eval.emit("_showAnswer(${Json.encodeToString(answer)}, '${bodyClass()}');")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -132,7 +132,15 @@ abstract class CardViewerViewModel(
         eval.emit("_showQuestion(${Json.encodeToString(question)}, ${Json.encodeToString(answer)}, '${bodyClass()}');")
     }
 
-    protected open suspend fun showAnswerInternal() {
+    /**
+     * Parses the card answer and sends a [eval] request to load it into the `qa` HTML div
+     *
+     * * [Anki reference](https://github.com/ankitects/anki/blob/c985acb9fe36d3651eb83cf4cfe44d046ec7458f/qt/aqt/reviewer.py#L460)
+     * * [Typescript reference](https://github.com/ankitects/anki/blob/c985acb9fe36d3651eb83cf4cfe44d046ec7458f/ts/reviewer/index.ts#L193)
+     *
+     * @see [stdHtml]
+     */
+    protected open suspend fun showAnswer() {
         Timber.v("showAnswer()")
         showingAnswer.emit(true)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -40,8 +40,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.jetbrains.annotations.VisibleForTesting
-import org.json.JSONObject
 import timber.log.Timber
 
 abstract class CardViewerViewModel(
@@ -195,54 +193,4 @@ abstract class CardViewerViewModel(
         } else {
             throw IllegalArgumentException("Unhandled POST request: $uri")
         }
-
-    companion object {
-        // ********************************** Type-in answer ************************************
-        /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L669] */
-        @VisibleForTesting
-        val typeAnsRe = Regex("\\[\\[type:(.+?)]]")
-
-        suspend fun getTypeAnswerField(
-            card: Card,
-            text: String,
-        ): JSONObject? {
-            val match = typeAnsRe.find(text) ?: return null
-
-            val typeAnsFieldName =
-                match.groups[1]!!.value.let {
-                    if (it.startsWith("cloze:")) {
-                        it.split(":")[1]
-                    } else {
-                        it
-                    }
-                }
-
-            val fields = withCol { card.noteType(this).flds }
-            for (i in 0 until fields.length()) {
-                val field = fields.get(i) as JSONObject
-                if (field.getString("name") == typeAnsFieldName) {
-                    return field
-                }
-            }
-            return null
-        }
-
-        suspend fun getExpectedTypeInAnswer(
-            card: Card,
-            field: JSONObject,
-        ): String? {
-            val fieldName = field.getString("name")
-            val expected = withCol { card.note(this@withCol).getItem(fieldName) }
-            return if (fieldName.startsWith("cloze:")) {
-                val clozeIdx = card.ord + 1
-                withCol {
-                    extractClozeForTyping(expected, clozeIdx).takeIf { it.isNotBlank() }
-                }
-            } else {
-                expected
-            }
-        }
-
-        fun getFontSize(field: JSONObject): String = field.getString("size")
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -107,7 +107,7 @@ class PreviewerViewModel(
                 showQuestion()
                 cardMediaPlayer.autoplayAllSoundsForSide(CardSide.QUESTION)
             } else if (backSideOnly.value && !showingAnswer.value) {
-                showAnswerInternal()
+                showAnswer()
                 cardMediaPlayer.autoplayAllSoundsForSide(CardSide.ANSWER)
             }
         }
@@ -147,7 +147,7 @@ class PreviewerViewModel(
     fun onNextButtonClick() {
         launchCatchingIO {
             if (!showingAnswer.value && !backSideOnly.value) {
-                showAnswerInternal()
+                showAnswer()
                 cardMediaPlayer.autoplayAllSoundsForSide(CardSide.ANSWER)
             } else {
                 currentIndex.update { it + 1 }
@@ -207,7 +207,7 @@ class PreviewerViewModel(
             asyncIO {
                 withCol { getCard(selectedCardIds[currentIndex.value]) }
             }
-        if (showAnswer) showAnswerInternal() else showQuestion()
+        if (showAnswer) showAnswer() else showQuestion()
         updateFlagIcon()
         updateMarkIcon()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -234,7 +234,10 @@ class PreviewerViewModel(
     }
 
     /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L671) */
-    override suspend fun typeAnsFilter(text: String): String =
+    override suspend fun typeAnsFilter(
+        text: String,
+        typedAnswer: String?,
+    ): String =
         if (showingAnswer.value) {
             val typeAnswer = TypeAnswer.getInstance(currentCard.await(), text)
             typeAnswer?.answerFilter() ?: text

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -41,8 +41,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
-import org.intellij.lang.annotations.Language
-import org.jetbrains.annotations.VisibleForTesting
 import timber.log.Timber
 
 class PreviewerViewModel(
@@ -254,30 +252,5 @@ class PreviewerViewModel(
                     PreviewerViewModel(previewerIdsFile, currentIndex, cardMediaPlayer)
                 }
             }
-
-        /** removes `[[type:]]` tags */
-        @VisibleForTesting
-        fun removeTypeAnswerTags(text: String) = typeAnsRe.replace(text, "")
-
-        /** Adapted from the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L720) */
-        suspend fun typeAnsAnswerFilter(
-            card: Card,
-            text: String,
-        ): String {
-            val typeAnswerField =
-                getTypeAnswerField(card, text)
-                    ?: return typeAnsRe.replace(text, "")
-            val expectedAnswer =
-                getExpectedTypeInAnswer(card, typeAnswerField)
-                    ?: return typeAnsRe.replace(text, "")
-            val typeFont = typeAnswerField.getString("font")
-            val typeSize = getFontSize(typeAnswerField)
-            val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
-
-            @Language("HTML")
-            val output =
-                """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
-            return typeAnsRe.replace(text, output)
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -236,9 +236,10 @@ class PreviewerViewModel(
     /** From the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L671) */
     override suspend fun typeAnsFilter(text: String): String =
         if (showingAnswer.value) {
-            typeAnsAnswerFilter(currentCard.await(), text)
+            val typeAnswer = TypeAnswer.getInstance(currentCard.await(), text)
+            typeAnswer?.answerFilter() ?: text
         } else {
-            removeTypeAnswerTags(text)
+            TypeAnswer.removeTags(text)
         }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -240,7 +240,7 @@ class PreviewerViewModel(
         if (showingAnswer.value) {
             typeAnsAnswerFilter(currentCard.await(), text)
         } else {
-            typeAnsQuestionFilter(text)
+            removeTypeAnswerTags(text)
         }
 
     companion object {
@@ -255,9 +255,9 @@ class PreviewerViewModel(
                 }
             }
 
-        /** removes `[[type:]]` blocks in questions */
+        /** removes `[[type:]]` tags */
         @VisibleForTesting
-        fun typeAnsQuestionFilter(text: String) = typeAnsRe.replace(text, "")
+        fun removeTypeAnswerTags(text: String) = typeAnsRe.replace(text, "")
 
         /** Adapted from the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L720) */
         suspend fun typeAnsAnswerFilter(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -184,7 +184,10 @@ class TemplatePreviewerViewModel(
     }
 
     // https://github.com/ankitects/anki/blob/df70564079f53e587dc44f015c503fdf6a70924f/qt/aqt/clayout.py#L579
-    override suspend fun typeAnsFilter(text: String): String =
+    override suspend fun typeAnsFilter(
+        text: String,
+        typedAnswer: String?,
+    ): String =
         if (showingAnswer.value) {
             val typeAnswer = TypeAnswer.getInstance(currentCard.await(), text)
             if (typeAnswer?.expectedAnswer?.isEmpty() == true) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -115,7 +115,7 @@ class TemplatePreviewerViewModel(
         if (isAfterRecreation) {
             launchCatchingIO {
                 // TODO: We should persist showingAnswer to SavedStateHandle
-                if (showingAnswer.value) showAnswerInternal() else showQuestion()
+                if (showingAnswer.value) showAnswer() else showQuestion()
             }
             return
         }
@@ -145,7 +145,7 @@ class TemplatePreviewerViewModel(
                 showQuestion()
                 loadAndPlaySounds(CardSide.QUESTION)
             } else {
-                showAnswerInternal()
+                showAnswer()
                 loadAndPlaySounds(CardSide.ANSWER)
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
@@ -15,81 +15,107 @@
  */
 package com.ichi2.anki.previewer
 
+import android.os.LocaleList
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.servicelayer.LanguageHintService
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
+import com.ichi2.utils.jsonObjectIterable
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.VisibleForTesting
 import org.json.JSONObject
 
-// Desktop source: https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L669
+/**
+ * Handles `type in the answer card` properties
+ *
+ * @see [combining]
+ * @see [imeHintLocales]
+ * */
+@NeedsTest("combining and non combining answers are properly parsed")
+@NeedsTest("cloze and non cloze 'type in the answer' cards are properly parsed")
+class TypeAnswer private constructor(
+    private val text: String,
+    /** whether combining characters should be compared. Defined by the presence of the
+     *   `nc:` specifier in the type answer tag */
+    private val combining: Boolean,
+    private val field: JSONObject,
+    var expectedAnswer: String,
+) {
+    /** a field property specific to AnkiDroid that allows to automatically select
+     *   a language for the keyboard. @see [LanguageHintService] */
+    val imeHintLocales: LocaleList? by lazy {
+        LanguageHintService.getImeHintLocales(this.field)
+    }
+
+    suspend fun answerFilter(typedAnswer: String = ""): String {
+        val typeFont = field.getString("font")
+        val typeSize = field.getString("size")
+        val answerComparison = withCol { compareAnswer(expectedAnswer, provided = typedAnswer, combining = combining) }
+
+        @Language("HTML")
+        val repl = """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
+        return typeAnsRe.replace(text, repl)
+    }
+
+    companion object {
+        /** removes `[[type:]]` tags from the given [text] */
+        fun removeTags(text: String): String = typeAnsRe.replace(text, "")
+
+        /**
+         * @return a [TypeAnswer] instance if [text] contains a `[[type:Field]]` tag
+         * with a valid field name, or null if not.
+         *
+         * ([Source](https://github.com/ankitects/anki/blob/8af63f81eb235b8d21df4e8eeaa6e02f46b3fbf6/qt/aqt/reviewer.py#L702))
+         */
+        suspend fun getInstance(
+            card: Card,
+            text: String,
+        ): TypeAnswer? {
+            val match = typeAnsRe.find(text) ?: return null
+            val fld = match.groups[1]?.value ?: return null
+
+            var combining = true
+            val typeAnsFieldName =
+                if (fld.startsWith("cloze:")) {
+                    fld.split(":")[1]
+                } else if (fld.startsWith("nc:")) {
+                    combining = false
+                    fld.split(":")[1]
+                } else {
+                    fld
+                }
+            val fields = withCol { card.noteType(this).flds }
+            val typeAnswerField =
+                fields.jsonObjectIterable().firstOrNull {
+                    it.getString("name") == typeAnsFieldName
+                } ?: return null
+            val expectedAnswer = getExpectedTypeInAnswer(card, typeAnswerField)
+
+            return TypeAnswer(
+                text = text,
+                combining = combining,
+                field = typeAnswerField,
+                expectedAnswer = expectedAnswer,
+            )
+        }
+
+        private suspend fun getExpectedTypeInAnswer(
+            card: Card,
+            field: JSONObject,
+        ): String {
+            val fieldName = field.getString("name")
+            val expected = withCol { card.note(this@withCol).getItem(fieldName) }
+            return if (fieldName.startsWith("cloze:")) {
+                val clozeIdx = card.ord + 1
+                withCol {
+                    extractClozeForTyping(expected, clozeIdx)
+                }
+            } else {
+                expected
+            }
+        }
+    }
+}
 
 @VisibleForTesting
 val typeAnsRe = Regex("\\[\\[type:(.+?)]]")
-
-/** removes `[[type:]]` tags */
-@VisibleForTesting
-fun removeTypeAnswerTags(text: String) = typeAnsRe.replace(text, "")
-
-suspend fun getTypeAnswerField(
-    card: Card,
-    text: String,
-): JSONObject? {
-    val match = typeAnsRe.find(text) ?: return null
-
-    val typeAnsFieldName =
-        match.groups[1]!!.value.let {
-            if (it.startsWith("cloze:")) {
-                it.split(":")[1]
-            } else {
-                it
-            }
-        }
-
-    val fields = withCol { card.noteType(this).flds }
-    for (i in 0 until fields.length()) {
-        val field = fields.get(i) as JSONObject
-        if (field.getString("name") == typeAnsFieldName) {
-            return field
-        }
-    }
-    return null
-}
-
-suspend fun getExpectedTypeInAnswer(
-    card: Card,
-    field: JSONObject,
-): String? {
-    val fieldName = field.getString("name")
-    val expected = withCol { card.note(this@withCol).getItem(fieldName) }
-    return if (fieldName.startsWith("cloze:")) {
-        val clozeIdx = card.ord + 1
-        withCol {
-            extractClozeForTyping(expected, clozeIdx).takeIf { it.isNotBlank() }
-        }
-    } else {
-        expected
-    }
-}
-
-fun getFontSize(field: JSONObject): String = field.getString("size")
-
-/** Adapted from the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L720) */
-suspend fun typeAnsAnswerFilter(
-    card: Card,
-    text: String,
-): String {
-    val typeAnswerField =
-        getTypeAnswerField(card, text)
-            ?: return typeAnsRe.replace(text, "")
-    val expectedAnswer =
-        getExpectedTypeInAnswer(card, typeAnswerField)
-            ?: return typeAnsRe.replace(text, "")
-    val typeFont = typeAnswerField.getString("font")
-    val typeSize = getFontSize(typeAnswerField)
-    val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
-
-    @Language("HTML")
-    val output =
-        """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
-    return typeAnsRe.replace(text, output)
-}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2024 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.libanki.Card
+import org.intellij.lang.annotations.Language
+import org.jetbrains.annotations.VisibleForTesting
+import org.json.JSONObject
+
+// Desktop source: https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L669
+
+@VisibleForTesting
+val typeAnsRe = Regex("\\[\\[type:(.+?)]]")
+
+/** removes `[[type:]]` tags */
+@VisibleForTesting
+fun removeTypeAnswerTags(text: String) = typeAnsRe.replace(text, "")
+
+suspend fun getTypeAnswerField(
+    card: Card,
+    text: String,
+): JSONObject? {
+    val match = typeAnsRe.find(text) ?: return null
+
+    val typeAnsFieldName =
+        match.groups[1]!!.value.let {
+            if (it.startsWith("cloze:")) {
+                it.split(":")[1]
+            } else {
+                it
+            }
+        }
+
+    val fields = withCol { card.noteType(this).flds }
+    for (i in 0 until fields.length()) {
+        val field = fields.get(i) as JSONObject
+        if (field.getString("name") == typeAnsFieldName) {
+            return field
+        }
+    }
+    return null
+}
+
+suspend fun getExpectedTypeInAnswer(
+    card: Card,
+    field: JSONObject,
+): String? {
+    val fieldName = field.getString("name")
+    val expected = withCol { card.note(this@withCol).getItem(fieldName) }
+    return if (fieldName.startsWith("cloze:")) {
+        val clozeIdx = card.ord + 1
+        withCol {
+            extractClozeForTyping(expected, clozeIdx).takeIf { it.isNotBlank() }
+        }
+    } else {
+        expected
+    }
+}
+
+fun getFontSize(field: JSONObject): String = field.getString("size")
+
+/** Adapted from the [desktop code](https://github.com/ankitects/anki/blob/1ff55475b93ac43748d513794bcaabd5d7df6d9d/qt/aqt/reviewer.py#L720) */
+suspend fun typeAnsAnswerFilter(
+    card: Card,
+    text: String,
+): String {
+    val typeAnswerField =
+        getTypeAnswerField(card, text)
+            ?: return typeAnsRe.replace(text, "")
+    val expectedAnswer =
+        getExpectedTypeInAnswer(card, typeAnswerField)
+            ?: return typeAnsRe.replace(text, "")
+    val typeFont = typeAnswerField.getString("font")
+    val typeSize = getFontSize(typeAnswerField)
+    val answerComparison = withCol { compareAnswer(expectedAnswer, provided = "") }
+
+    @Language("HTML")
+    val output =
+        """<div style="font-family: '$typeFont'; font-size: ${typeSize}px">$answerComparison</div>"""
+    return typeAnsRe.replace(text, output)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/LanguageHintService.kt
@@ -56,6 +56,11 @@ object LanguageHintService {
         Timber.i("Set field locale to %s", selectedLocale)
     }
 
+    fun getImeHintLocales(field: JSONObject?): LocaleList? {
+        if (field == null) return null
+        return getLanguageHintForField(field)?.let { LocaleList(it) }
+    }
+
     fun EditText.applyLanguageHint(languageHint: LanguageHint?) {
         this.imeHintLocales = if (languageHint != null) LocaleList(languageHint) else null
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -27,11 +27,11 @@ import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
 import android.widget.FrameLayout
+import android.widget.LinearLayout
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
 import androidx.appcompat.view.menu.SubMenuBuilder
 import androidx.appcompat.widget.ActionMenuView
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -298,7 +298,7 @@ class ReviewerFragment :
                     viewModel.onShowAnswer(typedAnswer = typedAnswer)
                 }
             }
-        val answerButtonsLayout = view.findViewById<ConstraintLayout>(R.id.answer_buttons)
+        val answerButtonsLayout = view.findViewById<LinearLayout>(R.id.answer_buttons)
 
         // TODO add some kind of feedback/animation after tapping show answer or the answer buttons
         viewModel.showingAnswer.collectLatestIn(lifecycleScope) { shouldShowAnswer ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -239,7 +239,7 @@ class ReviewerFragment :
         val showAnswerButton =
             view.findViewById<MaterialButton>(R.id.show_answer).apply {
                 setOnClickListener {
-                    viewModel.showAnswer()
+                    viewModel.onShowAnswer()
                 }
             }
         val answerButtonsLayout = view.findViewById<ConstraintLayout>(R.id.answer_buttons)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -23,6 +23,8 @@ import android.text.style.UnderlineSpan
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
 import android.widget.FrameLayout
 import androidx.activity.result.contract.ActivityResultContracts
@@ -30,6 +32,7 @@ import androidx.annotation.StringRes
 import androidx.appcompat.view.menu.SubMenuBuilder
 import androidx.appcompat.widget.ActionMenuView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -40,6 +43,8 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_NO_MORE_CARDS
 import com.ichi2.anki.CollectionManager
@@ -92,6 +97,7 @@ import com.ichi2.anki.utils.ext.collectLatestIn
 import com.ichi2.anki.utils.ext.menu
 import com.ichi2.anki.utils.ext.removeSubMenu
 import com.ichi2.anki.utils.ext.sharedPrefs
+import com.ichi2.anki.utils.ext.window
 import com.ichi2.libanki.sched.Counts
 import kotlinx.coroutines.launch
 
@@ -107,7 +113,13 @@ class ReviewerFragment :
         get() = requireView().findViewById(R.id.webview)
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        anchorView = this@ReviewerFragment.view?.findViewById(R.id.buttons_area)
+        val typeAnswerContainer = this@ReviewerFragment.view?.findViewById<View>(R.id.type_answer_container)
+        anchorView =
+            if (typeAnswerContainer?.isVisible == true) {
+                typeAnswerContainer
+            } else {
+                this@ReviewerFragment.view?.findViewById(R.id.buttons_area)
+            }
     }
 
     override fun onStop() {
@@ -128,6 +140,7 @@ class ReviewerFragment :
         }
 
         setupImmersiveMode(view)
+        setupTypeAnswer(view)
         setupAnswerButtons(view)
         setupCounts(view)
         setupMenu(view)
@@ -195,6 +208,47 @@ class ReviewerFragment :
         return true
     }
 
+    private fun setupTypeAnswer(view: View) {
+        // TODO keep text after configuration changes
+        val typeAnswerContainer = view.findViewById<MaterialCardView>(R.id.type_answer_container)
+        val typeAnswerEditText =
+            view.findViewById<TextInputEditText>(R.id.type_answer_edit_text).apply {
+                setOnEditorActionListener { editTextView, actionId, _ ->
+                    if (actionId == EditorInfo.IME_ACTION_DONE) {
+                        viewModel.onShowAnswer(editTextView.text.toString())
+                        return@setOnEditorActionListener true
+                    }
+                    false
+                }
+                setOnFocusChangeListener { editTextView, hasFocus ->
+                    val insetsController = WindowInsetsControllerCompat(window, editTextView)
+                    if (hasFocus) {
+                        insetsController.show(WindowInsetsCompat.Type.ime())
+                    } else {
+                        insetsController.hide(WindowInsetsCompat.Type.ime())
+                    }
+                }
+            }
+        val autoFocusTypeAnswer = sharedPrefs().getBoolean(getString(R.string.type_in_answer_focus_key), true)
+        viewModel.typeAnswerFlow.collectIn(lifecycleScope) { typeInAnswer ->
+            typeAnswerEditText.text = null
+            if (typeInAnswer == null) {
+                typeAnswerContainer.isVisible = false
+                return@collectIn
+            }
+            typeAnswerContainer.isVisible = true
+            typeAnswerEditText.apply {
+                if (imeHintLocales != typeInAnswer.imeHintLocales) {
+                    imeHintLocales = typeInAnswer.imeHintLocales
+                    context?.getSystemService<InputMethodManager>()?.restartInput(this)
+                }
+                if (autoFocusTypeAnswer) {
+                    requestFocus()
+                }
+            }
+        }
+    }
+
     private fun setupAnswerButtons(view: View) {
         val hideAnswerButtons = sharedPrefs().getBoolean(getString(R.string.hide_answer_buttons_key), false)
         if (hideAnswerButtons) {
@@ -238,8 +292,10 @@ class ReviewerFragment :
 
         val showAnswerButton =
             view.findViewById<MaterialButton>(R.id.show_answer).apply {
+                val editText = view.findViewById<TextInputEditText>(R.id.type_answer_edit_text)
                 setOnClickListener {
-                    viewModel.onShowAnswer()
+                    val typedAnswer = editText?.text?.toString()
+                    viewModel.onShowAnswer(typedAnswer = typedAnswer)
                 }
             }
         val answerButtonsLayout = view.findViewById<ConstraintLayout>(R.id.answer_buttons)
@@ -387,11 +443,12 @@ class ReviewerFragment :
 
         val ignoreDisplayCutout = sharedPrefs().getBoolean(getString(R.string.ignore_display_cutout_key), false)
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            val defaultTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime()
             val typeMask =
                 if (ignoreDisplayCutout) {
-                    WindowInsetsCompat.Type.systemBars()
+                    defaultTypes
                 } else {
-                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+                    defaultTypes or WindowInsetsCompat.Type.displayCutout()
                 }
             val bars = insets.getInsets(typeMask)
             v.updatePadding(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -132,7 +132,7 @@ class ReviewerViewModel(
         if (isAfterRecreation) {
             launchCatchingIO {
                 // TODO handle "Don't keep activities"
-                if (showingAnswer.value) showAnswerInternal() else showQuestion()
+                if (showingAnswer.value) showAnswer() else showQuestion()
             }
         } else {
             launchCatchingIO {
@@ -141,13 +141,19 @@ class ReviewerViewModel(
         }
     }
 
-    fun showAnswer() {
+    /**
+     * Sends an [eval] request to load the card answer, and updates components
+     * with behavior specific to the `Answer` card side.
+     *
+     * @see showAnswer
+     */
+    fun onShowAnswer() {
         launchCatchingIO {
             while (!statesMutated) {
                 delay(50)
             }
             updateNextTimes()
-            showAnswerInternal()
+            showAnswer()
             loadAndPlaySounds(CardSide.ANSWER)
             if (!autoAdvance.shouldWaitForAudio()) {
                 autoAdvance.onShowAnswer()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -424,7 +424,10 @@ class ReviewerViewModel(
     }
 
     // TODO
-    override suspend fun typeAnsFilter(text: String): String = text
+    override suspend fun typeAnsFilter(
+        text: String,
+        typedAnswer: String?,
+    ): String = text
 
     private suspend fun updateUndoAndRedoLabels() {
         undoLabelFlow.emit(withCol { undoLabel() })

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
@@ -76,7 +76,7 @@ class AutoAdvance(
             viewModel.launchCatchingIO {
                 delay(durationToShowQuestionFor())
                 when (questionAction()) {
-                    QuestionAction.SHOW_ANSWER -> viewModel.showAnswer()
+                    QuestionAction.SHOW_ANSWER -> viewModel.onShowAnswer()
                     QuestionAction.SHOW_REMINDER -> showReminder(TR.studyingQuestionTimeElapsed())
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Fragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Fragment.kt
@@ -17,8 +17,10 @@ package com.ichi2.anki.utils.ext
 
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
+import android.view.Window
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.showDialogFragmentImpl
 
@@ -33,3 +35,7 @@ val Fragment.packageManager: PackageManager
  * @see showDialogFragmentImpl
  */
 fun Fragment.showDialogFragment(newFragment: DialogFragment) = requireActivity().showDialogFragment(newFragment)
+
+/** @see FragmentActivity.getWindow */
+val Fragment.window: Window
+    get() = requireActivity().window

--- a/AnkiDroid/src/main/res/layout/fragment_audio_recording.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_audio_recording.xml
@@ -34,7 +34,7 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@id/action_done"
-            style="@style/CardView.PreviewerStyle" >
+            style="@style/CardView.ViewerStyle" >
 
             <LinearLayout
                 android:id="@+id/audio_recorder_layout"

--- a/AnkiDroid/src/main/res/layout/fragment_audio_video.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_audio_video.xml
@@ -33,7 +33,7 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@id/media_size_textview"
-            style="@style/CardView.PreviewerStyle" >
+            style="@style/CardView.ViewerStyle" >
 
             <androidx.media3.ui.PlayerView
                 android:layout_gravity="center"

--- a/AnkiDroid/src/main/res/layout/fragment_multimedia_image.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_multimedia_image.xml
@@ -32,7 +32,7 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toTopOf="@id/image_size_textview"
-            style="@style/CardView.PreviewerStyle" >
+            style="@style/CardView.ViewerStyle" >
 
             <WebView
                 android:id="@+id/multimedia_webview"

--- a/AnkiDroid/src/main/res/layout/previewer.xml
+++ b/AnkiDroid/src/main/res/layout/previewer.xml
@@ -39,7 +39,7 @@
             android:layout_height="0dp"
             app:layout_constraintTop_toBottomOf="@id/appbar"
             app:layout_constraintBottom_toTopOf="@id/slider"
-            style="@style/CardView.PreviewerStyle"
+            style="@style/CardView.ViewerStyle"
             >
 
             <WebView

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -9,23 +9,23 @@
     android:fitsSystemWindows="true"
     tools:context=".ui.windows.reviewer.ReviewerFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_marginBottom="4dp">
+        android:layout_marginBottom="4dp"
+        android:orientation="vertical">
 
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
+            >
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 app:navigationIcon="?attr/homeAsUpIndicator"
                 app:navigationContentDescription="@string/abc_action_bar_up_description"
                 android:layout_width="match_parent"
-                app:layout_constraintTop_toTopOf="parent"
                 android:layout_height="?attr/actionBarSize"
                 android:background="?attr/alternativeBackgroundColor"
                 >
@@ -71,29 +71,24 @@
             android:id="@+id/webview_container"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:layout_marginHorizontal="8dp"
+            android:layout_marginHorizontal="@dimen/reviewer_side_margin"
             android:layout_marginBottom="4dp"
-            app:layout_constraintTop_toBottomOf="@id/appbar"
-            app:layout_constraintBottom_toTopOf="@id/type_answer_container"
-            style="@style/CardView.ViewerStyle">
+            style="@style/CardView.ViewerStyle"
+            android:layout_weight="1">
 
             <WebView
                 android:id="@+id/webview"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-            </WebView>
+                android:layout_height="match_parent"/>
 
         </com.google.android.material.card.MaterialCardView>
 
         <!-- Use the same card style of the WebView -->
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/type_answer_container"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintStart_toStartOf="@id/webview_container"
-            app:layout_constraintEnd_toEndOf="@id/webview_container"
-            app:layout_constraintTop_toBottomOf="@id/webview_container"
-            app:layout_constraintBottom_toTopOf="@id/buttons_area"
+            android:layout_marginHorizontal="8dp"
             style="@style/CardView.ViewerStyle"
             android:layout_marginTop="4dp"
             android:layout_marginBottom="8dp"
@@ -120,17 +115,12 @@
 
         </com.google.android.material.card.MaterialCardView>
 
-
-
         <FrameLayout
             android:id="@+id/buttons_area"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="@dimen/touch_target"
             android:layout_marginTop="2dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="@id/webview_container"
-            app:layout_constraintStart_toStartOf="@id/webview_container"
-            app:layout_constraintTop_toBottomOf="@id/type_answer_container"
+            android:layout_marginHorizontal="@dimen/reviewer_side_margin"
             >
 
             <com.google.android.material.button.MaterialButton
@@ -143,7 +133,7 @@
                 tools:visibility="gone"
                 />
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <LinearLayout
                 android:id="@+id/answer_buttons"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -154,64 +144,52 @@
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/again_button"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:text="@string/ease_button_again"
                     android:backgroundTint="@color/again_button_bg"
                     android:textColor="@color/again_button_text"
-                    android:layout_marginHorizontal="3dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toStartOf="@id/hard_button"
+                    android:layout_marginEnd="@dimen/answer_button_margin_horizontal"
                     style="@style/AnswerButton"
+                    android:layout_weight="1"
                     />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/hard_button"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:text="@string/ease_button_hard"
                     android:backgroundTint="@color/hard_button_bg"
                     android:textColor="@color/hard_button_text"
-                    android:layout_marginHorizontal="3dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/again_button"
-                    app:layout_constraintEnd_toStartOf="@id/good_button"
+                    android:layout_marginHorizontal="@dimen/answer_button_margin_horizontal"
                     style="@style/AnswerButton"
+                    android:layout_weight="1"
                     />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/good_button"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:text="@string/ease_button_good"
                     android:backgroundTint="@color/good_button_bg"
                     android:textColor="@color/good_button_text"
-                    android:layout_marginHorizontal="3dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/hard_button"
-                    app:layout_constraintEnd_toStartOf="@id/easy_button"
+                    android:layout_marginHorizontal="@dimen/answer_button_margin_horizontal"
                     style="@style/AnswerButton"
+                    android:layout_weight="1"
                     />
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/easy_button"
                     android:layout_width="0dp"
-                    android:layout_height="0dp"
+                    android:layout_height="match_parent"
                     android:padding="0dp"
                     android:text="@string/ease_button_easy"
                     android:backgroundTint="@color/easy_button_bg"
                     android:textColor="@color/easy_button_text"
-                    android:layout_marginHorizontal="3dp"
-                    app:layout_constraintTop_toTopOf="parent"
-                    app:layout_constraintBottom_toBottomOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/good_button"
-                    app:layout_constraintEnd_toEndOf="parent"
+                    android:layout_marginStart="@dimen/answer_button_margin_horizontal"
                     style="@style/AnswerButton"
+                    android:layout_weight="1"
                     />
-            </androidx.constraintlayout.widget.ConstraintLayout>
+            </LinearLayout>
         </FrameLayout>
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -75,7 +75,7 @@
             android:layout_marginBottom="4dp"
             app:layout_constraintTop_toBottomOf="@id/appbar"
             app:layout_constraintBottom_toTopOf="@id/buttons_area"
-            style="@style/CardView.PreviewerStyle">
+            style="@style/CardView.ViewerStyle">
 
             <WebView
                 android:id="@+id/webview"

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -74,7 +74,7 @@
             android:layout_marginHorizontal="8dp"
             android:layout_marginBottom="4dp"
             app:layout_constraintTop_toBottomOf="@id/appbar"
-            app:layout_constraintBottom_toTopOf="@id/buttons_area"
+            app:layout_constraintBottom_toTopOf="@id/type_answer_container"
             style="@style/CardView.ViewerStyle">
 
             <WebView
@@ -85,6 +85,43 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- Use the same card style of the WebView -->
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/type_answer_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintStart_toStartOf="@id/webview_container"
+            app:layout_constraintEnd_toEndOf="@id/webview_container"
+            app:layout_constraintTop_toBottomOf="@id/webview_container"
+            app:layout_constraintBottom_toTopOf="@id/buttons_area"
+            style="@style/CardView.ViewerStyle"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/type_answer_hint"
+                app:endIconMode="clear_text"
+                app:boxBackgroundMode="filled"
+                app:boxStrokeWidth="0dp"
+                >
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/type_answer_edit_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:imeOptions="actionDone"
+                    android:inputType="text|textNoSuggestions"
+                    />
+            </com.google.android.material.textfield.TextInputLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+
+
         <FrameLayout
             android:id="@+id/buttons_area"
             android:layout_width="0dp"
@@ -93,7 +130,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="@id/webview_container"
             app:layout_constraintStart_toStartOf="@id/webview_container"
-            app:layout_constraintTop_toBottomOf="@id/webview_container"
+            app:layout_constraintTop_toBottomOf="@id/type_answer_container"
             >
 
             <com.google.android.material.button.MaterialButton

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -12,7 +12,7 @@
         android:layout_height="0dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/show_answer"
-        style="@style/CardView.PreviewerStyle"
+        style="@style/CardView.ViewerStyle"
         >
 
         <WebView

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/webview_container"
         android:layout_width="match_parent"
-        android:layout_marginHorizontal="8dp"
+        android:layout_marginHorizontal="@dimen/reviewer_side_margin"
         android:layout_height="0dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toTopOf="@id/show_answer"
         style="@style/CardView.ViewerStyle"
+        android:layout_weight="1"
         >
 
         <WebView
@@ -25,13 +25,10 @@
 
     <com.google.android.material.button.MaterialButton
         android:id="@+id/show_answer"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         style="@style/Widget.Material3.Button.TextButton"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/webview_container"
+        android:layout_marginHorizontal="@dimen/reviewer_side_margin"
         android:text="@string/show_answer"/>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/layout/template_previewer_container.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer_container.xml
@@ -9,21 +9,20 @@
     android:background="?attr/alternativeBackgroundColor"
     tools:context=".previewer.TemplatePreviewerPage">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <com.google.android.material.appbar.AppBarLayout
             android:id="@+id/appbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent">
+            android:layout_height="wrap_content">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
                 app:navigationContentDescription="@string/abc_action_bar_up_description"
                 app:navigationIcon="?attr/homeAsUpIndicator"
                 android:background="?attr/alternativeBackgroundColor">
@@ -45,8 +44,7 @@
             android:id="@+id/fragment_container"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/appbar"
-            app:layout_constraintBottom_toBottomOf="parent" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+            android:layout_weight="1"/>
+    </LinearLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/dimens.xml
+++ b/AnkiDroid/src/main/res/values/dimens.xml
@@ -33,4 +33,7 @@
     <dimen name="mtrl_snackbar_background_corner_radius">8dp</dimen>
     <dimen name="popup_corner_radius">8dp</dimen>
     <dimen name="dialog_corner_radius">8dp</dimen>
+
+    <dimen name="reviewer_side_margin">8dp</dimen>
+    <dimen name="answer_button_margin_horizontal">3dp</dimen>
 </resources>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -231,7 +231,7 @@
         <item name="android:textColor">?attr/progressDialogButtonTextColor</item>
     </style>
 
-    <style name="CardView.PreviewerStyle" parent="Widget.Material3.CardView.Elevated">
+    <style name="CardView.ViewerStyle" parent="Widget.Material3.CardView.Elevated">
         <item name="android:elevation">0.8dp</item>
     </style>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -23,7 +23,7 @@ class PreviewerViewModelTest {
     @Test
     fun `type answer fields are removed in questions`() {
         assertThat(
-            PreviewerViewModel.removeTypeAnswerTags("creu [[type:leu]]"),
+            removeTypeAnswerTags("creu [[type:leu]]"),
             equalTo("creu "),
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -23,7 +23,7 @@ class PreviewerViewModelTest {
     @Test
     fun `type answer fields are removed in questions`() {
         assertThat(
-            PreviewerViewModel.typeAnsQuestionFilter("creu [[type:leu]]"),
+            PreviewerViewModel.removeTypeAnswerTags("creu [[type:leu]]"),
             equalTo("creu "),
         )
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -23,7 +23,7 @@ class PreviewerViewModelTest {
     @Test
     fun `type answer fields are removed in questions`() {
         assertThat(
-            removeTypeAnswerTags("creu [[type:leu]]"),
+            TypeAnswer.removeTags("creu [[type:leu]]"),
             equalTo("creu "),
         )
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Implements type in the answer cards in the new reviewer natively. I don't know when/if I will implement the HTML version

## Fixes
* Fixes part of #14302 

## Approach

In the commits

## How Has This Been Tested?

Emulator 34

https://github.com/user-attachments/assets/9cd18075-393b-440e-b927-536e9e9f9e6a


https://github.com/user-attachments/assets/d99ca820-740e-40a6-8d69-6b0ab8969f46



## Learning (optional, can help others)

* InputMethodManager.restartInput can be used to restart the IME language hint immediately (it's on the javadoc of imeHintLocales)
* WindowInsetsControllerCompat can be used to reliably show the IME ([source](https://developer.android.com/develop/ui/views/touch-and-input/keyboard-input/visibility#ShowReliably))


I should learn more about Android MVVM and flow, specially to better handle configuration changes. Also, `ReviewerFragment` is getting big. Not sure if I can split some of it into other files, or if I should. The reviewer does a lot of things anyway

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
