### PR TITLE
Added option to choose click action in Card Browser in options dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -38,6 +38,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
 import androidx.annotation.CheckResult
 import androidx.annotation.MainThread
+import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
@@ -104,6 +105,8 @@ import com.ichi2.anki.model.SortType
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.PreviewerFragment
+import com.ichi2.anki.previewer.TemplatePreviewerArguments
+import com.ichi2.anki.previewer.TemplatePreviewerPage
 import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
@@ -345,6 +348,7 @@ open class CardBrowser :
             showUndoSnackbar(TR.browsingCardsUpdated(changed.count))
         }
 
+    // TODO: move onTap logic to ViewModel as per #18178
     @VisibleForTesting
     fun onTap(id: CardOrNoteId) =
         launchCatchingTask {
@@ -354,7 +358,22 @@ open class CardBrowser :
                 viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
             } else {
                 val cardId = viewModel.queryDataForCardEdit(id)
-                openNoteEditorForCard(cardId)
+                if (viewModel.tapCardToEdit) {
+                    openNoteEditorForCard(cardId)
+                } else {
+                    val args = viewModel.getTemplatePreviewArguments(id)
+                    val templatePreviewerArgs =
+                        TemplatePreviewerArguments(
+                            notetypeFile = NotetypeFile(this@CardBrowser, args.notetype),
+                            fields = args.fields,
+                            tags = args.tags,
+                            id = args.id,
+                            ord = args.ord,
+                            fillEmpty = args.fillEmpty,
+                        )
+                    val intent = TemplatePreviewerPage.getIntent(this@CardBrowser, templatePreviewerArgs)
+                    this@CardBrowser.startActivity(intent)
+                }
             }
         }
 
@@ -1599,7 +1618,12 @@ open class CardBrowser :
     }
 
     private fun showOptionsDialog() {
-        val dialog = BrowserOptionsDialog.newInstance(viewModel.cardsOrNotes, viewModel.isTruncated)
+        val dialog =
+            BrowserOptionsDialog.newInstance(
+                viewModel.cardsOrNotes,
+                viewModel.isTruncated,
+                viewModel.tapCardToEdit,
+            )
         dialog.show(supportFragmentManager, "browserOptionsDialog")
     }
 
@@ -1678,7 +1702,7 @@ open class CardBrowser :
         get() {
             val count = viewModel.rowCount
 
-            @androidx.annotation.StringRes val subtitleId =
+            @StringRes val subtitleId =
                 if (viewModel.cardsOrNotes == CARDS) {
                     R.plurals.card_browser_subtitle
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -49,6 +49,7 @@ import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.SortType
 import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.preferences.SharedPreferencesProvider
+import com.ichi2.anki.preferences.booleanPref
 import com.ichi2.anki.utils.ext.normalizeForSearch
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import com.ichi2.annotations.NeedsTest
@@ -56,7 +57,11 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.CardType
 import com.ichi2.libanki.ChangeManager
+import com.ichi2.libanki.Consts.DEFAULT_DECK_ID
 import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.Note
+import com.ichi2.libanki.NoteId
+import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.QueueType.ManuallyBuried
 import com.ichi2.libanki.QueueType.SiblingBuried
@@ -185,6 +190,8 @@ class CardBrowserViewModel(
     val flowOfIsTruncated: MutableStateFlow<Boolean> =
         MutableStateFlow(sharedPrefs().getBoolean("isTruncated", false))
     val isTruncated get() = flowOfIsTruncated.value
+
+    var tapCardToEdit by booleanPref("tapCardToEdit", true)
 
     var shouldIgnoreAccents: Boolean = false
 
@@ -482,6 +489,39 @@ class CardBrowserViewModel(
         sharedPrefs().edit {
             putBoolean("isTruncated", value)
         }
+    }
+
+    /**
+     * Returns arguments to open the [com.ichi2.anki.previewer.TemplatePreviewerPage] for a note
+     * In card mode: opens the note of that specific card
+     * In note mode: opens that note
+     * Works the same as going to the NoteEditor and then to the TemplatePreviewerPage
+     */
+    suspend fun getTemplatePreviewArguments(id: CardOrNoteId): TemplatePreviewerUiArguments {
+        val cardId = queryDataForCardEdit(id)
+        val noteId = withCol { notesOfCards(mutableListOf(cardId)).first() }
+        val note = withCol { getNote(noteId) }
+        val ord =
+            if (note.notetype.isCloze) {
+                val tempNote = withCol { Note.fromNotetypeId(this@withCol, note.notetype.id) }
+                tempNote.fields = note.fields
+                val clozeNumbers = withCol { clozeNumbersInNote(tempNote) }
+                if (clozeNumbers.isNotEmpty()) {
+                    clozeNumbers.first() - 1
+                } else {
+                    0
+                }
+            } else {
+                0
+            }
+        return TemplatePreviewerUiArguments(
+            notetype = withCol { note.notetype },
+            fields = note.fields,
+            tags = note.tags,
+            id = noteId,
+            ord = ord,
+            fillEmpty = false,
+        )
     }
 
     fun setIgnoreAccents(value: Boolean) {
@@ -1218,4 +1258,14 @@ fun BrowserColumns.Column.getLabel(cardsOrNotes: CardsOrNotes): String = if (car
 
 data class ColumnHeading(
     val label: String,
+)
+
+data class TemplatePreviewerUiArguments(
+    val notetype: NotetypeJson,
+    val fields: MutableList<String>,
+    val tags: MutableList<String>,
+    val id: NoteId = 0,
+    val ord: Int = 0,
+    val fillEmpty: Boolean = false,
+    val deckId: DeckId = DEFAULT_DECK_ID,
 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -66,6 +66,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
             viewModel.setTruncated(newTruncate)
         }
 
+        val newTapCardToEdit = dialogView.findViewById<RadioButton>(R.id.tap_to_edit_mode).isChecked
+
+        if (newTapCardToEdit != tapCardToEdit) {
+            viewModel.tapCardToEdit = newTapCardToEdit
+        }
+
         val newIgnoreAccent = dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).isChecked
         if (newIgnoreAccent != viewModel.shouldIgnoreAccents) {
             viewModel.setIgnoreAccents(newIgnoreAccent)
@@ -89,6 +95,9 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
         }
     }
 
+    // defaults to tapping on card to edit
+    private val tapCardToEdit by lazy { arguments?.getBoolean(TAP_CARD_TO_EDIT) ?: true }
+
     private val isTruncated by lazy {
         arguments?.getBoolean(IS_TRUNCATED_KEY) ?: run {
             Timber.w("BrowserOptionsDialog instantiated without configuration.")
@@ -104,6 +113,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
             dialogView.findViewById<RadioButton>(R.id.select_cards_mode).isChecked = true
         } else {
             dialogView.findViewById<RadioButton>(R.id.select_notes_mode).isChecked = true
+        }
+
+        if (tapCardToEdit) {
+            dialogView.findViewById<RadioButton>(R.id.tap_to_edit_mode).isChecked = true
+        } else {
+            dialogView.findViewById<RadioButton>(R.id.tap_to_preview_mode).isChecked = true
         }
 
         dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked = isTruncated
@@ -153,10 +168,12 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
     companion object {
         private const val CARDS_OR_NOTES_KEY = "cardsOrNotes"
         private const val IS_TRUNCATED_KEY = "isTruncated"
+        private const val TAP_CARD_TO_EDIT = "tapCardToEdit"
 
         fun newInstance(
             cardsOrNotes: CardsOrNotes,
             isTruncated: Boolean,
+            tapCardToEdit: Boolean,
         ): BrowserOptionsDialog {
             Timber.i("BrowserOptionsDialog::newInstance")
             return BrowserOptionsDialog().apply {
@@ -164,6 +181,7 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
                     bundleOf(
                         CARDS_OR_NOTES_KEY to (cardsOrNotes == CardsOrNotes.CARDS),
                         IS_TRUNCATED_KEY to isTruncated,
+                        TAP_CARD_TO_EDIT to tapCardToEdit,
                     )
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SharedPreferencesProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SharedPreferencesProvider.kt
@@ -17,9 +17,33 @@
 package com.ichi2.anki.preferences
 
 import android.content.SharedPreferences
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
 
 /** Provides a reference to [SharedPreferences] without a required Android dependency */
 // SharedPreferences is an interface, so this remains Android-free
 fun interface SharedPreferencesProvider {
     fun sharedPrefs(): SharedPreferences
 }
+
+@VisibleForTesting
+fun SharedPreferencesProvider.booleanPref(
+    key: String,
+    defaultValue: Boolean,
+): ReadWriteProperty<Any?, Boolean> =
+    object : ReadWriteProperty<Any?, Boolean> {
+        override fun getValue(
+            thisRef: Any?,
+            property: KProperty<*>,
+        ): Boolean = sharedPrefs().getBoolean(key, defaultValue)
+
+        override fun setValue(
+            thisRef: Any?,
+            property: KProperty<*>,
+            value: Boolean,
+        ) {
+            sharedPrefs().edit { putBoolean(key, value) }
+        }
+    }

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -44,6 +44,40 @@
         </LinearLayout>
 
         <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:orientation="vertical">
+
+            <com.ichi2.ui.FixedTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:text="@string/toggle_tap_action"
+                android:textStyle="bold" />
+
+            <RadioGroup
+                android:id="@+id/select_tap_mode"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="16dp"
+                android:layout_marginTop="8dp">
+
+                <RadioButton
+                    android:id="@+id/tap_to_preview_mode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tap_to_preview" />
+
+                <RadioButton
+                    android:id="@+id/tap_to_edit_mode"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/tap_to_edit" />
+            </RadioGroup>
+        </LinearLayout>
+
+        <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -325,6 +325,9 @@
     <string name="deck_shortcut_doesnt_exist">Deck deleted. Please remove the shortcut</string>
 
     <!-- Browser Options Dialog -->
+    <string name="toggle_tap_action">On tap</string>
+    <string name="tap_to_edit" comment="Label for toggle tap action to edit in BrowserOptionsDialog">Edit card</string>
+    <string name="tap_to_preview" comment="Label for toggle tap action to preview in BrowserOptionsDialog">Preview card</string>
     <string name="show_cards" comment="Label for toggle cards button in BrowserOptionsDialog">Cards</string>
     <string name="show_notes" comment="Label for toggle notes button in BrowserOptionsDialog">Notes</string>
     <string name="toggle_cards_notes">Toggle Cards/Notes</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Some users wanted to have the option to change the click action inside Card Browser, like being able to click on a card and open the preview for that card.

## Fixes
* Fixes #14425

## Approach
This change adds an option in the Card Browser options dialog to let the user choose whether the click action is for card preview or card edit.

![image](https://github.com/user-attachments/assets/a029342b-c90b-4895-a4dc-9a233042f957)

I added a boolean state flow tapCardToEdit to the CardBrowserViewModel that changes the onTap function in the CardBrowser and saves the tapCardToEdit to sharedPref when the user changes the on tap action in the Browser option dialog.
## How Has This Been Tested?

I've ran the automated test and have tested on my own device and made sure all the cards work including special card types like cloze and image occlusion and type in answer cards.

## Learning (optional, can help others)
I looked through the code in the Card Browser, putting breakpoints in places that seem to have things to do with the card preview screen, and traced it to the performPreview function in the NoteEditor, then I adapted the code to launch the TemplatePreviewerPage intent to the Card Browser.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
