### PR TITLE
fix(new reviewer): snackbar position if answer buttons are hidden

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -120,13 +120,7 @@ class ReviewerFragment :
         get() = requireView().findViewById(R.id.webview)
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        val typeAnswerContainer = this@ReviewerFragment.view?.findViewById<View>(R.id.type_answer_container)
-        anchorView =
-            if (typeAnswerContainer?.isVisible == true) {
-                typeAnswerContainer
-            } else {
-                this@ReviewerFragment.view?.findViewById(R.id.answer_buttons)
-            }
+        anchorView = this@ReviewerFragment.view?.findViewById(R.id.snackbar_anchor)
     }
 
     override fun onStop() {

--- a/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
@@ -226,5 +226,12 @@
             android:layout_marginEnd="@dimen/reviewer_side_margin"
             />
 
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/snackbar_anchor"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="top"
+            app:constraint_referenced_ids="type_answer_container, answer_buttons, show_answer"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -206,5 +206,13 @@
             android:layout_marginStart="12dp"
             />
 
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/snackbar_anchor"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:barrierDirection="top"
+            app:barrierAllowsGoneWidgets="false"
+            app:constraint_referenced_ids="type_answer_container, answer_buttons, show_answer"/>
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

If there were no type answer box nor answer buttons, the snackbar wouldn't show up in the new reviewer

## Approach

Add a ConstraintLayout Barrier

## How Has This Been Tested?

Emulator 35: Undo stuff in the new reviewer with `Hide answer buttons` enabled/disabled and in type-in-answer notetypes. Also tested in a tablet emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
