### PR TITLE
Fix SharedDecksActivity toolbar color for dark themes

### DIFF
--- a/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
+++ b/AnkiDroid/src/main/res/layout/activity_shared_decks.xml
@@ -17,7 +17,7 @@
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
         android:theme="@style/ActionBarStyle"
-        android:background="?attr/colorPrimary"
+        android:background="?attr/appBarColor"
         app:popupTheme="@style/ActionBar.Popup"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Saw this when I fixed the empty cards report appearance in dark themes.

Light and plain, no change:
![Screenshot from 2025-02-25 15-55-20](https://github.com/user-attachments/assets/ac5622d1-b4a4-4af1-b963-28957c508620)![Screenshot from 2025-02-25 16-01-41](https://github.com/user-attachments/assets/3d0a4611-fd40-4794-bc37-bffe53157294)

Before/after:

Black:

![Screenshot from 2025-02-25 15-53-07](https://github.com/user-attachments/assets/d3137ea9-f880-4964-b5aa-f45f6a687b27)![Screenshot from 2025-02-25 15-55-03](https://github.com/user-attachments/assets/c8939386-ba77-4363-a339-2d571e5ad61d)

Dark:

![Screenshot from 2025-02-25 15-53-25](https://github.com/user-attachments/assets/5607aadc-648b-40f6-ab69-4907e0497409)

![Screenshot from 2025-02-25 15-54-45](https://github.com/user-attachments/assets/259454a2-2c2b-4b32-a5b0-46f226a734c3)

## How Has This Been Tested?

Verified the toolbar's appearance in all themes.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
