### PR TITLE
Fix setColor function for dark theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -124,17 +124,36 @@ class BrowserMultiColumnAdapter(
             val pressedColor = darkenColor(color, 0.85f)
 
             require(pressedColor != color)
-            val rippleDrawable =
-                RippleDrawable(
-                    ColorStateList(
-                        arrayOf(intArrayOf(android.R.attr.state_pressed)),
-                        intArrayOf(pressedColor),
-                    ),
-                    ColorDrawable(color),
-                    null,
-                )
 
-            itemView.background = rippleDrawable
+            if (pressedColor == color) {
+                // Fallback color in case the pressedColor is the same as the input color
+                val fallbackColor = if (color == context.getColor(R.color.black)) {
+                    context.getColor(R.color.white)
+                } else {
+                    context.getColor(R.color.black)
+                }
+                val rippleDrawable =
+                    RippleDrawable(
+                        ColorStateList(
+                            arrayOf(intArrayOf(android.R.attr.state_pressed)),
+                            intArrayOf(fallbackColor),
+                        ),
+                        ColorDrawable(color),
+                        null,
+                    )
+                itemView.background = rippleDrawable
+            } else {
+                val rippleDrawable =
+                    RippleDrawable(
+                        ColorStateList(
+                            arrayOf(intArrayOf(android.R.attr.state_pressed)),
+                            intArrayOf(pressedColor),
+                        ),
+                        ColorDrawable(color),
+                        null,
+                    )
+                itemView.background = rippleDrawable
+            }
         }
 
         fun setIsTruncated(truncated: Boolean) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/android/ColorUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/android/ColorUtils.kt
@@ -1,0 +1,28 @@
+package com.ichi2.anki.utils.android
+
+import androidx.annotation.ColorInt
+
+/**
+ * Darkens a color by a given factor.
+ *
+ * @param color The color to darken.
+ * @param factor The factor by which to darken the color.
+ * @return The darkened color.
+ */
+@ColorInt
+fun darkenColor(@ColorInt color: Int, factor: Float): Int {
+    val a = android.graphics.Color.alpha(color)
+    val r = (android.graphics.Color.red(color) * factor).toInt()
+    val g = (android.graphics.Color.green(color) * factor).toInt()
+    val b = (android.graphics.Color.blue(color) * factor).toInt()
+
+    // Ensure the darkened color is different from the input color
+    return if (r == android.graphics.Color.red(color) &&
+        g == android.graphics.Color.green(color) &&
+        b == android.graphics.Color.blue(color)
+    ) {
+        android.graphics.Color.argb(a, r + 1, g + 1, b + 1)
+    } else {
+        android.graphics.Color.argb(a, r, g, b)
+    }
+}


### PR DESCRIPTION
- Fixes #17731

Fix the `setColor` function to handle cases where the `pressedColor` is the same as the input `color`.

* Add a fallback color in `setColor` function in `BrowserMultiColumnAdapter.kt` to handle cases where the `pressedColor` is the same as the input `color`.
* Add a new utility function `darkenColor` in `ColorUtils.kt` to ensure it always returns a color different from the input color.

