### PR TITLE
Unit Tests for initializeApkgExportUi and initializeNotesExportUi

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -97,8 +97,10 @@ class ExportDialogFragment : DialogFragment() {
         // start with the option for exporting a collection like on desktop unless we received a
         // deck id or a type of selection(plus selected ids), in this case preselect apkg export
         if ((extraDid != null && extraDid != -1L) || extraType != null) {
+            exportTypeSelector.setSelection(ExportConfiguration.Apkg.index)
             showExtrasOptionsFor(dialogView, ExportConfiguration.Apkg)
         } else {
+            exportTypeSelector.setSelection(ExportConfiguration.Collection.index)
             showExtrasOptionsFor(dialogView, ExportConfiguration.Collection)
         }
         return AlertDialog
@@ -304,10 +306,8 @@ class ExportDialogFragment : DialogFragment() {
                 selectedLabel.isVisible = false
             }
         }
-        exportTypeSelector.setSelection(targetConfig.index)
         ExportConfiguration.entries.forEach { config ->
-            container.findViewById<View>(config.layoutId).visibility =
-                if (config.layoutId == targetConfig.layoutId) View.VISIBLE else View.GONE
+            container.findViewById<View>(config.layoutId).isVisible = config.layoutId == targetConfig.layoutId
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -209,8 +209,6 @@ class ExportDialogFragment : DialogFragment() {
     /**
      * Initializes the views representing the extra options available when exporting a collection.
      */
-    @NeedsTest("Checkbox is only available on two selections ")
-    @NeedsTest("Checkbox defaults to false")
     @NeedsTest("Checkbox value is provided to the correct export functions (true/false)")
     private fun View.initializeCollectionExportUi() =
         with(CollectionManager.TR) {
@@ -227,8 +225,6 @@ class ExportDialogFragment : DialogFragment() {
     /**
      * Initializes the views representing the extra options available when exporting an Anki package.
      */
-    @NeedsTest("Checkbox is only available on two selections ")
-    @NeedsTest("Checkbox defaults to false")
     @NeedsTest("Checkbox value is provided to the correct export functions (true/false)")
     private fun View.initializeApkgExportUi() =
         with(CollectionManager.TR) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
@@ -1,0 +1,96 @@
+/*
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.export
+
+import androidx.fragment.app.testing.launchFragment
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isChecked
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ExportDialogFragmentTest : RobolectricTest() {
+    @Test
+    fun `Legacy export checkbox(default false) is shown only for collection and apkg`() {
+        launchFragment<ExportDialogFragment>(
+            themeResId = R.style.Theme_Light,
+        ).onFragment {
+            // check legacy checkboxes status for collection export
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingAnkiCollectionPackage()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+            onView(withId(R.id.export_legacy_checkbox_collection))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+            onView(withId(R.id.export_legacy_checkbox_collection))
+                .inRoot(isDialog())
+                .check(matches(not(isChecked())))
+            onView(withId(R.id.export_legacy_checkbox_apkg))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+
+            // check legacy checkboxes status for apkg export
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingAnkiDeckPackage()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+            onView(withId(R.id.export_legacy_checkbox_apkg))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+            onView(withId(R.id.export_legacy_checkbox_apkg))
+                .inRoot(isDialog())
+                .check(matches(not(isChecked())))
+            onView(withId(R.id.export_legacy_checkbox_collection))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+
+            // checkboxes are not shown for notes export
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingNotesInPlainText()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+            onView(withId(R.id.export_legacy_checkbox_apkg))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+            onView(withId(R.id.export_legacy_checkbox_collection))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+
+            // checkboxes are not shown for cards export
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingCardsInPlainText()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+            onView(withId(R.id.export_legacy_checkbox_apkg))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+            onView(withId(R.id.export_legacy_checkbox_collection))
+                .inRoot(isDialog())
+                .check(matches(not(isDisplayed())))
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added unit test to check the visibility and default checked status for the Apkg and Collection exports

## Fixes
* Added tests for initializeApkgExportUi() and initializeCollectionExportUi() both tagged with @NeedsTest("Checkbox is only available on two selections "), and @NeedsTest("Checkbox defaults to false").

## Approach
* Launching a fragment with the configs for each
* Using Espresso to do UI testing

## How Has This Been Tested?
Ran the unit tests multiple times to avoid flaky tests

## Learning (optional, can help others)
* How to create fragment tests with AnkiFragmentScenario which extends on AndroidX testing lib.
* How to use Espresso.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
