### PR TITLE
fix: flag not being set in old reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -399,7 +399,7 @@ open class Reviewer :
             return true
         }
 
-        Flag.entries.find { it.ordinal == item.itemId }?.let { flag ->
+        Flag.entries.find { it.id == item.itemId }?.let { flag ->
             Timber.i("Reviewer:: onOptionItemSelected Flag - ${flag.name} clicked")
             onFlag(currentCard, flag)
             return true


### PR DESCRIPTION
For some reason, the flag menu items used their code/order as ID before (that may lead to conflicts, so it isn't a good practice).

After 1a96697e6391647c0aecfc1b472400b00b846f32 they use proper IDs, but those IDs weren't handled at onOptionsItemSelected

## Fixes
* Fixes #17748

## How Has This Been Tested?

Issue reproduction steps

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
