### PR TITLE
Fix: Enable sharing .txt files for import in AnkiDroid

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -228,6 +228,31 @@
                     android:pathPattern=".*\\.csv"
                     android:scheme="file"
                     />
+                <!-- text files -->
+                <data
+                    android:host="*"
+                    android:mimeType="*/*"
+                    android:pathPattern=".*\\.txt"
+                    android:scheme="http"
+                    />
+                <data
+                    android:host="*"
+                    android:mimeType="*/*"
+                    android:pathPattern=".*\\.txt"
+                    android:scheme="https"
+                    />
+                <data
+                    android:host="*"
+                    android:mimeType="*/*"
+                    android:pathPattern=".*\\.txt"
+                    android:scheme="content"
+                    />
+                <data
+                    android:host="*"
+                    android:mimeType="*/*"
+                    android:pathPattern=".*\\.txt"
+                    android:scheme="file"
+                    />
             </intent-filter>
             <!-- MIME type matcher for .apkg files coming from providers like gmail which hide the file extension -->
             <intent-filter>
@@ -244,6 +269,7 @@
                 <data android:mimeType="text/comma-separated-values"/>
                 <data android:mimeType="text/csv"/>
                 <data android:mimeType="text/tsv"/>
+                <data android:mimeType="text/plain"/>
             </intent-filter>
 
             <!-- Keep it separate as when sharing image AnkiDroid would be shown with Image Occlusion label -->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -305,6 +305,7 @@ class IntentHandler : AbstractIntentHandler() {
                 "text/tsv",
                 "text/comma-separated-values",
                 "text/csv",
+                "text/plain",
             )
 
         private fun isValidViewIntent(intent: Intent): Boolean {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR adds the necessary intent-filter configuration to the AndroidManifest.xml to enable AnkiDroid to handle .txt files shared from the file manager for import

## Fixes
* Fixes #17873

## Approach
Added intent-filter for text/plain MIME type to support .txt file sharing and import

## How Has This Been Tested?
Physical Device (Redmi Note 13)

https://github.com/user-attachments/assets/aa18f9f4-a20d-4329-b332-928442642e3c

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)