### PR TITLE
feat(new reviewer): box frame style

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -44,6 +44,7 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
+import com.google.android.material.shape.ShapeAppearanceModel
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_NO_MORE_CARDS
@@ -98,6 +99,7 @@ import com.ichi2.anki.utils.ext.menu
 import com.ichi2.anki.utils.ext.removeSubMenu
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.window
+import com.ichi2.anki.utils.setMargins
 import com.ichi2.libanki.sched.Counts
 import kotlinx.coroutines.launch
 
@@ -140,6 +142,7 @@ class ReviewerFragment :
         }
 
         setupImmersiveMode(view)
+        setupFrame(view)
         setupTypeAnswer(view)
         setupAnswerButtons(view)
         setupCounts(view)
@@ -458,6 +461,18 @@ class ReviewerFragment :
                 bottom = bars.bottom,
             )
             WindowInsetsCompat.CONSUMED
+        }
+    }
+
+    private fun setupFrame(view: View) {
+        val frameStyleKey = getString(R.string.reviewer_frame_style_key)
+        val boxValue = getString(R.string.reviewer_frame_style_box_value)
+        if (sharedPrefs().getString(frameStyleKey, null) == boxValue) {
+            view.findViewById<MaterialCardView>(R.id.webview_container).apply {
+                setMargins(0)
+                cardElevation = 0F
+                shapeAppearanceModel = ShapeAppearanceModel() // Remove corners
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Layout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Layout.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils
+
+import android.view.ViewGroup.MarginLayoutParams
+import android.widget.FrameLayout
+
+fun FrameLayout.setMargins(value: Int) {
+    (layoutParams as? MarginLayoutParams)?.setMargins(value, value, value, value)
+}

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -79,7 +79,8 @@
             <WebView
                 android:id="@+id/webview"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
+                android:layout_height="match_parent"
+                tools:backgroundTint="@color/white"/>
 
         </com.google.android.material.card.MaterialCardView>
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -204,7 +204,7 @@
     <string name="keyboard">Keyboard</string>
     <string name="bluetooth">Bluetooth</string>
     <string name="answer_buttons" maxLength="41">Answer buttons</string>
-    <string name="card" maxLength="41">Card</string>
+    <string name="card" maxLength="41" comment="Generic term to refer to a card">Card</string>
     <string name="note" maxLength="41">Note</string>
     <string name="navigation" maxLength="41">Navigation</string>
     <string name="media" maxLength="41">Media</string>
@@ -440,6 +440,11 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="ignore_display_cutout" maxLength="41">Ignore display cutout</string>
     <string name="hide_answer_buttons" maxLength="41">Hide answer buttons</string>
     <string name="hide_hard_and_easy" maxLength="41">Hide ‘Hard’ and ‘Easy’ buttons</string>
+    <string name="reviewer_frame_style" maxLength="41">Frame style</string>
+    <string name="reviewer_frame_style_card" maxLength="41" comment="Style name of the 'Card' card frame of the Reviewer"
+        >Card</string>
+    <string name="reviewer_frame_style_box" maxLength="41" comment="Style name of the 'Box' card frame of the Reviewer"
+        >Box</string>
 
     <!--Keyboard shortcuts dialog-->
     <string name="open_settings" comment="Description of the shortcut that opens the app settings">Open settings</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -241,6 +241,20 @@
         <item>@string/hide_system_bars_all_value</item>
     </string-array>
 
+    <string-array name="reviewer_frame_style_entries">
+        <item>@string/reviewer_frame_style_card</item>
+        <item>@string/reviewer_frame_style_box</item>
+    </string-array>
+
+    <string name="reviewer_frame_style_card_value">0</string>
+    <string name="reviewer_frame_style_box_value">1</string>
+
+    <string-array name="reviewer_frame_style_values">
+        <item>@string/reviewer_frame_style_card_value</item>
+        <item>@string/reviewer_frame_style_box_value</item>
+    </string-array>
+
+
     <!-- Preferences headers summaries -->
     <string-array name="general_summary_entries">
         <item>@string/language</item>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -204,5 +204,6 @@
     <string name="hide_answer_buttons_key">hideAnswerButtons</string>
     <string name="hide_hard_and_easy_key">hideHardAndEasy</string>
     <string name="reviewer_menu_settings_key">reviewerMenuSettings</string>
+    <string name="reviewer_frame_style_key">reviewerFrameStyle</string>
 
 </resources>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -31,4 +31,12 @@
     <Preference
         android:title="Menu actions"
         android:key="@string/reviewer_menu_settings_key" />
+
+    <ListPreference
+        android:defaultValue="@string/reviewer_frame_style_card_value"
+        android:entries="@array/reviewer_frame_style_entries"
+        android:entryValues="@array/reviewer_frame_style_values"
+        android:key="@string/reviewer_frame_style_key"
+        android:title="@string/reviewer_frame_style"
+        app:useSimpleSummaryProvider="true"/>
 </androidx.preference.PreferenceScreen>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Anki's Webview frame is a rectangle stretched to the window borders, while the new reviewer has a nice `Card` like frame, which is more aesthetical.

Given that many card templates were created based on Anki's default frame, the `Card` style may not suit them well (e.g. by using a card template on the card frame, so the style ends up duplicated).

So, this PR gives an option to switch to the old frame, used by Anki and the old reviewer.

## How Has This Been Tested?

<details><summary>Screenshots</summary>

![Screenshot_20250106_201022](https://github.com/user-attachments/assets/f7611963-a9b7-47a6-a64f-bcd3a73c3abd)

![Box](https://github.com/user-attachments/assets/a6af85be-848a-4480-ab05-d2b518373b0a)

![Card](https://github.com/user-attachments/assets/2aa64046-be66-497d-a373-942d54ab8eef)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
