### PR TITLE
Improve congrats message when no cards due later in day

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -109,7 +109,7 @@
     <string name="empty_deck">This deck is empty</string>
     <string name="search_for_download_deck" comment="Deck search value for downloading deck" maxLength="28">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
-    <string name="studyoptions_congrats_finished">Congratulations! You have finished for now.</string>
+    <string name="studyoptions_congrats_finished">Congratulations! You have finished for today.</string>
     <string name="studyoptions_congrats_next_due_in" comment="The param will be replaced with 'The next card will be ready in X time'">Deck finished for now! %s</string>
     <string name="studyoptions_no_cards_due">No cards are due yet</string>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
After https://github.com/ankidroid/Anki-Android/pull/16566, the string `studyoptions_congrats_finished` is used only when there are no cards due later in the day. The previous wording was "You have finished for now." This might suggest that some cards may be due later in the day (it was indeed supposed to imply that before the above-mentioned PR). The changed text makes the meaning clearer.

## Fixes
* Fixes None

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Not tested

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
