### PR TITLE
Fixes #17970 - Pass DeckId to NoteEditor From Snackbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1603,8 +1603,8 @@ open class DeckPicker :
         dismissAllDialogFragments()
     }
 
-    fun addNote() {
-        val intent = NoteEditorLauncher.AddNote().toIntent(this)
+    fun addNote(did: DeckId? = null) {
+        val intent = NoteEditorLauncher.AddNote(did).toIntent(this)
         startActivity(intent)
     }
 
@@ -2137,7 +2137,7 @@ open class DeckPicker :
     ) {
         fun showEmptyDeckSnackbar() =
             showSnackbar(R.string.empty_deck) {
-                setAction(R.string.menu_add) { addNote() }
+                setAction(R.string.menu_add) { addNote(did) }
             }
 
         /** Check if we need to update the fragment or update the deck list */


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To improve user experience


## Fixes
* Fixes #17970 

## Approach
_How does this change address the problem?_
Just pass the deck id to make sure correct deck is selected

## How Has This Been Tested?
Manual testing

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
