### PR TITLE
Fix memory leak by stopping server in pageFragment by onDestroy

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -38,13 +38,12 @@ import kotlin.reflect.KClass
 /**
  * Base class for displaying Anki HTML pages
  */
-@Suppress("LeakingThis")
 open class PageFragment(
     @LayoutRes contentLayoutId: Int = R.layout.page_fragment,
 ) : Fragment(contentLayoutId),
     PostRequestHandler {
     lateinit var webView: WebView
-    private val server = AnkiServer(this).also { it.start() }
+    private lateinit var server: AnkiServer
 
     /**
      * A loading indicator for the page. May be shown before the WebView is loaded to
@@ -103,6 +102,7 @@ open class PageFragment(
         savedInstanceState: Bundle?,
     ) {
         val pageWebViewClient = onCreateWebViewClient(savedInstanceState)
+        server = AnkiServer(this).also { it.start() }
         webView =
             view.findViewById<WebView>(R.id.webview).apply {
                 with(settings) {
@@ -149,6 +149,11 @@ open class PageFragment(
         return activity.handleUiPostRequest(methodName, bytes)
             ?: handleCollectionPostRequest(methodName, bytes)
             ?: throw IllegalArgumentException("unhandled method: $methodName")
+    }
+
+    override fun onDestroyView() {
+        server.stop()
+        super.onDestroyView()
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description
This pull request addresses a memory leak that occurred when using the `AnkiServer` in conjunction with `PageFragment`. The memory leak was solved by explicitly shutting down the AnkiServer instance in the onDestroyView()

## Fixes
* Fixes Im not sure?

## Approach
The primary cause of the leak was that the `AnkiServer` held a direct reference to the `PageFragment` through the `postHandler`. The server, intended to run in the background, could outlive the fragment, when it was not shutdown.

To fix this, we took the following steps:

1. **Using `onDestroy`**: In the `AnkiPackageImporterFragment`, the `onDestroy` function is used to remove the `OnBackPressedCallback`.
 
These changes ensure that the `PageFragment` is no longer kept alive by the `AnkiServer`, allowing the garbage collector to reclaim the memory.

## How Has This Been Tested?

1.  **LeakCanary:** Used to verify that no leaks are detected when navigating to and from `PageFragment` instances.

Before Fix:
https://drive.google.com/file/d/1FjHFKZtKQ-J6JEIFaicgekwLEqO1HONI/view?usp=drive_link

After Fix (Apologies for splitting it across videos, LeakCanary took some time to decompile a mem dump)
https://drive.google.com/file/d/1FikDQn1mKcwQ9bggxFXjzdHMCZosTCZ8/view?usp=sharing
https://drive.google.com/file/d/1FgU01ggq7DLjnpQSTKO1Z5vn4Z1ndwpT/view?usp=sharing
https://drive.google.com/file/d/1FlOGDmmxR5qjcVq3i8H4jLv8fMYMP8zn/view?usp=sharing

## Learning (optional, can help others)
Not particularly anything noteworthy. There are some other memory leaks here and there as it can be seen in the videos so I shall work on those as well

## Checklist
_Please, go through these checks before submitting the PR._

- [✅] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✅] You have commented your code, particularly in hard-to-understand areas
- [✅] You have performed a self-review of your own code
- [✅] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [✅] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
