### PR TITLE
feat(deck-picker): make "empty filtered deck" undoable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2662,7 +2662,7 @@ open class DeckPicker :
         changes: OpChanges,
         handler: Any?,
     ) {
-        if (changes.studyQueues && handler !== this) {
+        if (changes.studyQueues && handler !== this && handler !== viewModel) {
             invalidateOptionsMenu()
             if (!activityPaused) {
                 // No need to update while the activity is paused, because `onResume` calls `refreshState` that calls `updateDeckList`.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -102,12 +102,11 @@ class DeckPickerViewModel : ViewModel() {
         }
 
     // TODO: move withProgress to the ViewModel, so we don't return 'Job'
-    // TODO: undoableOp { } on emptyDyn
     fun emptyFilteredDeck(deckId: DeckId): Job =
         viewModelScope.launch {
             Timber.i("empty filtered deck %s", deckId)
             withCol { decks.select(deckId) }
-            withCol { sched.emptyDyn(decks.selected()) }
+            undoableOp { sched.emptyDyn(decks.selected()) }
             flowOfDeckCountsChanged.emit(Unit)
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -449,9 +449,7 @@ open class Scheduler(
     /** Remove all cards from a dynamic deck
      * @param did The deck to empty. 0 means current deck.
      */
-    open fun emptyDyn(did: DeckId) {
-        col.backend.emptyFilteredDeck(did)
-    }
+    open fun emptyDyn(did: DeckId) = col.backend.emptyFilteredDeck(did)
 
     fun deckDueTree(): DeckNode = deckTree(true)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -119,6 +119,21 @@ class DeckPickerViewModelTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `empty filtered - undoable`() {
+        runTest {
+            val filteredDeckId = moveAllCardsToFilteredDeck()
+
+            // ChangeManager assert
+            ensureOpsExecuted(1) {
+                viewModel.emptyFilteredDeck(filteredDeckId).join()
+            }
+
+            // backend assert
+            assertThat("col undo status", col.undoStatus().undo, equalTo("Empty"))
+        }
+    }
+
     @CheckResult
     private suspend fun createEmptyCards(): List<CardId> {
         addNoteUsingNoteTypeName("Cloze", "{{c1::Hello}} {{c2::World}}", "").apply {


### PR DESCRIPTION
## Approach
* Part of the ViewModel move

## How Has This Been Tested?
S21: emptying a deck and testing undo, deck counts are updated on both

+ unit tests

## Learning (optional, can help others)
* https://github.com/ankidroid/Anki-Android/issues/17832

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
