### PR TITLE
Added Remove Background Image Option

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -54,7 +54,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
     override fun initSubscreen() {
         // Configure background
         backgroundImage = requirePreference<Preference>("deckPickerBackground")
-        removeBackgroundPref = requirePreference("remove_background_key")
+        removeBackgroundPref = requirePreference(getString(R.string.remove_background_image_option))
         backgroundImage!!.onPreferenceClickListener =
             Preference.OnPreferenceClickListener {
                 try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -45,6 +45,7 @@ import timber.log.Timber
 
 class AppearanceSettingsFragment : SettingsFragment() {
     private var backgroundImage: Preference? = null
+    private var removeBackgroundPref: Preference? = null
     override val preferenceResource: Int
         get() = R.xml.preferences_appearance
     override val analyticsScreenNameConstant: String
@@ -53,6 +54,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
     override fun initSubscreen() {
         // Configure background
         backgroundImage = requirePreference<Preference>("deckPickerBackground")
+        removeBackgroundPref = requirePreference("remove_background_key")
         backgroundImage!!.onPreferenceClickListener =
             Preference.OnPreferenceClickListener {
                 try {
@@ -63,6 +65,14 @@ class AppearanceSettingsFragment : SettingsFragment() {
                 }
                 true
             }
+
+        removeBackgroundPref?.setOnPreferenceClickListener {
+            showRemoveBackgroundImageDialog()
+            true
+        }
+
+        // Initially update visibility based on whether a background exists
+        updateRemoveBackgroundVisibility()
 
         val appThemePref = requirePreference<ListPreference>(R.string.app_theme_key)
         val dayThemePref = requirePreference<ListPreference>(R.string.day_theme_key)
@@ -150,12 +160,19 @@ class AppearanceSettingsFragment : SettingsFragment() {
         }
     }
 
+    private fun updateRemoveBackgroundVisibility() {
+        // Show "Remove Background" only if an image is set
+        removeBackgroundPref?.isVisible = BackgroundImage.shouldBeShown(requireContext())
+    }
+
     private fun showRemoveBackgroundImageDialog() {
         AlertDialog.Builder(requireContext()).show {
             title(R.string.remove_background_image)
             positiveButton(R.string.dialog_remove) {
                 if (BackgroundImage.remove(requireContext())) {
                     showSnackbar(R.string.background_image_removed)
+                    // Hide the preference after removal
+                    updateRemoveBackgroundVisibility()
                 } else {
                     showSnackbar(R.string.error_deleting_image)
                 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -176,6 +176,9 @@
     <!-- Deckpicker Background -->
     <string name="background_image_title" maxLength="41">Background</string>
     <string name="choose_an_image" maxLength="41">Select image</string>
+    <string name="background_image_summary" maxLength="41">Set Background Image</string>
+    <string name="remove_background_image_option" maxLength="41">Remove Background</string>
+    <string name="remove_background_image_option_summary" maxLength="41">Remove Background Image</string>
     <string name="remove_background_image">Remove background?</string>
     <!-- Card Template Browser Appearance -->
     <string name="restore_default" maxLength="28">Restore Default</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -34,6 +34,7 @@
     <string name="day_theme_key">dayTheme</string>
     <string name="night_theme_key">nightTheme</string>
     <string name="pref_deck_picker_background_key">deckPickerBackground</string>
+    <string name="pref_remove_background_key">removeBackgroundOption</string>
     <string name="custom_buttons_link_preference">custom_buttons_link</string>
     <string name="fullscreen_mode_preference">fullscreenMode</string>
     <string name="center_vertically_preference">centerVertically</string>

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -63,13 +63,13 @@
             android:key="@string/pref_deck_picker_background_key"
             android:shouldDisableView="true"
             android:icon="@drawable/wallpaper_icon"
-            android:summary="Set Background Image"
+            android:summary="@string/background_image_summary"
             android:title="@string/choose_an_image" />
         <Preference
-            android:key="remove_background_key"
-            android:summary="Remove Background Image"
+            android:key="@string/remove_background_image_option"
+            android:summary="@string/remove_background_image_option_summary"
             android:icon="@drawable/ic_remove"
-            android:title="Remove Background"/>
+            android:title="@string/remove_background_image_option"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_reviewer" >
         <Preference

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -63,7 +63,13 @@
             android:key="@string/pref_deck_picker_background_key"
             android:shouldDisableView="true"
             android:icon="@drawable/wallpaper_icon"
+            android:summary="Set Background Image"
             android:title="@string/choose_an_image" />
+        <Preference
+            android:key="remove_background_key"
+            android:summary="Remove Background Image"
+            android:icon="@drawable/ic_remove"
+            android:title="Remove Background"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_reviewer" >
         <Preference

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -91,6 +91,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.reviewer_frame_style_key, // reviewerFrameStyle
             R.string.hide_system_bars_key, // hideSystemBars
             R.string.ignore_display_cutout_key, // ignoreDisplayCutout
+            R.string.pref_remove_background_key, // removeBackgroundOption
         ).toStringResourceSet()
 
     @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Purpose / Description  
This PR fixes the issue of not having an explicit background removal option. Due to this, users may be confused about where to remove the background.

## Fixes  
* Adds an explicit background removal option to improve user experience.  

## Approach  
_This change addresses the problem by:_  
- Providing a clear and accessible way for users to remove backgrounds.  
- Ensuring a more intuitive UI to avoid confusion.  
- **ScreenShots**
![Screenshot_2025-03-07-23-17-33-388_com ichi2 anki debug 1](https://github.com/user-attachments/assets/77d7151a-d5fc-419f-8a1e-228d726e447b)
- **ScreenRecording**
https://github.com/user-attachments/assets/fe1b666c-c8a1-480a-8c7b-4dd7ed5230eb

## How Has This Been Tested?  
- Tested in **portrait** and **landscape** modes.  

- Used **Google Accessibility Scanner** to verify UI improvements.  
- **Device Used:** Redmi Note 8 Pro.  

## Checklist  
_Please go through these checks before submitting the PR._  

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).  
- [x] You have commented your code, particularly in hard-to-understand areas.  
- [x] You have performed a self-review of your own code.  
- [x] **UI Changes:** Included screenshots of all affected screens (especially showing new or changed strings).  
- [x] **UI Accessibility:** Tested changes using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor) and fixed any detected issues.  
