### PR TITLE
convert Deck to strongly typed value class

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -932,7 +932,7 @@ class ContentProviderTest : InstrumentedTest() {
                 assertNotNull("Check that the deck we received actually exists", deck)
                 assertEquals(
                     "Check that the received deck has the correct name",
-                    deck.getString("name"),
+                    deck.name,
                     deckName,
                 )
             }
@@ -966,7 +966,7 @@ class ContentProviderTest : InstrumentedTest() {
                 )
                 assertEquals(
                     "Check that received deck name equals real deck name",
-                    realDeck.getString("name"),
+                    realDeck.name,
                     returnedDeckName,
                 )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -58,6 +58,8 @@ class FilteredDeckOptions :
     val filteredDeck: FilteredDeck
         get() = super.deck as FilteredDeck
 
+    lateinit var secondFilterSign: CheckBoxPreference
+
     // TODO: not anymore used in libanki?
     private val dynExamples =
         arrayOf(
@@ -123,9 +125,8 @@ class FilteredDeckOptions :
                         "search" -> {
                             filteredDeck.firstFilter.search = value as String
                         }
-
                         "limit" -> {
-                            filteredDeck.firstFilter.limit = value as Int
+                            filteredDeck.firstFilter.limit = (value as String).toInt()
                         }
                         "order" -> {
                             filteredDeck.firstFilter.order = (value as String).toInt()
@@ -154,7 +155,7 @@ class FilteredDeckOptions :
                             }
                         }
                         "steps" -> {
-                            filteredDeck.delays = convertToJSON((value as String))
+                            filteredDeck.delays = convertToJSON(value as String)
                         }
                         "preset" -> {
                             val i: Int = (value as String).toInt()
@@ -223,8 +224,10 @@ class FilteredDeckOptions :
         deck = if (extras != null && extras.containsKey(EXTRAS_DECK_ID)) {
             col.decks.getLegacy(extras.getLong(EXTRAS_DECK_ID))
         } else {
+            Timber.d("no deckId supplied. Using current deck")
             null
         } ?: col.decks.current()
+        Timber.i("opened for deck %d", deck.id)
         registerExternalStorageListener()
         if (deck.isRegular) {
             Timber.w("Deck is not a dyn deck")
@@ -361,7 +364,7 @@ class FilteredDeckOptions :
 
     @Suppress("deprecation")
     private fun setupSecondFilterListener() {
-        val secondFilterSign = findPreference("filterSecond") as CheckBoxPreference
+        secondFilterSign = findPreference("filterSecond") as CheckBoxPreference
         val secondFilter = findPreference("secondFilter") as PreferenceCategory
         if (pref.hasSecondFilter) {
             secondFilter.isEnabled = true
@@ -416,5 +419,23 @@ class FilteredDeckOptions :
             deckId?.let { putExtra(EXTRAS_DECK_ID, it) }
             searchTerms?.let { putExtra(EXTRAS_SEARCH, it) }
         }
+
+        const val SEARCH = "search"
+        const val LIMIT = "limit"
+        const val ORDER = "order"
+        const val SEARCH_2 = "search_2"
+        const val LIMIT_2 = "limit_2"
+        const val ORDER_2 = "order_2"
+        const val STEPS = "steps"
+        const val STEPS_ON = "stepsOn"
+        const val PRESET = "preset"
+
+        fun createIntent(
+            context: Context,
+            did: DeckId,
+        ): Intent =
+            Intent(context, FilteredDeckOptions::class.java).apply {
+                putExtra("did", did)
+            }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -62,13 +62,13 @@ class FilteredDeckOptions :
     private val dynExamples =
         arrayOf(
             null,
-            "{'search'=\"is:new\", 'resched'=False, 'steps'=\"1\", 'order'=5}",
-            "{'search'=\"added:1\", 'resched'=False, 'steps'=\"1\", 'order'=5}",
-            "{'search'=\"rated:1:1\", 'order'=4}",
-            "{'search'=\"prop:due<=2\", 'order'=6}",
-            "{'search'=\"is:due tag:TAG\", 'order'=6}",
-            "{'search'=\"is:due\", 'order'=3}",
-            "{'search'=\"\", 'steps'=\"1 10 20\", 'order'=0}",
+            """{'search'="is:new", 'resched'=False, 'steps'="1", 'order'=5}""",
+            """{'search'="added:1", 'resched'=False, 'steps'="1", 'order'=5}""",
+            """{'search'="rated:1:1", 'order'=4}""",
+            """{'search'="prop:due<=2", 'order'=6}""",
+            """{'search'="is:due tag:TAG", 'order'=6}""",
+            """{'search'="is:due", 'order'=3}""",
+            """{'search'="", 'steps'="1 10 20", 'order'=0}""",
         )
 
     inner class DeckPreferenceHack : AppCompatPreferenceActivity<FilteredDeckOptions.DeckPreferenceHack>.AbstractPreferenceHack() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2759,7 +2759,7 @@ class NoteEditorFragment :
 
         getColUnsafe.notetypes.setCurrent(noteType)
         val currentDeck = getColUnsafe.decks.current()
-        currentDeck.put("mid", newId)
+        currentDeck.noteTypeId = newId
         getColUnsafe.decks.save(currentDeck)
 
         // Update deck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -115,6 +115,7 @@ import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.anki.libanki.Notetypes.Companion.NOT_FOUND_NOTE_TYPE
+import com.ichi2.anki.libanki.RegularDeck
 import com.ichi2.anki.libanki.Utils
 import com.ichi2.anki.libanki.clozeNumbersInNote
 import com.ichi2.anki.model.CardStateFilter
@@ -2758,7 +2759,7 @@ class NoteEditorFragment :
         }
 
         getColUnsafe.notetypes.setCurrent(noteType)
-        val currentDeck = getColUnsafe.decks.current()
+        val currentDeck = getColUnsafe.decks.current() as RegularDeck
         currentDeck.noteTypeId = newId
         getColUnsafe.decks.save(currentDeck)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -433,8 +433,8 @@ class StudyOptionsFragment :
             if (loadWithDeckOptions) {
                 loadWithDeckOptions = false
                 val deck = col!!.decks.current()
-                if (deck.isFiltered && deck.has("empty")) {
-                    deck.remove("empty")
+                if (deck.isFiltered && deck.hasEmpty()) {
+                    deck.removeEmpty()
                 }
                 launchCatchingTask { rebuildCram() }
             } else {
@@ -564,7 +564,7 @@ class StudyOptionsFragment :
             // Set the deck name
             val deck = col.decks.current()
             // Main deck name
-            val fullName = deck.getString("name")
+            val fullName = deck.name
             val name = Decks.path(fullName)
             val nameBuilder = StringBuilder()
             if (name.isNotEmpty()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -109,7 +109,7 @@ class DeckPickerViewModel(
             if (tree == null) return@combine FlattenedDeckList.empty
 
             // TODO: use flowOfFocusedDeck once it's set on all instances
-            val currentDeckId = withCol { decks.current().getLong("id") }
+            val currentDeckId = withCol { decks.current().id }
             Timber.i("currentDeckId: %d", currentDeckId)
 
             FlattenedDeckList(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -983,7 +983,7 @@ class CardContentProvider : ContentProvider() {
                     try {
                         val deckDesc = values.getAsString(FlashCardsContract.Deck.DECK_DESC)
                         if (deckDesc != null) {
-                            deck.put("desc", deckDesc)
+                            deck.description = deckDesc
                         }
                     } catch (e: JSONException) {
                         Timber.e(e, "Could not set a field of new deck %s", deckName)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -149,7 +149,7 @@ class ReminderService : BroadcastReceiver() {
             for (node in dues) {
                 val deck: Deck? = col.decks.getLegacy(node.did)
                 // Dynamic deck has no "conf", so are not added here.
-                if (deck != null && deck.optLong("conf") == dConfId) {
+                if (deck != null && deck.conf == dConfId) {
                     decks.add(node)
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/ReminderService.kt
@@ -27,10 +27,10 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.libanki.Collection
-import com.ichi2.anki.libanki.Deck
 import com.ichi2.anki.libanki.DeckConfigId
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.sched.DeckNode
+import com.ichi2.anki.libanki.RegularDeck
 import timber.log.Timber
 
 class ReminderService : BroadcastReceiver() {
@@ -147,7 +147,7 @@ class ReminderService : BroadcastReceiver() {
             val decks: MutableList<DeckNode> = ArrayList(dues.size)
             // This loop over top level deck only. No notification will ever occur for subdecks.
             for (node in dues) {
-                val deck: Deck? = col.decks.getLegacy(node.did)
+                val deck: RegularDeck? = col.decks.getLegacy(node.did) as? RegularDeck
                 // Dynamic deck has no "conf", so are not added here.
                 if (deck != null && deck.conf == dConfId) {
                     decks.add(node)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/JSONObject.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/JSONObject.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import org.json.JSONObject
+
+/**
+ * @return `null` if:
+ * * The key does not exist
+ * * The value is [null][JSONObject.NULL]
+ * * ⚠️ JVM only. The value is not a string (`{ }` etc...)
+ * Otherwise, returns the value mapped by [key]. In Android, that means the potentially non-string
+ * value is converted to string first.
+ */
+fun JSONObject.getStringOrNull(key: String): String? {
+    if (!has(key)) return null
+    if (isNull(key)) return null
+    return try {
+        // Note that [JSONObject]'s [getString] behavior differs between JVM and Android.
+        // In Android, the value is converted to string before being returned.
+        // In the JVM, a non string value is ignored and null is returned.
+        getString(key)
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -87,7 +87,7 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     // Instead we use a backing field.
     // We can't use `_deck` as this is only allowed for public properties.
     private var deckBackupField: Deck? = null
-    protected var deck: Deck
+    protected open var deck: Deck
         get() = deckBackupField!!
         set(value) {
             deckBackupField = value

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -82,7 +82,16 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     protected lateinit var col: Collection
         private set
     protected lateinit var pref: PreferenceHack
-    protected lateinit var deck: Deck
+
+    // value class can't be lateinit.
+    // Instead we use a backing field.
+    // We can't use `_deck` as this is only allowed for public properties.
+    private var deckBackupField: Deck? = null
+    protected var deck: Deck
+        get() = deckBackupField!!
+        set(value) {
+            deckBackupField = value
+        }
 
     abstract inner class AbstractPreferenceHack : SharedPreferences {
         val values: MutableMap<String, String> = HashUtil.hashMapInit(30) // At most as many as in cacheValues

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -36,6 +36,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.window.OnBackInvokedDispatcher.PRIORITY_OVERLAY
 import androidx.annotation.LayoutRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDelegate
@@ -81,7 +82,9 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
     private lateinit var unmountReceiver: BroadcastReceiver
     protected lateinit var col: Collection
         private set
-    protected lateinit var pref: PreferenceHack
+
+    @VisibleForTesting
+    internal lateinit var pref: PreferenceHack
 
     // value class can't be lateinit.
     // Instead we use a backing field.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/FilteredDeckOptionsTest.kt
@@ -1,0 +1,187 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.FilteredDeckOptions.Companion.LIMIT
+import com.ichi2.anki.FilteredDeckOptions.Companion.LIMIT_2
+import com.ichi2.anki.FilteredDeckOptions.Companion.ORDER
+import com.ichi2.anki.FilteredDeckOptions.Companion.ORDER_2
+import com.ichi2.anki.FilteredDeckOptions.Companion.SEARCH
+import com.ichi2.anki.FilteredDeckOptions.Companion.SEARCH_2
+import com.ichi2.anki.FilteredDeckOptions.Companion.STEPS
+import com.ichi2.anki.FilteredDeckOptions.Companion.STEPS_ON
+import com.ichi2.anki.FlashCardsContract.Note.MOD
+import com.ichi2.anki.FlashCardsContract.Note.USN
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.libanki.FilteredDeck
+import com.ichi2.testutils.isJsonHolderEqual
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.not
+import org.intellij.lang.annotations.Language
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FilteredDeckOptionsTest : RobolectricTest() {
+    companion object {
+        const val LRN_TODAY = "lrnToday"
+        const val REV_TODAY = "revToday"
+        const val NEW_TODAY = "newToday"
+        const val TIME_TODAY = "timeToday"
+        const val SEPARATE = "separate"
+        const val PREVIEW_DELAY = "previewDelay"
+        const val SEARCH = "search"
+        const val LIMIT = "limit"
+        const val ORDER = "order"
+        const val SEARCH_2 = "search_2"
+        const val LIMIT_2 = "limit_2"
+        const val ORDER_2 = "order_2"
+        const val STEPS = "steps"
+        const val STEPS_ON = "stepsOn"
+        const val PRESET = "preset"
+        const val DYN = "dyn"
+        const val NAME = "name"
+        const val BROWSER_COLLAPSED = "browserCollapsed"
+        const val COLLAPSED = "collapsed"
+        const val ID = "id"
+        const val DESCRIPTION = "desc"
+        const val RESCHED = "resched"
+        const val PREVIEW_AGAIN_SECS = "previewAgainSecs"
+        const val PREVIEW_HARD_SECS = "previewHardSecs"
+        const val PREVIEW_GOOD_SECS = "previewGoodSecs"
+        const val DELAYS = "delays"
+        const val TERMS = "terms"
+        const val EMPTY = "empty"
+    }
+
+    @Test
+    fun `integration test`() {
+        @Language("JSON")
+        val expected =
+            FilteredDeck(
+                """{
+                    "$ID" : 1737164378146,
+                    "$MOD" : 1737164378,
+                    "$NAME" : "Filtered",
+                    "$USN" : -1,
+                    "$LRN_TODAY" : [0,0],
+                    "$REV_TODAY" : [0,0],
+                    "$NEW_TODAY" : [0,0],
+                    "$TIME_TODAY" : [0,0],
+                    "$COLLAPSED" : false,
+                    "$BROWSER_COLLAPSED" : false,
+                    "$DESCRIPTION" : "",
+                    "$DYN" : 1,
+                    "$RESCHED" : true,
+                    "$TERMS" : [["", 100, 0]],
+                    "$SEPARATE" : true,
+                    "$DELAYS" : null,
+                    "$PREVIEW_DELAY" : 0,
+                    "$PREVIEW_AGAIN_SECS" : 60,
+                    "$PREVIEW_HARD_SECS" : 600,
+                    "$PREVIEW_GOOD_SECS" : 0
+                   }""",
+            )
+        assertThat("should not be using default deck", filteredDeckConfig.id, not(equalTo(Consts.DEFAULT_DECK_ID)))
+        assertThat("before", filteredDeckConfig.removeNonDeterministicValues(), isJsonHolderEqual(expected.removeNonDeterministicValues()))
+
+        withFilteredDeckOptions(newFilteredDeckId) {
+            @Suppress("DEPRECATION")
+            secondFilterSign.onPreferenceChangeListener.onPreferenceChange(null, true)
+            pref.edit(commit = true) {
+                putString(SEARCH_2, "search_2")
+                putString(LIMIT_2, "42")
+                putString(ORDER_2, "43")
+                putString(SEARCH, "search_1")
+                putString(LIMIT, "44")
+                putString(ORDER, "45")
+                putBoolean(RESCHED, false)
+                putInt(PREVIEW_AGAIN_SECS, 46)
+                putInt(PREVIEW_HARD_SECS, 47)
+                putInt(PREVIEW_GOOD_SECS, 48)
+                putBoolean(STEPS_ON, true)
+                putString(STEPS, "50 51 52")
+                // TODO: Create a test for PRESET
+            }
+        }
+
+        val updatedExpectation =
+            expected
+                .copyWith {
+                    val firstFilter = JSONArray(listOf("search_1", 44, 45))
+                    val secondFilter = JSONArray(listOf("search_2", 42, 43)) //
+                    it.put(TERMS, JSONArray(listOf(firstFilter, secondFilter)))
+                    it.put(RESCHED, false)
+                    it.put(PREVIEW_AGAIN_SECS, 46)
+                    it.put(PREVIEW_HARD_SECS, 47)
+                    it.put(PREVIEW_GOOD_SECS, 48)
+                    it.put(DELAYS, JSONArray(listOf(50, 51, 52)))
+                }
+        assertThat(
+            "after",
+            filteredDeckConfig.removeNonDeterministicValues(),
+            isJsonHolderEqual(updatedExpectation.removeNonDeterministicValues()),
+        )
+    }
+
+    /**
+     * A copy of [this] without its "id" and "mod" keys.
+     * Those two keys are the only non deterministic values, removing them allows to compare the returned value to some expected deck.
+     */
+    fun FilteredDeck.removeNonDeterministicValues() =
+        this.copyWith { copy ->
+            copy.remove("id")
+            copy.remove("mod")
+        }
+
+    /**
+     * The result of applying [block] to [this], leaving the input unchanged.
+     */
+    fun FilteredDeck.copyWith(block: (JSONObject) -> Unit) =
+        FilteredDeck(this.toString()).apply {
+            block(jsonObject)
+        }
+
+    private fun withFilteredDeckOptions(
+        deckId: DeckId,
+        block: FilteredDeckOptions.() -> Unit,
+    ) {
+        startRegularActivity<FilteredDeckOptions>(FilteredDeckOptions.createIntent(targetContext, deckId)).apply(block)
+    }
+
+    /**
+     * A filtered deck named "Filtered" with default config, always the same deck during a test.
+     */
+    private val filteredDeckConfig
+        get() =
+            newFilteredDeckId.let { did ->
+                col.decks.getLegacy(did) as FilteredDeck
+            }
+
+    /**
+     * The deck id of a fresh filtered deck. The deck is created the first time this value is accessed, the id is then constant.*/
+    private val newFilteredDeckId by lazy { col.decks.newFiltered("Filtered") }
+
+    private val defaultDeckConfig
+        get() = col.decks.configDictForDeckId(Consts.DEFAULT_DECK_ID)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
@@ -276,7 +277,7 @@ open class RobolectricTest :
         }
 
         @JvmStatic // Using protected members which are not @JvmStatic in the superclass companion is unsupported yet
-        protected fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(
+        protected fun <T : Activity?> startActivityNormallyOpenCollectionWithIntent(
             testClass: RobolectricTest,
             clazz: Class<T>?,
             i: Intent?,
@@ -351,14 +352,14 @@ open class RobolectricTest :
         return collectionModels.byName(noteTypeName)!!.deepClone()
     }
 
-    internal fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(
+    internal fun <T : Activity?> startActivityNormallyOpenCollectionWithIntent(
         clazz: Class<T>?,
         i: Intent?,
     ): T = startActivityNormallyOpenCollectionWithIntent(this, clazz, i)
 
-    internal inline fun <reified T : AnkiActivity?> startRegularActivity(): T = startRegularActivity(null)
+    internal inline fun <reified T : Activity?> startRegularActivity(): T = startRegularActivity(null)
 
-    internal inline fun <reified T : AnkiActivity?> startRegularActivity(i: Intent? = null): T =
+    internal inline fun <reified T : Activity?> startRegularActivity(i: Intent? = null): T =
         startActivityNormallyOpenCollectionWithIntent(T::class.java, i)
 
     fun equalFirstField(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -99,7 +99,7 @@ class CreateDeckDialogTest : RobolectricTest() {
         ensureExecutionOfScenario(DeckDialogType.DECK) { createDeckDialog, assertionCalled ->
             createDeckDialog.onNewDeckCreated = { id: DeckId ->
                 // a deck was created
-                assertThat(id, equalTo(col.decks.byName(deckName)!!.getLong("id")))
+                assertThat(id, equalTo(col.decks.byName(deckName)!!.id))
                 assertionCalled()
             }
             createDeckDialog.createDeck(deckName)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -38,8 +38,8 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.
 import com.ichi2.anki.dialogs.utils.performPositiveClick
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Consts
-import com.ichi2.anki.libanki.Deck
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.libanki.FilteredDeck
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiFragmentScenario
 import com.ichi2.testutils.isJsonHolderEqual
@@ -81,7 +81,7 @@ class CustomStudyDialogTest : RobolectricTest() {
             // Putting in the Strings value that AnkiDroid currently don't allow to configure.
             // Using setters when possible.
             val expected =
-                Deck(
+                FilteredDeck(
                     """
                 {
                     "lrnToday": [0, 0],
@@ -103,7 +103,7 @@ class CustomStudyDialogTest : RobolectricTest() {
                     previewHardSecs = 600
                     previewGoodSecs = 0
                     resched = false
-                    terms = JSONArray(listOf(Deck.Term("is:new added:1 deck:Default", 99999, 5).array))
+                    terms = JSONArray(listOf(FilteredDeck.Term("is:new added:1 deck:Default", 99999, 5).array))
                 }
             assertThat(expected, isJsonHolderEqual(customStudy))
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -38,17 +38,17 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.
 import com.ichi2.anki.dialogs.utils.performPositiveClick
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.Deck
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiFragmentScenario
-import com.ichi2.testutils.isJsonEqual
+import com.ichi2.testutils.isJsonHolderEqual
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
-import org.intellij.lang.annotations.Language
-import org.json.JSONObject
+import org.json.JSONArray
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -74,37 +74,38 @@ class CustomStudyDialogTest : RobolectricTest() {
             assertThat("Custom Study should be filtered", customStudy.isFiltered)
 
             // remove timestamps to allow us to compare JSON
-            customStudy.remove("id")
-            customStudy.remove("mod")
-            customStudy.remove("name")
+            customStudy.jsonObject.remove("id")
+            customStudy.jsonObject.remove("mod")
+            customStudy.jsonObject.remove("name")
 
-            // compare JSON
-            @Language("json")
+            // Putting in the Strings value that AnkiDroid currently don't allow to configure.
+            // Using setters when possible.
             val expected =
-                """
+                Deck(
+                    """
                 {
-                    "browserCollapsed": true,
-                    "collapsed": true,
-                    "delays": null,
-                    "desc": "",
-                    "dyn": 1,
                     "lrnToday": [0, 0],
                     "newToday": [0, 0],
                     "previewDelay": 10,
-                    "previewAgainSecs": 60,
-                    "previewHardSecs": 600,
-                    "previewGoodSecs": 0,
-                    "resched": false,
                     "revToday": [0, 0],
                     "separate": true,
-                    "terms": [
-                        ["is:new added:1 deck:Default", 99999, 5]
-                    ],
                     "timeToday": [0, 0],
                     "usn": -1
+                    }
+                    """,
+                ).apply {
+                    browserCollapsed = true
+                    collapsed = true
+                    delays = null
+                    description = ""
+                    isFiltered = true
+                    previewAgainSecs = 60
+                    previewHardSecs = 600
+                    previewGoodSecs = 0
+                    resched = false
+                    terms = JSONArray(listOf(Deck.Term("is:new added:1 deck:Default", 99999, 5).array))
                 }
-                """.trimIndent()
-            assertThat(customStudy, isJsonEqual(JSONObject(expected)))
+            assertThat(expected, isJsonHolderEqual(customStudy))
         }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -78,3 +78,5 @@ private fun jsonObjectOf(vararg pairs: Pair<String, Any>): JSONObject =
             put(key, value)
         }
     }
+
+fun isJsonHolderEqual(expectedValue: JSONObjectHolder) = IsJsonHolderEqual(expectedValue.jsonObject)

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
@@ -16,60 +16,206 @@
 
 package com.ichi2.anki.libanki
 
+import androidx.annotation.VisibleForTesting
 import anki.decks.Deck.Filtered.SearchTerm.Order
-import com.ichi2.anki.common.utils.ext.deepClonedInto
+import com.ichi2.anki.common.json.JSONObjectHolder
 import net.ankiweb.rsdroid.Translations
+import org.json.JSONArray
 import org.json.JSONObject
+import org.json.JSONObject.NULL
 
-class Deck : JSONObject {
-    /**
-     * Creates a copy from [JSONObject] and use it as a string
-     *
-     * This function will perform deepCopy on the passed object
-     *
-     * If you want to create a Deck without deepCopy
-     * @see Deck.from
-     */
-    constructor(json: JSONObject) : super() {
-        json.deepClonedInto(this)
-    }
-
+@JvmInline
+value class Deck(
+    @VisibleForTesting override val jsonObject: JSONObject,
+) : JSONObjectHolder {
     /**
      * Creates a deck object form a json string
      */
-    constructor(json: String) : super(json)
+    constructor(json: String) : this(JSONObject(json))
 
-    val isFiltered: Boolean
-        get() = getInt("dyn") != 0
+    /**
+     * Whether this deck is a filtered deck.
+     */
+    var isFiltered: Boolean
+        get() = jsonObject.getInt("dyn") != 0
 
-    val isNormal: Boolean
+        @VisibleForTesting
+        set(value) {
+            jsonObject.put("dyn", if (value) 1 else 0)
+        }
+
+    /**
+     * Whether this deck is a normal deck. That is, not a filtered deck.
+     */
+    var isNormal: Boolean
         get() = !isFiltered
 
+        @VisibleForTesting
+        set(value) {
+            isFiltered = !value
+        }
+
+    /**
+     * The name of the deck. Mutable. If you want a way to persistently represents this deck, use [id] instead.
+     */
     var name: String
-        get() = getString("name")
+        get() = jsonObject.getString("name")
         set(value) {
-            put("name", value)
+            jsonObject.put("name", value)
         }
 
+    /**
+     * If this deck as subdecks, whether those subdecks should be collapsed in the desktop card browser.
+     * Not used in ankidroid at the moment.
+     */
+    var browserCollapsed: Boolean
+        get() = jsonObject.getBoolean("browserCollapsed")
+        set(value) {
+            jsonObject.put("browserCollapsed", value)
+        }
+
+    /**
+     * If this deck as subdecks, whether those subdecks should be collapsed in the deck picker.
+     */
     var collapsed: Boolean
-        get() = getBoolean("collapsed")
+        get() = jsonObject.getBoolean("collapsed")
         set(value) {
-            put("collapsed", value)
+            jsonObject.put("collapsed", value)
         }
 
+    /**
+     * The id of the deck. Should be globally unique
+     * (created as a timestamp, very small chance of collision between two different decks from different users)
+     */
     var id: DeckId
-        get() = getLong("id")
+        get() = jsonObject.getLong("id")
         set(value) {
-            put("id", value)
+            jsonObject.put("id", value)
         }
 
-    var conf: Long
+    /**
+     * The id of the deck option.
+     */
+    var conf: DeckConfigId
         get() {
-            val value = optLong("conf")
+            val value = jsonObject.optLong("conf")
             return if (value > 0) value else 1
         }
         set(value) {
-            put("conf", value)
+            jsonObject.put("conf", value)
+        }
+
+    var noteTypeId: NoteTypeId?
+        get() = jsonObject.getLongOrNull("mid")
+        set(value) {
+            jsonObject.put("mid", value)
+        }
+
+    var resched: Boolean
+        get() = jsonObject.getBoolean("resched")
+        set(value) {
+            jsonObject.put("resched", value)
+        }
+
+    var previewAgainSecs: Int
+        get() = jsonObject.getInt("previewAgainSecs")
+        set(value) {
+            jsonObject.put("previewAgainSecs", value)
+        }
+    var previewHardSecs: Int
+        get() = jsonObject.getInt("previewHardSecs")
+        set(value) {
+            jsonObject.put("previewHardSecs", value)
+        }
+    var previewGoodSecs: Int
+        get() = jsonObject.getInt("previewGoodSecs")
+        set(value) {
+            jsonObject.put("previewGoodSecs", value)
+        }
+
+    /**
+     * An array of string. The i-th string correspond to the number of second/minute/hour or day for the i-th learning steps.
+     * See https://docs.ankiweb.net/deck-options.html#learning-steps
+     */
+    var delays: JSONArray?
+        get() = jsonObject.optJSONArray("delays")
+        set(value) {
+            jsonObject.put("delays", value ?: NULL)
+        }
+
+    fun removeEmpty() {
+        jsonObject.remove("empty")
+    }
+
+    fun hasEmpty() = jsonObject.has("empty")
+
+    /**
+     * The options configuring which cards are shown in a filtered deck.
+     * See https://docs.ankiweb.net/filtered-decks.html
+     */
+    @JvmInline
+    value class Term(
+        val array: JSONArray,
+    ) {
+        constructor(search: String, limit: Int, order: Int) : this(JSONArray(listOf(search, limit, order))) {}
+
+        /**
+         Only cards satisfying this search query are shown.
+         */
+        var search: String
+            get() = array.getString(0)
+            set(value) {
+                array.put(0, value)
+            }
+
+        /**
+         * At most this number of cards are shown.
+         */
+        var limit: Int
+            get() = array.getInt(1)
+            set(value) {
+                array.put(1, value)
+            }
+
+        /**
+         * The order in which cards are shown. See https://docs.ankiweb.net/filtered-decks.html#order.
+         */
+        var order: Int
+            get() = array.getInt(2)
+            set(value) {
+                array.put(2, value)
+            }
+
+        override fun toString(): String = array.toString()
+    }
+
+    /**
+     * The options deciding which cards are shown in a filtered deck.
+     */
+    val firstFilter: Term
+        get() = Term(terms.getJSONArray(0))
+
+    /**
+     * A second option to add more cards to the filtered deck.
+     */
+    var secondFilter: Term?
+        get() = terms.optJSONArray(1)?.let { Term(it) }
+        set(value) {
+            if (value == null) {
+                terms.remove(1)
+            } else {
+                terms.put(1, value?.array)
+            }
+        }
+
+    /**
+     * The array of filters. Only for filtered decks.
+     */
+    @VisibleForTesting
+    var terms: JSONArray
+        get() = jsonObject.getJSONArray("terms")
+        set(value) {
+            jsonObject.put("terms", value)
         }
 
     /**
@@ -78,9 +224,9 @@ class Deck : JSONObject {
      * May be HTML or Markdown, depending on [descriptionAsMarkdown].
      */
     var description: String
-        get() = optString("desc", "")
+        get() = jsonObject.optString("desc", "")
         set(value) {
-            put("desc", value)
+            jsonObject.put("desc", value)
         }
 
     /**
@@ -98,9 +244,9 @@ class Deck : JSONObject {
      * @see anki.i18n.GeneratedTranslations.deckConfigDescriptionNewHandlingHint
      */
     var descriptionAsMarkdown: Boolean
-        get() = optBoolean("md", false)
+        get() = jsonObject.optBoolean("md", false)
         set(value) {
-            put("md", value)
+            jsonObject.put("md", value)
         }
 }
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/FilteredDeck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/FilteredDeck.kt
@@ -1,0 +1,99 @@
+/****************************************************************************************
+ * Copyright (c) 2025 Arthur Milchior <arthur@milchior.fr>                             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.libanki
+
+import androidx.annotation.VisibleForTesting
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Represents a Filtered (a.k.a. Dynamic, Cram) deck.
+ */
+@JvmInline
+value class FilteredDeck(
+    override val jsonObject: JSONObject,
+) : Deck {
+    constructor(jsonObject: String) : this(JSONObject(jsonObject))
+
+    /**
+     * The options configuring which cards are shown in a filtered deck.
+     * See https://docs.ankiweb.net/filtered-decks.html
+     */
+    @JvmInline
+    value class Term(
+        val array: JSONArray,
+    ) {
+        constructor(search: String, limit: Int, order: Int) : this(JSONArray(listOf(search, limit, order)))
+
+        /**
+         Only cards satisfying this search query are shown.
+         */
+        var search: String
+            get() = array.getString(0)
+            set(value) {
+                array.put(0, value)
+            }
+
+        /**
+         * At most this number of cards are shown.
+         */
+        var limit: Int
+            get() = array.getInt(1)
+            set(value) {
+                array.put(1, value)
+            }
+
+        /**
+         * The order in which cards are shown. See https://docs.ankiweb.net/filtered-decks.html#order.
+         */
+        var order: Int
+            get() = array.getInt(2)
+            set(value) {
+                array.put(2, value)
+            }
+
+        override fun toString(): String = array.toString()
+    }
+
+    /**
+     * The options deciding which cards are shown in a filtered deck.
+     */
+    val firstFilter: Term
+        get() = Term(terms.getJSONArray(0))
+
+    /**
+     * A second option to add more cards to the filtered deck.
+     */
+    var secondFilter: Term?
+        get() = terms.optJSONArray(1)?.let { Term(it) }
+        set(value) {
+            if (value == null) {
+                terms.remove(1)
+            } else {
+                terms.put(1, value.array)
+            }
+        }
+
+    /**
+     * The array of filters. Only for filtered decks.
+     */
+    @VisibleForTesting
+    var terms: JSONArray
+        get() = jsonObject.getJSONArray("terms")
+        set(value) {
+            jsonObject.put("terms", value)
+        }
+}

--- a/libanki/src/main/java/com/ichi2/anki/libanki/FilteredDeck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/FilteredDeck.kt
@@ -96,4 +96,6 @@ value class FilteredDeck(
         set(value) {
             jsonObject.put("terms", value)
         }
+
+    override fun toString(): String = jsonObject.toString()
 }

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
@@ -147,7 +147,7 @@ class Notetypes(
     /** Get current model.*/
     @RustCleanup("Should use defaultsForAdding() instead")
     fun current(forDeck: Boolean = true): NotetypeJson {
-        var noteType = get(col.decks.current().getLongOrNull("mid"))
+        var noteType = get(col.decks.current().noteTypeId)
         if (!forDeck || noteType == null) {
             noteType = get(col.config.get("curModel") ?: 1L)
         }
@@ -766,7 +766,7 @@ class Notetypes(
  *
  * This better approximates `JSON.get` in the Python
  */
-private fun Deck.getLongOrNull(key: String): Long? {
+fun JSONObject.getLongOrNull(key: String): Long? {
     if (!has(key)) {
         return null
     }

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
@@ -147,7 +147,7 @@ class Notetypes(
     /** Get current model.*/
     @RustCleanup("Should use defaultsForAdding() instead")
     fun current(forDeck: Boolean = true): NotetypeJson {
-        var noteType = get(col.decks.current().noteTypeId)
+        var noteType = get((col.decks.current() as? RegularDeck)?.noteTypeId)
         if (!forDeck || noteType == null) {
             noteType = get(col.config.get("curModel") ?: 1L)
         }

--- a/libanki/src/main/java/com/ichi2/anki/libanki/RegularDeck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/RegularDeck.kt
@@ -1,0 +1,54 @@
+/****************************************************************************************
+ * Copyright (c) 2025 Arthur Milchior <arthur@milchior.fr>                             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.libanki
+
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.common.json.JSONObjectHolder
+import org.json.JSONObject
+
+/**
+ * Represents a regular (non-filtered) Deck.
+ */
+// The name "regular" can be found on https://docs.ankiweb.net/filtered-decks.html
+@JvmInline
+value class RegularDeck(
+    @VisibleForTesting override val jsonObject: JSONObject,
+) : JSONObjectHolder,
+    Deck {
+    /**
+     * Creates a deck object form a json string
+     */
+    constructor(json: String) : this(JSONObject(json))
+
+    /**
+     * The id of the deck option.
+     */
+    var conf: DeckConfigId
+        get() {
+            val value = jsonObject.optLong("conf")
+            return if (value > 0) value else 1
+        }
+        set(value) {
+            jsonObject.put("conf", value)
+        }
+
+    var noteTypeId: NoteTypeId?
+        get() = jsonObject.getLongOrNull("mid")
+        set(value) {
+            jsonObject.put("mid", value)
+        }
+}

--- a/libanki/src/main/java/com/ichi2/anki/libanki/backend/BackendUtils.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/backend/BackendUtils.kt
@@ -30,6 +30,8 @@ object BackendUtils {
 
     fun jsonToArray(json: ByteString): JSONArray = JSONArray(json.toStringUtf8())
 
+    fun toByteString(conf: JSONObjectHolder) = toByteString(conf.jsonObject)
+
     fun toByteString(conf: JSONObject): ByteString {
         val asString: String = conf.toString()
         return ByteString.copyFromUtf8(asString)

--- a/libanki/src/test/java/com/ichi2/anki/libanki/DeckTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/DeckTest.kt
@@ -1,0 +1,185 @@
+/****************************************************************************************
+ * Copyright (c) 2025 Arthur Milchior <arthur@milchior.fr>                             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.libanki
+
+import com.ichi2.anki.libanki.testutils.InMemoryAnkiTest
+import org.json.JSONArray
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DeckTest : InMemoryAnkiTest() {
+    val d = Deck("{}")
+
+    @Test
+    fun testFiltered() {
+        // `dyn` can't be set by the front-end anymore.
+        val d = Deck("""{"dyn" :1}""")
+        assertTrue(d.isFiltered)
+        assertFalse(d.isNormal, "This deck should not be normal")
+    }
+
+    @Test
+    fun testNormal() {
+        val d = Deck("""{"dyn" :0}""")
+        assertTrue(d.isNormal)
+        assertFalse(d.isFiltered, "this deck should not be filtered")
+    }
+
+    @Test
+    fun testName() {
+        val name = "foo"
+        d.name = name
+        assertEquals(name, d.name)
+    }
+
+    @Test
+    fun testBrowserCollapsed() {
+        d.browserCollapsed = true
+        assertTrue(d.browserCollapsed)
+        d.browserCollapsed = false
+        assertFalse(d.browserCollapsed, "browser should be collapsed")
+    }
+
+    @Test
+    fun testCollapsed() {
+        d.collapsed = true
+        assertTrue(d.collapsed)
+        d.collapsed = false
+        assertFalse(d.collapsed, "deck should be collapsed")
+    }
+
+    @Test
+    fun testId() {
+        val id = 42L
+        d.id = id
+        assertEquals(id, d.id)
+    }
+
+    @Test
+    fun testConfId() {
+        val confId = 42L
+        d.conf = confId
+        assertEquals(confId, d.conf)
+    }
+
+    @Test
+    fun testDescription() {
+        val description = "foo"
+        d.description = description
+        assertEquals(description, d.description)
+    }
+
+    @Test
+    fun testNoteTypeId() {
+        val noteTypeId = 42L
+        d.noteTypeId = noteTypeId
+        assertEquals(noteTypeId, d.noteTypeId)
+    }
+
+    @Test
+    fun testResched() {
+        d.resched = true
+        assertTrue(d.resched)
+        d.resched = false
+        assertTrue(!d.resched)
+    }
+
+    @Test
+    fun testPreview() {
+        val again = 1
+        val hard = 2
+        val good = 3
+        d.previewAgainSecs = again
+        d.previewHardSecs = hard
+        d.previewGoodSecs = good
+        assertEquals(d.previewAgainSecs, again)
+        assertEquals(d.previewHardSecs, hard)
+        assertEquals(d.previewGoodSecs, good)
+    }
+
+    @Test
+    fun testDelays() {
+        val delays = JSONArray()
+        delays.put("1h")
+        delays.put("1m")
+        assertEquals(d.delays, null)
+        d.delays = delays
+        assertEquals(d.delays, delays)
+        d.delays = null
+        assertEquals(d.delays, null)
+    }
+
+    @Test
+    fun testEmpty() {
+        val d = Deck("{empty: 4}")
+        d.removeEmpty()
+        // The property empty can be edited but never read in the frontend.
+        assertFalse(d.jsonObject.has("empty"), "Empty should be removed")
+    }
+
+    val search = "search"
+    val limit = 7
+    val order = 42
+    val t = Deck.Term(search, limit, order)
+
+    val search2 = "search2"
+    val limit2 = 7
+    val order2 = 44
+    val t2 = Deck.Term(search2, limit2, order2)
+
+    @Test
+    fun testSearch() {
+        val expectedSearch = "expectedSearch"
+        t.search = expectedSearch
+        assertEquals(expectedSearch, t.search)
+    }
+
+    @Test
+    fun testLimit() {
+        val expectedLimit = 7
+        t.limit = expectedLimit
+        assertEquals(expectedLimit, t.limit)
+    }
+
+    @Test
+    fun testOrder() {
+        val expectedOrder = 7
+        t.order = expectedOrder
+        assertEquals(expectedOrder, t.order)
+    }
+
+    @Test
+    fun testFirstFilter() {
+        // All decks are expected to have at least one term.
+        val d = Deck("""{"terms": [$t]}""")
+        val firstFilter = d.firstFilter
+        assertEquals(firstFilter.search, search)
+        assertEquals(firstFilter.limit, limit)
+        assertEquals(firstFilter.order, order)
+    }
+
+    @Test
+    fun testSecondFilter() {
+        val d = Deck("""{"terms": [$t]}""")
+        assertEquals(null, d.secondFilter)
+        d.secondFilter = t2
+        assertEquals(t2, d.secondFilter)
+        d.secondFilter = null
+        assertEquals(null, d.secondFilter)
+    }
+}

--- a/libanki/src/test/java/com/ichi2/anki/libanki/DecksTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/DecksTest.kt
@@ -164,9 +164,9 @@ class DecksTest : InMemoryAnkiTest() {
         val filtered = decks.getLegacy(filteredId)!!
         val deckId = addDeck("deck")
         val deck = decks.getLegacy(deckId)!!
-        assertThat(deck.isNormal, equalTo(true))
+        assertThat(deck.isRegular, equalTo(true))
         assertThat(deck.isFiltered, equalTo(false))
-        assertThat(filtered.isNormal, equalTo(false))
+        assertThat(filtered.isRegular, equalTo(false))
         assertThat(filtered.isFiltered, equalTo(true))
     }
 

--- a/libanki/src/test/java/com/ichi2/anki/libanki/NormalDeckTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/NormalDeckTest.kt
@@ -1,0 +1,48 @@
+/****************************************************************************************
+ * Copyright (c) 2025 Arthur Milchior <arthur@milchior.fr>                             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.libanki
+
+import com.ichi2.anki.libanki.Deck
+import com.ichi2.anki.libanki.FilteredDeck
+import com.ichi2.anki.libanki.RegularDeck
+import com.ichi2.anki.libanki.testutils.InMemoryAnkiTest
+import org.junit.Test
+import org.junit.jupiter.api.assertInstanceOf
+import kotlin.test.assertEquals
+
+class NormalDeckTest : InMemoryAnkiTest() {
+    val d = RegularDeck("""{"dyn": 1}""")
+
+    @Test
+    fun testConfId() {
+        val confId = 42L
+        d.conf = confId
+        assertEquals(confId, d.conf)
+    }
+
+    @Test
+    fun testNoteTypeId() {
+        val noteTypeId = 42L
+        d.noteTypeId = noteTypeId
+        assertEquals(noteTypeId, d.noteTypeId)
+    }
+
+    @Test
+    fun testFactory() {
+        val d = Deck.factory("""{"dyn": 1}""")
+        assertInstanceOf<FilteredDeck>(d)
+    }
+}

--- a/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
@@ -129,7 +129,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         }
         // give the child deck a different configuration
         val c2 = col.decks.addConfigReturningId("new conf")
-        col.decks.setConfigIdForDeckDict(col.decks.getLegacy(deck2)!!, c2)
+        col.decks.setConfigIdForDeckDict(col.decks.getLegacy(deck2)!! as RegularDeck, c2)
         // both confs have defaulted to a limit of 20
         Assert.assertEquals(20, col.sched.newCount().toLong())
         // first card we get comes from parent

--- a/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
@@ -853,7 +853,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         // cram deck
         val did = addDynamicDeck("Cram")
         val cram = col.decks.getLegacy(did)!!
-        cram.put("resched", false)
+        cram.resched = false
         col.decks.save(cram)
         col.sched.rebuildDyn(did)
         // grab the first card
@@ -1333,7 +1333,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         addBasicNote("foo", "bar")
         val did = addDynamicDeck("test")
         val deck = decks.getLegacy(did)!!
-        deck.put("resched", false)
+        deck.resched = false
         sched.rebuildDyn(did)
         var card: Card?
         for (i in 0..2) {

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -179,7 +179,7 @@ interface AnkiTest {
             col.decks.newFiltered(name).also { did ->
                 if (search == null) return@also
                 val deck = col.decks.getLegacy(did)!!
-                deck.getJSONArray("terms").getJSONArray(0).put(0, search)
+                deck.firstFilter.search = search
                 col.decks.save(deck)
                 col.sched.rebuildDyn(did)
             }

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
 import com.ichi2.anki.libanki.testutils.ext.addNote
+import com.ichi2.anki.libanki.FilteredDeck
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
@@ -178,7 +179,7 @@ interface AnkiTest {
         return try {
             col.decks.newFiltered(name).also { did ->
                 if (search == null) return@also
-                val deck = col.decks.getLegacy(did)!!
+                val deck = col.decks.getLegacy(did)!! as FilteredDeck
                 deck.firstFilter.search = search
                 col.decks.save(deck)
                 col.sched.rebuildDyn(did)


### PR DESCRIPTION
I loved David's recent work in using value class. And thought that we could finally kill the overhead cost of DeepClone in JSONObject. So I transformed `Deck` into a value class, and added the needed properties so that the other part of the code can use Deck without considering it as a JSONObject.