### PR TITLE
test: fix studio task recognition for jacoco test tasks

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -99,7 +99,7 @@ else
     classDir += "Debug"
 
 // Our merge report task
-def testReport = tasks.register('jacocoTestReport', JacocoReport) {
+tasks.register('jacocoTestReport', JacocoReport) {
     def htmlOutDir = project.layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -120,14 +120,12 @@ def testReport = tasks.register('jacocoTestReport', JacocoReport) {
             '**/*.exec',
             '**/*.ec'
     ])
-}
-testReport.configure {
     dependsOn('testPlayDebugUnitTest')
     dependsOn("connectedPlay${rootProject.androidTestVariantName}AndroidTest")
 }
 
 // A unit-test only report task
-def unitTestReport = tasks.register('jacocoUnitTestReport', JacocoReport) {
+tasks.register('jacocoUnitTestReport', JacocoReport) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -148,11 +146,11 @@ def unitTestReport = tasks.register('jacocoUnitTestReport', JacocoReport) {
             '**/*.exec'
 
     ])
+    dependsOn('testPlayDebugUnitTest')
 }
-unitTestReport.configure { dependsOn('testPlayDebugUnitTest') }
 
 // A connected android tests only report task
-def androidTestReport = tasks.register('jacocoAndroidTestReport', JacocoReport) {
+tasks.register('jacocoAndroidTestReport', JacocoReport) {
     def htmlOutDir = layout.buildDirectory.dir("reports/jacoco/$name/html").get().asFile
 
     doLast {
@@ -172,9 +170,8 @@ def androidTestReport = tasks.register('jacocoAndroidTestReport', JacocoReport) 
     executionData.from = fileTree(dir: project.layout.buildDirectory, includes: [
             '**/*.ec'
     ])
+    dependsOn("connectedPlay${rootProject.androidTestVariantName}AndroidTest")
 }
-
-androidTestReport.configure { dependsOn("connectedPlay${rootProject.androidTestVariantName}AndroidTest") }
 
 // Issue 16640 - some emulators run, but register zero coverage
 tasks.register('assertNonzeroAndroidTestCoverage') {


### PR DESCRIPTION
## Purpose / Description

if you do the task registration "bare" without assigning to a variable, Android Studio will recognize your tasks as run targets for UI usage

## Fixes

Nothing logged, was question from Arthur in Discord

## Approach

refactoring post-definition configuration into the task definition itself, so no local variable is needed and it's just a "bare" task creation

## How Has This Been Tested?

We have the play icon next to the targets now:

<img width="1195" alt="image" src="https://github.com/user-attachments/assets/d4ba7c8c-4097-41d5-ad67-c33c7168c57d" />



## Learning (optional, can help others)

Meh, IDEs are weird. Should have recognized the task registration without this change

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
