### PR TITLE
fix: allow tinting 'tick' icon

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_done_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_done_white.xml
@@ -1,4 +1,5 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<!-- for grep: tick check save -->
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>


### PR DESCRIPTION
I found it hard to find, so added some greppable strings

It also was not tintable, which made it invisible in any Material3 dialogs using it

**Testing: unchanged**
<img width="412" alt="Screenshot 2025-01-06 at 03 19 54" src="https://github.com/user-attachments/assets/702d834a-48f6-4f31-bc85-b9f5abe0f25c" />

**Testing: now working**
<img width="415" alt="Screenshot 2025-01-06 at 03 21 22" src="https://github.com/user-attachments/assets/088dd487-215f-42b1-947f-bed24f2f4ef4" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
