### PR TITLE
feat: allow pasting images as png

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki
 
 import android.content.ClipDescription
+import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
@@ -35,10 +36,38 @@ import java.io.IOException
 import java.io.InputStream
 import java.lang.IllegalStateException
 
+private typealias DisplayMediaError = (MediaRegistration.MediaError) -> Unit
+
 /**
  * Utility class for media registration and handling errors during media paste actions.
  */
 object MediaRegistration {
+    /**
+     * Represents different types of media errors.
+     */
+    sealed class MediaError {
+        data object GenericError : MediaError()
+
+        class ConversionError(
+            val message: String,
+        ) : MediaError()
+
+        data object ImageTooLarge : MediaError()
+
+        data object VideoTooLarge : MediaError()
+
+        data object AudioTooLarge : MediaError()
+
+        fun toHumanReadableString(context: Context): String =
+            when (this) {
+                is GenericError -> context.getString(R.string.multimedia_editor_something_wrong)
+                is ConversionError -> context.getString(R.string.multimedia_editor_png_paste_error, message)
+                is ImageTooLarge -> context.getString(R.string.note_editor_image_too_large)
+                is VideoTooLarge -> context.getString(R.string.note_editor_video_too_large)
+                is AudioTooLarge -> context.getString(R.string.note_editor_audio_too_large)
+            }
+    }
+
     // Use the same HTML if the same image is pasted multiple times.
     private val pastedMediaCache = HashMap<String, String?>()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki
 
 import android.content.ClipDescription
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
@@ -37,13 +36,9 @@ import java.io.InputStream
 import java.lang.IllegalStateException
 
 /**
- * RegisterMediaForWebView is used for registering media in temp path,
- * this class is required in summer note class for paste image event and in visual editor activity for importing media,
- * (extracted code to avoid duplication of code).
+ * Utility class for media registration and handling errors during media paste actions.
  */
-class MediaRegistration(
-    private val context: Context,
-) {
+object MediaRegistration {
     // Use the same HTML if the same image is pasted multiple times.
     private val pastedMediaCache = HashMap<String, String?>()
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -44,6 +44,7 @@
     <string name="pref_cat_advanced" maxLength="41">Advanced</string>
     <string name="pref_cat_workarounds" maxLength="41">Workarounds</string>
     <string name="pref_cat_plugins" maxLength="41">Plugins</string>
+    <string name="pref_cat_editing" maxLength="41">Editing</string>
 
     <!-- preferences.xml entries-->
     <string name="whiteboard_stroke_width" maxLength="41">Stroke width</string>
@@ -182,7 +183,6 @@
     <string name="accessibility" maxLength="41">Accessibility</string>
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
-    <string name="paste_as_png_summary">By default Anki pastes images on the clipboard as JPG files to save disk space. You can use this option to paste as PNG images instead.</string>
     <string name="exit_via_double_tap_back" maxLength="41">Press back twice to go back/exit</string>
     <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the reviewer or the app</string>
     <!-- Allow all files in media imports -->

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -6,7 +6,6 @@
     <string name="deck_for_new_cards_key">useCurrent</string>
     <string name="pref_language_key">language</string>
     <string name="analytics_opt_in_key">analytics_opt_in</string>
-    <string name="paste_png_key">pastePNG</string>
     <string name="error_reporting_mode_key">reportErrorMode</string>
     <!-- Reviewing -->
     <string name="pref_reviewing_screen_key">reviewingScreen</string>
@@ -28,6 +27,8 @@
     <string name="username_key">username</string>
     <!-- Backup -->
     <string name="pref_backup_limits_screen_key">backupLimitsScreen</string>
+    <!-- Editing -->
+    <string name="paste_png_key">pastePNG</string>
     <!-- Appearance -->
     <string name="pref_appearance_screen_key">appearance_preference_group</string>
     <string name="app_theme_key">appTheme</string>

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -44,12 +44,13 @@
             android:key="@string/analytics_opt_in_key"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />
+    <PreferenceCategory android:title="@string/pref_cat_editing">
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:title="@string/paste_as_png"
-            android:summary="@string/paste_as_png_summary"
             android:maxLength="41"
             android:key="@string/paste_png_key"/>
+    </PreferenceCategory>
         <PreferenceCategory android:title="@string/pref_cat_studying">
             <ListPreference
                 android:entries="@array/add_to_cur_labels"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Anki preserves the image format unless `Paste as png` is turned on, this PR allow the user to preserve the image format unless the option is turned on

## Fixes
* Fixes #17841

## How Has This Been Tested?
Tested on API 35 -> Google Emulator

## Approach
- MediaRegistration class was context dependent which is not a good practice hence converted it to `Object`
- `onPaste` ran a check to see if we want to convert a image to JPG or not, but Anki doesn't do that and preserves the image extension and in case paste as PNG is turned on then pastes the images as png, hence I updated the code to remove these JPG checks and proceed with original extension unless the paste as PNG is turned on
- fetch the boolean from `col` to see if we want to paste the image as PNG in NoteEditor 
- finally proceed to paste the image

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
