### PR TITLE
fix: animation names

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anim/ActivityTransitionAnimation.kt
@@ -31,7 +31,7 @@ object ActivityTransitionAnimation {
                 }
             Direction.RIGHT -> activity.overridePendingTransition(R.anim.slide_right_in, R.anim.slide_right_out)
             Direction.LEFT -> activity.overridePendingTransition(R.anim.slide_left_in, R.anim.slide_left_out)
-            Direction.FADE -> activity.overridePendingTransition(R.anim.fade_out, R.anim.fade_in)
+            Direction.FADE -> activity.overridePendingTransition(R.anim.fade_in, R.anim.fade_out)
             Direction.UP -> activity.overridePendingTransition(R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DOWN -> activity.overridePendingTransition(R.anim.slide_down_in, R.anim.slide_down_out)
             Direction.NONE -> activity.overridePendingTransition(R.anim.none, R.anim.none)
@@ -73,7 +73,7 @@ object ActivityTransitionAnimation {
                 }
             Direction.RIGHT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_right_in, R.anim.slide_right_out)
             Direction.LEFT -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_left_in, R.anim.slide_left_out)
-            Direction.FADE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_out, R.anim.fade_in)
+            Direction.FADE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.fade_in, R.anim.fade_out)
             Direction.UP -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_up_in, R.anim.slide_up_out)
             Direction.DOWN -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.slide_down_in, R.anim.slide_down_out)
             Direction.NONE -> ActivityOptionsCompat.makeCustomAnimation(activity, R.anim.none, R.anim.none)

--- a/AnkiDroid/src/main/res/anim/fade_in.xml
+++ b/AnkiDroid/src/main/res/anim/fade_in.xml
@@ -17,6 +17,6 @@
 
 <alpha xmlns:android="http://schemas.android.com/apk/res/android"
     android:duration="500"
-    android:fromAlpha="1.0"
+    android:fromAlpha="0.0"
     android:interpolator="@android:anim/decelerate_interpolator"
-    android:toAlpha="0.0" />
+    android:toAlpha="1.0" />

--- a/AnkiDroid/src/main/res/anim/fade_out.xml
+++ b/AnkiDroid/src/main/res/anim/fade_out.xml
@@ -17,7 +17,7 @@
 
 <alpha xmlns:android="http://schemas.android.com/apk/res/android"
     android:duration="500"
-    android:fromAlpha="0.0"
+    android:fromAlpha="1.0"
     android:interpolator="@android:anim/accelerate_interpolator"
-    android:toAlpha="1.0"
+    android:toAlpha="0.0"
     android:zAdjustment="top" />


### PR DESCRIPTION
`fade_in` and `fade_out` were switched

## How Has This Been Tested?
I was using these animations in a branch, they now look correct. I believe I've fixed the only references

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
