### PR TITLE
lint: enforce 'sentence_' prefix in `sentence_case.xml`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -100,7 +100,9 @@ class MediaCheckDialog : AsyncDialogFragment() {
                         setNeutralButton(R.string.dialog_cancel) { _, _ -> activity?.dismissAllDialogFragments() }
 
                         if (noHave.isNotEmpty()) {
-                            setNegativeButton(TR.mediaCheckAddTag().toSentenceCase(requireContext(), R.string.tag_missing)) { _, _ ->
+                            setNegativeButton(
+                                TR.mediaCheckAddTag().toSentenceCase(requireContext(), R.string.sentence_tag_missing),
+                            ) { _, _ ->
                                 (activity as MediaCheckDialogListener?)?.tagMissing(missingMediaNotes)
                                 activity?.dismissAllDialogFragments()
                             }

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -42,7 +42,7 @@ undoActionUndone()
     <string name="sentence_gesture_toggle_whiteboard">Toggle whiteboard</string>
     <string name="sentence_custom_study">Custom study</string>
     <string name="sentence_empty_cards">Empty cards</string>
-    <string name="tag_missing">Tag missing</string>
+    <string name="sentence_tag_missing">Tag missing</string>
     <string name="sentence_reposition_new_cards">Reposition new cards</string>
     <string name="sentence_find_and_replace">Find and replace</string>
     <string name="sentence_all_fields">All fields</string>

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/IssueRegistry.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.lint.rules.InvalidStringFormatDetector
 import com.ichi2.anki.lint.rules.JUnitNullAssertionDetector
 import com.ichi2.anki.lint.rules.NonPositionalFormatSubstitutions
 import com.ichi2.anki.lint.rules.PrintStackTraceUsage
+import com.ichi2.anki.lint.rules.SentenceCaseConventions
 import com.ichi2.anki.lint.rules.TranslationTypo
 import com.ichi2.anki.lint.rules.VariableNamingDetector
 
@@ -59,6 +60,7 @@ class IssueRegistry : IssueRegistry() {
                 JUnitNullAssertionDetector.ISSUE,
                 PrintStackTraceUsage.ISSUE,
                 NonPositionalFormatSubstitutions.ISSUE,
+                SentenceCaseConventions.ISSUE,
                 TranslationTypo.ISSUE,
                 FixedPreferencesTitleLength.PREFERENCES_ISSUE_MAX_LENGTH,
                 FixedPreferencesTitleLength.MENU_ISSUE_MAX_LENGTH,

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/SentenceCaseConventions.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/SentenceCaseConventions.kt
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.resources.ResourceFolderType
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.ResourceXmlDetector
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.XmlContext
+import com.android.tools.lint.detector.api.XmlScanner
+import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.utils.Constants
+import org.w3c.dom.Element
+
+/**
+ * Checks for issues in sentence-case.xml
+ */
+class SentenceCaseConventions :
+    ResourceXmlDetector(),
+    XmlScanner {
+    companion object {
+        @VisibleForTesting
+        val ID = "SentenceCaseConventions"
+
+        @VisibleForTesting
+        val EXPLANATION = "Sentence-case style guide"
+
+        private val implementation =
+            Implementation(SentenceCaseConventions::class.java, Scope.RESOURCE_FILE_SCOPE)
+        val ISSUE: Issue =
+            Issue.create(
+                ID,
+                EXPLANATION,
+                EXPLANATION,
+                Constants.ANKI_XML_CATEGORY,
+                Constants.ANKI_XML_PRIORITY,
+                Constants.ANKI_XML_SEVERITY,
+                implementation,
+            )
+    }
+
+    override fun getApplicableElements(): Collection<String> = listOf("string")
+
+    override fun appliesTo(folderType: ResourceFolderType): Boolean = folderType == ResourceFolderType.VALUES
+
+    override fun visitElement(
+        context: XmlContext,
+        element: Element,
+    ) {
+        if (context.file.name != "sentence-case.xml") {
+            return
+        }
+
+        // ensure 'name' starts with 'sentence_'
+        // Convention: avoids reviewers needing to check strings against 'GeneratedTranslations'
+        val elementName = element.getAttribute("name")
+        if (!elementName.startsWith("sentence_")) {
+            context.report(
+                issue = ISSUE,
+                location = context.getElementLocation(element),
+                message = "the 'name' attribute: '$elementName' should be prefixed with 'sentence_'",
+            )
+        }
+    }
+}

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/SentenceCaseConventionsTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/SentenceCaseConventionsTest.kt
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.lint.rules
+
+import com.android.tools.lint.checks.infrastructure.TestFiles
+import com.android.tools.lint.checks.infrastructure.TestLintResult
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.MatcherAssert.assertThat
+import org.intellij.lang.annotations.Language
+import org.junit.Test
+
+class SentenceCaseConventionsTest {
+    @Test
+    fun `valid file has no error`() {
+        checkSentenceCase(
+            """<resources>
+           |<string name="sentence_valid">Valid string</string>
+           |</resources>
+            """.trimMargin(),
+        ).expectClean()
+    }
+
+    @Test
+    fun `missing 'sentence_' prefix emits error`() {
+        checkSentenceCase(
+            """<resources>
+            |<string name="invalid_prefix">missing 'sentence_' prefix</string>
+            |</resources>
+            """.trimMargin(),
+        ).expectErrorCount(1)
+            .check({ output: String ->
+                assertThat("ID", output, containsString(SentenceCaseConventions.ID))
+                assertThat("message", output, containsString("the 'name' attribute: 'invalid_prefix' should be prefixed with 'sentence_'"))
+            })
+    }
+
+    private fun checkSentenceCase(
+        @Language("XML") input: String,
+    ): TestLintResult =
+        lint()
+            .allowMissingSdk()
+            .allowCompilationErrors()
+            .files(TestFiles.xml("res/values/sentence-case.xml", input))
+            .issues(SentenceCaseConventions.ISSUE)
+            .run()
+}


### PR DESCRIPTION
* https://github.com/ankidroid/Anki-Android/labels/Blocked%20by%20dependency #17943

## Purpose / Description
I made a bad review comment, and wasted time checking if `"Tag Missing"` was a duplicate string in the Anki Backend:

https://redirect.github.com/ankidroid/Anki-Android/pull/17943#discussion_r2002135876

## Approach
* Add a lint check, and fix a string:
  * `tag_missing` => `sentence_tag_missing`


## How Has This Been Tested?
Unit tests added

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
