### PR TITLE
fix(settings): disable ignoreDisplayCutout when necessary

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewerOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewerOptionsFragment.kt
@@ -16,11 +16,15 @@
 package com.ichi2.anki.preferences
 
 import android.os.Bundle
+import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.settings.enums.HideSystemBars
 
 /**
  * Developer options to test some of the new reviewer settings and features
@@ -50,6 +54,15 @@ class ReviewerOptionsFragment :
             val intent = SingleFragmentActivity.getIntent(requireContext(), ReviewerMenuSettingsFragment::class)
             startActivity(intent)
             true
+        }
+
+        val ignoreDisplayCutout =
+            requirePreference<SwitchPreferenceCompat>(R.string.ignore_display_cutout_key).apply {
+                isEnabled = Prefs.hideSystemBars != HideSystemBars.NONE
+            }
+
+        requirePreference<ListPreference>(R.string.hide_system_bars_key).setOnPreferenceChangeListener { value ->
+            ignoreDisplayCutout.isEnabled = value != HideSystemBars.NONE.entryValue
         }
     }
 }


### PR DESCRIPTION
`Ignore display cutout` is only useful if `Hide system bars` is set to something other than `None`

## How Has This Been Tested?

Emulator 35


https://github.com/user-attachments/assets/8974a546-7b09-42a6-b239-70049b3cd342



## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
