### PR TITLE
feat(new reviewer): buttons night mode colors

### DIFF
--- a/AnkiDroid/src/main/res/values-night/colors.xml
+++ b/AnkiDroid/src/main/res/values-night/colors.xml
@@ -7,4 +7,13 @@
     <color name="flag_pink">#A70D64</color>
     <color name="flag_turquoise">#138072</color>
     <color name="flag_purple">#6320A0</color>
+
+    <color name="again_button_bg">#1AB71C1C</color> <!-- Material red 900 with 10% alpha -->
+    <color name="again_button_text">@color/material_red_200</color>
+    <color name="hard_button_bg">#1AE65100</color> <!-- Material orange 900 with 10% alpha -->
+    <color name="hard_button_text">@color/material_orange_200</color>
+    <color name="good_button_bg">#1A2E7D32</color> <!-- Material green 800 with 10% alpha -->
+    <color name="good_button_text">@color/material_light_green_200</color>
+    <color name="easy_button_bg">#1A0277BD</color> <!-- Material light blue 800 with 10% alpha -->
+    <color name="easy_button_text">@color/material_light_blue_A100</color>
 </resources>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -53,11 +53,19 @@
     <color name="material_red_800">#ffC62828</color>
     <color name="material_red_900">#ffb71c1c</color>
     <color name="material_red_A700">#ffd50000</color>
+
+    <color name="material_orange_100">#FFE0B2</color>
+    <color name="material_orange_200">#FFCC80</color>
+    <color name="material_orange_300">#FFB74D</color>
+    <color name="material_orange_A100">#FFD180</color>
+    <color name="material_orange_A200">#FFAB40</color>
     <color name="material_orange_A700">#ffff6d00</color>
 
     <color name="material_indigo_200">#9fa8da</color>
     <color name="material_indigo_700">#ff303f9f</color>
     <color name="material_indigo_A700">#ff304ffe</color>
+    <color name="material_blue_100">#BBDEFB</color>
+    <color name="material_blue_200">#90CAF9</color>
     <color name="material_blue_400">#ff42a5f5</color>
     <color name="material_blue_500">#ff2196f3</color>
     <color name="material_blue_600">#ff1e88e5</color>
@@ -72,6 +80,8 @@
     <color name="material_light_blue_700">#ff0288d1</color>
     <color name="material_light_blue_800">#ff0277BD</color>
     <color name="material_light_blue_900">#ff01579B</color>
+    <color name="material_light_blue_A100">#80D8FF</color>
+    <color name="material_light_blue_A200">#40C4FF</color>
     <color name="material_light_blue_A700">#ff0091ea</color>
     <color name="material_cyan_A700">#ff00b8d4</color>
 
@@ -85,6 +95,8 @@
     <color name="material_green_900">#ff1B5E20</color>
     <color name="material_light_green_A700">#ff64dd17</color>
     <color name="material_lime_green_A700">#ffaeea00</color>
+
+    <color name="material_light_green_200">#C5E1A5</color>
 
     <color name="material_yellow_500">#ffffeb3b</color>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Many people don't know what `Work in progress` means and nag about colors of a developer option.

## Approach

Tested some variants of material colors until I got something I liked. The contrast had to be enough to pass accessibility scanners, but not too high to avoid eye strain/halo effect (like every app without much thought, and AnkiDroid with its black theme, do with white on pure black)

"But I want the black theme to have pure black buttttonssss". That kind of change doesn't conflict with this PR, so please discuss this somewhere else and do another PR if you want. I'm against it, so please do not try blocking this PR because of that.

## How Has This Been Tested?

Emulator 35, and Samsung Android 14 phone and tablet

<details>

![Screenshot_20250217_120331](https://github.com/user-attachments/assets/d7e5221e-7074-49a8-92c8-c31efe9240fc)

![Screenshot_20250217_125127](https://github.com/user-attachments/assets/aa24c09b-58be-496f-a1e9-78f1b71eb567)

</details>

## Learning (optional, can help others)

Android Studio has material colors embedded on its color picker

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
