### PR TITLE
build(deps): adopt latest Anki-Android-Backend 0.1.52-anki25.02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.13.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.0"
-ankiBackend = '0.1.51-anki25.02'
+ankiBackend = '0.1.52-anki25.02'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

Does exactly what it says in the commit, nothing more

There is nothing too special about the new backend artifact, it represents the same upstream anki as before, but packaged with locally updated direct dependencies. So this is just to make sure all those dependency updates work, which is why I'm starting on the dependency-updates branch