### PR TITLE
Replaced CustomStudyListener with FragmentResultApi in CustomStudyDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -24,7 +24,7 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
 import com.ichi2.utils.ExtendedFragmentFactory
 import com.ichi2.utils.FragmentFactoryUtils
@@ -41,9 +41,7 @@ import kotlin.reflect.jvm.jvmName
  *
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
-open class SingleFragmentActivity :
-    AnkiActivity(),
-    CustomStudyDialog.CustomStudyListener {
+open class SingleFragmentActivity : AnkiActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -52,7 +50,7 @@ open class SingleFragmentActivity :
         // This page *may* host the CustomStudyDialog (CongratsPage)
         // CustomStudyDialog requires a custom factory install during lifecycle or it can
         // crash during lifecycle resume after background kill
-        val customStudyDialogFactory = CustomStudyDialogFactory({ this.getColUnsafe }, this)
+        val customStudyDialogFactory = CustomStudyDialogFactory { this.getColUnsafe }
         customStudyDialogFactory.attachToActivity<ExtendedFragmentFactory>(this)
 
         super.onCreate(savedInstanceState)
@@ -80,6 +78,15 @@ open class SingleFragmentActivity :
             }
         supportFragmentManager.commit {
             replace(R.id.fragment_container, fragment, FRAGMENT_TAG)
+        }
+
+        supportFragmentManager.setFragmentResultListener(CustomStudyAction.REQUEST_KEY, this) { requestKey, bundle ->
+            when (CustomStudyAction.fromBundle(bundle)) {
+                CustomStudyAction.CUSTOM_STUDY_SESSION,
+                CustomStudyAction.EXTEND_STUDY_LIMITS,
+                ->
+                    openStudyOptionsAndFinish()
+            }
         }
     }
 
@@ -122,16 +129,6 @@ open class SingleFragmentActivity :
             }
         startActivity(intent, null)
         this.finish()
-    }
-
-    override fun onExtendStudyLimits() {
-        Timber.v("CustomStudyListener::onExtendStudyLimits()")
-        openStudyOptionsAndFinish()
-    }
-
-    override fun onCreateCustomStudySession() {
-        Timber.v("CustomStudyListener::onCreateCustomStudySession()")
-        openStudyOptionsAndFinish()
     }
 
     // END CustomStudyListener temporary implementation - should refactor out

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialogFactory.kt
@@ -16,14 +16,12 @@
 package com.ichi2.anki.dialogs.customstudy
 
 import androidx.fragment.app.Fragment
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.libanki.Collection
 import com.ichi2.utils.ExtendedFragmentFactory
 import java.util.function.Supplier
 
 class CustomStudyDialogFactory(
     val collectionSupplier: Supplier<Collection>,
-    private val customStudyListener: CustomStudyListener?,
 ) : ExtendedFragmentFactory() {
     override fun instantiate(
         classLoader: ClassLoader,
@@ -37,5 +35,5 @@ class CustomStudyDialogFactory(
         }
     }
 
-    fun newCustomStudyDialog(): CustomStudyDialog = CustomStudyDialog(collectionSupplier.get(), customStudyListener)
+    fun newCustomStudyDialog(): CustomStudyDialog = CustomStudyDialog(collectionSupplier.get())
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CongratsPage.kt
@@ -21,6 +21,7 @@ import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.setFragmentResultListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.flowWithLifecycle
@@ -36,6 +37,7 @@ import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.R
 import com.ichi2.anki.StudyOptionsActivity
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.preferences.sharedPrefs
@@ -55,7 +57,6 @@ import kotlin.math.round
 
 class CongratsPage :
     PageFragment(),
-    CustomStudyDialog.CustomStudyListener,
     ChangeManager.Subscriber {
     private val viewModel by viewModels<CongratsViewModel>()
 
@@ -110,6 +111,14 @@ class CongratsPage :
                 true
             }
         }
+
+        setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { requestKey, bundle ->
+            when (CustomStudyAction.fromBundle(bundle)) {
+                CustomStudyAction.CUSTOM_STUDY_SESSION,
+                CustomStudyAction.EXTEND_STUDY_LIMITS,
+                -> openStudyOptionsAndFinish()
+            }
+        }
     }
 
     override val bridgeCommands =
@@ -130,21 +139,10 @@ class CongratsPage :
     private fun onStudyMore() {
         val col = CollectionManager.getColUnsafe()
         val dialogFragment =
-            CustomStudyDialog(CollectionManager.getColUnsafe(), this).withArguments(
+            CustomStudyDialog(CollectionManager.getColUnsafe()).withArguments(
                 col.decks.selected(),
             )
         dialogFragment.show(childFragmentManager, null)
-    }
-
-    /******************************** CustomStudyListener methods ********************************/
-    override fun onExtendStudyLimits() {
-        Timber.v("CustomStudyListener::onExtendStudyLimits()")
-        openStudyOptionsAndFinish()
-    }
-
-    override fun onCreateCustomStudySession() {
-        Timber.v("CustomStudyListener::onCreateCustomStudySession()")
-        openStudyOptionsAndFinish()
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.Companion.toDomainModel
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialogFactory
 import com.ichi2.anki.dialogs.utils.performPositiveClick
 import com.ichi2.annotations.NeedsTest
@@ -41,7 +40,6 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiFragmentScenario
-import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.isJsonEqual
 import io.mockk.every
 import io.mockk.mockk
@@ -50,29 +48,14 @@ import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
-import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Mockito
 import org.mockito.kotlin.mock
 import org.robolectric.annotation.Config
 import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 class CustomStudyDialogTest : RobolectricTest() {
-    private var mockListener: CustomStudyListener? = null
-
-    override fun setUp() {
-        super.setUp()
-        mockListener = Mockito.mock(CustomStudyListener::class.java)
-    }
-
-    @After
-    override fun tearDown() {
-        super.tearDown()
-        Mockito.reset(mockListener)
-    }
-
     @Test
     fun `new custom study decks have expected structure - issue 6289`() =
         runTest {
@@ -244,16 +227,16 @@ class CustomStudyDialogTest : RobolectricTest() {
                 }
         }
 
-    private fun dialogFactory(col: Collection? = null) = CustomStudyDialogFactory({ col ?: this.col }, mockListener)
+    private fun dialogFactory(col: Collection? = null) = CustomStudyDialogFactory { col ?: this.col }
 
     private fun argumentsDisplayingMainScreen() =
-        CustomStudyDialog(mock(), ParametersUtils.whatever())
+        CustomStudyDialog(mock())
             .displayingMainScreen()
             .requireArguments()
 
     @Suppress("SameParameterValue")
     private fun argumentsDisplayingSubscreen(subscreen: ContextMenuOption) =
-        CustomStudyDialog(mock(), ParametersUtils.whatever())
+        CustomStudyDialog(mock())
             .displayingSubscreen(subscreen)
             .requireArguments()
 


### PR DESCRIPTION
## Purpose / Description
Replace `CustomStudyListener` with the `FragmentResultApi` to improve fragment communication.

## Fixes
* Fixes #17665

## Approach
Replaces the `CustomStudyListener` functions with `setFragmentResult` to pass `CustomStudyAction` inside a bundle. The result is then listened inside `DeckPicker` using `supportFragmentManager.setFragmentResultListener`.

## How Has This Been Tested?
Tested on Android 12

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
