### PR TITLE
NF: Introduce `isPrefererenceViewSplit`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -66,7 +66,7 @@ class HeaderFragment :
             requirePreference<SearchPreference>(R.string.search_preference_key).searchConfiguration,
         )
 
-        if (!resources.isWindowCompact()) {
+        if (settingsIsSplit) {
             parentFragmentManager.findFragmentById(R.id.settings_container)?.let {
                 val key = getHeaderKeyForFragment(it) ?: return@let
                 highlightPreference(key)
@@ -192,3 +192,11 @@ class HeaderFragment :
             }
     }
 }
+
+/**
+ * Whether the Settings view is split in two.
+ * If so, the left side contains the list of all preference categories, and the right side contains the category currently opened.
+ * Otherwise, the same view is used to show the list of categories first, and then one specific category.
+ */
+val Fragment.settingsIsSplit
+    get() = !resources.isWindowCompact()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -40,7 +40,6 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.utils.ext.sharedPrefs
-import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.utils.FragmentFactoryUtils
 import timber.log.Timber
 import kotlin.reflect.KClass
@@ -53,7 +52,7 @@ class PreferencesFragment :
     private val onBackPressedCallback =
         object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (resources.isWindowCompact() && childFragmentManager.backStackEntryCount > 0) {
+                if (!settingsIsSplit && childFragmentManager.backStackEntryCount > 0) {
                     childFragmentManager.popBackStack()
                 } else {
                     requireActivity().finish()
@@ -156,13 +155,13 @@ class PreferencesFragment :
         val fragmentClassName = arguments?.getString(INITIAL_FRAGMENT_EXTRA)
         val initialFragment =
             if (fragmentClassName == null) {
-                if (resources.isWindowCompact()) HeaderFragment() else GeneralSettingsFragment()
+                if (!settingsIsSplit) HeaderFragment() else GeneralSettingsFragment()
             } else {
                 FragmentFactoryUtils.instantiate<Fragment>(requireActivity(), fragmentClassName)
             }
         childFragmentManager.commit {
             // In big screens, show the headers fragment at the lateral navigation container
-            if (!resources.isWindowCompact()) {
+            if (settingsIsSplit) {
                 replace(R.id.lateral_nav_container, HeaderFragment())
             }
             replace(R.id.settings_container, initialFragment, initialFragment::class.java.name)


### PR DESCRIPTION
While reviewing a PR, I found unclear why we checked whether the window is compact. Admittedly, figuring out it means that the view is split in two was not hard, still, I believe it's best to put it behind a more descriptive value. This also ensure that if we decide to change the criteria we use to decide whether to split or not, we will have to change a single place.
