### PR TITLE
Enable feature complete repositioning of new cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -687,6 +687,7 @@ class CardBrowserViewModel(
     /**
      * Obtains data to be displayed to the user then sent to [repositionSelectedRows]
      */
+    @NeedsTest("verify behavior for repositioning with 'Randomize order'")
     suspend fun prepareToRepositionCards(): RepositionCardsRequest {
         val selectedCardIds = queryAllSelectedCardIds()
         // Only new cards may be repositioned (If any non-new found show error dialog and return false)
@@ -697,17 +698,22 @@ class CardBrowserViewModel(
         // query obtained from Anki Desktop
         // https://github.com/ankitects/anki/blob/1fb1cbbf85c48a54c05cb4442b1b424a529cac60/qt/aqt/operations/scheduling.py#L117
         try {
-            val (min, max) =
-                withCol {
-                    db.query("select min(due), max(due) from cards where type=? and odid=0", CardType.New.code).use {
-                        it.moveToNext()
-                        return@withCol Pair(max(0, it.getInt(0)), it.getInt(1))
-                    }
-                }
-            return RepositionData(
-                min = min,
-                max = max,
-            )
+            return withCol {
+                val (min, max) =
+                    db
+                        .query("select min(due), max(due) from cards where type=? and odid=0", CardType.New.code)
+                        .use {
+                            it.moveToNext()
+                            Pair(max(0, it.getInt(0)), it.getInt(1))
+                        }
+                val defaults = sched.repositionDefaults()
+                RepositionData(
+                    min = min,
+                    max = max,
+                    random = defaults.random,
+                    shift = defaults.shift,
+                )
+            }
         } catch (e: Exception) {
             // TODO: Remove this once we've verified no production errors
             Timber.w(e, "getting min/max position")
@@ -723,11 +729,16 @@ class CardBrowserViewModel(
      * @see [com.ichi2.libanki.sched.Scheduler.sortCards]
      * @return the number of cards which were repositioned
      */
-    suspend fun repositionSelectedRows(position: Int): Int {
+    suspend fun repositionSelectedRows(
+        position: Int,
+        step: Int,
+        shuffle: Boolean,
+        shift: Boolean,
+    ): Int {
         val ids = queryAllSelectedCardIds()
         Timber.d("repositioning %d cards to %d", ids.size, position)
         return undoableOp {
-            sched.sortCards(cids = ids, position, step = 1, shuffle = false, shift = true)
+            sched.sortCards(cids = ids, position, step = step, shuffle = shuffle, shift = shift)
         }.count
     }
 
@@ -1101,6 +1112,8 @@ sealed class RepositionCardsRequest {
     class RepositionData(
         val min: Int?,
         val max: Int?,
+        val random: Boolean = false,
+        val shift: Boolean = false,
     ) : RepositionCardsRequest() {
         val queueTop: Int?
         val queueBottom: Int?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -1,0 +1,121 @@
+/****************************************************************************************
+ * Copyright (c) 2025 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.browser
+
+import android.app.Dialog
+import android.os.Bundle
+import android.widget.CheckBox
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.google.android.material.textfield.TextInputEditText
+import com.google.android.material.textfield.TextInputLayout
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.utils.create
+import com.ichi2.utils.customView
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.textAsIntOrNull
+import com.ichi2.utils.title
+
+/**
+ * Follows desktop implementation to show the same ui with all the options to reposition new
+ * (currently selected) cards in [CardBrowser].
+ * See https://github.com/ankitects/anki/blob/44e01ea063e6d1b812ace9c001f7ba4a8ccf4479/qt/aqt/forms/reposition.ui#L14
+ * See https://github.com/ankitects/anki/blob/1fb1cbbf85c48a54c05cb4442b1b424a529cac60/qt/aqt/operations/scheduling.py#L107
+ */
+class RepositionCardFragment : DialogFragment() {
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val dialogView = layoutInflater.inflate(R.layout.fragment_reposition_card, null)
+        dialogView.findViewById<TextView>(R.id.queue_limits_label).text =
+            """
+            ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_TOP))}
+            ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_BOTTOM))} 
+            """.trimIndent()
+        dialogView.findViewById<TextInputLayout>(R.id.start_input_layout).hint =
+            TR.browsingStartPosition().removeSuffix(":")
+        dialogView.findViewById<TextInputLayout>(R.id.step_input_layout).hint =
+            TR.browsingStep().removeSuffix(":")
+        val randomCheck =
+            dialogView.findViewById<CheckBox>(R.id.randomize_order_check)?.apply {
+                text = TR.browsingRandomizeOrder()
+                isChecked = requireArguments().getBoolean(ARG_RANDOM)
+            } ?: error("Unexpected missing random checkbox!")
+        val shiftPositionCheck =
+            dialogView.findViewById<CheckBox>(R.id.shift_position_check)?.apply {
+                text = TR.browsingShiftPositionOfExistingCards()
+                isChecked = requireArguments().getBoolean(ARG_SHIFT)
+            } ?: error("Unexpected missing shift position checkbox!")
+        val title =
+            TR
+                .browsingRepositionNewCards()
+                .toSentenceCase(requireContext(), R.string.sentence_reposition_new_cards)
+        return AlertDialog.Builder(requireContext()).create {
+            title(text = title)
+            customView(dialogView)
+            negativeButton(R.string.dialog_cancel)
+            positiveButton(R.string.dialog_ok) {
+                val position =
+                    dialogView
+                        .findViewById<TextInputEditText>(R.id.start_input)
+                        .textAsIntOrNull() ?: return@positiveButton
+                val step =
+                    dialogView
+                        .findViewById<TextInputEditText>(R.id.step_input)
+                        ?.textAsIntOrNull() ?: return@positiveButton
+                setFragmentResult(
+                    REQUEST_REPOSITION_NEW_CARDS,
+                    bundleOf(
+                        ARG_POSITION to position,
+                        ARG_STEP to step,
+                        ARG_RANDOM to randomCheck.isChecked,
+                        ARG_SHIFT to shiftPositionCheck.isChecked,
+                    ),
+                )
+            }
+        }
+    }
+
+    companion object {
+        const val REQUEST_REPOSITION_NEW_CARDS = "request_repositions_new_cards"
+        private const val ARG_QUEUE_TOP = "arg_queue_top"
+        private const val ARG_QUEUE_BOTTOM = "arg_queue_bottom"
+        const val ARG_POSITION = "arg_position"
+        const val ARG_STEP = "arg_step"
+        const val ARG_RANDOM = "arg_random"
+        const val ARG_SHIFT = "arg_shift"
+
+        fun newInstance(
+            queueTop: Int,
+            queueBottom: Int,
+            random: Boolean,
+            shift: Boolean,
+        ) = RepositionCardFragment().apply {
+            arguments =
+                bundleOf(
+                    ARG_QUEUE_TOP to queueTop,
+                    ARG_QUEUE_BOTTOM to queueBottom,
+                    ARG_RANDOM to random,
+                    ARG_SHIFT to shift,
+                )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -33,6 +33,7 @@ import anki.scheduler.CongratsInfoResponse
 import anki.scheduler.CustomStudyDefaultsResponse
 import anki.scheduler.CustomStudyRequest
 import anki.scheduler.QueuedCards
+import anki.scheduler.RepositionDefaultsResponse
 import anki.scheduler.SchedTimingTodayResponse
 import anki.scheduler.SchedulingContext
 import anki.scheduler.SchedulingState
@@ -483,6 +484,9 @@ open class Scheduler(
 
     @CheckResult
     fun customStudyDefaults(deckId: DeckId): CustomStudyDefaultsResponse = col.backend.customStudyDefaults(deckId)
+
+    @CheckResult
+    fun repositionDefaults(): RepositionDefaultsResponse = col.backend.repositionDefaults()
 
     /**
      * @return Number of new card in current deck and its descendants. Capped at [REPORT_LIMIT]

--- a/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/queue_limits_label"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="4dp"
+        app:layout_constraintHorizontal_bias="0.0"
+        tools:text="Queue top: 1\nQueue bottom: 1656546754"/>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/start_input_layout"
+        android:imeOptions="actionDone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:layout_marginTop="8dp"
+        app:errorEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/queue_limits_label">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/start_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="8dp"
+            android:singleLine="true"
+            android:inputType="number"
+            android:text="0"
+            android:maxLines="1"
+            tools:ignore="HardcodedText" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/step_input_layout"
+        android:imeOptions="actionDone"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="24dp"
+        android:paddingEnd="24dp"
+        android:layout_marginTop="8dp"
+        app:errorEnabled="true"
+        app:layout_constraintTop_toBottomOf="@id/start_input_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/step_input"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawablePadding="8dp"
+            android:singleLine="true"
+            android:inputType="number"
+            android:text="1"
+            android:maxLines="1"
+            tools:ignore="HardcodedText" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <CheckBox
+        android:id="@+id/randomize_order_check"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        tools:text="Randomize order"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/step_input_layout"/>
+
+    <CheckBox
+        android:id="@+id/shift_position_check"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:checked="false"
+        tools:text="Shift position of existing cards"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/randomize_order_check"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -30,13 +30,7 @@
     <string name="no_tts_available_message">No text-to-speech language available</string>
     <string name="tts_no_tts">Don’t speak</string>
 
-    <string name="reposition_card_dialog_title">Reposition new card</string>
     <string name="reposition_card_not_new_error">Only new cards can be repositioned</string>
-
-    <plurals name="reposition_card_dialog_acknowledge">
-        <item quantity="one">%d card repositioned</item>
-        <item quantity="other">%d cards repositioned</item>
-    </plurals>
     <string name="reset_card_dialog_title">Reset card progress</string>
     <plurals name="reset_cards_dialog_acknowledge">
         <item quantity="one">%d card reset</item>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -43,5 +43,5 @@ undoActionUndone()
     <string name="sentence_custom_study">Custom study</string>
     <string name="sentence_empty_cards">Empty cards</string>
     <string name="tag_missing">Tag missing</string>
-
+    <string name="sentence_reposition_new_cards">Reposition new cards</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description

Shows a dialog very similar to desktop with the options to reposition new cards. 

How it looks:

![image](https://github.com/user-attachments/assets/9b3632c1-ef86-428b-a236-6a11d6479cd4)


## Fixes
* Fixes #9458
* Hopefully, also fixes #9457

## How Has This Been Tested?

Ran the tests. Manually verified the dialog.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
