### PR TITLE
fix: FAB multi-line layout margin adjust always cast to super-type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -42,6 +42,7 @@ import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.view.ViewPropertyAnimator
 import android.widget.ImageView
 import android.widget.LinearLayout
@@ -59,7 +60,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.appcompat.widget.TooltipCompat
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.app.ActivityCompat.OnRequestPermissionsResultCallback
 import androidx.core.content.edit
@@ -2261,11 +2261,9 @@ open class DeckPicker :
             val fabLinearLayout = findViewById<LinearLayout>(R.id.fabLinearLayout)
             // Adjust bottom margin of fabLinearLayout based on reviewSummaryTextView height
             reviewSummaryTextView.doOnLayout {
-                if (reviewSummaryTextView.lineCount > 1) {
-                    val layoutParams = fabLinearLayout.layoutParams as CoordinatorLayout.LayoutParams
-                    layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
-                    fabLinearLayout.layoutParams = layoutParams
-                }
+                val layoutParams = fabLinearLayout.layoutParams as ViewGroup.MarginLayoutParams
+                layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
+                fabLinearLayout.layoutParams = layoutParams
             }
         }
         Timber.d("Startup - Deck List UI Completed")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Fix a crash on FAB margin adjustment for multi-line "review summary" adjustment, that surfaced when the layout of the FAB changed slightly

## Fixes
* Fixes #17882

## Approach

The original FAB multi-line adjustment code only ran sometimes. It can run all the time though, with no harm.

Running all the time means that problems with the adjustment will show up immediately in the future instead of remaining latent unless specifically triggered.

That allowed for easy reproduction of the issue, even if you only review one card in a test deck in English, which would never trigger the issue otherwise.

The fix then is to cast to the widest type possible that has the needed Margins methods so that layout changes are less touchy as they may return different `MarginLayoutParams` sub-types, but they are all `MarginLayoutParams`

https://developer.android.com/reference/android/view/ViewGroup.MarginLayoutParams

## How Has This Been Tested?

Reproduced crash locally, reproduced fix locally

Reproduced that layout still looks good even with only one line of review text (see screenshot) since we now do the multi-line adjustment in that case as well



## Learning (optional, can help others)

PRs with casts deserve just as much scrutiny as PRs with `!!`s apparently. And if you cast to a layout class where the class at runtime will be driven by the layout, then I suppose you need to leave a comment in both places for future developers who might make changes.

But in general I think the lesson is "do not cast to layout-specific classes"

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<img width="318" alt="image" src="https://github.com/user-attachments/assets/44b6279b-9cd4-4bde-b612-85678b72dd8a" />

