### PR TITLE
improvement(browser-options): remove superfluous text

### DIFF
--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -26,7 +26,8 @@
             android:id="@+id/select_browser_mode"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_margin="16dp">
+            android:layout_marginTop="8dp"
+            android:layout_marginHorizontal="16dp">
 
             <RadioButton
                 android:id="@+id/select_cards_mode"
@@ -41,13 +42,6 @@
                 android:text="@string/show_notes" />
 
         </RadioGroup>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/toggle_browser_mode_help"
-            android:textColor="?android:attr/textColorSecondary"
-            android:layout_marginHorizontal="16dp" />
     </LinearLayout>
 
     <LinearLayout

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -328,7 +328,6 @@
     <string name="show_cards" comment="Label for toggle cards button in BrowserOptionsDialog">Cards</string>
     <string name="show_notes" comment="Label for toggle notes button in BrowserOptionsDialog">Notes</string>
     <string name="toggle_cards_notes">Toggle Cards/Notes</string>
-    <string name="toggle_browser_mode_help">Toggle Showing cards or notes in the browser</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3 lines of content</string>
     <string name="browser_options_dialog_heading">Browser Options</string>
 


### PR DESCRIPTION
"Toggle Showing cards or notes in the browser" wasn't useful to explain cards/notes mode

Added in 937a6560913ec383ab71a6a1b704b815b5ad88a8 (#12035)

## How Has This Been Tested?

<img width="340" alt="Screenshot 2025-01-08 at 01 11 19" src="https://github.com/user-attachments/assets/f42b82eb-a4d1-4e3a-9f88-96230a4ecc03" />

<img width="350" alt="Screenshot 2025-01-08 at 01 09 07" src="https://github.com/user-attachments/assets/f98d4632-9695-4ceb-a296-3481ba2e107a" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
