### PR TITLE
Fix Keyboard Shortcuts Behavior in Deck Picker (Fragmented)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2571,7 +2571,7 @@ open class DeckPicker :
     override val shortcuts
         get() =
             ShortcutGroup(
-                listOf(
+                listOfNotNull(
                     shortcut("A", R.string.menu_add_note),
                     shortcut("B", R.string.card_browser_context_menu),
                     shortcut("Y", R.string.pref_cat_sync),
@@ -2581,9 +2581,9 @@ open class DeckPicker :
                     shortcut("C", R.string.check_db),
                     shortcut("D", R.string.new_deck),
                     shortcut("F", R.string.new_dynamic_deck),
-                    shortcut("DEL", R.string.delete_deck_title),
-                    shortcut("Shift+DEL", R.string.delete_deck_without_confirmation),
-                    shortcut("R", R.string.rename_deck),
+                    if (fragmented) shortcut("DEL", R.string.contextmenu_deckpicker_delete_deck) else null,
+                    if (fragmented) shortcut("Shift+DEL", R.string.delete_deck_without_confirmation) else null,
+                    if (fragmented) shortcut("R", R.string.rename_deck) else null,
                     shortcut("P", R.string.open_settings),
                     shortcut("M", R.string.check_media),
                     shortcut("Ctrl+E", R.string.export_collection),


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Non-functional keyboard shortcuts were removed from the list in the deck picker when the screen is not fragmented.

## Fixes
* Fixes #17634

## Approach
Modified the shortcuts list to conditionally include the "DEL", "Shift+DEL", and "R" shortcuts based on the `fragmented` flag. These shortcuts are only included if `fragmented `is true, while others remain unchanged.

## How Has This Been Tested?
Chromebook

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)