### PR TITLE
fix(browse-options): better touch targets

### DIFF
--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -24,20 +24,20 @@
 
         <RadioGroup
             android:id="@+id/select_browser_mode"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginHorizontal="16dp">
 
             <RadioButton
                 android:id="@+id/select_cards_mode"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/show_cards" />
 
             <RadioButton
                 android:id="@+id/select_notes_mode"
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/show_notes" />
 
@@ -59,7 +59,7 @@
 
         <CheckBox
             android:id="@+id/truncate_checkbox"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/card_browser_truncate"
             android:layout_marginHorizontal="16dp" />


### PR DESCRIPTION
Previously, tapping to the right of a checkbox/radio button did not toggle it

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
