### PR TITLE
fix: "Toggle whiteboard" control icon & label do not match

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -233,7 +233,7 @@
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/toggle_whiteboard_command_key"
             android:title="@string/gesture_toggle_whiteboard"
-            android:icon="@drawable/ic_gesture_white"
+            android:icon="@drawable/ic_enable_whiteboard"
             />
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/clear_whiteboard_command_key"


### PR DESCRIPTION
[Approach has been updated] 
<!--- Please fill the necessary details below -->
## Purpose / Description
"Toggle whiteboard" control icon does not match the label and the actual action.
<img src="https://github.com/user-attachments/assets/64188766-0b02-451b-8a9b-3b865d8943f7" width="320px">

---
<img src="https://github.com/user-attachments/assets/95e832b7-b4bf-447e-9061-01eea259507d" width="320px">

---
<img src="https://github.com/user-attachments/assets/c8920f82-3d7d-4859-abda-cd83bc018076" width="320px">

## Fixes
* Fixes #18026

## Approach
- Change the icon for "Toggle whiteboard" item in Controls settings page

## How Has This Been Tested?

Checked on physical device (Android 11)

<img src="https://github.com/user-attachments/assets/43d7a970-af75-4a27-aced-e6c8cbfd3e84" width="320px">

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
