### PR TITLE
improvement(release): clarify files are under 'Assets'

### DIFF
--- a/tools/release-description.md
+++ b/tools/release-description.md
@@ -4,7 +4,7 @@
 
 ## For regular users
 
-Install `arm64-v8a` below. If it fails to install, use `Parallel.A`.
+Install `arm64-v8a` from the **Assets** section below. If it fails to install, use `Parallel.A`.
 
 `Parallel` builds install side-by-side with the main APK, allowing you to use different settings and profiles (via the `AnkiDroid directory` advanced setting and a different AnkiWeb login).
 


### PR DESCRIPTION
When I looked at the page, `Assets` was collapsed and had the same section styles as the other h2s so it was hard to distinguish what "Install `arm64-v8a`" meant

Note: Please close this PR immediately on any disagreements, this is a very quick 'nice to have'

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
