### PR TITLE
improvement: introduce DeckPickerViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -63,7 +63,6 @@ import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.getLabel
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
-import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
@@ -111,7 +110,6 @@ import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.SortOrder
 import com.ichi2.libanki.undoableOp
 import com.ichi2.ui.CardBrowserSearchView
-import com.ichi2.utils.HandlerUtils
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.TagsUtil.getUpdatedTags
@@ -119,9 +117,7 @@ import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
 import com.ichi2.widget.WidgetStatus.updateInBackground
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.Translations
@@ -1899,21 +1895,6 @@ open class CardBrowser :
             context: Context,
             viewModel: CardBrowserViewModel,
         ): Intent = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel).getIntent(context)
-    }
-
-    private fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
-        lifecycleScope.launch {
-            this@launchCollectionInLifecycleScope.collect {
-                if (isRobolectric) {
-                    // hack: lifecycleScope/runOnUiThread do not handle our
-                    // test dispatcher overriding both IO and Main
-                    // in tests, waitForAsyncTasksToComplete may be required.
-                    HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
-                } else {
-                    block(it)
-                }
-            }
-        }
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -52,6 +52,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
@@ -104,6 +105,7 @@ import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
+import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.BackupPromptDialog
 import com.ichi2.anki.dialogs.ConfirmationDialog
@@ -249,6 +251,8 @@ open class DeckPicker :
     CsvImportResultLauncherProvider,
     CollectionPermissionScreenLauncher,
     ExportDialogsFactoryProvider {
+    val viewModel: DeckPickerViewModel by viewModels()
+
     // Short animation duration from system
     private var shortAnimDuration = 0
     private var backButtonPressedToExit = false
@@ -319,14 +323,6 @@ open class DeckPicker :
      * work in onResume that might use the database and go straight to syncing.
      */
     private var syncOnResume = false
-
-    /**
-     * Keep track of which deck was last given focus in the deck list. If we find that this value
-     * has changed between deck list refreshes, we need to recenter the deck list to the new current
-     * deck.
-     */
-    @VisibleForTesting
-    internal var focusedDeck: DeckId = 0
 
     private var toolbarSearchItem: MenuItem? = null
     private var toolbarSearchView: AccessibleSearchView? = null
@@ -1449,7 +1445,7 @@ open class DeckPicker :
                     if (event.isShiftPressed) {
                         // Shortcut: Shift + DEL - Delete deck without confirmation dialog
                         Timber.i("Shift+DEL: Deck deck without confirmation")
-                        deleteDeck(focusedDeck)
+                        deleteDeck(viewModel.focusedDeck)
                     } else {
                         // Shortcut: DEL
                         Timber.i("Delete Deck from keypress")
@@ -1464,7 +1460,7 @@ open class DeckPicker :
                 // that is, when it appears in the trailing study option fragment
                 if (fragmented) {
                     Timber.i("Rename Deck from keypress")
-                    renameDeckDialog(focusedDeck)
+                    renameDeckDialog(viewModel.focusedDeck)
                     return true
                 }
             }
@@ -1515,15 +1511,15 @@ open class DeckPicker :
             val (deckName, totalCards, isFilteredDeck) =
                 withCol {
                     Triple(
-                        decks.name(focusedDeck),
-                        decks.cardCount(focusedDeck, includeSubdecks = true),
-                        decks.isFiltered(focusedDeck),
+                        decks.name(viewModel.focusedDeck),
+                        decks.cardCount(viewModel.focusedDeck, includeSubdecks = true),
+                        decks.isFiltered(viewModel.focusedDeck),
                     )
                 }
             val confirmDeleteDeckDialog =
                 DeckPickerConfirmDeleteDeckDialog.newInstance(
                     deckName = deckName,
-                    deckId = focusedDeck,
+                    deckId = viewModel.focusedDeck,
                     totalCards = totalCards,
                     isFilteredDeck = isFilteredDeck,
                 )
@@ -2130,7 +2126,7 @@ open class DeckPicker :
         withCol { decks.select(did) }
         // Also forget the last deck used by the Browser
         CardBrowser.clearLastDeckId()
-        focusedDeck = did
+        viewModel.focusedDeck = did
         val deck = deckListAdapter.getNodeByDid(did)
         if (deck.hasCardsReadyToStudy()) {
             openReviewerOrStudyOptions(selectionType)
@@ -2308,9 +2304,9 @@ open class DeckPicker :
             Timber.e(e, "RuntimeException setting time remaining")
         }
         val current = withCol { decks.current().optLong("id") }
-        if (focusedDeck != current) {
+        if (viewModel.focusedDeck != current) {
             scrollDecklistToDeck(current)
-            focusedDeck = current
+            viewModel.focusedDeck = current
         }
     }
 
@@ -2424,7 +2420,7 @@ open class DeckPicker :
                 }
             // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
             // to match and avoid unnecessary scrolls in `renderPage()`.
-            focusedDeck = Consts.DEFAULT_DECK_ID
+            viewModel.focusedDeck = Consts.DEFAULT_DECK_ID
             showSnackbar(TR.browsingCardsDeletedWithDeckname(changes.count, deckName), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -16,12 +16,27 @@
 
 package com.ichi2.anki.deckpicker
 
+import androidx.annotation.CheckResult
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import anki.i18n.GeneratedTranslations
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
+import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.undoableOp
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
 
 /** @see [DeckPicker] */
 class DeckPickerViewModel : ViewModel() {
+    /**
+     * @see deleteDeck
+     * @see DeckDeletionResult
+     */
+    val deckDeletedNotification = MutableSharedFlow<DeckDeletionResult>()
+
     /**
      * Keep track of which deck was last given focus in the deck list. If we find that this value
      * has changed between deck list refreshes, we need to recenter the deck list to the new current
@@ -29,4 +44,54 @@ class DeckPickerViewModel : ViewModel() {
      */
     // TODO: This should later be handled as a Flow
     var focusedDeck: DeckId = 0
+
+    /**
+     * Deletes the provided deck, child decks. and all cards inside.
+     *
+     * This is a slow operation and should be inside `withProgress`
+     *
+     * @param did ID of the deck to delete
+     */
+    @CheckResult // This is a slow operation and should be inside `withProgress`
+    fun deleteDeck(did: DeckId) =
+        viewModelScope.launch {
+            val deckName = withCol { decks.get(did)!!.name }
+            val changes = undoableOp { decks.remove(listOf(did)) }
+            // After deletion: decks.current() reverts to Default, necessitating `focusedDeck`
+            // to match and avoid unnecessary scrolls in `renderPage()`.
+            focusedDeck = Consts.DEFAULT_DECK_ID
+
+            deckDeletedNotification.emit(
+                DeckDeletionResult(deckName = deckName, cardsDeleted = changes.count),
+            )
+        }
+
+    /**
+     * Deletes the currently selected deck
+     *
+     * This is a slow operation and should be inside `withProgress`
+     */
+    @CheckResult
+    fun deleteSelectedDeck() =
+        viewModelScope.launch {
+            val targetDeckId = withCol { decks.selected() }
+            deleteDeck(targetDeckId).join()
+        }
+}
+
+/** Result of [DeckPickerViewModel.deleteDeck] */
+data class DeckDeletionResult(
+    val deckName: String,
+    val cardsDeleted: Int,
+) {
+    /**
+     * @see GeneratedTranslations.browsingCardsDeletedWithDeckname
+     */
+    // TODO: Somewhat questionable meaning: {count} cards deleted from {deck_name}.
+    @CheckResult
+    fun toHumanReadableString() =
+        TR.browsingCardsDeletedWithDeckname(
+            count = cardsDeleted,
+            deckName = deckName,
+        )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.deckpicker
+
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.DeckPicker
+import com.ichi2.libanki.DeckId
+
+/** @see [DeckPicker] */
+class DeckPickerViewModel : ViewModel() {
+    /**
+     * Keep track of which deck was last given focus in the deck list. If we find that this value
+     * has changed between deck list refreshes, we need to recenter the deck list to the new current
+     * deck.
+     */
+    // TODO: This should later be handled as a Flow
+    var focusedDeck: DeckId = 0
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -141,7 +141,11 @@ class Decks(
         type: DeckConfigId = 0L,
     ): DeckId = id(name = name, create = true, type = type)!!
 
-    fun remove(deckIds: Iterable<Long>): OpChangesWithCount = col.backend.removeDecks(dids = deckIds)
+    /**
+     * Deletes one or more decks from the collection
+     * @return [OpChangesWithCount]: the number of cards deleted
+     */
+    fun remove(deckIds: Iterable<DeckId>): OpChangesWithCount = col.backend.removeDecks(dids = deckIds)
 
     /** A sorted sequence of deck names and IDs. */
     @LibAnkiAlias("all_names_and_ids")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -716,7 +716,7 @@ class DeckPickerTest : RobolectricTest() {
         assertThat("unbury is not visible: deck has no cards", !col.sched.haveBuried())
 
         deckPicker {
-            assertThat("deck focus is set", focusedDeck, equalTo(emptyDeck))
+            assertThat("deck focus is set", viewModel.focusedDeck, equalTo(emptyDeck))
 
             // ACT: open up the Deck Context Menu
             val deckToClick =
@@ -727,7 +727,7 @@ class DeckPickerTest : RobolectricTest() {
 
             // ASSERT
             assertThat("unbury is visible: one card is buried", col.sched.haveBuried())
-            assertThat("deck focus has changed", focusedDeck, equalTo(deckWithCards))
+            assertThat("deck focus has changed", viewModel.focusedDeck, equalTo(deckWithCards))
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -209,8 +209,7 @@ class DeckPickerTest : RobolectricTest() {
                     DeckPicker::class.java,
                     Intent(),
                 )
-            deckPicker.confirmDeckDeletion(did)
-            advanceRobolectricLooperWithSleep()
+            deckPicker.viewModel.deleteDeck(did).join()
             assertThat("deck was deleted", col.decks.count(), equalTo(1))
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -196,7 +196,7 @@ class CreateDeckDialogTest : RobolectricTest() {
 
                 // After the last deck was created, delete a deck
                 if (decksCount() >= 10) {
-                    deckPicker.confirmDeckDeletion(did)
+                    deckPicker.viewModel.deleteDeck(did).join()
                     assertEquals(deckCounter.decrementAndGet(), decksCount())
 
                     assertEquals(deckCounter.get(), decksCount())


### PR DESCRIPTION
## Purpose / Description
We want more ViewModels in 2025. Let it start

## Approach
* Extract launchCollectionInLifecycleScope
* Document `remove`
* Create class
* Bring method across

## How Has This Been Tested?
Deleted a deck in the UI of an API 34 emulator via context menu

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
