### PR TITLE
Fix two bugs related to custom study by tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -464,7 +464,7 @@ class CustomStudyDialog :
         // and then set various options
         dyn.put("delays", JSONObject.NULL)
         val ar = dyn.getJSONArray("terms")
-        ar.getJSONArray(0).put(0, """deck:"$deckToStudyName" terms[0]""")
+        ar.getJSONArray(0).put(0, """deck:"$deckToStudyName" ${terms[0]}""")
         ar.getJSONArray(0).put(1, terms[1])
         @DynPriority val priority = terms[2] as Int
         ar.getJSONArray(0).put(2, priority)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -368,14 +368,16 @@ class CustomStudyDialog :
             }
             sb.append("(").append(arr.joinToString(" or ")).append(")")
         }
-        launchCatchingTask {
-            createTagsCustomStudySession(
-                arrayOf(
-                    sb.toString(),
-                    Consts.DYN_MAX_SIZE,
-                    Consts.DYN_RANDOM,
-                ),
-            )
+        activity?.launchCatchingTask {
+            withProgress {
+                createTagsCustomStudySession(
+                    arrayOf(
+                        sb.toString(),
+                        Consts.DYN_MAX_SIZE,
+                        Consts.DYN_RANDOM,
+                    ),
+                )
+            }
         }
     }
 
@@ -471,23 +473,16 @@ class CustomStudyDialog :
         Timber.i("Rebuilding Custom Study Deck")
         // PERF: Should be in background
         withCol { decks.save(dyn) }
-        // launch this in the activity scope, rather than the fragment scope
-        requireActivity().launchCatchingTask { rebuildDynamicDeck() }
+        Timber.d("Rebuilding dynamic deck...")
+        withCol { sched.rebuildDyn(decks.selected()) }
+        setFragmentResult(
+            CustomStudyAction.REQUEST_KEY,
+            bundleOf(
+                CustomStudyAction.BUNDLE_KEY to CustomStudyAction.CUSTOM_STUDY_SESSION.ordinal,
+            ),
+        )
         // Hide the dialogs (required due to a DeckPicker issue)
         requireActivity().dismissAllDialogFragments()
-    }
-
-    private suspend fun rebuildDynamicDeck() {
-        Timber.d("rebuildDynamicDeck()")
-        withProgress {
-            withCol { sched.rebuildDyn(decks.selected()) }
-            setFragmentResult(
-                CustomStudyAction.REQUEST_KEY,
-                bundleOf(
-                    CustomStudyAction.BUNDLE_KEY to CustomStudyAction.CUSTOM_STUDY_SESSION.ordinal,
-                ),
-            )
-        }
     }
 
     /**


### PR DESCRIPTION
## Purpose / Description

Blocked on 
* #17835 

Fixes two bugs related to custom study by tags:
- an IllegalStateException due to sending fragment results after the dialog was dimissed
- custom study by tags not actually working after a previous change around this code

Built on top of #17835 the last two commits are the fixes. This should go in before releasing as custom study by tags doesn't work otherwise. More info in the commits messages.

## How Has This Been Tested?

Ran the tests, manually checked custom study by tags.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
