### PR TITLE
Display "Current Interval" on the 'Set Due Date' dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -42,9 +42,11 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
 import com.google.android.material.textfield.TextInputLayout
+import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.CollectionManager.getColUnsafe
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.requireAnkiActivity
@@ -166,6 +168,21 @@ class SetDueDateDialog : DialogFragment() {
                     cb.isChecked = viewModel.updateIntervalToMatchDueDate
                     cb.setOnCheckedChangeListener { _, isChecked ->
                         viewModel.updateIntervalToMatchDueDate = isChecked
+                    }
+                }
+
+                findViewById<MaterialTextView>(R.id.current_interval_text)!!.also {
+                    // Current interval cannot be shown if multiple cards are selected
+                    if (viewModel.cardCount == 1) {
+                        val currentCard = getColUnsafe().getCard(cardIds[0])
+                        it.text =
+                            resources.getQuantityString(
+                                R.plurals.set_due_date_current_interval,
+                                currentCard.ivl,
+                                currentCard.ivl,
+                            )
+                    } else {
+                        it.isVisible = false
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -171,18 +171,18 @@ class SetDueDateDialog : DialogFragment() {
                     }
                 }
 
-                findViewById<MaterialTextView>(R.id.current_interval_text)!!.also {
+                findViewById<MaterialTextView>(R.id.current_interval_text)!!.also { tv ->
                     // Current interval cannot be shown if multiple cards are selected
                     if (viewModel.cardCount == 1) {
                         val currentCard = getColUnsafe().getCard(cardIds[0])
-                        it.text =
+                        tv.text =
                             resources.getQuantityString(
                                 R.plurals.set_due_date_current_interval,
                                 currentCard.ivl,
                                 currentCard.ivl,
                             )
                     } else {
-                        it.isVisible = false
+                        tv.isVisible = false
                     }
                 }
             }

--- a/AnkiDroid/src/main/res/layout/dialog_set_due_date.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_set_due_date.xml
@@ -58,6 +58,11 @@
             android:layout_height="wrap_content"
             />
 
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/current_interval_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp" />
 
         <com.google.android.material.checkbox.MaterialCheckBox
             android:id="@+id/change_interval"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -246,6 +246,10 @@ also changes the interval of the card"
         <item quantity="one">day</item>
         <item quantity="other">days</item>
     </plurals>
+    <plurals name="set_due_date_current_interval">
+        <item quantity="one">Current interval: %d day</item>
+        <item quantity="other">Current interval: %d days</item>
+    </plurals>
     <string name="range_delimiter" comment="Placed between two input boxes to denote a range">–</string>
     <string name="set_due_date_range_start" comment="'Set Due Date' may change the due date of a card to a random number of days in the future. This labels the 'minimum' value of this range (inclusive)">From</string>
     <string name="set_due_date_range_end" comment="'Set Due Date' may change the due date of a card to a random number of days in the future. This labels the 'maximum' value of this range (inclusive)">To</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

This PR enhances the 'Set Due Date' dialog by displaying the "Current Interval" when a single card is selected. This provides users with better context on the existing interval before setting a new due date. If multiple cards are selected, the interval is hidden, as displaying it would not be meaningful in that scenario.

## Fixes
* Fixes #16406

## Approach

Adds a display of the current interval to the "Set Due Date" dialog when a single card is selected. If multiple cards are selected, the interval is hidden as it would not be meaningful.

## How Has This Been Tested?

|Single date selection (single card)|Ranged date selection (single card)|Single date selection (multiple cards)|
|--|--|--|
|![image](https://github.com/user-attachments/assets/c7837a5c-2d31-4a06-87af-2b327579b960)|![image](https://github.com/user-attachments/assets/4a3a3815-1363-46d8-b433-2bae686af46d)|![image](https://github.com/user-attachments/assets/83d86eb4-1856-4aa3-8ab5-5ce203e6d717)|

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
