### PR TITLE
Add sorting by deck name to card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
@@ -50,6 +50,7 @@ enum class SortType(
     EASE("cardEase", 7),
     REVIEWS("cardReps", 8),
     LAPSES("cardLapses", 9),
+    DECK("deck", 10),
     ;
 
     fun save(

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -64,6 +64,7 @@
         <item>By ease</item>
         <item>By reviews</item>
         <item>By lapses</item>
+        <item>By deck name</item>
     </string-array>
     <string name="card_browser_select_all" maxLength="28">Select all</string>
     <string name="card_browser_select_none" maxLength="28">Select none</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
There was a feature request for a "Deck name" option in the sort options in CardBrowser

## Fixes
* Fixes #18169

## Approach
I added a sort option for "deck" in `com/ichi2/anki/model/SortType.kt` and also a string in `res/values/07-cardbrowser.xml::card_browser_order_labels` with the value "By deck name" which will be displayed in the dialog.

## How Has This Been Tested?
Manually Tested on physical device (Video showing the descending and ascending orders below).

https://github.com/user-attachments/assets/7650caee-526e-42fd-aa6c-e7088723fa4d


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
