### PR TITLE
Reset zoom on card flip in ReviewerFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -249,6 +249,11 @@ class ReviewerFragment :
         }
     }
 
+    private fun resetZoom() {
+        webView.settings.loadWithOverviewMode = false
+        webView.settings.loadWithOverviewMode = true
+    }
+
     private fun setupAnswerButtons(view: View) {
         val hideAnswerButtons = sharedPrefs().getBoolean(getString(R.string.hide_answer_buttons_key), false)
         if (hideAnswerButtons) {
@@ -309,6 +314,7 @@ class ReviewerFragment :
                 showAnswerButton.isVisible = true
                 answerButtonsLayout.isVisible = false
             }
+            resetZoom()
         }
 
         if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In new reviewer, zoom should reset on card flip

## Fixes
* Fixes #17706

## Approach
The solution is to toggle the `loadWithOverviewMode ` setting off and then back on. This forces the WebView to loads its content and apply the correct scaling.

## How Has This Been Tested?

Physical device (OPPO F21 Pro 5G).

https://github.com/user-attachments/assets/3dcff8ad-8083-4ed4-858e-7e7392acbd06



## Learning (optional, can help others)
https://stackoverflow.com/a/61627280/22445612

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
