### PR TITLE
fix: instant note editor to restore text when orientation changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -87,6 +87,8 @@ class InstantNoteEditorActivity :
     private val editMode: EditMode
         get() = viewModel.editorMode.value
 
+    private val updatedTextKey = "updatedText"
+
     private lateinit var editModeButton: MaterialButton
 
     private var editFieldsLayout: LinearLayout? = null
@@ -128,7 +130,10 @@ class InstantNoteEditorActivity :
             return
         }
 
-        handleSharedText(intent)
+        viewModel.setClozeFieldText(
+            savedInstanceState?.getString(updatedTextKey) ?: getSharedIntentText(intent),
+        )
+
         setupErrorListeners()
         prepareEditorDialog()
     }
@@ -180,12 +185,8 @@ class InstantNoteEditorActivity :
             }
     }
 
-    /** Handles the shared text received through an Intent. **/
-    private fun handleSharedText(receivedIntent: Intent) {
-        val sharedText = receivedIntent.getStringExtra(Intent.EXTRA_TEXT) ?: return
-        Timber.d("Setting cloze field text to $sharedText")
-        viewModel.setClozeFieldText(sharedText)
-    }
+    /** Gets the shared text received through an Intent. **/
+    private fun getSharedIntentText(receivedIntent: Intent): String? = receivedIntent.getStringExtra(Intent.EXTRA_TEXT)
 
     private fun openNoteEditor() {
         val sharedText = clozeEditTextField.text.toString()
@@ -249,6 +250,11 @@ class InstantNoteEditorActivity :
         dialogView.rootView.userClickOutsideDialog(
             exclude = instantAlertDialog.findViewById(R.id.instant_add_editor_root)!!,
         )
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        if (intentTextChanged()) outState.putString(updatedTextKey, clozeFieldText)
     }
 
     @KotlinCleanup("notetypeJson -> non-null")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The instant note editor re-init the view model cloze text to the raw text in case of orientation change and we want to avoid it and populate the fields/chips with the original text, hence save and restore the cloze text in case its changed

## Approach
Use `savedInstanceState`

## How Has This Been Tested?
Before: 
[Screen_recording_20250208_021505.webm](https://github.com/user-attachments/assets/40b28204-30fb-4ceb-8d49-53617c2124ed)


After: 
[Screen_recording_20250208_021425.webm](https://github.com/user-attachments/assets/32829c70-ce7c-4dca-960e-2f6f41d74ea3)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
