### PR TITLE
fix(import): import CSV/TSV files

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -241,6 +241,8 @@
                 <data android:mimeType="application/octet-stream"/>
                 <data android:mimeType="text/tab-separated-values"/>
                 <data android:mimeType="text/comma-separated-values"/>
+                <data android:mimeType="text/csv"/>
+                <data android:mimeType="text/tsv"/>
             </intent-filter>
 
             <!-- Keep it separate as when sharing image AnkiDroid would be shown with Image Occlusion label -->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -299,6 +299,14 @@ class IntentHandler : AbstractIntentHandler() {
         private const val CLIPBOARD_INTENT = "com.ichi2.anki.COPY_DEBUG_INFO"
         private const val CLIPBOARD_INTENT_EXTRA_DATA = "clip_data"
 
+        private val textMimeTypes =
+            setOf(
+                "text/tab-separated-values",
+                "text/tsv",
+                "text/comma-separated-values",
+                "text/csv",
+            )
+
         private fun isValidViewIntent(intent: Intent): Boolean {
             // Negating a negative because we want to call specific attention to the fact that it's invalid
             // #6312 - Smart Launcher provided an empty ACTION_VIEW, no point in importing here.
@@ -333,8 +341,7 @@ class IntentHandler : AbstractIntentHandler() {
                 val mimeType = intent.resolveMimeType()
                 when {
                     mimeType?.startsWith("image/") == true -> LaunchType.IMAGE_IMPORT
-                    mimeType == "text/tab-separated-values" ||
-                        mimeType == "text/comma-separated-values" -> LaunchType.TEXT_IMPORT
+                    textMimeTypes.contains(mimeType) -> LaunchType.TEXT_IMPORT
                     else -> LaunchType.FILE_IMPORT
                 }
             } else if ("com.ichi2.anki.DO_SYNC" == action) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -103,6 +103,7 @@ class ImportFileSelectionFragment : DialogFragment() {
                                     "text/comma-separated-values",
                                     "text/csv",
                                     "text/tab-separated-values",
+                                    "text/tsv",
                                 ),
                         ),
                     )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntentHandlerTest.kt
@@ -96,10 +96,14 @@ class IntentHandlerTest {
     fun textImportIntentReturnsTextImport() {
         testIntentType("content://valid", "text/tab-separated-values", LaunchType.TEXT_IMPORT)
         testIntentType("content://valid", "text/comma-separated-values", LaunchType.TEXT_IMPORT)
+        testIntentType("content://valid", "text/csv", LaunchType.TEXT_IMPORT)
+        testIntentType("content://valid", "text/tsv", LaunchType.TEXT_IMPORT)
 
         // Test for ACTION_SEND
         testIntentType("content://valid", "text/tab-separated-values", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
         testIntentType("content://valid", "text/comma-separated-values", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
+        testIntentType("content://valid", "text/csv", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
+        testIntentType("content://valid", "text/tsv", LaunchType.TEXT_IMPORT, Intent.ACTION_SEND)
     }
 
     private fun testIntentType(


### PR DESCRIPTION
## Purpose / Description
CSV files from Gmail on my S21 (Android 14) are `text/csv`

`text/tsv` is also used when coming from Gmail

## Fixes
* Fixes #17866 (maybe)

## Approach
* handle `text/csv`
* handle `text/tsv`

## How Has This Been Tested?

S21 on Android 14: I can see the Android Dev Build as an import option a few more times for CSVs

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!-- 40 mins, mostly diagnostics and testing with CSV, which was surprisingly problematic to export from Google Sheets-->