### PR TITLE
Enforce user-facing locale checks via lint; fixes #8917

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.libanki.sched
 
+import android.annotation.SuppressLint
 import anki.decks.DeckTreeNode
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.utils.append
@@ -130,6 +131,7 @@ data class DeckNode(
         }
     }
 
+    @SuppressLint("LocaleRootUsage")
     private fun nameMatchesFilter(filter: CharSequence?): Boolean {
         return if (filter == null) {
             true

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
@@ -25,6 +25,7 @@ import android.util.AttributeSet
 import android.view.View
 import com.google.android.material.color.MaterialColors
 import com.ichi2.utils.dpToPixels
+import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -62,7 +63,7 @@ class AxisValueDisplay(
         set(value) {
             field = value
             this.postInvalidate()
-            text = String.format("%.3f", value)
+            text = String.format(Locale.getDefault(), "%.3f", value)
             if (isExtremity) {
                 extremityListener?.invoke(field)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
+import android.annotation.SuppressLint
 import android.app.ActivityManager
 import android.content.ContentResolver
 import android.content.Context
@@ -132,7 +133,9 @@ object AdaptionUtil {
     }
 
     /** See: https://en.wikipedia.org/wiki/Vivo_(technology_company)  */
+
     val isVivo: Boolean
+        @SuppressLint("LocaleRootUsage")
         get() {
             val manufacturer = Build.MANUFACTURER ?: return false
             return manufacturer.lowercase(Locale.ROOT) == "vivo"

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AssetHelper.kt
@@ -35,6 +35,7 @@
  */
 package com.ichi2.utils
 
+import android.annotation.SuppressLint
 import android.net.Uri
 import android.webkit.MimeTypeMap
 import java.io.File
@@ -46,6 +47,7 @@ object AssetHelper {
      Returns the extension of [path].
      It uses [MimeTypeMap.getFileExtensionFromUrl], with the path transformed into a Uri.
      */
+    @SuppressLint("LocaleRootUsage")
     fun getFileExtensionFromFilePath(path: String): String =
         MimeTypeMap.getFileExtensionFromUrl(
             Uri.fromFile(File(path)).toString().lowercase(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.utils
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.ContentResolver
 import android.content.Context
@@ -84,6 +85,7 @@ object ImportUtils {
         FileImporter().showImportUnsuccessfulDialog(activity, errorMessage, exitActivity)
     }
 
+    @SuppressLint("LocaleRootUsage")
     fun isCollectionPackage(filename: String?): Boolean =
         filename != null && (filename.lowercase(Locale.ROOT).endsWith(".colpkg") || "collection.apkg" == filename)
 
@@ -419,9 +421,11 @@ object ImportUtils {
                 DialogHandler.storeMessage(dialogMessage.toMessage())
             }
 
+            @SuppressLint("LocaleRootUsage")
             internal fun isDeckPackage(filename: String?): Boolean =
                 filename != null && filename.lowercase(Locale.ROOT).endsWith(".apkg") && "collection.apkg" != filename
 
+            @SuppressLint("LocaleRootUsage")
             fun hasExtension(
                 filename: String,
                 extension: String?,

--- a/lint-release.xml
+++ b/lint-release.xml
@@ -347,8 +347,9 @@
     <issue id="InconsistentLayout" severity="ignore" />
     <issue id="InflateParams" severity="ignore" />
     <issue id="StaticFieldLeak" severity="ignore" />
-    <issue id="DefaultLocale" severity="ignore" />
+    <issue id="DefaultLocale" severity="error" />
     <issue id="LocaleFolder" severity="ignore" />
+    <issue id="LocaleRootUsage" severity="error" />
     <issue id="GetLocales" severity="ignore" />
     <issue id="InvalidResourceFolder" severity="ignore" />
     <issue id="WrongRegion" severity="ignore" />

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.lint.rules.FixedPreferencesTitleLength
 import com.ichi2.anki.lint.rules.HardcodedPreferenceKey
 import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
+import com.ichi2.anki.lint.rules.LocaleRootDetector
 import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage
 import com.ichi2.anki.lint.rules.TranslationTypo
@@ -57,6 +58,7 @@ class IssueRegistry : IssueRegistry() {
                 DuplicateCrowdInStrings.ISSUE,
                 HardcodedPreferenceKey.ISSUE,
                 JUnitNullAssertionDetector.ISSUE,
+                LocaleRootDetector.ISSUE,
                 PrintStackTraceUsage.ISSUE,
                 NonPositionalFormatSubstitutions.ISSUE,
                 TranslationTypo.ISSUE,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LocaleRootDetector.kt
@@ -1,0 +1,111 @@
+/*
+ *  Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+@file:Suppress("UnstableApiUsage")
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.client.api.UElementHandler
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import com.intellij.psi.PsiField
+import org.jetbrains.uast.UCallExpression
+import org.jetbrains.uast.UExpression
+import org.jetbrains.uast.UQualifiedReferenceExpression
+import org.jetbrains.uast.UReferenceExpression
+
+/**
+ * Flags any usage of Locale.ROOT in code, requiring explicit suppression for valid cases.
+ */
+class LocaleRootDetector :
+    Detector(),
+    SourceCodeScanner {
+    companion object {
+        @VisibleForTesting
+        const val ID = "LocaleRootUsage"
+
+        @VisibleForTesting
+        const val DESCRIPTION = "Avoid using Locale.ROOT for user-facing text without explicit suppression"
+
+        private const val EXPLANATION =
+            "Using Locale.ROOT for user-facing text formatting is discouraged. " +
+                "Please use Locale.getDefault() or the device's locale for proper localization, or suppress."
+
+        private val implementation =
+            Implementation(
+                LocaleRootDetector::class.java,
+                Scope.JAVA_FILE_SCOPE,
+            )
+
+        val ISSUE: Issue =
+            Issue.create(
+                ID,
+                DESCRIPTION,
+                EXPLANATION,
+                Constants.ANKI_TIME_CATEGORY,
+                Constants.ANKI_TIME_PRIORITY,
+                Constants.ANKI_TIME_SEVERITY,
+                implementation,
+            )
+    }
+
+    override fun getApplicableUastTypes() = listOf(UCallExpression::class.java)
+
+    override fun createUastHandler(context: JavaContext): UElementHandler =
+        object : UElementHandler() {
+            override fun visitCallExpression(node: UCallExpression) {
+                node.valueArguments.forEach { arg ->
+                    if (isLocaleRootUsage(arg as? UExpression)) {
+                        context.report(
+                            ISSUE,
+                            arg,
+                            context.getLocation(arg),
+                            DESCRIPTION,
+                            createFix(),
+                        )
+                    }
+                }
+            }
+        }
+
+    private fun isLocaleRootUsage(arg: UExpression?): Boolean {
+        val uRef = arg as? UQualifiedReferenceExpression ?: return false
+        val receiver = uRef.receiver
+        val selector = uRef.selector as? UReferenceExpression ?: return false
+
+        // Check if receiver is "Locale" and selector resolves to Locale.ROOT
+        val receiverText = receiver.asSourceString()
+        val resolvedField = selector.resolve() as? PsiField ?: return false
+
+        return receiverText == "Locale" &&
+            resolvedField.containingClass?.qualifiedName == "java.util.Locale" &&
+            resolvedField.name == "ROOT"
+    }
+
+    private fun createFix(): LintFix =
+        fix()
+            .name("Replace with Locale.getDefault(), or suppress")
+            .replace()
+            .text("Locale.ROOT")
+            .with("Locale.getDefault()")
+            .build()
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LocaleRootDetectorTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/LocaleRootDetectorTest.kt
@@ -1,0 +1,79 @@
+/****************************************************************************************
+ * Copyright (c) 2024 Spencer Poisseroux <me@spoisseroux.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.checks.infrastructure.TestFile.JavaTestFile.create
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import com.android.tools.lint.checks.infrastructure.TestMode
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class LocaleRootDetectorTest {
+    @Language("JAVA")
+    private val invalidCode =
+        """
+        package com.ichi2.test;
+        import java.util.Locale;
+        import java.text.NumberFormat;
+        import static java.util.Locale.ROOT;
+
+        public class InvalidClass {
+            public void invalidMethod() {
+                String.format(Locale.ROOT, "Number: %d", 42); // Should be flagged
+                NumberFormat.getInstance(ROOT); // Should be ignored, static import
+            }
+        }
+        """.trimIndent()
+
+    @Language("JAVA")
+    private val suppressedCode =
+        """
+        package com.ichi2.test;
+        import java.util.Locale;
+        import androidx.annotation.SuppressLint;
+
+        @SuppressLint("LocaleRootUsage")
+        public class SuppressedClass {
+            public void suppressedMethod() {
+                String id = String.format(Locale.ROOT, "ID_%d", 123);
+            }
+        }
+        """.trimIndent()
+
+    @Test
+    fun `allows suppressed Locale ROOT usage`() {
+        lint()
+            .testModes(TestMode.DEFAULT)
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(create(suppressedCode))
+            .issues(LocaleRootDetector.ISSUE)
+            .run()
+            .expectClean()
+    }
+
+    @Test
+    fun `detects explicit Locale ROOT usage`() {
+        lint()
+            .testModes(TestMode.DEFAULT)
+            .allowMissingSdk()
+            .files(create(invalidCode))
+            .issues(LocaleRootDetector.ISSUE)
+            .run()
+            .expectErrorCount(1)
+            .expectContains("String.format(Locale.ROOT")
+    }
+}


### PR DESCRIPTION
## Purpose / Description
User-facing text formatting sometimes uses Locale.ROOT or lacks explicit locale, leading to incorrect number/date formats 

## Fixes
* Fixes #8917

## Approach
- Created LocaleRootDetector to flag Locale.ROOT in user-facing formatting methods (ie., String.format(), NumberFormat).
- Activated DefaultLocale lint rule to enforce explicit Locale parameters.
- Updated violations to use Locale.getDefault() where appropriate.

## How Has This Been Tested?
./gradlew clean lint 

## Learning (optional, can help others)
[Android custom lint rules](https://googlesamples.github.io/android-custom-lint-rules/)
Used existing custom lint rules as a template

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [NA] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [NA] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
