### PR TITLE
enhancement: improve reposition field dialog

### DIFF
--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -11,7 +11,6 @@
     <string name="toast_last_field">Note types must have at least one field</string>
     <string name="toast_empty_name">You must enter a name</string>
     <string name="toast_duplicate_field">Field name already used</string>
-    <string name="toast_out_of_range">You must enter a valid value</string>
 
 
     <!--Plurals-->
@@ -46,7 +45,6 @@
     <string name="model_field_editor_rename">Rename field</string>
     <string name="model_field_editor_language_hint">Set keyboard language hint</string>
     <string name="model_field_editor_reposition_menu">Reposition field</string>
-    <string name="model_field_editor_reposition">Reposition field (enter a value %1$d–%2$d)</string>
     <string name="model_field_editor_toggle_sticky">Remember last input when adding</string>
     <string name="model_field_editor_changing">Updating fields</string>
     <string name="model_field_editor_sort_field">Sort by this field</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Anki prefill the current position of the field and allow user to update it if they want to, this PR makes the dialog consistent with Anki reposition dialog 
<img width="460" alt="Screenshot 2025-01-30 at 2 57 32 AM" src="https://github.com/user-attachments/assets/6fa8c8c6-3229-4d74-8909-adb52d8b922b" />

Current UI:
<img width="380" alt="Screenshot 2025-01-30 at 3 03 46 AM" src="https://github.com/user-attachments/assets/d8b6e8f8-6ef5-4128-85c1-8da4a2d16443" />


## How Has This Been Tested?
Google emulator API 31

New UI:
<img width="367" alt="Screenshot 2025-01-30 at 2 57 08 AM" src="https://github.com/user-attachments/assets/f7cb34c9-784e-4cc5-a9c2-8abda0e31046" />


## Learning (optional, can help others)
I found this out when I was trying to reproduce some other bug, so just pushing this simple improvement 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
