### PR TITLE
improvement(browser-options): fix casing of title

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -330,7 +330,7 @@
     <string name="toggle_cards_notes">Toggle Cards/Notes</string>
     <string name="toggle_browser_mode_help">Toggle Showing cards or notes in the browser</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3 lines of content</string>
-    <string name="browser_options_dialog_heading">Browser Options</string>
+    <string name="browser_options_dialog_heading">Browser options</string>
 
     <string name="audio_saved">Recording saved</string>
 


### PR DESCRIPTION
## How Has This Been Tested?

<img width="342" alt="Screenshot 2025-01-08 at 01 18 32" src="https://github.com/user-attachments/assets/ffb78805-2889-480e-8e36-039bc6219282" />

<img width="342" alt="Screenshot 2025-01-08 at 01 18 32" src="https://github.com/user-attachments/assets/3c6a209e-14ac-4c11-8057-4004c596b46a" />

* #15760

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
