### PR TITLE
release: retain old minSdk artifacts when publishing new releases

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -256,6 +256,25 @@ android {
 play {
     serviceAccountCredentials.set(file("${homePath}/src/AnkiDroid-GCP-Publish-Credentials.json"))
     track.set('alpha')
+
+    // any time we bump minSdk we want Play Store to retain the old artifacts by version code,
+    // so that they remain available for older devices
+    retain {
+        artifacts.set([
+                20700300L, // (2.7, minSdk 10, universal APK)
+                20804300L, // (2.8.4, minSdk 10, universal APK)
+                21004300L, // (2.10.4, minSdk 15, universal APK)
+                // release-2.14 minSdk 16: missing and not re-publishable, see issue 17791
+                121603300L, // (2.16.3, minSdk 21, ABI armeabi-v7a)
+                221603300L, // (2.16.3, minSdk 21, ABI x86)
+                321603300L, // (2.16.3, minSdk 21, ABI arm64-v8a)
+                421603300L, // (2.16.3, minSdk 21, ABI x86_64)
+                121904300L, // (2.19.4, minSdk 23, ABI armeabi-v7a)
+                221904300L, // (2.19.4, minSdk 23, ABI x86)
+                321904300L, // (2.19.4, minSdk 23, ABI arm64-v8a)
+                421904300L, // (2.19.4, minSdk 23, ABI x86_64)
+        ])
+    }
 }
 
 // Install Git pre-commit hook for Ktlint

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,13 @@
 [versions]
 compileSdk = "35"
+
+# Changing minSdk means newer AnkiDroid versions will not support older devices.
+# However the Play Store will keep old AnkiDroid versions available for older
+# devices *if* you also change AnkiDroid/build.gradle play { retain {} } block
+# to include the version codes of the last released version for the older
+# minSdk. It is critical to update those version codes when you change this.
 minSdk = "24"  # also in testlib/build.gradle.kts
+
 targetSdk = "34"  # also in  ../robolectricDownloader.gradle
 acra = '5.12.0'
 ktlint = '1.5.0'


### PR DESCRIPTION

## Purpose / Description

We discovered, much to our surprise, that with the split ABIs we've been running for years the Play Store does not automatically retain old builds from previous minSdk changes

## Fixes
* Fixes #17791 
 
## Approach

Investigated manual changes to retain builds on the play store, and re-released a build from release-2.19 (2.19.4) to investigate what was possible

Investigated our auto-publisher for Play Store and discovered they have a `retain` feature that should work - using that here

## How Has This Been Tested?

It isn't possible to test this manually other than seeing on Play Store that it is possible to retain old builds manually (it is!)

The test here will be to build a new alpha post-merge and see what APKs were included in it

## Learning (optional, can help others)

Just learned how incredibly long a latent bug can exist before noticing - these old minSdk versions have been dropped from our production track since release-2.10 !

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
