### PR TITLE
Fix media notification stuck issue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -87,6 +87,7 @@ class SyncMediaWorker(
         }
 
         Timber.d("SyncMediaWorker: success")
+        notificationManager.cancel(NotificationId.SYNC_MEDIA) // Pd8a3
         return Result.success()
     }
 
@@ -96,6 +97,7 @@ class SyncMediaWorker(
             val status = backend.mediaSyncStatus()
             if (!status.active) {
                 Timber.i("Ended media sync notification updates")
+                notificationManager.cancel(NotificationId.SYNC_MEDIA) // Pef99
                 break
             }
             // avoid sending repeated notifications


### PR DESCRIPTION
Fixes #17639

Add code to dismiss the syncing media notification after the media sync is complete.

* Add `notificationManager.cancel(NotificationId.SYNC_MEDIA)` in `SyncMediaWorker` to cancel the notification after the media sync is complete.
* Modify `monitorProgress` in `SyncMediaWorker` to dismiss the notification when the sync is complete.

