### PR TITLE
Fix Toolbar Visibility in Fullscreen Reviewer Mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -42,6 +42,7 @@ import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.RelativeLayout
 import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.CheckResult
 import androidx.annotation.DrawableRes
@@ -214,6 +215,7 @@ open class Reviewer :
         if (!ensureStoragePermissions()) {
             return
         }
+        enableEdgeToEdge()
         colorPalette = findViewById(R.id.whiteboard_editor)
         answerTimer = AnswerTimer(findViewById(R.id.card_time))
         textBarNew = findViewById(R.id.new_number)
@@ -246,6 +248,8 @@ open class Reviewer :
         if (typeAnswer?.autoFocusEditText() == true) {
             answerField?.focusWithKeyboard()
         }
+
+        fullScreenHandler.sendEmptyMessageDelayed(0, INITIAL_HIDE_DELAY.toLong())
     }
 
     override fun onDestroy() {
@@ -343,9 +347,9 @@ open class Reviewer :
 
     override fun getContentViewAttr(fullscreenMode: FullScreenMode): Int =
         when (fullscreenMode) {
-            FullScreenMode.BUTTONS_ONLY -> R.layout.reviewer_fullscreen
+            FullScreenMode.BUTTONS_AND_MENU_WITH_STATUS_BAR -> R.layout.reviewer
+            FullScreenMode.BUTTONS_AND_MENU_ONLY -> R.layout.reviewer_fullscreen
             FullScreenMode.FULLSCREEN_ALL_GONE -> R.layout.reviewer_fullscreen_noanswers
-            FullScreenMode.BUTTONS_AND_MENU -> R.layout.reviewer
         }
 
     public override fun fitsSystemWindows(): Boolean = !fullscreenMode.isFullScreenReview()
@@ -1419,14 +1423,14 @@ open class Reviewer :
             val visible = flags and View.SYSTEM_UI_FLAG_HIDE_NAVIGATION == 0
             Timber.d("System UI visibility change. Visible: %b", visible)
             if (visible) {
-                showViewWithAnimation(toolbar)
                 if (fullscreenMode == FullScreenMode.FULLSCREEN_ALL_GONE) {
+                    showViewWithAnimation(toolbar)
                     showViewWithAnimation(topbar)
                     showViewWithAnimation(answerButtons)
                 }
             } else {
-                hideViewWithAnimation(toolbar)
                 if (fullscreenMode == FullScreenMode.FULLSCREEN_ALL_GONE) {
+                    hideViewWithAnimation(toolbar)
                     hideViewWithAnimation(topbar)
                     hideViewWithAnimation(answerButtons)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -248,8 +248,6 @@ open class Reviewer :
         if (typeAnswer?.autoFocusEditText() == true) {
             answerField?.focusWithKeyboard()
         }
-
-        fullScreenHandler.sendEmptyMessageDelayed(0, INITIAL_HIDE_DELAY.toLong())
     }
 
     override fun onDestroy() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/FullScreenMode.kt
@@ -23,23 +23,23 @@ import timber.log.Timber
 enum class FullScreenMode(
     private val prefValue: String,
 ) {
-    /** Display both navigation and buttons (default) */
-    BUTTONS_AND_MENU("0"),
+    /** Display both navigation and buttons with status bar (default) */
+    BUTTONS_AND_MENU_WITH_STATUS_BAR("0"),
 
-    /** Remove the menu bar, keeps answer button. */
-    BUTTONS_ONLY("1"),
+    /** Remove the status bar, keeps answer button and menu bar. */
+    BUTTONS_AND_MENU_ONLY("1"),
 
-    /** Remove both menu bar and buttons. Can only be set if gesture is on. */
+    /** Remove menu bar, buttons and status bar. Can only be set if gesture is on. */
     FULLSCREEN_ALL_GONE("2"),
     ;
 
     fun getPreferenceValue() = prefValue
 
-    fun isFullScreenReview() = this != BUTTONS_AND_MENU
+    fun isFullScreenReview() = this != BUTTONS_AND_MENU_WITH_STATUS_BAR
 
     companion object {
         const val PREF_KEY = "fullscreenMode"
-        val DEFAULT = BUTTONS_AND_MENU
+        val DEFAULT = BUTTONS_AND_MENU_WITH_STATUS_BAR
 
         fun fromPreference(prefs: SharedPreferences): FullScreenMode {
             val value = prefs.getString(PREF_KEY, DEFAULT.prefValue)
@@ -55,7 +55,7 @@ enum class FullScreenMode(
             // clear fullscreen flag as we use a integer
             val fullScreenModeKey = PREF_KEY
             val old = preferences.getBoolean("fullscreenReview", false)
-            val newValue = if (old) BUTTONS_ONLY else BUTTONS_AND_MENU
+            val newValue = if (old) BUTTONS_AND_MENU_ONLY else BUTTONS_AND_MENU_WITH_STATUS_BAR
             preferences.edit {
                 putString(fullScreenModeKey, newValue.getPreferenceValue())
                 remove("fullscreenReview")

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -48,8 +48,7 @@
     <FrameLayout
         android:id="@+id/answer_options_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:id="@+id/ease_buttons"

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen.xml
@@ -8,10 +8,14 @@ xmlns:android="http://schemas.android.com/apk/res/android">
         android:id="@+id/fullscreen_frame"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
-        <include layout="@layout/reviewer_topbar"
+        <include layout="@layout/toolbar"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"/>
+        <include layout="@layout/reviewer_topbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_below="@id/toolbar"/>
         <include
             layout="@layout/reviewer_mic_tool_bar"
             android:layout_width="match_parent"
@@ -27,16 +31,10 @@ xmlns:android="http://schemas.android.com/apk/res/android">
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
             android:layout_above="@+id/bottom_area_layout"/>
-        <include layout="@layout/reviewer_answer_buttons"/>
-    </RelativeLayout>
-    <!-- Controls that are overlaid over the main content when the user interrupts immersive mode -->
-    <FrameLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
-        <include layout="@layout/toolbar"
+        <include layout="@layout/reviewer_answer_buttons"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="top"/>
-    </FrameLayout>
+            android:layout_alignParentBottom="true"/>
+    </RelativeLayout>
+    <!-- Controls that are overlaid over the main content when the user interrupts immersive mode -->
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -7,7 +7,8 @@
     <!-- AbstractFlashcardViewer pulls layout params from parent, casting it as RelativeLayout -->
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:fitsSystemWindows="true">
         <!-- Main content that takes up the fullscreen -->
         <include
             layout="@layout/reviewer_mic_tool_bar"

--- a/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_fullscreen_noanswers.xml
@@ -36,7 +36,10 @@
                 android:layout_height="wrap_content"
                 android:layout_centerHorizontal="true"
                 android:layout_above="@+id/bottom_area_layout"/>
-            <include layout="@layout/reviewer_answer_buttons"/>
+            <include layout="@layout/reviewer_answer_buttons"
+                tools:layout_width="match_parent"
+                tools:layout_height="wrap_content"
+                tools:layout_alignParentBottom="true"/>
 
         </RelativeLayout>
     </RelativeLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -321,7 +321,7 @@ class ReviewerNoParamTest : RobolectricTest() {
 
     private fun startReviewerFullScreen(): ReviewerExt {
         val sharedPrefs = targetContext.sharedPrefs()
-        setPreference(sharedPrefs, FullScreenMode.BUTTONS_ONLY)
+        setPreference(sharedPrefs, FullScreenMode.BUTTONS_AND_MENU_ONLY)
         return ReviewerTest.startReviewer(this, ReviewerExt::class.java)
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This PR fixes the bug where the toolbar is hidden in semi-fullscreen reviewer.

## Fixes
* Fixes #15762

## Approach

- Updated FullScreenMode enum:
    - Renamed `BUTTONS_ONLY` to `BUTTONS_AND_MENU_ONLY`.
    - Renamed `BUTTONS_AND_MENU` to `BUTTONS_AND_MENU_WITH_STATUS_BAR`.
- Added `enableEdgeToEdge()` in Reviewer.
- Moved toolbar into the reviewer_fullscreen layout.
- Moved answer buttons in reviewer_fullscreen_noanswers layout.
- Updated `fitsSystemWindows` to exclude `BUTTONS_AND_MENU_WITH_STATUS_BAR`.
- Updated `fitsSystemWindows` to `true` in `reviewer_fullscreen_noanswers.xml` to ensure that the card content does not get obscured by the camera cutout.
- Removed `fitsSystemWindows` from `reviewer_answer_buttons`.
- Update old `fullscreenReview` preference to use new enum.

## How Has This Been Tested?

|Fullscreen mode|Reviewer|Reviewer (answer revealed)|
|:--:|--|--|
|Off|![image](https://github.com/user-attachments/assets/9362bfe3-a5d9-4bce-ad81-b0eff801a429)|![image](https://github.com/user-attachments/assets/c607472f-bc2b-4761-8e3c-8085ff2b8072)|
|Hide the system bars|![image](https://github.com/user-attachments/assets/5de9b8af-ea9d-4626-9a89-9efb7a27c339)|![image](https://github.com/user-attachments/assets/be4437ba-e638-482e-a978-edef87c8e4b2)|
|Hide the system bars and answer buttons|![image](https://github.com/user-attachments/assets/88af05a3-2b64-426b-b052-7f04a71c805c)|![image](https://github.com/user-attachments/assets/b79e19e7-48b0-4d5a-b42f-48b575b5d8e1)|

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
