### PR TITLE
Add a skip button for all files access permission

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -32,7 +32,6 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
@@ -57,6 +56,7 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.INCOMP
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.isLoggedIn
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.showImportDialog
@@ -512,7 +512,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             "DatabaseErrorDialog: Before Create New Collection",
                         )
                         if (skipButton) {
-                            val sharedPrefsEdit = sharedPrefs().edit()
+                            val sharedPrefsEdit = context.sharedPrefs().edit()
                             sharedPrefsEdit.putBoolean("skipStoragePermission", true)
                             sharedPrefsEdit.apply()
                         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -32,6 +32,7 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.BackupManager
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.CollectionManager
@@ -496,7 +497,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
 
         companion object {
             /** A dialog which creates a new collection in an unsafe location */
-            fun displayResetToNewDirectoryDialog(context: AnkiActivity) {
+            fun displayResetToNewDirectoryDialog(
+                context: AnkiActivity,
+                skipButton: Boolean = false,
+            ) {
                 AlertDialog.Builder(context).show {
                     title(R.string.backup_new_collection)
                     setIcon(R.drawable.ic_warning)
@@ -507,6 +511,11 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             "closeCollection: %s",
                             "DatabaseErrorDialog: Before Create New Collection",
                         )
+                        if (skipButton) {
+                            val sharedPrefsEdit = sharedPrefs().edit()
+                            sharedPrefsEdit.putBoolean("skipStoragePermission", true)
+                            sharedPrefsEdit.apply()
+                        }
                         CollectionManager.closeCollectionBlocking()
                         CollectionHelper.resetAnkiDroidDirectory(context)
                         context.closeCollectionAndFinish()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/Full30and31PermissionsFragment.kt
@@ -51,5 +51,6 @@ class Full30and31PermissionsFragment : PermissionsFragment(R.layout.permissions_
         view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {
             accessAllFilesLauncher.showManageAllFilesScreen()
         }
+        (activity as? PermissionsActivity)?.setSkipButtonVisible(true)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -22,10 +22,12 @@ import android.os.Parcelable
 import androidx.activity.addCallback
 import androidx.appcompat.widget.AppCompatButton
 import androidx.core.content.IntentCompat
+import androidx.core.view.isVisible
 import androidx.fragment.app.commit
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.UninstallListItem.Companion.displayResetToNewDirectoryDialog
 import com.ichi2.themes.Themes
 import com.ichi2.themes.setTransparentStatusBar
 
@@ -55,6 +57,10 @@ class PermissionsActivity : AnkiActivity() {
             finish()
         }
 
+        findViewById<AppCompatButton>(R.id.skip_button).setOnClickListener {
+            displayResetToNewDirectoryDialog(ankiActivity, true)
+        }
+
         val permissionSet =
             requireNotNull(IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)) {
                 "PERMISSIONS_SET_EXTRA not set"
@@ -73,6 +79,10 @@ class PermissionsActivity : AnkiActivity() {
 
     fun setContinueButtonEnabled(isEnabled: Boolean) {
         findViewById<AppCompatButton>(R.id.continue_button).isEnabled = isEnabled
+    }
+
+    fun setSkipButtonVisible(isVisible: Boolean) {
+        findViewById<AppCompatButton>(R.id.skip_button).isVisible = isVisible
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/TiramisuPermissionsFragment.kt
@@ -52,5 +52,6 @@ class TiramisuPermissionsFragment : PermissionsFragment(R.layout.permissions_tir
         view.findViewById<PermissionItem>(R.id.all_files_permission).setOnSwitchClickListener {
             accessAllFilesLauncher.showManageAllFilesScreen()
         }
+        (activity as? PermissionsActivity)?.setSkipButtonVisible(true)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -26,9 +26,9 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
 import timber.log.Timber
@@ -175,7 +175,7 @@ object Permissions {
 
     fun canManageExternalStorage(context: Context): Boolean {
         // TODO: See if we can move this to a testing manifest
-        if (isRobolectric or sharedPrefs().getBoolean("skipStoragePermission", false)) {
+        if (isRobolectric or context.sharedPrefs().getBoolean("skipStoragePermission", false)) {
             return false
         }
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -26,6 +26,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
@@ -174,7 +175,7 @@ object Permissions {
 
     fun canManageExternalStorage(context: Context): Boolean {
         // TODO: See if we can move this to a testing manifest
-        if (isRobolectric) {
+        if (isRobolectric or sharedPrefs().getBoolean("skipStoragePermission", false)) {
             return false
         }
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&

--- a/AnkiDroid/src/main/res/layout/permissions_activity.xml
+++ b/AnkiDroid/src/main/res/layout/permissions_activity.xml
@@ -40,6 +40,18 @@
         </ScrollView>
 
         <com.google.android.material.button.MaterialButton
+            android:id="@+id/skip_button"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:paddingVertical="12dp"
+            android:text="@string/dialog_skip"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/permissions_scroll_area"
+            />
+
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/continue_button"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -75,6 +75,7 @@
     <string name="dialog_keep">Keep</string>
     <string name="dialog_remove">Remove</string>
     <string name="dialog_continue">Continue</string>
+    <string name="dialog_skip">Skip</string>
     <string name="dialog_processing">Processing…</string>
     <string name="dialog_positive_create" comment="Create a new collection, probably erasing the previous one, may be necessary in case of error.">Create</string>
     <string name="dialog_positive_delete" maxLength="28">Delete</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Add a skip button to the require all files access permission screen.

## Fixes
N/A
(Related to issue #13574 but this pull request does not fully resolve issue.)

## Approach
On the require all files access permission screen, add a skip button so user can proceed as if it were a play build.
[Screen_recording_20241222_232511.webm](https://github.com/user-attachments/assets/14c2826f-f378-4558-9275-6c629914c4d0)
![VideoCapture_20241223-214019-1](https://github.com/user-attachments/assets/fb7188e8-1c4e-4323-b555-49a39e31e16c)

## How Has This Been Tested?
SDK 35 emulator, SDK 33 physical device, and SDK 24 emulator

## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)