### PR TITLE
rename ViewerAction.EDIT_NOTE

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -45,7 +45,7 @@ enum class ViewerAction(
     REDO(R.id.action_redo, R.drawable.ic_redo, R.string.redo, MENU_ONLY),
     FLAG_MENU(R.id.action_flag, R.drawable.ic_flag_transparent, R.string.menu_flag, MENU_ONLY),
     MARK(R.id.action_mark, R.drawable.ic_star, R.string.menu_mark_note, MENU_ONLY),
-    EDIT_NOTE(R.id.action_edit_note, R.drawable.ic_mode_edit_white, R.string.cardeditor_title_edit_card, MENU_ONLY),
+    EDIT(R.id.action_edit_note, R.drawable.ic_mode_edit_white, R.string.cardeditor_title_edit_card, MENU_ONLY),
     BURY_MENU(R.id.action_bury, R.drawable.ic_flip_to_back_white, R.string.menu_bury, MENU_ONLY),
     SUSPEND_MENU(R.id.action_suspend, R.drawable.ic_suspend, R.string.menu_suspend, MENU_ONLY),
     DELETE(R.id.action_delete, R.drawable.ic_delete_white, R.string.menu_delete_note, MENU_ONLY),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -62,7 +62,7 @@ import com.ichi2.anki.preferences.reviewer.ViewerAction.BURY_NOTE
 import com.ichi2.anki.preferences.reviewer.ViewerAction.CARD_INFO
 import com.ichi2.anki.preferences.reviewer.ViewerAction.DECK_OPTIONS
 import com.ichi2.anki.preferences.reviewer.ViewerAction.DELETE
-import com.ichi2.anki.preferences.reviewer.ViewerAction.EDIT_NOTE
+import com.ichi2.anki.preferences.reviewer.ViewerAction.EDIT
 import com.ichi2.anki.preferences.reviewer.ViewerAction.FLAG_BLUE
 import com.ichi2.anki.preferences.reviewer.ViewerAction.FLAG_GREEN
 import com.ichi2.anki.preferences.reviewer.ViewerAction.FLAG_MENU
@@ -175,7 +175,7 @@ class ReviewerFragment :
             ADD_NOTE -> launchAddNote()
             CARD_INFO -> launchCardInfo()
             DECK_OPTIONS -> launchDeckOptions()
-            EDIT_NOTE -> launchEditNote()
+            EDIT -> launchEditNote()
             DELETE -> viewModel.deleteNote()
             MARK -> viewModel.toggleMark()
             REDO -> viewModel.redo()


### PR DESCRIPTION
to EDIT

this allows to share the same preference key of `ViewerCommand`, since the name is the same now

This change will reset its position in the toolbar, but it doesn't need a preference upgrade because the new reviewer is a developer option

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
