### PR TITLE
Fix: Card  browser  list contents not shown just after language change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -571,6 +571,7 @@ open class CardBrowser :
                 adapter.addAll(viewModel.column2Candidates.map { it.getLabel(cardsOrNotes) })
             }
         }
+        viewModel.flowOfInitCompleted.launchCollectionInLifecycleScope(::initCompletedChanged)
         viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
         viewModel.flowOfSearchQueryExpanded.launchCollectionInLifecycleScope(::onSearchQueryExpanded)
         viewModel.flowOfSelectedRows.launchCollectionInLifecycleScope(::onSelectedRowsChanged)
@@ -582,7 +583,6 @@ open class CardBrowser :
         viewModel.flowOfIsInMultiSelectMode.launchCollectionInLifecycleScope(::isInMultiSelectModeChanged)
         viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
-        viewModel.flowOfInitCompleted.launchCollectionInLifecycleScope(::initCompletedChanged)
         viewModel.flowOfCardsOrNotes.launchCollectionInLifecycleScope(::cardsOrNotesChanged)
     }
 
@@ -891,6 +891,12 @@ open class CardBrowser :
 
     override fun onResume() {
         super.onResume()
+        lifecycleScope.launch {
+            // Reinitialize active browser columns when returning to this screen.
+            // Ensures the card browser displays the correct columns and data after a language change or configuration update.
+            val cardsOrNotes = viewModel.cardsOrNotes
+            viewModel.setupColumns(cardsOrNotes)
+        }
         selectNavigationItem(R.id.nav_browser)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -333,7 +333,7 @@ class CardBrowserViewModel(
         }
     }
 
-    private suspend fun setupColumns(cardsOrNotes: CardsOrNotes) {
+    suspend fun setupColumns(cardsOrNotes: CardsOrNotes) {
         Timber.d("loading columns columns for %s mode", cardsOrNotes)
         val columns = BrowserColumnCollection.load(sharedPrefs(), cardsOrNotes)
         flowOfColumn1.update { columns.columns[0] }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the issue where the card browser list contents were not shown just after a language change. The fix ensures the columns and data are properly reinitialized and displayed after the language is switched.

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/17803

## Approach
This change reinitializes the browser columns using a ``lifecycleScope`` to ensure proper display of list content when returning to the screen after a language change.

## How Has This Been Tested?
The issue was tested by switching between different languages and verifying that the card browser's list contents. 
Physical Device (Samsung Galaxy A6+)


https://github.com/user-attachments/assets/26158132-7fce-4535-9778-84699e9affc0




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
