### PR TITLE
fix: Leech toasts have switched with each other

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1093,9 +1093,9 @@ open class Reviewer :
                 state.topCard.load(getColUnsafe)
                 val leechMessage: String =
                     if (state.topCard.queue.buriedOrSuspended()) {
-                        resources.getString(R.string.leech_notification)
-                    } else {
                         resources.getString(R.string.leech_suspend_notification)
+                    } else {
+                        resources.getString(R.string.leech_notification)
                     }
                 showSnackbar(leechMessage, Snackbar.LENGTH_SHORT)
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Leech toasts have switched messages with each other

## Fixes
* Fixes #17806

## Approach
Replace strings for leech toasts with each other

## How Has This Been Tested?

Checked on physical device (Android 11)

<img src="https://github.com/user-attachments/assets/ed590c2e-a901-488f-9828-7a2dbdad24e6" width="320px">

↓

<img src="https://github.com/user-attachments/assets/3a7ac91d-bc56-4687-9e16-4fd6fd1a2ac9" width="320px">

-----
<img src="https://github.com/user-attachments/assets/18b40825-d446-4538-9215-bf0d76228e15" width="320px">

↓
<img src="https://github.com/user-attachments/assets/ba66788a-7198-4a17-a682-700c7bb0a7e6" width="320px">


https://github.com/user-attachments/assets/daaf0569-c3fd-42c6-9fe9-cd43573fb18e



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
