### PR TITLE
Corrected Note Type Field Mapping (#18131)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -274,6 +274,8 @@ open class DeckPicker :
 
     private lateinit var floatingActionMenu: DeckPickerFloatingActionMenu
 
+    private lateinit var currentAnkiDroidDirectory: String
+
     // flag asking user to do a full sync which is used in upgrade path
     private var recommendOneWaySync = false
 
@@ -900,7 +902,7 @@ open class DeckPicker :
             backgroundView.setBackgroundResource(0)
             return false
         }
-        val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
+        currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
         val imgFile = File(currentAnkiDroidDirectory, "DeckPickerBackground.png")
         if (!imgFile.exists()) {
             Timber.d("No DeckPicker background image")
@@ -2237,8 +2239,23 @@ open class DeckPicker :
                 layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
                 fabLinearLayout.layoutParams = layoutParams
             }
+            Timber.d("Startup - Deck List UI Completed")
         }
-        Timber.d("Startup - Deck List UI Completed")
+    }
+
+    /**
+     * Updates the background visibility based on the collection state
+     * Hides the background when collection is empty for better text readability
+     */
+    private fun updateBackgroundVisibility(collectionIsEmpty: Boolean) {
+        val backgroundView = findViewById<ImageView>(R.id.background)
+        if (collectionIsEmpty) {
+            Timber.d("Collection is empty, hiding background image")
+            backgroundView.visibility = View.GONE
+        } else {
+            Timber.d("Collection has cards, showing background image if available")
+            backgroundView.visibility = View.VISIBLE
+        }
     }
 
     private suspend fun renderPage(collectionIsEmpty: Boolean) {
@@ -2251,6 +2268,8 @@ open class DeckPicker :
             return
         }
 
+        // Update background visibility based on collection state
+        updateBackgroundVisibility(collectionIsEmpty)
         // Check if default deck is the only available and there are no cards
         val isEmpty = tree.children.size == 1 && tree.children[0].did == 1L && collectionIsEmpty
         if (animationDisabled()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -274,8 +274,6 @@ open class DeckPicker :
 
     private lateinit var floatingActionMenu: DeckPickerFloatingActionMenu
 
-    private lateinit var currentAnkiDroidDirectory: String
-
     // flag asking user to do a full sync which is used in upgrade path
     private var recommendOneWaySync = false
 
@@ -902,7 +900,7 @@ open class DeckPicker :
             backgroundView.setBackgroundResource(0)
             return false
         }
-        currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
+        val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
         val imgFile = File(currentAnkiDroidDirectory, "DeckPickerBackground.png")
         if (!imgFile.exists()) {
             Timber.d("No DeckPicker background image")
@@ -2239,23 +2237,8 @@ open class DeckPicker :
                 layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
                 fabLinearLayout.layoutParams = layoutParams
             }
-            Timber.d("Startup - Deck List UI Completed")
         }
-    }
-
-    /**
-     * Updates the background visibility based on the collection state
-     * Hides the background when collection is empty for better text readability
-     */
-    private fun updateBackgroundVisibility(collectionIsEmpty: Boolean) {
-        val backgroundView = findViewById<ImageView>(R.id.background)
-        if (collectionIsEmpty) {
-            Timber.d("Collection is empty, hiding background image")
-            backgroundView.visibility = View.GONE
-        } else {
-            Timber.d("Collection has cards, showing background image if available")
-            backgroundView.visibility = View.VISIBLE
-        }
+        Timber.d("Startup - Deck List UI Completed")
     }
 
     private suspend fun renderPage(collectionIsEmpty: Boolean) {
@@ -2268,8 +2251,6 @@ open class DeckPicker :
             return
         }
 
-        // Update background visibility based on collection state
-        updateBackgroundVisibility(collectionIsEmpty)
         // Check if default deck is the only available and there are no cards
         val isEmpty = tree.children.size == 1 && tree.children[0].did == 1L && collectionIsEmpty
         if (animationDisabled()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2676,51 +2676,36 @@ class NoteEditor :
         oldNotetype: NotetypeJson,
         newNotetype: NotetypeJson,
     ): Map<Int, Int> {
-        // Get field maps for both old and new note types
         val oldFieldMap = Notetypes.fieldMap(oldNotetype)
         val newFieldMap = Notetypes.fieldMap(newNotetype)
 
-        // Create a result map that will hold the mapping from old field indices to new field indices
         val resultMap: MutableMap<Int, Int> = HashUtil.hashMapInit(oldFieldMap.size)
 
-        // Create a set to track which new fields have already been mapped to
         val mappedNewFieldIndices = mutableSetOf<Int>()
 
-        // First, map fields with the same name
         for ((oldFieldName, oldFieldData) in oldFieldMap) {
             val oldFieldIndex = oldFieldData.first
 
             // Find the corresponding field in the new note type (if any)
-            val newFieldData = newFieldMap[oldFieldName]
-            if (newFieldData != null) {
+            newFieldMap[oldFieldName]?.let { newFieldData ->
                 val newFieldIndex = newFieldData.first
                 resultMap[oldFieldIndex] = newFieldIndex
                 mappedNewFieldIndices.add(newFieldIndex)
             }
         }
 
-        // For any old fields not mapped yet, try to map them to unused new fields with the same index (if possible)
+        // For any old fields not mapped yet, trying to map them to unused new fields with the same index (if possible)
         for (oldIndex in 0 until oldFieldMap.size) {
             if (!resultMap.containsKey(oldIndex)) {
-                // Try to use the same index if it's available
-                if (oldIndex < newFieldMap.size && !mappedNewFieldIndices.contains(oldIndex)) {
-                    resultMap[oldIndex] = oldIndex
-                    mappedNewFieldIndices.add(oldIndex)
-                } else {
-                    // Find any available index in the new note type
-                    for (newIndex in 0 until newFieldMap.size) {
-                        if (!mappedNewFieldIndices.contains(newIndex)) {
-                            resultMap[oldIndex] = newIndex
-                            mappedNewFieldIndices.add(newIndex)
-                            break
-                        }
+                val newIndex =
+                    when {
+                        oldIndex < newFieldMap.size && !mappedNewFieldIndices.contains(oldIndex) -> oldIndex
+
+                        else -> (0 until newFieldMap.size).firstOrNull { it !in mappedNewFieldIndices } ?: 0
                     }
 
-                    // If we couldn't find any available field, map to the first field (some content is better than none)
-                    if (!resultMap.containsKey(oldIndex) && newFieldMap.isNotEmpty()) {
-                        resultMap[oldIndex] = 0
-                    }
-                }
+                resultMap[oldIndex] = newIndex
+                mappedNewFieldIndices.add(newIndex)
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorFieldMappingTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorFieldMappingTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024 Tushar Sadhwani <tushar.sadhwani000@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import com.ichi2.libanki.NotetypeJson
+import org.json.JSONArray
+import org.json.JSONObject
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NoteEditorFieldMappingTest {
+    /**
+     * Create a NotetypeJson with the specified field names.
+     *
+     * @param fieldNames List of field names to create in the note type
+     * @return A NotetypeJson object with the specified fields
+     */
+    private fun createNotetypeWithFields(fieldNames: List<String>): NotetypeJson {
+        val fieldsArray = JSONArray()
+
+        fieldNames.forEachIndexed { index, name ->
+            val field =
+                JSONObject().apply {
+                    put("name", name)
+                    put("ord", index)
+                    put("sticky", false)
+                    put("font", "Arial")
+                    put("size", 20)
+                }
+            fieldsArray.put(field)
+        }
+
+        val noteTypeJson =
+            JSONObject().apply {
+                put("name", "Test Note Type")
+                put("id", 1L)
+                put("flds", fieldsArray)
+                put("tmpls", JSONArray())
+                put("type", 0)
+                put("sortf", 0)
+            }
+
+        return NotetypeJson(noteTypeJson)
+    }
+
+    /**
+     * Test implementation of mapFieldsByNames for testing
+     *
+     * This matches the implementation in NoteEditor class but is isolated for testing
+     */
+    private fun mapFieldsByNames(
+        oldNotetype: NotetypeJson,
+        newNotetype: NotetypeJson,
+    ): Map<Int, Int> {
+        val oldFieldMap = oldNotetype.fieldsNames.withIndex().associate { it.value to it.index }
+        val newFieldMap = newNotetype.fieldsNames.withIndex().associate { it.value to it.index }
+
+        val mapping = mutableMapOf<Int, Int>()
+        val usedNewIndices = mutableSetOf<Int>()
+
+        // First pass: map fields with same name
+        for ((oldIndex, oldName) in oldNotetype.fieldsNames.withIndex()) {
+            val newIndex = newFieldMap[oldName]
+            if (newIndex != null) {
+                mapping[oldIndex] = newIndex
+                usedNewIndices.add(newIndex)
+            }
+        }
+
+        // Second pass: map remaining fields in order
+        for ((oldIndex, _) in oldNotetype.fieldsNames.withIndex()) {
+            if (!mapping.containsKey(oldIndex)) {
+                // Find the first unused new field index
+                val newIndex =
+                    newNotetype.fieldsNames.indices.firstOrNull {
+                        it !in usedNewIndices
+                    } ?: if (newNotetype.fieldsNames.isNotEmpty()) 0 else null
+
+                if (newIndex != null) {
+                    mapping[oldIndex] = newIndex
+                    usedNewIndices.add(newIndex)
+                }
+            }
+        }
+
+        return mapping
+    }
+
+    @Test
+    fun testExactMatchingFields() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+        val newNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // Each field should map to the same position
+        assertEquals(0, mapping[0])
+        assertEquals(1, mapping[1])
+        assertEquals(2, mapping[2])
+    }
+
+    @Test
+    fun testReorderedMatchingFields() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+        val newNotetype = createNotetypeWithFields(listOf("Back", "Extra", "Front"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // Fields should be mapped by name, not position
+        assertEquals(2, mapping[0]) // Front -> index 2
+        assertEquals(0, mapping[1]) // Back -> index 0
+        assertEquals(1, mapping[2]) // Extra -> index 1
+    }
+
+    @Test
+    fun testNoMatchingFields() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+        val newNotetype = createNotetypeWithFields(listOf("Question", "Answer", "Additional"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // With no matching names, fields should map to the corresponding positions
+        assertEquals(0, mapping[0])
+        assertEquals(1, mapping[1])
+        assertEquals(2, mapping[2])
+    }
+
+    @Test
+    fun testPartialMatchingFields() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+        val newNotetype = createNotetypeWithFields(listOf("Front", "Answer", "Extra"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // Front and Extra should map by name, Back should map to the remaining field
+        assertEquals(0, mapping[0]) // Front -> index 0
+        assertEquals(1, mapping[1]) // Back -> index 1 (only available)
+        assertEquals(2, mapping[2]) // Extra -> index 2
+    }
+
+    @Test
+    fun testFewerFieldsInNewNotetype() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+        val newNotetype = createNotetypeWithFields(listOf("Front", "Back"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // Front and Back should map by name, Extra should map to an existing field (first available)
+        assertEquals(0, mapping[0]) // Front -> index 0
+        assertEquals(1, mapping[1]) // Back -> index 1
+
+        // Extra would map to the first field (index 0) if no other matches
+        // This is a fallback behavior when the new note type has fewer fields
+        assertEquals(0, mapping[2])
+    }
+
+    @Test
+    fun testMoreFieldsInNewNotetype() {
+        val oldNotetype = createNotetypeWithFields(listOf("Front", "Back"))
+        val newNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // Front and Back should map by name, new field "Extra" is unused
+        assertEquals(0, mapping[0]) // Front -> index 0
+        assertEquals(1, mapping[1]) // Back -> index 1
+    }
+
+    @Test
+    fun testComplexExample() {
+        // Example from the issue: ABC -> ACD
+        val oldNotetype = createNotetypeWithFields(listOf("A", "B", "C"))
+        val newNotetype = createNotetypeWithFields(listOf("A", "C", "D"))
+
+        val mapping = mapFieldsByNames(oldNotetype, newNotetype)
+
+        // A and C should map by name, B should map to the unmapped field D
+        assertEquals(0, mapping[0]) // A -> index 0
+        assertEquals(2, mapping[1]) // B -> index 2 (D, as it's the only unmapped field)
+        assertEquals(1, mapping[2]) // C -> index 1
+    }
+}


### PR DESCRIPTION
## Purpose / Description

This PR improves the field mapping logic when changing note types in the Note Editor. Previously, fields were mapped purely by position, which often led to data being placed in inappropriate fields when switching between note types with similar fields in different positions.

With this change, fields are now mapped by name first, then by position as a fallback. This means when users change a note type, fields with matching names will retain their content, regardless of their position in the note type.

## Changes Made

### 1. Added `mapFieldsByNames` Method to NoteEditor class to map fields by name first:

```kotlin
    /**
     * Maps fields from old note type to new note type based on field names.
     *
     * @param oldNotetype The source note type
     * @param newNotetype The target note type
     * @return A mapping from old field index to new field index, matching fields by name when possible
     */
    private fun mapFieldsByNames(
        oldNotetype: NotetypeJson,
        newNotetype: NotetypeJson,
    ): Map<Int, Int> {
        // Get field maps for both old and new note types
        val oldFieldMap = Notetypes.fieldMap(oldNotetype)
        val newFieldMap = Notetypes.fieldMap(newNotetype)

        // Create a result map that will hold the mapping from old field indices to new field indices
        val resultMap: MutableMap<Int, Int> = HashUtil.hashMapInit(oldFieldMap.size)

        // Create a set to track which new fields have already been mapped to
        val mappedNewFieldIndices = mutableSetOf<Int>()

        // First, map fields with the same name
        for ((oldFieldName, oldFieldData) in oldFieldMap) {
            val oldFieldIndex = oldFieldData.first

            // Find the corresponding field in the new note type (if any)
            val newFieldData = newFieldMap[oldFieldName]
            if (newFieldData != null) {
                val newFieldIndex = newFieldData.first
                resultMap[oldFieldIndex] = newFieldIndex
                mappedNewFieldIndices.add(newFieldIndex)
            }
        }

        // For any old fields not mapped yet, try to map them to unused new fields with the same index (if possible)
        for (oldIndex in 0 until oldFieldMap.size) {
            if (!resultMap.containsKey(oldIndex)) {
                // Try to use the same index if it's available
                if (oldIndex < newFieldMap.size && !mappedNewFieldIndices.contains(oldIndex)) {
                    resultMap[oldIndex] = oldIndex
                    mappedNewFieldIndices.add(oldIndex)
                } else {
                    // Find any available index in the new note type
                    for (newIndex in 0 until newFieldMap.size) {
                        if (!mappedNewFieldIndices.contains(newIndex)) {
                            resultMap[oldIndex] = newIndex
                            mappedNewFieldIndices.add(newIndex)
                            break
                        }
                    }

                    // If we couldn't find any available field, map to the first field (some content is better than none)
                    if (!resultMap.containsKey(oldIndex) && newFieldMap.isNotEmpty()) {
                        resultMap[oldIndex] = 0
                    }
                }
            }
        }

        return resultMap
    }

```

### 2. Modified `EditNoteTypeListener.onItemSelected` Method  to use the new mapping logic:

**Before:**
```kotlin
val itemsLength = editorNote!!.items().size
modelChangeFieldMap = HashUtil.hashMapInit(itemsLength)
for (i in 0 until itemsLength) {
    modelChangeFieldMap!![i] = i
}
```

**After:**
```kotlin
val oldModel = currentEditedCard!!.noteType(getColUnsafe)
modelChangeFieldMap = mapFieldsByNames(oldModel, newModel).toMutableMap()
```

### 3. Added Comprehensive Test Cases in `NoteEditorFieldMappingTest`:

Created a new test class `NoteEditorFieldMappingTest` with multiple test scenarios to verify field mapping behavior.

**Example Test Case:**
```kotlin
@Test
fun testReorderedMatchingFields() {
    val oldNotetype = createNotetypeWithFields(listOf("Front", "Back", "Extra"))
    val newNotetype = createNotetypeWithFields(listOf("Back", "Extra", "Front"))

    val mapping = mapFieldsByNames(oldNotetype, newNotetype)

    assertEquals(2, mapping[0]) // Front -> index 2
    assertEquals(0, mapping[1]) // Back -> index 0
    assertEquals(1, mapping[2]) // Extra -> index 1
}
```

## Approach

1. Fields are first mapped by name to ensure logical consistency.
2. If no name match exists, the same index is used when possible.
3. Otherwise, the first available unmapped index is assigned.
4. As a last resort, unmatched fields are mapped to the first field.

## Example Use Case

For example, when switching from a note type with fields `["A", "B", "C"]` to `["A", "C", "D"]`:

- **Field A** content stays in **Field A** (matched by name).
- **Field C** content stays in **Field C** (matched by name).
- **Field B** content moves to **Field D** (only remaining unmapped field).

This prevents incorrect positional mapping where fields might be misplaced.

## Testing


Added unit tests in NoteEditorFieldMappingTest that cover all the scenarios described above.

## Screeenshots
 Before & After Mapping Fix:
<img width="335" alt="Screenshot 2025-03-25 at 5 49 14 PM" src="https://github.com/user-attachments/assets/a2d2d084-8bd2-4571-8703-3fc087789887" />
<img width="335" alt="Screenshot 2025-03-25 at 5 48 59 PM" src="https://github.com/user-attachments/assets/52319572-3562-4518-b738-93eb76012475" />
Closes #18131
