### PR TITLE
fix: use consistent label for Whiteboard editor in "App bar buttons" page

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -186,7 +186,6 @@
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>
 
-    <string name="title_whiteboard_pen_color" maxLength="41">Whiteboard pen color</string>
     <string name="title_whiteboard_editor" maxLength="28">Whiteboard editor</string>
 
     <string name="user_is_a_robot">Detected automated test. If you are a human, contact AnkiDroid support</string>

--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -175,7 +175,7 @@ TODO: Add a unit test
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_whiteboard_pen_color_key"
-            android:title="@string/title_whiteboard_pen_color"
+            android:title="@string/title_whiteboard_editor"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
             android:defaultValue="2"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Fix discrepancy in the labels for "Whiteboard editor" option
![image](https://github.com/user-attachments/assets/78f2d413-3e3a-4f00-a090-9192b3229bd0)


## Fixes 
* N/A

## Approach
- Use the same string with Reviewer, in App bar settings page
- Remove the unused string, `Whiteboard pen color`

## How Has This Been Tested?
Checked in physical device (Android 11)
![image](https://github.com/user-attachments/assets/4dabdb38-ead7-403a-a81c-9573610c8b12)

https://github.com/user-attachments/assets/9fea3794-50e8-4d58-9f43-02e59864dab3




## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
