### PR TITLE
fix: decode media names before inserting into the database

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -19,10 +19,8 @@
 
 package com.ichi2.anki.multimediacard.fields
 
-import android.net.Uri
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Collection
 import org.jsoup.Jsoup
@@ -77,11 +75,9 @@ class ImageField :
 
     companion object {
         @VisibleForTesting
-        @NeedsTest("files with HTML illegal chars can be imported and rendered")
         fun formatImageFileName(file: File): String =
             if (file.exists()) {
-                val encodedName = Uri.encode(file.name)
-                """<img src="$encodedName">"""
+                """<img src="${file.name}">"""
             } else {
                 ""
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
### Issue:

**Check Media** shows incorrect values when media filenames contain special characters (spaces, %, &, =, etc.) on Android, while the desktop version works as expected.

### Cause:

According to the [Anki manual](https://docs.ankiweb.net/media.html#media) (https://docs.ankiweb.net/media.html#media), filenames with spaces or special characters appear differently in the HTML editor compared to how they are stored on disk. For example, `hello 100%.jpg` is displayed as `hello%20100%25.jpg` in the editor.

HTML encoding is likely applied because certain characters have special meanings in URLs and HTML syntax. Without proper encoding, the card rendering engine may fail to locate or display media files with special characters in their names.

For instance, if a file named `test,.jpg` is referenced in a card, it gets encoded as `test%2C.jpg` in the editor for proper rendering, while the actual file on disk remains `test,.jpg`.

### Observations:

- When adding a card using the **desktop version**, the original filename is stored in the `collection.anki2` database (`notes` table).
- When adding media via **Android**, the filename is stored in an encoded format.
Scrrenshot of the notes table :
<img width="749" alt="synv_ev" src="https://github.com/user-attachments/assets/203a3460-6b7a-4d96-be4f-61425d937f3e" />


This discrepancy causes the `check_media` function to return incorrect results for media files added from Android when their names include special characters.

## Approach

Now, while adding card in a deck `addNote()` function is called
https://github.com/Sahil06012002/Anki-Android/blob/fb3eec394463e19f0b3db3fdaa5b6b1eb156879a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt#L1198
that stores the note in the database.

Decoding the media filenames before storing them in the database resolves the issue.
Before calling `addNote(editorNote!!, deckId)`, the `fields` parameter in `editorNote` is updated to replace encoded filenames with their decoded versions :
https://github.com/Sahil06012002/Anki-Android/blob/fb3eec394463e19f0b3db3fdaa5b6b1eb156879a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt#L2579 .


## Fixes
* Fixes #17972

## How Has This Been Tested?
- Tested on a **physical device (Android 12)**.
- Attached a video demonstrating the fix in 
https://github.com/user-attachments/assets/721fba7e-07d0-4523-a851-3f8bfc7f6910


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
