### PR TITLE
feat: show snackbar if no data connection in shared deck download

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2028,6 +2028,11 @@ open class DeckPicker :
             )
 
     fun openAnkiWebSharedDecks() {
+        if (!NetworkUtils.isOnline) {
+            showSnackbar(R.string.check_network)
+            Timber.d("DeckPicker:: No network, Shared deck download failed")
+            return
+        }
         val intent = Intent(this, SharedDecksActivity::class.java)
         startActivity(intent)
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Dont open the webview in case no network is detected and show a snackbar instead


## How Has This Been Tested?
Locally API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
