### PR TITLE
test(card-browser): handle language changes

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -997,6 +997,20 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Suppress("SpellCheckingInspection") // German
+    @Test
+    fun `columns headings - language change`() =
+        runViewModelTest {
+            fun firstHeading() = flowOfColumnHeadings.value.first().label
+
+            assertThat("English", firstHeading(), equalTo("Sort Field"))
+
+            col.reopenWithLanguage("de")
+            onReinit()
+
+            assertThat("German", firstHeading(), equalTo("Sortierfeld"))
+        }
+
     private fun assertDate(str: String?) {
         // 2025-01-09 @ 18:06
         assertNotNull(str)

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.testutils
 
+import androidx.appcompat.app.AppCompatDelegate
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.ioDispatcher
 import com.ichi2.anki.isCollectionEmpty
@@ -32,6 +33,7 @@ import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.ext.addNote
+import com.ichi2.utils.LanguageUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -191,6 +193,20 @@ interface TestClass {
     /** Ensures [isCollectionEmpty] returns `false` */
     fun ensureNonEmptyCollection() {
         addNotes(1)
+    }
+
+    /**
+     * Closes and reopens the backend using the provided [language], typically for
+     * [CollectionManager.TR] calls
+     *
+     * This does not set the [application locales][AppCompatDelegate.setApplicationLocales]
+     *
+     * @param language tag in the form: `de` or `zh-CN`
+     */
+    suspend fun Collection.reopenWithLanguage(language: String) {
+        LanguageUtil.setDefaultBackendLanguages(language)
+        CollectionManager.discardBackend()
+        CollectionManager.getColUnsafe()
     }
 
     fun selectDefaultDeck() {


### PR DESCRIPTION
Fixed in 3ea835e21d96b3ad7f681995b6cffc2e3f775b1c

* Issue #17367

----

Realized this was a ViewModel test which I'd missed.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 25 mins :/, took some refactorings to come to this solution -->