### PR TITLE
Enhancement: Card Browser two taps to change column

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -67,6 +67,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
 import com.ichi2.anki.browser.CardOrNoteId
 import com.ichi2.anki.browser.ColumnHeading
+import com.ichi2.anki.browser.ColumnSelectionDialogFragment
 import com.ichi2.anki.browser.FindAndReplaceDialogFragment
 import com.ichi2.anki.browser.PreviewerIdsFile
 import com.ichi2.anki.browser.RepositionCardFragment
@@ -576,18 +577,54 @@ open class CardBrowser :
             }
         }
 
+        fun showColumnSelectionDialog(selectedColumn: ColumnHeading) {
+            Timber.d("Fetching available columns for: ${selectedColumn.label}")
+
+            // Prevent multiple dialogs from opening
+            if (supportFragmentManager.findFragmentByTag("ColumnSelectionDialog") != null) {
+                Timber.d("ColumnSelectionDialog is already shown, ignoring duplicate click.")
+                return
+            }
+
+            lifecycleScope.launch {
+                val (_, availableColumns) = viewModel.previewColumnHeadings(viewModel.cardsOrNotes)
+
+                if (availableColumns.isEmpty()) {
+                    Timber.w("No available columns to replace ${selectedColumn.label}")
+                    showSnackbar(R.string.no_columns_available)
+                    return@launch
+                }
+
+                val dialog = ColumnSelectionDialogFragment.newInstance(selectedColumn)
+                dialog.show(supportFragmentManager, "ColumnSelectionDialog")
+            }
+        }
+
         fun onColumnNamesChanged(columnCollection: List<ColumnHeading>) {
             Timber.d("column names changed")
-            // reset headings
             browserColumnHeadings.removeAllViews()
 
-            // set up the new columns
             val layoutInflater = LayoutInflater.from(browserColumnHeadings.context)
             for (column in columnCollection) {
                 Timber.d("setting up column %s", column)
                 layoutInflater.inflate(R.layout.browser_column_heading, browserColumnHeadings, false).apply {
-                    browserColumnHeadings.addView(this)
-                    (this as TextView).text = column.label
+                    val columnView = this as TextView
+                    columnView.text = column.label
+
+                    // Attach click listener to open the selection dialog
+                    columnView.setOnClickListener {
+                        Timber.d("Clicked column: ${column.label}")
+                        showColumnSelectionDialog(column)
+                    }
+
+                    // Attach long press listener to open the manage column dialog
+                    columnView.setOnLongClickListener {
+                        Timber.d("Long-pressed column: ${column.label}")
+                        val dialog = BrowserColumnSelectionFragment.createInstance(viewModel.cardsOrNotes)
+                        dialog.show(supportFragmentManager, null)
+                        true
+                    }
+                    browserColumnHeadings.addView(columnView)
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -36,10 +36,10 @@ import timber.log.Timber
 
 class ColumnSelectionDialogFragment : DialogFragment() {
     private val viewModel: CardBrowserViewModel by activityViewModels()
-    private val columnToReplace: ColumnWithSample
+    private val columnToReplace: ColumnHeading
         get() =
             requireNotNull(
-                BundleCompat.getParcelable(requireArguments(), "selected_column", ColumnWithSample::class.java),
+                BundleCompat.getParcelable(requireArguments(), "selected_column", ColumnHeading::class.java),
             )
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
@@ -103,16 +103,16 @@ class ColumnSelectionDialogFragment : DialogFragment() {
     companion object {
         private const val SELECTED_COLUMN = "selected_column"
 
-        fun newInstance(selectedColumn: ColumnWithSample): ColumnSelectionDialogFragment =
+        fun newInstance(selectedColumn: ColumnHeading): ColumnSelectionDialogFragment =
             ColumnSelectionDialogFragment().apply {
                 arguments = bundleOf(SELECTED_COLUMN to selectedColumn)
             }
 
         fun CardBrowserViewModel.updateSelectedColumn(
-            selectedColumn: ColumnWithSample,
+            selectedColumn: ColumnHeading,
             newColumn: ColumnWithSample,
         ) = viewModelScope.launch {
-            val replacementKey = selectedColumn.columnType.ankiColumnKey
+            val replacementKey = selectedColumn.ankiColumnKey
             val replacements =
                 activeColumns.toMutableList().apply {
                     replaceAll { if (it.ankiColumnKey == replacementKey) newColumn.columnType else it }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -1,0 +1,133 @@
+/*
+ *  Copyright (c) 2025 Siddhesh Jondhale <jondhale2004@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.browser
+
+import android.os.Build
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.*
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import timber.log.Timber
+
+class ColumnSelectionDialogFragment : DialogFragment() {
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+    private var selectedColumn: ColumnWithSample? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        selectedColumn =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                requireArguments().getParcelable("selected_column", ColumnWithSample::class.java)
+            } else {
+                @Suppress("DEPRECATION")
+                requireArguments().getParcelable("selected_column")
+            }
+
+        viewModel.fetchAvailableColumns(viewModel.cardsOrNotes)
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
+
+        val dialogBuilder = AlertDialog.Builder(requireActivity())
+        val listView = ListView(requireContext())
+
+        val adapter = object : ArrayAdapter<ColumnWithSample>(
+            requireContext(),
+            android.R.layout.simple_list_item_2,
+            android.R.id.text1,
+            mutableListOf()
+        ) {
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val context = parent.context
+                val view = convertView ?: LayoutInflater.from(context)
+                    .inflate(android.R.layout.simple_list_item_2, parent, false)
+
+                val column = getItem(position)
+
+                // Column Label
+                view.findViewById<TextView>(android.R.id.text1).apply {
+                    text = column?.label ?: "No Columns Available"
+                    textSize = 16f
+                    setTypeface(null, android.graphics.Typeface.BOLD)
+                    setTextColor(context.getColor(android.R.color.black))
+                }
+                // Column SampleValue
+                view.findViewById<TextView>(android.R.id.text2).apply {
+                    text = if (column?.sampleValue.isNullOrBlank()) "-" else column?.sampleValue
+                    textSize = 12f
+                    setTextColor(context.getColor(android.R.color.black))
+                    ellipsize = android.text.TextUtils.TruncateAt.END
+                    maxLines = 1
+                }
+
+                return view
+            }
+
+        }
+
+        listView.adapter = adapter
+
+        // Handle column selection from the list
+        listView.setOnItemClickListener { _, _, position, _ ->
+            val selected = adapter.getItem(position)
+
+            if (selected?.label == "No Columns Available") {
+                Timber.e("Ignoring then click when there is not Columns Available")
+                return@setOnItemClickListener
+            }
+
+            if (selected != null) {
+                viewModel.updateSelectedColumn(selectedColumn, selected)
+                dismissAllowingStateLoss()
+            }
+        }
+
+        // Observe availableColumns and update ListView dynamically
+        viewModel.availableColumns.observe(this) { availableColumns ->
+            Timber.d("Updating dialog with available columns")
+            adapter.clear()
+
+            if (availableColumns.isEmpty()) {
+                Timber.e("No available columns found")
+                adapter.add(ColumnWithSample("No Columns Available", CardBrowserColumn.QUESTION, null)) // Show placeholder
+            } else {
+                adapter.addAll(availableColumns)
+            }
+
+            adapter.notifyDataSetChanged()
+        }
+
+        return dialogBuilder
+            .setTitle(selectedColumn?.label ?: "Default")
+            .setView(listView)
+            .setNegativeButton(android.R.string.cancel) { _, _ -> dismissAllowingStateLoss() }
+            .create()
+    }
+
+    companion object {
+        fun newInstance(selectedColumn: ColumnWithSample): ColumnSelectionDialogFragment =
+            ColumnSelectionDialogFragment().apply {
+                arguments = Bundle().apply {
+                    putParcelable("selected_column", selectedColumn)
+                }
+            }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/item_column_selection.xml
+++ b/AnkiDroid/src/main/res/layout/item_column_selection.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/listPreferredItemHeight"
+    android:orientation="vertical"
+    android:paddingVertical="8dp"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:background="?android:attr/selectableItemBackground">
+
+    <TextView
+        android:id="@+id/column_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold"/>
+
+    <TextView
+        android:id="@+id/column_example"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:singleLine="true"/>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -65,6 +65,8 @@
         <item>By reviews</item>
         <item>By lapses</item>
     </string-array>
+    <string name="change">Change</string>
+    <string name="no_columns_available">No Columns Available</string>
     <string name="card_browser_select_all" maxLength="28">Select all</string>
     <string name="card_browser_select_none" maxLength="28">Select none</string>
     <string name="card_browser_no_cards_in_deck">No cards found in deck ‘%s’</string>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -65,7 +65,7 @@
         <item>By reviews</item>
         <item>By lapses</item>
     </string-array>
-    <string name="change">Change</string>
+    <string name="change">Change column</string>
     <string name="no_columns_available">No Columns Available</string>
     <string name="card_browser_select_all" maxLength="28">Select all</string>
     <string name="card_browser_select_none" maxLength="28">Select none</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added dialog on single-click of column name to show available columns for change, as mentioned in the issue.


## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/17910

## Approach
- **Added a single-tap listener** to each column heading (`TextView` inside `browser_column_headings`) to open a dialog.  
- **Dialog now displays:**
  - The **title** with the name of the currently selected column.
  - **A list of available columns** (those not currently in use).
- **On column selection:**
  - Calls `updateActiveColumns()` from `CardBrowserViewModel.kt` to apply the change **without reloading all columns**.

## How Has This Been Tested?
Tested by long-pressing the column heading to open the manage columns dialog and single-clicking to change columns, both functioning as expected. Physical Device: (Samsung Galaxy A6+)

Video: 

https://github.com/user-attachments/assets/0af661ac-d02a-4702-a30b-b5216777b058




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens.
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).
