### PR TITLE
NF: Correct `reps` documentation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -483,7 +483,7 @@ class Collection(
 
     fun startTimebox() {
         startTime = TimeManager.time.intTime()
-        startReps = sched.reps
+        startReps = sched.numberOfAnswersRecorded
     }
 
     data class TimeboxReached(
@@ -503,7 +503,7 @@ class Collection(
         return if (elapsed > limit) {
             TimeboxReached(
                 limit,
-                sched.reps - startReps,
+                sched.numberOfAnswersRecorded - startReps,
             ).also {
                 startTimebox()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -142,7 +142,7 @@ open class Scheduler(
         ease: Ease,
     ): OpChanges =
         col.backend.answerCard(buildAnswer(info.topCard, info.states, ease)).also {
-            reps += 1
+            numberOfAnswersRecorded += 1
         }
 
     /** Legacy path, used by tests. */
@@ -153,7 +153,7 @@ open class Scheduler(
         val top = queuedCards.cardsList.first()
         val answer = buildAnswer(card, top.states, ease)
         col.backend.answerCard(answer)
-        reps += 1
+        numberOfAnswersRecorded += 1
         // tests assume the card was mutated
         card.load(col)
     }
@@ -209,10 +209,11 @@ open class Scheduler(
             QueuedCards.Queue.UNRECOGNIZED, null -> TODO("unrecognized queue")
         }
 
-    /** @return Number of repetitions today. Note that a repetition is the fact that the scheduler sent a card, and not the fact that the card was answered.
-     * So buried, suspended, ... cards are also counted as repetitions.
+    /**
+     * Number of [answerCard] was called since this scheduler object was created.
+     * Note that when the user undo a review, this number is not decremented.
      */
-    var reps: Int = 0
+    var numberOfAnswersRecorded: Int = 0
 
     /** Only provided for legacy unit tests. */
     fun nextIvl(


### PR DESCRIPTION
`reps` used to have a different meaning than today. I'd actually love to rename this variable, but it's the name used in upstream, so I guess it would not be accepted.

I considered adding more information, such as the fact that in practice, it mostly means that this value is reset when ankidroid restart, with maybe some exceptions. Or that we should only care about the difference between values at different point in time and not about the actual value of this variable. But actually it does not matter. It's only used for timebox and has 3 occurrences in the codebase. Any more documentation would be overkill.

Fixed #6830. Well actually, it was fixed in
7a65160e0e23e20080091a30abdd4c05fc610e06 long ago, but the documen tation did not reflect that. So let's claim I just fixed a 5 yo bug!