### PR TITLE
Add utility method for setting a fragment result listener in a FragmentActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -110,6 +110,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.ifNotZero
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckDropDownAdapter.SubtitleListener
 import com.ichi2.annotations.NeedsTest
@@ -451,7 +452,7 @@ open class CardBrowser :
 
         setupFlows()
         registerOnForgetHandler { viewModel.queryAllSelectedCardIds() }
-        supportFragmentManager.setFragmentResultListener(REQUEST_REPOSITION_NEW_CARDS, this) { _, bundle ->
+        setFragmentResultListener(REQUEST_REPOSITION_NEW_CARDS) { _, bundle ->
             repositionCardsNoValidation(
                 position = bundle.getInt(RepositionCardFragment.ARG_POSITION),
                 step = bundle.getInt(RepositionCardFragment.ARG_STEP),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -136,6 +136,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.SyncErrorDialog.SyncErrorDialogListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
 import com.ichi2.anki.export.ActivityExportingDelegate
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.export.ExportDialogsFactory
@@ -158,6 +159,7 @@ import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.anki.worker.SyncMediaWorker
@@ -603,7 +605,7 @@ open class DeckPicker :
 
         checkWebviewVersion(this)
 
-        supportFragmentManager.setFragmentResultListener(CustomStudyAction.REQUEST_KEY, this) { requestKey, bundle ->
+        setFragmentResultListener(REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION -> {
                     Timber.d("Custom study created")
@@ -620,16 +622,12 @@ open class DeckPicker :
             }
         }
 
-        supportFragmentManager.setFragmentResultListener(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU, this) { requestKey, arguments ->
-            when (requestKey) {
-                DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU ->
-                    handleContextMenuSelection(
-                        arguments.getSerializableCompat<DeckPickerContextMenuOption>(DeckPickerContextMenu.CONTEXT_MENU_DECK_OPTION)
-                            ?: error("Unable to retrieve selected context menu option"),
-                        arguments.getLong(DeckPickerContextMenu.CONTEXT_MENU_DECK_ID, -1),
-                    )
-                else -> error("Unexpected fragment result key! Did you forget to update DeckPicker?")
-            }
+        setFragmentResultListener(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU) { _, bundle ->
+            handleContextMenuSelection(
+                bundle.getSerializableCompat<DeckPickerContextMenuOption>(DeckPickerContextMenu.CONTEXT_MENU_DECK_OPTION)
+                    ?: error("Unable to retrieve selected context menu option"),
+                bundle.getLong(DeckPickerContextMenu.CONTEXT_MENU_DECK_ID, -1),
+            )
         }
 
         pullToSyncWrapper.configureView(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -23,10 +23,13 @@ import android.os.Bundle
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.edit
+import androidx.core.os.BundleCompat
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption
-import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.handleCollectionSetupOption
+import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.FRAGMENT_KEY
+import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.RESULT_KEY
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.annotations.NeedsTest
 import timber.log.Timber
 
@@ -58,7 +61,9 @@ class IntroductionActivity : AnkiActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.introduction_activity)
 
-        handleCollectionSetupOption { option ->
+        setFragmentResultListener(FRAGMENT_KEY) { _, bundle ->
+            val option =
+                BundleCompat.getParcelable(bundle, RESULT_KEY, CollectionSetupOption::class.java) ?: error("Missing introduction option!")
             when (option) {
                 CollectionSetupOption.DeckPickerWithNewCollection -> startDeckPicker()
                 CollectionSetupOption.SyncFromExistingAccount -> openLoginDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -25,6 +25,7 @@ import androidx.fragment.app.commit
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.themes.setTransparentStatusBar
 import com.ichi2.utils.FragmentFactoryUtils
 import timber.log.Timber
@@ -74,7 +75,7 @@ open class SingleFragmentActivity : AnkiActivity() {
             replace(R.id.fragment_container, fragment, FRAGMENT_TAG)
         }
 
-        supportFragmentManager.setFragmentResultListener(CustomStudyAction.REQUEST_KEY, this) { requestKey, bundle ->
+        setFragmentResultListener(CustomStudyAction.REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION,
                 CustomStudyAction.EXTEND_STUDY_LIMITS,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -26,6 +26,8 @@ import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.StudyOptionsFragment.StudyOptionsListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.libanki.ChangeManager
 import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.widget.WidgetStatus
@@ -49,7 +51,7 @@ class StudyOptionsActivity :
         }
         setResult(RESULT_OK)
 
-        supportFragmentManager.setFragmentResultListener(CustomStudyAction.REQUEST_KEY, this) { requestKey, bundle ->
+        setFragmentResultListener(REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {
                 CustomStudyAction.CUSTOM_STUDY_SESSION,
                 CustomStudyAction.EXTEND_STUDY_LIMITS,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -48,6 +48,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.ARG_SEARCH
 import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.REQUEST_FIND_AND_REPLACE
 import com.ichi2.anki.notetype.ManageNotetypes
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
@@ -203,16 +204,15 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
 }
 
 fun CardBrowser.registerFindReplaceHandler(action: (FindReplaceResult) -> Unit) {
-    supportFragmentManager.setFragmentResultListener(REQUEST_FIND_AND_REPLACE, this) { _, bundle ->
+    setFragmentResultListener(REQUEST_FIND_AND_REPLACE) { _, bundle ->
         action(
             FindReplaceResult(
                 search = bundle.getString(ARG_SEARCH) ?: error("Missing required argument: search"),
-                replacement =
-                    bundle.getString(ARG_REPLACEMENT) ?: error("Missing required argument: replacement"),
+                replacement = bundle.getString(ARG_REPLACEMENT) ?: error("Missing required argument: replacement"),
                 field = bundle.getString(ARG_FIELD) ?: error("Missing required argument: field"),
-                bundle.getBoolean(ARG_ONLY_SELECTED_NOTES, true),
-                bundle.getBoolean(ARG_MATCH_CASE, false),
-                bundle.getBoolean(ARG_REGEX, false),
+                onlyOnSelectedNotes = bundle.getBoolean(ARG_ONLY_SELECTED_NOTES, true),
+                matchCase = bundle.getBoolean(ARG_MATCH_CASE, false),
+                regex = bundle.getBoolean(ARG_REGEX, false),
             ),
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/introduction/SetupCollectionFragment.kt
@@ -37,10 +37,8 @@ import android.os.Bundle
 import android.os.Parcelable
 import android.view.View
 import android.widget.Button
-import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.setFragmentResult
 import com.ichi2.anki.R
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption.DeckPickerWithNewCollection
@@ -90,13 +88,5 @@ class SetupCollectionFragment : Fragment(R.layout.introduction_layout) {
     companion object {
         const val FRAGMENT_KEY = "collectionSetup"
         const val RESULT_KEY = "result"
-
-        /** Handles a result from a [SetupCollectionFragment] */
-        fun FragmentActivity.handleCollectionSetupOption(handleResult: (CollectionSetupOption) -> Unit) {
-            supportFragmentManager.setFragmentResultListener(FRAGMENT_KEY, this) { _, b ->
-                val item = BundleCompat.getParcelable(b, RESULT_KEY, CollectionSetupOption::class.java)!!
-                handleResult(item)
-            }
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.annotations.NeedsTest
@@ -156,7 +157,7 @@ class ForgetCardsDialog : DialogFragment() {
  * @param cardsIdsProducer lambda which returns the list of cards for which to reset the progress
  */
 internal fun AnkiActivity.registerOnForgetHandler(cardsIdsProducer: suspend () -> List<CardId>) {
-    supportFragmentManager.setFragmentResultListener(ForgetCardsDialog.REQUEST_KEY_FORGET, this) { _, bundle: Bundle ->
+    setFragmentResultListener(ForgetCardsDialog.REQUEST_KEY_FORGET) { _, bundle ->
         forgetCards(
             cardsIdsProducer = cardsIdsProducer,
             restoreOriginalPositionIfPossible = bundle.getBoolean(ForgetCardsDialog.ARG_RESTORE_ORIGINAL),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentResult.kt
@@ -1,0 +1,35 @@
+/****************************************************************************************
+ * Copyright (c) 2025 lukstbit <52494258+lukstbit@users.noreply.github.com>             *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+package com.ichi2.anki.utils.ext
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.setFragmentResultListener
+
+/**
+ * Utility method that simplifies setting a fragment result listener in a [FragmentActivity].
+ * Similar to [Fragment.setFragmentResultListener] library method.
+ *
+ * @param requestKey identifier for the request
+ * @param listener a callback triggered when the result associated to [requestKey] is set.
+ */
+fun FragmentActivity.setFragmentResultListener(
+    requestKey: String,
+    listener: ((requestKey: String, bundle: Bundle) -> Unit),
+) {
+    supportFragmentManager.setFragmentResultListener(requestKey, this, listener)
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Adds a method to simplify setting a fragment result listener in a FragmentActtivity. Similar with the [Fragment.setFragmentResultListener()](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:fragment/fragment-ktx/src/main/java/androidx/fragment/app/Fragment.kt?q=file:androidx%2Ffragment%2Fapp%2FFragment.kt%20function:setFragmentResultListener) platform method.

Feel free to disagree with this and I can close it.

Also, I looked into creating an extension to return a result class in the listener but I don't think it's worth the effort and it doesn't simplify things at all.

## How Has This Been Tested?

Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
