### PR TITLE
fix: Top side of card is cut off when "Center align" enabled & content is long

### DIFF
--- a/AnkiDroid/src/main/assets/flashcard.css
+++ b/AnkiDroid/src/main/assets/flashcard.css
@@ -116,7 +116,7 @@ preferred over using JavaScript.
 .vertically_centered {
   position: absolute;
   width: 100%;
-  height: 100%;
+  min-height: 100%;
   display: -webkit-box;
   -webkit-box-align: stretch;
   -webkit-box-pack: center;


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When "Center align" is enabled and the content of the card is so long that cannot be shown entirely without scrolling, the top side of the content is trimmed.
<img src="https://github.com/user-attachments/assets/a7204429-53ba-4905-9a2f-d6860116d6fd" width="320px">


## Fixes
* Fixes #17998

## Approach
Use `min-height: 100%` instead of `height: 100%` in `vertically_centered` class

## How Has This Been Tested?
Checked in physical device (Android 11)

**Pattern A**  (front: short, back: short)

-- | Start | Scroll to Top | Show Answer | Scroll to Top
---|---|---|---|----
**Before**| OK![Image](https://github.com/user-attachments/assets/75a01406-b763-4f28-9db2-303bdc33bb95) | OK (No need) ![Image](https://github.com/user-attachments/assets/75a01406-b763-4f28-9db2-303bdc33bb95) | OK ![Image](https://github.com/user-attachments/assets/4d8796ab-c551-4534-96d7-0acd70b06380) | OK (No need) ![Image](https://github.com/user-attachments/assets/4d8796ab-c551-4534-96d7-0acd70b06380) 
**After** | OK ![image](https://github.com/user-attachments/assets/88b61f46-f48b-476a-b3b4-a720a1a9f376) | OK (No need) ![image](https://github.com/user-attachments/assets/2b810b0b-dc10-494a-8036-7dfb787cc332) | OK ![image](https://github.com/user-attachments/assets/2adf40c5-5ee8-4044-8e17-b1807956f919) | OK (No need) ![image](https://github.com/user-attachments/assets/34f1c942-7967-418f-aebe-cd4c46b8c6d8)

---
**Pattern B** (front: short, back: long)

-- | Start | Scroll to Top | Show Answer | Scroll to Top
---|---|---|---|----
**Before**| OK ![Image](https://github.com/user-attachments/assets/2de8691d-bece-467f-8ec4-eff4f9fc0aff) | OK (No need) ![Image](https://github.com/user-attachments/assets/2de8691d-bece-467f-8ec4-eff4f9fc0aff)| **NG** (The beginning of Back is not shown) ![Image](https://github.com/user-attachments/assets/6e20b418-e5cc-4dd5-8694-ad4d76054704) | **Bad** (impossible) ![Image](https://github.com/user-attachments/assets/930b68c2-dfbf-4b7e-8ff3-dc673340a61f)
**After**| OK ![image](https://github.com/user-attachments/assets/3f752279-40bc-4f96-a8e1-b045919a9849) | OK (No need) ![image](https://github.com/user-attachments/assets/3f752279-40bc-4f96-a8e1-b045919a9849) | OK (the beginning of Back is shown) ![image](https://github.com/user-attachments/assets/f629ecce-9bf9-49c9-a786-c5ac42d4ac2c)  | OK (possible) ![image](https://github.com/user-attachments/assets/257fbaad-4898-4ac2-90c3-8508da80a897)

---
**Pattern C** (front: long, back: short)
-- | Start | Scroll to Top | Show Answer | Scroll to Top
---|---|---|---|----
**Before** | **NG** (The beginning of Front is not shown) ![Image](https://github.com/user-attachments/assets/c1895c80-74e0-46e1-9722-c0f6a8e15da9) | **Bad** (impossible) ![Image](https://github.com/user-attachments/assets/c1584614-3e50-47a5-b1a5-fff6e586e23c) | OK (The beginning of Back is shown) ![Image](https://github.com/user-attachments/assets/801085fb-87b5-48ba-a115-332a9b4b691f) | **Bad** (impossible) ![Image](https://github.com/user-attachments/assets/e58aab59-65f5-4134-858d-1522703f1c5f)
**After** | OK (the beginning of Front is shown) ![image](https://github.com/user-attachments/assets/ea0f603d-5274-483e-9d8b-c55a6d731d4a) | OK (No need) ![image](https://github.com/user-attachments/assets/ea0f603d-5274-483e-9d8b-c55a6d731d4a) | OK (the beginning of Back is shown) ![image](https://github.com/user-attachments/assets/d1036f6d-e7d1-4c9b-898f-b32dea49f2a8) | OK (possible) ![image](https://github.com/user-attachments/assets/62f94314-fe79-470e-aedc-d4f0a52759c7)

---

**Pattern D** (front: long, back: long)
-- | Start | Scroll to Top | Show Answer | Scroll to Top
---|---|---|---|----
**Before** | **NG** (The beginning of Front is not shown) ![Image](https://github.com/user-attachments/assets/3dcf8657-9991-42ab-895e-c369e2bcdd97) | **Bad** (impossible) ![Image](https://github.com/user-attachments/assets/ccdd8429-8a9e-4861-af7d-a6f0bc65d8d2) | OK (The beginning of Back is shown) ![Image](https://github.com/user-attachments/assets/c4923471-aa65-4067-99b6-7e371a5e6d82) | **Bad** (impossible) ![Image](https://github.com/user-attachments/assets/af42ea29-c631-4fbb-8f6d-b7731fc86991)
**After** | OK (the beginning of Front is shown) ![image](https://github.com/user-attachments/assets/f5319369-4c02-4a04-a499-31dbe484c9d7) | OK (no need) ![image](https://github.com/user-attachments/assets/f5319369-4c02-4a04-a499-31dbe484c9d7) | OK (the beginning of Back is shown) ![image](https://github.com/user-attachments/assets/61dc9a57-0b17-4555-9d69-b558a5238da0) | OK (possible) ![image](https://github.com/user-attachments/assets/fd7ccd7a-ef9e-4503-9852-967f10ad2988)

## Note
Scrolling to bottom works properly in all cases.



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
