### PR TITLE
fix: reviewer test fix for local failures

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -237,7 +237,7 @@ class ReviewerTest : RobolectricTest() {
 
             val cards =
                 arrayOf(
-                    addRevBasicNoteDueToday("1", "bar").firstCard(),
+                    addBasicNote("1", "bar").firstCard(),
                     addBasicNote("2", "bar").firstCard(),
                     addBasicNote("3", "bar").firstCard(),
                 )


### PR DESCRIPTION
This test disabled in CI but failed for me every time locally

It worked until the only other user of the test required a change that broke this one - git bisect indicates it was in commit:

56ec7096262ec5d5f2c53499b24ea002bdc84013

There was no real reason I could see that the test I modified need a card specifically due today though? So the change seems reasonable, and it definitely fixes it for me in local testing

## How Has This Been Tested?

> ./gradlew :AnkiDroid:testPlayDebug --tests "*testLrnQueueAfterUndo*"

## Learning (optional, can help others)

I learned how to drive git bisect slightly better

