### PR TITLE
fix:focus keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -313,6 +313,7 @@ class TagsDialog : AnalyticsDialogFragment {
                 }.input(
                     hint = getString(R.string.tag_name),
                     inputType = InputType.TYPE_CLASS_TEXT,
+                    displayKeyboard = true,
                 ) { d: AlertDialog?, input: CharSequence ->
                     addTag(input.toString())
                     d?.dismiss()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Keyboard is not opening on adding tags (TagsDialog).

## Approach
Set `displayKeyboard` to true

## How Has This Been Tested?
Physical device (OPPO F21 Pro 5G).
https://github.com/user-attachments/assets/eedb754a-be65-402e-9a5e-49a3a8b49e37

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
