### PR TITLE
fix: flag color in new reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -49,6 +49,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
+import androidx.appcompat.widget.ThemeUtils
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
@@ -1077,9 +1078,14 @@ open class CardBrowser :
                 }
 
             for ((flag, displayName) in Flag.queryDisplayNames()) {
-                subMenu
-                    .add(groupId, flag.code, Menu.NONE, displayName)
-                    .setIcon(flag.drawableRes)
+                val item =
+                    subMenu
+                        .add(groupId, flag.code, Menu.NONE, displayName)
+                        .setIcon(flag.drawableRes)
+                if (flag == Flag.NONE) {
+                    val color = ThemeUtils.getThemeAttrColor(this@CardBrowser, android.R.attr.colorControlNormal)
+                    item.icon?.mutate()?.setTint(color)
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Flag.kt
@@ -37,13 +37,8 @@ enum class Flag(
      * Color for the background of cards with this flag in the card browser.
      */
     @ColorRes val browserColorRes: Int?,
-    /**
-     * Flag drawn to represents this flagInTheReviewer if it differs from [drawableRes].
-     * @TODO: Checks whether we can use colorControlNormal everywhere.
-     */
-    @DrawableRes val drawableReviewerRes: Int? = null,
 ) {
-    NONE(0, R.id.flag_none, R.drawable.ic_flag_lightgrey, null, R.drawable.ic_flag_transparent),
+    NONE(0, R.id.flag_none, R.drawable.ic_flag_transparent, null),
     RED(1, R.id.flag_red, R.drawable.ic_flag_red, R.color.flag_red),
     ORANGE(
         2,
@@ -67,11 +62,6 @@ enum class Flag(
         R.color.flag_purple,
     ),
     ;
-
-    /**
-     * Flag drawn to represents this flagInTheReviewer.
-     */
-    @DrawableRes fun drawableReviewerRes() = drawableReviewerRes ?: drawableRes
 
     /**
      * Retrieves the name associated with the flag. This may be user-defined

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -48,6 +48,7 @@ import androidx.annotation.IntDef
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
+import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
@@ -734,9 +735,13 @@ open class Reviewer :
         val flagIcon = menu.findItem(R.id.action_flag)
         if (flagIcon != null) {
             if (currentCard != null) {
-                flagIcon.setIcon(currentCard!!.userFlag().drawableReviewerRes())
+                val flag = currentCard!!.userFlag()
+                flagIcon.setIcon(flag.drawableRes)
+                if (flag == Flag.NONE && actionButtons.status.flagsIsOverflown()) {
+                    val flagColor = ThemeUtils.getThemeAttrColor(this, android.R.attr.colorControlNormal)
+                    flagIcon.icon?.mutate()?.setTint(flagColor)
+                }
             }
-            flagIcon.iconAlpha = alpha
         }
 
         // Anki Desktop Translations
@@ -879,11 +884,8 @@ open class Reviewer :
     private fun setupFlags(subMenu: SubMenu) {
         lifecycleScope.launch {
             for ((flag, displayName) in Flag.queryDisplayNames()) {
-                val menuItem =
-                    subMenu
-                        .add(Menu.NONE, flag.code, Menu.NONE, displayName)
-                        .setIcon(flag.drawableRes)
-                flagItemIds.add(menuItem.itemId)
+                subMenu.findItem(flag.id).setTitle(displayName)
+                flagItemIds.add(flag.id)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -109,6 +109,8 @@ class ActionButtonStatus {
 
     fun buryIsDisabled(): Boolean = customButtons[R.id.action_bury] == MENU_DISABLED
 
+    fun flagsIsOverflown(): Boolean = customButtons[R.id.action_flag] == SHOW_AS_ACTION_NEVER
+
     companion object {
         const val SHOW_AS_ACTION_NEVER = MenuItem.SHOW_AS_ACTION_NEVER
         const val SHOW_AS_ACTION_IF_ROOM = MenuItem.SHOW_AS_ACTION_IF_ROOM

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -58,7 +58,38 @@
         android:icon="@drawable/ic_flag_transparent"
         ankidroid:showAsAction="always" >
         <menu>
-            <!-- flags are dynamically added -->
+            <item
+                android:id="@id/flag_none"
+                android:icon="@drawable/ic_flag_lightgrey"
+                tools:title="No Flag"/>
+            <item
+                android:id="@id/flag_red"
+                tools:title="Red"
+                android:icon="@drawable/ic_flag_red"/>
+            <item
+                android:id="@id/flag_orange"
+                tools:title="Orange"
+                android:icon="@drawable/ic_flag_orange"/>
+            <item
+                android:id="@id/flag_green"
+                tools:title="Green"
+                android:icon="@drawable/ic_flag_green"/>
+            <item
+                android:id="@id/flag_blue"
+                tools:title="Blue"
+                android:icon="@drawable/ic_flag_blue"/>
+            <item
+                android:id="@id/flag_pink"
+                tools:title="Pink"
+                android:icon="@drawable/ic_flag_pink"/>
+            <item
+                android:id="@id/flag_turquoise"
+                tools:title="Turquoise"
+                android:icon="@drawable/ic_flag_turquoise"/>
+            <item
+                android:id="@id/flag_purple"
+                tools:title="Purple"
+                android:icon="@drawable/ic_flag_purple"/>
         </menu>
     </item>
     <item


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

the new reviewer "Flag.NONE" icon had a different color because it wasn't using the new property `drawableReviewerRes` introduced in #17434

<details><summary>Screenshot of the issue</summary>

![issue](https://github.com/user-attachments/assets/5be7e1f1-2e23-4adb-904a-c5b9443c246c)

</details>

## Approach

I solved the TODO of Flag.kt and used colorControlNormal everywhere.

## How Has This Been Tested?

<details><summary>Screenshots</summary>

![browser (1)](https://github.com/user-attachments/assets/6e202f0e-1d9c-4f21-9e62-a1d5b864f46b)
![browser (3)](https://github.com/user-attachments/assets/92301a24-4ee2-49dd-af9a-af805afe770d)
![browser (4)](https://github.com/user-attachments/assets/de3bf9e9-620c-4808-bad7-5765185b0cd1)
![new reviewer](https://github.com/user-attachments/assets/2343f21e-597f-4e98-b06c-79e268b4ac7a)
![reviewer](https://github.com/user-attachments/assets/a29db2a8-6be7-442c-9e3b-09abfde2e67c)
![reviewer2](https://github.com/user-attachments/assets/13326fb0-95b6-4250-a531-dc5b1c6a0474)
![reviewer3](https://github.com/user-attachments/assets/9d962b1c-b110-498b-acdb-41f73f8f3789)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
