### PR TITLE
Fix: Update all associated cardIds of a note 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1261,7 +1261,10 @@ class NoteEditor :
             // changed did? this has to be done first as remFromDyn() involves a direct write to the database
             if (currentEditedCard != null && currentEditedCard!!.currentDeckId() != deckId) {
                 reloadRequired = true
-                undoableOp { setDeck(listOf(currentEditedCard!!.id), deckId) }
+                // Obtain all card IDs for the current note
+                val allCardIds = editorNote!!.cardIds(getColUnsafe)
+                // Update the deck for every card of that note
+                undoableOp { setDeck(allCardIds, deckId) }
                 // refresh the card object to reflect the database changes from above
                 currentEditedCard!!.load(getColUnsafe)
                 // also reload the note object


### PR DESCRIPTION
This PR fixes a bug in the Note Editor where only the currentEditedCard deckID was being updated when a note was modified, instead of updating all associated cards linked to that note.

* Fixes #17415 

To address this issue:

- Replaced the single-card update (setDeck(listOf(currentEditedCard!!.id), deckId)) with an update that uses all associated card IDs:

The fix has been tested with the following scenarios:

✅ Edited a cloze note three times and verified that all linked cards updated correctly.
✅ Checked behavior when undoing changes, ensuring all cards revert correctly.
✅ Manually tested on:
Emulator (Pixel_3a_API_34_arm64-v8a)

✅ Automated Tests: 
Ran the concrete methods FieldEditLineTest and NoteEditorTabOrderTest.kt

[ankiDroid-screen_recording.webm](https://github.com/user-attachments/assets/3bf864ee-8f93-4a90-a8af-3c95c7a618c1)

**There's a separate issue that I noticed re: Congrats Snackbar, even when I am not "reviewing" the card if the edit is done via AbstractFlashcardViewer and if there are no more cards left in the deck after I change the deck type of a cloze note with two associated cards , the snackbar is triggered as there are no more cards left in the deck. 
From the initial investigation, if no card is available in the current deck, the reviewer closes with RESULT_NO_MORE_CARDS, triggering the congrats message. I just wanted to flag this - I can create a new bug for this if it makes sense**

