### PR TITLE
Refactor image cropping fragment and remove dependency on AnkiFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -39,10 +39,8 @@ import androidx.core.content.IntentCompat
 import androidx.core.os.BundleCompat
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
-import com.canhub.cropper.CropException
 import com.google.android.material.button.MaterialButton
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.DrawingActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.multimedia.MultimediaActivity.Companion.EXTRA_MEDIA_OPTIONS
@@ -193,10 +191,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
                                 ImageCropper.CropResultData::class.java,
                             )
                         Timber.d("Cropped image data: $cropResultData")
-
-                        if (cropResultData?.error != null) {
-                            handleCropResultError(error = cropResultData.error)
-                        }
 
                         if (cropResultData?.uriPath == null || cropResultData.uriContent == null) return@registerForActivityResult
                         updateAndDisplayImageSize(cropResultData.uriPath)
@@ -642,21 +636,6 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             Timber.w(e, "Error reading SVG from URI")
             null
         }
-
-    private fun handleCropResultError(error: Exception) {
-        // cropImage can give us more information. Not sure it is actionable so for now just log it.
-        Timber.w(error, "cropImage threw an error")
-        // condition can be removed if #12768 get fixed by Canhub
-        if (error is CropException.Cancellation) {
-            Timber.i(error, "CropException caught, seemingly nothing to do ")
-        } else {
-            showErrorDialog(resources.getString(R.string.activity_result_unexpected))
-            CrashReportService.sendExceptionReport(
-                error,
-                "cropImage threw an error",
-            )
-        }
-    }
 
     /**
      * Rotate and compress the image, with the side effect of the current image being backed by a new file

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -33,6 +33,7 @@ import androidx.core.view.MenuProvider
 import com.canhub.cropper.CropImageView
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.AnkiFragment
+import com.ichi2.anki.R
 import com.ichi2.anki.snackbar.showSnackbar
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
@@ -41,13 +42,13 @@ import timber.log.Timber
  * Fragment for cropping images within the AnkiDroid, uses [CropImageView] to crop the image and
  * sends the image uri as result.
  *
- * Portions of this code were adapted from the Canub project.
+ * Portions of this code were adapted from the CanHub project.
  * Original source: https://github.com/CanHub/Android-Image-Cropper
  *
  * Attribution to the original authors of the CanHub/Android-Image-Cropper for their contributions.
  */
 class ImageCropper :
-    AnkiFragment(com.ichi2.anki.R.layout.fragment_image_cropper),
+    AnkiFragment(R.layout.fragment_image_cropper),
     CropImageView.OnSetImageUriCompleteListener,
     CropImageView.OnCropImageCompleteListener {
     private lateinit var cropImageView: CropImageView
@@ -57,16 +58,17 @@ class ImageCropper :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        cropImageView = findViewById(com.ichi2.anki.R.id.cropImageView)
-        ankiActivity.setSupportActionBar(findViewById(com.ichi2.anki.R.id.toolbar))
-        setOptions()
+        ankiActivity.setSupportActionBar(view.findViewById(R.id.toolbar))
+        cropImageView =
+            view.findViewById<CropImageView>(R.id.cropImageView).apply {
+                setOnSetImageUriCompleteListener(this@ImageCropper)
+                setOnCropImageCompleteListener(this@ImageCropper)
+                cropRect = Rect(100, 300, 500, 1200)
+                val originalImageUri =
+                    BundleCompat.getParcelable(requireArguments(), CROP_IMAGE_URI, Uri::class.java)
+                setImageUriAsync(originalImageUri)
+            }
         setUpMenu()
-        cropImageView.setOnSetImageUriCompleteListener(this)
-        cropImageView.setOnCropImageCompleteListener(this)
-
-        val originalImageUri =
-            BundleCompat.getParcelable(requireArguments(), CROP_IMAGE_URI, Uri::class.java)
-        cropImageView.setImageUriAsync(originalImageUri)
     }
 
     private fun setUpMenu() {
@@ -86,7 +88,7 @@ class ImageCropper :
                         menuItem.icon?.setTint(
                             MaterialColors.getColor(
                                 requireContext(),
-                                com.ichi2.anki.R.attr.toolbarIconColor,
+                                R.attr.toolbarIconColor,
                                 0,
                             ),
                         )
@@ -133,7 +135,7 @@ class ImageCropper :
     ) {
         if (error != null) {
             Timber.e(error, "Failed to load image by URI")
-            showSnackbar(com.ichi2.anki.R.string.something_wrong)
+            showSnackbar(R.string.something_wrong)
         }
     }
 
@@ -154,12 +156,8 @@ class ImageCropper :
             activity?.finish()
         } else {
             Timber.e(result.error, "Failed to crop image")
-            showSnackbar(com.ichi2.anki.R.string.something_wrong)
+            showSnackbar(R.string.something_wrong)
         }
-    }
-
-    private fun setOptions() {
-        cropImageView.cropRect = Rect(100, 300, 500, 1200)
     }
 
     override fun onDestroyView() {

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -27,11 +27,11 @@ import android.view.Menu
 import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import com.canhub.cropper.CropImageView
-import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.AnkiFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.snackbar.showSnackbar
@@ -58,7 +58,13 @@ class ImageCropper :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        ankiActivity.setSupportActionBar(view.findViewById(R.id.toolbar))
+        (activity as? AppCompatActivity)?.apply {
+            setSupportActionBar(view.findViewById(R.id.toolbar))
+            // there's no need for a title anyway and if we don't set it we end up with "AnkiDroid"
+            // as the title which is useless
+            supportActionBar?.title = ""
+            supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        }
         cropImageView =
             view.findViewById<CropImageView>(R.id.cropImageView).apply {
                 setOnSetImageUriCompleteListener(this@ImageCropper)
@@ -80,19 +86,8 @@ class ImageCropper :
                     menuInflater: MenuInflater,
                 ) {
                     menu.clear()
+                    // TODO make our own menu, we shouldn't rely on third party menu files
                     menuInflater.inflate(com.canhub.cropper.R.menu.crop_image_menu, menu)
-
-                    // Canhub has white color icons we need to change that
-                    for (i in 0 until menu.size()) {
-                        val menuItem = menu.getItem(i)
-                        menuItem.icon?.setTint(
-                            MaterialColors.getColor(
-                                requireContext(),
-                                R.attr.toolbarIconColor,
-                                0,
-                            ),
-                        )
-                    }
                 }
 
                 override fun onMenuItemSelected(menuItem: MenuItem): Boolean =

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -48,8 +48,6 @@ import timber.log.Timber
  */
 class ImageCropper :
     Fragment(R.layout.fragment_image_cropper),
-    CropImageView.OnSetImageUriCompleteListener,
-    CropImageView.OnCropImageCompleteListener,
     MenuProvider {
     private lateinit var cropImageView: CropImageView
 
@@ -67,8 +65,8 @@ class ImageCropper :
         }
         cropImageView =
             view.findViewById<CropImageView>(R.id.cropImageView).apply {
-                setOnSetImageUriCompleteListener(this@ImageCropper)
-                setOnCropImageCompleteListener(this@ImageCropper)
+                setOnSetImageUriCompleteListener(::onSetImageUriComplete)
+                setOnCropImageCompleteListener(::onCropImageComplete)
                 cropRect = Rect(100, 300, 500, 1200)
                 val originalImageUri =
                     BundleCompat.getParcelable(requireArguments(), CROP_IMAGE_URI, Uri::class.java)
@@ -116,9 +114,9 @@ class ImageCropper :
             else -> false
         }
 
-    override fun onSetImageUriComplete(
-        view: CropImageView,
-        uri: Uri,
+    private fun onSetImageUriComplete(
+        @Suppress("UNUSED_PARAMETER") view: CropImageView,
+        @Suppress("UNUSED_PARAMETER") uri: Uri,
         error: Exception?,
     ) {
         if (error != null) {
@@ -127,8 +125,8 @@ class ImageCropper :
         }
     }
 
-    override fun onCropImageComplete(
-        view: CropImageView,
+    private fun onCropImageComplete(
+        @Suppress("UNUSED_PARAMETER") view: CropImageView,
         result: CropImageView.CropResult,
     ) {
         if (result.error == null) {

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -30,8 +30,8 @@ import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
 import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
 import com.canhub.cropper.CropImageView
-import com.ichi2.anki.AnkiFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.snackbar.showSnackbar
 import kotlinx.parcelize.Parcelize
@@ -47,7 +47,7 @@ import timber.log.Timber
  * Attribution to the original authors of the CanHub/Android-Image-Cropper for their contributions.
  */
 class ImageCropper :
-    AnkiFragment(R.layout.fragment_image_cropper),
+    Fragment(R.layout.fragment_image_cropper),
     CropImageView.OnSetImageUriCompleteListener,
     CropImageView.OnCropImageCompleteListener,
     MenuProvider {
@@ -137,7 +137,7 @@ class ImageCropper :
                 CROP_IMAGE_RESULT,
                 CropResultData(
                     uriContent = result.uriContent,
-                    uriPath = result.getUriFilePath(ankiActivity),
+                    uriPath = context?.let { result.getUriFilePath(it) },
                 ),
             )
             activity?.setResult(Activity.RESULT_OK, resultIntent)

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -142,7 +142,16 @@ class ImageCropper :
         result: CropImageView.CropResult,
     ) {
         if (result.error == null) {
-            sendCropResult(result)
+            val resultIntent = Intent()
+            resultIntent.putExtra(
+                CROP_IMAGE_RESULT,
+                CropResultData(
+                    uriContent = result.uriContent,
+                    uriPath = result.getUriFilePath(ankiActivity),
+                ),
+            )
+            activity?.setResult(Activity.RESULT_OK, resultIntent)
+            activity?.finish()
         } else {
             Timber.e(result.error, "Failed to crop image")
             showSnackbar(com.ichi2.anki.R.string.something_wrong)
@@ -151,18 +160,6 @@ class ImageCropper :
 
     private fun setOptions() {
         cropImageView.cropRect = Rect(100, 300, 500, 1200)
-    }
-
-    private fun sendCropResult(result: CropImageView.CropResult) {
-        val resultIntent =
-            Intent().apply {
-                putExtra(
-                    CROP_IMAGE_RESULT,
-                    CropResultData(error = result.error, uriContent = result.uriContent, uriPath = result.getUriFilePath(ankiActivity)),
-                )
-            }
-        activity?.setResult(Activity.RESULT_OK, resultIntent)
-        activity?.finish()
     }
 
     override fun onDestroyView() {
@@ -185,7 +182,6 @@ class ImageCropper :
 
     @Parcelize
     data class CropResultData(
-        val error: Exception? = null,
         val uriContent: Uri? = null,
         val uriPath: String? = null,
     ) : Parcelable

--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -29,7 +29,6 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
-import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
 import com.canhub.cropper.CropImageView
 import com.ichi2.anki.AnkiFragment
@@ -50,7 +49,8 @@ import timber.log.Timber
 class ImageCropper :
     AnkiFragment(R.layout.fragment_image_cropper),
     CropImageView.OnSetImageUriCompleteListener,
-    CropImageView.OnCropImageCompleteListener {
+    CropImageView.OnCropImageCompleteListener,
+    MenuProvider {
     private lateinit var cropImageView: CropImageView
 
     override fun onViewCreated(
@@ -74,54 +74,47 @@ class ImageCropper :
                     BundleCompat.getParcelable(requireArguments(), CROP_IMAGE_URI, Uri::class.java)
                 setImageUriAsync(originalImageUri)
             }
-        setUpMenu()
+        requireActivity().addMenuProvider(this, viewLifecycleOwner)
     }
 
-    private fun setUpMenu() {
-        val menuHost: MenuHost = ankiActivity
-        menuHost.addMenuProvider(
-            object : MenuProvider {
-                override fun onCreateMenu(
-                    menu: Menu,
-                    menuInflater: MenuInflater,
-                ) {
-                    menu.clear()
-                    // TODO make our own menu, we shouldn't rely on third party menu files
-                    menuInflater.inflate(com.canhub.cropper.R.menu.crop_image_menu, menu)
-                }
-
-                override fun onMenuItemSelected(menuItem: MenuItem): Boolean =
-                    when (menuItem.itemId) {
-                        com.canhub.cropper.R.id.crop_image_menu_crop -> {
-                            Timber.d("Crop image clicked")
-                            cropImageView.croppedImageAsync()
-                            true
-                        }
-
-                        com.canhub.cropper.R.id.ic_rotate_right_24 -> {
-                            Timber.d("Rotate right clicked")
-                            cropImageView.rotateImage(90)
-                            true
-                        }
-
-                        com.canhub.cropper.R.id.ic_flip_24_horizontally -> {
-                            Timber.d("Flip horizontally clicked")
-
-                            cropImageView.flipImageHorizontally()
-                            true
-                        }
-
-                        com.canhub.cropper.R.id.ic_flip_24_vertically -> {
-                            Timber.d("Flip vertically clicked")
-                            cropImageView.flipImageVertically()
-                            true
-                        }
-
-                        else -> false
-                    }
-            },
-        )
+    override fun onCreateMenu(
+        menu: Menu,
+        menuInflater: MenuInflater,
+    ) {
+        menu.clear()
+        // TODO make our own menu, we shouldn't rely on third party menu files
+        menuInflater.inflate(com.canhub.cropper.R.menu.crop_image_menu, menu)
     }
+
+    override fun onMenuItemSelected(menuItem: MenuItem): Boolean =
+        when (menuItem.itemId) {
+            com.canhub.cropper.R.id.crop_image_menu_crop -> {
+                Timber.d("Crop image clicked")
+                cropImageView.croppedImageAsync()
+                true
+            }
+
+            com.canhub.cropper.R.id.ic_rotate_right_24 -> {
+                Timber.d("Rotate right clicked")
+                cropImageView.rotateImage(90)
+                true
+            }
+
+            com.canhub.cropper.R.id.ic_flip_24_horizontally -> {
+                Timber.d("Flip horizontally clicked")
+
+                cropImageView.flipImageHorizontally()
+                true
+            }
+
+            com.canhub.cropper.R.id.ic_flip_24_vertically -> {
+                Timber.d("Flip vertically clicked")
+                cropImageView.flipImageVertically()
+                true
+            }
+
+            else -> false
+        }
 
     override fun onSetImageUriComplete(
         view: CropImageView,

--- a/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
@@ -25,28 +25,20 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <com.google.android.material.appbar.AppBarLayout
-            android:id="@+id/app_bar"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toTopOf="@id/cropImageView"
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <com.google.android.material.appbar.MaterialToolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layout_constraintTop_toTopOf="parent"
-                app:navigationContentDescription="@string/abc_action_bar_up_description"
-                app:navigationIcon="?attr/homeAsUpIndicator" />
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:background="?attr/appBarColor"
+            android:theme="@style/ActionBarStyle"
+            app:layout_constraintTop_toTopOf="parent"/>
 
-        </com.google.android.material.appbar.AppBarLayout>
-
-        <!-- Image Cropper fill the remaining available height -->
         <com.canhub.cropper.CropImageView
             android:id="@+id/cropImageView"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintTop_toBottomOf="@id/app_bar"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -51,7 +51,6 @@
     <string name="crop_button" maxLength="28">Crop image</string>
     <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to compress it?</string>
     <string name="select_image_failed">"Select image failed, Please retry"</string>
-    <string name="activity_result_unexpected">App returned an unexpected value. You may need to use a different app</string>
     <string name="audio_recording_field_list" comment="Displays a list of the field data in the note editor while audio recording is taking place">Field Contents</string>
 
     <string name="reselect" maxLength="28">Reselect</string>


### PR DESCRIPTION
## Purpose / Description
Adds minor refactorings to improve the image cropping fragment and at the end removes the dependency on AnkiFragment. Did a bunch of smaller commits so it's easier to review, I'll squash when it's time to merge.

Before and after:
<img src="https://github.com/user-attachments/assets/d0a5b49b-228f-470e-94c6-4b7d1022cc48" width="300px" height="700px"/><img src="https://github.com/user-attachments/assets/73e9f1da-bffe-46db-bf7e-7dc10d03da86" width="300px" height="700px"/>

## How Has This Been Tested?

Ran the tests and manually tested the screen.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
