### PR TITLE
NF: transform object to data object

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -135,21 +135,21 @@ object InitialActivity {
     fun isLatestVersion(preferences: SharedPreferences): Boolean = preferences.getString("lastVersion", "") == pkgVersionName
 
     sealed class StartupFailure {
-        object SDCardNotMounted : StartupFailure()
+        data object SDCardNotMounted : StartupFailure()
 
-        object DirectoryNotAccessible : StartupFailure()
+        data object DirectoryNotAccessible : StartupFailure()
 
-        object FutureAnkidroidVersion : StartupFailure()
+        data object FutureAnkidroidVersion : StartupFailure()
 
         class DBError(
             val exception: Exception,
         ) : StartupFailure()
 
-        object DatabaseLocked : StartupFailure()
+        data object DatabaseLocked : StartupFailure()
 
-        object WebviewFailed : StartupFailure()
+        data object WebviewFailed : StartupFailure()
 
-        object DiskFull : StartupFailure()
+        data object DiskFull : StartupFailure()
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Consts.kt
@@ -22,13 +22,13 @@ import kotlin.annotation.Retention
 sealed class CardType(
     val code: Int,
 ) {
-    object New : CardType(0)
+    data object New : CardType(0)
 
-    object Lrn : CardType(1)
+    data object Lrn : CardType(1)
 
-    object Rev : CardType(2)
+    data object Rev : CardType(2)
 
-    object Relearning : CardType(3)
+    data object Relearning : CardType(3)
 
     class Unknown(
         code: Int,
@@ -49,21 +49,21 @@ sealed class CardType(
 sealed class QueueType(
     val code: Int,
 ) {
-    object ManuallyBuried : QueueType(-3)
+    data object ManuallyBuried : QueueType(-3)
 
-    object SiblingBuried : QueueType(-2)
+    data object SiblingBuried : QueueType(-2)
 
-    object Suspended : QueueType(-1)
+    data object Suspended : QueueType(-1)
 
-    object New : QueueType(0)
+    data object New : QueueType(0)
 
-    object Lrn : QueueType(1)
+    data object Lrn : QueueType(1)
 
-    object Rev : QueueType(2)
+    data object Rev : QueueType(2)
 
-    object DayLearnRelearn : QueueType(3)
+    data object DayLearnRelearn : QueueType(3)
 
-    object Preview : QueueType(4)
+    data object Preview : QueueType(4)
 
     class Unknown(
         code: Int,
@@ -98,9 +98,9 @@ sealed class QueueType(
 sealed class NoteTypeKind(
     val code: Int,
 ) {
-    object Std : NoteTypeKind(0)
+    data object Std : NoteTypeKind(0)
 
-    object Cloze : NoteTypeKind(1)
+    data object Cloze : NoteTypeKind(1)
 
     class Unknown(
         code: Int,


### PR DESCRIPTION
As requested by David in a recent PR adding enum in consts. I looked for all obejcts in sealed class/interface. I didn't touch object, even if named, that are not part of a sealed class/interface, as it's not clear that it's a big deal if `toString` does not show their name.