### PR TITLE
Prevent double Discard Changes dialog on Android back swipe gesture

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -31,11 +31,14 @@ object DiscardChangesDialog {
         positiveButtonText: String = context.getString(R.string.discard),
         negativeButtonText: String = CollectionManager.TR.addingKeepEditing(),
         message: String = CollectionManager.TR.addingDiscardCurrentInput(),
+        isCancellable: Boolean = true,
+        negativeMethod: () -> Unit = {},
         positiveMethod: () -> Unit,
     ) = AlertDialog.Builder(context).show {
+        setCancelable(isCancellable)
         Timber.i("showing 'discard changes' dialog")
         message(text = message)
         positiveButton(text = positiveButtonText) { positiveMethod() }
-        negativeButton(text = negativeButtonText)
+        negativeButton(text = negativeButtonText) { negativeMethod() }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -96,6 +96,8 @@ class InstantNoteEditorActivity :
     private lateinit var singleTapLayout: LinearLayout
     private lateinit var singleTapLayoutTitle: FixedTextView
 
+    private var isDialogShowing = false
+
     /** Gets the actual cloze field text value **/
     private val clozeFieldText: String?
         get() = viewModel.actualClozeFieldText.value
@@ -103,6 +105,7 @@ class InstantNoteEditorActivity :
     private val dialogBackCallback =
         object : OnBackPressedCallback(false) {
             override fun handleOnBackPressed() {
+                if (isDialogShowing) return
                 showDiscardChangesDialog()
             }
         }
@@ -600,7 +603,11 @@ class InstantNoteEditorActivity :
     }
 
     private fun showDiscardChangesDialog() {
-        DiscardChangesDialog.showDialog(this) {
+        isDialogShowing = true
+        DiscardChangesDialog.showDialog(this, isCancellable = false, negativeMethod = {
+            isDialogShowing = false
+        }) {
+            isDialogShowing = false
             Timber.i("InstantNoteEditorActivity:: OK button pressed to confirm discard changes")
             finish()
         }


### PR DESCRIPTION
## Purpose / Description
Instant Card: Double "discard changes" window appears on Android "Back" swipe gesture  #17864


## Fixes
* Fixes #17864

## Approach
To handle the issue effectively, we introduce a flag (`isDialogShowing` ) to monitor the visibility of the AlertDialog.

By default, the AlertDialog gets dismissed when clicked outside, but the flag (`isDialogShowing`) remains `true`. This prevents the dialog from appearing again when needed.

To address this, we modify the `showDialog` function  in the `DiscardChangesDialog.kt` file  to accept an `isCancellable` parameter. Setting `setCancelable(false)` ensures that the dialog is not dismissed when clicking outside, allowing us to manage the flag correctly.

This update changes the default behavior of this particular AlertDialog, preventing it from being dismissed when clicking outside the dialog. Seeking guidance on whether this change is acceptable.

This approach ensures that `isDialogShowing` is updated properly when the dialog is dismissed, preventing unexpected behavior.

## How Has This Been Tested?
`Tested` on Android device and attached screen recording.



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


Uploading screen-rec.mp4…


