### PR TITLE
fix(lint-crowdin): more links to translations

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
@@ -116,7 +116,17 @@ data class CrowdinContext(
     val languageTag: CrowdinLanguageTag,
     val fileIdentifier: CrowdinFileIdentifier,
 ) {
-    private fun getStringName(element: Element): String? = if (element.hasAttribute("name")) element.getAttribute("name") else null
+    private fun getStringName(element: Element?): String? {
+        if (element == null) return null
+        return when (element.tagName) {
+            // <string-array> or <plurals>
+            "item" -> {
+                val parentElement = element.parentNode as? Element? ?: return null
+                getStringName(parentElement)
+            }
+            else -> if (element.hasAttribute("name")) element.getAttribute("name") else null
+        }
+    }
 
     fun getEditUrl(element: Element): String? {
         val stringName = getStringName(element) ?: return null

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/Crowdin.kt
@@ -47,7 +47,7 @@ value class CrowdinFileIdentifier(
                 "11-arrays" to 8174,
                 "16-multimedia-editor" to 8229,
                 "17-model-manager" to 8230,
-                "19-standard-models" to 8232,
+                "18-standard-models" to 8232,
                 "20-search-preference" to 8236,
             ).mapValues { CrowdinFileIdentifier(it.value.toLong()) }
 


### PR DESCRIPTION
## Purpose / Description

This makes it easier to resolve lint errors. URLs were not provided, now:

* https://crowdin.com/editor/ankidroid/8170/en-uk#q=card_browser_order_labels
* https://crowdin.com/editor/ankidroid/8232/en-sat#q=back_field_name

## Approach
* fix a filename
* link the parent element if `<string-array><item>` is detected

## How Has This Been Tested?
```sh
 ./gradlew buildPlayDebug && ./gradlew lintPlayDebug
```

```patch
Index: lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt	(revision 9478b354b6da9912de627fad6b0148fc19bd288d)
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt	(date 1742324099978)
@@ -137,7 +137,7 @@
         }
 
         // TODO(14903): remove "values" check once lint passes without it
-        if ("values" == context.file.parentFile.name && element.textContent.trim() != element.textContent) {
+        if (element.textContent.trim() != element.textContent) {
             var isValid = true
             element.childNodes.forEach {
                 if (it is CDATASection) {
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
