### PR TITLE
fix: study options opening old reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -149,7 +149,6 @@ import com.ichi2.anki.servicelayer.checkMedia
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckAdapter
@@ -2472,12 +2471,7 @@ open class DeckPicker :
     }
 
     private fun openReviewer() {
-        val intent =
-            if (sharedPrefs().getBoolean("newReviewer", false)) {
-                ReviewerFragment.getIntent(this)
-            } else {
-                Intent(this, Reviewer::class.java)
-            }
+        val intent = Reviewer.getIntent(this)
         reviewLauncher.launch(intent)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -437,7 +437,7 @@ abstract class NavigationDrawerActivity :
                 return
             }
             // Review Cards Shortcut
-            val intentReviewCards = Intent(context, Reviewer::class.java)
+            val intentReviewCards = Reviewer.getIntent(context)
             intentReviewCards.action = Intent.ACTION_VIEW
             intentReviewCards.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
             intentReviewCards.putExtra(EXTRA_STARTED_WITH_SHORTCUT, true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -21,6 +21,7 @@ import android.Manifest
 import android.animation.Animator
 import android.animation.AnimatorListenerAdapter
 import android.annotation.SuppressLint
+import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -92,6 +93,7 @@ import com.ichi2.anki.servicelayer.NoteService.isMarked
 import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.utils.remainingTime
@@ -1666,5 +1668,12 @@ open class Reviewer :
 
         /** Default (500ms) time for action snackbars, such as undo, bury and suspend */
         const val ACTION_SNACKBAR_TIME = 500
+
+        fun getIntent(context: Context): Intent =
+            if (context.sharedPrefs().getBoolean("newReviewer", false)) {
+                ReviewerFragment.getIntent(context)
+            } else {
+                Intent(context, Reviewer::class.java)
+            }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -90,7 +90,8 @@ class StudyOptionsActivity :
                 launchCatchingTask {
                     undoAndShowSnackbar()
                     // TODO why are we going to the Reviewer from here? Desktop doesn't do this
-                    Intent(this@StudyOptionsActivity, Reviewer::class.java)
+                    Reviewer
+                        .getIntent(this@StudyOptionsActivity)
                         .apply { flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT }
                         .also { startActivity(it) }
                     finish()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -207,7 +207,7 @@ class StudyOptionsFragment :
 
     private fun openReviewer() {
         Timber.i("openReviewer()")
-        val reviewer = Intent(activity, Reviewer::class.java)
+        val reviewer = Reviewer.getIntent(requireContext())
         if (fragmented) {
             toReviewer = true
             Timber.i("openReviewer() fragmented mode")


### PR DESCRIPTION
## Fixes
* Fixes #17714

## Approach
* Search for Reviewer::class.java uses
* Replace most of them (the only one left defaults to the new reviewer as well)

## How Has This Been Tested?

* Open the study options screen
* Tap study
* The new reviewer shows up (before this fix, the old reviewer was shown)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
