### PR TITLE
lint: fix trailing spaces in /values 

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -237,8 +237,7 @@
     <string name="note_editor_audio_too_large">The audio file is too large, please insert the audio manually</string>
     <string name="ankidroid_cannot_open_after_backup_try_again"
         comment="After an Android backup is restored, AnkiDroid opens and shows this message.
-        Opening AnkiDroid again will work correctly">
-        Android backup in progress. Please try again</string>
+        Opening AnkiDroid again will work correctly">Android backup in progress. Please try again</string>
 
 
     <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
@@ -334,20 +333,15 @@
     <string name="deleting_selected_notes">Deleting selected notes</string>
 
     <string name="tts_voices_default_text" comment="The default text to speak when selecting
-    Text to speech voices"
-        >
-        Tap a voice to listen
-    </string>
+    Text to speech voices">Tap a voice to listen</string>
 
     <string name="tts_voices_selected_voice_should_be_installed" comment="If a voice has been tapped, is installable
 but not installed, we want to inform the user that they should install it for the best experience
-There will also be an option to use it without downloading">Voice should be installed before use
-    </string>
+There will also be an option to use it without downloading">Voice should be installed before use</string>
 
     <string name="tts_voices_use_selected_voice_without_install" comment="A user has been
 informed that a voice should be installed before use. This is text on a snackbar button which
-allows them to use the voice without installing it">Use anyway
-    </string>
+allows them to use the voice without installing it">Use anyway</string>
 
     <string name="tts_voices_playback_error_new" comment="an error occurred when playing a text to speech
 voice. The parameter is a technical error code such as 'ERROR_NOT_INSTALLED_YET' or 'ERROR_NETWORK_TIMEOUT'"
@@ -357,20 +351,14 @@ voice. The parameter is a technical error code such as 'ERROR_NOT_INSTALLED_YET'
     <string name="tts_voices_chip_filter_to_internet" comment="
     Filters a list of text to speech voices, to enable/disable voices which require the internet to
     function.
-    This is on a chip control, so keep the text short, ideally one word">
-        Internet
-    </string>
+    This is on a chip control, so keep the text short, ideally one word">Internet</string>
 
     <string name="tts_voices_chip_filter_to_installable_audio" comment="
     Displays a list of Text to Speech voices which should be downloaded/installed before use
-    This is on a chip control, so keep the text short, ideally one word">
-        Install
-    </string>
+    This is on a chip control, so keep the text short, ideally one word">Install</string>
 
     <string name="tts_voices_failed_opening_tts_system_settings" comment="error message if
-opening the system text to speech settings fails">
-        Failed to open text to speech settings
-    </string>
+opening the system text to speech settings fails">Failed to open text to speech settings</string>
 
     <string name="shared_decks_login_required">Please log in to download more decks</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -40,7 +40,7 @@
     <string name="answering_error_title">Database error</string>
     <string name="answering_error_message">Writing to the collection failed. The database could be corrupt or there may not to be enough empty space on disk.\n\nIf this happens more often, try checking the database, repairing the collection or restoring it from a backup. Touch “options” for that.\n\Or it could be an AnkiDroid bug as well; please report the error so that we can check this.</string>
     <string name="answering_error_report">Report error</string>
-   <string name="storage_full_message">There is not enough free storage space to open AnkiDroid. Free up some space to continue. </string>
+   <string name="storage_full_message">There is not enough free storage space to open AnkiDroid. Free up some space to continue.</string>
     <string name="repair_deck_dialog">Do you really want to try to repair the database?\n\nBefore starting the attempt, a copy will be created in subfolder “%s”.</string>
     <string name="intent_aedict_empty">Category “default” is empty</string>
     <string name="intent_aedict_category">To add cards to AnkiDroid remove all Notepad categories or add one named “default”</string>
@@ -217,13 +217,8 @@
     <string name="button_do_not_show_again" comment="permanently dismisses a dialog">Don\'t show again</string>
 
     <string name="dismiss_backup_warning_title">Data loss warning</string>
-    <string name="dismiss_backup_warning_new_user">
-        Due to Android privacy changes, your data and automated backups will be deleted from your phone if the app is uninstalled
-    </string>
-
-    <string name="dismiss_backup_warning_upgrade">
-        Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled
-    </string>
+    <string name="dismiss_backup_warning_new_user">Due to Android privacy changes, your data and automated backups will be deleted from your phone if the app is uninstalled</string>
+    <string name="dismiss_backup_warning_upgrade">Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled</string>
 
     <string name="deck_already_exists">Deck already exists</string>
     <string name="empty_deck_name">Deck name cannot be empty</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -294,9 +294,7 @@ this formatter is used if the bind only applies to both the question and the ans
     <string name="pref_cat_dev_options" maxLength="41">Developer options</string>
     <string name="dev_options_enabled_pref" maxLength="41">Enable developer options</string>
     <string name="disable_dev_options">Disable developer options</string>
-    <string name="dev_options_warning">
-        Please be sure before enabling developer options. These options are dangerous and could break the app or corrupt your collection.\n\nNote that these options are not suited for most users and therefore are not translated, so they are in English.
-    </string>
+    <string name="dev_options_warning">Please be sure before enabling developer options. These options are dangerous and could break the app or corrupt your collection.\n\nNote that these options are not suited for most users and therefore are not translated, so they are in English.</string>
 
     <!-- #######################################################################################
          #################################### Backup options ###################################

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -56,8 +56,8 @@
 
 
     <!--Model Add Suffixes-->
-    <string name="model_browser_add_add">Add: %1$s </string> <!--This prefix is used for standard note types-->
-    <string name="model_browser_add_clone">Clone: %1$s </string>
+    <string name="model_browser_add_add">Add: %1$s</string> <!--This prefix is used for standard note types-->
+    <string name="model_browser_add_clone">Clone: %1$s</string>
 
     <!--Browser Appearance-->
     <string name="card_template_browser_appearance_summary">Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”</string>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -25,10 +25,12 @@ import com.android.tools.lint.detector.api.ResourceXmlDetector
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
+import com.android.utils.forEach
 import com.google.common.annotations.VisibleForTesting
 import com.ichi2.anki.lint.utils.Constants
 import com.ichi2.anki.lint.utils.CrowdinContext.Companion.toCrowdinContext
 import com.ichi2.anki.lint.utils.ext.isRightToLeftLanguage
+import org.w3c.dom.CDATASection
 import org.w3c.dom.Element
 
 /**
@@ -132,6 +134,20 @@ class TranslationTypo :
         // remove empty strings
         if (element.textContent.isEmpty() && element.getAttribute("name") != "empty_string") {
             element.reportIssue("should not be empty")
+        }
+
+        // TODO(14903): remove "values" check once lint passes without it
+        if ("values" == context.file.parentFile.name && element.textContent.trim() != element.textContent) {
+            var isValid = true
+            element.childNodes.forEach {
+                if (it is CDATASection) {
+                    isValid = false
+                }
+            }
+
+            if (isValid) {
+                element.reportIssue("should not contain trailing whitespace")
+            }
         }
     }
 }

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -97,8 +97,8 @@ class TranslationTypo :
             return
         }
 
-        // Only check <string> or <plurals><item>, not the container
-        if ("resources" == element.tagName) {
+        // Ignore container tags: visitElement already handles visiting sub-tags (<item>/<string>)
+        if (element.tagName in listOf("resources", "plurals", "string-array")) {
             return
         }
 

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -52,6 +52,28 @@ class TranslationTypoTest {
     }
 
     @Test
+    fun `plurals - javascript fails`() {
+        val invalidLowerCase = """<resources>
+           <plurals name="pl">
+               <item quantity="other">>javascript</item>
+           </plurals>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(invalidLowerCase, "should be 'JavaScript'")
+    }
+
+    @Test
+    fun `string array - javascript fails`() {
+        val invalidLowerCase = """<resources>
+           <string-array name="arr">
+               <item>javascript</item>
+           </string-array>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(invalidLowerCase, "should be 'JavaScript'")
+    }
+
+    @Test
     fun `vandalism fails`() {
         val stringRemoved = """<resources>
            <string name="hello"></string>

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.lint.rules
 
 import com.ichi2.anki.lint.testutils.assertXmlStringsHasError
 import com.ichi2.anki.lint.testutils.assertXmlStringsNoIssues
+import org.junit.Ignore
 import org.junit.Test
 
 /**
@@ -86,6 +87,77 @@ class TranslationTypoTest {
     fun `vandalism passes with empty_string key`() {
         val stringRemoved = """<resources>
            <string name="empty_string"></string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsNoIssues(stringRemoved)
+    }
+
+    @Test
+    fun `additional spacing before is flagged`() {
+        val stringRemoved = """<resources>
+           <string name="hello"> hello</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlFile = stringRemoved,
+            expectedError = "should not contain trailing whitespace",
+            ignoreCData = true,
+        )
+    }
+
+    @Test
+    fun `additional spacing after is flagged`() {
+        val stringRemoved = """<resources>
+           <string name="hello">hello </string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(
+            xmlFile = stringRemoved,
+            expectedError = "should not contain trailing whitespace",
+            ignoreCData = true,
+        )
+    }
+
+    @Test
+    fun `cdata with no spaces is not flagged`() {
+        val stringRemoved = """<resources>
+           <string name="export_email_text"><![CDATA[
+                        Hi!
+                        <br/><br/>
+                        This is an Anki flashcards deck sent from AnkiDroid[1].
+                        Try to open it using one of the available Anki distributions[2] and enjoy easy and efficient learning!<br/><br/>
+                        [1] %1${"\$s"}<br/>
+                        [2] %2${"\$s"}
+                ]]></string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsNoIssues(stringRemoved)
+    }
+
+    @Test
+    @Ignore("The ellipsis is unescaped")
+    @Suppress("UNUSED_EXPRESSION")
+    fun `ellipsis escaping is unchanged`() {
+        """<resources>
+            <string name="empty_filtered_deck">필터링된 덱을 비우는 중&#8230; </string>
+        </resources>"""
+
+        // TODO
+    }
+
+    @Test
+    fun `cdata with spaces is not flagged`() {
+        val stringRemoved = """<resources>
+           <string name="export_email_text">
+                <![CDATA[
+                        Hi!
+                        <br/><br/>
+                        This is an Anki flashcards deck sent from AnkiDroid[1].
+                        Try to open it using one of the available Anki distributions[2] and enjoy easy and efficient learning!<br/><br/>
+                        [1] %1${"\$s"}<br/>
+                        [2] %2${"\$s"}
+                ]]>
+            </string>
         </resources>"""
 
         TranslationTypo.ISSUE.assertXmlStringsNoIssues(stringRemoved)

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/testutils/LintAssert.kt
@@ -18,7 +18,9 @@ package com.ichi2.anki.lint.testutils
 
 import com.android.tools.lint.checks.infrastructure.TestFiles
 import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestMode
 import com.android.tools.lint.detector.api.Issue
+import com.intellij.util.applyIf
 import org.intellij.lang.annotations.Language
 import org.junit.Assert.assertTrue
 
@@ -60,12 +62,14 @@ fun Issue.assertXmlStringsHasError(
     expectedError: String,
     androidLanguageFolder: String? = null,
     fileName: String? = null,
+    ignoreCData: Boolean = false,
 ) {
     val languageQualifier = if (androidLanguageFolder != null) "-$androidLanguageFolder" else ""
     val resourceFileName = fileName ?: "constants"
     TestLintTask
         .lint()
         .allowMissingSdk()
+        .applyIf(ignoreCData) { skipTestModes(TestMode.CDATA) }
         .allowCompilationErrors()
         .files(TestFiles.xml("res/values$languageQualifier/$resourceFileName.xml", xmlFile))
         .issues(this)


### PR DESCRIPTION

## Fixes
* Part of #14903 

## Approach
* Add a lint rule
* Attempt the autofix, and fail: converting an `Element` back to the actual XML as it appeared on screen is difficult
* Only apply the lint rule to `/values` for now, fix the remainder on Crowdin

## How Has This Been Tested?
Unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
