### PR TITLE
Added option to choose click action in Card Browser in options dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -186,6 +186,10 @@ class CardBrowserViewModel(
         MutableStateFlow(sharedPrefs().getBoolean("isTruncated", false))
     val isTruncated get() = flowOfIsTruncated.value
 
+    val flowOfTapCardToEdit: MutableStateFlow<Boolean> =
+        MutableStateFlow(sharedPrefs().getBoolean("tapCardToEdit", true))
+    val tapCardToEdit get() = flowOfTapCardToEdit.value
+
     var shouldIgnoreAccents: Boolean = false
 
     var defaultBrowserSearch: String? = null
@@ -481,6 +485,15 @@ class CardBrowserViewModel(
         }
         sharedPrefs().edit {
             putBoolean("isTruncated", value)
+        }
+    }
+
+    fun setTapCardToEdit(value: Boolean) {
+        viewModelScope.launch {
+            flowOfTapCardToEdit.emit(value)
+        }
+        sharedPrefs().edit {
+            putBoolean("tapCardToEdit", value)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -66,6 +66,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
             viewModel.setTruncated(newTruncate)
         }
 
+        val newTapCardToEdit = dialogView.findViewById<RadioButton>(R.id.tap_to_edit_mode).isChecked
+
+        if (newTapCardToEdit != tapCardToEdit) {
+            viewModel.setTapCardToEdit(newTapCardToEdit)
+        }
+
         val newIgnoreAccent = dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).isChecked
         if (newIgnoreAccent != viewModel.shouldIgnoreAccents) {
             viewModel.setIgnoreAccents(newIgnoreAccent)
@@ -89,6 +95,9 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
         }
     }
 
+    // defaults to tapping on card to edit
+    private val tapCardToEdit by lazy { arguments?.getBoolean(TAP_CARD_TO_EDIT) ?: true }
+
     private val isTruncated by lazy {
         arguments?.getBoolean(IS_TRUNCATED_KEY) ?: run {
             Timber.w("BrowserOptionsDialog instantiated without configuration.")
@@ -104,6 +113,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
             dialogView.findViewById<RadioButton>(R.id.select_cards_mode).isChecked = true
         } else {
             dialogView.findViewById<RadioButton>(R.id.select_notes_mode).isChecked = true
+        }
+
+        if (tapCardToEdit) {
+            dialogView.findViewById<RadioButton>(R.id.tap_to_edit_mode).isChecked = true
+        } else {
+            dialogView.findViewById<RadioButton>(R.id.tap_to_preview_mode).isChecked = true
         }
 
         dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked = isTruncated
@@ -153,10 +168,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
     companion object {
         private const val CARDS_OR_NOTES_KEY = "cardsOrNotes"
         private const val IS_TRUNCATED_KEY = "isTruncated"
+        private const val TAP_CARD_TO_EDIT = "tapCardToEdit"
 
         fun newInstance(
             cardsOrNotes: CardsOrNotes,
             isTruncated: Boolean,
+            tapCardToEdit: Boolean,
         ): BrowserOptionsDialog {
             Timber.i("BrowserOptionsDialog::newInstance")
             return BrowserOptionsDialog().apply {
@@ -164,6 +181,7 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
                     bundleOf(
                         CARDS_OR_NOTES_KEY to (cardsOrNotes == CardsOrNotes.CARDS),
                         IS_TRUNCATED_KEY to isTruncated,
+                        TAP_CARD_TO_EDIT to tapCardToEdit,
                     )
             }
         }

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -10,6 +10,41 @@
         android:orientation="vertical">
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_margin="8dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:text="On Tap"
+                android:textStyle="bold" />
+
+
+            <RadioGroup
+                android:id="@+id/select_tap_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:layout_marginHorizontal="16dp">
+
+                <RadioButton
+                    android:id="@+id/tap_to_preview_mode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Preview card" />
+
+                <RadioButton
+                    android:id="@+id/tap_to_edit_mode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="Edit card" />
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Some users wanted to have the option to change the click action inside Card Browser, like being able to click on a card and open the preview for that card.

## Fixes
* Fixes #14425

## Approach
This change adds an option in the Card Browser options dialog to let the user choose whether the click action is for card preview or card edit.

![image](https://github.com/user-attachments/assets/a029342b-c90b-4895-a4dc-9a233042f957)

I added a boolean state flow tapCardToEdit to the CardBrowserViewModel that changes the onTap function in the CardBrowser and saves the tapCardToEdit to sharedPref when the user changes the on tap action in the Browser option dialog.
## How Has This Been Tested?

I've ran the automated test and have tested on my own device and made sure all the cards work including special card types like cloze and image occlusion and type in answer cards.

## Learning (optional, can help others)
I looked through the code in the Card Browser, putting breakpoints in places that seem to have things to do with the card preview screen, and traced it to the performPreview function in the NoteEditor, then I adapted the code to launch the TemplatePreviewerPage intent to the Card Browser.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
