### PR TITLE
build(deps): adopt backend 1.51-anki25.02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.12.1"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.0"
-ankiBackend = '0.1.50-anki25.02'
+ankiBackend = '0.1.51-anki25.02'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

Keeping it brief: does exactly what the title says

I would like to get this in before we start betas, so it gets wide testing. Can always revert, but wide testing is the only way to know if we need to in my humble opinion