### PR TITLE
Improved empty collection background UI

### DIFF
--- a/AnkiDroid/src/main/res/drawable/blue_rounded_background.xml
+++ b/AnkiDroid/src/main/res/drawable/blue_rounded_background.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#27a3e1" />
+    <corners android:radius="18dp" />
+    <gradient
+        android:type="radial"
+        android:gradientRadius="250dp"
+        android:centerX="50%"
+        android:centerY="50%"
+        android:startColor="#27a3e1"
+        android:centerColor="#0f2a47"
+        android:endColor="#27a3e1" />
+
+</shape>

--- a/AnkiDroid/src/main/res/drawable/gray_rounded_background.xml
+++ b/AnkiDroid/src/main/res/drawable/gray_rounded_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="#7d7d7d" />
+    <corners android:radius="17dp" />
+    <gradient
+        android:type="radial"
+        android:gradientRadius="350dp"
+        android:centerX="50%"
+        android:centerY="50%"
+        android:startColor="#7d7d7d"
+        android:centerColor="#0f2a47"
+        android:endColor="#7d7d7d" />
+</shape>

--- a/AnkiDroid/src/main/res/layout/deck_picker.xml
+++ b/AnkiDroid/src/main/res/layout/deck_picker.xml
@@ -72,19 +72,37 @@
                         app:srcCompat="@drawable/anki_box" />
 
                     <com.ichi2.ui.FixedTextView
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="8dp"
                         android:gravity="center"
                         android:text="@string/no_cards_placeholder_title"
+                        android:background="@drawable/blue_rounded_background"
+                        android:padding="6dp"
+                        android:textColor="@color/white"
+                        android:textStyle="bold|normal"
+                        android:layout_gravity="center_horizontal"
+                        android:shadowColor="@color/black"
+                        android:shadowDy="2"
+                        android:shadowDx="2"
+                        android:shadowRadius="2"
                         style="@style/TextAppearance.AppCompat.Medium" />
 
                     <com.ichi2.ui.FixedTextView
-                        android:layout_width="match_parent"
+                        android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:gravity="center"
                         android:textAlignment="center"
                         android:text="@string/no_cards_placeholder_description"
+                        android:background="@drawable/gray_rounded_background"
+                        android:layout_gravity="center_horizontal"
+                        android:padding="6dp"
+                        android:textStyle="bold"
+                        android:textColor="@color/white"
+                        android:shadowColor="@color/black"
+                        android:shadowDx="1.5"
+                        android:shadowDy="1.5"
+                        android:shadowRadius="3"
                         style="@style/TextAppearance.AppCompat.Body1" />
                 </LinearLayout>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Improved the Background of the text "Collection is Empty" and "Start Adding cards using + icon." so that user can still read these texts when a background image is applied.

## Fixes
* Fixes #18073<!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
To enhance readability, I have introduced a background overlay for the text displayed when the collection is empty. This ensures sufficient contrast between the text and the selected background, making messages like "Collection is Empty" and "Start adding cards using the + icon" more legible under various themes and backgrounds.

https://github.com/user-attachments/assets/d25d0d16-ce79-417e-bd87-f5368eb45f95


## How Has This Been Tested?
Tested on Emulator ( API 31)
UI Change tested using Google Accessibility Scanner 
![accessibility test](https://github.com/user-attachments/assets/982df31f-7949-4631-9e97-a54a0dfc5065)


## Checklist
_Please, go through these checks before submitting the PR._

- [ y] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ y] You have performed a self-review of your own code
- [ y] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ y] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
