### PR TITLE
Add Auto-Scroll Support for RecyclerView in Multiselect View

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -101,6 +101,9 @@ class CardBrowserViewModel(
     private val manualInit: Boolean = false,
 ) : ViewModel(),
     SharedPreferencesProvider by preferences {
+    var lastSelectedPosition: Int = 0
+    var oldCardTopOffset: Int = 0
+
     // TODO: abstract so we can use a `Context` and `pref_display_filenames_in_browser_key`
     val showMediaFilenames = sharedPrefs().getBoolean("card_browser_show_media_filenames", false)
 
@@ -1029,6 +1032,12 @@ class CardBrowserViewModel(
         data class Error(
             val error: String,
         ) : SearchState
+    }
+
+    fun saveScrollingState(id: CardOrNoteId) {
+        cards.indexOf(id).takeIf { it >= 0 }?.let { position ->
+            lastSelectedPosition = position
+        }
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -937,6 +937,23 @@ class CardBrowserTest : RobolectricTest() {
         }
 
     @Test
+    fun checkIfScrollPositionSavedOnLongPress() =
+        runTest {
+            val cardBrowser = getBrowserWithNotes(10)
+            cardBrowser.longClickRowAtPosition(5)
+            assertThat(cardBrowser.viewModel.lastSelectedPosition, equalTo(5))
+        }
+
+    @Test
+    fun checkIfScrollPositionSavedOnTap() =
+        runTest {
+            val cardBrowser = getBrowserWithNotes(10)
+            cardBrowser.longClickRowAtPosition(1)
+            cardBrowser.clickRowAtPosition(5)
+            assertThat(cardBrowser.viewModel.lastSelectedPosition, equalTo(5))
+        }
+
+    @Test
     fun `column spinner positions are set if no preferences exist`() =
         runBlocking {
             // GIVEN: No shared preferences exist for display column selections


### PR DESCRIPTION
## Purpose / Description
Fixes the missing auto-scroll functionality when switching to multi-select mode in RecyclerView, ensuring a smoother user experience.


## Fixes
* Fixes #17747

## Approach
This change adds the missing auto-scroll functionality, ensuring that the RecyclerView scrolls smoothly when entering multi-select mode, improving usability.

## How Has This Been Tested?
Samsung F23 5G
https://github.com/user-attachments/assets/9b2dc926-2fbc-4a4c-b4df-7c44a461fc6f


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
