### PR TITLE
fix: instant note editor tap mode inconsistency

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -84,7 +84,8 @@ class InstantNoteEditorActivity :
 
     private var dialogView: View? = null
 
-    private var editMode = EditMode.ADVANCED
+    private val editMode: EditMode
+        get() = viewModel.editorMode.value
 
     private lateinit var editModeButton: MaterialButton
 
@@ -217,6 +218,8 @@ class InstantNoteEditorActivity :
             editFieldsLayout?.addView(editField)
         }
 
+        setLayoutVisibility()
+
         instantAlertDialog =
             AlertDialog.Builder(this).show {
                 setView(dialogView)
@@ -304,10 +307,9 @@ class InstantNoteEditorActivity :
         editModeButton.setOnClickListener {
             viewModel.setClozeFieldText(textBox.text.toString())
             when (editMode) {
-                EditMode.SINGLE_TAP -> {
+                EditMode.ADVANCED -> {
                     hideKeyboard()
                     textBox.setText(clozeFieldText)
-                    editMode = EditMode.ADVANCED
                     viewModel.setEditorMode(EditMode.SINGLE_TAP)
                     editModeButton.setIconResource(R.drawable.ic_mode_edit_white)
 
@@ -318,14 +320,26 @@ class InstantNoteEditorActivity :
                     viewModel.setClozeFieldText(textBox.text.toString())
                 }
 
-                EditMode.ADVANCED -> {
-                    viewModel.setEditorMode(EditMode.ADVANCED)
+                EditMode.SINGLE_TAP -> {
                     editModeButton.setIconResource(R.drawable.ic_touch)
-                    editMode = EditMode.SINGLE_TAP
+                    viewModel.setEditorMode(EditMode.ADVANCED)
 
                     singleTapLayout.visibility = View.GONE
                     editFieldsLayout?.visibility = View.VISIBLE
                 }
+            }
+        }
+    }
+
+    private fun setLayoutVisibility() {
+        when (editMode) {
+            EditMode.SINGLE_TAP -> {
+                singleTapLayout.visibility = View.VISIBLE
+                editFieldsLayout?.visibility = View.GONE
+            }
+            EditMode.ADVANCED -> {
+                singleTapLayout.visibility = View.GONE
+                editFieldsLayout?.visibility = View.VISIBLE
             }
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The note editor mode from view model was not used instead a var from the activity class was used, this PR handles the editor mode via ViewModel and sets the views


## Approach
Use mode from view model only

## How Has This Been Tested?
before:
[Screen_recording_20250208_032036.webm](https://github.com/user-attachments/assets/0775dd01-9695-4f25-9938-b05f115b94c8)

after:
[Screen_recording_20250208_031955.webm](https://github.com/user-attachments/assets/cfddf08b-60b1-4fd2-82df-e18d82e902d6)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
