### PR TITLE
feat: report bug shortcut

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -516,6 +516,11 @@ open class DeckPicker :
             syncOnResume = true
         }
 
+        if (intent.hasExtra(INTENT_REPORT_BUG)) {
+            Timber.i("DeckPicker::  Reporting bug, launched from shortcut")
+            ankiActivity.openUrl(Uri.parse(AnkiDroidApp.feedbackUrl))
+        }
+
         setContentView(R.layout.homescreen)
         enableToolbar()
         handleStartup()
@@ -2566,6 +2571,9 @@ open class DeckPicker :
             )
 
     companion object {
+        /** Opens the url to report bug from the ShortcutManager */
+        const val INTENT_REPORT_BUG = "reportBug"
+
         /**
          * Result codes from other activities
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -19,6 +19,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.res.Configuration
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.LayoutInflater
@@ -33,6 +35,7 @@ import androidx.appcompat.app.ActionBarDrawerToggle
 import androidx.appcompat.widget.Toolbar
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.pm.ShortcutInfoCompat
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.graphics.drawable.IconCompat
@@ -478,6 +481,29 @@ abstract class NavigationDrawerActivity :
                     .setIntent(intentAddNote)
                     .build()
 
+            // Report bug shortcut
+            val intentReportBug = Intent(context, DeckPicker::class.java)
+            intentReportBug.action = Intent.ACTION_VIEW
+            intentReportBug.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+            intentReportBug.putExtra(DeckPicker.INTENT_REPORT_BUG, true)
+
+            val iconDrawable = ContextCompat.getDrawable(context, R.drawable.ic_bug_report_black_24dp)?.mutate()
+            iconDrawable?.setTint(ContextCompat.getColor(context, R.color.wb_fg_color_inv))
+
+            val bitmap = Bitmap.createBitmap(iconDrawable!!.intrinsicWidth, iconDrawable.intrinsicHeight, Bitmap.Config.ARGB_8888)
+            val canvas = Canvas(bitmap)
+            iconDrawable.setBounds(0, 0, canvas.width, canvas.height)
+            iconDrawable.draw(canvas)
+
+            val reportBugShortcut =
+                ShortcutInfoCompat
+                    .Builder(context, "reportBugShortcut")
+                    .setShortLabel(context.getString(R.string.help_item_report_bug))
+                    .setLongLabel(context.getString(R.string.help_item_report_bug))
+                    .setIcon(IconCompat.createWithBitmap(bitmap))
+                    .setIntent(intentReportBug)
+                    .build()
+
             // CardBrowser Shortcut
             val intentCardBrowser = Intent(context, CardBrowser::class.java)
             intentCardBrowser.action = Intent.ACTION_VIEW
@@ -496,6 +522,7 @@ abstract class NavigationDrawerActivity :
                     reviewCardsShortcut,
                     noteEditorShortcut,
                     cardBrowserShortcut,
+                    reportBugShortcut,
                 ),
             )
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Allow reporting bug from the shortcut menu of the app, open the report bug URL on DeckPicker screen

## Approach
- Adds a new shortcut in the shortcut menu, allowing user to report a bug directly from the shortcuts 
- Change the color of the report bug icon from the code as its white in color so we change the tint to blue


## How Has This Been Tested?
Google emulator API 35:
<img width="236" alt="Screenshot 2025-01-31 at 8 14 37 PM" src="https://github.com/user-attachments/assets/1831f416-eb44-49c2-925c-123651e6d322" />



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
