### PR TITLE
Collapse browser toolbar on scrolling the card list

### DIFF
--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -6,46 +6,61 @@
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     >
 
-    <LinearLayout
+    <com.google.android.material.appbar.AppBarLayout
+        android:background="@null"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" >
+        android:layout_height="wrap_content"
+        >
 
-        <include layout="@layout/toolbar" />
-
+        <!-- Note: AppBarLayout itself is a vertical LinearLayout, so strictly speaking
+             here it is not necessary to have another LinearLayout as a child.
+             Instead we could be setting app:layout_scrollFlags on the individual children.
+             However, the <include> tag can only override a very limited set of arguments,
+             so the alternatives here would be not using the <include> tag,
+             or having app:layout_scrollFlags directly in the included layout. -->
         <LinearLayout
-            android:id="@+id/browser_column_headings"
-            android:layout_width="match_parent"
-            android:background="@drawable/browser_heading_bottom_divider"
-            android:orientation="horizontal"
-            android:paddingVertical="2dp"
-            android:layout_height="wrap_content"
-            android:longClickable="true">
-
-        </LinearLayout>
-
-        <com.google.android.material.progressindicator.LinearProgressIndicator
-            android:id="@+id/browser_progress"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:indeterminate="true"
-            android:visibility="gone"
-            />
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/card_browser_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:background="?android:attr/colorBackground"
-            android:overScrollFooter="@color/transparent"
-            android:clipToPadding="false"
-            android:paddingBottom="72dp"
-            android:drawSelectorOnTop="true"
-            tools:listitem="@layout/card_item_browser"
-            />
+            android:orientation="vertical"
+            app:layout_scrollFlags="scroll|enterAlways"
+            >
 
-    </LinearLayout>
+            <include layout="@layout/toolbar" />
 
+            <LinearLayout
+                android:id="@+id/browser_column_headings"
+                android:layout_width="match_parent"
+                android:background="@drawable/browser_heading_bottom_divider"
+                android:orientation="horizontal"
+                android:paddingVertical="2dp"
+                android:layout_height="wrap_content"
+                android:longClickable="true"
+                />
+        </LinearLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/card_browser_list"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/colorBackground"
+        android:overScrollFooter="@color/transparent"
+        android:clipToPadding="false"
+        android:paddingBottom="72dp"
+        android:drawSelectorOnTop="true"
+        tools:listitem="@layout/card_item_browser"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        />
+
+    <com.google.android.material.progressindicator.LinearProgressIndicator
+        android:id="@+id/browser_progress"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:indeterminate="true"
+        android:visibility="gone"
+        android:layout_gravity="bottom"
+        />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Purpose / Description
Collapse browser toolbar on scrolling the card list. The toolbar takes space and may take even more space when browser chips are introduced (see #17355, #12554).

https://github.com/user-attachments/assets/c6e2ece3-11f6-4bbb-8b9f-278206ae569b

## Approach
Pretty straightforward, use `AppBarLayout`. I used [my old commit](https://github.com/ankidroid/Anki-Android/commit/e17f986a47678ff206cfcfb7e8de41cb317c426d) which had some issues, namely:

* Sometimes the fling gesture would be treated as a scroll gesture, with things just stopping scrolling instead of continuing scrolling after finger was lifted off the screen, and
* If the card list had only a few cards, it wouldn't move with gestures and the toolbar could be stuck in half-collapsed state.

I suspected that these issues would be resolved with moving to `RecyclerView`, and it seems that they have.

See also the commit message.

## How Has This Been Tested?

Briefly tested on my device API 34 and emulator API 24. Requires more on-hand testing to ensure the above issues are truly gone.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)