### PR TITLE
Always show 'Rebuild' & 'Empty' icons on filter deck's "Deck overview" app bar

### DIFF
--- a/AnkiDroid/src/main/res/menu/study_options_fragment.xml
+++ b/AnkiDroid/src/main/res/menu/study_options_fragment.xml
@@ -12,13 +12,13 @@
         android:title="@string/rebuild_cram_label"
         android:visibility = "gone"
         android:icon="@drawable/ic_refresh_white"
-        ankidroid:showAsAction="ifRoom"/>
+        ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_empty"
         android:title="@string/empty_cram_label"
         android:visibility = "gone"
         android:icon="@drawable/ic_clear_white"
-        ankidroid:showAsAction="ifRoom"/>
+        ankidroid:showAsAction="always"/>
     <item
         android:id="@+id/action_custom_study"
         android:title="@string/custom_study"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When the app has undoable actions, "Rebuild" icon and "Empty" icon are pushed out from the app bar into the menu (in my phone):
![image](https://github.com/user-attachments/assets/8add5fc7-975e-419f-8a9a-888fa6c8c4b4)
(2.21alpha5)

This PR is intended to show them in the screen consistently, as in the desktop version:
![image](https://github.com/user-attachments/assets/99573b5f-68b3-45fb-9f18-82ecb746a6ef)





## Fixes
N/A

## How Has This Been Tested?
Physical device (Android 11)
<img src="https://github.com/user-attachments/assets/be6ef088-3f48-46aa-b6a8-c47b1a952471" width="320px">



## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
