### PR TITLE
Fix getsize() and getMetrics deprecations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -21,9 +21,11 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Insets
 import android.graphics.Paint
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.os.Build
 import android.util.AttributeSet
 import android.util.DisplayMetrics
 import android.util.TypedValue
@@ -33,6 +35,7 @@ import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.WindowInsets
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.annotation.ColorInt
@@ -234,10 +237,23 @@ class Toolbar : FrameLayout {
     private val screenWidth: Int
         get() {
             val displayMetrics = DisplayMetrics()
-            (context as Activity)
-                .windowManager
-                .defaultDisplay
-                .getMetrics(displayMetrics)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                val windowMetrics =
+                    (context as Activity)
+                        .windowManager
+                        .currentWindowMetrics
+                val insets: Insets =
+                    windowMetrics.getWindowInsets().getInsetsIgnoringVisibility(
+                        WindowInsets.Type.navigationBars()
+                            or WindowInsets.Type.displayCutout(),
+                    )
+                displayMetrics.widthPixels = windowMetrics.bounds.width() - (insets.right + insets.left)
+            } else {
+                (context as Activity)
+                    .windowManager
+                    .defaultDisplay
+                    .getMetrics(displayMetrics)
+            }
             return displayMetrics.widthPixels
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
@@ -17,8 +17,11 @@
 package com.ichi2.utils
 
 import android.content.Context
+import android.graphics.Insets
 import android.graphics.Point
+import android.os.Build
 import android.view.Window
+import android.view.WindowInsets
 import android.view.WindowManager
 import com.ichi2.anki.AnkiDroidApp
 import kotlin.math.roundToInt
@@ -26,9 +29,22 @@ import kotlin.math.roundToInt
 object DisplayUtils {
     @Suppress("DEPRECATION") // #9333: defaultDisplay & getSize
     fun getDisplayDimensions(wm: WindowManager): Point {
-        val display = wm.defaultDisplay
         val point = Point()
-        display.getSize(point)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            val bounds = wm.currentWindowMetrics.bounds
+            val insets: Insets =
+                wm.currentWindowMetrics
+                    .getWindowInsets()
+                    .getInsetsIgnoringVisibility(
+                        WindowInsets.Type.navigationBars()
+                            or WindowInsets.Type.displayCutout(),
+                    )
+            point.x = bounds.width() - (insets.right + insets.left)
+            point.y = bounds.height() - (insets.top + insets.bottom)
+        } else {
+            val display = wm.defaultDisplay
+            display.getSize(point)
+        }
         return point
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Replaced deprecated methods Display.getMetrics() and Display.getSize(Point) with WindowManager.getCurrentWindowMetrics().getBounds() for Android R (API 30+) to obtain screen dimensions. Additionally, used Configuration.densityDpi for retrieving screen density. For backward compatibility, retained the use of Display.getMetrics() and Display.getSize(Point) on older Android versions

## Fixes
* Fixes #9333

## How Has This Been Tested?

The changes were tested using Logcat by logging the values obtained from WindowMetrics.getBounds() and comparing them with the values from Display.getSize(Point) and Display.getMetrics(). The results were consistent across devices running Android 30+ and older versions.

 - getmetrix() 
![WhatsApp Image 2025-01-24 at 4 01 53 PM](https://github.com/user-attachments/assets/1eb50bef-c573-4975-95e2-e4ffff326f83)

- getSize()

![WhatsApp Image 2025-01-24 at 4 06 59 PM](https://github.com/user-attachments/assets/011092c9-2ba8-458f-a68b-08275615d78d)
1st log is of getSize() used by UsageAnalitics
2nd , 3rd log is of getSize() used by whiteboard portrate, landscape



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
