### PR TITLE
Implemented `CardsOrNotes` as `Parcelable`.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/CardsOrNotes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/CardsOrNotes.kt
@@ -16,15 +16,18 @@
 
 package com.ichi2.anki.model
 
+import android.os.Parcelable
 import anki.config.ConfigKey
 import com.ichi2.libanki.Collection
+import kotlinx.parcelize.Parcelize
 
 /**
  * Config: Whether the `CardBrowser` is in "Cards" or "Notes" mode
  *
  * @see ConfigKey.Bool.BROWSER_TABLE_SHOW_NOTES_MODE
  */
-enum class CardsOrNotes {
+@Parcelize
+enum class CardsOrNotes : Parcelable {
     CARDS,
     NOTES,
     ;


### PR DESCRIPTION
## Purpose / Description
Implement Parcelable for the CardsOrNotes enum to ensure compatibility with getParcelable() on API <= 33, where the method validates if the class implements Parcelable.

## Fixes
- Fixes #17881

## Approach
Used the `@Parcelize` annotation to implement the Parcelable interface for the CardsOrNotes enum. This ensures the enum is recognized as Parcelable on API < =33 when getParcelable() is called, addressing compatibility issues without requiring manual implementation of Parcelable methods.

## How Has This Been Tested?
```
AnkiDroid Version = 2.21alpha9-debug (85f96484cf03c287508b6b5d92285dfd583d2107)
Backend Version = 0.1.48-anki24.11 (24.11 c47638ca36f99dd4f3b81ae82d964aec66e392e0)
Android Version = 13 (SDK 33)
ProductFlavor = amazon
Device Info = Google | google | emu64x | sdk_gphone64_x86_64 | sdk_gphone64_x86_64 | ranchu
Webview User Agent = Mozilla/5.0 (Linux; Android 13; sdk_gphone64_x86_64 Build/TE1A.220922.010; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/103.0.5060.71 Mobile Safari/537.36
ACRA UUID = ce5c9d43-7fba-4f09-98a7-4fecff9400db
FSRS = 1.4.3 (Enabled: false)
Crash Reports Enabled = false
```
[Screen_recording_20250127_190642.webm](https://github.com/user-attachments/assets/7460d333-4a13-45f7-af4e-f97344d9290a)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
