### PR TITLE
feat(empty-cards): Add 'keep notes' checkbox

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -123,6 +123,7 @@ import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
 import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog
 import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.dialogs.EditDeckDescriptionDialog
+import com.ichi2.anki.dialogs.EmptyCardsDialogFragment
 import com.ichi2.anki.dialogs.ImportDialog.ImportDialogListener
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ApkgImportResultLauncherProvider
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.CsvImportResultLauncherProvider
@@ -1154,7 +1155,10 @@ open class DeckPicker :
             }
             R.id.action_empty_cards -> {
                 Timber.i("DeckPicker:: Empty cards button pressed")
-                handleEmptyCards()
+                EmptyCardsDialogFragment().show(
+                    supportFragmentManager,
+                    EmptyCardsDialogFragment.TAG,
+                )
                 return true
             }
             R.id.action_model_browser_open -> {
@@ -2502,32 +2506,6 @@ open class DeckPicker :
     private fun openReviewer() {
         val intent = Reviewer.getIntent(this)
         reviewLauncher.launch(intent)
-    }
-
-    private fun handleEmptyCards() {
-        launchCatchingTask {
-            val emptyCards =
-                withProgress(R.string.emtpy_cards_finding) {
-                    viewModel.findEmptyCards()
-                }
-            AlertDialog.Builder(this@DeckPicker).show {
-                setTitle(TR.emptyCardsWindowTitle())
-                if (emptyCards.isEmpty()) {
-                    setMessage(TR.emptyCardsNotFound())
-                    setPositiveButton(R.string.dialog_ok) { _, _ -> }
-                } else {
-                    setMessage(getString(R.string.empty_cards_count, emptyCards.size))
-                    setPositiveButton(R.string.dialog_positive_delete) { _, _ ->
-                        launchCatchingTask {
-                            withProgress(TR.emptyCardsDeleting()) {
-                                viewModel.deleteEmptyCards(emptyCards).join()
-                            }
-                        }
-                    }
-                    setNegativeButton(R.string.dialog_cancel) { _, _ -> }
-                }
-            }
-        }
     }
 
     private fun createSubDeckDialog(did: DeckId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2025 lukstbit <52494258+lukstbit@users.noreply.github.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.View
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import anki.card_rendering.EmptyCardsReport
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.EmptyCardsUiState.EmptyCardsSearchFailure
+import com.ichi2.anki.dialogs.EmptyCardsUiState.EmptyCardsSearchResult
+import com.ichi2.anki.dialogs.EmptyCardsUiState.SearchingForEmptyCards
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.withProgress
+import com.ichi2.libanki.emptyCids
+import com.ichi2.utils.message
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
+import com.ichi2.utils.title
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * A dialog that searches for empty cards and presents the user with the option to delete them.
+ * A user may 'keep notes', which retains the first card of each note, even if the note is empty.
+ */
+class EmptyCardsDialogFragment : DialogFragment() {
+    private val viewModel by viewModels<EmptyCardsViewModel>()
+    private val loadingContainer: View?
+        get() = dialog?.findViewById(R.id.loading_container)
+    private val loadingMessage: TextView?
+        get() = dialog?.findViewById(R.id.text)
+    private val emptyCardsResultsContainer: View?
+        get() = dialog?.findViewById(R.id.empty_cards_results_container)
+    private val emptyCardsResultsMessage: TextView?
+        get() = dialog?.findViewById(R.id.empty_cards_results_message)
+    private val keepNotesWithNoValidCards: CheckBox?
+        get() = dialog?.findViewById(R.id.preserve_notes)
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        bindToState()
+        viewModel.searchForEmptyCards()
+        val dialogView = layoutInflater.inflate(R.layout.dialog_empty_cards, null)
+        dialogView.findViewById<CheckBox>(R.id.preserve_notes)?.text =
+            TR.emptyCardsPreserveNotesCheckbox()
+
+        return AlertDialog
+            .Builder(requireContext())
+            .show {
+                setTitle(
+                    TR
+                        .emptyCardsWindowTitle()
+                        .toSentenceCase(context, R.string.sentence_empty_cards),
+                )
+                setPositiveButton(R.string.dialog_ok) { _, _ ->
+                    val state = viewModel.uiState.value
+                    if (state is EmptyCardsSearchResult) {
+                        // this dialog is only shown from DeckPicker so we use it directly to avoid
+                        // fragment result listeners and the possibility of the search report
+                        // exceeding the result Bundle's limits
+                        if (state.emptyCardsReport.emptyCids().isEmpty()) return@setPositiveButton
+                        (requireActivity() as DeckPicker).startDeletingEmptyCards(
+                            state.emptyCardsReport,
+                            keepNotesWithNoValidCards?.isChecked ?: true,
+                        )
+                    }
+                }
+                setNegativeButton(R.string.dialog_cancel) { _, _ ->
+                    Timber.i("Empty cards dialog cancelled")
+                }
+                setView(dialogView)
+            }.also {
+                // the initial start state is a loading state as we are looking for the empty cards,
+                // so there's no "action" for ok just yet
+                it.positiveButton.isEnabled = false
+            }
+    }
+
+    private fun bindToState() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect { state ->
+                    when (state) {
+                        is SearchingForEmptyCards -> {
+                            loadingMessage?.text = getString(R.string.emtpy_cards_finding)
+                            loadingContainer?.isVisible = true
+                            emptyCardsResultsContainer?.isVisible = false
+                            (dialog as? AlertDialog)?.positiveButton?.apply {
+                                isEnabled = false
+                                text = getString(R.string.dialog_ok)
+                            }
+                        }
+
+                        is EmptyCardsSearchResult -> {
+                            loadingContainer?.isVisible = false
+                            val emptyCards = state.emptyCardsReport.emptyCids()
+                            if (emptyCards.isEmpty()) {
+                                emptyCardsResultsMessage?.text = TR.emptyCardsNotFound()
+                                // nothing to delete so also hide the preserve notes check box
+                                keepNotesWithNoValidCards?.isVisible = false
+                                (dialog as? AlertDialog)?.positiveButton?.text =
+                                    getString(R.string.dialog_ok)
+                            } else {
+                                keepNotesWithNoValidCards?.isVisible = true
+                                emptyCardsResultsMessage?.text =
+                                    getString(R.string.empty_cards_count, emptyCards.size)
+                                (dialog as? AlertDialog)?.positiveButton?.text =
+                                    getString(R.string.dialog_positive_delete)
+                            }
+                            (dialog as? AlertDialog)?.positiveButton?.isEnabled = true
+                            emptyCardsResultsContainer?.isVisible = true
+                        }
+
+                        is EmptyCardsSearchFailure -> {
+                            // the dialog is informational so there's nothing to do but show the
+                            // error and exit
+                            AlertDialog.Builder(requireActivity()).show {
+                                title(R.string.vague_error)
+                                message(text = state.throwable.toString())
+                                positiveButton(R.string.dialog_ok) { }
+                            }
+                            dismissNow()
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    companion object {
+        const val TAG = "EmptyCardsDialog"
+    }
+}
+
+// TODO the fragment should just send a fragment result to the DeckPicker with the report and keep
+//  notes flag(currently the report can exceed the transport Bundle capacity so we call it directly)
+fun DeckPicker.startDeletingEmptyCards(
+    report: EmptyCardsReport,
+    keepNotes: Boolean,
+) {
+    Timber.i(
+        "Starting to delete found %d empty cards, keepNotes: %b",
+        report.emptyCids().size,
+        keepNotes,
+    )
+    launchCatchingTask {
+        withProgress(TR.emptyCardsDeleting()) {
+            viewModel.deleteEmptyCards(report, keepNotes).join()
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsViewModel.kt
@@ -1,0 +1,63 @@
+/****************************************************************************************
+ * Copyright (c) 2025 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import anki.card_rendering.EmptyCardsReport
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.dialogs.EmptyCardsUiState.EmptyCardsSearchFailure
+import com.ichi2.anki.dialogs.EmptyCardsUiState.EmptyCardsSearchResult
+import com.ichi2.anki.dialogs.EmptyCardsUiState.SearchingForEmptyCards
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** @see EmptyCardsDialogFragment */
+class EmptyCardsViewModel : ViewModel() {
+    private val _uiState =
+        MutableStateFlow<EmptyCardsUiState>(SearchingForEmptyCards)
+    val uiState: StateFlow<EmptyCardsUiState> = _uiState.asStateFlow()
+
+    fun searchForEmptyCards() {
+        viewModelScope.launch {
+            runCatching { withCol { getEmptyCards() } }
+                .onFailure { exception ->
+                    if (exception is CancellationException) {
+                        throw exception
+                    }
+                    _uiState.emit(EmptyCardsSearchFailure(exception))
+                }.onSuccess { emptyCardsReport ->
+                    _uiState.emit(EmptyCardsSearchResult(emptyCardsReport))
+                }
+        }
+    }
+}
+
+sealed class EmptyCardsUiState {
+    data object SearchingForEmptyCards : EmptyCardsUiState()
+
+    data class EmptyCardsSearchResult(
+        val emptyCardsReport: EmptyCardsReport,
+    ) : EmptyCardsUiState()
+
+    data class EmptyCardsSearchFailure(
+        val throwable: Throwable,
+    ) : EmptyCardsUiState()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -594,7 +594,7 @@ class Collection(
     fun updateNotes(notes: Iterable<Note>): OpChanges = backend.updateNotes(notes = notes.map { it.toBackendNote() }, skipUndoEntry = false)
 
     @NotInLibAnki
-    fun emptyCids(): List<CardId> = getEmptyCards().notesList.flatMap { it.cardIdsList }
+    fun emptyCids(): List<CardId> = getEmptyCards().emptyCids()
 
     /** Fixes and optimizes the database. If any errors are encountered, a list of
      * problems is returned. Throws if DB is unreadable. */
@@ -680,3 +680,6 @@ class Collection(
 
     fun setPreferences(preferences: Preferences): OpChanges = backend.setPreferences(preferences)
 }
+
+@NotInLibAnki
+fun EmptyCardsReport.emptyCids(): List<CardId> = notesList.flatMap { it.cardIdsList }

--- a/AnkiDroid/src/main/res/layout/dialog_empty_cards.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_empty_cards.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/loading_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/listPreferredItemHeight"
+        android:paddingVertical="12dp"
+        android:paddingHorizontal="24dp">
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/loading_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/text"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            app:layout_constraintHorizontal_bias="0.0"
+            android:indeterminate="true" />
+
+        <TextView
+            android:id="@+id/text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/loading_indicator"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:textAppearance="?attr/textAppearanceBody1"
+            tools:text="Processing..." />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <LinearLayout
+        android:id="@+id/empty_cards_results_container"
+        android:visibility="gone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:paddingStart="@dimen/side_margin"
+        android:paddingEnd="@dimen/side_margin">
+
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/empty_cards_results_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingStart="8dp"
+            android:paddingBottom="8dp"
+            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+            tools:text="Cards to delete: 123" />
+
+        <CheckBox
+            android:id="@+id/preserve_notes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:checked="true"
+            tools:text="Keep notes with no valid cards" />
+    </LinearLayout>
+</FrameLayout>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -41,5 +41,6 @@ undoActionUndone()
     <string name="sentence_gesture_abort_sync">Abort learning and sync</string>
     <string name="sentence_gesture_toggle_whiteboard">Toggle whiteboard</string>
     <string name="sentence_custom_study">Custom study</string>
+    <string name="sentence_empty_cards">Empty cards</string>
 
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -38,6 +38,7 @@ class SentenceCaseTest : RobolectricTest() {
             assertThat(TR.browsingToggleBury().toSentenceCase(this, R.string.sentence_toggle_bury), equalTo("Toggle bury"))
             assertThat(TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date), equalTo("Set due date"))
             assertThat(TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study), equalTo("Custom study"))
+            assertThat(TR.emptyCardsWindowTitle().toSentenceCase(this, R.string.sentence_empty_cards), equalTo("Empty cards"))
 
             assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
             assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
> Hey all, I found a possible improvement to avoid some data loss as of 2.20.0.
>
> In Anki desktop, the Empty Cards feature asks if it should not only delete cards that are empty, but also associated notes that would remain without any valid cards.
>
> On AnkiDroid, this is on by default. Notes with no valid cards get deleted when I press the Empty Cards.
> 
> I noticed because I made blank placeholder notes that I wanted to later fill in with questions & answers.
>
> It'd be nice if the mobile version also asked first

## Fixes
* Issue #17213

## Approach
* Extract to a DialogFragment
* Implement the feature using a custom layout and a checkbox
* Fixup the dialog a bit (Material theme + fix title)

## How Has This Been Tested?
Unit tested, somewhat

![image](https://github.com/user-attachments/assets/938ec2a3-7533-4d0c-8321-d4be345ded1a)


## Learning (optional, can help others)
* A custom view is needed if you want a message AND checkboxes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 1h45 :O -->