### PR TITLE
Fix more ActivityNotFoundExceptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/AndroidUtils.kt
@@ -14,6 +14,7 @@
 
 package com.ichi2.anki.utils
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -28,6 +29,7 @@ import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.copyToClipboard
+import timber.log.Timber
 
 /**
  * Acquire a wake lock and release it after running [block].
@@ -73,7 +75,16 @@ fun Context.openUrl(uri: Uri) {
         }
         return
     }
-    startActivity(Intent(Intent.ACTION_VIEW, uri))
+    try {
+        startActivity(Intent(Intent.ACTION_VIEW, uri))
+    } catch (ex: Exception) {
+        Timber.w("No app found to handle opening an external url from ${this::class.java.name}")
+        if (this is FragmentActivity) {
+            showSnackbar(R.string.activity_start_failed)
+        } else {
+            showThemedToast(this, R.string.activity_start_failed, false)
+        }
+    }
 }
 
 // necessary for Fragments that are BaseSnackbarBuilderProvider to work correctly
@@ -82,7 +93,12 @@ fun Fragment.openUrl(uri: Uri) {
         showSnackbar(getString(R.string.no_browser_msg, uri.toString()))
         return
     }
-    startActivity(Intent(Intent.ACTION_VIEW, uri))
+    try {
+        startActivity(Intent(Intent.ACTION_VIEW, uri))
+    } catch (ex: ActivityNotFoundException) {
+        Timber.w("No app found to handle opening an external url from ${Fragment::class.java.name}")
+        showSnackbar(R.string.activity_start_failed)
+    }
 }
 
 fun Fragment.openUrl(

--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabActivityHelper.kt
@@ -15,6 +15,7 @@
 package com.ichi2.compat.customtabs
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.net.Uri
 import android.os.Bundle
 import androidx.annotation.CheckResult
@@ -23,6 +24,8 @@ import androidx.browser.customtabs.CustomTabsClient
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsServiceConnection
 import androidx.browser.customtabs.CustomTabsSession
+import com.ichi2.anki.R
+import com.ichi2.anki.snackbar.showSnackbar
 import timber.log.Timber
 
 /**
@@ -171,7 +174,12 @@ class CustomTabActivityHelper : ServiceConnectionCallback {
                 }
             } else {
                 customTabsIntent.intent.setPackage(packageName)
-                customTabsIntent.launchUrl(activity, uri)
+                try {
+                    customTabsIntent.launchUrl(activity, uri)
+                } catch (ex: ActivityNotFoundException) {
+                    Timber.w("No app found to handle opening an external url from CustomTabsActivityHelper")
+                    activity.showSnackbar(R.string.activity_start_failed)
+                }
             }
         }
 


### PR DESCRIPTION
## Purpose / Description

In both the shared decks screen and the account login the user could trigger an ACTION_VIEW(ex. mailto link) which went through our custom tabs implementation which finally tried to start and activity(and failed if no app to handle it was present). 

Example bug report: https://ankidroid.org/acra/app/1/bug/280476/report/003eb5ab-bb37-484a-a3f7-0ec9bda1767c
Example stacktrace:

```
android.content.ActivityNotFoundException: No Activity found to handle Intent { act=android.intent.action.VIEW dat=https://ankiweb.net/... pkg=com.power.browser (has extras) }
	at android.app.Instrumentation.checkStartActivityResult(Instrumentation.java:2100)
	at android.app.Instrumentation.execStartActivity(Instrumentation.java:1747)
	at android.app.Activity.startActivityForResult(Activity.java:5473)
	at androidx.activity.ComponentActivity.startActivityForResult(ComponentActivity.kt:704)
	at android.app.Activity.startActivity(Activity.java:5813)
	at androidx.core.content.ContextCompat.startActivity(ContextCompat.java:297)
	at androidx.browser.customtabs.CustomTabsIntent.launchUrl(CustomTabsIntent.java:662)
	at com.ichi2.compat.customtabs.CustomTabActivityHelper$Companion.openCustomTab(CustomTabActivityHelper.kt:167)
	at com.ichi2.anki.AnkiActivity.openUrl(AnkiActivity.kt:440)
	at com.ichi2.anki.MyAccount.initAllContentViews$lambda$13(MyAccount.kt:251)
	at android.view.View.performClick(View.java:7792)
	at android.widget.TextView.performClick(TextView.java:16112)
	at com.google.android.material.button.MaterialButton.performClick(MaterialButton.java:1218)
	at android.view.View.performClickInternal(View.java:7769)
	at android.view.View.access$3800(View.java:910)
	at android.view.View$PerformClick.run(View.java:30218)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loopOnce(Looper.java:226)
	at android.os.Looper.loop(Looper.java:313)
	at android.app.ActivityThread.main(ActivityThread.java:8751)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
```


## How Has This Been Tested?

Just ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
