### PR TITLE
Fixes #Issue-17520   Ensures testlib is built

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -281,13 +281,6 @@ tasks.register('copyTestLibIntoAndroidTest', Copy) {
 tasks.named('preBuild').configure { dependsOn('copyTestLibIntoAndroidTest') }
 tasks.named('runKtlintCheckOverAndroidTestSourceSet').configure { mustRunAfter('copyTestLibIntoAndroidTest') }
 
-// Issue 17520 - ensures testlib is built
-tasks.named("assemble").configure {
-    dependsOn(":testlib:assemblePlayDebugAndroidTest")
-}
-
-
-
 // Issue 11078 - some emulators run, but run zero tests, and still report success
 tasks.register('assertNonzeroAndroidTests') {
     doLast {
@@ -307,7 +300,13 @@ tasks.register('assertNonzeroAndroidTests') {
     }
 }
 afterEvaluate {
-    tasks.named(androidTestName).configure { finalizedBy('assertNonzeroAndroidTests') }
+    tasks.named("connectedPlay${rootProject.androidTestVariantName}AndroidTest").configure {
+        finalizedBy('assertNonzeroAndroidTests')
+    }
+    tasks.named("packagePlay${rootProject.androidTestVariantName}AndroidTest").configure {
+        // Issue 17520 - ensures testlib is built
+        dependsOn(":testlib:assemblePlay${rootProject.androidTestVariantName}")
+    }
 }
 
 apply from: "./robolectricDownloader.gradle"

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -281,6 +281,13 @@ tasks.register('copyTestLibIntoAndroidTest', Copy) {
 tasks.named('preBuild').configure { dependsOn('copyTestLibIntoAndroidTest') }
 tasks.named('runKtlintCheckOverAndroidTestSourceSet').configure { mustRunAfter('copyTestLibIntoAndroidTest') }
 
+// Issue 17520 - ensures testlib is built
+tasks.named("assemble").configure {
+    dependsOn(":testlib:assemblePlayDebugAndroidTest")
+}
+
+
+
 // Issue 11078 - some emulators run, but run zero tests, and still report success
 tasks.register('assertNonzeroAndroidTests') {
     doLast {

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -123,7 +123,7 @@ def testReport = tasks.register('jacocoTestReport', JacocoReport) {
 }
 testReport.configure {
     dependsOn('testPlayDebugUnitTest')
-    dependsOn(rootProject.androidTestName)
+    dependsOn("connectedPlay${rootProject.androidTestVariantName}AndroidTest")
 }
 
 // A unit-test only report task
@@ -174,7 +174,7 @@ def androidTestReport = tasks.register('jacocoAndroidTestReport', JacocoReport) 
     ])
 }
 
-androidTestReport.configure { dependsOn(rootProject.androidTestName) }
+androidTestReport.configure { dependsOn("connectedPlay${rootProject.androidTestVariantName}AndroidTest") }
 
 // Issue 16640 - some emulators run, but register zero coverage
 tasks.register('assertNonzeroAndroidTestCoverage') {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -130,8 +130,8 @@ val preDexEnabled by extra("true" == System.getProperty("pre-dex", "true"))
 val universalApkEnabled by extra("true" == System.getProperty("universal-apk", "false"))
 
 val testReleaseBuild by extra(System.getenv("TEST_RELEASE_BUILD") == "true")
-var androidTestName by extra(
-    if (testReleaseBuild) "connectedPlayReleaseAndroidTest" else "connectedPlayDebugAndroidTest"
+var androidTestVariantName by extra(
+    if (testReleaseBuild) "Release" else "Debug"
 )
 
 val gradleTestMaxParallelForks by extra(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To ensure that GitHub Actions runs ./gradlew :testlib:assemblePlayDebugAndroidTest at some point to ensure that testlib compiles

## Fixes
* Fixes #17520 

## Approach
By adding a dependency on this task from AnkiDroid's androidTest in build.gradle

## How Has This Been Tested?

By building it locally on my PC.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
