### PR TITLE
test: mark DeckPicker context menu test flaky on windows

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -441,7 +441,6 @@ dependencies {
     testImplementation libs.kotlin.test.junit5
     testImplementation libs.kotlinx.coroutines.test
     testImplementation libs.mockk
-    testImplementation libs.commons.exec // obtaining the OS
     testImplementation libs.androidx.fragment.testing
     // in a JvmTest we need org.json.JSONObject to not be mocked
     testImplementation libs.json

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -21,18 +21,18 @@ import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.exception.UnknownDatabaseVersionException
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
-import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Storage
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.BackendEmulatingOpenConflict
 import com.ichi2.testutils.BackupManagerTestUtilities
 import com.ichi2.testutils.DbUtils
+import com.ichi2.testutils.common.Flaky
+import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.grantWritePermissions
 import com.ichi2.testutils.revokeWritePermissions
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.ResourceLoader
-import org.apache.commons.exec.OS
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.hamcrest.Matchers.equalTo
@@ -492,6 +492,7 @@ class DeckPickerTest : RobolectricTest() {
         }
 
     @Test
+    @Flaky(OS.WINDOWS)
     fun `ContextMenu unburied cards when selecting UNBURY`() =
         runTest {
             startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
@@ -543,11 +544,8 @@ class DeckPickerTest : RobolectricTest() {
 
     @Test
     @RunInBackground
-    @NeedsTest("fix this on Windows")
+    @Flaky(OS.WINDOWS)
     fun version16CollectionOpens() {
-        if (OS.isFamilyWindows()) {
-            assumeTrue("test is flaky on Windows", false)
-        }
         try {
             setupColV16()
             InitialActivityWithConflictTest.setupForValid(targetContext)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,8 +67,6 @@ colorpicker = "1.2.0"
 commonsCollections4 = "4.4"
 # https://commons.apache.org/proper/commons-compress/changes-report.html
 commonsCompress = "1.27.1"
-# https://commons.apache.org/proper/commons-exec/changes-report.html
-commonsExec = "1.4.0"
 # https://commons.apache.org/proper/commons-io/changes-report.html
 commonsIo = "2.18.0"
 coroutines = '1.10.1'
@@ -182,7 +180,6 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidxTest" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
 androidx-work-testing = { module = "androidx.work:work-testing", version.ref = "androidxWork" }
-commons-exec = { module = "org.apache.commons:commons-exec", version.ref = "commonsExec" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
 ivanshafran-shared-preferences-mock = { module = "io.github.ivanshafran:shared-preferences-mock", version.ref = "sharedPreferencesMock" }


### PR DESCRIPTION
See Issue 
- #17821

This one is messing up my merge queue, driving me crazy.

Marking flaky

Had to de-conflict the "OS" symbol because something else appears to have been marked flaky, perhaps before we had a good annotation? Anyway, we have a good annotation now so I converted the previous windows cutout to a Flaky annotation