### PR TITLE
Fix #15993: Scroll position wrong after editing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -352,6 +352,8 @@ open class CardBrowser :
                 viewModel.saveScrollingState(id)
                 viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
             } else {
+                viewModel.lastSelectedPosition = (cardsListView.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
+                viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
                 val cardId = viewModel.queryDataForCardEdit(id)
                 openNoteEditorForCard(cardId)
             }
@@ -895,6 +897,7 @@ open class CardBrowser :
     override fun onResume() {
         super.onResume()
         selectNavigationItem(R.id.nav_browser)
+        autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
     }
 
     @KotlinCleanup("Add a few variables to get rid of the !!")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When editing a card in the CardBrowser, after scrolling down and selecting a card at the bottom of the list, the scroll position is lost when returning to the CardBrowser.

https://github.com/user-attachments/assets/4728dc4d-6032-4d28-aa27-3e151b8c7e44

## Fixes
* Fixes #15993 <!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
I added several breakpoints in the code and debugged the process of editing a card in the CardBrowser. After scrolling down, selecting a card at the end of the list, and saving it, I noticed that the scroll position was not being correctly stored when clicking on the card. As a result, when returning to the CardBrowser after the edit, the scroll would not maintain the expected position and would return inconsistently.
I now save the position of the first visible item when clicking on a card (onTap()), and when returning to the CardBrowser after saving, the scroll is adjusted back to the previously saved position (onResume()).

## How Has This Been Tested?
I tested in the emulator 34 and 35  the process of editing a card in CardBrowser, and now the scroll is adjusted back to the previously saved position.

https://github.com/user-attachments/assets/5b09b4d5-5f4d-4ebc-be67-bb0ed0486449

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
