### PR TITLE
Duplicate Due column Fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnCollection.kt
@@ -66,7 +66,9 @@ class BrowserColumnCollection(
                     val value = mode.defaultColumns()
                     value.split(SEPARATOR_CHAR).map { CardBrowserColumn.fromColumnKey(it) }
                 }
-            return BrowserColumnCollection(columns)
+            // shared preferences had duplicate columns for unknown reasons
+            // this removes duplicates on load, any saves will be de-duplicated
+            return BrowserColumnCollection(columns.distinct())
         }
 
         class ColumnReplacement(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1154,6 +1154,27 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
+    fun `loading duplicate columns returns distinct`() {
+        // GIVEN: Shared preferences exists for display column selections
+        // with duplicate values
+        getSharedPrefs().edit {
+            putString(BrowserConfig.ACTIVE_CARD_COLUMNS_KEY, "question|cardDue|cardDue|deck")
+        }
+
+        // WHEN: CardBrowser is created
+        val cardBrowser: CardBrowser = getBrowserWithNotes(7)
+
+        // THEN: CardBrowser only shows distinct columns.
+        for ((i, column) in listOf("Question", "Due", "Deck").withIndex()) {
+            assertThat(
+                "column ${i + 1} reset to default",
+                cardBrowser.columnHeadings[i],
+                equalTo(column),
+            )
+        }
+    }
+
+    @Test
     @Ignore("issues with launchCollectionInLifecycleScope")
     fun `column titles update when moving to notes mode`() =
         withBrowser {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The columns sometimes were not distinct in CardBrowser.

## Fixes
* Fixes #17892

## Approach
I modified `BrowserColumnCollection::load` to return only distinct columns.

## How Has This Been Tested?
I wrote a unit test to override the CardBrowser columns in SharedPreferences so it has duplicate values and checked its distinctness afterward.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
