### PR TITLE
Fix IllegalArgumentException in setColor method for Dark theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -121,9 +121,12 @@ class BrowserMultiColumnAdapter(
         fun setColor(
             @ColorInt color: Int,
         ) {
-            val pressedColor = darkenColor(color, 0.85f)
+            var pressedColor = darkenColor(color, 0.85f)
 
-            require(pressedColor != color)
+            if (pressedColor == color) {
+                pressedColor = darkenColor(color, 0.7f)
+            }
+
             val rippleDrawable =
                 RippleDrawable(
                     ColorStateList(


### PR DESCRIPTION
Fixes #17731

Update `setColor` method in `BrowserMultiColumnAdapter` to handle very dark colors

* Change `pressedColor` to a variable and adjust it if it is equal to `color`
* Modify `require` statement to check if `pressedColor` is equal to `color` and adjust `pressedColor` if necessary

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ankidroid/Anki-Android/pull/17738?shareId=e67e617c-222b-4b89-ba4f-ddb7fcf0debe).