### PR TITLE
fix(empty-cards): make undoable, correct result, use backend strings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -531,9 +531,11 @@ class Collection(
             Timber.d("removeNotes: %d changes", it.count)
         }
 
-    fun removeCardsAndOrphanedNotes(cardIds: Iterable<Long>) {
-        backend.removeCards(cardIds)
-    }
+    /**
+     * @return the number of deleted cards. **Note:** if an invalid/duplicate [CardId] is provided,
+     * the output count may be less than the input.
+     */
+    fun removeCardsAndOrphanedNotes(cardIds: Iterable<CardId>) = backend.removeCards(cardIds)
 
     fun addNote(
         note: Note,

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -116,7 +116,6 @@
     <!-- Empty cards -->
     <string name="emtpy_cards_finding">Finding empty cards…</string>
     <string name="empty_cards_count">Cards to delete: %d</string>
-    <string name="empty_cards_deleted">Cards deleted: %d</string>
 
 
     <!-- Multimedia - Edit Field Activity -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -1,0 +1,106 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.deckpicker
+
+import androidx.annotation.CheckResult
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.libanki.CardId
+import com.ichi2.libanki.undoStatus
+import com.ichi2.testutils.ensureOpsExecuted
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import timber.log.Timber
+
+/** Test of [DeckPickerViewModel] */
+@RunWith(AndroidJUnit4::class)
+class DeckPickerViewModelTest : RobolectricTest() {
+    private val viewModel = DeckPickerViewModel()
+
+    @Test
+    fun `empty cards - flow`() =
+        runTest {
+            val cardsToEmpty = createEmptyCards()
+
+            viewModel.emptyCardsNotification.test {
+                // test a 'normal' deletion
+                viewModel.deleteEmptyCards(cardsToEmpty).join()
+
+                expectMostRecentItem().also {
+                    assertThat("cards deleted", it.cardsDeleted, equalTo(1))
+                }
+
+                // ensure a duplicate output is displayed to the user
+                val newCardsToEmpty = createEmptyCards()
+                viewModel.deleteEmptyCards(newCardsToEmpty).join()
+
+                expectMostRecentItem().also {
+                    assertThat("cards deleted: duplicate output", it.cardsDeleted, equalTo(1))
+                }
+
+                // send the same collection in, but with the same ids.
+                // the output should only show 1 card deleted
+                val emptyCardsSentTwice = createEmptyCards()
+                viewModel.deleteEmptyCards(emptyCardsSentTwice + emptyCardsSentTwice).join()
+
+                expectMostRecentItem().also {
+                    assertThat("cards deleted: duplicate input", it.cardsDeleted, equalTo(1))
+                }
+
+                // test an empty list: a no-op should inform the user, rather than do nothing
+                viewModel.deleteEmptyCards(listOf()).join()
+
+                expectMostRecentItem().also {
+                    assertThat("'no cards deleted' is notified", it.cardsDeleted, equalTo(0))
+                }
+            }
+        }
+
+    @Test
+    fun `empty cards - undoable`() =
+        runTest {
+            val cardsToEmpty = createEmptyCards()
+
+            // ChangeManager assert
+            ensureOpsExecuted(1) {
+                viewModel.deleteEmptyCards(cardsToEmpty).join()
+            }
+
+            // backend assert
+            assertThat("col undo status", col.undoStatus().undo, equalTo("Empty Cards"))
+        }
+
+    @CheckResult
+    private suspend fun createEmptyCards(): List<CardId> {
+        addNoteUsingNoteTypeName("Cloze", "{{c1::Hello}} {{c2::World}}", "").apply {
+            setField(0, "{{c1::Hello}}")
+            col.updateNote(this)
+        }
+        return viewModel.findEmptyCards().also { cardsToEmpty ->
+            assertThat("there are empty cards", cardsToEmpty, not(empty()))
+            Timber.d("created %d empty cards: [%s]", cardsToEmpty.size, cardsToEmpty)
+        }
+    }
+
+    /** test helper to use [deleteEmptyCards] without an [EmptyCards] instance */
+    private fun DeckPickerViewModel.deleteEmptyCards(list: List<CardId>) = deleteEmptyCards(EmptyCards(list))
+}


### PR DESCRIPTION
## Purpose / Description
* #16945

## Fixes
* Fixes #16945

## Approach
* Extract operation to ViewModel
* Extract output to Flow
* add `opChanges { }`
* Use the result of `opChangesWithCount`
* Use `TR` rather than `strings`
* Add `Undo` to the snackbar, and only show it for a short duration
* Test!

## How Has This Been Tested?

⚠️ Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
