### PR TITLE
feat(deck-options): progress dialog for Optimize

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -25,6 +25,7 @@ import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.FragmentActivity
 import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.dialogs.DiscardChangesDialog
@@ -237,15 +238,18 @@ suspend fun FragmentActivity.updateDeckConfigsRaw(input: ByteArray): ByteArray {
                 extractProgress = {
                     text =
                         if (progress.hasComputeParams()) {
-                            val tr = CollectionManager.TR
                             val value = progress.computeParams
                             val label =
-                                tr.deckConfigOptimizingPreset(
+                                TR.deckConfigOptimizingPreset(
                                     currentCount = value.currentPreset,
                                     totalCount = value.totalPresets,
                                 )
-                            val pct = if (value.total > 0) (value.current / value.total * 100) else 0
-                            val reviewsLabel = tr.deckConfigPercentOfReviews(pct = pct.toString(), reviews = value.reviews)
+                            val pct = if (value.total > 0) (value.current.toDouble() / value.total.toDouble() * 100.0) else 0.0
+                            val reviewsLabel =
+                                TR.deckConfigPercentOfReviews(
+                                    pct = "%.1f".format(pct),
+                                    reviews = value.reviews,
+                                )
                             label + "\n" + reviewsLabel
                         } else {
                             getString(R.string.dialog_processing)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -36,7 +36,6 @@ import com.ichi2.libanki.getDeckNamesRaw
 import com.ichi2.libanki.getFieldNamesRaw
 import com.ichi2.libanki.getImportAnkiPackagePresetsRaw
 import com.ichi2.libanki.getNotetypeNamesRaw
-import com.ichi2.libanki.sched.computeFsrsParamsRaw
 import com.ichi2.libanki.sched.computeOptimalRetentionRaw
 import com.ichi2.libanki.sched.evaluateParamsRaw
 import com.ichi2.libanki.sched.simulateFsrsReviewRaw
@@ -77,7 +76,6 @@ val collectionMethods =
         "getFieldNames" to { bytes -> getFieldNamesRaw(bytes) },
         "cardStats" to { bytes -> cardStatsRaw(bytes) },
         "getDeckConfigsForUpdate" to { bytes -> getDeckConfigsForUpdateRaw(bytes) },
-        "computeFsrsParams" to { bytes -> computeFsrsParamsRaw(bytes) },
         "computeOptimalRetention" to { bytes -> computeOptimalRetentionRaw(bytes) },
         "evaluateParams" to { bytes -> evaluateParamsRaw(bytes) },
         "simulateFsrsReview" to { bytes -> simulateFsrsReviewRaw(bytes) },
@@ -124,6 +122,7 @@ val uiMethods =
                 withCol { updateImageOcclusionNoteRaw(bytes) }
             }
         },
+        "computeFsrsParams" to { bytes -> lifecycleScope.async { computeFsrsParams(bytes) } },
     )
 
 suspend fun FragmentActivity?.handleUiPostRequest(


### PR DESCRIPTION
## Fixes
* Fixes #16642

## Approach
* move to a UI backend method
* Fix a bug in percentage calculation
* Use the same progress extraction method as `updateDeckConfigsRaw`

## How Has This Been Tested?

<img width="546" alt="Screenshot 2025-01-14 at 09 06 48" src="https://github.com/user-attachments/assets/ee529ba4-9141-46a5-a877-b75944a0789e" />

<details>

<summary>old</summary>

<img width="564" alt="Screenshot 2025-01-14 at 01 26 19" src="https://github.com/user-attachments/assets/15503de7-71ab-46e4-868c-66794206dbc0" />

</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 55 minutes -->