### PR TITLE
Fix shortcut to currently open deck in reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -160,13 +160,19 @@ class IntentHandler : AbstractIntentHandler() {
                 }
             }
         CollectionManager.getColUnsafe().decks.select(deckId)
-        // Clean the stack out under the reviewer to avoid any incorrect activities / dialogs /
-        // data state from prior app usage showing after reviewer exits if going to reviewer directly
-        TaskStackBuilder
-            .create(applicationContext)
-            .addNextIntent(reloadIntent)
-            .addNextIntent(reviewIntent)
-            .startActivities()
+        // Check if the reviewer is already open and if the current deck matches the deck in the shortcut
+        if (Reviewer.isReviewerOpen && Reviewer.currentDeckId == deckId) {
+            // Bring the app to the foreground without changing the current card
+            Reviewer.bringToForeground()
+        } else {
+            // Clean the stack out under the reviewer to avoid any incorrect activities / dialogs /
+            // data state from prior app usage showing after reviewer exits if going to reviewer directly
+            TaskStackBuilder
+                .create(applicationContext)
+                .addNextIntent(reloadIntent)
+                .addNextIntent(reviewIntent)
+                .startActivities()
+        }
         finish()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -236,6 +236,7 @@ open class Reviewer :
     override fun onPause() {
         answerTimer.pause()
         super.onPause()
+        saveCurrentCardAndState()
     }
 
     override fun onResume() {
@@ -247,6 +248,7 @@ open class Reviewer :
         if (typeAnswer?.autoFocusEditText() == true) {
             answerField?.focusWithKeyboard()
         }
+        restoreCurrentCardAndState()
     }
 
     override fun onDestroy() {
@@ -1677,5 +1679,27 @@ open class Reviewer :
             } else {
                 Intent(context, Reviewer::class.java)
             }
+    }
+
+    override fun saveCurrentCardAndState() {
+        val state = queueState ?: return
+        val card = currentCard ?: return
+        val sharedPreferences = getSharedPreferences("ReviewerState", Context.MODE_PRIVATE)
+        with(sharedPreferences.edit()) {
+            putLong("currentCardId", card.id)
+            putString("currentQueueState", state.toJson())
+            apply()
+        }
+    }
+
+    override fun restoreCurrentCardAndState() {
+        val sharedPreferences = getSharedPreferences("ReviewerState", Context.MODE_PRIVATE)
+        val cardId = sharedPreferences.getLong("currentCardId", -1)
+        val stateJson = sharedPreferences.getString("currentQueueState", null) ?: return
+        val state = CurrentQueueState.fromJson(stateJson)
+        if (cardId != -1L && state != null) {
+            currentCard = getColUnsafe.getCard(cardId)
+            queueState = state
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerUi.kt
@@ -18,4 +18,6 @@ package com.ichi2.anki.reviewer
 
 interface ReviewerUi {
     val isDisplayingAnswer: Boolean
+    fun saveCurrentCardState()
+    fun restoreCurrentCardState()
 }


### PR DESCRIPTION
Fixes #17772

Add functionality to maintain the current card and state when reopening the app through a shortcut.

* Modify `IntentHandler.kt` to check if the reviewer is already open and if the current deck matches the deck in the shortcut. If the reviewer is open and the deck matches, bring the app to the foreground without changing the current card. If the reviewer is not open or the deck does not match, proceed with the existing logic to open the deck.
* Update `Reviewer.kt` to add methods to save and restore the current card and state when the app is minimized and reopened through a shortcut. Call these methods in the `onPause` and `onResume` methods.
* Modify `ReviewerUi.kt` to add methods to save and restore the current card and state.

