### PR TITLE
Add missing setting entries to the setting search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -26,7 +26,6 @@ import androidx.preference.PreferenceFragmentCompat
 import com.bytehamster.lib.preferencesearch.SearchConfiguration
 import com.bytehamster.lib.preferencesearch.SearchPreference
 import com.ichi2.anki.BuildConfig
-import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.settings.Prefs
@@ -51,7 +50,7 @@ class HeaderFragment :
         setPreferencesFromResource(R.xml.preference_headers, rootKey)
 
         requirePreference<HeaderPreference>(R.string.pref_backup_limits_screen_key)
-            .title = CollectionManager.TR.preferencesBackups()
+            .title = TR.preferencesBackups()
 
         requirePreference<Preference>(R.string.pref_advanced_screen_key).apply {
             if (AdaptionUtil.isXiaomiRestrictedLearningDevice) {
@@ -143,6 +142,11 @@ class HeaderFragment :
                             R.string.card_browser_enable_external_context_menu,
                             activity.getString(R.string.context_menu_anki_card_label),
                         ),
+                    ).withSummary(
+                        activity.getString(
+                            R.string.card_browser_enable_external_context_menu_summary,
+                            activity.getString(R.string.context_menu_anki_card_label),
+                        ),
                     ).withResId(R.xml.preferences_general)
                     .addBreadcrumb(activity.getString(R.string.pref_cat_general))
                     .addBreadcrumb(activity.getString(R.string.pref_cat_system_wide))
@@ -154,9 +158,31 @@ class HeaderFragment :
                             R.string.card_browser_enable_external_context_menu,
                             activity.getString(R.string.card_browser_context_menu),
                         ),
+                    ).withSummary(
+                        activity.getString(
+                            R.string.card_browser_enable_external_context_menu_summary,
+                            activity.getString(R.string.card_browser_context_menu),
+                        ),
                     ).withResId(R.xml.preferences_general)
                     .addBreadcrumb(activity.getString(R.string.pref_cat_general))
                     .addBreadcrumb(activity.getString(R.string.pref_cat_system_wide))
+
+                indexItem()
+                    .withKey(activity.getString(R.string.show_audio_play_buttons_key))
+                    .withTitle(
+                        TR.preferencesShowPlayButtonsOnCardsWith(),
+                    ).withResId(R.xml.preferences_appearance)
+                    .addBreadcrumb(activity.getString(R.string.pref_cat_appearance))
+                    .addBreadcrumb(activity.getString(R.string.pref_cat_reviewer))
+
+                indexItem()
+                    .withKey(activity.getString(R.string.one_way_sync_key))
+                    .withTitle(
+                        activity.getString(R.string.one_way_sync_title),
+                    ).withSummary(TR.preferencesOnNextSyncForceChangesIn())
+                    .withResId(R.xml.preferences_sync)
+                    .addBreadcrumb(activity.getString(R.string.pref_cat_sync))
+                    .addBreadcrumb(activity.getString(R.string.pref_cat_advanced))
             }
 
             // Some preferences and categories are only shown conditionally,

--- a/AnkiDroid/src/main/res/xml/preferences_appearance.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_appearance.xml
@@ -36,6 +36,7 @@
             android:title="@string/app_theme"
             android:icon="@drawable/ic_color_lens_white_24dp"
             app:useSimpleSummaryProvider="true"/>
+        <!--day and night theme label is ignored in search to avoid a duplicate entry and "theme" preference's entry-->
         <ListPreference
             android:defaultValue="1"
             android:entries="@array/day_theme_labels"
@@ -70,6 +71,7 @@
             android:title="@string/remove_wallpaper_image"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_reviewer" >
+        <!-- This is ignored in the search as it opens a submenu. The submenu content is what should actually appear in search result. -->
         <Preference
             android:summary="@string/custom_buttons_summary"
             android:title="@string/custom_buttons"

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -7,6 +7,7 @@
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
     android:title="@string/custom_sync_server_title"
     android:key="@string/pref_custom_sync_server_screen_key">
+    <!--this preference is ignored because it's not actually a preference but an explanation of the subscreen content. So it should not be indexed in the preference search.-->
     <com.ichi2.preferences.HtmlHelpPreference
         android:summary="@string/custom_sync_server_help2"
         app:substitution1="@string/link_custom_sync_server_help_learn_more_en"

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -53,7 +53,11 @@
         android:title="@string/metered_sync_title"
         android:summary="@string/metered_sync_summary" />
     <PreferenceCategory android:title="@string/pref_cat_advanced">
+        <!-- `search:ignore` is set so that we can add this preference manually in the search index.
+        We want to add it manually because we provide the summary at run time instead of build time, because it comes from the backend.
+        If we didn't ignore it, searching for the title would return this preference twice.-->
         <Preference
+            search:ignore="true"
             android:key="@string/one_way_sync_key"
             android:title="@string/one_way_sync_title"
             tools:summary="On next sync, force changes in one direction" />

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -57,6 +57,7 @@
             android:key="@string/one_way_sync_key"
             android:title="@string/one_way_sync_title"
             tools:summary="On next sync, force changes in one direction" />
+        <!-- This is ignored in the search as it opens a submenu. The submenu content is what should actually appear in search result. -->
         <Preference
             android:key="@string/custom_sync_server_key"
             android:title="@string/custom_sync_server_title"


### PR DESCRIPTION
I had to ensure tha the "one-way sync" entry has not `android:` content. Otherwise, it would appear twice in the search result when its title was searched.

This is not ideal, but currently the search library we use don't allow to edit a preference entry (and its not a trivial change to allow such edit; I tried to look whether it can be done or not, it seems it require to change the way files are processed in the library)