### PR TITLE
fix: Thickness of Default Flag icon has been increased to match other material icons

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_flag_transparent.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flag_transparent.xml
@@ -4,9 +4,9 @@
     android:viewportWidth="24"
     android:viewportHeight="24"
     android:tint="?attr/colorControlNormal">
-  <path
-      android:strokeWidth="1"
-      android:pathData="M14.4,6L14,4H5v17h2v-7h5.6l0.4,2h7V6z"
-      android:fillColor="#00000000"
-      android:strokeColor="#ffffff"/>
+    <path
+        android:strokeWidth="1.6"
+        android:pathData="M14.4,6L14,4H5v17h3v-7h5.6l0.4,2h7V6z"
+        android:fillColor="#00000000"
+        android:strokeColor="#ffffff"/>
 </vector>


### PR DESCRIPTION
**Description**
1. The `SrokeWidth` of default flag has been increased to `1.6` to match other material icons.
2. The `pathData` of the flag has been changed to make pole wider.
- Type of change: Bug fix (non-breaking change which fixes an issue)

* Fixes #16252 

**Approach**
The following parameters have been changed in the `ic_flag_transparent.xml` file.
1. `pathData="M14.4,6L14,4H5v17h3v-7h5.6l0.4,2h7V6z`
2. `strokeWidth="1.6"`

**How Has This Been Tested?**
- [X] Opened the application.
- [X] Created a new Deck.
- [X] Noticed the Flag icon after clicking the menu at the top right corner and compared it with other material icons.

**Before:**
![Screenshot_20250106-071817_AnkiDroid](https://github.com/user-attachments/assets/ed224811-cada-44e3-979b-e3eeb718a88a)

**After:**
![Screenshot_20250105-230909_AnkiDroid](https://github.com/user-attachments/assets/3de05241-6497-44da-9194-2ffb8d0f2563)

**Before:**
![bf](https://github.com/user-attachments/assets/6f98b3b1-78cd-4eaa-8b90-b43a44d2c324)

**After:**
![af](https://github.com/user-attachments/assets/b2320b1f-df3c-47e7-a4eb-de5edf8aa680)
