### PR TITLE
Added test to check if notification can fire

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -18,21 +18,33 @@ package com.ichi2.anki.tests
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
+import androidx.core.content.edit
 import androidx.test.annotation.UiThreadTest
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.IdlingPolicies
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.IdlingResource
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
+import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.greaterThanOrEqualTo
+import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import timber.log.Timber
+import java.util.concurrent.TimeUnit
 import kotlin.test.junit.JUnitAsserter.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
@@ -40,12 +52,47 @@ import kotlin.test.junit.JUnitAsserter.assertNotNull
 
 @KotlinCleanup("Enable JUnit 5 in androidTest and use JUnit5Asserter to match the standard tests")
 class NotificationChannelTest : InstrumentedTest() {
+    companion object {
+        // amount of time to wait for notification to show up in testNotification
+        private const val NOTIFICATION_TEST_IDLE_SECONDS: Long = 5
+    }
+
     @get:Rule
     var runtimePermissionRule = GrantStoragePermission.instance
     private var currentAPI = -1
     private var targetAPI = -1
 
     private lateinit var manager: NotificationManager
+    private lateinit var notificationIdlingResource: NotificationIdlingResource
+
+    /**
+     * Espresso resource that waits for a notification to appear
+     * For use in testNotification
+     */
+    private class NotificationIdlingResource(
+        private val notificationManager: NotificationManager,
+    ) : IdlingResource {
+        @Volatile
+        private var callback: IdlingResource.ResourceCallback? = null
+
+        @Volatile
+        private var isIdle = false
+
+        override fun getName(): String = "NotificationIdlingResource"
+
+        override fun isIdleNow(): Boolean {
+            isIdle = notificationManager.activeNotifications.isNotEmpty()
+            Timber.d("Running notification test: waiting for notification to appear...")
+            if (isIdle) {
+                callback?.onTransitionToIdle()
+            }
+            return isIdle
+        }
+
+        override fun registerIdleTransitionCallback(callback: IdlingResource.ResourceCallback?) {
+            this.callback = callback
+        }
+    }
 
     @Before
     @UiThreadTest
@@ -55,9 +102,39 @@ class NotificationChannelTest : InstrumentedTest() {
         currentAPI = sdkVersion
         targetAPI = targetContext.applicationInfo.targetSdkVersion
         manager = targetContext.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        // grant permission to post notifications
+        getInstrumentation().uiAutomation.executeShellCommand(
+            "pm grant ${targetContext.packageName} android.permission.POST_NOTIFICATIONS",
+        )
+
+        notificationIdlingResource = NotificationIdlingResource(manager)
+        IdlingRegistry.getInstance().register(notificationIdlingResource)
+        IdlingPolicies.setIdlingResourceTimeout(NOTIFICATION_TEST_IDLE_SECONDS, TimeUnit.SECONDS)
+
+        // set minimum amount of due cards to trigger a notification to zero to force a notification
+        val preferences = targetContext.sharedPrefs()
+        preferences.edit(commit = true) {
+            putString(targetContext.getString(R.string.pref_notifications_minimum_cards_due_key), "0")
+        }
+    }
+
+    @After
+    fun tearDown() {
+        IdlingRegistry.getInstance().unregister(notificationIdlingResource)
     }
 
     private fun channelsInAPI(): Boolean = currentAPI >= 26
+
+    @Test
+    fun testNotification() {
+        NotificationService.triggerNotificationFor(testContext)
+        Espresso.onIdle()
+        val notification = manager.activeNotifications.firstOrNull()
+
+        assertNotNull("Notification was sent", notification)
+        assertThat("Notification has correct id", NotificationService.WIDGET_NOTIFY_ID, equalTo(notification!!.id))
+    }
 
     @Test
     fun testChannelCreation() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -20,6 +20,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.Channel
@@ -33,7 +34,8 @@ import timber.log.Timber
 class NotificationService : BroadcastReceiver() {
     companion object {
         /** The id of the notification for due cards.  */
-        private const val WIDGET_NOTIFY_ID = 1
+        @VisibleForTesting
+        const val WIDGET_NOTIFY_ID = 1
 
         fun triggerNotificationFor(context: Context) {
             Timber.i("NotificationService: OnStartCommand")


### PR DESCRIPTION
## Purpose / Description
Added a test to NotificationChannelTest.kt which triggers a notification and checks to see if it is received. In the process, it sets up an IdlingResource to ensure assert statements do not run before the notification arrives.

I wrote this test in the process of creating my GSoC application, as the project description describes the need to "find a way to test [...] notifications, manually and with automated tests." Hopefully, whoever is selected for the summer project will find this test useful and can retool it to their liking.

I was not sure if I should create a new test file, as I am a fairly new contributor here (is it really right to group a notification-firing test together with a test of notification channels?) -- please let me know if I should amend this by pulling the code out into a new file. Alternatively, I could rename "NotificationChannelTest.kt" to "NotificationTest.kt" so that the filename is more general.

## Fixes
Adds a new test, increasing code coverage.

## Approach
The "minimum cards needed to trigger a notification" preference is set to zero. A NotificationService notification is requested. The code uses an Idling Resource to wait at most five seconds. Finally, we check if the notification is present.

## How Has This Been Tested?
The test runs correctly on both my own device (API 34) and on freshly booted emulators (API 35 and API 30 tested).

## Learning
I initially used a more brief `SystemClock.sleep(5000);` statement to wait for the notification to arrive, but that seemed a bit hacky. Let me know if using SystemClock is actually more readable and I'll remove the IdlingResource.

If anyone else is trying to figure out how to run instrumented notification tests, make sure to include the `executeShellCommand` line. This caused me a bit of pain.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)