### PR TITLE
fix: audio autoplay in template previewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -29,6 +29,8 @@ import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.Consts.DEFAULT_DECK_ID
+import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.NotetypeJson
@@ -84,6 +86,7 @@ class TemplatePreviewerViewModel(
                         ord = ordFlow.value,
                         customNoteType = notetype,
                         fillEmpty = fillEmpty,
+                        deckId = arguments.deckId,
                     )
                 }
             }
@@ -231,6 +234,7 @@ data class TemplatePreviewerArguments(
     val id: NoteId = 0,
     val ord: Int = 0,
     val fillEmpty: Boolean = false,
+    val deckId: DeckId = DEFAULT_DECK_ID,
 ) : Parcelable {
     val notetype: NotetypeJson get() = notetypeFile.getNotetype()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -105,10 +105,11 @@ class Note : Cloneable {
         customNoteType: NotetypeJson? = null,
         customTemplate: CardTemplate? = null,
         fillEmpty: Boolean = false,
+        deckId: DeckId = DEFAULT_DECK_ID,
     ): Card {
         val card = Card(col, id = null)
         card.ord = ord
-        card.did = DEFAULT_DECK_ID
+        card.did = deckId
 
         val model = customNoteType ?: notetype
         val template =


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #17693

## Approach

libanki's ephemeralCard() method always used the default deck id (the desktop version has the same issue).

That leads to using the default deck config for the template previews.

This fixes the issue by adding an optional deckId argument

## How Has This Been Tested?

1. Add a new deck type
2. Set `Don't play audios automatically` of the new deck type to true
3. Set `Don't play audios automatically` of the `Default` to false
4. Assign the new deck type to a card with audio
5. Open the card

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
