### PR TITLE
improvement(custom-study): disable unusable items

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -40,11 +40,11 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_NEW
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_REV
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_AHEAD
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_FORGOT
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_NEW
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_PREVIEW
-import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_REV
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_TAGS
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.Companion.toDomainModel
 import com.ichi2.anki.dialogs.tags.TagsDialog
@@ -192,8 +192,8 @@ class CustomStudyDialog(
                     )
                 requireActivity().showDialogFragment(dialogFragment)
             }
-            STUDY_NEW,
-            STUDY_REV,
+            EXTEND_NEW,
+            EXTEND_REV,
             STUDY_FORGOT,
             STUDY_AHEAD,
             STUDY_PREVIEW,
@@ -226,8 +226,8 @@ class CustomStudyDialog(
         ContextMenuOption.entries
             .map {
                 when (it) {
-                    STUDY_NEW -> Pair(it, defaults.extendNew.isUsable)
-                    STUDY_REV -> Pair(it, defaults.extendReview.isUsable)
+                    EXTEND_NEW -> Pair(it, defaults.extendNew.isUsable)
+                    EXTEND_REV -> Pair(it, defaults.extendReview.isUsable)
                     else -> Pair(it, true)
                 }
             }.forEach { (menuItem, isItemEnabled) ->
@@ -275,7 +275,7 @@ class CustomStudyDialog(
                 setSelectAllOnFocus(true)
                 requestFocus()
                 // a user may enter a negative value when extending limits
-                if (contextMenuOption == STUDY_NEW || contextMenuOption == STUDY_REV) {
+                if (contextMenuOption == EXTEND_NEW || contextMenuOption == EXTEND_REV) {
                     inputType = EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_FLAG_SIGNED
                 }
             }
@@ -315,8 +315,8 @@ class CustomStudyDialog(
             customStudyRequest {
                 deckId = dialogDeckId
                 when (contextMenuOption) {
-                    STUDY_NEW -> newLimitDelta = userEntry
-                    STUDY_REV -> reviewLimitDelta = userEntry
+                    EXTEND_NEW -> newLimitDelta = userEntry
+                    EXTEND_REV -> reviewLimitDelta = userEntry
                     STUDY_FORGOT -> forgotDays = userEntry
                     STUDY_AHEAD -> reviewAheadDays = userEntry
                     STUDY_PREVIEW -> previewDays = userEntry
@@ -329,7 +329,7 @@ class CustomStudyDialog(
                 collection.sched.customStudy(request)
             }
             when (contextMenuOption) {
-                STUDY_NEW, STUDY_REV ->
+                EXTEND_NEW, EXTEND_REV ->
                     customStudyListener?.onExtendStudyLimits()
                 STUDY_FORGOT, STUDY_AHEAD, STUDY_PREVIEW -> customStudyListener?.onCreateCustomStudySession()
                 STUDY_TAGS -> TODO("This branch has not been covered before")
@@ -343,7 +343,7 @@ class CustomStudyDialog(
             STUDY_FORGOT -> sharedPrefs().edit { putInt("forgottenDays", userEntry) }
             STUDY_AHEAD -> sharedPrefs().edit { putInt("aheadDays", userEntry) }
             STUDY_PREVIEW -> sharedPrefs().edit { putInt("previewDays", userEntry) }
-            STUDY_NEW, STUDY_REV -> {
+            EXTEND_NEW, EXTEND_REV -> {
                 // Nothing to do in ankidroid. The default value is provided by the backend.
             }
             STUDY_TAGS -> TODO("This branch has not been covered before")
@@ -381,8 +381,8 @@ class CustomStudyDialog(
     private val text1: String
         get() =
             when (selectedSubDialog) {
-                STUDY_NEW -> defaults.labelForNewQueueAvailable()
-                STUDY_REV -> defaults.labelForReviewQueueAvailable()
+                EXTEND_NEW -> defaults.labelForNewQueueAvailable()
+                EXTEND_REV -> defaults.labelForReviewQueueAvailable()
                 STUDY_FORGOT,
                 STUDY_AHEAD,
                 STUDY_PREVIEW,
@@ -396,8 +396,8 @@ class CustomStudyDialog(
         get() {
             val res = resources
             return when (selectedSubDialog) {
-                STUDY_NEW -> res.getString(R.string.custom_study_new_extend)
-                STUDY_REV -> res.getString(R.string.custom_study_rev_extend)
+                EXTEND_NEW -> res.getString(R.string.custom_study_new_extend)
+                EXTEND_REV -> res.getString(R.string.custom_study_rev_extend)
                 STUDY_FORGOT -> res.getString(R.string.custom_study_forgotten)
                 STUDY_AHEAD -> res.getString(R.string.custom_study_ahead)
                 STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
@@ -412,8 +412,8 @@ class CustomStudyDialog(
         get() {
             val prefs = requireActivity().sharedPrefs()
             return when (selectedSubDialog) {
-                STUDY_NEW -> defaults.extendNew.initialValue.toString()
-                STUDY_REV -> defaults.extendReview.initialValue.toString()
+                EXTEND_NEW -> defaults.extendNew.initialValue.toString()
+                EXTEND_REV -> defaults.extendReview.initialValue.toString()
                 STUDY_FORGOT -> prefs.getInt("forgottenDays", 1).toString()
                 STUDY_AHEAD -> prefs.getInt("aheadDays", 1).toString()
                 STUDY_PREVIEW -> prefs.getInt("previewDays", 1).toString()
@@ -492,10 +492,10 @@ class CustomStudyDialog(
         val getTitle: Resources.() -> String,
     ) {
         /** Increase today's new card limit */
-        STUDY_NEW({ TR.customStudyIncreaseTodaysNewCardLimit() }),
+        EXTEND_NEW({ TR.customStudyIncreaseTodaysNewCardLimit() }),
 
         /** Increase today's review card limit */
-        STUDY_REV({ TR.customStudyIncreaseTodaysReviewCardLimit() }),
+        EXTEND_REV({ TR.customStudyIncreaseTodaysReviewCardLimit() }),
 
         /** Review forgotten cards */
         STUDY_FORGOT({ TR.customStudyReviewForgottenCards() }),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -184,7 +184,7 @@ class SetDueDateDialog : DialogFragment() {
 
     companion object {
         const val ARG_CARD_IDS = "ARGS_CARD_IDS"
-        const val MAX_WIDTH_DP = 450
+        const val MAX_WIDTH_DP = 450f
 
         @CheckResult
         fun newInstance(cardIds: List<CardId>) =
@@ -309,5 +309,5 @@ private fun AnkiActivity.updateDueDate(viewModel: SetDueDateViewModel) =
         showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
     }
 
-// TODO: See if we can turn this to a `val` when context parameters are back
-fun Int.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density + 0.5f).toInt()
+// TODO: better to use 16.dp ... toPx(context)
+fun Float.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density + 0.5f).toInt()

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
@@ -17,11 +17,13 @@
 package com.ichi2.utils
 
 import android.app.Activity
+import android.content.Context
 import android.graphics.Rect
 import android.view.MotionEvent
 import android.view.View
 import androidx.core.view.OnReceiveContentListener
 import androidx.draganddrop.DropHelper
+import com.ichi2.anki.scheduling.dpToPx
 
 /** @see View.performClick */
 fun View.performClickIfEnabled() {
@@ -65,4 +67,57 @@ fun View.configureView(
         options,
         onReceiveContentListener,
     )
+}
+
+/**
+ * Sets the relative padding for all dimensions of the view
+ *
+ * The view may add on the space required to display the scrollbars,
+ * depending on the style and visibility of the scrollbars.
+ * So the values returned from `getPadding` calls
+ * may be different from the values set in this call.
+ */
+fun View.setPaddingRelative(px: Int) = setPaddingRelative(px, px, px, px)
+
+/**
+ * Sets the relative padding for all dimensions of the view
+ *
+ * The view may add on the space required to display the scrollbars,
+ * depending on the style and visibility of the scrollbars.
+ * So the values returned from `getPadding` calls
+ * may be different from the values set in this call.
+ */
+@Suppress("unused")
+fun View.setPaddingRelative(dp: Dp) = setPaddingRelative(dp.toPx(context))
+
+/**
+ * Sets the relative padding
+ *
+ * The view may add on the space required to display the scrollbars,
+ * depending on the style and visibility of the scrollbars.
+ * So the values returned from `getPadding` calls
+ * may be different from the values set in this call.
+ */
+// Since we're in Kotlin, this now allows named arguments!
+@Suppress("unused")
+fun View.setPaddingRelative(
+    start: Dp,
+    top: Dp,
+    end: Dp,
+    bottom: Dp,
+) = setPaddingRelative(start.toPx(context), top.toPx(context), end.toPx(context), bottom.toPx(context))
+
+/** Returns a [Dp] instance equal to this [Int] number of display pixels. */
+val Int.dp
+    get() = Dp(dp = this.toFloat())
+
+/**
+ * Helper for 'display pixels' to 'pixels' conversions
+ */
+@JvmInline
+value class Dp(
+    val dp: Float,
+) {
+    // TODO: improve once we have context parameters
+    fun toPx(context: Context) = dp.dpToPx(context)
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -136,7 +136,7 @@ class CustomStudyDialogTest : RobolectricTest() {
 
         // extend limits with a value of '1'
         withCustomStudyFragment(
-            args = argumentsDisplayingSubscreen(ContextMenuOption.STUDY_NEW),
+            args = argumentsDisplayingSubscreen(ContextMenuOption.EXTEND_NEW),
         ) { dialogFragment: CustomStudyDialog ->
 
             onSubscreenEditText()
@@ -154,7 +154,7 @@ class CustomStudyDialogTest : RobolectricTest() {
 
         // ensure 'newExtendByValue' is used by our UI
         withCustomStudyFragment(
-            args = argumentsDisplayingSubscreen(ContextMenuOption.STUDY_NEW),
+            args = argumentsDisplayingSubscreen(ContextMenuOption.EXTEND_NEW),
         ) { dialogFragment: CustomStudyDialog ->
             onSubscreenEditText()
                 .check(matches(withText(newExtendByValue.toString())))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -19,10 +19,9 @@ import android.os.Bundle
 import androidx.appcompat.app.AlertDialog
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.replaceText
-import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.RootMatchers.isDialog
-import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -47,6 +46,7 @@ import com.ichi2.testutils.isJsonEqual
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
@@ -172,7 +172,7 @@ class CustomStudyDialogTest : RobolectricTest() {
         ) { dialogFragment: CustomStudyDialog ->
             onView(withText(TR.customStudyIncreaseTodaysNewCardLimit()))
                 .inRoot(isDialog())
-                .check(matches(isDisplayed()))
+                .check(matches(isEnabled()))
         }
     }
 
@@ -187,7 +187,7 @@ class CustomStudyDialogTest : RobolectricTest() {
         ) { dialogFragment: CustomStudyDialog ->
             onView(withText(TR.customStudyIncreaseTodaysNewCardLimit()))
                 .inRoot(isDialog())
-                .check(doesNotExist())
+                .check(matches(not(isEnabled())))
         }
     }
 
@@ -202,7 +202,7 @@ class CustomStudyDialogTest : RobolectricTest() {
         ) { dialogFragment: CustomStudyDialog ->
             onView(withText(TR.customStudyIncreaseTodaysReviewCardLimit()))
                 .inRoot(isDialog())
-                .check(matches(isDisplayed()))
+                .check(matches(isEnabled()))
         }
     }
 
@@ -217,7 +217,7 @@ class CustomStudyDialogTest : RobolectricTest() {
         ) { dialogFragment: CustomStudyDialog ->
             onView(withText(TR.customStudyIncreaseTodaysReviewCardLimit()))
                 .inRoot(isDialog())
-                .check(doesNotExist())
+                .check(matches(not(isEnabled())))
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It was requested that the unusable items were disabled rather than removed

## Issue

* Fixes https://github.com/ankidroid/Anki-Android/issues/17666

## Approach
Use a custom `ListView` to make it happen, styled the same as the standard one, because clicking on the standard one closes the dialog
Then style it the same
Then handle disabling ripple effects

## How Has This Been Tested?
<img src="https://github.com/user-attachments/assets/b7b92027-d332-4986-bef1-a33b34203f24" width=200px />

## Learning (optional, can help others)
Android is no fun. This took too long

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


<!-- Time on PR: 1h12m -->