### PR TITLE
style: align flag colors and card browser background colors with upst…

### DIFF
--- a/AnkiDroid/src/main/res/values-night/colors.xml
+++ b/AnkiDroid/src/main/res/values-night/colors.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="UnusedResources,DuplicateCrowdInStrings">
-    <color name="flag_red">#D32525</color>
-    <color name="flag_orange">#BB7A17</color>
-    <color name="flag_green">#057A05</color>
-    <color name="flag_blue">#1A4FC2</color>
-    <color name="flag_pink">#A70D64</color>
-    <color name="flag_turquoise">#138072</color>
-    <color name="flag_purple">#6320A0</color>
+    <!--    For Card background in Card browser-->
+    <color name="flag_red">#A54B4B</color>
+    <color name="flag_orange">#A97C4D</color>
+    <color name="flag_green">#599F73</color>
+    <color name="flag_blue">#406EA7</color>
+    <color name="flag_pink">#A072A8</color>
+    <color name="flag_turquoise">#3F9C8D</color>
+    <color name="flag_purple">#8058A8</color>
+
+    <!--    For flag icons-->
+    <color name="flag_reviewer_red">#F87171</color>
+    <color name="flag_reviewer_orange">#FDBA74</color>
+    <color name="flag_reviewer_green">#86EFAC</color>
+    <color name="flag_reviewer_blue">#60A5FA</color>
+    <color name="flag_reviewer_pink">#F0ABFC</color>
+    <color name="flag_reviewer_turquoise">#5EEAD4</color>
+    <color name="flag_reviewer_purple">#C084FC</color>
 
     <color name="again_button_bg">#1AB71C1C</color> <!-- Material red 900 with 10% alpha -->
     <color name="again_button_text">@color/material_red_200</color>

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -108,22 +108,22 @@
     <color name="note_editor_selected_item_text">#000000</color>
 
     <!-- For Card background in Card Browser -->
-    <color name="flag_red">#FF4747</color>
-    <color name="flag_orange">#FFB647</color>
-    <color name="flag_green">#6FF06F</color>
-    <color name="flag_blue">#5289FF</color>
-    <color name="flag_pink">#FF99F1</color>
-    <color name="flag_turquoise">#85FFEF</color>
-    <color name="flag_purple">#C398EC</color>
+    <color name="flag_red">#FFB0B0</color>
+    <color name="flag_orange">#FFD7B6</color>
+    <color name="flag_green">#A3FFC5</color>
+    <color name="flag_blue">#AFCDFF</color>
+    <color name="flag_pink">#FDF2FF</color>
+    <color name="flag_turquoise">#75FFEE</color>
+    <color name="flag_purple">#E6CBFF</color>
 
     <!-- For flag icons -->
-    <color name="flag_reviewer_red">#ff0000</color>
-    <color name="flag_reviewer_orange">#ff9800</color>
-    <color name="flag_reviewer_green">#057A05</color>
-    <color name="flag_reviewer_blue">#ff1976d2</color>
-    <color name="flag_reviewer_pink">#FF82EE</color>
-    <color name="flag_reviewer_turquoise">#00D1B5</color>
-    <color name="flag_reviewer_purple">#9649DD</color>
+    <color name="flag_reviewer_red">#EF4444</color>
+    <color name="flag_reviewer_orange">#FB923C</color>
+    <color name="flag_reviewer_green">#4ADE80</color>
+    <color name="flag_reviewer_blue">#3B82F6</color>
+    <color name="flag_reviewer_pink">#E879F9</color>
+    <color name="flag_reviewer_turquoise">#2DD4BF</color>
+    <color name="flag_reviewer_purple">#A855F7</color>
 
     <color name="badge_error">#f45000</color>
     <color name="badge_warning">#ff5e13</color>


### PR DESCRIPTION
…ream Anki desktop

<!--- Please fill the necessary details below -->
## Purpose / Description
The colors used in flag icons of the reviewer, and card browser background were different from Anki Desktop, this PR tries to match the flag colors and card browser background colors to the colors of the upstream desktop in both the dark and light modes.

## Fixes
* Fixes #18018 

## Approach
I presumed that the flag colors inside Anki Android are static values, unlike Anki desktop, I tried to match the exact values of dark, and light modes of flag icon colors and card browser flag background colors.

The flag icon colors were changed to the desktop upstream colors values [_vars.scss](https://github.com/ankitects/anki/blob/main/ts/lib/sass/_vars.scss), as these are directly used in [theme.py](https://github.com/ankitects/anki/blob/main/qt/aqt/theme.py) to generate the flag icons.

The card browser background colors are generated from [browser/table/__init__.py](https://github.com/ankitects/anki/blob/main/qt/aqt/browser/table/__init__.py) using the same color variables from `_vars.scss` but with _150% darker or lighter_ variation depending on the theme using `QColor`  class's `lighter` and `darker` methods.

As these colors are generated and not hardcoded in the desktop upstream, I found the color values by writing my own python script which uses `QColor` from `PyQt6` and `_var.scss`'s color variables and does the required lighter and darker variation, and verified them by trying to log the colors from the desktop build.

## How Has This Been Tested?
UI tested comparisons below
### _For the flag icon colors in the reviewer_
Light mode
| Desktop | Before (Android) | After commit (Android) | 
| ------ | ------ | ------ |
| ![image](https://github.com/user-attachments/assets/35af40a9-a07e-4f38-852e-afcae5e3694b) | ![image](https://github.com/user-attachments/assets/2d66ce8a-6365-4b51-9cd4-ce6b15c54679) | ![image](https://github.com/user-attachments/assets/b3fe9915-9633-4045-8292-64953449936e) | 


Dark mode
| Desktop | Before (Android) | After commit (Android) | 
| ------ | ------ | ------ |
| ![image](https://github.com/user-attachments/assets/7b09ea64-183f-4a2b-a047-f201a7f43aec) | ![image](https://github.com/user-attachments/assets/1c867837-d111-44e0-a1f1-c18f6af415a7) | ![image](https://github.com/user-attachments/assets/bff381ea-50aa-4cd9-bfc9-f2be9a452b5c) |


### _For the card browser backgrounds_

Light mode
| Desktop | Before (Android) | After commit (Android) | 
| ------ | ------ | ------ |
| ![image](https://github.com/user-attachments/assets/db3deceb-cd96-494a-a371-82ba8f51ce73) | ![image](https://github.com/user-attachments/assets/da25fc77-d521-4e96-b50a-771894bc984f) | ![image](https://github.com/user-attachments/assets/c592e439-6baf-4e25-9abc-c9ad93e761ad) | 

Dark mode
| Desktop | Before (Android) | After commit (Android) | 
| ------ | ------ | ------ |
| ![image](https://github.com/user-attachments/assets/2b6e1977-2d90-4bee-8504-1c8efa34ab29) | ![image](https://github.com/user-attachments/assets/b66236c2-d218-460e-a79b-2e13e1266ed4) | ![image](https://github.com/user-attachments/assets/26b7b6be-21d0-4231-9c12-860801bc62a6) | 


# Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
