### PR TITLE
fix :'Type Answer' Edit Box visibility issue

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -12,6 +12,7 @@
         android:id="@+id/answer_field"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:visibility="gone"
         android:hint="@string/type_answer_hint"
         android:imeOptions="actionDone"
         android:inputType="text|textNoSuggestions" />


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Temporary Display of 'Type Answer' Edit Box Below Toolbar During Study Activity Launch

## Fixes
* Fixes #17676 

## Approach
I have set the visibility of answer_field (FixedEditText) to GONE to ensure it remains hidden during loading.

## How Has This Been Tested?
Physical Device

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
