### PR TITLE
refactor: extract Binding equality to original classes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -162,13 +162,9 @@ sealed interface Binding {
 
         private fun ctrlMatches(event: KeyEvent): Boolean = ctrl == event.isCtrlPressed
 
-        private fun altMatches(event: KeyEvent): Boolean = altMatches(event.isAltPressed)
+        private fun altMatches(event: KeyEvent): Boolean = alt == event.isAltPressed
 
         open fun shiftMatches(shiftPressed: Boolean): Boolean = shift == shiftPressed
-
-        fun ctrlMatches(ctrlPressed: Boolean): Boolean = ctrl == ctrlPressed
-
-        fun altMatches(altPressed: Boolean): Boolean = alt == altPressed
 
         override fun toString() =
             buildString {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -23,6 +23,7 @@ import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.utils.StringUtil
 import com.ichi2.utils.lastIndexOfOrNull
 import timber.log.Timber
+import java.util.Objects
 
 sealed interface Binding {
     data class GestureInput(
@@ -75,6 +76,7 @@ sealed interface Binding {
         val modifierKeys: ModifierKeys
     }
 
+    @Suppress("EqualsOrHashCode")
     data class KeyCode(
         val keycode: Int,
         override val modifierKeys: ModifierKeys = ModifierKeys.none(),
@@ -101,8 +103,12 @@ sealed interface Binding {
                 append(modifierKeys.toString())
                 append(keycode)
             }
+
+        // don't include the modifierKeys
+        override fun hashCode(): Int = Objects.hash(keycode)
     }
 
+    @Suppress("EqualsOrHashCode")
     data class UnicodeCharacter(
         val unicodeCharacter: Char,
         override val modifierKeys: ModifierKeys = AppDefinedModifierKeys.allowShift(),
@@ -121,6 +127,9 @@ sealed interface Binding {
                 append(modifierKeys.toString())
                 append(unicodeCharacter)
             }
+
+        // don't include the modifierKeys
+        override fun hashCode(): Int = Objects.hash(unicodeCharacter)
     }
 
     data object UnknownBinding : Binding {
@@ -168,7 +177,7 @@ sealed interface Binding {
                 if (shift) append("Shift+")
             }
 
-        fun semiStructuralEquals(keys: ModifierKeys): Boolean {
+        private fun semiStructuralEquals(keys: ModifierKeys): Boolean {
             if (this.alt != keys.alt || this.ctrl != keys.ctrl) {
                 return false
             }
@@ -178,6 +187,10 @@ sealed interface Binding {
                     this.shiftMatches(false) == keys.shiftMatches(false)
             )
         }
+
+        override fun equals(other: Any?): Boolean = other is ModifierKeys && semiStructuralEquals(other)
+
+        override fun hashCode(): Int = Objects.hash(ctrl, alt, shift, shiftMatches(true), shiftMatches(false))
 
         companion object {
             fun none(): ModifierKeys = ModifierKeys(shift = false, ctrl = false, alt = false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -186,7 +186,7 @@ sealed interface Binding {
 
         override fun equals(other: Any?): Boolean = other is ModifierKeys && semiStructuralEquals(other)
 
-        override fun hashCode(): Int = Objects.hash(ctrl, alt, shift, shiftMatches(true), shiftMatches(false))
+        override fun hashCode(): Int = Objects.hash(ctrl, alt, shiftMatches(true))
 
         companion object {
             fun none(): ModifierKeys = ModifierKeys(shift = false, ctrl = false, alt = false)
@@ -213,7 +213,7 @@ sealed interface Binding {
     }
 
     /** Modifier keys which cannot be defined by a binding  */
-    private class AppDefinedModifierKeys private constructor() : ModifierKeys(false, false, false) {
+    class AppDefinedModifierKeys private constructor() : ModifierKeys(false, false, false) {
         override fun shiftMatches(shiftPressed: Boolean): Boolean = true
 
         companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -22,11 +22,8 @@ import androidx.annotation.CheckResult
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
-import com.ichi2.anki.reviewer.Binding.AxisButtonBinding
 import com.ichi2.anki.reviewer.Binding.GestureInput
 import com.ichi2.anki.reviewer.Binding.KeyBinding
-import com.ichi2.anki.reviewer.Binding.KeyCode
-import com.ichi2.anki.reviewer.Binding.UnicodeCharacter
 import com.ichi2.utils.hash
 import timber.log.Timber
 import java.util.Objects
@@ -47,48 +44,14 @@ class MappableBinding(
         if (other == null) return false
 
         val otherBinding = (other as MappableBinding).binding
-        val bindingEquals =
-            when {
-                binding is KeyCode && otherBinding is KeyCode -> binding.keycode == otherBinding.keycode && modifierEquals(otherBinding)
-                binding is UnicodeCharacter && otherBinding is UnicodeCharacter -> {
-                    binding.unicodeCharacter == otherBinding.unicodeCharacter &&
-                        modifierEquals(otherBinding)
-                }
-                binding is GestureInput && otherBinding is GestureInput -> binding.gesture == otherBinding.gesture
-                binding is AxisButtonBinding && otherBinding is AxisButtonBinding -> {
-                    binding.axis == otherBinding.axis && binding.threshold == otherBinding.threshold
-                }
-                else -> false
-            }
-        if (!bindingEquals) {
+        if (binding != otherBinding) {
             return false
         }
 
         return screen.screenEquals(other.screen)
     }
 
-    override fun hashCode(): Int {
-        // don't include the modifierKeys or mSide
-        val bindingHash =
-            when (binding) {
-                is KeyCode -> binding.keycode
-                is UnicodeCharacter -> binding.unicodeCharacter
-                is GestureInput -> binding.gesture
-                is AxisButtonBinding -> hash(binding.axis.motionEventValue, binding.threshold.toInt())
-                else -> 0
-            }
-        return Objects.hash(bindingHash, screen.prefix)
-    }
-
-    private fun modifierEquals(otherBinding: KeyBinding): Boolean {
-        // equals allowing subclasses
-        val keys = otherBinding.modifierKeys
-        val thisKeys = (this.binding as KeyBinding).modifierKeys
-        if (thisKeys === keys) return true
-        return thisKeys.semiStructuralEquals(keys)
-
-        // allow subclasses to work - a subclass which overrides shiftMatches will return true on one of the tests
-    }
+    override fun hashCode(): Int = Objects.hash(binding, screen.prefix)
 
     fun toDisplayString(context: Context): String = screen.toDisplayString(context, binding)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -25,6 +25,8 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import kotlin.reflect.KFunction1
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class BindingTest {
     @Test
@@ -66,6 +68,21 @@ class BindingTest {
     fun testUnknownToString() {
         // This seems sensible - serialising an unknown will mean that nothing is saved.
         assertThat(Binding.unknown().toString(), equalTo(""))
+    }
+
+    @Test
+    fun testModifierKeysEquality() {
+        val one = Binding.AppDefinedModifierKeys.allowShift()
+        val two = Binding.ModifierKeys(shift = true, ctrl = false, alt = false)
+
+        assertTrue(one.shiftMatches(true))
+        assertTrue(one.shiftMatches(false))
+
+        assertTrue(two.shiftMatches(true))
+        assertFalse(two.shiftMatches(false))
+
+        assertEquals(one, two)
+        assertEquals(one.hashCode(), two.hashCode())
     }
 
     private fun testModifierKeys(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingTest.kt
@@ -25,14 +25,13 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import kotlin.reflect.KFunction1
-import kotlin.reflect.KFunction2
 
 class BindingTest {
     @Test
     fun modifierKeys_Are_Loaded() {
         testModifierKeys("shift", KeyEvent::isShiftPressed, Binding.ModifierKeys::shiftMatches)
-        testModifierKeys("ctrl", KeyEvent::isCtrlPressed, Binding.ModifierKeys::ctrlMatches)
-        testModifierKeys("alt", KeyEvent::isAltPressed, Binding.ModifierKeys::altMatches)
+        testModifierKeys("ctrl", KeyEvent::isCtrlPressed) { k, ctrlPressed -> k.ctrl == ctrlPressed }
+        testModifierKeys("alt", KeyEvent::isAltPressed) { k, altPressed -> k.alt == altPressed }
     }
 
     @Test
@@ -72,7 +71,7 @@ class BindingTest {
     private fun testModifierKeys(
         name: String,
         event: KFunction1<KeyEvent, Boolean>,
-        getValue: KFunction2<Binding.ModifierKeys, Boolean, Boolean>,
+        getValue: (Binding.ModifierKeys, Boolean) -> Boolean,
     ) {
         fun testModifierResult(
             event: KFunction1<KeyEvent, Boolean>,


### PR DESCRIPTION
so it's possible to compare bindings without a MappableBinding

## How Has This Been Tested?

I'm trusting the unit tests. Went around and tested some keybinds and gestures and they still work.

I couldn't test some keybinds like `*` (mark default) and `!` (suspend default) even before these changes. They are only recognized as `Shift+1` and `Shift+8` here

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
