### PR TITLE
Rename model to note type in content provider

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -87,21 +87,21 @@ class ContentProviderTest : InstrumentedTest() {
      */
     private val testDeckIds: MutableList<Long> = ArrayList(TEST_DECKS.size + 1)
     private lateinit var createdNotes: ArrayList<Uri>
-    private var modelId: Long = 0
+    private var noteTypeId = 0L
     private var dummyFields = emptyStringArray(1)
 
     /**
-     * Initially create one note for each model.
+     * Initially create one note for each note type.
      */
     @Before
     fun setUp() {
         Timber.i("setUp()")
         createdNotes = ArrayList()
         tearDown = true
-        // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        val model = createBasicModel()
-        modelId = model.getLong("id")
-        val fields = model.fieldsNames
+        // Add a new basic note type that we use for testing purposes (existing note types could potentially be corrupted)
+        val noteType = createBasicNoteType()
+        noteTypeId = noteType.getLong("id")
+        val fields = noteType.fieldsNames
         // Use the names of the fields as test values for the notes which will be added
         dummyFields = fields.toTypedArray()
         // create test decks and add one note for every deck
@@ -120,21 +120,21 @@ class ContentProviderTest : InstrumentedTest() {
                  * set-down, */
                 val did = col.decks.byName(partialName!!)?.id ?: col.decks.id(partialName)
                 testDeckIds.add(did)
-                createdNotes.add(setupNewNote(col, modelId, did, dummyFields, TEST_TAG))
+                createdNotes.add(setupNewNote(col, noteTypeId, did, dummyFields, TEST_TAG))
                 partialName += "::"
             }
         }
         // Add a note to the default deck as well so that testQueryNextCard() works
-        createdNotes.add(setupNewNote(col, modelId, 1, dummyFields, TEST_TAG))
+        createdNotes.add(setupNewNote(col, noteTypeId, 1, dummyFields, TEST_TAG))
     }
 
-    private fun createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
-        val m =
+    private fun createBasicNoteType(name: String = BASIC_NOTE_TYPE_NAME): NotetypeJson {
+        val noteTYpe =
             BackendUtils
                 .fromJsonBytes(
                     col.getStockNotetypeLegacy(StockNotetype.Kind.KIND_BASIC),
                 ).apply { set("name", name) }
-        col.addNotetypeLegacy(BackendUtils.toJsonBytes(m))
+        col.addNotetypeLegacy(BackendUtils.toJsonBytes(noteTYpe))
         return col.notetypes.byName(name)!!
     }
 
@@ -166,21 +166,21 @@ class ContentProviderTest : InstrumentedTest() {
             numDecksBeforeTest,
             col.decks.count(),
         )
-        // Delete test model
+        // Delete test note type
         col.modSchemaNoCheck()
-        removeAllModelsByName(col, BASIC_MODEL_NAME)
-        removeAllModelsByName(col, TEST_MODEL_NAME)
+        removeAllNoteTypesByName(col, BASIC_NOTE_TYPE_NAME)
+        removeAllNoteTypesByName(col, TEST_NOTE_TYPE_NAME)
     }
 
     @Throws(Exception::class)
-    private fun removeAllModelsByName(
+    private fun removeAllNoteTypesByName(
         col: com.ichi2.libanki.Collection,
         name: String,
     ) {
-        var testModel = col.notetypes.byName(name)
-        while (testModel != null) {
-            col.notetypes.rem(testModel)
-            testModel = col.notetypes.byName(name)
+        var testNoteType = col.notetypes.byName(name)
+        while (testNoteType != null) {
+            col.notetypes.rem(testNoteType)
+            testNoteType = col.notetypes.byName(name)
         }
     }
 
@@ -224,7 +224,7 @@ class ContentProviderTest : InstrumentedTest() {
         // Add the note
         val values =
             ContentValues().apply {
-                put(FlashCardsContract.Note.MID, modelId)
+                put(FlashCardsContract.Note.MID, noteTypeId)
                 put(FlashCardsContract.Note.FLDS, Utils.joinFields(TEST_NOTE_FIELDS))
                 put(FlashCardsContract.Note.TAGS, TEST_TAG)
             }
@@ -241,9 +241,9 @@ class ContentProviderTest : InstrumentedTest() {
             TEST_NOTE_FIELDS.toMutableList(),
         )
         assertEquals("Check that tag was set correctly", TEST_TAG, addedNote.tags[0])
-        val model: JSONObject? = col.notetypes.get(modelId)
-        assertNotNull("Check model", model)
-        val expectedNumCards = model!!.getJSONArray("tmpls").length()
+        val noteType: JSONObject? = col.notetypes.get(noteTypeId)
+        assertNotNull("Check note type", noteType)
+        val expectedNumCards = noteType!!.getJSONArray("tmpls").length()
         assertEquals("Check that correct number of cards generated", expectedNumCards, addedNote.numberOfCards(col))
         // Now delete the note
         cr.delete(newNoteUri, null, null)
@@ -254,14 +254,14 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     /**
-     * Check that inserting a note with an invalid modelId returns a reasonable exception
+     * Check that inserting a note with an invalid noteTypeId returns a reasonable exception
      */
     @Test
-    fun testInsertNoteWithBadModelId() {
-        val invalidModelId = 12
+    fun testInsertNoteWithBadNoteTypeId() {
+        val invalidNoteTypeId = 12
         val values =
             ContentValues().apply {
-                put(FlashCardsContract.Note.MID, invalidModelId)
+                put(FlashCardsContract.Note.MID, invalidNoteTypeId)
                 put(FlashCardsContract.Note.FLDS, Utils.joinFields(TEST_NOTE_FIELDS))
                 put(FlashCardsContract.Note.TAGS, TEST_TAG)
             }
@@ -279,23 +279,23 @@ class ContentProviderTest : InstrumentedTest() {
         // Get required objects for test
         val cr = contentResolver
         var col = col
-        // Add a new basic model that we use for testing purposes (existing models could potentially be corrupted)
-        var model: NotetypeJson? = createBasicModel()
-        val modelId = model!!.getLong("id")
+        // Add a new basic note type that we use for testing purposes (existing note types could potentially be corrupted)
+        var noteType: NotetypeJson? = createBasicNoteType()
+        val noteTypeId = noteType!!.getLong("id")
         // Add the note
-        val modelUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, modelId)
+        val noteTypeUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, noteTypeId)
         val testIndex =
-            TEST_MODEL_CARDS.size - 1 // choose the last one because not the same as the basic model template
-        val expectedOrd = model.getJSONArray("tmpls").length()
+            TEST_NOTE_TYPE_CARDS.size - 1 // choose the last one because not the same as the basic note type template
+        val expectedOrd = noteType.getJSONArray("tmpls").length()
         val cv =
             ContentValues().apply {
-                put(FlashCardsContract.CardTemplate.NAME, TEST_MODEL_CARDS[testIndex])
-                put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, TEST_MODEL_QFMT[testIndex])
-                put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, TEST_MODEL_AFMT[testIndex])
-                put(FlashCardsContract.CardTemplate.BROWSER_QUESTION_FORMAT, TEST_MODEL_QFMT[testIndex])
-                put(FlashCardsContract.CardTemplate.BROWSER_ANSWER_FORMAT, TEST_MODEL_AFMT[testIndex])
+                put(FlashCardsContract.CardTemplate.NAME, TEST_NOTE_TYPE_CARDS[testIndex])
+                put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, TEST_NOTE_TYPE_QFMT[testIndex])
+                put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, TEST_NOTE_TYPE_AFMT[testIndex])
+                put(FlashCardsContract.CardTemplate.BROWSER_QUESTION_FORMAT, TEST_NOTE_TYPE_QFMT[testIndex])
+                put(FlashCardsContract.CardTemplate.BROWSER_ANSWER_FORMAT, TEST_NOTE_TYPE_AFMT[testIndex])
             }
-        val templatesUri = Uri.withAppendedPath(modelUri, "templates")
+        val templatesUri = Uri.withAppendedPath(noteTypeUri, "templates")
         val templateUri = cr.insert(templatesUri, cv)
         col = reopenCol() // test that the changes are physically saved to the DB
         assertNotNull("Check template uri", templateUri)
@@ -306,9 +306,9 @@ class ContentProviderTest : InstrumentedTest() {
                 templateUri!!,
             ),
         )
-        model = col.notetypes.get(modelId)
-        assertNotNull("Check model", model)
-        val template = model!!.getJSONArray("tmpls").getJSONObject(expectedOrd)
+        noteType = col.notetypes.get(noteTypeId)
+        assertNotNull("Check note type", noteType)
+        val template = noteType!!.getJSONArray("tmpls").getJSONObject(expectedOrd)
         assertEquals(
             "Check template JSONObject ord",
             expectedOrd,
@@ -316,14 +316,14 @@ class ContentProviderTest : InstrumentedTest() {
         )
         assertEquals(
             "Check template name",
-            TEST_MODEL_CARDS[testIndex],
+            TEST_NOTE_TYPE_CARDS[testIndex],
             template.getString("name"),
         )
-        assertEquals("Check qfmt", TEST_MODEL_QFMT[testIndex], template.getString("qfmt"))
-        assertEquals("Check afmt", TEST_MODEL_AFMT[testIndex], template.getString("afmt"))
-        assertEquals("Check bqfmt", TEST_MODEL_QFMT[testIndex], template.getString("bqfmt"))
-        assertEquals("Check bafmt", TEST_MODEL_AFMT[testIndex], template.getString("bafmt"))
-        col.notetypes.rem(model)
+        assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.getString("qfmt"))
+        assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[testIndex], template.getString("afmt"))
+        assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[testIndex], template.getString("bqfmt"))
+        assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[testIndex], template.getString("bafmt"))
+        col.notetypes.rem(noteType)
     }
 
     /**
@@ -335,23 +335,23 @@ class ContentProviderTest : InstrumentedTest() {
         // Get required objects for test
         val cr = contentResolver
         var col = col
-        var model: NotetypeJson? = createBasicModel()
-        val modelId = model!!.getLong("id")
-        val initialFieldsArr = model.flds
+        var noteType: NotetypeJson? = createBasicNoteType()
+        val noteTypeId = noteType!!.getLong("id")
+        val initialFieldsArr = noteType.flds
         val initialFieldCount = initialFieldsArr.length()
-        val noteTypeUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, modelId)
+        val noteTypeUri = ContentUris.withAppendedId(FlashCardsContract.Model.CONTENT_URI, noteTypeId)
         val insertFieldValues = ContentValues()
         insertFieldValues.put(FlashCardsContract.Model.FIELD_NAME, TEST_FIELD_NAME)
         val fieldUri = cr.insert(Uri.withAppendedPath(noteTypeUri, "fields"), insertFieldValues)
         assertNotNull("Check field uri", fieldUri)
         // Ensure that the changes are physically saved to the DB
         col = reopenCol()
-        model = col.notetypes.get(modelId)
+        noteType = col.notetypes.get(noteTypeId)
         // Test the field is as expected
         val fieldId = ContentUris.parseId(fieldUri!!)
         assertEquals("Check field id", initialFieldCount.toLong(), fieldId)
-        assertNotNull("Check model", model)
-        val fldsArr = model!!.flds
+        assertNotNull("Check note type", noteType)
+        val fldsArr = noteType!!.flds
         assertEquals(
             "Check fields length",
             (initialFieldCount + 1),
@@ -362,7 +362,7 @@ class ContentProviderTest : InstrumentedTest() {
             TEST_FIELD_NAME,
             fldsArr.last().name,
         )
-        col.notetypes.rem(model)
+        col.notetypes.rem(noteType)
     }
 
     /**
@@ -376,7 +376,7 @@ class ContentProviderTest : InstrumentedTest() {
             .query(
                 FlashCardsContract.Note.CONTENT_URI_V2,
                 null,
-                "mid=$modelId",
+                "mid=$noteTypeId",
                 null,
                 null,
             ).use { cursor ->
@@ -552,69 +552,69 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     /**
-     * Check that inserting a new model works as expected
+     * Check that inserting a new note type works as expected
      */
     @Test
-    fun testInsertAndUpdateModel() {
+    fun testInsertAndUpdateNoteType() {
         val cr = contentResolver
         var cv =
             ContentValues().apply {
-                // Insert a new model
-                put(FlashCardsContract.Model.NAME, TEST_MODEL_NAME)
-                put(FlashCardsContract.Model.FIELD_NAMES, Utils.joinFields(TEST_MODEL_FIELDS))
-                put(FlashCardsContract.Model.NUM_CARDS, TEST_MODEL_CARDS.size)
+                // Insert a new note type
+                put(FlashCardsContract.Model.NAME, TEST_NOTE_TYPE_NAME)
+                put(FlashCardsContract.Model.FIELD_NAMES, Utils.joinFields(TEST_NOTE_TYPE_FIELDS))
+                put(FlashCardsContract.Model.NUM_CARDS, TEST_NOTE_TYPE_CARDS.size)
             }
-        val modelUri = cr.insert(FlashCardsContract.Model.CONTENT_URI, cv)
-        assertNotNull("Check inserted model isn't null", modelUri)
-        assertNotNull("Check last path segment exists", modelUri!!.lastPathSegment)
-        val mid = modelUri.lastPathSegment!!.toLong()
+        val noteTypeUri = cr.insert(FlashCardsContract.Model.CONTENT_URI, cv)
+        assertNotNull("Check inserted note type isn't null", noteTypeUri)
+        assertNotNull("Check last path segment exists", noteTypeUri!!.lastPathSegment)
+        val mid = noteTypeUri.lastPathSegment!!.toLong()
         var col = reopenCol()
         try {
-            var model: NotetypeJson? = col.notetypes.get(mid)
-            assertNotNull("Check model", model)
-            assertEquals("Check model name", TEST_MODEL_NAME, model!!.getString("name"))
+            var noteType = col.notetypes.get(mid)
+            assertNotNull("Check note type", noteType)
+            assertEquals("Check note type name", TEST_NOTE_TYPE_NAME, noteType!!.getString("name"))
             assertEquals(
                 "Check templates length",
-                TEST_MODEL_CARDS.size,
-                model.getJSONArray("tmpls").length(),
+                TEST_NOTE_TYPE_CARDS.size,
+                noteType.getJSONArray("tmpls").length(),
             )
             assertEquals(
                 "Check field length",
-                TEST_MODEL_FIELDS.size,
-                model.flds.length(),
+                TEST_NOTE_TYPE_FIELDS.size,
+                noteType.getJSONArray("flds").length(),
             )
-            val fields = model.flds
+            val fields = noteType.flds
             for (i in 0 until fields.length()) {
                 assertEquals(
                     "Check name of fields",
-                    TEST_MODEL_FIELDS[i],
+                    TEST_NOTE_TYPE_FIELDS[i],
                     fields[i].name,
                 )
             }
-            // Test updating the model CSS (to test updating MODELS_ID Uri)
+            // Test updating the note type CSS (to test updating NOTE_TYPES_ID Uri)
             cv = ContentValues()
-            cv.put(FlashCardsContract.Model.CSS, TEST_MODEL_CSS)
+            cv.put(FlashCardsContract.Model.CSS, TEST_NOTE_TYPE_CSS)
             assertThat(
-                cr.update(modelUri, cv, null, null),
+                cr.update(noteTypeUri, cv, null, null),
                 greaterThan(0),
             )
             col = reopenCol()
-            model = col.notetypes.get(mid)
-            assertNotNull("Check model", model)
-            assertEquals("Check css", TEST_MODEL_CSS, model!!.getString("css"))
-            // Update each of the templates in model (to test updating MODELS_ID_TEMPLATES_ID Uri)
-            for (i in TEST_MODEL_CARDS.indices) {
+            noteType = col.notetypes.get(mid)
+            assertNotNull("Check note type", noteType)
+            assertEquals("Check css", TEST_NOTE_TYPE_CSS, noteType!!.getString("css"))
+            // Update each of the templates in note type (to test updating NOTE_TYPES_ID_TEMPLATES_ID Uri)
+            for (i in TEST_NOTE_TYPE_CARDS.indices) {
                 cv =
                     ContentValues().apply {
-                        put(FlashCardsContract.CardTemplate.NAME, TEST_MODEL_CARDS[i])
-                        put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, TEST_MODEL_QFMT[i])
-                        put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, TEST_MODEL_AFMT[i])
-                        put(FlashCardsContract.CardTemplate.BROWSER_QUESTION_FORMAT, TEST_MODEL_QFMT[i])
-                        put(FlashCardsContract.CardTemplate.BROWSER_ANSWER_FORMAT, TEST_MODEL_AFMT[i])
+                        put(FlashCardsContract.CardTemplate.NAME, TEST_NOTE_TYPE_CARDS[i])
+                        put(FlashCardsContract.CardTemplate.QUESTION_FORMAT, TEST_NOTE_TYPE_QFMT[i])
+                        put(FlashCardsContract.CardTemplate.ANSWER_FORMAT, TEST_NOTE_TYPE_AFMT[i])
+                        put(FlashCardsContract.CardTemplate.BROWSER_QUESTION_FORMAT, TEST_NOTE_TYPE_QFMT[i])
+                        put(FlashCardsContract.CardTemplate.BROWSER_ANSWER_FORMAT, TEST_NOTE_TYPE_AFMT[i])
                     }
                 val tmplUri =
                     Uri.withAppendedPath(
-                        Uri.withAppendedPath(modelUri, "templates"),
+                        Uri.withAppendedPath(noteTypeUri, "templates"),
                         i.toString(),
                     )
                 assertThat(
@@ -623,26 +623,26 @@ class ContentProviderTest : InstrumentedTest() {
                     greaterThan(0),
                 )
                 col = reopenCol()
-                model = col.notetypes.get(mid)
-                assertNotNull("Check model", model)
-                val template = model!!.getJSONArray("tmpls").getJSONObject(i)
+                noteType = col.notetypes.get(mid)
+                assertNotNull("Check note type", noteType)
+                val template = noteType!!.getJSONArray("tmpls").getJSONObject(i)
                 assertEquals(
                     "Check template name",
-                    TEST_MODEL_CARDS[i],
+                    TEST_NOTE_TYPE_CARDS[i],
                     template.getString("name"),
                 )
-                assertEquals("Check qfmt", TEST_MODEL_QFMT[i], template.getString("qfmt"))
-                assertEquals("Check afmt", TEST_MODEL_AFMT[i], template.getString("afmt"))
-                assertEquals("Check bqfmt", TEST_MODEL_QFMT[i], template.getString("bqfmt"))
-                assertEquals("Check bafmt", TEST_MODEL_AFMT[i], template.getString("bafmt"))
+                assertEquals("Check qfmt", TEST_NOTE_TYPE_QFMT[i], template.getString("qfmt"))
+                assertEquals("Check afmt", TEST_NOTE_TYPE_AFMT[i], template.getString("afmt"))
+                assertEquals("Check bqfmt", TEST_NOTE_TYPE_QFMT[i], template.getString("bqfmt"))
+                assertEquals("Check bafmt", TEST_NOTE_TYPE_AFMT[i], template.getString("bafmt"))
             }
         } finally {
-            // Delete the model (this will force a full-sync)
+            // Delete the note type (this will force a full-sync)
             col.modSchemaNoCheck()
             try {
-                val model = col.notetypes.get(mid)
-                assertNotNull("Check model", model)
-                col.notetypes.rem(model!!)
+                val noteType = col.notetypes.get(mid)
+                assertNotNull("Check note type", noteType)
+                col.notetypes.rem(noteType!!)
             } catch (e: ConfirmModSchemaException) {
                 // This will never happen
             }
@@ -653,52 +653,52 @@ class ContentProviderTest : InstrumentedTest() {
      * Query .../models URI
      */
     @Test
-    fun testQueryAllModels() {
+    fun testQueryAllNoteType() {
         val cr = contentResolver
-        // Query all available models
-        val allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null)
-        assertNotNull(allModels)
-        allModels.use {
+        // Query all available note types
+        val allNoteTypes = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null)
+        assertNotNull(allNoteTypes)
+        allNoteTypes.use {
             assertThat(
                 "Check that there is at least one result",
-                allModels.count,
+                allNoteTypes.count,
                 greaterThan(0),
             )
-            while (allModels.moveToNext()) {
-                val modelId =
-                    allModels.getLong(allModels.getColumnIndex(FlashCardsContract.Model._ID))
-                val modelUri =
+            while (allNoteTypes.moveToNext()) {
+                val noteTypeId =
+                    allNoteTypes.getLong(allNoteTypes.getColumnIndex(FlashCardsContract.Model._ID))
+                val noteTypeUri =
                     Uri.withAppendedPath(
                         FlashCardsContract.Model.CONTENT_URI,
-                        modelId.toString(),
+                        noteTypeId.toString(),
                     )
-                val singleModel = cr.query(modelUri, null, null, null, null)
-                assertNotNull(singleModel)
-                singleModel.use {
+                val singleNoteType = cr.query(noteTypeUri, null, null, null, null)
+                assertNotNull(singleNoteType)
+                singleNoteType.use {
                     assertEquals(
                         "Check that there is exactly one result",
                         1,
                         it.count,
                     )
                     assertTrue("Move to beginning of cursor", it.moveToFirst())
-                    val nameFromModels =
-                        allModels.getString(allModels.getColumnIndex(FlashCardsContract.Model.NAME))
-                    val nameFromModel =
-                        it.getString(allModels.getColumnIndex(FlashCardsContract.Model.NAME))
+                    val nameFromNoteTypes =
+                        allNoteTypes.getString(allNoteTypes.getColumnIndex(FlashCardsContract.Model.NAME))
+                    val nameFromNoteType =
+                        it.getString(allNoteTypes.getColumnIndex(FlashCardsContract.Model.NAME))
                     assertEquals(
-                        "Check that model names are the same",
-                        nameFromModel,
-                        nameFromModels,
+                        "Check that note type names are the same",
+                        nameFromNoteType,
+                        nameFromNoteTypes,
                     )
                     val flds =
-                        allModels.getString(allModels.getColumnIndex(FlashCardsContract.Model.FIELD_NAMES))
+                        allNoteTypes.getString(allNoteTypes.getColumnIndex(FlashCardsContract.Model.FIELD_NAMES))
                     assertThat(
                         "Check that valid number of fields",
                         Utils.splitFields(flds).size,
                         greaterThanOrEqualTo(1),
                     )
                     val numCards =
-                        allModels.getInt(allModels.getColumnIndex(FlashCardsContract.Model.NUM_CARDS))
+                        allNoteTypes.getInt(allNoteTypes.getColumnIndex(FlashCardsContract.Model.NUM_CARDS))
                     assertThat(
                         "Check that valid number of cards",
                         numCards,
@@ -776,19 +776,19 @@ class ContentProviderTest : InstrumentedTest() {
     }
 
     /**
-     * Check that querying the current model gives a valid result
+     * Check that querying the current note type gives a valid result
      */
     @Test
-    fun testQueryCurrentModel() {
+    fun testQueryCurrentNoteType() {
         val cr = contentResolver
         val uri =
             Uri.withAppendedPath(
                 FlashCardsContract.Model.CONTENT_URI,
                 FlashCardsContract.Model.CURRENT_MODEL_ID,
             )
-        val modelCursor = cr.query(uri, null, null, null, null)
-        assertNotNull(modelCursor)
-        modelCursor.use {
+        val noteTypeCursor = cr.query(uri, null, null, null, null)
+        assertNotNull(noteTypeCursor)
+        noteTypeCursor.use {
             assertEquals(
                 "Check that there is exactly one result",
                 1,
@@ -1274,7 +1274,7 @@ class ContentProviderTest : InstrumentedTest() {
 
     /** Test that a null did will not crash the provider (#6378)  */
     @Test
-    fun testProviderProvidesDefaultForEmptyModelDeck() {
+    fun testProviderProvidesDefaultForEmptyNoteTypeDeck() {
         assumeTrue(
             "This causes mild data corruption - should not be run on a collection you care about",
             isEmulator(),
@@ -1282,16 +1282,16 @@ class ContentProviderTest : InstrumentedTest() {
         col.notetypes.all()[0].put("did", JSONObject.NULL)
 
         val cr = contentResolver
-        // Query all available models
-        val allModels = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null)
-        assertNotNull(allModels)
+        // Query all available note types
+        val allNoteTypes = cr.query(FlashCardsContract.Model.CONTENT_URI, null, null, null, null)
+        assertNotNull(allNoteTypes)
     }
 
     @Test
     fun pureAnswerHandledQuotedHtmlElement() {
         // <hr id="answer"> is also used
-        val modelName = addNonClozeModel("Test", arrayOf("One", "Two"), "{{One}}", "{{One}}<hr id=\"answer\">{{Two}}")
-        val note = col.newNote(col.notetypes.byName(modelName)!!)
+        val noteTypeName = addNonClozeNoteType("Test", arrayOf("One", "Two"), "{{One}}", "{{One}}<hr id=\"answer\">{{Two}}")
+        val note = col.newNote(col.notetypes.byName(noteTypeName)!!)
         note.setItem("One", "1")
         note.setItem("Two", "2")
         col.addNote(note)
@@ -1355,7 +1355,7 @@ class ContentProviderTest : InstrumentedTest() {
         get() = testContext.contentResolver
 
     companion object {
-        private const val BASIC_MODEL_NAME = "com.ichi2.anki.provider.test.basic.x94oa3F"
+        private const val BASIC_NOTE_TYPE_NAME = "com.ichi2.anki.provider.test.basic.x94oa3F"
         private const val TEST_FIELD_NAME = "TestFieldName"
         private const val TEST_FIELD_VALUE = "test field value"
         private const val TEST_TAG = "aldskfhewjklhfczmxkjshf"
@@ -1370,13 +1370,13 @@ class ContentProviderTest : InstrumentedTest() {
                 "cmxieunwoogyxsctnjmv::abcdefgh::ZYXW",
                 "cmxieunwoogyxsctnjmv::INSBGDS",
             )
-        private const val TEST_MODEL_NAME = "com.ichi2.anki.provider.test.a1x6h9l"
-        private val TEST_MODEL_FIELDS = arrayOf("FRONTS", "BACK")
-        private val TEST_MODEL_CARDS = arrayOf("cArD1", "caRD2")
-        private val TEST_MODEL_QFMT = arrayOf("{{FRONTS}}", "{{BACK}}")
-        private val TEST_MODEL_AFMT = arrayOf("{{BACK}}", "{{FRONTS}}")
+        private const val TEST_NOTE_TYPE_NAME = "com.ichi2.anki.provider.test.a1x6h9l"
+        private val TEST_NOTE_TYPE_FIELDS = arrayOf("FRONTS", "BACK")
+        private val TEST_NOTE_TYPE_CARDS = arrayOf("cArD1", "caRD2")
+        private val TEST_NOTE_TYPE_QFMT = arrayOf("{{FRONTS}}", "{{BACK}}")
+        private val TEST_NOTE_TYPE_AFMT = arrayOf("{{BACK}}", "{{FRONTS}}")
         private val TEST_NOTE_FIELDS = arrayOf("dis is za Fr0nt", "Te\$t")
-        private const val TEST_MODEL_CSS = "styleeeee"
+        private const val TEST_NOTE_TYPE_CSS = "styleeeee"
 
         @Suppress("SameParameterValue")
         private fun setupNewNote(
@@ -1407,21 +1407,21 @@ class ContentProviderTest : InstrumentedTest() {
         }
     }
 
-    fun addNonClozeModel(
+    fun addNonClozeNoteType(
         name: String,
         fields: Array<String>,
         qfmt: String?,
         afmt: String?,
     ): String {
-        val model = col.notetypes.new(name)
+        val noteType = col.notetypes.new(name)
         for (field in fields) {
-            col.notetypes.addFieldInNewModel(model, col.notetypes.newField(field))
+            col.notetypes.addFieldInNewModel(noteType, col.notetypes.newField(field))
         }
         val t = Notetypes.newTemplate("Card 1")
         t.put("qfmt", qfmt)
         t.put("afmt", afmt)
-        col.notetypes.addTemplateInNewModel(model, t)
-        col.notetypes.add(model)
+        col.notetypes.addTemplateInNewModel(noteType, t)
+        col.notetypes.add(noteType)
         return name
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -41,7 +41,6 @@ import com.ichi2.libanki.Consts
 import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
-import com.ichi2.libanki.Field
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.NoteTypeId
@@ -74,9 +73,9 @@ import java.io.IOException
  * * .../notes/#/cards (access cards of note)
  * * .../notes/#/cards/# (access specific card of note)
  * * .../models (search for models)
- * * .../models/# (direct access to model). String id 'current' can be used in place of # for the current model
- * * .../models/#/fields (access to field definitions of a model)
- * * .../models/#/templates (access to card templates of a model)
+ * * .../models/# (direct access to model). String id 'current' can be used in place of # for the current note type
+ * * .../models/#/fields (access to field definitions of a note type)
+ * * .../models/#/templates (access to card templates of a note type)
  * * .../schedule (access the study schedule)
  * * .../decks (access the deck list)
  * * .../decks/# (access the specified deck)
@@ -97,12 +96,12 @@ class CardContentProvider : ContentProvider() {
         private const val NOTES_ID_CARDS = 1003
         private const val NOTES_ID_CARDS_ORD = 1004
         private const val NOTES_V2 = 1005
-        private const val MODELS = 2000
-        private const val MODELS_ID = 2001
-        private const val MODELS_ID_EMPTY_CARDS = 2002
-        private const val MODELS_ID_TEMPLATES = 2003
-        private const val MODELS_ID_TEMPLATES_ID = 2004
-        private const val MODELS_ID_FIELDS = 2005
+        private const val NOTE_TYPES = 2000
+        private const val NOTE_TYPES_ID = 2001
+        private const val NOTE_TYPES_ID_EMPTY_CARDS = 2002
+        private const val NOTE_TYPES_ID_TEMPLATES = 2003
+        private const val NOTE_TYPES_ID_TEMPLATES_ID = 2004
+        private const val NOTE_TYPES_ID_FIELDS = 2005
         private const val SCHEDULE = 3000
         private const val DECKS = 4000
         private const val DECK_SELECTED = 4001
@@ -148,12 +147,12 @@ class CardContentProvider : ContentProvider() {
             addUri("notes/#", NOTES_ID)
             addUri("notes/#/cards", NOTES_ID_CARDS)
             addUri("notes/#/cards/#", NOTES_ID_CARDS_ORD)
-            addUri("models", MODELS)
-            addUri("models/*", MODELS_ID) // the model ID can also be "current"
-            addUri("models/*/empty_cards", MODELS_ID_EMPTY_CARDS)
-            addUri("models/*/templates", MODELS_ID_TEMPLATES)
-            addUri("models/*/templates/#", MODELS_ID_TEMPLATES_ID)
-            addUri("models/*/fields", MODELS_ID_FIELDS)
+            addUri("models", NOTE_TYPES)
+            addUri("models/*", NOTE_TYPES_ID) // the note type ID can also be "current"
+            addUri("models/*/empty_cards", NOTE_TYPES_ID_EMPTY_CARDS)
+            addUri("models/*/templates", NOTE_TYPES_ID_TEMPLATES)
+            addUri("models/*/templates/#", NOTE_TYPES_ID_TEMPLATES_ID)
+            addUri("models/*/fields", NOTE_TYPES_ID_FIELDS)
             addUri("schedule/", SCHEDULE)
             addUri("decks/", DECKS)
             addUri("decks/#", DECKS_ID)
@@ -182,12 +181,12 @@ class CardContentProvider : ContentProvider() {
         return when (sUriMatcher.match(uri)) {
             NOTES_V2, NOTES -> FlashCardsContract.Note.CONTENT_TYPE
             NOTES_ID -> FlashCardsContract.Note.CONTENT_ITEM_TYPE
-            NOTES_ID_CARDS, MODELS_ID_EMPTY_CARDS -> FlashCardsContract.Card.CONTENT_TYPE
+            NOTES_ID_CARDS, NOTE_TYPES_ID_EMPTY_CARDS -> FlashCardsContract.Card.CONTENT_TYPE
             NOTES_ID_CARDS_ORD -> FlashCardsContract.Card.CONTENT_ITEM_TYPE
-            MODELS -> FlashCardsContract.Model.CONTENT_TYPE
-            MODELS_ID -> FlashCardsContract.Model.CONTENT_ITEM_TYPE
-            MODELS_ID_TEMPLATES -> FlashCardsContract.CardTemplate.CONTENT_TYPE
-            MODELS_ID_TEMPLATES_ID -> FlashCardsContract.CardTemplate.CONTENT_ITEM_TYPE
+            NOTE_TYPES -> FlashCardsContract.Model.CONTENT_TYPE
+            NOTE_TYPES_ID -> FlashCardsContract.Model.CONTENT_ITEM_TYPE
+            NOTE_TYPES_ID_TEMPLATES -> FlashCardsContract.CardTemplate.CONTENT_TYPE
+            NOTE_TYPES_ID_TEMPLATES_ID -> FlashCardsContract.CardTemplate.CONTENT_ITEM_TYPE
             SCHEDULE -> FlashCardsContract.ReviewInfo.CONTENT_TYPE
             DECKS, DECK_SELECTED, DECKS_ID -> FlashCardsContract.Deck.CONTENT_TYPE
             else -> throw IllegalArgumentException("uri $uri is not supported")
@@ -199,7 +198,7 @@ class CardContentProvider : ContentProvider() {
 
     /** Enforce permissions for all updates on Android M and above. Otherwise block depending on URI and client app  */
     private fun shouldEnforceUpdateSecurity(uri: Uri): Boolean {
-        val whitelist = listOf(NOTES_ID_CARDS_ORD, MODELS_ID, MODELS_ID_TEMPLATES_ID, SCHEDULE, DECK_SELECTED)
+        val whitelist = listOf(NOTES_ID_CARDS_ORD, NOTE_TYPES_ID, NOTE_TYPES_ID_TEMPLATES_ID, SCHEDULE, DECK_SELECTED)
         return !whitelist.contains(sUriMatcher.match(uri)) || knownRogueClient()
     }
 
@@ -260,53 +259,53 @@ class CardContentProvider : ContentProvider() {
                 addCardToCursor(currentCard, rv, col, columns)
                 rv
             }
-            MODELS -> {
-                val models = col.notetypes
+            NOTE_TYPES -> {
+                val noteTypes = col.notetypes
                 val columns = projection ?: FlashCardsContract.Model.DEFAULT_PROJECTION
                 val rv = MatrixCursor(columns, 1)
-                for (modelId: NoteTypeId in models.ids()) {
-                    addModelToCursor(modelId, models, rv, columns)
+                for (noteTypeId: NoteTypeId in noteTypes.ids()) {
+                    addNoteTypeToCursor(noteTypeId, noteTypes, rv, columns)
                 }
                 rv
             }
-            MODELS_ID -> {
-                val modelId = getModelIdFromUri(uri, col)
+            NOTE_TYPES_ID -> {
+                val noteTypeId = getNoteTypeIdFromUri(uri, col)
                 val columns = projection ?: FlashCardsContract.Model.DEFAULT_PROJECTION
                 val rv = MatrixCursor(columns, 1)
-                addModelToCursor(modelId, col.notetypes, rv, columns)
+                addNoteTypeToCursor(noteTypeId, col.notetypes, rv, columns)
                 rv
             }
-            MODELS_ID_TEMPLATES -> {
-                // Direct access model templates
-                val models = col.notetypes
-                val currentModel = models.get(getModelIdFromUri(uri, col))
+            NOTE_TYPES_ID_TEMPLATES -> {
+                // Direct access note type templates
+                val noteTypes = col.notetypes
+                val currentNoteType = noteTypes.get(getNoteTypeIdFromUri(uri, col))
                 val columns = projection ?: FlashCardsContract.CardTemplate.DEFAULT_PROJECTION
                 val rv = MatrixCursor(columns, 1)
                 try {
-                    val templates = currentModel!!.getJSONArray("tmpls")
+                    val templates = currentNoteType!!.getJSONArray("tmpls")
                     var idx = 0
                     while (idx < templates.length()) {
                         val template = templates.getJSONObject(idx)
-                        addTemplateToCursor(template, currentModel, idx + 1, models, rv, columns)
+                        addTemplateToCursor(template, currentNoteType, idx + 1, noteTypes, rv, columns)
                         idx++
                     }
                 } catch (e: JSONException) {
-                    throw IllegalArgumentException("Model is malformed", e)
+                    throw IllegalArgumentException("Note type is malformed", e)
                 }
                 rv
             }
-            MODELS_ID_TEMPLATES_ID -> {
-                // Direct access model template with specific ID
-                val models = col.notetypes
+            NOTE_TYPES_ID_TEMPLATES_ID -> {
+                // Direct access note type template with specific ID
+                val noteTypes = col.notetypes
                 val ord = uri.lastPathSegment!!.toInt()
-                val currentModel = models.get(getModelIdFromUri(uri, col))
+                val currentNoteType = noteTypes.get(getNoteTypeIdFromUri(uri, col))
                 val columns = projection ?: FlashCardsContract.CardTemplate.DEFAULT_PROJECTION
                 val rv = MatrixCursor(columns, 1)
                 try {
                     val template = getTemplateFromUri(uri, col)
-                    addTemplateToCursor(template, currentModel, ord + 1, models, rv, columns)
+                    addTemplateToCursor(template, currentNoteType, ord + 1, noteTypes, rv, columns)
                 } catch (e: JSONException) {
-                    throw IllegalArgumentException("Model is malformed", e)
+                    throw IllegalArgumentException("Note type is malformed", e)
                 }
                 rv
             }
@@ -506,10 +505,10 @@ class CardContentProvider : ContentProvider() {
                     throw IllegalArgumentException("Currently only updates of decks are supported")
                 }
             }
-            MODELS -> throw IllegalArgumentException("Cannot update models in bulk")
-            MODELS_ID -> {
+            NOTE_TYPES -> throw IllegalArgumentException("Cannot update models in bulk")
+            NOTE_TYPES_ID -> {
                 // Get the input parameters
-                val newModelName = values!!.getAsString(FlashCardsContract.Model.NAME)
+                val newNoteTypeName = values!!.getAsString(FlashCardsContract.Model.NAME)
                 val newCss = values.getAsString(FlashCardsContract.Model.CSS)
                 val newDid = values.getAsString(FlashCardsContract.Model.DECK_ID)
                 val newFieldList = values.getAsString(FlashCardsContract.Model.FIELD_NAMES)
@@ -522,47 +521,47 @@ class CardContentProvider : ContentProvider() {
                 val newLatexPost = values.getAsString(FlashCardsContract.Model.LATEX_POST)
                 val newLatexPre = values.getAsString(FlashCardsContract.Model.LATEX_PRE)
                 // Get the original note JSON
-                val model = col.notetypes.get(getModelIdFromUri(uri, col))
+                val noteType = col.notetypes.get(getNoteTypeIdFromUri(uri, col))
                 try {
-                    // Update model name and/or css
-                    if (newModelName != null) {
-                        model!!.put("name", newModelName)
+                    // Update noteType name and/or css
+                    if (newNoteTypeName != null) {
+                        noteType!!.put("name", newNoteTypeName)
                         updated++
                     }
                     if (newCss != null) {
-                        model!!.put("css", newCss)
+                        noteType!!.put("css", newCss)
                         updated++
                     }
                     if (newDid != null) {
                         if (col.decks.isFiltered(newDid.toLong())) {
-                            throw IllegalArgumentException("Cannot set a filtered deck as default deck for a model")
+                            throw IllegalArgumentException("Cannot set a filtered deck as default deck for a noteType")
                         }
-                        model!!.put("did", newDid)
+                        noteType!!.put("did", newDid)
                         updated++
                     }
                     if (newSortf != null) {
-                        model!!.put("sortf", newSortf)
+                        noteType!!.put("sortf", newSortf)
                         updated++
                     }
                     if (newType != null) {
-                        model!!.put("type", newType)
+                        noteType!!.put("type", newType)
                         updated++
                     }
                     if (newLatexPost != null) {
-                        model!!.put("latexPost", newLatexPost)
+                        noteType!!.put("latexPost", newLatexPost)
                         updated++
                     }
                     if (newLatexPre != null) {
-                        model!!.put("latexPre", newLatexPre)
+                        noteType!!.put("latexPre", newLatexPre)
                         updated++
                     }
-                    col.notetypes.save(model!!)
+                    col.notetypes.save(noteType!!)
                 } catch (e: JSONException) {
-                    Timber.e(e, "JSONException updating model")
+                    Timber.e(e, "JSONException updating noteType")
                 }
             }
-            MODELS_ID_TEMPLATES -> throw IllegalArgumentException("Cannot update templates in bulk")
-            MODELS_ID_TEMPLATES_ID -> {
+            NOTE_TYPES_ID_TEMPLATES -> throw IllegalArgumentException("Cannot update templates in bulk")
+            NOTE_TYPES_ID_TEMPLATES_ID -> {
                 val mid = values!!.getAsLong(FlashCardsContract.CardTemplate.MODEL_ID)
                 val ord = values.getAsInteger(FlashCardsContract.CardTemplate.ORD)
                 val name = values.getAsString(FlashCardsContract.CardTemplate.NAME)
@@ -574,11 +573,11 @@ class CardContentProvider : ContentProvider() {
                 if (mid != null || ord != null) {
                     throw IllegalArgumentException("Updates to mid or ord are not allowed")
                 }
-                // Update the model
+                // Update the noteType
                 try {
                     val templateOrd = uri.lastPathSegment!!.toInt()
-                    val existingModel = col.notetypes.get(getModelIdFromUri(uri, col))
-                    val templates = existingModel!!.getJSONArray("tmpls")
+                    val existingNoteType = col.notetypes.get(getNoteTypeIdFromUri(uri, col))
+                    val templates = existingNoteType!!.getJSONArray("tmpls")
                     val template = templates.getJSONObject(templateOrd)
                     if (name != null) {
                         template.put("name", name)
@@ -600,12 +599,12 @@ class CardContentProvider : ContentProvider() {
                         template.put("bafmt", bafmt)
                         updated++
                     }
-                    // Save the model
+                    // Save the noteType
                     templates.put(templateOrd, template)
-                    existingModel.put("tmpls", templates)
-                    col.notetypes.save(existingModel)
+                    existingNoteType.put("tmpls", templates)
+                    col.notetypes.save(existingNoteType)
                 } catch (e: JSONException) {
-                    throw IllegalArgumentException("Model is malformed", e)
+                    throw IllegalArgumentException("Note type is malformed", e)
                 }
             }
             SCHEDULE -> {
@@ -690,8 +689,8 @@ class CardContentProvider : ContentProvider() {
                 1
             }
 //            MODELS_ID_EMPTY_CARDS -> {
-//                val model = col.models.get(getModelIdFromUri(uri, col)) ?: return -1
-//                val cids: List<Long> = col.genCards(col.models.nids(model), model)!!
+//                val noteType = col.models.get(getNoteTypeIdFromUri(uri, col)) ?: return -1
+//                val cids: List<Long> = col.genCards(col.models.nids(noteType), noteType)!!
 //                col.removeCardsAndOrphanedNotes(cids)
 //                cids.size
 //            }
@@ -735,7 +734,7 @@ class CardContentProvider : ContentProvider() {
     }
 
     /**
-     * This implementation optimizes for when the notes are grouped according to model.
+     * This implementation optimizes for when the notes are grouped according to note type.
      */
     private fun bulkInsertNotes(
         valuesArr: Array<ContentValues>?,
@@ -755,14 +754,14 @@ class CardContentProvider : ContentProvider() {
             val values: ContentValues = valuesArr[i]
             val flds = values.getAsString(FlashCardsContract.Note.FLDS) ?: continue
 //                val allowEmpty = AllowEmpty.fromBoolean(values.getAsBoolean(FlashCardsContract.Note.ALLOW_EMPTY))
-            val thisModelId = values.getAsLong(FlashCardsContract.Note.MID)
-            if (thisModelId == null || thisModelId < 0) {
-                Timber.d("Unable to get model at index: %d", i)
+            val thisNoteTypeId = values.getAsLong(FlashCardsContract.Note.MID)
+            if (thisNoteTypeId == null || thisNoteTypeId < 0) {
+                Timber.d("Unable to get note type at index: %d", i)
                 continue
             }
             val fldsArray = Utils.splitFields(flds)
             // Create empty note
-            val newNote = Note.fromNotetypeId(col, thisModelId)
+            val newNote = Note.fromNotetypeId(col, thisNoteTypeId)
             // Set fields
             // Check that correct number of flds specified
             if (fldsArray.size != newNote.fields.size) {
@@ -803,12 +802,12 @@ class CardContentProvider : ContentProvider() {
             NOTES -> {
                 /* Insert new note with specified fields and tags
                  */
-                val modelId = values!!.getAsLong(FlashCardsContract.Note.MID)
+                val noteTypeId = values!!.getAsLong(FlashCardsContract.Note.MID)
                 val flds = values.getAsString(FlashCardsContract.Note.FLDS)
                 val tags = values.getAsString(FlashCardsContract.Note.TAGS)
 //                val allowEmpty = AllowEmpty.fromBoolean(values.getAsBoolean(FlashCardsContract.Note.ALLOW_EMPTY))
                 // Create empty note
-                val newNote = Note.fromNotetypeId(col, modelId)
+                val newNote = Note.fromNotetypeId(col, noteTypeId)
                 // Set fields
                 val fldsArray = Utils.splitFields(flds)
                 // Check that correct number of flds specified
@@ -833,9 +832,9 @@ class CardContentProvider : ContentProvider() {
             NOTES_ID_CARDS, NOTES_ID_CARDS_ORD -> throw IllegalArgumentException(
                 "Not possible to insert cards directly (only through NOTES)",
             )
-            MODELS -> {
+            NOTE_TYPES -> {
                 // Get input arguments
-                val modelName = values!!.getAsString(FlashCardsContract.Model.NAME)
+                val noteTypeName = values!!.getAsString(FlashCardsContract.Model.NAME)
                 val css = values.getAsString(FlashCardsContract.Model.CSS)
                 val did = values.getAsLong(FlashCardsContract.Model.DECK_ID)
                 val fieldNames = values.getAsString(FlashCardsContract.Model.FIELD_NAMES)
@@ -845,20 +844,20 @@ class CardContentProvider : ContentProvider() {
                 val latexPost = values.getAsString(FlashCardsContract.Model.LATEX_POST)
                 val latexPre = values.getAsString(FlashCardsContract.Model.LATEX_PRE)
                 // Throw exception if required fields empty
-                if (modelName == null || fieldNames == null || numCards == null) {
-                    throw IllegalArgumentException("Model name, field_names, and num_cards can't be empty")
+                if (noteTypeName == null || fieldNames == null || numCards == null) {
+                    throw IllegalArgumentException("Note type name, field_names, and num_cards can't be empty")
                 }
                 if (did != null && col.decks.isFiltered(did)) {
-                    throw IllegalArgumentException("Cannot set a filtered deck as default deck for a model")
+                    throw IllegalArgumentException("Cannot set a filtered deck as default deck for a note type")
                 }
-                // Create a new model
-                val mm = col.notetypes
-                val newModel = mm.new(modelName)
+                // Create a new note type
+                val noteTypes = col.notetypes
+                val newNoteType = noteTypes.new(noteTypeName)
                 return try {
                     // Add the fields
                     val allFields = Utils.splitFields(fieldNames)
                     for (f: String? in allFields) {
-                        mm.addFieldInNewModel(newModel, mm.newField(f!!))
+                        noteTypes.addFieldInNewModel(newNoteType, noteTypes.newField(f!!))
                     }
                     // Add some empty card templates
                     var idx = 0
@@ -871,48 +870,48 @@ class CardContentProvider : ContentProvider() {
                             answerField = allFields[1]
                         }
                         t.put("afmt", "{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{$answerField}}")
-                        mm.addTemplateInNewModel(newModel, t)
+                        noteTypes.addTemplateInNewModel(newNoteType, t)
                         idx++
                     }
                     // Add the CSS if specified
                     if (css != null) {
-                        newModel.put("css", css)
+                        newNoteType.put("css", css)
                     }
                     // Add the did if specified
                     if (did != null) {
-                        newModel.put("did", did)
+                        newNoteType.put("did", did)
                     }
                     if (sortf != null && sortf < allFields.size) {
-                        newModel.put("sortf", sortf)
+                        newNoteType.put("sortf", sortf)
                     }
                     if (type != null) {
-                        newModel.put("type", type)
+                        newNoteType.put("type", type)
                     }
                     if (latexPost != null) {
-                        newModel.put("latexPost", latexPost)
+                        newNoteType.put("latexPost", latexPost)
                     }
                     if (latexPre != null) {
-                        newModel.put("latexPre", latexPre)
+                        newNoteType.put("latexPre", latexPre)
                     }
-                    // Add the model to collection (from this point on edits will require a full-sync)
-                    mm.add(newModel)
+                    // Add the note type to collection (from this point on edits will require a full-sync)
+                    noteTypes.add(newNoteType)
 
                     // Get the mid and return a URI
-                    val mid = newModel.getLong("id").toString()
+                    val mid = newNoteType.getLong("id").toString()
                     Uri.withAppendedPath(FlashCardsContract.Model.CONTENT_URI, mid)
                 } catch (e: JSONException) {
-                    Timber.e(e, "Could not set a field of new model %s", modelName)
+                    Timber.e(e, "Could not set a field of new note type %s", noteTypeName)
                     null
                 }
             }
-            MODELS_ID -> throw IllegalArgumentException("Not possible to insert model with specific ID")
-            MODELS_ID_TEMPLATES -> {
+            NOTE_TYPES_ID -> throw IllegalArgumentException("Not possible to insert note type with specific ID")
+            NOTE_TYPES_ID_TEMPLATES -> {
                 run {
                     val notetypes: Notetypes = col.notetypes
-                    val mid: NoteTypeId = getModelIdFromUri(uri, col)
-                    val existingModel: NotetypeJson =
+                    val mid: NoteTypeId = getNoteTypeIdFromUri(uri, col)
+                    val existingNoteType: NotetypeJson =
                         notetypes.get(mid)
-                            ?: throw IllegalArgumentException("model missing: $mid")
+                            ?: throw IllegalArgumentException("note type missing: $mid")
                     val name: String = values!!.getAsString(FlashCardsContract.CardTemplate.NAME)
                     val qfmt: String = values.getAsString(FlashCardsContract.CardTemplate.QUESTION_FORMAT)
                     val afmt: String = values.getAsString(FlashCardsContract.CardTemplate.ANSWER_FORMAT)
@@ -924,9 +923,9 @@ class CardContentProvider : ContentProvider() {
                         t.put("afmt", afmt)
                         t.put("bqfmt", bqfmt)
                         t.put("bafmt", bafmt)
-                        notetypes.addTemplate(existingModel, t)
-                        notetypes.update(existingModel)
-                        t = existingModel.tmpls.get(existingModel.tmpls.length() - 1) as JSONObject
+                        notetypes.addTemplate(existingNoteType, t)
+                        notetypes.update(existingNoteType)
+                        t = existingNoteType.tmpls.get(existingNoteType.tmpls.length() - 1) as JSONObject
                         return ContentUris.withAppendedId(uri, t.getInt("ord").toLong())
                     } catch (e: ConfirmModSchemaException) {
                         throw IllegalArgumentException("Unable to add template without user requesting/accepting full-sync", e)
@@ -935,21 +934,23 @@ class CardContentProvider : ContentProvider() {
                     }
                 }
             }
-            MODELS_ID_TEMPLATES_ID -> throw IllegalArgumentException("Not possible to insert template with specific ORD")
-            MODELS_ID_FIELDS -> {
+            NOTE_TYPES_ID_TEMPLATES_ID -> throw IllegalArgumentException("Not possible to insert template with specific ORD")
+            NOTE_TYPES_ID_FIELDS -> {
                 run {
                     val notetypes: Notetypes = col.notetypes
-                    val mid: NoteTypeId = getModelIdFromUri(uri, col)
-                    val existingModel: NotetypeJson =
+                    val mid: NoteTypeId = getNoteTypeIdFromUri(uri, col)
+                    val existingNoteType: NotetypeJson =
                         notetypes.get(mid)
-                            ?: throw IllegalArgumentException("model missing: $mid")
+                            ?: throw IllegalArgumentException("note type missing: $mid")
                     val name: String =
                         values!!.getAsString(FlashCardsContract.Model.FIELD_NAME)
-                            ?: throw IllegalArgumentException("field name missing for model: $mid")
-                    val field: Field = notetypes.newField(name)
+                            ?: throw IllegalArgumentException("field name missing for note type: $mid")
+                    val field = notetypes.newField(name)
                     try {
-                        notetypes.addFieldLegacy(existingModel, field)
-                        return ContentUris.withAppendedId(uri, (existingModel.flds.length() - 1).toLong())
+                        notetypes.addFieldLegacy(existingNoteType, field)
+
+                        val flds: JSONArray = existingNoteType.getJSONArray("flds")
+                        return ContentUris.withAppendedId(uri, (flds.length() - 1).toLong())
                     } catch (e: ConfirmModSchemaException) {
                         throw IllegalArgumentException("Unable to insert field: $name", e)
                     } catch (e: JSONException) {
@@ -1050,18 +1051,18 @@ class CardContentProvider : ContentProvider() {
         }
     }
 
-    private fun addModelToCursor(
-        modelId: NoteTypeId,
+    private fun addNoteTypeToCursor(
+        noteTypeId: NoteTypeId,
         notetypes: Notetypes,
         rv: MatrixCursor,
         columns: Array<String>,
     ) {
-        val jsonObject = notetypes.get(modelId)
+        val jsonObject = notetypes.get(noteTypeId)
         val rb = rv.newRow()
         try {
             for (column in columns) {
                 when (column) {
-                    FlashCardsContract.Model._ID -> rb.add(modelId)
+                    FlashCardsContract.Model._ID -> rb.add(noteTypeId)
                     FlashCardsContract.Model.NAME -> rb.add(jsonObject!!.getString("name"))
                     FlashCardsContract.Model.FIELD_NAMES -> {
                         @KotlinCleanup("maybe jsonObject.fieldsNames. Difference: optString vs get")
@@ -1089,7 +1090,7 @@ class CardContentProvider : ContentProvider() {
             }
         } catch (e: JSONException) {
             Timber.e(e, "Error parsing JSONArray")
-            throw IllegalArgumentException("Model $modelId is malformed", e)
+            throw IllegalArgumentException("Model $noteTypeId is malformed", e)
         }
     }
 
@@ -1298,19 +1299,19 @@ class CardContentProvider : ContentProvider() {
         return col.getNote(noteId)
     }
 
-    private fun getModelIdFromUri(
+    private fun getNoteTypeIdFromUri(
         uri: Uri,
         col: Collection,
     ): Long {
-        val modelIdSegment = uri.pathSegments[1]
+        val noteTypeIdSegment = uri.pathSegments[1]
         val id: Long =
-            if (modelIdSegment == FlashCardsContract.Model.CURRENT_MODEL_ID) {
+            if (noteTypeIdSegment == FlashCardsContract.Model.CURRENT_MODEL_ID) {
                 col.notetypes.current().optLong("id", -1)
             } else {
                 try {
                     uri.pathSegments[1].toLong()
                 } catch (e: NumberFormatException) {
-                    throw IllegalArgumentException("Model ID must be either numeric or the String CURRENT_MODEL_ID", e)
+                    throw IllegalArgumentException("Note type ID must be either numeric or the String CURRENT_NOTE_TYPE_ID", e)
                 }
             }
         return id
@@ -1321,9 +1322,9 @@ class CardContentProvider : ContentProvider() {
         uri: Uri,
         col: Collection,
     ): JSONObject {
-        val model: JSONObject? = col.notetypes.get(getModelIdFromUri(uri, col))
+        val noteType: JSONObject? = col.notetypes.get(getNoteTypeIdFromUri(uri, col))
         val ord = uri.lastPathSegment!!.toInt()
-        return model!!.getJSONArray("tmpls").getJSONObject(ord)
+        return noteType!!.getJSONArray("tmpls").getJSONObject(ord)
     }
 
     private fun throwSecurityException(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1311,7 +1311,7 @@ class CardContentProvider : ContentProvider() {
                 try {
                     uri.pathSegments[1].toLong()
                 } catch (e: NumberFormatException) {
-                    throw IllegalArgumentException("Note type ID must be either numeric or the String CURRENT_NOTE_TYPE_ID", e)
+                    throw IllegalArgumentException("Note type ID must be either numeric or the String CURRENT_MODEL_ID", e)
                 }
             }
         return id


### PR DESCRIPTION
In this case, I only renamed private values and local variables,as the content provider is used to provide content to external entities, its API should not be changed. I also added some documentation to explain why we have those old names.

We could consider duplicating "model" to "note type" in the entire API, and noting "model" as deprecated. But I really don't think that's it's worth deprecating anything. And if we don't plan to deprecate, I don't think it's worth having duplicate API either.