### PR TITLE
NF: rename `model` into `noteType` in unit tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -299,8 +299,8 @@ open class CardTemplateEditor :
     }
 
     fun noteTypeHasChanged(): Boolean {
-        val oldModel: NotetypeJson? = getColUnsafe.notetypes.get(noteTypeId)
-        return tempNoteType != null && tempNoteType!!.notetype.toString() != oldModel.toString()
+        val oldNoteType: NotetypeJson? = getColUnsafe.notetypes.get(noteTypeId)
+        return tempNoteType != null && tempNoteType!!.notetype.toString() != oldNoteType.toString()
     }
 
     private fun showDiscardChangesDialog() =
@@ -1129,7 +1129,7 @@ open class CardTemplateEditor :
             // pending deletes could orphan cards
             if (!CardTemplateNotetype.isOrdinalPendingAdd(tempModel!!, position)) {
                 val currentDeletes = tempModel.getDeleteDbOrds(position)
-                val cardIds = withCol { notetypes.getCardIdsForModel(tempModel.noteTypeId, currentDeletes) }
+                val cardIds = withCol { notetypes.getCardIdsForNoteType(tempModel.noteTypeId, currentDeletes) }
                 if (cardIds == null) {
                     // It is possible but unlikely that a user has an in-memory template addition that would
                     // generate cards making the deletion safe, but we don't handle that. All users who do

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -664,7 +664,7 @@ class Notetypes(
      * @return null if deleting ords would orphan notes, long[] of related card ids to delete if it is safe
      */
     @Suppress("ktlint:standard:max-line-length")
-    fun getCardIdsForModel(
+    fun getCardIdsForNoteType(
         noteTypeId: NoteTypeId,
         ords: IntArray,
     ): List<Long>? {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -30,7 +30,7 @@ import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.createBasicTypingModel
+import com.ichi2.utils.createBasicTypingNoteType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
@@ -251,8 +251,8 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     @Flaky(OS.ALL, "executeCommand(FLIP_OR_ANSWER_EASE4) cannot be awaited")
     fun typedLanguageIsSet() =
         runTest {
-            val withLanguage = col.createBasicTypingModel("a")
-            val normal = col.createBasicTypingModel("b")
+            val withLanguage = col.createBasicTypingNoteType("a")
+            val normal = col.createBasicTypingNoteType("b")
             val typedField = 1 // BACK
 
             LanguageHintService.setLanguageHintForField(col.notetypes, withLanguage, typedField, Locale("ja"))
@@ -261,12 +261,12 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
             addNoteUsingNoteTypeName(normal.name, "one", "two")
             val viewer = getViewer(false)
 
-            assertThat("A model with a language hint (japanese) should use it", viewer.hintLocale, equalTo("ja"))
+            assertThat("A note type with a language hint (japanese) should use it", viewer.hintLocale, equalTo("ja"))
 
             viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
             viewer.executeCommand(ViewerCommand.FLIP_OR_ANSWER_EASE4)
 
-            assertThat("A default model should have no preference", viewer.hintLocale, nullValue())
+            assertThat("A default note type should have no preference", viewer.hintLocale, nullValue())
         }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -24,7 +24,7 @@ import com.ichi2.anki.AnkiDroidJsAPI.Companion.VALUE_KEY
 import com.ichi2.anki.utils.ext.CardExt.setFlag
 import com.ichi2.libanki.CardType
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.BASIC_MODEL_NAME
+import com.ichi2.utils.BASIC_NOTE_TYPE_NAME
 import net.ankiweb.rsdroid.withoutUnicodeIsolation
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
@@ -41,7 +41,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiGetNextTimeTest() =
         runTest {
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
 
@@ -74,7 +74,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiTestCurrentCard() =
         runTest {
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
 
@@ -184,7 +184,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiJsUiTest() =
         runTest {
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
 
@@ -226,7 +226,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         runTest {
             // js api test for marking and flagging card
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
 
@@ -286,7 +286,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             // count number of notes, if buried or suspended then
             // in scheduling the count will be less than previous scheduling
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
             addBasicNote("baz", "bak")
@@ -354,7 +354,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
         runTest {
             TimeManager.reset()
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didA
             addBasicNote("foo", "bar")
             addBasicNote("baz", "bak")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -805,7 +805,7 @@ class CardBrowserTest : RobolectricTest() {
     /** PR #8553  */
     @Test
     fun checkDisplayOrderPersistence() {
-        // Start the Card Browser with Basic Model
+        // Start the Card Browser with Basic Note Type
         ensureCollectionLoadIsSynchronous()
         var cardBrowserController =
             Robolectric

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -49,12 +49,12 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Test
     @Throws(Exception::class)
     fun testEditTemplateContents() {
-        val modelName = "Basic"
+        val noteTypeName = "Basic"
 
-        // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
-        val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+        // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
+        val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+        intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
         var templateEditorController =
             Robolectric
                 .buildActivity(CardTemplateEditor::class.java, intent)
@@ -64,23 +64,23 @@ class CardTemplateEditorTest : RobolectricTest() {
                 .visible()
         saveControllerForCleanup(templateEditorController)
         var testEditor = templateEditorController.get()
-        assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
+        assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
 
-        // Change the model and make sure it registers as changed, but the database is unchanged
+        // Change the note type and make sure it registers as changed, but the database is unchanged
         var templateFront = testEditor.findViewById<EditText>(R.id.editor_editText)
-        val testModelQfmtEdit = "!@#$%^&*TEST*&^%$#@!"
-        templateFront.text.append(testModelQfmtEdit)
+        val testNoteTypeQfmtEdit = "!@#$%^&*TEST*&^%$#@!"
+        templateFront.text.append(testNoteTypeQfmtEdit)
         advanceRobolectricLooperWithSleep()
-        assertTrue("Model did not change after edit?", testEditor.noteTypeHasChanged())
+        assertTrue("Note type did not change after edit?", testEditor.noteTypeHasChanged())
         assertEquals(
             "Change already in database?",
-            collectionBasicModelOriginal.toString().trim {
+            collectionBasicNoteTypeOriginal.toString().trim {
                 it <= ' '
             },
-            getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
         )
 
-        // Kill and restart the Activity, make sure model edit is preserved
+        // Kill and restart the Activity, make sure note type edit is preserved
         val outBundle = Bundle()
         templateEditorController.saveInstanceState(outBundle)
         templateEditorController.pause().stop().destroy()
@@ -94,13 +94,13 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         testEditor = templateEditorController.get()
         var shadowTestEditor = shadowOf(testEditor)
-        assertTrue("model change not preserved across activity lifecycle?", testEditor.noteTypeHasChanged())
+        assertTrue("note type change not preserved across activity lifecycle?", testEditor.noteTypeHasChanged())
         assertEquals(
             "Change already in database?",
-            collectionBasicModelOriginal.toString().trim {
+            collectionBasicNoteTypeOriginal.toString().trim {
                 it <= ' '
             },
-            getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
         )
 
         // Make sure we get a confirmation dialog if we hit the back button
@@ -109,14 +109,14 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard current input?")
         clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, false)
         advanceRobolectricLooperWithSleep()
-        assertTrue("model change not preserved despite canceling back button?", testEditor.noteTypeHasChanged())
+        assertTrue("note type change not preserved despite canceling back button?", testEditor.noteTypeHasChanged())
 
         // Make sure we things are cleared out after a cancel
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
         assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard current input?")
         clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, false)
         advanceRobolectricLooperWithSleep()
-        assertFalse("model change not cleared despite discarding changes?", testEditor.noteTypeHasChanged())
+        assertFalse("note type change not cleared despite discarding changes?", testEditor.noteTypeHasChanged())
 
         // Get going for content edit assertions again...
         templateEditorController =
@@ -130,9 +130,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         testEditor = templateEditorController.get()
         shadowTestEditor = shadowOf(testEditor)
         templateFront = testEditor.findViewById(R.id.editor_editText)
-        templateFront.text.append(testModelQfmtEdit)
+        templateFront.text.append(testNoteTypeQfmtEdit)
         advanceRobolectricLooperWithSleep()
-        assertTrue("Model did not change after edit?", testEditor.noteTypeHasChanged())
+        assertTrue("Note type did not change after edit?", testEditor.noteTypeHasChanged())
 
         // Make sure we pass the edit to the Previewer
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
@@ -143,38 +143,38 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Previewer not started?", CardViewerActivity::class.java.name, shadowIntent.intentClass.name)
         assertEquals(
             "Change already in database?",
-            collectionBasicModelOriginal.toString().trim {
+            collectionBasicNoteTypeOriginal.toString().trim {
                 it <= ' '
             },
-            getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
         )
         shadowTestEditor.receiveResult(startedIntent, Activity.RESULT_OK, Intent())
 
         // Save the template then fetch it from the collection to see if it was saved correctly
-        val testEditorModelEdited = testEditor.tempNoteType?.notetype
+        val testEditorNoteTypeEdited = testEditor.tempNoteType?.notetype
         advanceRobolectricLooperWithSleep()
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
-        val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        val collectionBasicNoteTypeCopyEdited = getCurrentDatabaseNoteTypeCopy(noteTypeName)
+        assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
-            "model did not save?",
-            testEditorModelEdited.toString().trim {
+            "note type did not save?",
+            testEditorNoteTypeEdited.toString().trim {
                 it <= ' '
             },
-            collectionBasicModelCopyEdited.toString().trim { it <= ' ' },
+            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
         )
-        assertTrue("model does not have our change?", collectionBasicModelCopyEdited.toString().contains(testModelQfmtEdit))
+        assertTrue("Note type does not have our change?", collectionBasicNoteTypeCopyEdited.toString().contains(testNoteTypeQfmtEdit))
     }
 
     @Test
     fun testDeleteTemplate() {
-        val modelName = "Basic (and reversed card)"
+        val noteTypeName = "Basic (and reversed card)"
 
-        // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
-        val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+        // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
+        val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+        intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
         val templateEditorController =
             Robolectric
                 .buildActivity(CardTemplateEditor::class.java, intent)
@@ -184,8 +184,8 @@ class CardTemplateEditorTest : RobolectricTest() {
                 .visible()
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
-        assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
+        assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
+        assertEquals("Note type should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
 
         // Try to delete the template - click delete, click confirm for card delete, click confirm again for full sync
         val shadowTestEditor = shadowOf(testEditor)
@@ -194,8 +194,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getAlertDialogText(true))
         clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
         advanceRobolectricLooperWithSleep()
-        assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
-        assertEquals("Model should have 1 template now", 1, testEditor.tempNoteType?.templateCount)
+        assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
+        assertEquals("Note type should have 1 template now", 1, testEditor.tempNoteType?.templateCount)
 
         // Try to delete the template again, but there's only one
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
@@ -207,24 +207,24 @@ class CardTemplateEditorTest : RobolectricTest() {
         )
         assertEquals(
             "Change already in database?",
-            collectionBasicModelOriginal.toString().trim {
+            collectionBasicNoteTypeOriginal.toString().trim {
                 it <= ' '
             },
-            getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
         )
 
         // Save the change to the database and make sure there's only one template after
-        val testEditorModelEdited = testEditor.tempNoteType?.notetype
+        val testEditorNoteTypeEdited = testEditor.tempNoteType?.notetype
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
-        val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        val collectionBasicNoteTypeCopyEdited = getCurrentDatabaseNoteTypeCopy(noteTypeName)
+        assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
-            "model did not save?",
-            testEditorModelEdited.toString().trim {
+            "Note type did not save?",
+            testEditorNoteTypeEdited.toString().trim {
                 it <= ' '
             },
-            collectionBasicModelCopyEdited.toString().trim { it <= ' ' },
+            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
         )
     }
 
@@ -232,10 +232,10 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Throws(Exception::class)
     fun testTemplateAdd() {
         // Make sure we test previewing a new card template - not working for real yet
-        val modelName = "Basic"
-        val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+        val noteTypeName = "Basic"
+        val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+        intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
         val templateEditorController =
             Robolectric
                 .buildActivity(CardTemplateEditor::class.java, intent)
@@ -253,11 +253,11 @@ class CardTemplateEditorTest : RobolectricTest() {
         // if AnkiDroid moves to match AnkiDesktop it will pop a dialog to confirm card create
         // Assert.assertEquals("Wrong dialog shown?", "This will create NN cards. Proceed?", getDialogText());
         // clickDialogButton(WhichButton.POSITIVE);
-        assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
+        assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
         assertEquals("Change not pending add?", 1, CardTemplateNotetype.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempNoteType!!, 0))
         assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
         assertTrue("Ordinal not pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
-        assertEquals("Model should have 2 templates now", 2, testEditor.tempNoteType!!.templateCount)
+        assertEquals("Note type should have 2 templates now", 2, testEditor.tempNoteType!!.templateCount)
 
         // Make sure we pass the new template to the Previewer
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_preview))
@@ -266,37 +266,37 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Previewer not started?", CardViewerActivity::class.java.name, shadowIntent.intentClass.name)
         assertEquals(
             "Change already in database?",
-            collectionBasicModelOriginal.toString().trim {
+            collectionBasicNoteTypeOriginal.toString().trim {
                 it <= ' '
             },
-            getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
         )
 
         // Save the change to the database and make sure there are two templates after
-        val testEditorModelEdited = testEditor.tempNoteType?.notetype
+        val testEditorNoteTypeEdited = testEditor.tempNoteType?.notetype
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
         advanceRobolectricLooperWithSleep()
-        val collectionBasicModelCopyEdited = getCurrentDatabaseModelCopy(modelName)
-        assertNotEquals("model is unchanged?", collectionBasicModelOriginal, collectionBasicModelCopyEdited)
+        val collectionBasicNoteTypeCopyEdited = getCurrentDatabaseNoteTypeCopy(noteTypeName)
+        assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
-            "model did not save?",
-            testEditorModelEdited.toString().trim {
+            "Note type did not save?",
+            testEditorNoteTypeEdited.toString().trim {
                 it <= ' '
             },
-            collectionBasicModelCopyEdited.toString().trim { it <= ' ' },
+            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
         )
     }
 
     /**
-     * In a model with two card templates using different fields, some notes may only use card 1,
+     * In a note type with two card templates using different fields, some notes may only use card 1,
      * and some may only use card 2. If you delete the 2nd template,
      * it will cause the notes that only use card 2 to disappear.
      *
-     * So the unit test would then be to make a model like the "basic (optional reverse card)"
+     * So the unit test would then be to make a note type like the "basic (optional reverse card)"
      * with two fields Enable1 and Enable2, and two templates "card 1" and "card 2".
      * Both cards use selective generation, so they're empty unless the corresponding field is set.
      *
-     * So then in the unit test you make the model, add the two templates, then you add two notes,
+     * So then in the unit test you make the note type, add the two templates, then you add two notes,
      * with Enable1 and Enable2 respectively set to "y".
      * Then you try to delete one of the templates and it should fail
      *
@@ -308,12 +308,12 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Test
     fun testDeleteTemplateWithSelectivelyGeneratedCards() =
         runTest {
-            val modelName = "Basic (optional reversed card)"
-            val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+            val noteTypeName = "Basic (optional reversed card)"
+            val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
 
-            // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
+            // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
             val intent = Intent(Intent.ACTION_VIEW)
-            intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+            intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
             val templateEditorController =
                 Robolectric
                     .buildActivity(
@@ -325,8 +325,8 @@ class CardTemplateEditorTest : RobolectricTest() {
                     .visible()
             saveControllerForCleanup(templateEditorController)
             val testEditor = templateEditorController.get()
-            assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
-            assertEquals("Model should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
+            assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
+            assertEquals("Note type should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
 
@@ -337,10 +337,10 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertEquals("Wrong dialog shown?", "Delete the “Card 1” card type, and its 0 cards?", getAlertDialogText(true))
             clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, true)
             advanceRobolectricLooperWithSleep()
-            assertFalse("Model should not have changed", testEditor.noteTypeHasChanged())
+            assertFalse("Note type should not have changed", testEditor.noteTypeHasChanged())
 
             // Create note with forward and back info, Add Reverse is empty, so should only be one card
-            val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
+            val selectiveGeneratedNote = col.newNote(collectionBasicNoteTypeOriginal)
             selectiveGeneratedNote.setField(0, "TestFront")
             selectiveGeneratedNote.setField(1, "TestBack")
             val fields = selectiveGeneratedNote.fields
@@ -348,7 +348,7 @@ class CardTemplateEditorTest : RobolectricTest() {
                 Timber.d("Got a field: %s", field)
             }
             col.addNote(selectiveGeneratedNote)
-            assertEquals("selective generation should result in one card", 1, getModelCardCount(collectionBasicModelOriginal))
+            assertEquals("selective generation should result in one card", 1, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
 
             // Try to delete the template again, but there's selective generation means it would orphan the note
             assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_delete))
@@ -362,44 +362,44 @@ class CardTemplateEditorTest : RobolectricTest() {
             advanceRobolectricLooperWithSleep()
             assertNull(
                 "Can delete used template?",
-                collectionBasicModelOriginal.getCardIds(0),
+                collectionBasicNoteTypeOriginal.getCardIds(0),
             )
             assertEquals(
                 "Change already in database?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertEquals("Change incorrectly added to list?", 0, testEditor.templateChangeCount)
 
             // Assert can delete 'Card 2'
-            assertNotNull("Cannot delete unused template?", collectionBasicModelOriginal.getCardIds(1))
+            assertNotNull("Cannot delete unused template?", collectionBasicNoteTypeOriginal.getCardIds(1))
 
             // Edit note to have Add Reverse set to 'y' so we get a second card
             selectiveGeneratedNote.setField(2, "y")
             selectiveGeneratedNote.flush()
 
             // - assert two cards
-            assertEquals("should be two cards now", 2, getModelCardCount(collectionBasicModelOriginal))
+            assertEquals("should be two cards now", 2, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
 
             // - assert can delete either Card template but not both
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNull("Can delete both templates?", collectionBasicModelOriginal.getCardIds(0, 1))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
 
             // A couple more notes to make sure things are okay
-            val secondNote = col.newNote(collectionBasicModelOriginal)
+            val secondNote = col.newNote(collectionBasicNoteTypeOriginal)
             secondNote.setField(0, "TestFront2")
             secondNote.setField(1, "TestBack2")
             secondNote.setField(2, "y")
             col.addNote(secondNote)
 
             // - assert can delete either Card template but not both
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNull("Can delete both templates?", collectionBasicModelOriginal.getCardIds(0, 1))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
         }
 
     /**
@@ -408,12 +408,12 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Test
     fun testDeleteTemplateWithGeneratedCards() =
         runTest {
-            val modelName = "Basic (and reversed card)"
-            var collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+            val noteTypeName = "Basic (and reversed card)"
+            var collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
 
-            // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
+            // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
             var intent = Intent(Intent.ACTION_VIEW)
-            intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+            intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
             var templateEditorController =
                 Robolectric
                     .buildActivity(
@@ -425,17 +425,17 @@ class CardTemplateEditorTest : RobolectricTest() {
                     .visible()
             saveControllerForCleanup(templateEditorController)
             var testEditor = templateEditorController.get()
-            assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
-            assertEquals("Model should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
+            assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
+            assertEquals("Note type should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
 
             // Create note with forward and back info
-            val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
+            val selectiveGeneratedNote = col.newNote(collectionBasicNoteTypeOriginal)
             selectiveGeneratedNote.setField(0, "TestFront")
             selectiveGeneratedNote.setField(1, "TestBack")
             col.addNote(selectiveGeneratedNote)
-            assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal))
+            assertEquals("card generation should result in two cards", 2, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
 
             // Test if we can delete the template - should be possible - but cancel the delete
             var shadowTestEditor = shadowOf(testEditor)
@@ -448,21 +448,21 @@ class CardTemplateEditorTest : RobolectricTest() {
             )
             clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, true)
             advanceRobolectricLooperWithSleep()
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNull("Can delete both templates?", collectionBasicModelOriginal.getCardIds(0, 1))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no change?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
-            assertEquals("Model should have 2 templates still", 2, testEditor.tempNoteType?.templateCount)
+            assertEquals("Note type should have 2 templates still", 2, testEditor.tempNoteType?.templateCount)
 
             // Add a template - click add, click confirm for card add, click confirm again for full sync
             addCardType(testEditor, shadowTestEditor)
-            assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
+            assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
             assertEquals(
                 "Change added but not adjusted correctly?",
                 2,
@@ -473,14 +473,14 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertTrue("Ordinal not pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(2))
             assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
             advanceRobolectricLooperWithSleep()
-            assertFalse("Model should now be unchanged", testEditor.noteTypeHasChanged())
-            assertEquals("card generation should result in three cards", 3, getModelCardCount(collectionBasicModelOriginal))
-            // reload the model for future comparison after saving the edit
-            collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+            assertFalse("Note type should now be unchanged", testEditor.noteTypeHasChanged())
+            assertEquals("card generation should result in three cards", 3, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
+            // reload the note type for future comparison after saving the edit
+            collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
 
             // Start the CardTemplateEditor back up after saving (which closes the thing...)
             intent = Intent(Intent.ACTION_VIEW)
-            intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+            intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
             templateEditorController =
                 Robolectric
                     .buildActivity(CardTemplateEditor::class.java, intent)
@@ -490,11 +490,11 @@ class CardTemplateEditorTest : RobolectricTest() {
                     .visible()
             testEditor = templateEditorController.get()
             shadowTestEditor = shadowOf(testEditor)
-            assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
+            assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(2))
-            assertEquals("Model should have 3 templates now", 3, testEditor.tempNoteType?.templateCount)
+            assertEquals("Note type should have 3 templates now", 3, testEditor.tempNoteType?.templateCount)
 
             // Add another template - but we work in memory for a while before saving
             addCardType(testEditor, shadowTestEditor)
@@ -503,8 +503,8 @@ class CardTemplateEditorTest : RobolectricTest() {
                 3,
                 CardTemplateNotetype.getAdjustedAddOrdinalAtChangeIndex(testEditor.tempNoteType!!, 0),
             )
-            assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
-            assertEquals("Model should have 4 templates now", 4, testEditor.tempNoteType?.templateCount)
+            assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
+            assertEquals("Note type should have 4 templates now", 4, testEditor.tempNoteType?.templateCount)
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(2))
@@ -540,19 +540,19 @@ class CardTemplateEditorTest : RobolectricTest() {
             advanceRobolectricLooperWithSleep()
 
             // - assert can delete any 1 or 2 Card templates but not all
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(2))
-            assertNotNull("Cannot delete two templates?", collectionBasicModelOriginal.getCardIds(0, 1))
-            assertNotNull("Cannot delete two templates?", collectionBasicModelOriginal.getCardIds(0, 2))
-            assertNotNull("Cannot delete two templates?", collectionBasicModelOriginal.getCardIds(1, 2))
-            assertNull("Can delete all templates?", collectionBasicModelOriginal.getCardIds(0, 1, 2))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(2))
+            assertNotNull("Cannot delete two templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
+            assertNotNull("Cannot delete two templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 2))
+            assertNotNull("Cannot delete two templates?", collectionBasicNoteTypeOriginal.getCardIds(1, 2))
+            assertNull("Can delete all templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1, 2))
             assertEquals(
                 "Change already in database?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
             assertEquals(
                 "Change added but not adjusted correctly?",
@@ -576,13 +576,13 @@ class CardTemplateEditorTest : RobolectricTest() {
             advanceRobolectricLooperWithSleep()
             assertNotEquals(
                 "Change not in database?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
-            assertEquals("Model should have 2 templates now", 2, getCurrentDatabaseModelCopy(modelName).templates.length())
-            assertEquals("should be two cards", 2, getModelCardCount(collectionBasicModelOriginal))
+            assertEquals("Note type should have 2 templates now", 2, getCurrentDatabaseNoteTypeCopy(noteTypeName).templates.length())
+            assertEquals("should be two cards", 2, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
         }
 
     /**
@@ -591,12 +591,12 @@ class CardTemplateEditorTest : RobolectricTest() {
     @Test
     fun testDeletePendingAddExistingCardCount() =
         runTest {
-            val modelName = "Basic (optional reversed card)"
-            val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+            val noteTypeName = "Basic (optional reversed card)"
+            val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
 
-            // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
+            // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
             val intent = Intent(Intent.ACTION_VIEW)
-            intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+            intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
             val templateEditorController =
                 Robolectric
                     .buildActivity(
@@ -608,18 +608,18 @@ class CardTemplateEditorTest : RobolectricTest() {
                     .visible()
             saveControllerForCleanup(templateEditorController)
             val testEditor = templateEditorController.get()
-            assertFalse("Model should not have changed yet", testEditor.noteTypeHasChanged())
-            assertEquals("Model should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
+            assertFalse("Note type should not have changed yet", testEditor.noteTypeHasChanged())
+            assertEquals("Note type should have 2 templates now", 2, testEditor.tempNoteType?.templateCount)
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
 
             // Create note with forward and back info
-            val selectiveGeneratedNote = col.newNote(collectionBasicModelOriginal)
+            val selectiveGeneratedNote = col.newNote(collectionBasicNoteTypeOriginal)
             selectiveGeneratedNote.setField(0, "TestFront")
             selectiveGeneratedNote.setField(1, "TestBack")
             selectiveGeneratedNote.setField(2, "y")
             col.addNote(selectiveGeneratedNote)
-            assertEquals("card generation should result in two cards", 2, getModelCardCount(collectionBasicModelOriginal))
+            assertEquals("card generation should result in two cards", 2, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
 
             // Delete ord 1 / 'Card 2' and check the message
             val shadowTestEditor = shadowOf(testEditor)
@@ -633,22 +633,22 @@ class CardTemplateEditorTest : RobolectricTest() {
             )
             clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
             advanceRobolectricLooperWithSleep()
-            assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNull("Can delete both templates?", collectionBasicModelOriginal.getCardIds(0, 1))
+            assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no save?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
-            assertEquals("Model should have 1 template", 1, testEditor.tempNoteType?.templateCount)
+            assertEquals("Note type should have 1 template", 1, testEditor.tempNoteType?.templateCount)
 
             // Add a template - click add, click confirm for card add, click confirm again for full sync
             addCardType(testEditor, shadowTestEditor)
-            assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
+            assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
             assertEquals(
                 "Change added but not adjusted correctly?",
                 1,
@@ -656,7 +656,7 @@ class CardTemplateEditorTest : RobolectricTest() {
             )
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertTrue("Ordinal not pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(1))
-            assertEquals("Model should have 2 templates", 2, testEditor.tempNoteType?.templateCount)
+            assertEquals("Note type should have 2 templates", 2, testEditor.tempNoteType?.templateCount)
 
             // Delete ord 1 / 'Card 2' again and check the message - it's in the same spot as the pre-existing template but there are no cards actually associated
             testEditor.viewPager.currentItem = 1
@@ -669,32 +669,32 @@ class CardTemplateEditorTest : RobolectricTest() {
             )
             clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, true)
             advanceRobolectricLooperWithSleep()
-            assertTrue("Model should have changed", testEditor.noteTypeHasChanged())
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(0))
-            assertNotNull("Cannot delete template?", collectionBasicModelOriginal.getCardIds(1))
-            assertNull("Can delete both templates?", collectionBasicModelOriginal.getCardIds(0, 1))
+            assertTrue("Note type should have changed", testEditor.noteTypeHasChanged())
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(0))
+            assertNotNull("Cannot delete template?", collectionBasicNoteTypeOriginal.getCardIds(1))
+            assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no save?",
-                collectionBasicModelOriginal.toString().trim {
+                collectionBasicNoteTypeOriginal.toString().trim {
                     it <= ' '
                 },
-                getCurrentDatabaseModelCopy(modelName).toString().trim { it <= ' ' },
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
             )
-            assertEquals("Model should have 1 template", 1, testEditor.tempNoteType?.templateCount)
+            assertEquals("Note type should have 1 template", 1, testEditor.tempNoteType?.templateCount)
 
             // Save it out and make some assertions
             assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(R.id.action_confirm))
             advanceRobolectricLooperWithSleep()
-            assertFalse("Model should now be unchanged", testEditor.noteTypeHasChanged())
-            assertEquals("card generation should result in 1 card", 1, getModelCardCount(collectionBasicModelOriginal))
+            assertFalse("Note type should now be unchanged", testEditor.noteTypeHasChanged())
+            assertEquals("card generation should result in 1 card", 1, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
         }
 
     @Test
     fun testDeckOverride() {
-        val modelName = "Basic (optional reversed card)"
-        val model = getCurrentDatabaseModelCopy(modelName)
+        val noteTypeName = "Basic (optional reversed card)"
+        val noteType = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", model.id)
+        intent.putExtra("noteTypeId", noteType.id)
         val editor = super.startActivityNormallyOpenCollectionWithIntent(CardTemplateEditor::class.java, intent)
         val template = editor.tempNoteType?.getTemplate(0)
         MatcherAssert.assertThat("Deck ID element should exist", template?.jsonObject?.has("did"), Matchers.equalTo(true))
@@ -708,12 +708,12 @@ class CardTemplateEditorTest : RobolectricTest() {
 
     @Test
     fun testContentPreservedAfterChangingEditorView() {
-        val modelName = "Basic"
+        val noteTypeName = "Basic"
 
-        // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
-        val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+        // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
+        val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+        intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
         val templateEditorController =
             Robolectric
                 .buildActivity(CardTemplateEditor::class.java, intent)
@@ -724,20 +724,20 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
 
-        // Change the model and make sure it registers as changed, but the database is unchanged
+        // Change the note type and make sure it registers as changed, but the database is unchanged
         val templateEditText = testEditor.findViewById<EditText>(R.id.editor_editText)
-        val testModelQfmtEdit = "!@#$%^&*TEST*&^%$#@!"
-        val updatedFrontContent = templateEditText.text.append(testModelQfmtEdit).toString()
+        val testNoteTypeQfmtEdit = "!@#$%^&*TEST*&^%$#@!"
+        val updatedFrontContent = templateEditText.text.append(testNoteTypeQfmtEdit).toString()
         advanceRobolectricLooperWithSleep()
         val cardTemplateFragment = testEditor.currentFragment
-        val tempModel = testEditor.tempNoteType
+        val tempNoteType = testEditor.tempNoteType
         // set Bottom Navigation View to Style
-        cardTemplateFragment!!.setCurrentEditorView(R.id.styling_edit, tempModel!!.css, R.string.card_template_editor_styling)
+        cardTemplateFragment!!.setCurrentEditorView(R.id.styling_edit, tempNoteType!!.css, R.string.card_template_editor_styling)
 
         // set Bottom Navigation View to Front
         cardTemplateFragment.setCurrentEditorView(
             R.id.front_edit,
-            tempModel.getTemplate(0).qfmt,
+            tempNoteType.getTemplate(0).qfmt,
             R.string.card_template_editor_front,
         )
 
@@ -747,12 +747,12 @@ class CardTemplateEditorTest : RobolectricTest() {
 
     @Test
     fun testBottomNavigationViewLayoutTransition() {
-        val modelName = "Basic"
+        val noteTypeName = "Basic"
 
-        // Start the CardTemplateEditor with a specific model, and make sure the model starts unchanged
-        val collectionBasicModelOriginal = getCurrentDatabaseModelCopy(modelName)
+        // Start the CardTemplateEditor with a specific note type, and make sure the note type starts unchanged
+        val collectionBasicNoteTypeOriginal = getCurrentDatabaseNoteTypeCopy(noteTypeName)
         val intent = Intent(Intent.ACTION_VIEW)
-        intent.putExtra("noteTypeId", collectionBasicModelOriginal.id)
+        intent.putExtra("noteTypeId", collectionBasicNoteTypeOriginal.id)
         val templateEditorController =
             Robolectric
                 .buildActivity(CardTemplateEditor::class.java, intent)
@@ -763,21 +763,21 @@ class CardTemplateEditorTest : RobolectricTest() {
         saveControllerForCleanup(templateEditorController)
         val testEditor = templateEditorController.get()
 
-        // Change the model and make sure it registers as changed, but the database is unchanged
+        // Change the note type and make sure it registers as changed, but the database is unchanged
         val templateEditText = testEditor.findViewById<EditText>(R.id.editor_editText)
         advanceRobolectricLooperWithSleep()
         val cardTemplateFragment = testEditor.currentFragment
-        val tempModel = testEditor.tempNoteType
+        val tempNoteType = testEditor.tempNoteType
 
         // check if current view is front(default) view
-        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempModel!!.getTemplate(0).qfmt))
+        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempNoteType!!.getTemplate(0).qfmt))
         assumeThat(cardTemplateFragment!!.currentEditorViewId, Matchers.equalTo(R.id.front_edit))
 
         // set Bottom Navigation View to Style
-        cardTemplateFragment.setCurrentEditorView(R.id.styling_edit, tempModel.css, R.string.card_template_editor_styling)
+        cardTemplateFragment.setCurrentEditorView(R.id.styling_edit, tempNoteType.css, R.string.card_template_editor_styling)
 
         // check if current view is changed or not
-        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempModel.css))
+        assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempNoteType.css))
         assumeThat(cardTemplateFragment.currentEditorViewId, Matchers.equalTo(R.id.styling_edit))
     }
 
@@ -838,7 +838,7 @@ Hello World{{Front}}
         )
     }
 
-    private fun getModelCardCount(notetype: NotetypeJson): Int {
+    private fun getNoteTypeCardCount(notetype: NotetypeJson): Int {
         var cardCount = 0
         for (noteId in col.notetypes.nids(notetype)) {
             cardCount += col.getNote(noteId).numberOfCards()
@@ -854,5 +854,5 @@ Hello World{{Front}}
     private val CardTemplateEditor.templateChangeCount
         get() = tempNoteType?.templateChanges?.size
 
-    private suspend fun NotetypeJson.getCardIds(vararg ords: Int): List<Long>? = withCol { notetypes.getCardIdsForModel(id, ords) }
+    private suspend fun NotetypeJson.getCardIds(vararg ords: Int): List<Long>? = withCol { notetypes.getCardIdsForNoteType(id, ords) }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateNotetypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateNotetypeTest.kt
@@ -34,7 +34,7 @@ import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 class CardTemplateNotetypeTest : RobolectricTest() {
     @Test
     @Throws(Exception::class)
-    fun testTempModelStorage() {
+    fun testTempNoteTypeStorage() {
         // Start off with clean state in the cache dir
         CardTemplateNotetype.clearTempNoteTypeFiles()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ModelFieldEditorTest.kt
@@ -58,7 +58,7 @@ class ModelFieldEditorTest(
      * @param forbiddenFieldName The forbidden field name to identify
      */
     private fun testForIllegalCharacters(forbiddenFieldName: String) {
-        val modelFields = getCurrentDatabaseModelCopy("Basic").fieldsNames
+        val modelFields = getCurrentDatabaseNoteTypeCopy("Basic").fieldsNames
         val fieldName = modelFields[modelFields.size - 1]
         MatcherAssert.assertThat("forbidden character detected!", fieldName, Matchers.not(Matchers.equalTo(forbiddenFieldName)))
     }
@@ -104,12 +104,12 @@ class ModelFieldEditorTest(
         AlertDialog.Builder(ContextThemeWrapper(targetContext, R.style.Theme_Light)).show {
             positiveButton(text = "") {
                 try {
-                    val modelName = "Basic"
+                    val noteTypeName = "Basic"
 
                     // start ModelFieldEditor activity
                     val intent = Intent()
-                    intent.putExtra("title", modelName)
-                    intent.putExtra("noteTypeID", col.notetypes.idForName(modelName)!!)
+                    intent.putExtra("title", noteTypeName)
+                    intent.putExtra("noteTypeID", col.notetypes.idForName(noteTypeName)!!)
                     val modelFieldEditor =
                         startActivityNormallyOpenCollectionWithIntent(
                             this@ModelFieldEditorTest,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -51,7 +51,7 @@ import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.BASIC_MODEL_NAME
+import com.ichi2.utils.BASIC_NOTE_TYPE_NAME
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue
@@ -276,10 +276,8 @@ class ReviewerTest : RobolectricTest() {
     @Test
     fun jsAnkiGetDeckName() =
         runTest {
-            val models = col.notetypes
-
             val didAb = addDeck("A::B")
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_NOTE_TYPE_NAME)
             basic!!.did = didAb
             addBasicNote("foo", "bar")
 
@@ -453,14 +451,13 @@ class ReviewerTest : RobolectricTest() {
     @Throws(ConfirmModSchemaException::class)
     @KotlinCleanup("use a assertNotNull which returns rather than !!")
     private fun addNoteWithThreeCards() {
-        val models = col.notetypes
-        var notetype: NotetypeJson = models.copy(models.current())
+        var notetype = col.notetypes.copy(col.notetypes.current())
         notetype.name = "Three"
-        models.add(notetype)
-        notetype = models.byName("Three")!!
+        col.notetypes.add(notetype)
+        notetype = col.notetypes.byName("Three")!!
 
-        cloneTemplate(models, notetype, "1")
-        cloneTemplate(models, notetype, "2")
+        cloneTemplate(col.notetypes, notetype, "1")
+        cloneTemplate(col.notetypes, notetype, "2")
 
         val newNote = col.newNote()
         newNote.setField(0, "Hello")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -363,9 +363,9 @@ open class RobolectricTest :
     }
 
     @Throws(JSONException::class)
-    protected fun getCurrentDatabaseModelCopy(modelName: String): NotetypeJson {
+    protected fun getCurrentDatabaseNoteTypeCopy(noteTypeName: String): NotetypeJson {
         val collectionModels = col.notetypes
-        return collectionModels.byName(modelName)!!.deepClone()
+        return collectionModels.byName(noteTypeName)!!.deepClone()
     }
 
     internal fun <T : AnkiActivity?> startActivityNormallyOpenCollectionWithIntent(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -54,13 +54,13 @@ class NoteServiceTest : RobolectricTest() {
     // tests if the text fields of the notes are the same after calling updateJsonNoteFromMultimediaNote
     @Test
     fun updateJsonNoteTest() {
-        val testModel = col.notetypes.byName("Basic")
-        val multiMediaNote: IMultimediaEditableNote? = NoteService.createEmptyNote(testModel!!)
+        val testNoteType = col.notetypes.byName("Basic")
+        val multiMediaNote: IMultimediaEditableNote? = NoteService.createEmptyNote(testNoteType!!)
         multiMediaNote!!.getField(0)!!.text = "foo"
         multiMediaNote.getField(1)!!.text = "bar"
 
         val basicNote =
-            Note.fromNotetypeId(col, testModel.id).apply {
+            Note.fromNotetypeId(col, testNoteType.id).apply {
                 setField(0, "this should be changed to foo")
                 setField(1, "this should be changed to bar")
             }
@@ -73,11 +73,11 @@ class NoteServiceTest : RobolectricTest() {
     // tests if updateJsonNoteFromMultimediaNote throws a RuntimeException if the ID's of the notes don't match
     @Test
     fun updateJsonNoteRuntimeErrorTest() {
-        // model with ID 42
+        // note type with ID 42
         var testNotetype = NotetypeJson("""{"flds": [{"name": "foo bar", "ord": "1"}], "id": "42"}""")
         val multiMediaNoteWithID42: IMultimediaEditableNote? = NoteService.createEmptyNote(testNotetype)
 
-        // model with ID 45
+        // note type with ID 45
         testNotetype = col.notetypes.newBasicNotetype()
         testNotetype.id = 45
         col.notetypes.add(testNotetype)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -20,7 +20,7 @@ import anki.notes.NoteFieldsCheckResponse
 import anki.notetypes.StockNotetype
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.createBasicModel
+import com.ichi2.utils.createBasicNoteType
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.equalTo
@@ -183,7 +183,7 @@ class CollectionTest : JvmTest() {
         val numberOfStandardModels = StockNotetype.Kind.entries.count { it != StockNotetype.Kind.UNRECOGNIZED }
         assertEquals(col.notetypes.all().size, numberOfStandardModels)
         for (i in 0..99) {
-            col.createBasicModel()
+            col.createBasicNoteType()
         }
         assertEquals(col.notetypes.all().size, (100 + numberOfStandardModels))
     }

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/StorageRustTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/StorageRustTest.kt
@@ -29,9 +29,9 @@ class StorageRustTest : JvmTest() {
     @Test
     @Config(qualifiers = "en")
     fun testModelCount() {
-        val modelNames = col.notetypes.all().map { x -> x.name }
+        val noteTypeNames = col.notetypes.all().map { x -> x.name }
         MatcherAssert.assertThat(
-            modelNames,
+            noteTypeNames,
             Matchers.containsInAnyOrder(
                 "Basic",
                 "Basic (and reversed card)",

--- a/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/NoteTypeTest.kt
@@ -94,18 +94,18 @@ class NoteTypeTest {
     }
 }
 
-const val BASIC_MODEL_NAME = "Basic"
+const val BASIC_NOTE_TYPE_NAME = "Basic"
 
 /**
  * Creates a basic model.
  *
- * Note: changes to this model will propagate to [createBasicTypingModel] as that model is built on
+ * Note: changes to this model will propagate to [createBasicTypingNoteType] as that model is built on
  * top of the model returned by this function.
  *
  * @param name name of the new model
  * @return the new model
  */
-fun Collection.createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
+fun Collection.createBasicNoteType(name: String = BASIC_NOTE_TYPE_NAME): NotetypeJson {
     val noteType =
         getStockNotetype(StockNotetype.Kind.KIND_BASIC).apply { this.name = name }
     addNotetypeLegacy(BackendUtils.toJsonBytes(noteType))
@@ -115,10 +115,10 @@ fun Collection.createBasicModel(name: String = BASIC_MODEL_NAME): NotetypeJson {
 /**
  * Creates a basic typing model.
  *
- * @see createBasicModel
+ * @see createBasicNoteType
  */
-fun Collection.createBasicTypingModel(name: String): NotetypeJson {
-    val noteType = createBasicModel(name)
+fun Collection.createBasicTypingNoteType(name: String): NotetypeJson {
+    val noteType = createBasicNoteType(name)
     noteType.templates[0].apply {
         qfmt = "{{Front}}\n\n{{type:Back}}"
         afmt = "{{Front}}\n\n<hr id=answer>\n\n{{type:Back}}"


### PR DESCRIPTION
This also change the name of some methods that are tested.

This is not changing all instance of the word "model"  that represents a note type, this commit is already big enough to let more changes for a future PR


Some more part of https://github.com/ankidroid/Anki-Android/pull/17598