### PR TITLE
fix: Syncing media notification getting stuck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -84,6 +84,9 @@ class SyncMediaWorker(
                 setContentTitle(CollectionManager.TR.syncMediaFailed())
             }
             return Result.failure()
+        } finally {
+            Timber.i("SyncMediaWorker stopped, notification cleared")
+            notificationManager.cancel(NotificationId.SYNC_MEDIA)
         }
 
         Timber.d("SyncMediaWorker: success")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 I found out that the notification gets stuck after the exception is thrown and not cleared at times, hence force clear the notification once the worker has stopped

## Fixes
* Fixes #17639

## Approach
Force clear the sync notification in case the worker is not running 

## How Has This Been Tested?
Google emulator API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
