### PR TITLE
Fix crash in flashcard viewer when socket permission is denied

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -81,6 +81,7 @@ import com.drakeet.drawer.FullDraggableContainer
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
+import com.ichi2.anki.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
@@ -273,8 +274,6 @@ abstract class AbstractFlashcardViewer :
 
     /** Handle joysticks/pedals */
     protected lateinit var motionEventHandler: MotionEventHandler
-
-    val server = AnkiServer(this).also { it.start() }
 
     @get:VisibleForTesting
     var cardContent: String? = null
@@ -1549,7 +1548,7 @@ abstract class AbstractFlashcardViewer :
         if (card != null) {
             card.settings.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
             card.loadDataWithBaseURL(
-                server.baseUrl(),
+                getMediaBaseUrl(getMediaDirectory(AnkiDroidApp.instance).path),
                 content,
                 "text/html",
                 null,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -248,11 +248,6 @@ open class Reviewer :
         }
     }
 
-    override fun onDestroy() {
-        super.onDestroy()
-        server.stop()
-    }
-
     protected val flagToDisplay: Flag
         get() {
             return FlagToDisplay(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I would like to use Anki offline (without the "Network" permission from GrapheneOS turned on).
In #15718, you showed potential interest for a PR.

## Fixes
* Partially fixes #15718 by not crashing on flashcard view (deck options and statistics screens are still unavailable)
* Avoids creating a socket and thread for other users when not needed

## Approach
_How does this change address the problem?_
I initially wanted to implement a fallback when `server` cannot be started, but I noticed that in the flashcard viewer, the server wasn't actually used in this screen (or at least, it was my understanding. If that's not the case, I can make an alternative implementation with a `try`/`catch`).

This change allows to use AnkiDroid without a socket for basic needs: creating a deck and training with decks (with default options).

Depending on your openness, I can make other PRs to fix other pages using the socket from `AnkiServer`.
- For pages like statistics, I’m not sure the socket is needed. My understanding is that the socket is needed to process `POST` requests, and it looks like all interaction there, is in JavaScript.
- For pages needing the socket, I can try making a more friendly crash screen, explaining the socket permission is needed. This will avoid you useless reports (even if it is documented, it requires finding the information and being able to read English, so better show the information directly in app).
- For deck options, I think it would fall into "pages needing the socket", but I can understand some users with socket permission denied may still want to tweak some of them. I can suggest:
    - a fallback screen with only basic deck options shown there and a warning that more options are available when turning network permission on
    - a more complex option (that remains to be tested) could be to intercept with JavaScript calls to Kotlin when the form changes, instead of posting it to a server, and processing it there
    - just show a message saying you can't progress further (the "more friendly crash screen" described previously)

Thank you for reading


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

I tested with a deck using sound, images and/or basic HTML, and it worked, where it would previously crash.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
