### PR TITLE
NF: adding a comment to 12-dont-translate

### DIFF
--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -20,7 +20,7 @@
     Adding or removing new line at the start/end of the string cause crowdin to require a new translation. Let's check if a comment before lead to a translation need!
     Adding this kind of XML comment does not cause the need for a new translation!
     -->
-    <string name="crowdin_second_string_to_test">
+    <string name="crowdin_second_string_to_test" comment="Changing the order of the strings didn't cause a need for a new translation. Let's add this comment; if it's not removed it means the comment didn't cause a requirement for a new translation!">
         This will be used to check that changing the order of strings does not require translation.
     </string>
     <string


### PR DESCRIPTION
This is here only to ensure that adding a tag comment don't cause a need for translation.