### PR TITLE
fix:focus keyboard on edit description dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.utils.ext.description
 import com.ichi2.anki.utils.ext.update
 import com.ichi2.libanki.DeckId
 import com.ichi2.themes.Themes
+import com.ichi2.utils.AndroidUiUtils.setFocusAndOpenKeyboard
 import timber.log.Timber
 
 /**
@@ -79,6 +80,7 @@ class EditDeckDescriptionDialog : DialogFragment() {
                 }.also { toolbar ->
                     launchCatchingTask { toolbar.title = withCol { decks.get(deckId)!!.name } }
                 }
+            setFocusAndOpenKeyboard(deckDescriptionInput) { deckDescriptionInput.setSelection(deckDescriptionInput.text!!.length) }
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Keyboard does not appear automatically when opening the EditDeckDescriptionDialog.

## Approach
Request focus on deckDescriptionInput
Use postDelayed() to show the keyboard after layout rendering

## How Has This Been Tested?
OPPO CPH2341

https://github.com/user-attachments/assets/1d1be482-14f5-42a4-8b11-ec17dbfb3e21



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
