### PR TITLE
Showing Badge for Blank Card Fronts in Previewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -55,8 +55,14 @@ class TemplatePreviewerPage : Fragment(R.layout.template_previewer_container) {
         val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)
 
         lifecycleScope.launch {
-            for (templateName in viewModel.getTemplateNames()) {
-                tabLayout.addTab(tabLayout.newTab().setText(templateName))
+            val cardsWithEmptyFronts = viewModel.cardsWithEmptyFronts?.await()
+            for ((index, templateName) in viewModel.getTemplateNames().withIndex()) {
+                val newTab = tabLayout.newTab().setText(templateName)
+                if (cardsWithEmptyFronts?.get(index) == true) {
+                    val badge = newTab.getOrCreateBadge()
+                    badge.horizontalOffset = -4
+                }
+                tabLayout.addTab(newTab)
             }
             tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))
             tabLayout.addOnTabSelectedListener(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
@@ -57,6 +57,21 @@ class TemplatePreviewerViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `empty front field detected correctly for tab badge`() =
+        runOptionalReversedTest(
+            fields =
+                mutableListOf(
+                    "we have two normal fields",
+                    "and purposefully leave the third blank",
+                    "",
+                ),
+        ) {
+            onPageFinished(false)
+            assertThat(this.cardsWithEmptyFronts!!.await()[0], equalTo(false))
+            assertThat(this.cardsWithEmptyFronts!!.await()[1], equalTo(true))
+        }
+
     private fun runClozeTest(
         ord: Int = 0,
         fields: MutableList<String>? = null,
@@ -67,6 +82,23 @@ class TemplatePreviewerViewModelTest : JvmTest() {
             TemplatePreviewerArguments(
                 notetypeFile = NotetypeFile(tempDirectory.root, notetype),
                 fields = fields ?: mutableListOf("{{c1::foo}} {{c2::bar}}", "anki"),
+                tags = mutableListOf(),
+                ord = ord,
+            )
+        val viewModel = TemplatePreviewerViewModel(arguments, mock())
+        block(viewModel)
+    }
+
+    private fun runOptionalReversedTest(
+        ord: Int = 0,
+        fields: MutableList<String>? = null,
+        block: suspend TemplatePreviewerViewModel.() -> Unit,
+    ) = runTest {
+        val notetype = col.notetypes.byName("Basic (optional reversed card)")!!
+        val arguments =
+            TemplatePreviewerArguments(
+                notetypeFile = NotetypeFile(tempDirectory.root, notetype),
+                fields = fields ?: mutableListOf("question text", "answer text", "y"),
                 tags = mutableListOf(),
                 ord = ord,
             )


### PR DESCRIPTION
## Purpose / Description
There is currently no way of telling at a glance whether a card's front is blank via the previewer screen for a card (found by navigating to the Add Note editor and then pressing the eye in the top right corner).

## Fixes
* Fixes #18107

## Approach
I could not find a way to determine if a card was empty directly from the previewer fragment screen's arguments. It seems code for checking whether a card's front is empty is located in the main Anki repository rather than AnkiDroid. See [here](https://github.com/ankitects/anki/blob/d52889f45c3f7999a45fd2dde367f79f3bc3bad4/ftl/core/card-template-rendering.ftl#L4) and [here](https://github.com/ankitects/anki/blob/d52889f45c3f7999a45fd2dde367f79f3bc3bad4/rslib/src/notetype/mod.rs#L410) in particular, if I am not mistaken. As such, the approach taken here is to check whether the HTML the Anki code injects the "question" side of the card is present, and if so, that information is stored on the ViewModel. The Page fragment reads this ViewModel field and displays a red warning badge as suggested by @BrayanDSO in #18107.

An image of the updated UI is below.

![UIChangeImage](https://github.com/user-attachments/assets/926dbce6-a842-4577-80f5-38771c6aec2a)

## How Has This Been Tested?
An obvious rejoinder would be that if Anki changes how it displays empty card fronts, then this code may break. I have written a unit test in TemplatePreviewerViewModelTest that will fail if this happens. Of course, if a better solution is possible than simply checking if the error HTML is present, we should refactor this change. I must confess to being slightly unknowledgeable about how to retrieve card contents optimally.

The main example I tested the code on is if an optionally-reversed note does not have its reverse card enabled.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

This is my first PR in this repository. Apologies in advance for any mistakes I might have accidentally overlooked.