### PR TITLE
fix(browse): fix regression showing borders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -39,8 +39,10 @@ import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import anki.collection.OpChanges
@@ -379,6 +381,11 @@ open class CardBrowser :
         // Load reference to action bar title
         actionBarTitle = findViewById(R.id.toolbar_title)
         cardsListView = findViewById(R.id.card_browser_list)
+        DividerItemDecoration(this, DividerItemDecoration.VERTICAL).apply {
+            setDrawable(ContextCompat.getDrawable(this@CardBrowser, R.drawable.browser_divider)!!)
+            cardsListView.addItemDecoration(this)
+        }
+
         // get the font and font size from the preferences
         // make a new list adapter mapping the data in mCards to column1 and column2 of R.layout.card_item_browser
         cardsAdapter =

--- a/AnkiDroid/src/main/res/drawable/browser_divider.xml
+++ b/AnkiDroid/src/main/res/drawable/browser_divider.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <!-- 0.5 appears badly aliased on Emulators -->
+    <size android:height="0.6dp" android:width="2dp"/>
+    <solid android:color="?attr/cardBrowserDivider" />
+</shape>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -39,8 +39,6 @@
             android:id="@+id/card_browser_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="?android:attr/colorBackground"
-            android:divider="?attr/cardBrowserDivider"
             android:overScrollFooter="@color/transparent"
             android:dividerHeight="0.5dp"
             android:clipToPadding="false"

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -79,7 +79,7 @@
         <item name="goodButtonRippleRef">@drawable/footer_button_ripple</item>
         <item name="easyButtonRippleRef">@drawable/footer_button_ripple</item>
         <!-- Card Browser Colors -->
-        <item name="cardBrowserDivider">?attr/dividerHorizontal</item>
+        <item name="cardBrowserDivider">#CCCCCC</item>
         <!-- Browser colors -->
         <item name="suspendedColor">#FFFFB2</item>
         <item name="buriedColor">#FFCE7C</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -36,7 +36,7 @@
         <item name="goodButtonRippleRef">@drawable/footer_button_all_plain_ripple</item>
         <item name="easyButtonRippleRef">@drawable/footer_button_all_plain_ripple</item>
         <!-- Card Browser Colors -->
-        <item name="cardBrowserDivider">?attr/dividerHorizontal</item>
+        <item name="cardBrowserDivider">#CCCCCC</item>
         <!-- Note editor colors -->
         <item name="editTextBackgroundColor">#EBCCCCCC</item>
         <item name="toolbarBackgroundColor">#D6D7D7</item>


### PR DESCRIPTION
## Fixes
* Fixes #17751

## Approach
Use `DividerItemDecoration`

## How Has This Been Tested?

API 34 emulator

<img width="421" alt="Screenshot 2025-01-07 at 22 58 48" src="https://github.com/user-attachments/assets/d541da21-6d6e-4a95-9b5c-d90ea33188a9" />
<img width="413" alt="Screenshot 2025-01-07 at 22 59 15" src="https://github.com/user-attachments/assets/b88710dd-6c85-4ab1-a59b-b33cce07f510" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 1.5 hours. SAD-->