### PR TITLE
release: set release name explicitly

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -275,6 +275,11 @@ play {
                 421904300L, // (2.19.4, minSdk 23, ABI x86_64)
         ])
     }
+
+    // If you retain APKs in a release with different names as we do above,
+    // the plugin + Play Store has no idea how to name the release except by date.
+    // release name is developer only, but sane names really help, so set one
+    releaseName.set(android.defaultConfig.versionName)
 }
 
 // Install Git pre-commit hook for Ktlint


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description

auto-naming doesn't work if you have APKs in a release with different versions, as we do with our new retain settings for older minSdk support

## Fixes
* Fixes #17800 

## Approach

RTFM on the Triple-T publish, auto-complete in Android Studio to get the variable

## How Has This Been Tested?

Can't test it other than to make sure builds still work local and CI so I don't break anything

Real test is when we do 2.21alpha7 to see if the release name is meaningful vs 2025-01-17 or whatever date we build it

## Learning (optional, can help others)

There are always follow-on effects for any positive change. Yaks to be shaved. Progress to be made, slowly.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
