### PR TITLE
[Cleanup]: Resolve Android Studio Warnings (#13282)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -22,7 +22,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
 import androidx.activity.OnBackPressedCallback
-import androidx.activity.addCallback
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -47,7 +47,6 @@ class CardTemplateNotetype(
     }
 
     private var _templateChanges = ArrayList<Array<Any>>()
-    var editedModelFileName: String? = null
 
     fun toBundle(): Bundle =
         bundleOf(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -198,7 +198,7 @@ object CollectionHelper {
      *
      * @return Absolute path to the AnkiDroid directory in primary shared/external storage
      */
-    val legacyAnkiDroidDirectory: String
+    private val legacyAnkiDroidDirectory: String
         get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid").absolutePath
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -610,9 +610,6 @@ class NoteEditor :
         savedInstanceState.putStringArrayList("tags", selectedTags?.let { ArrayList(it) })
     }
 
-    private val fieldsAsBundleForPreview: Bundle
-        get() = NoteService.getFieldsAsBundleForPreview(editFields, shouldReplaceNewlines())
-
     // Finish initializing the fragment after the collection has been correctly loaded
     private fun setupEditor(col: Collection) {
         val intent = requireActivity().intent

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -76,7 +76,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     fun isColInitialized() = ::col.isInitialized
 
     protected var prefChanged = false
-    lateinit var unmountReceiver: BroadcastReceiver
+    private lateinit var unmountReceiver: BroadcastReceiver
     protected lateinit var col: Collection
         private set
     protected lateinit var pref: PreferenceHack

--- a/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/RtlCompliantActionProvider.kt
@@ -29,7 +29,7 @@ class RtlCompliantActionProvider(
     context: Context,
 ) : ActionProviderCompat(context) {
     @VisibleForTesting
-    val activity: Activity
+    val activity: Activity = unwrapContext(context)
 
     /**
      * The action to perform when clicking the associated menu item. By default this delegates to
@@ -73,9 +73,5 @@ class RtlCompliantActionProvider(
                 throw ClassCastException("Passed context should be either an instanceof Activity or a ContextWrapper wrapping an Activity")
             }
         }
-    }
-
-    init {
-        activity = unwrapContext(context)
     }
 }


### PR DESCRIPTION
## Purpose / Description
Reducing Android Studio warnings by cleaning up unused code and fixing initialization.

## Fixes
* Contributes towards #13282 ``[Cleanup]: Fix Android Studio Warnings``

## Approach

- Made the unmountReceiver property private in `AppCompatPreferenceActivity.kt`.
- Removed the unused import **(import androidx.activity.addCallback)** in `CardTemplateBrowserAppearanceEditor.kt`.
- Removed the unused **property editedModelFileName** in `CardTemplateNotetype.kt`.
- Fixed the unresolved reference to **BuildConfig** in `CardTemplateNotetype.kt`.
- Made the **legacyAnkiDroidDirectory property** private in `CollectionHelper.kt`.
- Removed the unused **property fieldsAsBundleForPreview** in `NoteEditor.kt`.
- Fixed the initialization of `activity` in `RtlCompliantActionProvider.kt` **by assigning it immediately during declaration**, **rather than inside the init block**. This ensures proper initialization and avoids potential issues.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code
