### PR TITLE
fix: reminder question time elapsed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -127,6 +127,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
 import com.ichi2.anki.utils.OnlyOnce.Method.ANSWER_CARD
 import com.ichi2.anki.utils.OnlyOnce.preventSimultaneousExecutions
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -1300,7 +1301,7 @@ abstract class AbstractFlashcardViewer :
         easeButton1!!.performSafeClick()
     }
 
-    override fun automaticShowAnswer() {
+    override fun automaticShowAnswer(action: QuestionAction) {
         if (flipCardLayout!!.isEnabled && flipCardLayout!!.visibility == View.VISIBLE) {
             flipCardLayout!!.performClick()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -53,11 +53,13 @@ import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import anki.frontend.SetSchedulingStatesRequest
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.getInverseTransition
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Whiteboard.Companion.createInstance
 import com.ichi2.anki.Whiteboard.OnPaintColorChangeListener
@@ -94,6 +96,7 @@ import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.utils.remainingTime
@@ -970,6 +973,22 @@ open class Reviewer :
         // explicitly do not call super
         if (easeButton1!!.canPerformClick) {
             action.execute(this)
+        }
+    }
+
+    override fun automaticShowAnswer(action: QuestionAction) {
+        if (flipCardLayout!!.isVisible) {
+            execute(action)
+        }
+    }
+
+    fun execute(action: QuestionAction) {
+        val command = action.toCommand()
+        if (command != null) {
+            Timber.i("Executing %s", command)
+            executeCommand(command)
+        } else {
+            showSnackbar(TR.studyingQuestionTimeElapsed())
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -26,6 +26,8 @@ import com.ichi2.anki.reviewer.AnswerButtons.GOOD
 import com.ichi2.anki.reviewer.AnswerButtons.HARD
 import com.ichi2.anki.reviewer.AutomaticAnswerAction.Companion.answerAction
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction.Companion.questionAction
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckConfig
@@ -89,7 +91,7 @@ class AutomaticAnswer(
                 Timber.d("showAnswer: disabled")
                 return@Runnable
             }
-            target.automaticShowAnswer()
+            target.automaticShowAnswer(settings.questionAction)
         }
     private val showQuestionTask =
         Runnable {
@@ -211,7 +213,7 @@ class AutomaticAnswer(
     }
 
     interface AutomaticallyAnswered {
-        fun automaticShowAnswer()
+        fun automaticShowAnswer(action: QuestionAction)
 
         fun automaticShowQuestion(action: AutomaticAnswerAction)
     }
@@ -249,6 +251,7 @@ class AutomaticAnswer(
  */
 class AutomaticAnswerSettings(
     val answerAction: AutomaticAnswerAction = AutomaticAnswerAction.BURY_CARD,
+    val questionAction: QuestionAction = QuestionAction.SHOW_ANSWER,
     private val secondsToShowQuestionFor: Double = 60.0,
     private val secondsToShowAnswerFor: Double = 20.0,
 ) {
@@ -273,6 +276,7 @@ class AutomaticAnswerSettings(
             val conf = col.decks.configDictForDeckId(selectedDid)
             return AutomaticAnswerSettings(
                 answerAction = conf.answerAction,
+                questionAction = conf.questionAction,
                 secondsToShowQuestionFor = conf.secondsToShowQuestion,
                 secondsToShowAnswerFor = conf.secondsToShowAnswer,
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/QuestionAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/QuestionAction.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.ui.windows.reviewer.autoadvance
 
+import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.libanki.DeckConfig
 import com.ichi2.libanki.DeckConfig.Companion.QUESTION_ACTION
 
@@ -24,6 +25,13 @@ enum class QuestionAction(
     SHOW_ANSWER(0),
     SHOW_REMINDER(1),
     ;
+
+    /** Convert to a [ViewerCommand] */
+    fun toCommand(): ViewerCommand? =
+        when (this) {
+            SHOW_ANSWER -> ViewerCommand.SHOW_ANSWER
+            SHOW_REMINDER -> null
+        }
 
     companion object {
         fun from(code: Int): QuestionAction = entries.firstOrNull { it.code == code } ?: SHOW_ANSWER

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.reviewer.AutomaticAnswer
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.AutomaticAnswerSettings
 import com.ichi2.anki.servicelayer.LanguageHintService
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
 import com.ichi2.libanki.undoableOp
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.common.Flaky
@@ -285,7 +286,8 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
         runTest {
             val controller = getViewerController(addCard = true, startedWithShortcut = false)
             val viewer = controller.get()
-            viewer.automaticAnswer = AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, 5.0, 5.0))
+            viewer.automaticAnswer =
+                AutomaticAnswer(viewer, AutomaticAnswerSettings(AutomaticAnswerAction.BURY_CARD, QuestionAction.SHOW_ANSWER, 5.0, 5.0))
             viewer.executeCommand(ViewerCommand.SHOW_ANSWER)
             assertThat("messages after flipping card", viewer.hasAutomaticAnswerQueued(), equalTo(true))
             controller.pause()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.reviewer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.reviewer.AutomaticAnswer.AutomaticallyAnswered
+import com.ichi2.anki.ui.windows.reviewer.autoadvance.QuestionAction
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.JvmTest
 import org.hamcrest.CoreMatchers.equalTo
@@ -124,9 +125,9 @@ class AutomaticAnswerTest : JvmTest() {
 
         val automaticAnswerHandler =
             object : AutomaticallyAnswered {
-                override fun automaticShowAnswer() {
+                override fun automaticShowAnswer(action: QuestionAction) {
                     automaticAnswerHandle?.simulateCardFlip()
-                    automaticallyAnswered?.automaticShowAnswer()
+                    automaticallyAnswered?.automaticShowAnswer(action)
                 }
 
                 override fun automaticShowQuestion(action: AutomaticAnswerAction) {
@@ -150,7 +151,7 @@ class AutomaticAnswerTest : JvmTest() {
         var answerShown: Boolean = false,
         var questionShown: Boolean = false,
     ) : AutomaticallyAnswered {
-        override fun automaticShowAnswer() {
+        override fun automaticShowAnswer(action: QuestionAction) {
             answerShown = true
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Auto Advance "Question time elapsed" reminder does not work

## Fixes
* Fixes #17765

## Approach
show snackbar on `automaticShowAnswer()`

## How Has This Been Tested?
Physical device (OPPO F21 Pro 5G).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)