### PR TITLE
refactor(libanki): extract & document 'CardTemplate[s]'

### DIFF
--- a/.idea/dictionaries/anki.xml
+++ b/.idea/dictionaries/anki.xml
@@ -10,7 +10,9 @@
       <w>apkg</w>
       <w>apkgaa</w>
       <w>bafmt</w>
+      <w>bfont</w>
       <w>bqfmt</w>
+      <w>bsize</w>
       <w>cid</w>
       <w>cids</w>
       <w>cloze</w>

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -45,6 +45,7 @@ import com.ichi2.libanki.getStockNotetypeLegacy
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.common.assertThrows
+import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.emptyStringArray
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.hamcrest.MatcherAssert.assertThat
@@ -240,9 +241,9 @@ class ContentProviderTest : InstrumentedTest() {
             TEST_NOTE_FIELDS.toMutableList(),
         )
         assertEquals("Check that tag was set correctly", TEST_TAG, addedNote.tags[0])
-        val noteType: JSONObject? = col.notetypes.get(noteTypeId)
+        val noteType: NotetypeJson? = col.notetypes.get(noteTypeId)
         assertNotNull("Check note type", noteType)
-        val expectedNumCards = noteType!!.getJSONArray("tmpls").length()
+        val expectedNumCards = noteType!!.tmpls.length()
         assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.numberOfCards(col))
         // Now delete the note
         cr.delete(newNoteUri, null, null)
@@ -285,7 +286,7 @@ class ContentProviderTest : InstrumentedTest() {
         val noteTypeUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, noteTypeId)
         val testIndex =
             TEST_NOTE_TYPE_CARDS.size - 1 // choose the last one because not the same as the basic note type template
-        val expectedOrd = noteType.getJSONArray("tmpls").length()
+        val expectedOrd = noteType.tmpls.length()
         val cv =
             ContentValues().apply {
                 put(FlashCardsContract.CardTemplate.NAME, TEST_NOTE_TYPE_CARDS[testIndex])
@@ -307,21 +308,21 @@ class ContentProviderTest : InstrumentedTest() {
         )
         noteType = col.notetypes.get(noteTypeId)
         assertNotNull("Check note type", noteType)
-        val template = noteType!!.getJSONArray("tmpls").getJSONObject(expectedOrd)
+        val template = noteType!!.tmpls[expectedOrd]
         assertEquals(
             "Check template JSONObject ord",
             expectedOrd,
-            template.getInt("ord"),
+            template.ord,
         )
         assertEquals(
             "Check template name",
             TEST_NOTE_TYPE_CARDS[testIndex],
-            template.getString("name"),
+            template.name,
         )
-        assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.getString("qfmt"))
-        assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[testIndex], template.getString("afmt"))
-        assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.getString("bqfmt"))
-        assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[testIndex], template.getString("bafmt"))
+        assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.qfmt)
+        assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[testIndex], template.afmt)
+        assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.bqfmt)
+        assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[testIndex], template.bafmt)
         col.notetypes.rem(noteType)
     }
 
@@ -575,7 +576,7 @@ class ContentProviderTest : InstrumentedTest() {
             assertEquals(
                 "Check templates length",
                 TEST_NOTE_TYPE_CARDS.size,
-                noteType.getJSONArray("tmpls").length(),
+                noteType.tmpls.length(),
             )
             assertEquals(
                 "Check field length",
@@ -624,16 +625,16 @@ class ContentProviderTest : InstrumentedTest() {
                 col = reopenCol()
                 noteType = col.notetypes.get(mid)
                 assertNotNull("Check note type", noteType)
-                val template = noteType!!.getJSONArray("tmpls").getJSONObject(i)
+                val template = noteType!!.tmpls[i]
                 assertEquals(
                     "Check template name",
                     TEST_NOTE_TYPE_CARDS[i],
-                    template.getString("name"),
+                    template.name,
                 )
-                assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[i], template.getString("qfmt"))
-                assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[i], template.getString("afmt"))
-                assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[i], template.getString("bqfmt"))
-                assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[i], template.getString("bafmt"))
+                assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[i], template.qfmt)
+                assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[i], template.afmt)
+                assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[i], template.bqfmt)
+                assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[i], template.bafmt)
             }
         } finally {
             // Delete the note type (this will force a full-sync)
@@ -1402,19 +1403,22 @@ class ContentProviderTest : InstrumentedTest() {
         }
     }
 
+    @KotlinCleanup("duplicate of TestClass method")
     fun addNonClozeNoteType(
         name: String,
         fields: Array<String>,
-        qfmt: String?,
-        afmt: String?,
+        qfmt: String,
+        afmt: String,
     ): String {
         val noteType = col.notetypes.new(name)
         for (field in fields) {
             col.notetypes.addFieldInNewModel(noteType, col.notetypes.newField(field))
         }
-        val t = Notetypes.newTemplate("Card 1")
-        t.put("qfmt", qfmt)
-        t.put("afmt", afmt)
+        val t =
+            Notetypes.newTemplate("Card 1").also { t ->
+                t.qfmt = qfmt
+                t.afmt = afmt
+            }
         col.notetypes.addTemplateInNewModel(noteType, t)
         col.notetypes.add(noteType)
         return name

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -2282,7 +2282,16 @@ open class CardBrowser :
                 CardBrowserColumn.SFLD -> card.note(col).sFld(col)
                 CardBrowserColumn.DECK -> col.decks.name(card.did)
                 CardBrowserColumn.TAGS -> card.note(col).stringTags(col)
-                CardBrowserColumn.CARD -> if (inCardMode) card.template(col).optString("name") else "${card.note(col).numberOfCards(col)}"
+                CardBrowserColumn.CARD ->
+                    if (inCardMode) {
+                        card
+                            .template(
+                                col,
+                            ).jsonObject
+                            .optString("name")
+                    } else {
+                        "${card.note(col).numberOfCards(col)}"
+                    }
                 CardBrowserColumn.DUE -> dueString(col, card)
                 CardBrowserColumn.EASE -> if (inCardMode) getEaseForCards() else getAvgEaseForNotes()
                 CardBrowserColumn.CHANGED -> LanguageUtil.getShortDateFormatFromS(if (inCardMode) card.mod else card.note(col).mod.toLong())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -26,12 +26,12 @@ import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged
 import com.ichi2.anki.dialogs.DiscardChangesDialog
+import com.ichi2.libanki.CardTemplate
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import org.jetbrains.annotations.Contract
-import org.json.JSONObject
 import timber.log.Timber
 
 /** Allows specification of the Question and Answer format of a card template in the Card Browser
@@ -187,9 +187,9 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         val question: String = question ?: VALUE_USE_DEFAULT
         val answer: String = answer ?: VALUE_USE_DEFAULT
 
-        fun applyTo(template: JSONObject) {
-            template.put("bqfmt", question)
-            template.put("bafmt", answer)
+        fun applyTo(template: CardTemplate) {
+            template.bqfmt = question
+            template.bafmt = answer
         }
 
         companion object {
@@ -220,12 +220,8 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         @CheckResult
         fun getIntentFromTemplate(
             context: Context,
-            template: JSONObject,
-        ): Intent {
-            val browserQuestionTemplate = template.getString("bqfmt")
-            val browserAnswerTemplate = template.getString("bafmt")
-            return getIntent(context, browserQuestionTemplate, browserAnswerTemplate)
-        }
+            template: CardTemplate,
+        ): Intent = getIntent(context, template.bqfmt, template.bafmt)
 
         @CheckResult
         fun getIntent(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -25,6 +25,7 @@ import androidx.core.os.bundleOf
 import com.ichi2.async.saveModel
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.libanki.CardTemplate
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.NotetypeJson
@@ -62,13 +63,13 @@ class CardTemplateNotetype(
         }
     }
 
-    fun getTemplate(ord: Int): JSONObject {
+    fun getTemplate(ord: Int): CardTemplate {
         Timber.d("getTemplate() on ordinal %s", ord)
-        return notetype.getJSONArray("tmpls").getJSONObject(ord)
+        return notetype.tmpls[ord]
     }
 
     val templateCount: Int
-        get() = notetype.getJSONArray("tmpls").length()
+        get() = notetype.tmpls.length()
 
     val modelId: NoteTypeId
         get() = notetype.getLong("id")
@@ -82,14 +83,14 @@ class CardTemplateNotetype(
 
     fun updateTemplate(
         ordinal: Int,
-        template: JSONObject,
+        template: CardTemplate,
     ) {
-        notetype.getJSONArray("tmpls").put(ordinal, template)
+        notetype.tmpls[ordinal] = template
     }
 
-    fun addNewTemplate(newTemplate: JSONObject) {
+    fun addNewTemplate(newTemplate: CardTemplate) {
         Timber.d("addNewTemplate()")
-        addTemplateChange(ChangeType.ADD, newTemplate.getInt("ord"))
+        addTemplateChange(ChangeType.ADD, newTemplate.ord)
     }
 
     fun removeTemplate(ord: Int) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -742,7 +742,7 @@ class NoteEditor :
         // Deck Selector
         val deckTextView = findViewById<TextView>(R.id.CardEditorDeckText)
         // If edit mode and more than one card template distinguish between "Deck" and "Card deck"
-        if (!addNote && editorNote!!.notetype.getJSONArray("tmpls").length() > 1) {
+        if (!addNote && editorNote!!.notetype.tmpls.length() > 1) {
             deckTextView.setText(R.string.CardEditorCardDeck)
         }
         deckSpinnerSelection =
@@ -2527,20 +2527,21 @@ class NoteEditor :
     }
 
     /** Update the list of card templates for current note type  */
-    private fun updateCards(model: JSONObject?) {
+    @KotlinCleanup("make non-null")
+    private fun updateCards(model: NotetypeJson?) {
         Timber.d("updateCards()")
-        val tmpls = model!!.getJSONArray("tmpls")
+        val tmpls = model!!.tmpls
         var cardsList = StringBuilder()
         // Build comma separated list of card names
         Timber.d("updateCards() template count is %s", tmpls.length())
-        for (i in 0 until tmpls.length()) {
-            var name = tmpls.getJSONObject(i).optString("name")
+        for ((i, tmpl) in tmpls.withIndex()) {
+            var name = tmpl.jsonObject.optString("name")
             // If more than one card, and we have an existing card, underline existing card
             if (!addNote &&
                 tmpls.length() > 1 &&
                 model === editorNote!!.notetype &&
                 currentEditedCard != null &&
-                currentEditedCard!!.template(getColUnsafe).optString("name") == name
+                currentEditedCard!!.template(getColUnsafe).jsonObject.optString("name") == name
             ) {
                 name = "<u>$name</u>"
             }
@@ -2550,7 +2551,7 @@ class NoteEditor :
             }
         }
         // Make cards list red if the number of cards is being reduced
-        if (!addNote && tmpls.length() < editorNote!!.notetype.getJSONArray("tmpls").length()) {
+        if (!addNote && tmpls.length() < editorNote!!.notetype.tmpls.length()) {
             cardsList = StringBuilder("<font color='red'>$cardsList</font>")
         }
         cardsButton!!.text =
@@ -2695,7 +2696,7 @@ class NoteEditor :
                 @KotlinCleanup("Check if this ever happens")
                 val tmpls =
                     try {
-                        newModel.getJSONArray("tmpls")
+                        newModel.tmpls
                     } catch (e: Exception) {
                         Timber.w("error in obtaining templates from model %s", allModelIds!![pos])
                         return

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.CardTemplateNotetype
 import com.ichi2.anki.browser.CardBrowserColumn
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NotetypeJson
+import com.ichi2.utils.KotlinCleanup
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withContext
@@ -95,8 +96,8 @@ suspend fun renderBrowserQA(
 
 /**
  * Handles everything for a model change at once - template add / deletes as well as content updates
- * @return Pair<Boolean, String> : (true, null) when success, (false, exceptionMessage) when failure
  */
+@KotlinCleanup("strongly type templateChanges")
 fun saveModel(
     col: Collection,
     notetype: NotetypeJson,
@@ -106,17 +107,17 @@ fun saveModel(
     val oldModel = col.notetypes.get(notetype.getLong("id"))
 
     // TODO: make undoable
-    val newTemplates = notetype.getJSONArray("tmpls")
+    val newTemplates = notetype.tmpls
     for (change in templateChanges) {
-        val oldTemplates = oldModel!!.getJSONArray("tmpls")
+        val oldTemplates = oldModel!!.tmpls
         when (change[1] as CardTemplateNotetype.ChangeType) {
             CardTemplateNotetype.ChangeType.ADD -> {
                 Timber.d("doInBackgroundSaveModel() adding template %s", change[0])
-                col.notetypes.addTemplate(oldModel, newTemplates.getJSONObject(change[0] as Int))
+                col.notetypes.addTemplate(oldModel, newTemplates[change[0] as Int])
             }
             CardTemplateNotetype.ChangeType.DELETE -> {
                 Timber.d("doInBackgroundSaveModel() deleting template currently at ordinal %s", change[0])
-                col.notetypes.remTemplate(oldModel, oldTemplates.getJSONObject(change[0] as Int))
+                col.notetypes.remTemplate(oldModel, oldTemplates[change[0] as Int])
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -30,7 +30,6 @@ import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.TimeManager
 import net.ankiweb.rsdroid.RustCleanup
-import org.json.JSONObject
 
 /**
  * A Card is the ultimate entity subject to review; it encapsulates the scheduling parameters (from which to derive
@@ -218,12 +217,12 @@ open class Card : Cloneable {
     open fun noteType(col: Collection): NotetypeJson = note(col).notetype
 
     @LibAnkiAlias("template")
-    fun template(col: Collection): JSONObject {
+    fun template(col: Collection): CardTemplate {
         val m = noteType(col)
         return if (m.isStd) {
-            m.getJSONArray("tmpls").getJSONObject(ord)
+            m.tmpls[ord]
         } else {
-            noteType(col).getJSONArray("tmpls").getJSONObject(0)
+            noteType(col).tmpls[0]
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplate.kt
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki
+
+import com.ichi2.utils.JSONObjectHolder
+import com.ichi2.utils.deepClone
+import net.ankiweb.rsdroid.RustCleanup
+import org.json.JSONObject
+
+/**
+ * A card template is a HTML template, combined with [fields][Field] to produce [cards][Card].
+ * Since templates exist on the [note][Note]-level, each template can be used to bulk-change the
+ * styling/displayed fields of cards it  generates from the associated [note type][NotetypeJson].
+ *
+ * In a standard note, 1 template maps to at most 1 card if [requirements][NotetypeJson.req] are met
+ * In a cloze note, 1 template maps to 1 to many cards
+ *
+ * An example of the template HTML: [afmt] of a 'Basic' Note
+ * ```
+ * {{FrontSide}}
+ *
+ * <hr id=answer>
+ *
+ * {{Back}}
+ * ```
+ *
+ * The template also defines 'browser' fields: [bqfmt], [bafmt], `bfont` & `bsize` which affect how
+ * [Browse][com.ichi2.anki.CardBrowser] displays the field. Typically used to remove extraneous
+ * information, making it easier to find cards. See: https://www.youtube.com/shorts/JbxNP4pSIBA
+ *
+ * ## Additional Properties
+ * TODO: `did` (Deck Override) is used in AnkiDroid and should be documented.
+ *  This property should always be set
+ *
+ * TODO: Anki Desktop (2024) defines the following properties which this class should document for
+ *  completeness
+ * * bfont: '' - the font used in Browse
+ * * bsize: 0 - the font size used in Browse
+ * * id: 1556256845231882422
+ *
+ * ## Links
+ * * [Anki Manual](https://docs.ankiweb.net/templates/intro.html)
+ */
+@JvmInline
+value class CardTemplate(
+    override val jsonObject: JSONObject,
+) : JSONObjectHolder {
+    /**
+     * The user-facing name of the template
+     *
+     * By default, Anki uses `Card 1`
+     */
+    var name: String
+        get() = jsonObject.getString("name")
+        set(value) {
+            jsonObject.put("name", value)
+        }
+
+    /** The 0-based ordinal of the template */
+    val ord: Int
+        get() = jsonObject.getInt("ord")
+
+    /**
+     * Format string for the question when reviewing
+     *
+     * Example:
+     *
+     * ```
+     * {{Front}}
+     * ```
+     */
+    var qfmt: String
+        get() = jsonObject.getString("qfmt")
+        set(value) {
+            jsonObject.put("qfmt", value)
+        }
+
+    /**
+     * Format string for the answer when reviewing
+     *
+     * Example
+     * ```
+     * {{FrontSide}}
+     *
+     * <hr id=answer>
+     *
+     * {{Back}}
+     * ```
+     */
+    var afmt: String
+        get() = jsonObject.getString("afmt")
+        set(value) {
+            jsonObject.put("afmt", value)
+        }
+
+    /**
+     * Format string for the question of the card **when displayed in Browse**
+     */
+    var bqfmt: String
+        get() = jsonObject.getString("bqfmt")
+        set(value) {
+            jsonObject.put("bqfmt", value)
+        }
+
+    /**
+     * Format string for the answer of the card **when displayed in Browse**
+     */
+    var bafmt: String
+        get() = jsonObject.getString("bafmt")
+        set(value) {
+            jsonObject.put("bafmt", value)
+        }
+
+    /** @see ord */
+    @RustCleanup("Check JSONObject.NULL")
+    fun setOrd(value: Int?) = jsonObject.put("ord", if (value == null) JSONObject.NULL else value)
+
+    fun deepClone() = CardTemplate(jsonObject.deepClone())
+
+    override fun toString() = jsonObject.toString()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplates.kt
@@ -16,14 +16,20 @@
 
 package com.ichi2.libanki
 
+import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.utils.JSONContainer
 import org.json.JSONArray
 import org.json.JSONObject
 
-/** A collection of [Field] */
+/**
+ * A collection of [CardTemplate]
+ *
+ * @see NotetypeJson.tmpls
+ */
 @JvmInline
-value class Fields(
+@NotInLibAnki
+value class CardTemplates(
     override val jsonArray: JSONArray,
-) : JSONContainer<Field> {
-    override fun constructor(obj: JSONObject) = Field(obj)
+) : JSONContainer<CardTemplate> {
+    override fun constructor(obj: JSONObject) = CardTemplate(obj)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Field.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Field.kt
@@ -17,6 +17,7 @@
 package com.ichi2.libanki
 
 import com.ichi2.anki.utils.ext.getStringOrNull
+import com.ichi2.utils.JSONObjectHolder
 import net.ankiweb.rsdroid.RustCleanup
 import org.json.JSONObject
 
@@ -52,8 +53,8 @@ import org.json.JSONObject
  */
 @JvmInline
 value class Field(
-    val jsonObject: JSONObject,
-) {
+    override val jsonObject: JSONObject,
+) : JSONObjectHolder {
     /**
      * The user-facing name of the field.
      *

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Field.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Field.kt
@@ -111,4 +111,6 @@ value class Field(
     /** @see ord */
     @RustCleanup("Check JSONObject.NULL")
     fun setOrd(value: Int?) = jsonObject.put("ord", if (value == null) JSONObject.NULL else value)
+
+    override fun toString() = jsonObject.toString()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -104,7 +104,7 @@ class Note : Cloneable {
         col: Collection,
         ord: Int = 0,
         customNoteType: NotetypeJson? = null,
-        customTemplate: Template? = null,
+        customTemplate: CardTemplate? = null,
         fillEmpty: Boolean = false,
     ): Card {
         val card = Card(col, id = null)
@@ -117,10 +117,10 @@ class Note : Cloneable {
                 customTemplate.deepClone()
             } else {
                 val index = if (model.type == MODEL_STD) ord else 0
-                model.tmpls.getJSONObject(index)
+                model.tmpls[index]
             }
         // may differ in cloze case
-        template["ord"] = card.ord
+        template.setOrd(card.ord)
 
         val output =
             TemplateManager.TemplateRenderContext

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -136,4 +136,44 @@ class NotetypeJson : JSONObject {
         set(value) {
             put("type", value)
         }
+
+    /**
+     * Defines the requirements for generating cards (for [standard note types][Consts.MODEL_STD])
+     *
+     * A requirement states that either one of, or all of a set of fields must be non-empty to
+     * generate a card using a template. Meaning for a standard note, each template has a
+     * requirement, which generates 0 or 1 cards
+     *
+     * **Example - Basic (optional reversed card):**
+     *
+     * * Fields: `["Front", "Back", "Add Reverse"]`
+     * * `req: [[0, 'any', [0]], [1, 'all', [1, 2]]]`
+     *
+     * meaning:
+     *
+     * * Card 1 needs "Front" to be non-empty
+     * * Card 2 needs both "Back" and "Add Reverse" to be non-empty
+     *
+     * The array is of the form `[T, string, list]`, where:
+     * - `T` is the ordinal of the template.
+     * - `string` is 'none', 'all' or 'any'.
+     * - `list` contains ordinals of fields, in increasing order.
+     *
+     * The output is defined based on the `string`:
+     * - if `"none"'`, no cards are generated for this template. `list` should be empty.
+     * - if `"all"'`, the card is generated if all fields in `list` are non-empty
+     * - if `"any"'`, the card is generated if any field in `list` is non-empty.
+     *
+     * See [The algorithm to decide how to compute req from the template]
+     * (https://github.com/Arthur-Milchior/anki/blob/commented/documentation//templates_generation_rules.md) is explained on:
+     */
+    @Deprecated(
+        "req is no longer used. Exists for backwards compatibility:" +
+            "https://forums.ankiweb.net/t/is-req-still-used-or-present/9977",
+    )
+    var req: JSONArray
+        get() = getJSONArray("req")
+        set(value) {
+            put("req", value)
+        }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -104,10 +104,10 @@ class NotetypeJson : JSONObject {
             put("flds", value.jsonArray)
         }
 
-    var tmpls: JSONArray
-        get() = getJSONArray("tmpls")
+    var tmpls: CardTemplates
+        get() = CardTemplates(getJSONArray("tmpls"))
         set(value) {
-            put("tmpls", value)
+            put("tmpls", value.jsonArray)
         }
 
     var id: Long

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -28,9 +28,7 @@ import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.utils.append
 import com.ichi2.libanki.utils.len
-import com.ichi2.utils.deepClone
 import net.ankiweb.rsdroid.exceptions.BackendTemplateException
-import org.json.JSONObject
 
 private typealias Union<A, B> = Pair<A, B>
 private typealias TemplateReplacementList = MutableList<Union<String?, TemplateManager.TemplateReplacement?>>
@@ -122,7 +120,7 @@ class TemplateManager {
         note: Note,
         browser: Boolean = false,
         notetype: NotetypeJson? = null,
-        template: JSONObject? = null,
+        template: CardTemplate? = null,
         private var fillEmpty: Boolean = false,
     ) {
         @Suppress("ktlint:standard:backing-property-naming")
@@ -135,7 +133,7 @@ class TemplateManager {
         private var _browser: Boolean = browser
 
         @Suppress("ktlint:standard:backing-property-naming")
-        private var _template: JSONObject? = template
+        private var _template: CardTemplate? = template
 
         private var noteType: NotetypeJson = notetype ?: note.notetype
 
@@ -150,7 +148,7 @@ class TemplateManager {
                 note: Note,
                 card: Card,
                 notetype: NotetypeJson,
-                template: JSONObject,
+                template: CardTemplate,
                 fillEmpty: Boolean,
             ): TemplateRenderContext =
                 TemplateRenderContext(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONContainer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONContainer.kt
@@ -1,0 +1,75 @@
+/*
+ *  Copyright (c) 2024 Arthur Milchior <arthur@milchior.fr>
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+
+import com.ichi2.libanki.utils.NotInLibAnki
+import com.ichi2.libanki.utils.append
+import com.ichi2.libanki.utils.index
+import com.ichi2.libanki.utils.insert
+import com.ichi2.libanki.utils.remove
+import org.json.JSONArray
+import org.json.JSONObject
+
+@NotInLibAnki
+interface JSONObjectHolder {
+    val jsonObject: JSONObject
+}
+
+@NotInLibAnki
+interface JSONContainer<T : JSONObjectHolder> : Iterable<T> {
+    val jsonArray: JSONArray
+
+    fun constructor(obj: JSONObject): T
+
+    override fun iterator() =
+        jsonArray
+            .jsonObjectIterator()
+            .asSequence()
+            .map(::constructor)
+            .iterator()
+
+    operator fun get(index: Int) = constructor(jsonArray.getJSONObject(index))
+
+    /**
+     * Sets/replaces the value at [index].
+     *
+     * This `null` pads this array to the required length if necessary.
+     *
+     * @see JSONArray.put
+     */
+    operator fun set(
+        index: Int,
+        field: T,
+    ) {
+        jsonArray.put(index, field.jsonObject)
+    }
+
+    fun length() = jsonArray.length()
+
+    fun append(template: T) = jsonArray.append(template.jsonObject)
+
+    fun remove(template: T) = jsonArray.remove(template.jsonObject)
+
+    fun index(template: T) = jsonArray.index(template.jsonObject)
+
+    fun insert(
+        idx: Int,
+        template: T,
+    ) = jsonArray.insert(idx, template.jsonObject)
+}
+
+fun <T : JSONObjectHolder> len(templates: JSONContainer<T>) = templates.jsonArray.length()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -580,7 +580,7 @@ class CardTemplateEditorTest : RobolectricTest() {
                 },
                 getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
             )
-            assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).getJSONArray("tmpls").length())
+            assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).tmpls.length())
             assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal))
         }
 
@@ -696,13 +696,13 @@ class CardTemplateEditorTest : RobolectricTest() {
         intent.putExtra("modelId", model.id)
         val editor = super.startActivityNormallyOpenCollectionWithIntent(CardTemplateEditor::class.java, intent)
         val template = editor.tempModel?.getTemplate(0)
-        MatcherAssert.assertThat("Deck ID element should exist", template?.has("did"), Matchers.equalTo(true))
-        MatcherAssert.assertThat("Deck ID element should be null", template?.get("did"), Matchers.equalTo(JSONObject.NULL))
+        MatcherAssert.assertThat("Deck ID element should exist", template?.jsonObject?.has("did"), Matchers.equalTo(true))
+        MatcherAssert.assertThat("Deck ID element should be null", template?.jsonObject?.get("did"), Matchers.equalTo(JSONObject.NULL))
         editor.onDeckSelected(SelectableDeck(1, "hello"))
-        MatcherAssert.assertThat("Deck ID element should be changed", template?.get("did"), Matchers.equalTo(1L))
+        MatcherAssert.assertThat("Deck ID element should be changed", template?.jsonObject?.get("did"), Matchers.equalTo(1L))
         editor.onDeckSelected(null)
-        MatcherAssert.assertThat("Deck ID element should exist", template!!.has("did"), Matchers.equalTo(true))
-        MatcherAssert.assertThat("Deck ID element should be null", template["did"], Matchers.equalTo(JSONObject.NULL))
+        MatcherAssert.assertThat("Deck ID element should exist", template!!.jsonObject.has("did"), Matchers.equalTo(true))
+        MatcherAssert.assertThat("Deck ID element should be null", template.jsonObject["did"], Matchers.equalTo(JSONObject.NULL))
     }
 
     @Test
@@ -736,7 +736,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         // set Bottom Navigation View to Front
         cardTemplateFragment.setCurrentEditorView(
             R.id.front_edit,
-            tempModel.getTemplate(0).getString("qfmt"),
+            tempModel.getTemplate(0).qfmt,
             R.string.card_template_editor_front,
         )
 
@@ -769,7 +769,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         val tempModel = testEditor.tempModel
 
         // check if current view is front(default) view
-        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempModel!!.getTemplate(0).getString("qfmt")))
+        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempModel!!.getTemplate(0).qfmt))
         assumeThat(cardTemplateFragment!!.currentEditorViewId, Matchers.equalTo(R.id.front_edit))
 
         // set Bottom Navigation View to Style

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -28,6 +28,7 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.formatApiResult
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.getDataFromRequest
 import com.ichi2.anki.AnkiDroidJsAPITest.Companion.jsApiContract
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand.FLIP_OR_ANSWER_EASE1
 import com.ichi2.anki.cardviewer.ViewerCommand.MARK
@@ -46,7 +47,7 @@ import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.utils.BASIC_MODEL_NAME
-import com.ichi2.utils.deepClone
+import com.ichi2.utils.KotlinCleanup
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -446,12 +447,13 @@ class ReviewerTest : RobolectricTest() {
     }
 
     @Throws(ConfirmModSchemaException::class)
+    @KotlinCleanup("use a assertNotNull which returns rather than !!")
     private fun addNoteWithThreeCards() {
         val models = col.notetypes
-        var notetype: NotetypeJson? = models.copy(models.current())
-        notetype!!.put("name", "Three")
+        var notetype: NotetypeJson = models.copy(models.current())
+        notetype.put("name", "Three")
         models.add(notetype)
-        notetype = models.byName("Three")
+        notetype = models.byName("Three")!!
 
         cloneTemplate(models, notetype, "1")
         cloneTemplate(models, notetype, "2")
@@ -466,18 +468,18 @@ class ReviewerTest : RobolectricTest() {
     @Throws(ConfirmModSchemaException::class)
     private fun cloneTemplate(
         notetypes: Notetypes,
-        notetype: NotetypeJson?,
+        notetype: NotetypeJson,
         extra: String,
     ) {
-        val tmpls = notetype!!.getJSONArray("tmpls")
-        val defaultTemplate = tmpls.getJSONObject(0)
+        val tmpls = notetype.tmpls
+        val defaultTemplate = tmpls.first()
 
         val newTemplate = defaultTemplate.deepClone()
-        newTemplate.put("ord", tmpls.length())
+        newTemplate.setOrd(tmpls.length())
 
-        val cardName = CollectionManager.TR.cardTemplatesCard(tmpls.length() + 1)
-        newTemplate.put("name", cardName)
-        newTemplate.put("qfmt", newTemplate.getString("qfmt") + extra)
+        val cardName = TR.cardTemplatesCard(tmpls.length() + 1)
+        newTemplate.name = cardName
+        newTemplate.qfmt += extra
 
         notetypes.addTemplate(notetype, newTemplate)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -57,7 +57,7 @@ class CardTest : JvmTest() {
         col.addNote(note)
         val c = note.cards()[0]
         col.notetypes.current().getLong("id")
-        assertEquals(0, c.template().getInt("ord"))
+        assertEquals(0, c.template().ord)
     }
 
     @Test
@@ -70,15 +70,19 @@ class CardTest : JvmTest() {
         val noteType = col.notetypes.current()
         val noteTypes = col.notetypes
         // adding a new template should automatically create cards
-        var t = Notetypes.newTemplate("rev")
-        t.put("qfmt", "{{Front}}1")
-        t.put("afmt", "")
+        var t =
+            Notetypes.newTemplate("rev").apply {
+                qfmt = "{{Front}}1"
+                afmt = ""
+            }
         noteTypes.addTemplateModChanged(noteType, t)
         noteTypes.save(noteType)
         assertEquals(2, note.numberOfCards())
         // if the template is changed to remove cards, they'll be removed
-        t = noteType.getJSONArray("tmpls").getJSONObject(1)
-        t.put("qfmt", "{{Back}}")
+        t =
+            noteType.tmpls[1].apply {
+                qfmt = "{{Back}}"
+            }
         noteTypes.save(noteType)
         val rep = col.emptyCids()
         col.removeCardsAndOrphanedNotes(rep)
@@ -124,12 +128,11 @@ class CardTest : JvmTest() {
         val fld2 = models.newField("C")
         fld2.setOrd(null)
         models.addFieldLegacy(model, fld2)
-        val tmpls = model.getJSONArray("tmpls")
-        tmpls.getJSONObject(0).put("qfmt", "{{A}}{{B}}{{C}}")
+        model.tmpls[0].qfmt = "{{A}}{{B}}{{C}}"
         // ensure first card is always generated,
         // because at last one card is generated
         val tmpl = Notetypes.newTemplate("AND_OR")
-        tmpl.put("qfmt", "        {{A}}    {{#B}}        {{#C}}            {{B}}        {{/C}}    {{/B}}")
+        tmpl.qfmt = "        {{A}}    {{#B}}        {{#C}}            {{B}}        {{/C}}    {{/B}}"
         models.addTemplate(model, tmpl)
         models.save(model)
         models.setCurrent(model)
@@ -168,7 +171,7 @@ class CardTest : JvmTest() {
         val models = col.notetypes
         val model = models.byName("Basic")
         assertNotNull(model)
-        val tmpls = model.getJSONArray("tmpls")
+        val tmpls = model.tmpls
         models.renameFieldLegacy(model, model.flds[0], "First")
         models.renameFieldLegacy(model, model.flds[1], "Front")
         val fld2 = models.newField("AddIfEmpty")
@@ -177,9 +180,9 @@ class CardTest : JvmTest() {
 
         // ensure first card is always generated,
         // because at last one card is generated
-        tmpls.getJSONObject(0).put("qfmt", "{{AddIfEmpty}}{{Front}}{{First}}")
+        tmpls[0].qfmt = "{{AddIfEmpty}}{{Front}}{{First}}"
         val tmpl = Notetypes.newTemplate("NOT")
-        tmpl.put("qfmt", "    {{^AddIfEmpty}}        {{Front}}    {{/AddIfEmpty}}    ")
+        tmpl.qfmt = "    {{^AddIfEmpty}}        {{Front}}    {{/AddIfEmpty}}    "
         models.addTemplate(model, tmpl)
         models.save(model)
         models.setCurrent(model)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -113,8 +113,8 @@ class CollectionTest : JvmTest() {
         val noteType = col.notetypes.current()
         val noteTypes = col.notetypes
         val t = Notetypes.newTemplate("Reverse")
-        t.put("qfmt", "{{Back}}")
-        t.put("afmt", "{{Front}}")
+        t.qfmt = "{{Back}}"
+        t.afmt = "{{Front}}"
         noteTypes.addTemplateModChanged(noteType, t)
         noteTypes.save(noteType)
         assertEquals(2, col.cardCount())
@@ -194,7 +194,7 @@ class CollectionTest : JvmTest() {
         val noteTypes = col.notetypes
         val noteType = noteTypes.current()
         // filter should work
-        noteType.getJSONArray("tmpls").getJSONObject(0).put("qfmt", "{{kana:Front}}")
+        noteType.tmpls[0].qfmt = "{{kana:Front}}"
         noteTypes.save(noteType)
         val n = col.newNote()
         n.setItem("Front", "foo[abc]")
@@ -207,7 +207,7 @@ class CollectionTest : JvmTest() {
         val question = c.question(true)
         assertThat("Question «$question» does not contains «anki:play».", question, Matchers.containsString("anki:play"))
         // it shouldn't throw an error while people are editing
-        noteType.getJSONArray("tmpls").getJSONObject(0).put("qfmt", "{{kana:}}")
+        noteType.tmpls[0].qfmt = "{{kana:}}"
         noteTypes.save(noteType)
         c.question(true)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FieldTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FieldTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.libanki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.EmptyApplication
+import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -41,5 +42,20 @@ class FieldTest : AndroidTest {
 
         jsonObject.put("tag", "1")
         assertEquals("1", field.imageOcclusionTag, message = """{ tag: 1 }""")
+    }
+
+    @Test
+    fun `toString is unchanged`() {
+        @Language("JSON")
+        val expected = """{"name":"Test"}"""
+
+        val jsonObject = JSONObject()
+        jsonObject.put("name", "Test")
+
+        val field = Field(JSONObject())
+        field.name = "Test"
+
+        assertEquals(jsonObject.toString(), field.toString())
+        assertEquals(expected, field.toString())
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -138,9 +138,11 @@ class FinderTest : JvmTest() {
         var noteType = col.notetypes.current()
         noteType = col.notetypes.copy(noteType)
         val noteTypes = col.notetypes
-        val t = Notetypes.newTemplate("Reverse")
-        t.put("qfmt", "{{Back}}")
-        t.put("afmt", "{{Front}}")
+        val t =
+            Notetypes.newTemplate("Reverse").apply {
+                qfmt = "{{Back}}"
+                afmt = "{{Front}}"
+            }
         noteTypes.addTemplateModChanged(noteType, t)
         noteTypes.save(noteType)
         note = col.newNote()

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -16,7 +16,6 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.libanki.Consts.MODEL_CLOZE
 import com.ichi2.libanki.Utils.stripHTML
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.testutils.JvmTest
@@ -502,16 +501,6 @@ class NotetypeTest : JvmTest() {
         assertEquals(
             1,
             col.db.queryScalar("select count() from cards where nid = ?", note.id),
-        )
-    }
-
-    private fun reqSize(notetype: NotetypeJson?) {
-        if (notetype!!.getInt("type") == MODEL_CLOZE) {
-            return
-        }
-        assertEquals(
-            notetype.getJSONArray("req").length(),
-            notetype.getJSONArray("tmpls").length(),
         )
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -899,13 +899,17 @@ open class SchedulerTest : JvmTest() {
         // add two more templates and set second active
         val noteType = col.notetypes.current()
         val noteTypes = col.notetypes
-        var t = Notetypes.newTemplate("Reverse")
-        t.put("qfmt", "{{Back}}")
-        t.put("afmt", "{{Front}}")
+        var t =
+            Notetypes.newTemplate("Reverse").apply {
+                qfmt = "{{Back}}"
+                afmt = "{{Front}}"
+            }
         noteTypes.addTemplateModChanged(noteType, t)
-        t = Notetypes.newTemplate("f2")
-        t.put("qfmt", "{{Front}}1")
-        t.put("afmt", "{{Back}}")
+        t =
+            Notetypes.newTemplate("f2").apply {
+                qfmt = "{{Front}}1"
+                afmt = "{{Back}}"
+            }
         noteTypes.addTemplateModChanged(noteType, t)
         noteTypes.save(noteType)
         // create a new note; it should have 3 cards

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -103,16 +103,18 @@ interface TestClass {
     fun addNonClozeModel(
         name: String,
         fields: Array<String>,
-        qfmt: String?,
-        afmt: String?,
+        qfmt: String,
+        afmt: String,
     ): String {
         val model = col.notetypes.new(name)
         for (field in fields) {
             col.notetypes.addFieldInNewModel(model, col.notetypes.newField(field))
         }
-        val t = Notetypes.newTemplate("Card 1")
-        t.put("qfmt", qfmt)
-        t.put("afmt", afmt)
+        val t =
+            Notetypes.newTemplate("Card 1").also { tmpl ->
+                tmpl.qfmt = qfmt
+                tmpl.afmt = afmt
+            }
         col.notetypes.addTemplateInNewModel(model, t)
         col.notetypes.add(model)
         return name

--- a/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
@@ -119,9 +119,10 @@ fun Collection.createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
  */
 fun Collection.createBasicTypingModel(name: String): NotetypeJson {
     val noteType = createBasicModel(name)
-    val t = noteType.getJSONArray("tmpls").getJSONObject(0)
-    t.put("qfmt", "{{Front}}\n\n{{type:Back}}")
-    t.put("afmt", "{{Front}}\n\n<hr id=answer>\n\n{{type:Back}}")
+    noteType.tmpls[0].apply {
+        qfmt = "{{Front}}\n\n{{type:Back}}"
+        afmt = "{{Front}}\n\n<hr id=answer>\n\n{{type:Back}}"
+    }
     notetypes.save(noteType)
     return noteType
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It felt like https://github.com/ankidroid/Anki-Android/pull/17649 was well received, and I have capacity for a small mechanical change

* https://github.com/ankidroid/Anki-Android/pull/17649

## Approach
* Generate `CardTemplates` and define collection accessors
* Generate `CardTemplate` and define accessors
* Update `NotetypeJson.tmpls` and fix breakages
* Update all uses of `getJsonObject("tmpls")`

## How Has This Been Tested?
Unit tested only

## Learning (optional, can help others)
* I explained `NotetypeJson.req`
* 🐞 value classes do not have the same string representation as their wrapped class
* I don't particularly like what the new linter did to my `apply` calls in the tests
* I forgot about `bfont` and `bsize` properties

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
