### PR TITLE
Correct matchesJsonValue

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -81,22 +81,22 @@ class CustomStudyDialogTest : RobolectricTest() {
             val expected =
                 """
                 {
-                    "browserCollapsed": false,
-                    "collapsed": false,
+                    "browserCollapsed": true,
+                    "collapsed": true,
                     "delays": null,
                     "desc": "",
                     "dyn": 1,
                     "lrnToday": [0, 0],
                     "newToday": [0, 0],
-                    "previewDelay": 0,
+                    "previewDelay": 10,
                     "previewAgainSecs": 60,
                     "previewHardSecs": 600,
                     "previewGoodSecs": 0,
-                    "resched": true,
+                    "resched": false,
                     "revToday": [0, 0],
                     "separate": true,
                     "terms": [
-                        ["deck:\"Default\" prop:due<=1", 99999, 6]
+                        ["is:new added:1 deck:Default", 99999, 5]
                     ],
                     "timeToday": [0, 0],
                     "usn": -1

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -29,15 +29,17 @@ private fun matchesJsonValue(
     expectedValue: JSONObject,
     actualValue: JSONObject,
 ): Boolean {
-    val expectedMap = expectedValue.keys().asSequence().associateWith { actualValue[it] }
-
-    val itemKeys = actualValue.keys().asSequence().toList()
-    val differentKeys =
-        itemKeys
-            .associateWith { actualValue[it] }
-            .filter { expectedMap[it.key].toString() != it.value.toString() }
-
-    return differentKeys.isEmpty() && expectedMap.size == itemKeys.size
+    // Checks the objects have the same keys
+    if (expectedValue.keys().asSequence().toSet() != actualValue.keys().asSequence().toSet()) {
+        return false
+    }
+    // And that each key have the same associated values in both object.
+    for (key in expectedValue.keys()) {
+        if (expectedValue[key] != actualValue[key]) {
+            return false
+        }
+    }
+    return true
 }
 
 // TODO: This doesn't describe the inputs in the correct order


### PR DESCRIPTION
`expectedMap` used to associated the keys of the `expectedValue` to the values of `actualValue`.

As `differtKeys` also looked at the values in `actualValue`, it means the values of `expectedValues` were always ignored.

I hope that this new writting, checking for the equality of the set of keys, and then for the equalities of value, will be more readable and hence improve the test suite.

Luckily enough we only had one failing test. I corrected the expected value in the test. As we use the default filtered deck provided by the back-end I don't expect the implementation to be buggy here.
