### PR TITLE
refactors: logging/fragments: prep for Anki 25.01

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -91,8 +91,12 @@ open class SingleFragmentActivity : AnkiActivity() {
         }
     }
 
+    /** Reference to the hosted fragment */
+    val fragment
+        get() = supportFragmentManager.findFragmentByTag(FRAGMENT_TAG)
+
     override val shortcuts: ShortcutGroup?
-        get() = (supportFragmentManager.findFragmentByTag(FRAGMENT_TAG) as? ShortcutGroupProvider)?.shortcuts
+        get() = (fragment as? ShortcutGroupProvider)?.shortcuts
 
     companion object {
         const val FRAGMENT_NAME_EXTRA = "fragmentName"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -36,6 +36,7 @@ open class PageChromeClient : WebChromeClient() {
         message: String?,
         result: JsResult?,
     ): Boolean {
+        Timber.d("Displaying alert() dialog")
         try {
             AlertDialog.Builder(view.context).show {
                 message?.let { message(text = message) }
@@ -62,6 +63,7 @@ open class PageChromeClient : WebChromeClient() {
         message: String?,
         result: JsResult?,
     ): Boolean {
+        Timber.d("Displaying confirm() dialog")
         try {
             AlertDialog.Builder(view.context).show {
                 message?.let { message(text = message) }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The changes required for https://github.com/ankidroid/Anki-Android/issues/17845 will need to be squashed so we do not break the code when we bump the backend

This is the first of a series of 3 pull requests:

* **we are here** refactors which can go in before the backend bump
* bump the backend and fix Deck Options
* use the new backend functionality to fix Deck Options loading

The purpose of logs is to make debugging deck options easier
The fragment will be accessed in a later commit

## Fixes
* Start of #17845

## How Has This Been Tested?
The final commit of the series works, manually on my S21

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
