### PR TITLE
fix(card-browser): crashed in Dark Mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -38,7 +38,9 @@ import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.android.darkenColor
+import com.ichi2.anki.utils.android.lightenColorAbsolute
 import com.ichi2.anki.utils.ext.findViewById
+import com.ichi2.annotations.NeedsTest
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 import kotlin.math.abs
@@ -119,10 +121,19 @@ class BrowserMultiColumnAdapter(
             checkBoxView.isChecked = value
         }
 
+        @NeedsTest("17731 - maybe check all activities load in dark mode, at least check this code")
         fun setColor(
             @ColorInt color: Int,
         ) {
-            val pressedColor = darkenColor(color, 0.85f)
+            var pressedColor = darkenColor(color, 0.85f)
+
+            if (pressedColor == color) {
+                // if the color is black, we can't darken it.
+                // A non-black background looks unusual, so the 'press' should lighten the color
+
+                // 25% was determined by visual inspection
+                pressedColor = lightenColorAbsolute(pressedColor, 0.25f)
+            }
 
             require(pressedColor != color)
             val rippleDrawable =

--- a/common/src/main/java/com/ichi2/anki/utils/android/ColorUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/utils/android/ColorUtils.kt
@@ -40,6 +40,25 @@ fun darkenColor(
 }
 
 /**
+ * Lightens the provided ARGB color by a provided [amount]
+ *
+ * @param argb The ARGB color to transform
+ * @param amount Amount to lighten, between 0.0f (no change) and 1.0f (100% brightness)
+ * @return The lightened color in ARGB
+ */
+@ColorInt
+fun lightenColorAbsolute(
+    @ColorInt argb: Int,
+    amount: Float,
+): Int {
+    val hsv = argb.toHSV()
+    // https://en.wikipedia.org/wiki/HSL_and_HSV
+    // The third component is the 'value', or 'lightness/darkness'
+    hsv[2] = (hsv[2] + amount).clamp(0f, 1f)
+    return Color.HSVToColor(hsv)
+}
+
+/**
  * Converts an ARGB color to an array of its HSV components
  *
  * [0] is Hue: `[0..360[`


### PR DESCRIPTION
## Purpose / Description
We had an assertion that the `pressed color != color`, and this failed if the color was black

In this case, we lighten the color by 25%
## Fixes
* Fixes #17731

## Approach
As above

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/9e490243-6d6a-4222-a869-cdaba1df2c57)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 18 mins + 7 with 'reviews'-->