### PR TITLE
fix: Kotlin 2.1.20 Upgrade Errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -854,7 +854,6 @@ open class DeckPicker :
                 }
             is DiskFull -> displayNoStorageError()
             is DBError -> displayDatabaseFailure(CustomExceptionData.fromException(failure.exception))
-            else -> displayDatabaseFailure()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -409,7 +409,7 @@ class IntentHandler : AbstractIntentHandler() {
                     showError(
                         activity,
                         activity.getString(R.string.something_wrong),
-                        ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker.javaClass.simpleName),
+                        ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker::class.java.simpleName),
                         true,
                     )
                     return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ExportReadyDialog.kt
@@ -79,7 +79,7 @@ class ExportReadyDialog(
                 showError(
                     activity,
                     activity.getString(R.string.something_wrong),
-                    ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker.javaClass.simpleName),
+                    ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker::class.java.simpleName),
                     true,
                 )
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/MediaCheckDialog.kt
@@ -284,7 +284,7 @@ class MediaCheckDialog : AsyncDialogFragment() {
                         showError(
                             activity,
                             activity.getString(R.string.something_wrong),
-                            ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker.javaClass.simpleName),
+                            ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker::class.java.simpleName),
                             true,
                         )
                         return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -321,7 +321,7 @@ class SyncErrorDialog : AsyncDialogFragment() {
                 showError(
                     activity,
                     activity.getString(R.string.something_wrong),
-                    ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker.javaClass.simpleName),
+                    ClassCastException(activity.javaClass.simpleName + " is not " + DeckPicker::class.java.simpleName),
                     true,
                 )
                 return

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -167,7 +167,6 @@ object Sound {
                     SoundOrVideoTag.Type.VIDEO -> asVideo(tag)
                 }
             }
-            else -> throw IllegalStateException("unrecognised tag")
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
* 'when' is exhaustive so 'else' is redundant here.
* The resulting type of this 'javaClass' call is 'Class<DeckPicker.Companion>' and not 'Class<DeckPicker>'. Use '::class.java' to access type 'Class<DeckPicker>'.

## Fixes
* See PR #18140

## How Has This Been Tested?
Just checked if it built, none of the changes were scary

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
