### PR TITLE
improvement(set-due-date): simplify for FSRS by removing "set interval to same value"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -683,10 +683,11 @@ open class Reviewer :
         }
     }
 
-    private fun showDueDateDialog() {
-        val dialog = SetDueDateDialog.newInstance(listOf(currentCardId!!))
-        showDialogFragment(dialog)
-    }
+    private fun showDueDateDialog() =
+        launchCatchingTask {
+            val dialog = SetDueDateDialog.newInstance(listOf(currentCardId!!))
+            showDialogFragment(dialog)
+        }
 
     private fun showResetCardDialog() {
         Timber.i("showResetCardDialog() Reset progress button pressed")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateViewModel.kt
@@ -44,6 +44,25 @@ class SetDueDateViewModel : ViewModel() {
     /** The cards to change the due date of */
     lateinit var cardIds: List<CardId>
 
+    /** Whether the Free Spaced Repetition Scheduler is enabled */
+    // initialized in init()
+    private var fsrsEnabled: Boolean = false
+        set(value) {
+            field = value
+            Timber.d("fsrsEnabled : %b", value)
+            if (value) {
+                Timber.d("updateIntervalToMatchDueDate forced to true: FSRS is enabled")
+                this.updateIntervalToMatchDueDate = true
+            }
+        }
+
+    /** Whether the user can set [updateIntervalToMatchDueDate] */
+    val canSetUpdateIntervalToMatchDueDate
+        // this only makes sense in SM-2, where the due date does not directly impact the next
+        // interval calculation. In FSRS, the current date is taken into account
+        // so ivl should match due date for simplicity
+        get() = !fsrsEnabled
+
     /**
      * The number of cards which will be affected
      *
@@ -75,15 +94,30 @@ class SetDueDateViewModel : ViewModel() {
             refreshIsValid()
         }
 
-    /** If `true`, the interval of the card is updated to match the calculated due date */
+    /**
+     * If `true`, the interval of the card is updated to match the calculated due date
+     *
+     * This is only supported when using SM-2. In FSRS, there's no reason for ivl != due date,
+     * as the date when a card is seen affects the scheduling.
+     *
+     * @throws UnsupportedOperationException if unset when FSRS is enabled
+     */
     var updateIntervalToMatchDueDate: Boolean = false
+        get() = if (fsrsEnabled) true else field
         set(value) {
             Timber.d("updateIntervalToMatchDueDate: %b", value)
+            if (fsrsEnabled && !value) {
+                throw UnsupportedOperationException("due date must match interval if using FSRS")
+            }
             field = value
         }
 
-    fun init(cardIds: LongArray) {
+    fun init(
+        cardIds: LongArray,
+        fsrsEnabled: Boolean,
+    ) {
         this.cardIds = cardIds.toList()
+        this.fsrsEnabled = fsrsEnabled
     }
 
     fun setNextDateRangeStart(value: Int?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -53,13 +53,18 @@ object DebugInfoService {
     }
 
     private fun isSendingCrashReports(context: Context): Boolean = CrashReportService.isAcraEnabled(context, false)
-
-    private suspend fun getFSRSStatus(): Boolean? =
-        try {
-            CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs", false) }
-        } catch (e: Throwable) {
-            // Error and Exception paths are the same, so catch Throwable
-            Timber.w(e)
-            null
-        }
 }
+
+/**
+ * Whether the Free Spaced Repetition Scheduler is enabled
+ *
+ * Note: this can return `null` if the collection is not openable
+ */
+suspend fun getFSRSStatus(): Boolean? =
+    try {
+        CollectionManager.withOpenColOrNull { config.get<Boolean>("fsrs", false) }
+    } catch (e: Throwable) {
+        // Error and Exception paths are the same, so catch Throwable
+        Timber.w(e)
+        null
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BundleUtils.kt
@@ -63,3 +63,15 @@ object BundleUtils {
             getInt(key)
         }
 }
+
+/**
+ * Retrieves a [Boolean] value from a [Bundle] using a key, throws if not found
+ *
+ * @param key A string key
+ * @return the value associated with [key]
+ * @throws IllegalStateException If [key] does not exist in the bundle
+ */
+fun Bundle.requireBoolean(key: String): Boolean {
+    check(containsKey(key)) { "key: '$key' not found" }
+    return getBoolean(key)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/SetDueDateDialogTest.kt
@@ -39,6 +39,7 @@ import org.junit.runner.RunWith
 
 @Ignore("selectTab(1) does not attach Ids")
 @NeedsTest("get the tests working")
+@NeedsTest("set interval to same value visibility with FSRS")
 @RunWith(AndroidJUnit4::class)
 class SetDueDateDialogTest : RobolectricTest() {
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
@@ -18,6 +18,8 @@ package com.ichi2.utils
 import android.os.Bundle
 import com.ichi2.utils.BundleUtils.getNullableLong
 import com.ichi2.utils.BundleUtils.requireLong
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import org.mockito.Mockito.anyString
@@ -83,6 +85,34 @@ class BundleUtilsTest {
 
         verify(mockedBundle).containsKey(eq(KEY))
         verify(mockedBundle).getLong(eq(KEY))
+
+        assertEquals(expected, value)
+    }
+
+    @Test
+    fun test_RequireBoolean_NotFound_ThrowsException() {
+        val mockedBundle = mock(Bundle::class.java)
+
+        whenever(mockedBundle.containsKey(anyString())).thenReturn(false)
+
+        val exception = assertFailsWith<IllegalStateException> { mockedBundle.requireBoolean(KEY) }
+
+        assertThat(exception.message, equalTo("key: 'KEY' not found"))
+        verify(mockedBundle).containsKey(eq(KEY))
+    }
+
+    @Test
+    fun test_RequireBoolean_Found_ReturnIt() {
+        val expected = true
+        val mockedBundle = mock(Bundle::class.java)
+
+        whenever(mockedBundle.containsKey(anyString())).thenReturn(true)
+        whenever(mockedBundle.getBoolean(anyString())).thenReturn(expected)
+
+        val value = mockedBundle.requireBoolean(KEY)
+
+        verify(mockedBundle).containsKey(eq(KEY))
+        verify(mockedBundle).getBoolean(eq(KEY))
 
         assertEquals(expected, value)
     }

--- a/testlib/src/main/java/com/ichi2/testutils/common/AnkiAssert.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/common/AnkiAssert.kt
@@ -33,6 +33,4 @@ import org.junit.function.ThrowingRunnable
 inline fun <reified T : Throwable> assertThrows(
     message: String? = null,
     runnable: ThrowingRunnable,
-) {
-    org.junit.Assert.assertThrows(message, T::class.java, runnable)
-}
+): T = org.junit.Assert.assertThrows(message, T::class.java, runnable)


### PR DESCRIPTION
## Purpose / Description
I wanted to simplify the dialog, especially explaining what "set interval to same value" due to user feedback.

But, it didn't make sense to me for FSRS.

After a sufficiently long discussion with Expertium & Jarrett, we discovered:

* Expertium previously wasn't aware of the `!` option
* This was raised as an issue previously: https://forums.ankiweb.net/t/set-due-date-doesnt-update-the-interval-of-card/52646


## Fixes
* Fixes #17707

## Approach
When FSRS is enabled, there is no reason for due date to be inconsistent with interval

So, hide 'set interval to same value' and use `true`

Confirmed by Jarrett and Expertium, paraphrased:

> Expertium: when FSRS is enabled, is there any reason for keeping `ivl` not consistent with due date? Because I'm pretty sure there isn't
> Jarrett: Yeah, there isn’t.

https://discord.com/channels/368267295601983490/1282005522513530952/1324758732122624020

## How Has This Been Tested?

Logs when FSRS enabled:

```
16:48:23.999 Scheduler               com.ichi2.anki.debug                 I  updating due date of 1 card(s) to '12!'
```

When disabled and unticked

```
16:49:50.330 Scheduler               com.ichi2.anki.debug                 I  updating due date of 1 card(s) to '12'
```

Ticking the checkbox still works

Unit tests have been added

Screenshots:

<img width="368" alt="Screenshot 2025-01-03 at 16 49 46" src="https://github.com/user-attachments/assets/7c47539c-ed4a-4a91-bbdf-746be912b6c4" />
<img width="369" alt="Screenshot 2025-01-03 at 16 48 14" src="https://github.com/user-attachments/assets/b4d3b89b-b220-4e35-9d27-475073cf2455" />

## Learning (optional, can help others)
Deep dives can improve the UX

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 1:11:33 spent on the PR & 1 comment reply, more on issue diagnostics -->