### PR TITLE
feat(new reviewer): answer buttons height setting

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -37,6 +37,7 @@ import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
@@ -260,9 +261,11 @@ class ReviewerFragment :
     }
 
     private fun setupAnswerButtons(view: View) {
-        val hideAnswerButtons = sharedPrefs().getBoolean(getString(R.string.hide_answer_buttons_key), false)
+        val prefs = sharedPrefs()
+        val hideAnswerButtons = prefs.getBoolean(getString(R.string.hide_answer_buttons_key), false)
+        val buttonsAreaLayout = view.findViewById<FrameLayout>(R.id.buttons_area)
         if (hideAnswerButtons) {
-            view.findViewById<FrameLayout>(R.id.buttons_area).isVisible = false
+            buttonsAreaLayout.isVisible = false
             return
         }
 
@@ -323,9 +326,18 @@ class ReviewerFragment :
             resetZoom()
         }
 
-        if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
+        if (prefs.getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
             hardButton.isVisible = false
             easyButton.isVisible = false
+        }
+
+        val buttonsHeight = prefs.getInt("answerButtonSize", 100)
+        if (buttonsHeight != 100) {
+            buttonsAreaLayout.post {
+                buttonsAreaLayout.updateLayoutParams {
+                    height = buttonsAreaLayout.measuredHeight * buttonsHeight / 100
+                }
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -312,12 +312,13 @@ class ReviewerFragment :
 
         // TODO add some kind of feedback/animation after tapping show answer or the answer buttons
         viewModel.showingAnswer.collectLatestIn(lifecycleScope) { shouldShowAnswer ->
+            // use INVISIBLE instead of GONE to keep the same button height
             if (shouldShowAnswer) {
-                showAnswerButton.isVisible = false
-                answerButtonsLayout.isVisible = true
+                showAnswerButton.visibility = View.INVISIBLE
+                answerButtonsLayout.visibility = View.VISIBLE
             } else {
-                showAnswerButton.isVisible = true
-                answerButtonsLayout.isVisible = false
+                showAnswerButton.visibility = View.VISIBLE
+                answerButtonsLayout.visibility = View.INVISIBLE
             }
             resetZoom()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -112,6 +112,10 @@ class ReviewerViewModel(
         ChangeManager.subscribe(this)
         launchCatchingIO {
             updateUndoAndRedoLabels()
+            // The height of the answer buttons may increase if `Show button time` is enabled.
+            // To ensure consistent height, load the times to match the height of the `Show answer`
+            // button with the answer buttons.
+            updateNextTimes()
         }
         cardMediaPlayer.setOnSoundGroupCompletedListener {
             launchCatchingIO {

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -120,6 +120,7 @@
             android:id="@+id/buttons_area"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="@dimen/touch_target"
             android:layout_marginTop="2dp"
             android:layout_marginHorizontal="@dimen/reviewer_side_margin"
             >
@@ -131,14 +132,14 @@
                 android:layout_height="match_parent"
                 style="@style/Widget.Material3.Button.TextButton"
                 android:visibility="visible"
-                tools:visibility="gone"
+                tools:visibility="invisible"
                 />
 
             <LinearLayout
                 android:id="@+id/answer_buttons"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:visibility="gone"
+                android:visibility="invisible"
                 tools:visibility="visible"
                 >
 


### PR DESCRIPTION
## Fixes
* Fixes #17734

## Approach

1. Fix an issue with #17777, that leads to the `Show answer` being smaller than the answer buttons (it can be seen in the PR video)
2. Implement the `Answer buttons size` feature of the old reviewer

## How Has This Been Tested?

<details><summary>Consistent height</summary>

![q](https://github.com/user-attachments/assets/63b96c1b-534c-4018-98ff-79568e310e35)
![a](https://github.com/user-attachments/assets/d3c8e1ed-acf0-4689-a25c-cc259610cd88)

</details>

<details><summary>Answer buttons size</summary>

![ans](https://github.com/user-attachments/assets/b6037f80-aa4d-4dfe-b1f8-a9f59d1dbd5f)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
