### PR TITLE
Fix #14201: stripe in fullscreen and buttons top

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -49,7 +49,7 @@
         android:id="@+id/answer_options_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:fitsSystemWindows="true">
+        android:fitsSystemWindows="false"> <!-- Set to false due to #14201   -->
 
         <LinearLayout
             android:id="@+id/ease_buttons"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
A small stripe appears above the card in "Fullscreen mode > Hide the system bars" and "Answer button position > Top"
(Not my screenshot, from the issue)

![v33](https://github.com/user-attachments/assets/98f944af-f226-4d15-ae88-836de82e2b64)

## Fixes
* Fixes #14201 

## Approach
I changed the background color of answer buttons in their layout file to debug and I realized the size of the stripe was the same size as the navigation bar used for controls or the small white line to show the navigation type was "gestures". I then changed android:fitsSystemWindows from true to false so it would "ignore" the navigation bar, this makes it so when the answer buttons are at the top they don't have the stripe that accounts for the navigation bar under.

![bug_navType1](https://github.com/user-attachments/assets/4a21960a-5e97-4282-9054-e158d64965b8)
![bug_navType2](https://github.com/user-attachments/assets/813831d9-4616-46b8-860e-4e8e0ae6aefc)

To note this bug only happens in fullscreen ("Fullscreen mode" - "Hide the systems bars") so when "Answer buttons position" - "Bottom" there are no buttons under the navigation bar because it disappears. Before this change it may have also been considered a bug that the buttons were floating a little bit.

I expected this change would indeed put the answer buttons under the navigation bar when not in fullscreen mode or when the user leaves the immersive mode (the buttons are actually moved up to accommodate for the navigation bar), but it doesn't and I couldn't figure out if this was because of code elsewhere or Android.

## How Has This Been Tested?
I tested in the emulator 35, 34 and 24, I thought the fact it worked when not in fullscreen was because of a newer android version.

![image](https://github.com/user-attachments/assets/f91cdcf4-ef63-40c7-9d5f-07c817c507e0)


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
