### PR TITLE
Fix: button resizing issue for large font sizes in new reviewer UI

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -119,7 +119,7 @@
         <FrameLayout
             android:id="@+id/buttons_area"
             android:layout_width="match_parent"
-            android:layout_height="@dimen/touch_target"
+            android:layout_height="wrap_content"
             android:layout_marginTop="2dp"
             android:layout_marginHorizontal="@dimen/reviewer_side_margin"
             >


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the issue where answer buttons in the new reviewer UI were being clipped when large font sizes were applied. The fix ensures the buttons resize dynamically to accommodate larger text

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/17734

## Approach
Changed the ``FrameLayout`` containing the answer buttons in the new reviewer UI to ``android:layout_height="wrap_content"`` to prevent vertical clipping when large font sizes are applied.

## How Has This Been Tested?
The issue was tested by increasing the system font size and verifying that the answer buttons in the new reviewer UI resize properly without clipping.  Physical Device (Samsung Galaxy A6+)

Video:

https://github.com/user-attachments/assets/d7807e84-849f-427c-aa56-89911e5d46a7


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
