### PR TITLE
fix: Allow access to internal storage images in WebView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -547,7 +547,9 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
         // Get the WebView and set it visible
         view?.findViewById<WebView>(R.id.multimedia_webview)?.apply {
             visibility = View.VISIBLE
-
+            settings.apply {
+                allowFileAccess = true
+            }
             // Load image based on its MIME type
             // SVGs require special handling due to their XML-based format and rendering complexities.
             // Raster images (e.g., JPG, PNG) can be rendered directly using an <img> tag in HTML.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Image Shared to AnkiDroid Doesn't Load

## Fixes
* Fixes #17776

## Approach
Enable WebView to access internal storage by configuring allowFileAccess settings. This ensures images from internal storage can be securely rendered in the WebView.

## How Has This Been Tested?
Physical device (OPPO F21 Pro 5G)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
