### PR TITLE
Don't allow empty name in flag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FlagAdapter.kt
@@ -91,13 +91,18 @@ class FlagAdapter(
         }
 
         holder.saveButton.setOnClickListener {
-            val updatedTextName = holder.flagNameEdit.text.toString()
+            val updatedTextName =
+                holder.flagNameEdit.text
+                    .toString()
+                    .ifEmpty { flagItem.title }
             holder.flagNameViewLayout.visibility = View.VISIBLE
             holder.flagNameEditLayout.visibility = View.GONE
             val updatedFlagItem = flagItem.copy(title = updatedTextName)
             val updatedDataset = currentList.toMutableList()
-            lifecycleScope.launch {
-                flagItem.renameTo(updatedTextName)
+            if (updatedFlagItem.title != flagItem.title) {
+                lifecycleScope.launch {
+                    flagItem.renameTo(updatedTextName)
+                }
             }
             updatedFlagItem.isInEditMode = false
             updatedDataset[position] = updatedFlagItem


### PR DESCRIPTION
## Purpose / Description
Fixes the issue where a flag could be renamed to an empty value in the Card Browser. Now, empty flag names are not allowed.

## Fixes
* Fixes #17854

## Approach
If user tries to save empty flag name then set it back to the default name which was used.

## How Has This Been Tested?
Physical device (OPPO F21 Pro 5G)

https://github.com/user-attachments/assets/96e85978-83e1-422d-864e-25b2d6c60e5c



## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)