### PR TITLE
NF: Simplify `currentDeckId`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1128,7 +1128,7 @@ class NoteEditor :
             }
         }
         // changed deck?
-        if (!addNote && currentEditedCard != null && currentEditedCard!!.currentDeckId().did != deckId) {
+        if (!addNote && currentEditedCard != null && currentEditedCard!!.currentDeckId() != deckId) {
             return true
         }
         // changed fields?
@@ -1260,7 +1260,7 @@ class NoteEditor :
             // Regular changes in note content
             var modified = false
             // changed did? this has to be done first as remFromDyn() involves a direct write to the database
-            if (currentEditedCard != null && currentEditedCard!!.currentDeckId().did != deckId) {
+            if (currentEditedCard != null && currentEditedCard!!.currentDeckId() != deckId) {
                 reloadRequired = true
                 undoableOp { setDeck(listOf(currentEditedCard!!.id), deckId) }
                 // refresh the card object to reflect the database changes from above
@@ -2235,7 +2235,7 @@ class NoteEditor :
         fun calculateDeckId(): DeckId {
             if (deckId != 0L) return deckId
             if (note != null && !addNote && currentEditedCard != null) {
-                return currentEditedCard!!.currentDeckId().did
+                return currentEditedCard!!.currentDeckId()
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
@@ -42,7 +42,7 @@ class AutoAdvance(
     private var settings =
         viewModel.asyncIO {
             val card = viewModel.currentCard.await()
-            AutoAdvanceSettings.createInstance(card.currentDeckId().did)
+            AutoAdvanceSettings.createInstance(card.currentDeckId())
         }
 
     private suspend fun durationToShowQuestionFor() = settings.await().durationToShowQuestionFor
@@ -64,7 +64,7 @@ class AutoAdvance(
         cancelQuestionAndAnswerActionJobs()
         settings =
             viewModel.asyncIO {
-                AutoAdvanceSettings.createInstance(card.currentDeckId().did)
+                AutoAdvanceSettings.createInstance(card.currentDeckId())
             }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -234,14 +234,14 @@ open class Card : Cloneable {
 
     @LibAnkiAlias("current_deck_id")
     @NeedsTest("Test functionality which calls this")
-    fun currentDeckId() = deckId { did = oDid.ifZero { this@Card.did } }
+    fun currentDeckId() = oDid.ifZero { did }
 
     /**
      * Time limit for answering in milliseconds.
      */
     @LibAnkiAlias("time_limit")
     fun timeLimit(col: Collection): Int {
-        val conf = col.decks.configDictForDeckId(currentDeckId().did)
+        val conf = col.decks.configDictForDeckId(currentDeckId())
         return conf.getInt("maxTaken") * 1000
     }
 
@@ -281,18 +281,18 @@ open class Card : Cloneable {
 
     @LibAnkiAlias("should_show_timer")
     fun shouldShowTimer(col: Collection): Boolean {
-        val options = col.decks.configDictForDeckId(currentDeckId().did)
+        val options = col.decks.configDictForDeckId(currentDeckId())
         return DeckConfig.parseTimerOpt(options, true)
     }
 
     @LibAnkiAlias("replay_question_audio_on_answer_side")
     fun replayQuestionAudioOnAnswerSide(col: Collection): Boolean {
-        val conf = col.decks.configDictForDeckId(currentDeckId().did)
+        val conf = col.decks.configDictForDeckId(currentDeckId())
         return conf.optBoolean("replayq", true)
     }
 
     @LibAnkiAlias("autoplay")
-    fun autoplay(col: Collection): Boolean = col.decks.configDictForDeckId(currentDeckId().did).getBoolean("autoplay")
+    fun autoplay(col: Collection): Boolean = col.decks.configDictForDeckId(currentDeckId()).getBoolean("autoplay")
 
     @NotInLibAnki
     public override fun clone(): Card =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -763,7 +763,7 @@ class Collection(
     ): String = backend.extractClozeForTyping(text = text, ordinal = ordinal)
 
     fun defaultsForAdding(currentReviewCard: Card? = null): anki.notes.DeckAndNotetype {
-        val homeDeck = currentReviewCard?.currentDeckId()?.did ?: 0L
+        val homeDeck = currentReviewCard?.currentDeckId() ?: 0L
         return backend.defaultsForAdding(homeDeckOfCurrentReviewCard = homeDeck)
     }
 


### PR DESCRIPTION
The function was only used with `currentDeckId().did`. So no need to add `did` to a protobuf structure.
