### PR TITLE
Showing Badge for Blank Card Fronts in Previewer, Continued

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -55,8 +55,14 @@ class TemplatePreviewerPage : Fragment(R.layout.template_previewer_container) {
         val tabLayout = view.findViewById<TabLayout>(R.id.tab_layout)
 
         lifecycleScope.launch {
-            for (templateName in viewModel.getTemplateNames()) {
-                tabLayout.addTab(tabLayout.newTab().setText(templateName))
+            val cardsWithEmptyFronts = viewModel.cardsWithEmptyFronts?.await()
+            for ((index, templateName) in viewModel.getTemplateNames().withIndex()) {
+                val newTab = tabLayout.newTab().setText(templateName)
+                if (cardsWithEmptyFronts?.get(index) == true) {
+                    val badge = newTab.getOrCreateBadge()
+                    badge.horizontalOffset = -4
+                }
+                tabLayout.addTab(newTab)
             }
             tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))
             tabLayout.addOnTabSelectedListener(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
@@ -57,6 +57,21 @@ class TemplatePreviewerViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `empty front field detected correctly for tab badge`() =
+        runOptionalReversedTest(
+            fields =
+                mutableListOf(
+                    "we have two normal fields",
+                    "and purposefully leave the third blank",
+                    "",
+                ),
+        ) {
+            onPageFinished(false)
+            assertThat(this.cardsWithEmptyFronts!!.await()[0], equalTo(false))
+            assertThat(this.cardsWithEmptyFronts!!.await()[1], equalTo(true))
+        }
+
     private fun runClozeTest(
         ord: Int = 0,
         fields: MutableList<String>? = null,
@@ -67,6 +82,23 @@ class TemplatePreviewerViewModelTest : JvmTest() {
             TemplatePreviewerArguments(
                 notetypeFile = NotetypeFile(tempDirectory.root, notetype),
                 fields = fields ?: mutableListOf("{{c1::foo}} {{c2::bar}}", "anki"),
+                tags = mutableListOf(),
+                ord = ord,
+            )
+        val viewModel = TemplatePreviewerViewModel(arguments, mock())
+        block(viewModel)
+    }
+
+    private fun runOptionalReversedTest(
+        ord: Int = 0,
+        fields: MutableList<String>? = null,
+        block: suspend TemplatePreviewerViewModel.() -> Unit,
+    ) = runTest {
+        val notetype = col.notetypes.byName("Basic (optional reversed card)")!!
+        val arguments =
+            TemplatePreviewerArguments(
+                notetypeFile = NotetypeFile(tempDirectory.root, notetype),
+                fields = fields ?: mutableListOf("question text", "answer text", "y"),
                 tags = mutableListOf(),
                 ord = ord,
             )


### PR DESCRIPTION
**Continues PR #18147**

Apologies for the inconvenience -- I accidentally closed the old PR while cleaning up my git history to be in line with the stated merge requirements. Having this in a new, separate PR is a bit annoying but I can't seem to reopen the old PR. I'll try not to let this happen again in the future.

This is rebased to main and is on a separate branch, eliminating the annoying "merge: ..." commit and putting everything into a single commit. I've implemented the suggestions from @BrayanDSO. The horizontal offset is now -4.

My tests show this code should work. Once it's merged, I'll create an issue on the upstream Anki repository to add a backend function so we can get rid of the string-matching hack in the future.

Please let me know if there are any other changes I should make and I'll be happy to correct them.