### PR TITLE
minor fix: remove extra space in newer string

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -176,7 +176,7 @@
     <!-- Deckpicker Background -->
     <string name="background_image_title" maxLength="41">Background</string>
     <string name="choose_an_image" maxLength="41">Select image</string>
-    <string name="remove_wallpaper_image" maxLength="41"> Remove background</string>
+    <string name="remove_wallpaper_image" maxLength="41">Remove background</string>
     <string name="remove_background_image">Remove background?</string>
     <!-- Card Template Browser Appearance -->
     <string name="restore_default" maxLength="28">Restore Default</string>


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Remove an extra space in a recently added string for https://github.com/ankidroid/Anki-Android/pull/18071
![image](https://github.com/user-attachments/assets/75794930-cee9-4868-9674-20d7266a511c)


## Fixes
N/A

## Approach
Remove the space in the source file

## How Has This Been Tested?
Test omitted



## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
