### PR TITLE
fix(pre-commit-hook): update pre-commit hook to correctly handle `.diff` file 

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -43,11 +43,13 @@ runKtlint () {
     if [ -s $diff_path ]; then
         git apply --ignore-whitespace $diff_path
         apply_exit_code=$?
-        if [apply_exit_code -ne 0]; then
+        if [ $apply_exit_code -ne 0 ]; then
             echo "`git apply` failed. You can find a patch of the version of the code before your `git commit` in $diff_path"
         else
             rm $diff_path
         fi
+    else
+      rm $diff_path
     fi
     unset diff_path
 


### PR DESCRIPTION
## Description
Fix pre-commit hook creating empty `.diff` files by removing empty `.diff` during ktlint formatting.

## Fixes
* Fixes #18003 

## Approach
- Remove the `.diff` file when there are no unstaged changes.
- Fixed syntax: `if [apply_exit_code -ne 0]` -> `if [ $apply_exit_code -ne 0 ]`

## How Has This Been Tested?
- Ran pre-commit hook with Kotlin files.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
