### PR TITLE
test(deck-options): discard changes dialog

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -2,6 +2,12 @@ name: 🛠️ Emulator Tests
 
 on:
   workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Number of iterations to run. Default 1. Max 256."
+        required: true
+        default: 1
+        type: number
   pull_request:
   push:
     # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same
@@ -14,9 +20,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  emulator_test:
-    name: Android Emulator Test
+  # We want to generate our matrix dynamically
+  # Initial job generates the matrix as a JSON, and following job will use deserialize and use the result
+  matrix_prep:
+    # Do not run the scheduled jobs on forks
+    if: (github.event_name == 'schedule' && github.repository == 'ankidroid/Anki-Android') || (github.event_name != 'schedule')
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.result }}
+    steps:
+      - id: build-matrix
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // by default, we will run one iteration
+            let iterationArray = [0]
+
+            // workflow dispatch will be a drop-down of different options
+            if (context.eventName === "workflow_dispatch") {
+              const inputs = ${{ toJSON(inputs) }}
+              console.log('inputs is: ' + JSON.stringify(inputs))
+
+              const iterationInput = inputs.iterations
+              console.log('iterations input is: ' + iterationInput)
+              // this will expand for example with input 5 => [0, 1, 2, 3, 4]
+              iterationArray = []
+              for (let i = 0; i < iterationInput; i++) {
+                iterationArray.push(i);
+              }
+              console.log('iterationArray is: ' + iterationArray)
+            }
+
+            // If we are running on a schedule it's our periodic passive scan for flakes
+            // Goal is to run enough iterations on all systems that we have confidence there are no flakes
+            if (context.eventName === "schedule") {
+              const iterationCount = 15
+              for (let i = 0; i < iterationCount; i++) {
+                iterationArray.push(i);
+              }
+            }
+
+            // TODO Refactor to make these dynamic with a low/high bracket only on schedule, not push
+            // For now this is the latest supported API. Previously API 29 was fastest.
+            // #13695: This was reverted to API 30, 31 was unstable. This should be fixed
+            let apiLevel = [30];
+
+            // These are used for performance tuning what emulator to use.
+            // try different architectures, targets, delays etc
+            let arch = ['x86_64'];
+            let target = ['google_apis'];
+            let firstBootDelay = [600];
+
+            return {
+              "iteration": iterationArray,
+              "api-level": apiLevel,
+              "arch": arch,
+              "target": target,
+              "first-boot-delay": firstBootDelay
+            }
+      - name: Debug Output
+        run: echo "${{ steps.build-matrix.outputs.result }}"
+
+  # This uses the matrix generated from the matrix-prep stage
+  # it will run unit tests on whatever OS combinations are desired
+  emulator_test:
+    name: Android Emulator Test (${{ matrix.api-level }}, ${{ matrix.arch }}, ${{ matrix.target }}, ${{ matrix.first-boot-delay }}, ${{ matrix.iteration }})
+    runs-on: ubuntu-latest
+    needs: matrix_prep
     timeout-minutes: 75
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -29,16 +99,7 @@ jobs:
       KEYALIAS: nrkeystorealias
     strategy:
       fail-fast: false
-      matrix:
-        # Refactor to make these dynamic with a low/high bracket only on schedule, not push
-        # For now this is the latest supported API. Previously API 29 was fastest.
-        # #13695: This was reverted to API 30, 31 was unstable. This should be fixed
-        api-level: [30]
-        arch: [x86_64]
-        target: [google_apis]
-        first-boot-delay: [600]
-        # This is useful for benchmarking, do 0, 1, 2, etc (up to 256 max job-per-matrix limit) for averages
-        iteration: [0]
+      matrix: ${{fromJson(needs.matrix_prep.outputs.matrix)}}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: insightsengineering/disk-space-reclaimer@v1

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -17,6 +17,12 @@
 package com.ichi2.anki.pages
 
 import androidx.lifecycle.Lifecycle.State
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isEnabled
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
@@ -25,9 +31,11 @@ import com.ichi2.anki.tests.InstrumentedTest
 import com.ichi2.anki.testutil.findFragmentById
 import com.ichi2.libanki.Consts
 import com.ichi2.testutils.common.assertTrueWithTimeout
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import timber.log.Timber
 import kotlin.test.assertEquals
 
 /** Tests [DeckOptions] */
@@ -42,8 +50,29 @@ class DeckOptionsTest : InstrumentedTest() {
     @Test
     fun discardChangesIsNotShownIfNoChanges() = testDeckOptions { assertBackPressClosesOptions() }
 
+    @Test
+    fun discardChangesIsShownIfChangeMade() {
+        testDeckOptions { makeChange() }
+
+        Espresso.pressBack()
+
+        onView(withText("Discard current input?"))
+            .inRoot(isDialog())
+            .check(matches(isEnabled()))
+    }
+
+    @Test
+    @Ignore("broken on main")
+    fun discardChangesIsNotShownIfChangeIsReversed() =
+        testDeckOptions {
+            makeChangeAndUndo()
+            assertBackPressClosesOptions()
+        }
+
     /**
-     * Runs [block] with [DeckOptions] as the receiver. Intended for tests
+     * Runs [block] with [DeckOptions] as the receiver. Intended for test setup
+     *
+     * `onView` should not be called inside this method, instead call it afterwards
      */
     private fun testDeckOptions(block: (DeckOptions).() -> Unit) {
         assertEquals(State.RESUMED, activityRule.scenario.state)
@@ -58,4 +87,37 @@ private fun DeckOptions.assertBackPressClosesOptions() {
     requireActivity().onBackPressedDispatcher.onBackPressed()
     // we assert this as [actuallyClose] launches a task
     assertTrueWithTimeout("fragment closing") { isClosingFragment }
+}
+
+/** Changes an option, so there are unsaved changes */
+private fun DeckOptions.makeChange() {
+    toggleFsrs()
+}
+
+/** Changes an option, and undoes the change so there are no unsaved changes */
+private fun DeckOptions.makeChangeAndUndo() {
+    toggleFsrs()
+    toggleFsrs()
+}
+
+private fun DeckOptions.toggleFsrs() {
+    val js =
+        """
+        // Find the FSRS heading. This is not translated. Exclude the FSRS modal. 
+        const element = Array.from(document.getElementsByTagName("h1")).filter(x => x.innerText == "FSRS" && !x.classList.contains("modal-title"))[0];
+        // Find the 'FSRS' container
+        const container = element.closest(".container");
+        // Find the only checkbox, and click it
+        container.querySelectorAll('input[type="checkbox"]')[0].click()
+        """.trimIndent()
+
+    fun execToggleFsrsJs() = this.webView.evaluateJavascript(js) {}
+
+    if (pageWebViewClient.callbacksExecuted) {
+        Timber.v("scheduling JS callback: 'toggleFsrs'")
+        execToggleFsrsJs()
+    } else {
+        Timber.v("scheduling JS callback: 'toggleFsrs'")
+        pageWebViewClient.onPageFinishedCallbacks.add { execToggleFsrsJs() }
+    }
 }

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import androidx.lifecycle.Lifecycle.State
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.findFragmentById
+import com.ichi2.libanki.Consts
+import com.ichi2.testutils.common.assertTrueWithTimeout
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+/** Tests [DeckOptions] */
+@RunWith(AndroidJUnit4::class)
+class DeckOptionsTest : InstrumentedTest() {
+    @get:Rule
+    val activityRule =
+        ActivityScenarioRule<SingleFragmentActivity>(
+            DeckOptions.getIntent(testContext, Consts.DEFAULT_DECK_ID),
+        )
+
+    @Test
+    fun discardChangesIsNotShownIfNoChanges() = testDeckOptions { assertBackPressClosesOptions() }
+
+    /**
+     * Runs [block] with [DeckOptions] as the receiver. Intended for tests
+     */
+    private fun testDeckOptions(block: (DeckOptions).() -> Unit) {
+        assertEquals(State.RESUMED, activityRule.scenario.state)
+        activityRule.scenario.onActivity { activity ->
+            block(activity.findFragmentById<DeckOptions>(R.id.fragment_container))
+        }
+    }
+}
+
+private fun DeckOptions.assertBackPressClosesOptions() {
+    // we can't use Espresso.pressBackUnconditionally() as this may be called inside onActivity
+    requireActivity().onBackPressedDispatcher.onBackPressed()
+    // we assert this as [actuallyClose] launches a task
+    assertTrueWithTimeout("fragment closing") { isClosingFragment }
+}

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/FragmentActivity.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/FragmentActivity.kt
@@ -1,0 +1,33 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.testutil
+
+import androidx.annotation.IdRes
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
+
+/**
+ * Finds a fragment identified by [id] and casts it to the provided type
+ *
+ * @return The fragment
+ *
+ * @see FragmentManager.findFragmentById
+ */
+inline fun <reified T : Fragment> FragmentActivity.findFragmentById(
+    @IdRes id: Int,
+): T = this.supportFragmentManager.findFragmentById(id) as T

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -25,6 +25,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.annotation.CallSuper
 import androidx.annotation.LayoutRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import com.google.android.material.appbar.MaterialToolbar
@@ -45,6 +46,9 @@ open class PageFragment(
     PostRequestHandler {
     lateinit var webView: WebView
     private val server = AnkiServer(this).also { it.start() }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    lateinit var pageWebViewClient: PageWebViewClient
 
     /**
      * Override this to set a custom [WebViewClient] to the page.
@@ -93,7 +97,7 @@ open class PageFragment(
         view: View,
         savedInstanceState: Bundle?,
     ) {
-        val pageWebViewClient = onCreateWebViewClient(savedInstanceState)
+        pageWebViewClient = onCreateWebViewClient(savedInstanceState)
         webView =
             view.findViewById<WebView>(R.id.webview).apply {
                 with(settings) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageWebViewClient.kt
@@ -21,6 +21,7 @@ import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.annotation.VisibleForTesting
 import androidx.core.view.isVisible
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.OnPageFinishedCallback
@@ -38,6 +39,9 @@ open class PageWebViewClient : WebViewClient() {
     open val promiseToWaitFor: String? = null
 
     val onPageFinishedCallbacks: MutableList<OnPageFinishedCallback> = mutableListOf()
+
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    var callbacksExecuted: Boolean = false
 
     override fun shouldInterceptRequest(
         view: WebView,
@@ -94,6 +98,7 @@ open class PageWebViewClient : WebViewClient() {
         super.onPageFinished(view, url)
         if (view == null) return
         onPageFinishedCallbacks.map { callback -> callback.onPageFinished(view) }
+        callbacksExecuted = true
         if (promiseToWaitFor == null) {
             /** [PageFragment.webView] is invisible by default to avoid flashes while
              * the page is loaded, and can be made visible again after it finishes loading */

--- a/testlib/build.gradle.kts
+++ b/testlib/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
     implementation(libs.hamcrest.library)
     implementation(libs.junit.jupiter)
     implementation(libs.androidx.test.junit)
+    implementation(libs.kotlin.test)
     testImplementation(libs.junit.vintage.engine)
     testImplementation(libs.androidx.test.rules)
     testRuntimeOnly(libs.junit.platform.launcher)

--- a/testlib/src/main/java/com/ichi2/testutils/common/AnkiAssert.kt
+++ b/testlib/src/main/java/com/ichi2/testutils/common/AnkiAssert.kt
@@ -17,6 +17,11 @@
 package com.ichi2.testutils.common
 
 import org.junit.function.ThrowingRunnable
+import timber.log.Timber
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Asserts that [runnable] throws an exception of type [T] when
@@ -34,3 +39,42 @@ inline fun <reified T : Throwable> assertThrows(
     message: String? = null,
     runnable: ThrowingRunnable,
 ): T = org.junit.Assert.assertThrows(message, T::class.java, runnable)
+
+/**
+ * Asserts that the given [block] returns `true` within [timeout]
+ *
+ * Currently used for WebView callbacks which are difficult to listen for
+ *
+ * @param message message to show on failure
+ * @param timeout Duration after which to fail
+ * @param sleepDuration Duration to wait and try again. NOTE: Exclusive of time to execute [block]
+ * @param block The assertion which should return `true`
+ */
+fun assertTrueWithTimeout(
+    message: String,
+    // 10ms is typically sufficient, but I want more leeway for CI.
+    // This is a maximum bound and typically will not be hit
+    timeout: Duration = 1.seconds,
+    sleepDuration: Duration = 10.milliseconds,
+    block: () -> Boolean,
+) {
+    require(timeout.inWholeMilliseconds > 0) { "timeout > 0" }
+    require(sleepDuration.inWholeMilliseconds > 0) { "sleepDuration > 0" }
+
+    var totalSleepTime = Duration.ZERO
+
+    while (totalSleepTime < timeout) {
+        if (block()) {
+            if (totalSleepTime > 0.milliseconds) {
+                Timber.v("assertion true after %s", totalSleepTime)
+            }
+            return
+        }
+
+        Timber.v("assertion failed, waiting %s", sleepDuration)
+        Thread.sleep(sleepDuration.inWholeMilliseconds)
+        totalSleepTime += sleepDuration
+    }
+
+    assertTrue("timeout ($timeout): $message", block)
+}


### PR DESCRIPTION
## Purpose / Description
@Arthur-Milchior said this would be hard. I knew he was right, and I did it anyway. I would regret my time spent here, but it will hopefully lead to more regression coverage for our backend pages

## Issue
* #14438

## Approach
* A lot of banging my head against the wall
* A few extractions of class internals so they can be tested (callbacks executed/`DeckOptions.isClosingFragment`)
* A quick discussion on the Anki Discord regarding whether it's easy to drive the Svelte UI via JS (it's not)
  * https://discord.com/channels/368267295601983490/373169624797282304/1331422200535842826
* Then roll up my sleeves, get things done

## How Has This Been Tested?

* My personal S21 (Android 14)
* API 30 emulator

> [!WARNING]
> This needs a number of reruns in CI to be sure it's stable

## Learning (optional, can help others)
This is the first test of `anki.pages`, and hopefully will allow us to stop a few 'brown paper bag' bugs in future, such as when we broke Statistics

`onView` can't be called inside `onActivity`. There feels like a lot of bad advice here, and the easy option is to move the assertion outside `onActivity`: https://stackoverflow.com/questions/61953249/how-to-access-activity-from-activityscenariorule

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 3 hours 10 mins, mostly on `onView` learnings -->