### PR TITLE
NF: set "play" variant as default

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -179,6 +179,7 @@ android {
     flavorDimensions += "appStore"
     productFlavors {
         create('play') {
+            getIsDefault().set(true)
             dimension "appStore"
         }
         create('amazon') {


### PR DESCRIPTION
This will ensure that new contributors can run androidTest on emulators without having to change the variant.

Syntax found on
https://stackoverflow.com/posts/60197203/revisions

Tested by using the "Re-import with defaults" button in the variant setting.