### PR TITLE
feat(debug-info): log more device info & reduce vertical space used

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -41,21 +41,13 @@ object DebugInfoService {
         val isFSRSEnabled = getFSRSStatus()
         return """
             AnkiDroid Version = $pkgVersionName (${BuildConfig.GIT_COMMIT_HASH})
-            
             Backend Version = ${BuildConfig.BACKEND_VERSION} (${BackendBuildConfig.ANKI_DESKTOP_VERSION} ${BackendBuildConfig.ANKI_COMMIT_HASH})
-            
             Android Version = ${Build.VERSION.RELEASE} (SDK ${Build.VERSION.SDK_INT})
-            
             ProductFlavor = ${BuildConfig.FLAVOR}
-            
             Device Info = ${Build.MANUFACTURER} | ${Build.BRAND} | ${Build.DEVICE} | ${Build.PRODUCT} | ${Build.MODEL} | ${Build.HARDWARE}
-
             Webview User Agent = $webviewUserAgent
-            
             ACRA UUID = ${Installation.id(info)}
-            
             FSRS = ${BackendBuildConfig.FSRS_VERSION} (Enabled: $isFSRSEnabled)
-            
             Crash Reports Enabled = ${isSendingCrashReports(info)}
             """.trimIndent()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -48,12 +48,8 @@ object DebugInfoService {
             
             ProductFlavor = ${BuildConfig.FLAVOR}
             
-            Manufacturer = ${Build.MANUFACTURER}
-            
-            Model = ${Build.MODEL}
-            
-            Hardware = ${Build.HARDWARE}
-            
+            Device Info = ${Build.MANUFACTURER} | ${Build.BRAND} | ${Build.DEVICE} | ${Build.PRODUCT} | ${Build.MODEL} | ${Build.HARDWARE}
+
             Webview User Agent = $webviewUserAgent
             
             ACRA UUID = ${Installation.id(info)}


### PR DESCRIPTION
And reduce the amount of vertical space used

We want this for e-ink identification:

* Issue #17618

This is the same fingerprint as used in https://github.com/koreader/android-luajit-launcher/blob/6bba3f4bb4da8073d0f4ea4f270828c8603aa54d/app/src/main/java/org/koreader/launcher/device/DeviceInfo.kt#L134-L139

## How Has This Been Tested?

```diff
AnkiDroid Version = 2.21alpha4-debug (6ce39e2b9d6c64462986953f7f502be7e4c509c1)
-
Backend Version = 0.1.48-anki24.11 (24.11 c47638ca36f99dd4f3b81ae82d964aec66e392e0)
-
Android Version = 14 (SDK 34)
-
ProductFlavor = full
-
+ Device Info = samsung | samsung | o1s | o1sxeea | SM-G991B | exynos2100
- Manufacturer = samsung
-
- Model = SM-G991B
-
- Hardware = exynos2100
-
Webview User Agent = Mozilla/5.0 (Linux; Android 14; SM-G991B Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.135 Mobile Safari/537.36
-
ACRA UUID = 9ff2e57a-1926-4d25-b1b9-05453c01c54b
-
FSRS = 1.4.3 (Enabled: false)
-
Crash Reports Enabled = false
```

=>

```
AnkiDroid Version = 2.21alpha4-debug (d731fe06112bb2982144930dfbf1bd32b22704d0)
Backend Version = 0.1.48-anki24.11 (24.11 c47638ca36f99dd4f3b81ae82d964aec66e392e0)
Android Version = 14 (SDK 34)
ProductFlavor = full
Device Info = samsung | samsung | o1s | o1sxeea | SM-G991B | exynos2100
Webview User Agent = Mozilla/5.0 (Linux; Android 14; SM-G991B Build/UP1A.231005.007; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/131.0.6778.135 Mobile Safari/537.36
ACRA UUID = 9ff2e57a-1926-4d25-b1b9-05453c01c54b
FSRS = 1.4.3 (Enabled: false)
Crash Reports Enabled = false
```

## Learning (optional, can help others)
It doesn't say my device is a S21...

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
