### PR TITLE
feat: toggle auto advance in new reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -128,6 +128,7 @@ class CardMediaPlayer : Closeable {
         }
 
     private var playSoundsJob: Job? = null
+    val isPlaying get() = playSoundsJob != null
 
     private var onSoundGroupCompleted: (() -> Unit)? = null
 
@@ -224,7 +225,7 @@ class CardMediaPlayer : Closeable {
     }
 
     suspend fun stopSounds() {
-        if (playSoundsJob != null) Timber.i("stopping sounds")
+        if (isPlaying) Timber.i("stopping sounds")
         cancelPlaySoundsJob(playSoundsJob)
         ReadText.stopTts() // TODO: Reconsider design
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -54,6 +54,7 @@ enum class ViewerAction(
     DECK_OPTIONS(R.id.action_deck_options, R.drawable.ic_tune_white, R.string.menu__deck_options, DISABLED),
     CARD_INFO(R.id.action_card_info, R.drawable.ic_dialog_info, R.string.card_info_title, DISABLED),
     ADD_NOTE(R.id.action_add_note, R.drawable.ic_add, R.string.menu_add_note, DISABLED),
+    TOGGLE_AUTO_ADVANCE(R.id.action_toggle_auto_advance, R.drawable.ic_fast_forward, R.string.toggle_auto_advance, DISABLED),
     USER_ACTION_1(R.id.user_action_1, R.drawable.user_action_1, R.string.user_action_1, DISABLED),
     USER_ACTION_2(R.id.user_action_2, R.drawable.user_action_2, R.string.user_action_2, DISABLED),
     USER_ACTION_3(R.id.user_action_3, R.drawable.user_action_3, R.string.user_action_3, DISABLED),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -76,6 +76,7 @@ import com.ichi2.anki.preferences.reviewer.ViewerAction.REDO
 import com.ichi2.anki.preferences.reviewer.ViewerAction.SUSPEND_CARD
 import com.ichi2.anki.preferences.reviewer.ViewerAction.SUSPEND_MENU
 import com.ichi2.anki.preferences.reviewer.ViewerAction.SUSPEND_NOTE
+import com.ichi2.anki.preferences.reviewer.ViewerAction.TOGGLE_AUTO_ADVANCE
 import com.ichi2.anki.preferences.reviewer.ViewerAction.UNDO
 import com.ichi2.anki.preferences.reviewer.ViewerAction.UNSET_FLAG
 import com.ichi2.anki.preferences.reviewer.ViewerAction.USER_ACTION_1
@@ -180,6 +181,7 @@ class ReviewerFragment :
             MARK -> viewModel.toggleMark()
             REDO -> viewModel.redo()
             UNDO -> viewModel.undo()
+            TOGGLE_AUTO_ADVANCE -> viewModel.toggleAutoAdvance()
             BURY_NOTE -> viewModel.buryNote()
             BURY_CARD -> viewModel.buryCard()
             SUSPEND_NOTE -> viewModel.suspendNote()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -314,6 +314,28 @@ class ReviewerViewModel(
         autoAdvance.cancelQuestionAndAnswerActionJobs()
     }
 
+    fun toggleAutoAdvance() {
+        launchCatchingIO {
+            autoAdvance.isEnabled = !autoAdvance.isEnabled
+
+            val message =
+                if (autoAdvance.isEnabled) {
+                    CollectionManager.TR.actionsAutoAdvanceActivated()
+                } else {
+                    CollectionManager.TR.actionsAutoAdvanceDeactivated()
+                }
+            actionFeedbackFlow.emit(message)
+
+            if (autoAdvance.shouldWaitForAudio() && cardMediaPlayer.isPlaying) return@launchCatchingIO
+
+            if (showingAnswer.value) {
+                autoAdvance.onShowAnswer()
+            } else {
+                autoAdvance.onShowQuestion()
+            }
+        }
+    }
+
     /* *********************************************************************************************
      *************************************** Internal methods ***************************************
      ********************************************************************************************* */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
@@ -36,6 +36,13 @@ import kotlinx.coroutines.delay
 class AutoAdvance(
     val viewModel: ReviewerViewModel,
 ) {
+    var isEnabled = false
+        set(value) {
+            field = value
+            if (!value) {
+                cancelQuestionAndAnswerActionJobs()
+            }
+        }
     private var questionActionJob: Job? = null
     private var answerActionJob: Job? = null
 
@@ -70,7 +77,7 @@ class AutoAdvance(
 
     suspend fun onShowQuestion() {
         answerActionJob?.cancel()
-        if (!durationToShowQuestionFor().isPositive()) return
+        if (!durationToShowQuestionFor().isPositive() || !isEnabled) return
 
         questionActionJob =
             viewModel.launchCatchingIO {
@@ -84,7 +91,7 @@ class AutoAdvance(
 
     suspend fun onShowAnswer() {
         questionActionJob?.cancel()
-        if (!durationToShowAnswerFor().isPositive()) return
+        if (!durationToShowAnswerFor().isPositive() || !isEnabled) return
 
         answerActionJob =
             viewModel.launchCatchingIO {

--- a/AnkiDroid/src/main/res/values/ids.xml
+++ b/AnkiDroid/src/main/res/values/ids.xml
@@ -37,6 +37,7 @@
     <item type="id" name="action_bury_note"/>
     <item type="id" name="action_suspend_card"/>
     <item type="id" name="action_suspend_note"/>
+    <item type="id" name="action_toggle_auto_advance"/>
 
     <item type="id" name="user_action_1"/>
     <item type="id" name="user_action_2"/>


### PR DESCRIPTION
it also changes the behavior to match the desktop code, so auto advance only starts after the user toggles it

## Fixes
* Fixes part of #17701

## How Has This Been Tested?

[Nothing.webm](https://github.com/user-attachments/assets/9f66b666-08a7-4354-9bc6-8bfea26aa0e6)

[more.webm](https://github.com/user-attachments/assets/7d1370de-09ec-4429-b21c-d90d26c77bcc)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
