### PR TITLE
fix(deck-options): add progress bar to stop flickering

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -91,8 +91,12 @@ open class SingleFragmentActivity : AnkiActivity() {
         }
     }
 
+    /** Reference to the hosted fragment */
+    val fragment
+        get() = supportFragmentManager.findFragmentByTag(FRAGMENT_TAG)
+
     override val shortcuts: ShortcutGroup?
-        get() = (supportFragmentManager.findFragmentByTag(FRAGMENT_TAG) as? ShortcutGroupProvider)?.shortcuts
+        get() = (fragment as? ShortcutGroupProvider)?.shortcuts
 
     companion object {
         const val FRAGMENT_NAME_EXTRA = "fragmentName"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -18,10 +18,12 @@ package com.ichi2.anki.pages
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
+import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
 import anki.collection.OpChanges
 import anki.collection.Progress
@@ -136,6 +138,15 @@ class DeckOptions : PageFragment() {
         }
     }
 
+    /** @see onWebViewReady */
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        pageLoadingIndicator.isVisible = true
+        super.onViewCreated(view, savedInstanceState)
+    }
+
     override fun onWebViewCreated(webView: WebView) {
         // addJavascriptInterface needs to happen before loadUrl
         webView.addJavascriptInterface(ModalJavaScriptInterfaceListener(), "ankidroid")
@@ -151,6 +162,11 @@ class DeckOptions : PageFragment() {
 
         return object : PageWebViewClient() {
             private val ankiManualHostRegex = Regex("^docs\\.ankiweb\\.net\$")
+
+            /** @see onWebViewReady */
+            override fun onShowWebView(webView: WebView) {
+                // no-op: handled in onVebViewReady
+            }
 
             override fun shouldOverrideUrlLoading(
                 view: WebView?,
@@ -205,7 +221,8 @@ class DeckOptions : PageFragment() {
 
     fun onWebViewReady() {
         Timber.d("WebView ready to receive input")
-        // TODO: handle this
+        webView.isVisible = true
+        pageLoadingIndicator.isVisible = false
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -30,7 +30,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.ProgressContext
 import com.ichi2.anki.R
-import com.ichi2.anki.dialogs.DiscardChangesDialog
+import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
@@ -67,43 +67,23 @@ class DeckOptions : PageFragment() {
             override fun handleOnBackPressed() {
                 Timber.v("DeckOptions: requesting the webview to handle the user close request.")
                 webView.evaluateJavascript("anki.deckOptionsPendingChanges()") {
-                    // No callback. Checking whether there are change is asynchronous. Javascript will use the BridgeCommand to request
-                    // Kotlin to either close (if there is no change) or request the user to confirm they want to discard the changes.
+                    // Callback is handled in the WebView:
+                    //  * A 'discard changes' dialog may be shown, using confirm()
+                    //  * if no changes, or changes discarded, `deckOptionsRequireClose` is called
+                    //    which PostRequestHandler handles and calls on this fragment
                 }
             }
         }
 
-    override val bridgeCommands =
-        mapOf<String, () -> Unit>(
-            "confirmDiscardChanges" to {
-                launchCatchingTask {
-                    requestConfirmDiscard()
-                }
-            },
-            "_close" to {
-                actuallyClose()
-            },
-        )
-
     /**
      * Close the view, discarding change if needed.
      */
-    private fun actuallyClose() {
+    fun actuallyClose() {
         onBackFromDeckOptions.isEnabled = false
         Timber.v("webView: navigating back")
         launchCatchingTask {
             // Required to be in a task to ensure the callback is disabled.
             requireActivity().onBackPressedDispatcher.onBackPressed()
-        }
-    }
-
-    /**
-     * Request the user to confirm they want to close the options, discarding change. If they accept, do it.
-     */
-    private fun requestConfirmDiscard() {
-        Timber.v("DeckOptions: showing 'discard changes'")
-        DiscardChangesDialog.showDialog(requireActivity()) {
-            actuallyClose()
         }
     }
 
@@ -223,6 +203,11 @@ class DeckOptions : PageFragment() {
         webView.evaluateJavascript(closeJs, {})
     }
 
+    fun onWebViewReady() {
+        Timber.d("WebView ready to receive input")
+        // TODO: handle this
+    }
+
     companion object {
         fun getIntent(
             context: Context,
@@ -306,4 +291,27 @@ private fun ProgressContext.toUpdatingCardsString(): String? {
         currentCardsCount = params.current,
         totalCardsCount = params.total,
     )
+}
+
+private fun FragmentActivity.requireDeckOptionsFragment(): DeckOptions {
+    require(this is SingleFragmentActivity) { "activity must be SingleFragmentActivity" }
+    return requireNotNull(this.fragment as? DeckOptions?) { "fragment must be DeckOptions" }
+}
+
+/**
+ * Called when Deck Options WebView is ready to receive requests.
+ */
+fun FragmentActivity.deckOptionsReady(input: ByteArray): ByteArray {
+    requireDeckOptionsFragment().onWebViewReady()
+    return input
+}
+
+/**
+ * Force closing the deck options
+ *
+ * This is called after a 'discard changes?' dialog is accepted
+ */
+fun FragmentActivity.deckOptionsRequireClose(input: ByteArray): ByteArray {
+    requireDeckOptionsFragment().actuallyClose()
+    return input
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageChromeClient.kt
@@ -36,6 +36,7 @@ open class PageChromeClient : WebChromeClient() {
         message: String?,
         result: JsResult?,
     ): Boolean {
+        Timber.d("Displaying alert() dialog")
         try {
             AlertDialog.Builder(view.context).show {
                 message?.let { message(text = message) }
@@ -62,6 +63,7 @@ open class PageChromeClient : WebChromeClient() {
         message: String?,
         result: JsResult?,
     ): Boolean {
+        Timber.d("Displaying confirm() dialog")
         try {
             AlertDialog.Builder(view.context).show {
                 message?.let { message(text = message) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -28,6 +28,7 @@ import androidx.annotation.LayoutRes
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.progressindicator.CircularProgressIndicator
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.themes.Themes
@@ -45,6 +46,15 @@ open class PageFragment(
     PostRequestHandler {
     lateinit var webView: WebView
     private val server = AnkiServer(this).also { it.start() }
+
+    /**
+     * A loading indicator for the page. May be shown before the WebView is loaded to
+     * stop flickering
+     *
+     * @exception IllegalStateException if accessed before [onViewCreated]
+     */
+    val pageLoadingIndicator: CircularProgressIndicator
+        get() = requireView().findViewById(R.id.page_loading)
 
     /**
      * Override this to set a custom [WebViewClient] to the page.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -123,6 +123,8 @@ val uiMethods =
             }
         },
         "computeFsrsParams" to { bytes -> lifecycleScope.async { computeFsrsParams(bytes) } },
+        "deckOptionsReady" to { bytes -> lifecycleScope.async { deckOptionsReady(bytes) } },
+        "deckOptionsRequireClose" to { bytes -> lifecycleScope.async { deckOptionsRequireClose(bytes) } },
     )
 
 suspend fun FragmentActivity?.handleUiPostRequest(

--- a/AnkiDroid/src/main/res/layout/page_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/page_fragment.xml
@@ -2,6 +2,7 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -15,10 +16,32 @@
         app:navigationIcon="?attr/homeAsUpIndicator"
         />
 
-    <WebView
-        android:id="@+id/webview"
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:visibility="invisible"/>
+        >
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/page_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:visibility="visible" />
+
+        <WebView
+            android:id="@+id/webview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:visibility="invisible"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
 </LinearLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.0"
-ankiBackend = '0.1.48-anki24.11'
+ankiBackend = '0.1.49-anki25.01rc1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION
* https://github.com/ankidroid/Anki-Android/labels/Blocked%20by%20dependency https://github.com/ankidroid/Anki-Android/pull/17890

## Purpose / Description

> [!IMPORTANT]
> Only review the last commit

This is the last of a series of 3 pull requests:

* refactors which can go in before the backend bump
* bump the backend and fix Deck Options
* **(we are here)**  use the new backend functionality to fix Deck Options loading

## Fixes
* Fixes #14194 - deck options no longer flicker

## Approach
`deckOptionsReady` allows us to know exactly when the backend is ready, instead of showing the WebView in `PageWebViewClient.onPageFinished`.

Stop showing the WebView in `onPageFinished`, and wait for `deckOptionsReady`

A `CircularProgressIndicator` has been added as the wait is noticeable (~300ms)

Once the WebView is shown, hide the Progress Bar

`promiseToWaitFor` and `:page-fully-loaded` are also removed as unused, and these were primarily for DeckOptions

## How Has This Been Tested?
Personal S21 (Android 14)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
