### PR TITLE
Fixed sudden crash when  try to manage columns

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
@@ -187,7 +187,11 @@ class BrowserColumnSelectionFragment : DialogFragment(R.layout.browser_columns_s
                     recyclerView: RecyclerView,
                     viewHolder: RecyclerView.ViewHolder,
                 ) {
-                    columnAdapter.refreshDataset()
+                    // Use post to defer adapter refresh and avoid IllegalStateException during layout
+                    super.clearView(recyclerView, viewHolder)
+                    recyclerView.post {
+                        columnAdapter.refreshDataset()
+                    }
                 }
             }
         val itemTouchHelper = ItemTouchHelper(callback)


### PR DESCRIPTION
## Purpose / Description
Fix a crash in the column management screen when dragging columns. The app crashes with an `IllegalStateException` when trying to update the `RecyclerView` adapter while the `RecyclerView` is still computing layout or scrolling.

## Fixes
* Fixes  #17999

## Approach
Modified the `clearView` method in the `ItemTouchHelper` callback to defer the adapter refresh operation using `recyclerView.post()`. This ensures that the adapter is only updated after the current layout pass is complete, preventing the `IllegalStateException`.

## How Has This Been Tested?
Tested on **Android 11** by:
- Opening the **card browser**
- Selecting **"Manage columns"** option
- Dragging columns between sections (**Active** and **Available**)
- Rapidly reordering multiple columns

No more crashes occur when manipulating columns.

## Learning (optional, can help others)
This is a common issue with `RecyclerView` where modifying adapter data during layout or scrolling operations leads to crashes. The Android View's `post()` method is useful for deferring UI operations until after the current UI thread work is complete.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings).
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).
