### PR TITLE
Enable full report about empty cards

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_empty_cards.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_empty_cards.xml
@@ -52,30 +52,42 @@
             tools:text="Processing..." />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-    <LinearLayout
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/empty_report_label"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:layout_marginHorizontal="24dp"
+        android:visibility="gone"
+        android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
+        tools:text="Cards to delete: 123" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/empty_cards_results_container"
         android:visibility="gone"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:paddingStart="@dimen/side_margin"
         android:paddingEnd="@dimen/side_margin">
 
-        <com.ichi2.ui.FixedTextView
-            android:id="@+id/empty_cards_results_message"
+        <WebView
+            android:id="@+id/report"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingStart="8dp"
-            android:paddingBottom="8dp"
-            android:textAppearance="@style/TextAppearance.Material3.BodyLarge"
-            tools:text="Cards to delete: 123" />
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/preserve_notes"/>
 
         <CheckBox
             android:id="@+id/preserve_notes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:checked="true"
-            tools:text="Keep notes with no valid cards" />
-    </LinearLayout>
+            tools:text="Keep notes with no valid cards"
+            android:layout_marginTop="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </FrameLayout>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -114,8 +114,6 @@
 
     <!-- Empty cards -->
     <string name="emtpy_cards_finding">Finding empty cards…</string>
-    <string name="empty_cards_count">Cards to delete: %d</string>
-
 
     <!-- Multimedia - Edit Field Activity -->
     <string name="multimedia_editor_audio_permission_refused">Could not obtain microphone permission.</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Adds the required changes to make the empty cards dialog show the same report that desktop does about empty cards. Also makes the relevant ids clickable to open the card browser with a query on that id for easy access. Also shows a notice text when there are no empty cards. 

Note: I had serious issues in making the WebView with the report appearing properly between configurations.

Some images:

phone-portrait/phone-empty

<img width="300" height="700" src="https://github.com/user-attachments/assets/ea52f5c4-199c-4368-a7ee-d3988778a9a2"/><img width="300" height="700" src="https://github.com/user-attachments/assets/f42a1a00-31c3-489b-ada7-4707a5555b2d"/>

phone-landscape
![empty_cards_phone_landscape](https://github.com/user-attachments/assets/ade732df-78d9-4a1a-aaac-569542262e45)

tablet
<img width="500" height="700" src="https://github.com/user-attachments/assets/caaa01a7-5e7d-4fef-8b6e-b4f3fe6581da"/>
![empty_cards_tablet_landscape](https://github.com/user-attachments/assets/dc15539a-e18c-4193-b643-991c08fb85e3)

## Fixes
* Fixes #17213

## How Has This Been Tested?

Ran the tests and opened the dialog in various configurations.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
