### PR TITLE
Managed back stack for parent fragments in the app settings

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/preferences/PreferencesNavigationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/preferences/PreferencesNavigationTest.kt
@@ -1,0 +1,105 @@
+/**
+ *  Copyright (c) 2025 Amit Bisht <iamitsbisht07@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import android.content.Context
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.typeText
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.DrawerActions
+import androidx.test.espresso.matcher.ViewMatchers.hasFocus
+import androidx.test.espresso.matcher.ViewMatchers.hasMinimumChildCount
+import androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withClassName
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withResourceName
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.R
+import com.ichi2.anki.testutil.GrantStoragePermission
+import com.ichi2.anki.testutil.closeGetStartedScreenIfExists
+import com.ichi2.anki.testutil.grantPermissions
+import com.ichi2.anki.utils.isWindowCompact
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.endsWith
+import org.junit.Assume.assumeTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PreferencesNavigationTest {
+    @get:Rule
+    val runtimePermissionRule = grantPermissions(GrantStoragePermission.storagePermission)
+
+    /**
+     * Verifies navigation behavior when the search bar is tapped.
+     * - When the user searches for something using the search bar,the search view should close upon pressing the back button.
+     * - The back button should not close the entire preferences activity.
+     */
+    @Test
+    fun testOnCompactMode() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        assumeTrue(context.resources.isWindowCompact())
+        ActivityScenario.launch(IntentHandler::class.java)
+        closeGetStartedScreenIfExists()
+        onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
+        onView(withId(R.id.nav_settings)).perform(click())
+        onView(withId(R.id.search)).perform(click())
+        onView(allOf(withId(R.id.search), hasFocus())).perform(typeText("Controls"))
+        pressBack()
+        // Checking the list of Settings Categories are displayed on the basis of our search "Controls"
+        onView(allOf(withResourceName("list"), isAssignableFrom(RecyclerView::class.java))).check(
+            matches(
+                hasMinimumChildCount(1),
+            ),
+        )
+        pressBack()
+        onView(withId(R.id.settings_container)).check(matches(isDisplayed()))
+    }
+
+    /**
+     * Verifies navigation behavior when multiple menus are opened.
+     * - Even after opening multiple menus, pressing the back button should
+     * close the preference activity instead of navigating back through the previously opened menus.
+     */
+    @Test
+    fun testOnNonCompactMode() {
+        fun isTablet(context: Context): Boolean = context.resources.configuration.smallestScreenWidthDp >= 600
+
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        assumeTrue(isTablet(context))
+        ActivityScenario.launch(IntentHandler::class.java)
+        closeGetStartedScreenIfExists()
+        onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
+        onView(withId(R.id.nav_settings)).perform(click())
+        onView(withId(R.id.search)).perform(click())
+        onView(allOf(withId(R.id.search), hasFocus())).perform(typeText("Card"))
+        onView(withText(R.string.card_zoom)).perform(click())
+        onView(withId(R.id.settings_container)).check(matches(isDisplayed()))
+        onView(withText(R.string.notification_pref)).perform(click())
+        pressBack()
+        onView(withClassName(endsWith("PreferencesActivity"))).check(doesNotExist())
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -54,6 +54,8 @@ class PreferencesFragment :
             override fun handleOnBackPressed() {
                 if (!settingsIsSplit && childFragmentManager.backStackEntryCount > 0) {
                     childFragmentManager.popBackStack()
+                } else if (parentFragmentManager.backStackEntryCount > 0) {
+                    parentFragmentManager.popBackStack()
                 } else {
                     requireActivity().finish()
                 }


### PR DESCRIPTION
## **Purpose / Description**

- Issue: The Settings screen closes when searching and the Back button or the Navigation icon is pressed, causing the user to restart their search.

- Why it Matters: This issue creates a significant usability barrier, hindering users' ability to effectively use the settings. Addressing it will make the settings experience more efficient and less frustrating.

## **Fixes**

* Fixes  https://github.com/ankidroid/Anki-Android/issues/18051#issue-2892805733

## **Approach**

- Before: Child fragments were effectively managed within the handleOnBackPressed() method. However, this method did not manage the back stack for the parent fragment, which is directly hosted by the activity.

- After the changes: Now, the method also manages the parent fragment's back stack, ensuring it remains on the screen when the user is searching and presses the back button or navigation icon, instead of navigating directly to the home screen.

## **How Has This Been Tested?**

This issue has been tested on a physical device running on Android 15, as well as on Android Emulators (API 35 and API 34), with all possible navigation states.

This video clip shows how it is working now:
(Please avoid the playback speed, make it normal, due to the length of the video it is edited to 2x)
https://github.com/user-attachments/assets/dd1b8d11-c4b0-4fce-9f57-52ad939e8f82

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
