### PR TITLE
Fix : Deck Picker Arrow doesn't rotate on expanding and collapsing the deck.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -36,6 +36,7 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.sched.DeckNode
 import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.RustCleanup
+import timber.log.Timber
 
 /**
  * A [RecyclerView.Adapter] used to show the list of decks inside [com.ichi2.anki.DeckPicker].
@@ -153,7 +154,10 @@ class DeckAdapter(
             deckLayout.setPaddingRelative(startPadding, 0, endPadding, 0)
         }
         if (node.children.isNotEmpty()) {
-            holder.deckExpander.setOnClickListener { onDeckChildrenToggled(node.did) }
+            holder.deckExpander.setOnClickListener {
+                onDeckChildrenToggled(node.did)
+                notifyItemChanged(position) // Ensure UI updates
+            }
         } else {
             holder.deckExpander.isClickable = false
             holder.deckExpander.setOnClickListener(null)
@@ -201,9 +205,11 @@ class DeckAdapter(
             if (node.collapsed) {
                 expander.setImageDrawable(expandImage)
                 expander.contentDescription = expander.context.getString(R.string.expand)
+                Timber.d("Deck Collapsed")
             } else {
                 expander.setImageDrawable(collapseImage)
                 expander.contentDescription = expander.context.getString(R.string.collapse)
+                Timber.d("Deck Expanded")
             }
         } else {
             expander.visibility = View.INVISIBLE


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In the deck picker, arrow doesn't rotate on expanding or collapsing the deck.

## Fixes
* Fixes #17915

## Approach
`deckExpander` (the dropdown arrow) visibility and click behavior depend on `node.children.isNotEmpty()`. When the user toggles the expansion state (by clicking `deckExpander`), the dataset changes, but without `notifyItemChanged(position)`, the UI does not get updated.

## How Has This Been Tested?
## API 24
[android7.webm](https://github.com/user-attachments/assets/10667db4-57fe-4330-b7b4-ef361fe474fb)

## API 34

[androidapi35.webm](https://github.com/user-attachments/assets/6e500c7f-21df-4a08-9e67-90571e5b5f12)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
