### PR TITLE
Add mathjax block and mathjax chemistry

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -48,6 +48,7 @@ import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.convertDpToPixel
@@ -124,6 +125,10 @@ class Toolbar : FrameLayout {
         setupButtonWrappingText(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")
         findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }
+        findViewById<View>(R.id.note_editor_toolbar_button_insert_mathjax).setOnLongClickListener {
+            displayInsertMathJaxEquationsDialog()
+            true
+        }
 
         val parentLayout = findViewById<LinearLayout>(R.id.editor_toolbar_internal)
         parentLayout.children.forEach { child ->
@@ -303,6 +308,31 @@ class Toolbar : FrameLayout {
                 onFormat(formatter)
             }
             title(R.string.insert_heading)
+        }
+    }
+
+    /**
+     * Displays a dialog that allows the user to insert a MathJax equation in different formats.
+     */
+    private fun displayInsertMathJaxEquationsDialog() {
+        data class MathJaxOption(
+            val label: String,
+            val prefix: String,
+            val suffix: String,
+        ) {
+            fun toTextWrapper() = TextWrapper(prefix = this.prefix, suffix = this.suffix)
+        }
+
+        val mathjaxOptions =
+            arrayOf(
+                MathJaxOption(TR.editingMathjaxBlock(), prefix = "\\[\\", suffix = "\\]"),
+                MathJaxOption(TR.editingMathjaxChemistry(), prefix = "\\( \\ce{", suffix = "} \\)"),
+            )
+        AlertDialog.Builder(context).show {
+            setItems(mathjaxOptions.map(MathJaxOption::label).toTypedArray()) { _, index ->
+                onFormat(mathjaxOptions[index].toTextWrapper())
+            }
+            title(R.string.insert_mathjax)
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Adding mathjax block and mathjax chemistry options by showing a menu dialog

## Fixes
* Fixes #18174 <!-- replace this comment with the issue number e.g. 'Fixes #100'-->

## Approach
_How does this change address the problem?_

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
