### PR TITLE
feat(new reviewer): join "Hide 'answer buttons'" prefs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/PrefKey.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/PrefKey.kt
@@ -23,6 +23,7 @@ object PrefKey {
 
     // **************************************** Reviewer **************************************** //
     const val FRAME_STYLE = "reviewerFrameStyle"
+    const val SHOW_ANSWER_BUTTONS = "showAnswerButtons"
 
     // ************************************** Accessibility ************************************* //
     const val ANSWER_BUTTON_SIZE = "answerButtonSize"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.settings.enums.FrameStyle
 import com.ichi2.anki.settings.enums.PrefEnum
+import com.ichi2.anki.settings.enums.ShowAnswerButtons
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
@@ -131,6 +132,9 @@ object Prefs {
 
     val frameStyle: FrameStyle
         get() = getEnum(PrefKey.FRAME_STYLE, FrameStyle.CARD)
+
+    val showAnswerButtons: ShowAnswerButtons
+        get() = getEnum(PrefKey.SHOW_ANSWER_BUTTONS, ShowAnswerButtons.ALL)
 
     // ************************************** Accessibility ************************************* //
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/enums/ShowAnswerButtons.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/enums/ShowAnswerButtons.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <brayandso.dev@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.settings.enums
+
+/** [com.ichi2.anki.R.array.show_answer_buttons_values] */
+enum class ShowAnswerButtons(
+    override val entryValue: String,
+) : PrefEnum {
+    ALL("0"),
+    GOOD_AND_AGAIN("1"),
+    NONE("2"),
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -94,6 +94,7 @@ import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.previewer.CardViewerFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.FrameStyle
+import com.ichi2.anki.settings.enums.ShowAnswerButtons
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
@@ -263,10 +264,8 @@ class ReviewerFragment :
     }
 
     private fun setupAnswerButtons(view: View) {
-        val prefs = sharedPrefs()
-        val hideAnswerButtons = prefs.getBoolean(getString(R.string.hide_answer_buttons_key), false)
         val buttonsAreaLayout = view.findViewById<FrameLayout>(R.id.buttons_area)
-        if (hideAnswerButtons) {
+        if (Prefs.showAnswerButtons == ShowAnswerButtons.NONE) {
             buttonsAreaLayout.isVisible = false
             return
         }
@@ -328,7 +327,7 @@ class ReviewerFragment :
             resetZoom()
         }
 
-        if (prefs.getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
+        if (Prefs.showAnswerButtons == ShowAnswerButtons.GOOD_AND_AGAIN) {
             hardButton.isVisible = false
             easyButton.isVisible = false
         }

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -438,8 +438,12 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="hide_system_bars_all_bars" comment="Setting option to hide all the system bars"
         >All</string>
     <string name="ignore_display_cutout" maxLength="41">Ignore display cutout</string>
-    <string name="hide_answer_buttons" maxLength="41">Hide answer buttons</string>
-    <string name="hide_hard_and_easy" maxLength="41">Hide ‘Hard’ and ‘Easy’ buttons</string>
+    <string name="show_answer_buttons" maxLength="41">Show answer buttons</string>
+    <string name="show_answer_buttons_all" maxLength="41" comment="Option to show all answer buttons">All</string>
+    <string name="show_answer_buttons_good_and_again" maxLength="41" comment="Option to show only the ‘Good’ and ‘Again’ answer buttons">‘Good’ and ‘Again’</string>
+    <string name="show_answer_buttons_none" maxLength="41" comment="Option to show no answer buttons">None</string>
+
+
     <string name="reviewer_frame_style" maxLength="41">Frame style</string>
     <string name="reviewer_frame_style_card" maxLength="41" comment="Style name of the 'Card' card frame of the Reviewer"
         >Card</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -254,6 +254,22 @@
         <item>@string/reviewer_frame_style_box_value</item>
     </string-array>
 
+    <!-- Reviewer settings > Show answer buttons  -->
+    <string-array name="show_answer_buttons_entries">
+        <item>@string/show_answer_buttons_all</item>
+        <item>@string/show_answer_buttons_good_and_again</item>
+        <item>@string/show_answer_buttons_none</item>
+    </string-array>
+
+    <string name="show_answer_buttons_all_value">0</string>
+    <string name="show_answer_buttons_good_and_again_value">1</string>
+    <string name="show_answer_buttons_none_value">2</string>
+
+    <string-array name="show_answer_buttons_values">
+        <item>@string/show_answer_buttons_all_value</item>
+        <item>@string/show_answer_buttons_good_and_again_value</item>
+        <item>@string/show_answer_buttons_none_value</item>
+    </string-array>
 
     <!-- Preferences headers summaries -->
     <string-array name="general_summary_entries">

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -201,8 +201,7 @@
     <!-- Reviewer options -->
     <string name="hide_system_bars_key">hideSystemBars</string>
     <string name="ignore_display_cutout_key">ignoreDisplayCutout</string>
-    <string name="hide_answer_buttons_key">hideAnswerButtons</string>
-    <string name="hide_hard_and_easy_key">hideHardAndEasy</string>
+    <string name="show_answer_buttons_key">showAnswerButtons</string>
     <string name="reviewer_menu_settings_key">reviewerMenuSettings</string>
     <string name="reviewer_frame_style_key">reviewerFrameStyle</string>
 

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -16,16 +16,13 @@
         android:title="@string/ignore_display_cutout"
         />
 
-    <SwitchPreferenceCompat
-        android:defaultValue="false"
-        android:key="@string/hide_answer_buttons_key"
-        android:title="@string/hide_answer_buttons"
-        />
-
-    <SwitchPreferenceCompat
-        android:defaultValue="false"
-        android:key="@string/hide_hard_and_easy_key"
-        android:title="@string/hide_hard_and_easy"
+    <ListPreference
+        android:key="@string/show_answer_buttons_key"
+        android:title="@string/show_answer_buttons"
+        android:defaultValue="@string/show_answer_buttons_all_value"
+        android:entries="@array/show_answer_buttons_entries"
+        android:entryValues="@array/show_answer_buttons_values"
+        app:useSimpleSummaryProvider="true"
         />
 
     <Preference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -21,6 +21,7 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.analytics.UsageAnalytics.preferencesWhoseChangesShouldBeReported
 import com.ichi2.anki.preferences.PreferenceTestUtils
 import com.ichi2.anki.preferences.SettingsFragment
+import com.ichi2.anki.settings.PrefKey
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Test
@@ -81,8 +82,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             "customSyncCertificate",
             // Experimental settings
             "reviewerMenuSettings",
-            "hideAnswerButtons",
-            "hideHardAndEasy",
+            PrefKey.SHOW_ANSWER_BUTTONS,
             "reviewerFrameStyle",
             "hideSystemBars",
             "ignoreDisplayCutout",


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

`Hide 'easy' and 'again'` and `Hide answer buttons` are being joined into a single ListPreference called `Show answer buttons` with the options:
- All
- Good and Again
- None

## Approach

Blocked by #17816 

Remove the old preferences and add a new one

## How Has This Been Tested?

[join.webm](https://github.com/user-attachments/assets/bba5e326-7e91-4037-99eb-4ebd64e6f1ff)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
