### PR TITLE
fix: reminder question time elapsed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvance.kt
@@ -77,7 +77,7 @@ class AutoAdvance(
 
     suspend fun onShowQuestion() {
         answerActionJob?.cancel()
-        if (!durationToShowQuestionFor().isPositive() || !isEnabled) return
+        if (!durationToShowQuestionFor().isPositive() && !isEnabled) return
 
         questionActionJob =
             viewModel.launchCatchingIO {
@@ -91,7 +91,7 @@ class AutoAdvance(
 
     suspend fun onShowAnswer() {
         questionActionJob?.cancel()
-        if (!durationToShowAnswerFor().isPositive() || !isEnabled) return
+        if (!durationToShowAnswerFor().isPositive() && !isEnabled) return
 
         answerActionJob =
             viewModel.launchCatchingIO {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Auto Advance "Question time elapsed" reminder does not work

## Fixes
* Fixes #17765

## Approach
Show reminder/answer automatically on when both `durationToShowQuestionFor().isPositive()` and `isEnabled `are false

## How Has This Been Tested?
Physical device (OPPO F21 Pro 5G).


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)