### PR TITLE
feat(card-browser): default search text & ignore accents in search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -25,11 +25,15 @@ import android.widget.CheckBox
 import android.widget.LinearLayout
 import android.widget.RadioButton
 import android.widget.RadioGroup
+import android.widget.TextView
 import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.BrowserColumnSelectionFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
@@ -60,6 +64,16 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
 
         if (newTruncate != isTruncated) {
             viewModel.setTruncated(newTruncate)
+        }
+
+        val newIgnoreAccent = dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).isChecked
+        if (newIgnoreAccent != viewModel.shouldIgnoreAccents) {
+            viewModel.setIgnoreAccents(newIgnoreAccent)
+        }
+
+        val newSearchValue = dialogView.findViewById<TextInputEditText>(R.id.default_search_text).text?.toString() ?: ""
+        if (newSearchValue != viewModel.defaultBrowserSearch) {
+            viewModel.setDefaultSearchText(newSearchValue)
         }
     }
 
@@ -103,6 +117,20 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
 
         dialogView.findViewById<Button>(R.id.manage_columns_button).setOnClickListener {
             openColumnManager()
+        }
+
+        dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).apply {
+            text = TR.preferencesIgnoreAccentsInSearch()
+            isChecked = viewModel.shouldIgnoreAccents
+        }
+
+        dialogView.findViewById<TextInputLayout>(R.id.default_search_input_layout).hint = TR.preferencesDefaultSearchText()
+
+        dialogView.findViewById<TextView>(R.id.browsing_text_view).text = TR.preferencesBrowsing()
+
+        dialogView.findViewById<TextInputEditText>(R.id.default_search_text).apply {
+            hint = TR.preferencesDefaultSearchTextExample()
+            setText(viewModel.defaultBrowserSearch ?: "")
         }
 
         return MaterialAlertDialogBuilder(requireContext()).run {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import java.text.Normalizer
+import java.util.regex.Pattern
+
+private val DIACRITICAL_MARKS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+")
+
+/**
+ * Normalizes the given string by removing diacritical marks (accents) to enable accent-insensitive searches.
+ *
+ * This method uses Unicode normalization in **NFD (Normalization Form Decomposition)** mode, which separates
+ * base characters from their diacritical marks. Then, it removes all combining diacritical marks using a regex.
+ *
+ * Example usage:
+ * ```
+ * val input = "café naïve résumé"
+ * val normalized = input.normalizeForSearch()
+ * println(normalized) // Output: "cafe naive resume"
+ * ```
+ *
+ * @receiver The input string that may contain accented characters.
+ * @return A new string with accents removed.
+ */
+fun String.normalizeForSearch(): String {
+    val normalized = Normalizer.normalize(this, Normalizer.Form.NFD)
+    return DIACRITICAL_MARKS_PATTERN.matcher(normalized).replaceAll("")
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Config.kt
@@ -20,7 +20,6 @@ import anki.config.ConfigKey
 import com.google.protobuf.kotlin.toByteStringUtf8
 import com.ichi2.libanki.utils.NotInLibAnki
 import kotlinx.serialization.SerializationException
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
@@ -64,6 +63,15 @@ class Config(
         value: Boolean,
     ) {
         backend.setConfigBool(key, value, false)
+    }
+
+    fun getString(key: ConfigKey.String): String = backend.getConfigString(key)
+
+    fun setString(
+        key: ConfigKey.String,
+        value: String,
+    ) {
+        backend.setConfigString(key, value, false)
     }
 
     @NotInLibAnki

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -2,92 +2,90 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
+    android:layout_height="match_parent"
+    xmlns:tools="http://schemas.android.com/tools">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical">
 
-    <LinearLayout
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_margin="8dp">
 
-        <TextView
+            <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/toggle_cards_notes"
             android:textStyle="bold"
             android:layout_marginHorizontal="16dp" />
 
-        <RadioGroup
+            <RadioGroup
             android:id="@+id/select_browser_mode"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
             android:layout_marginHorizontal="16dp">
 
-            <RadioButton
+                <RadioButton
                 android:id="@+id/select_cards_mode"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/show_cards" />
 
-            <RadioButton
+                <RadioButton
                 android:id="@+id/select_notes_mode"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/show_notes" />
+            </RadioGroup>
+        </LinearLayout>
 
-        </RadioGroup>
-    </LinearLayout>
-
-    <LinearLayout
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_margin="8dp">
 
-        <TextView
+            <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/card_browser_truncate"
             android:textStyle="bold"
             android:layout_marginHorizontal="16dp" />
 
-        <CheckBox
+            <CheckBox
             android:id="@+id/truncate_checkbox"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/card_browser_truncate"
             android:layout_marginHorizontal="16dp" />
 
-        <TextView
+            <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/truncate_content_help"
             android:textColor="?android:attr/textColorSecondary"
             android:layout_marginHorizontal="16dp" />
+        </LinearLayout>
 
-    </LinearLayout>
-
-    <LinearLayout
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_margin="8dp">
 
-        <com.ichi2.ui.FixedTextView
+            <com.ichi2.ui.FixedTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/browse_manage_columns_main_heading"
             android:textStyle="bold"
             android:layout_marginHorizontal="16dp" />
 
-        <!-- full width to increase touch target size on tablets -->
-        <com.google.android.material.button.MaterialButton
+            <!-- full width to increase touch target size on tablets -->
+            <com.google.android.material.button.MaterialButton
             android:id="@+id/manage_columns_button"
             style="@style/Widget.Material3.Button.TextButton"
             android:layout_width="match_parent"
@@ -98,23 +96,22 @@
             android:layout_marginHorizontal="16dp"
             android:singleLine="true"
             android:text="@string/browse_manage_columns" />
+        </LinearLayout>
 
-    </LinearLayout>
-
-    <LinearLayout
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
         android:layout_margin="8dp">
 
-        <TextView
+            <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/menu_flag"
             android:textStyle="bold"
             android:layout_marginHorizontal="16dp" />
 
-        <LinearLayout
+            <LinearLayout
             android:gravity="center"
             android:minHeight="?attr/listPreferredItemHeightSmall"
             android:id="@+id/action_rename_flag"
@@ -124,20 +121,17 @@
             android:orientation="horizontal"
             android:layout_height="match_parent">
 
-            <ImageView
+                <ImageView
                 android:layout_width="wrap_content"
                 android:src="@drawable/ic_flag_transparent"
                 android:layout_height="match_parent"/>
 
-            <com.ichi2.ui.FixedTextView
+                <com.ichi2.ui.FixedTextView
                 android:layout_marginStart="4dp"
                 android:layout_width="match_parent"
                 android:text="@string/rename_flag"
                 android:layout_height="wrap_content"/>
+            </LinearLayout>
         </LinearLayout>
-
-      </LinearLayout>
-
     </LinearLayout>
-
 </ScrollView>

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -72,6 +72,45 @@
         </LinearLayout>
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:layout_marginBottom="8dp"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="Browsing"
+                android:textStyle="bold"
+                android:layout_marginHorizontal="16dp" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/default_search_input_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+                app:expandedHintEnabled="false"
+                app:endIconMode="clear_text"
+                android:layout_marginHorizontal="16dp"
+                tools:hint="Default search text">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/default_search_text"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:hint="eg. 'deck:current'"
+                    android:inputType="text" />
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <CheckBox
+                android:id="@+id/ignore_accents_checkbox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                tools:text="Ignore accents in search (slower)"/>
+        </LinearLayout>
+
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -78,6 +78,7 @@
             android:orientation="vertical">
 
             <TextView
+                android:id="@+id/browsing_text_view"
                 android:layout_marginBottom="8dp"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/StringNormalizationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/StringNormalizationTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import com.ichi2.anki.utils.ext.normalizeForSearch
+import org.junit.Assert.assertEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class StringNormalizationTest {
+    @ParameterizedTest
+    @CsvSource(
+        "café Ábaco naïve résumé, cafe Abaco naive resume",
+        "élégant déjà vu, elegant deja vu",
+        "hello world, hello world",
+        "'', ''",
+        "1234!@# café, 1234!@# cafe",
+    )
+    fun `test normalizeForSearch`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.normalizeForSearch())
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Allows user to set default search text like Anki
- User can opt in for ignoring accents in string

## Approach
Create new preference category and handle the searching in cardbrowser, the way I did it can be seen in commits as they are clear

## How Has This Been Tested?
Google emulator API35:

<img width="374" alt="Screenshot 2025-02-03 at 2 07 21 AM" src="https://github.com/user-attachments/assets/bc3eed44-ff67-40dc-b1c4-a3d8fb3cd27c" />

[Screen_recording_20250203_020641.webm](https://github.com/user-attachments/assets/44619318-0e0f-4972-851b-df9e65e42ef9)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
