### PR TITLE
fix(new reviewer): suspend/bury submenus

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -28,6 +28,7 @@
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 -keep class androidx.core.app.ActivityCompat$* { *; }
 -keep class androidx.concurrent.futures.** { *; }
+-keep class androidx.appcompat.view.menu.MenuItemImpl { *; } # .utils.ext.MenuItemImpl
 
 # Ignore unused packages
 -dontwarn javax.naming.**


### PR DESCRIPTION
## Purpose / Description

.utils.ext.MenuItemImpl methods use reflection, and proguard obfuscated the names in `release` builds.

## Fixes
* Fixes #17950 

## How Has This Been Tested?

Build a `release` build, then do the issue reproduction steps

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
