### PR TITLE
Fixed the empty regular deck check, now uses foreach to check all the…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2134,19 +2134,11 @@ open class DeckPicker :
             return
         }
 
-        when (queryCompletedDeckCustomStudyAction(did)) {
-            CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED,
-            CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY,
-            CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED,
-            CompletedDeckStatus.DAILY_STUDY_LIMIT_REACHED,
-            -> {
-                onDeckCompleted()
-            }
-            CompletedDeckStatus.EMPTY_REGULAR_DECK -> {
-                // If the deck is empty (& has no children) then show a message saying it's empty
-                showEmptyDeckSnackbar()
-                updateUi()
-            }
+        if (isDeckAndSubdeckEmpty(did)) {
+            showEmptyDeckSnackbar()
+            updateUi()
+        } else {
+            onDeckCompleted()
         }
     }
 
@@ -2635,38 +2627,15 @@ open class DeckPicker :
     }
 
     /**
-     * Returns how a user can 'custom study' a deck with no more pending cards
+     * Returns if the deck and its subdecks are all empty.
      *
      * @param did The id of a deck with no pending cards to review
      */
-    private suspend fun queryCompletedDeckCustomStudyAction(did: DeckId): CompletedDeckStatus =
-        when {
-            withCol { sched.hasCardsTodayAfterStudyAheadLimit() } -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
-            withCol { sched.newDue() || sched.revDue() } -> CompletedDeckStatus.LEARN_AHEAD_LIMIT_REACHED
-            withCol { decks.isFiltered(did) } -> CompletedDeckStatus.DYNAMIC_DECK_NO_LIMITS_REACHED
-            getNodeByDid(did).children.isEmpty() &&
-                withCol {
-                    decks.isEmpty(did)
-                } -> CompletedDeckStatus.EMPTY_REGULAR_DECK
-            else -> CompletedDeckStatus.REGULAR_DECK_NO_MORE_CARDS_TODAY
+    private suspend fun isDeckAndSubdeckEmpty(did: DeckId): Boolean {
+        val node = getNodeByDid(did)
+        return withCol {
+            node.all { decks.isEmpty(it.did) }
         }
-
-    /** Status for a deck with no current cards to review */
-    enum class CompletedDeckStatus {
-        /** No cards for today, but there would be if the user waited */
-        LEARN_AHEAD_LIMIT_REACHED,
-
-        /** No cards for today, but either the 'new' or 'review' limit was reached */
-        DAILY_STUDY_LIMIT_REACHED,
-
-        /** No cards are available, but the deck was dynamic */
-        DYNAMIC_DECK_NO_LIMITS_REACHED,
-
-        /** The deck contained no cards and had no child decks */
-        EMPTY_REGULAR_DECK,
-
-        /** The user has completed their studying for today, and there are future reviews */
-        REGULAR_DECK_NO_MORE_CARDS_TODAY,
     }
 
     override fun getApkgFileImportResultLauncher(): ActivityResultLauncher<Intent> = apkgFileImportResultLauncher

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -26,7 +26,7 @@ data class DeckNode(
     val node: DeckTreeNode,
     val fullDeckName: String,
     val parent: WeakReference<DeckNode>? = null,
-) {
+) : Iterable<DeckNode> {
     var collapsed = node.collapsed
     val revCount = node.reviewCount
     val newCount = node.newCount
@@ -89,6 +89,12 @@ data class DeckNode(
             child.forEach(fn)
         }
     }
+
+    override fun iterator(): Iterator<DeckNode> =
+        sequence {
+            if (node.level > 0) yield(this@DeckNode)
+            for (child in children) yieldAll(child)
+        }.iterator()
 
     /** Convert the tree into a flat list, where matching decks and the children/parents
      * are included. Decks inside collapsed decks are not considered. */


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Creating a deck A::B, if B subdeck is empty and parent A is empty, clicking on the parent it should show 'this deck is empty', instead of the finished deck message._

## Fixes
* Fixes #17965 

## Approach
_The earlier code just checked for the following conditions:_
- If the deck clicked has subdecks (at the topmost list level only) - `getNodeByDid(did).children.isEmpty()`
- If only the deck clicked has 0 cards - `decks.isEmpty(did)`

This would fail at cases where the deck has subdecks, which are also empty.

_Now the check is done to not just check subdecks, but the count of cards of these subdecks too._
- using the `forEach` recursive function of `DeckNode` to traverse the entire tree of subdecks to check if all of them are empty for triggering the empty deck snackbar

## How Has This Been Tested?
ran all tests from `./gradlew jacocoTestReport` on emulator (android 15 VanillaIceCream)
PC config:
processor: i5 12500H
RAM: 16GB
SDK: 21
results: ran with 0 failures
Also I tested with creation of "A::B::C", "A::B" decks, and adding the cards to the subdecks.
| clicking on A | shows finished deck on A click |
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/76f871fe-5724-42ee-a5cf-01fe791409ad) | ![image](https://github.com/user-attachments/assets/1de2a059-1a4d-4a49-a7d2-0b5419e6c08f) | 

| clicking on B | shows finished deck on B | 
| ------ | ------ |
| ![image](https://github.com/user-attachments/assets/5f2e58bd-a330-4caa-8867-c91aaa725757) | ![image](https://github.com/user-attachments/assets/389a3c95-2b1f-4c45-bc4c-a942cfd9813e) | 

**After fix**
| clicking on A | clicking on B | 
| ------ | ------ | 
| ![image](https://github.com/user-attachments/assets/71b1feb0-5b16-43c8-b1d2-70bba0d77626) | ![image](https://github.com/user-attachments/assets/77101a27-1155-4091-a6c3-644f579d1d7f) | 

## Update commit - [2e33db4](https://github.com/ankidroid/Anki-Android/pull/18007/commits/2e33db48ecd6d6855f16039e0a41fe324e1a407f)
Now uses a new function `isDeckAndSubdeckEmpty`, and DeckNode implements Iterable<DeckNode>, and hence the entire tree empty check is done using deckNode.all{}, which efficiently returns true or false.
Also refactored the previous query function that returned enums.

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)-->

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
