### PR TITLE
Refactor: Card Analysis Widget for more clean look.

### DIFF
--- a/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
+++ b/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
@@ -27,7 +27,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/widget_card_analysis_rounded_inner_background"
         android:orientation="horizontal"
-        android:padding="20dp">
+        android:padding="16dp">
 
         <TextView
             android:id="@+id/deckNew_card_analysis_widget"
@@ -67,9 +67,9 @@
         android:id="@+id/deckNameCardAnalysis"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="70dp"
+        android:layout_marginTop="64dp"
         android:gravity="center"
-        android:padding="20dp"
+        android:padding="15dp"
         android:paddingBottom="5dp"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="24sp"

--- a/AnkiDroid/src/main/res/layout/widget_card_analysis_drawable_v31.xml
+++ b/AnkiDroid/src/main/res/layout/widget_card_analysis_drawable_v31.xml
@@ -12,7 +12,7 @@
         android:layout_height="wrap_content"
         android:background="@drawable/widget_card_analysis_rounded_inner_background"
         android:orientation="horizontal"
-        android:padding="20dp">
+        android:padding="16dp">
 
         <TextView
             android:layout_width="0dp"
@@ -52,7 +52,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center"
-        android:padding="20dp"
+        android:padding="15dp"
         android:paddingBottom="5dp"
         android:text="@string/deck1Name_deck_picker_widget"
         android:textColor="?android:attr/textColorPrimary"

--- a/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
@@ -1,6 +1,6 @@
-<!-- JPG type of file used in previewImage property because the SVG format is not supported on all devices.
+<!-- JPG type of file used in previewImage property because the SVG and Vector format is not supported on all devices.
      The widths and heights parameters are determined as follows:
-     The default is 3 cells in width and 2 in height.
+     The default size is 3 cells wide and 2 cells high, but the grid layout typically determines the final dimensions.
      Following https://developer.android.com/develop/ui/views/appwidgets/layouts#anatomy_determining_size
      we used the portrait mode cell size for the width and the landscape mode cell size for the height. Leading to:
      * height between 102 and 315


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The Card Analysis Widget appears larger than necessary for its content, resulting in wasted space.

## Fixes
* https://github.com/ankidroid/Anki-Android/issues/17968

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/12b6db4e-d04e-4fde-bd3b-9530f09ba3c1)

![image](https://github.com/user-attachments/assets/2e173025-b4f3-42bb-9b54-06f2410927bf)
![image](https://github.com/user-attachments/assets/8b58f7e9-091b-4c9f-a135-c713f5aa2e0e)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
