### PR TITLE
refactor: reduce verbosity of 'findViewById'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.android.darkenColor
+import com.ichi2.anki.utils.ext.findViewById
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import kotlin.math.abs
@@ -69,9 +70,9 @@ class BrowserMultiColumnAdapter(
         holder: View,
     ) : RecyclerView.ViewHolder(holder) {
         var id: CardOrNoteId? = null
-        private val checkBoxView = this.itemView.findViewById<CheckBox>(R.id.card_checkbox)
-        private val firstColumnView = this.itemView.findViewById<TextView>(R.id.card_sfld)
-        private val secondColumnView = this.itemView.findViewById<TextView>(R.id.card_column2)
+        private val checkBoxView = findViewById<CheckBox>(R.id.card_checkbox)
+        private val firstColumnView = findViewById<TextView>(R.id.card_sfld)
+        private val secondColumnView = findViewById<TextView>(R.id.card_column2)
 
         init {
             this.itemView.setOnClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
@@ -32,6 +32,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.textfield.TextInputEditText
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.ext.findViewById
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -46,15 +47,15 @@ class FlagAdapter(
     inner class FlagViewHolder(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
-        val flagImageView: ImageView = itemView.findViewById(R.id.ic_flag)
-        val flagNameText: TextView = itemView.findViewById(R.id.flag_name)
-        val flagNameEdit: TextInputEditText = itemView.findViewById(R.id.flag_name_edit_text)
-        val editButton: MaterialButton = itemView.findViewById(R.id.action_edit_flag)
-        val saveButton: MaterialButton = itemView.findViewById(R.id.action_save_flag_name)
-        val cancelButton: MaterialButton = itemView.findViewById(R.id.action_cancel_flag_rename)
+        val flagImageView: ImageView = findViewById(R.id.ic_flag)
+        val flagNameText: TextView = findViewById(R.id.flag_name)
+        val flagNameEdit: TextInputEditText = findViewById(R.id.flag_name_edit_text)
+        val editButton: MaterialButton = findViewById(R.id.action_edit_flag)
+        val saveButton: MaterialButton = findViewById(R.id.action_save_flag_name)
+        val cancelButton: MaterialButton = findViewById(R.id.action_cancel_flag_rename)
 
-        val flagNameViewLayout: LinearLayout = itemView.findViewById(R.id.flag_name_view_layout)
-        val flagNameEditLayout: LinearLayout = itemView.findViewById(R.id.edit_flag_name_layout)
+        val flagNameViewLayout: LinearLayout = findViewById(R.id.flag_name_view_layout)
+        val flagNameEditLayout: LinearLayout = findViewById(R.id.edit_flag_name_layout)
     }
 
     override fun onCreateViewHolder(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -28,6 +28,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.OnContextAndLongClickListener
 import com.ichi2.anki.OnContextAndLongClickListener.Companion.setOnContextAndLongClickListener
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.ext.findViewById
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.ui.CheckBoxTriStates
 import com.ichi2.ui.CheckBoxTriStates.State.CHECKED
@@ -51,11 +52,11 @@ class TagsArrayAdapter(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
         internal lateinit var node: TagTreeNode
-        internal val expandButton: ImageButton = itemView.findViewById(R.id.id_expand_button)
-        internal val checkBoxView: CheckBoxTriStates = itemView.findViewById(R.id.tags_dialog_tag_item_checkbox)
+        internal val expandButton: ImageButton = findViewById(R.id.id_expand_button)
+        internal val checkBoxView: CheckBoxTriStates = findViewById(R.id.tags_dialog_tag_item_checkbox)
 
         // TextView contains the displayed tag (only the last part), while the full tag is stored in TagTreeNode
-        internal val textView: TextView = itemView.findViewById(R.id.tags_dialog_tag_item_text)
+        internal val textView: TextView = findViewById(R.id.tags_dialog_tag_item_text)
 
         @get:VisibleForTesting(otherwise = VisibleForTesting.NONE)
         val text: String

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.widget.AppCompatImageView
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.ext.findViewById
 
 class ReviewerMenuSettingsAdapter(
     private val items: List<ReviewerMenuSettingsRecyclerItem>,
@@ -72,10 +73,10 @@ class ReviewerMenuSettingsAdapter(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
         fun bind(action: ViewerAction) {
-            action.titleRes.let { itemView.findViewById<TextView>(R.id.title).setText(it) }
-            action.drawableRes?.let { itemView.findViewById<AppCompatImageView>(R.id.icon).setBackgroundResource(it) }
+            action.titleRes.let { findViewById<TextView>(R.id.title).setText(it) }
+            action.drawableRes?.let { findViewById<AppCompatImageView>(R.id.icon).setBackgroundResource(it) }
 
-            itemView.findViewById<AppCompatImageView>(R.id.drag_handle).setOnTouchListener { _, event ->
+            findViewById<AppCompatImageView>(R.id.drag_handle).setOnTouchListener { _, event ->
                 if (event.action == MotionEvent.ACTION_DOWN) {
                     onDragHandleTouchedListener?.invoke(this)
                 }
@@ -89,7 +90,7 @@ class ReviewerMenuSettingsAdapter(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
         fun bind(displayCategory: MenuDisplayType) {
-            itemView.findViewById<MaterialTextView>(R.id.title).setText(displayCategory.title)
+            findViewById<MaterialTextView>(R.id.title).setText(displayCategory.title)
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/RecyclerView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/RecyclerView.kt
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.view.View
+import androidx.annotation.IdRes
+import androidx.recyclerview.widget.RecyclerView
+
+/** @see View.findViewById */
+fun <T : View> RecyclerView.ViewHolder.findViewById(
+    @IdRes id: Int,
+) = itemView.findViewById<T>(id)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/ButtonItemAdapter.kt
@@ -32,6 +32,7 @@ import android.widget.ImageButton
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.ext.findViewById
 import com.ichi2.ui.ButtonItemAdapter.ButtonVH
 
 /**
@@ -73,9 +74,9 @@ class ButtonItemAdapter(
         private val adapter: ButtonItemAdapter,
     ) : RecyclerView.ViewHolder(itemView),
         View.OnClickListener {
-        val title: TextView = itemView.findViewById(R.id.card_browser_my_search_name_textview)
-        val button: ImageButton =
-            itemView.findViewById<ImageButton?>(R.id.card_browser_my_search_remove_button).apply {
+        val title: TextView = findViewById(R.id.card_browser_my_search_name_textview)
+        val button =
+            findViewById<ImageButton>(R.id.card_browser_my_search_remove_button).apply {
                 setOnClickListener(this@ButtonVH)
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
+import com.ichi2.anki.utils.ext.findViewById
 import com.ichi2.libanki.DeckId
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,8 +50,8 @@ class WidgetConfigScreenAdapter(
     class DeckViewHolder(
         itemView: View,
     ) : RecyclerView.ViewHolder(itemView) {
-        val deckNameTextView: TextView = itemView.findViewById(R.id.deck_name)
-        val removeButton: ImageButton = itemView.findViewById(R.id.action_button_remove_deck)
+        val deckNameTextView: TextView = findViewById(R.id.deck_name)
+        val removeButton: ImageButton = findViewById(R.id.action_button_remove_deck)
     }
 
     /** Creates and inflates the view for each item in the RecyclerView

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -19,14 +19,11 @@ import android.annotation.SuppressLint
 import android.content.Intent
 import android.os.Bundle
 import android.text.TextUtils
-import android.view.View
 import android.widget.Spinner
-import androidx.annotation.IdRes
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.search.BrowserRow
 import anki.search.BrowserRow.Color
@@ -53,6 +50,7 @@ import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN1_KEYS
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN2_KEYS
+import com.ichi2.anki.utils.ext.findViewById
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.BrowserConfig
@@ -1274,10 +1272,6 @@ fun CardBrowser.getVisibleRows() =
     }.toList().also {
         assertThat("has visible rows", it.any())
     }
-
-fun <T : View> RecyclerView.ViewHolder.findViewById(
-    @IdRes id: Int,
-): T = this.itemView.findViewById(id)
 
 val CardBrowser.isShowingSelectAll: Boolean
     get() {


### PR DESCRIPTION
Working through the browser column selection feature, the verbosity felt needless here, and led to line wrapping

## How Has This Been Tested?

API 34 emulator - primarily 'My Searches', which used the `ButtonItemAdapter`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
