### PR TITLE
feat(reposition): show queue top & bottom

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -30,10 +30,13 @@ import anki.search.BrowserColumns
 import anki.search.BrowserRow
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.DeckSpinnerSelection.Companion.ALL_DECKS_ID
 import com.ichi2.anki.Flag
 import com.ichi2.anki.PreviewerDestination
+import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.export.ExportDialogFragment.ExportType
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.model.CardStateFilter
@@ -46,6 +49,7 @@ import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
+import com.ichi2.libanki.CardType
 import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.QueueType
@@ -605,6 +609,41 @@ class CardBrowserViewModel(
     }
 
     /**
+     * Obtains data to be displayed to the user then sent to [repositionSelectedRows]
+     */
+    suspend fun prepareToRepositionCards(): RepositionCardsRequest {
+        val selectedCardIds = queryAllSelectedCardIds()
+        // Only new cards may be repositioned (If any non-new found show error dialog and return false)
+        if (selectedCardIds.any { withCol { getCard(it).queue != QueueType.New } }) {
+            return RepositionCardsRequest.ContainsNonNewCardsError
+        }
+
+        // query obtained from Anki Desktop
+        // https://github.com/ankitects/anki/blob/1fb1cbbf85c48a54c05cb4442b1b424a529cac60/qt/aqt/operations/scheduling.py#L117
+        try {
+            val (min, max) =
+                withCol {
+                    db.query("select min(due), max(due) from cards where type=? and odid=0", CardType.New.code).use {
+                        it.moveToNext()
+                        return@withCol Pair(max(0, it.getInt(0)), it.getInt(1))
+                    }
+                }
+            return RepositionData(
+                min = min,
+                max = max,
+            )
+        } catch (e: Exception) {
+            // TODO: Remove this once we've verified no production errors
+            Timber.w(e, "getting min/max position")
+            CrashReportService.sendExceptionReport(e, "prepareToRepositionCards")
+            return RepositionData(
+                min = null,
+                max = null,
+            )
+        }
+    }
+
+    /**
      * @see [com.ichi2.libanki.sched.Scheduler.sortCards]
      * @return the number of cards which were repositioned
      */
@@ -953,6 +992,37 @@ class PreviewerIdsFile(
 
                 override fun newArray(size: Int): Array<PreviewerIdsFile> = arrayOf()
             }
+    }
+}
+
+sealed class RepositionCardsRequest {
+    /** Only new cards may be repositioned */
+    data object ContainsNonNewCardsError : RepositionCardsRequest()
+
+    /** Should contain queue top & bottom positions. Null on error */
+    class RepositionData(
+        val min: Int?,
+        val max: Int?,
+    ) : RepositionCardsRequest() {
+        val queueTop: Int?
+        val queueBottom: Int?
+
+        init {
+            if (min != null && max != null) {
+                // queue top: the lower of the two
+                queueTop = min(min, max)
+                queueBottom = max(min, max)
+            } else {
+                queueTop = null
+                queueBottom = null
+            }
+        }
+
+        fun toHumanReadableContent(): String? {
+            if (queueTop == null || queueBottom == null) return null
+            // ints are required for the translation
+            return TR.browsingQueueTop(queueTop) + "\n" + TR.browsingQueueBottom(queueBottom)
+        }
     }
 }
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -32,7 +32,6 @@
     <string name="unused_strings">\n\nUnused files:\n</string>
 
     <string name="reposition_card_dialog_title">Reposition new card</string>
-    <string name="reposition_card_dialog_message">Start position:</string>
     <string name="reposition_card_not_new_error">Only new cards can be repositioned</string>
 
     <plurals name="reposition_card_dialog_acknowledge">

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -63,6 +63,7 @@ interface TestClass {
         card.queue = QueueType.Rev
         card.type = CardType.Rev
         card.due = col.sched.today
+        col.updateCards(listOf(card), skipUndoEntry = true)
         return note
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Requested a long time ago in https://github.com/ankidroid/Anki-Android/issues/9458
## Fixes
* Fixes part of https://github.com/ankidroid/Anki-Android/issues/9458

## Approach
* Use query from Anki Desktop

## How Has This Been Tested?
<img width="553" alt="Screenshot 2025-01-10 at 02 28 25" src="https://github.com/user-attachments/assets/126dd66c-70b8-4e7d-b988-29db6868d35c" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
