### PR TITLE
feat: add support for choosing a custom backup location (#15034)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.libanki.createBackup
 import kotlinx.coroutines.Dispatchers
@@ -59,5 +60,11 @@ private suspend fun createBackup(force: Boolean) {
     // move this outside 'withCol' to avoid blocking
     withContext(Dispatchers.IO) {
         CollectionManager.getBackend().awaitBackupCompletion()
+
+        // move to custom backup directory after creation if set
+        val context = AnkiDroidApp.instance.applicationContext
+        sharedPrefs().getString("backup_directory", null)?.let {
+            BackupManager().moveBackupFilesFromDefault(context)
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -383,6 +383,10 @@ object CollectionManager {
             ensureBackendInner()
             importCollectionPackage(backend!!, collectionPathInValidFolder(), colpkgPath)
         }
+        // delete after import if the path is in cache (temp to get absolutePath)
+        File(colpkgPath).takeIf { it.parent == AnkiDroidApp.instance.baseContext.cacheDir.absolutePath }?.apply {
+            delete()
+        }
     }
 
     fun setTestDispatcher(dispatcher: CoroutineDispatcher) {

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -142,6 +142,11 @@
     <string name="image_max_size_allowed">Maximum image size %d MB allowed</string>
     <string name="image_dimensions_too_large">Image dimensions are too large (%1$d × %2$d)</string>
 
+    <!-- Backup Folder-->
+    <string name="no_folder_selected">No folder selected</string>
+    <string name="remove_backup_folder">Remove backup folder?</string>
+    <string name="backup_folder_removed">Backup folder removed</string>
+
     <!-- Global Intent handler -->
     <!-- Also used by Card Browser, not renaming to save translators effort -->
     <string name="intent_handler_failed_no_storage_permission">Missing required storage permission. Please grant storage permission then retry your action.</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -21,6 +21,7 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- generic strings -->
     <string name="disabled">Disabled</string>
+    <string name="not_set">Not Set</string>
     <plurals name="pref_summ_minutes">
         <item quantity="one">%d min</item>
         <item quantity="other">%d mins</item>
@@ -308,11 +309,15 @@ this formatter is used if the bind only applies to both the question and the ans
         To be safe, please periodically synchronize your collection, or back up exports of it.
         <br><br>
         You can restore from a backup and export your collection in the deck list menu.
+        <br><br>
+        You can set a custom folder for backups, this is useful for permanent backups in case AnkiDroid is uninstalled.
+        It will mirror the default backup directory, following your backup preferences.
     ]]></string>
     <string name="pref__minutes_between_automatic_backups__title" maxLength="41">Minutes between automatic backups</string>
     <string name="pref__daily_backups_to_keep__title" maxLength="41">Daily backups to keep</string>
     <string name="pref__weekly_backups_to_keep__title" maxLength="41">Weekly backups to keep</string>
     <string name="pref__monthly_backups_to_keep__title" maxLength="41">Monthly backups to keep</string>
+    <string name="pref__backup_directory_path__title">Custom Backup Location</string>
 
     <!-- #######################################################################################
          ################################# Manage space activity ###############################

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -202,6 +202,7 @@
     <string name="pref_daily_backups_to_keep_key">daily_backups_to_keep</string>
     <string name="pref_weekly_backups_to_keep_key">weekly_backups_to_keep</string>
     <string name="pref_monthly_backups_to_keep_key">monthly_backups_to_keep</string>
+    <string name="pref_backup_directory_key">backup_directory</string>
 
     <!-- Reviewer options -->
     <string name="hide_system_bars_key">hideSystemBars</string>

--- a/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
@@ -33,4 +33,8 @@
         android:title="@string/pref__monthly_backups_to_keep__title"
         android:persistent="false"
         app:min="0"/>
-</PreferenceScreen>
+    <Preference
+        android:key="@string/pref_backup_directory_key"
+        android:title="@string/pref__backup_directory_path__title"
+        android:summary="@string/not_set"/>
+</PreferenceScreen> 


### PR DESCRIPTION
## Purpose / Description
Add an option to have custom backup location. It is useful if AnkiDroid is uninstalled or if you want to sync it with cloud-synced folder

## Fixes
* Fixes #15034

## Approach
![Screenshot_2025 03 30_20 58 35 890](https://github.com/user-attachments/assets/914b6e34-1dab-4558-877b-5d994b3aed4c)
I've added another preference in the backup settings with the key "backup_directory". When clicked, it opens a file picker that returns a URI. This URI is saved in the preference solely for updating the preference summary, while file transfers/movements use contentResolver.persistedUriPermissions.

There are three scenarios:

- When the user first sets a custom directory, the backup is moved from the default directory to the selected URI.

- When the user removes the custom directory, the backup is moved from the last custom directory back to the default directory.

- When the user updates an existing custom directory to a new one, the backup is moved from the first directory to the second.

Additionally, when a new backup is created, it checks for a custom directory. If one is set, the backup is moved there. When restoring a backup, it also checks for a custom directory, if set. 

To restore from custom directory, I use a trick where the colpkg file is copied to the cache directory as a temporary file. This is necessary because the backend expects an absolute file path, not an SAF URI. By copying the file to a temporary location, I can retrieve its absolute path for processing. Once the import is complete, the temporary file is deleted.

If there is better implementation, I am always open to improve the code

## How Has This Been Tested?

### Adding Backup Location
- Open settings, Navigate to Backup → Custom Backup Location
- Select a folder.
Expected Outcome: Backup Files should be in the Custom Backup Location
Verification: Check the selected folder in your file manager or open the file picker again to confirm the move. 


### Changing Backup Location (Persisted URI to Persisted URI)
- Ensure a custom backup location is already set.
- Open the file picker and choose another folder.
Expected Outcome: The backup should be moved to the new folder without issues. The old folder doesn't have any colpkg file left.

### Deleting Backup Location
- Ensure a custom backup location is set.
- Open the file picker, but instead of selecting a new folder, press back 2-3 times to return to the Deck Picker screen.
Expected Outcome: A dialog should appear asking "remove folder?"
Press "Yes" to confirm.
Verification: The previously set folder should now be empty.

### Get backup files from custom folder
- Ensure a custom backup location is set.
- Press the action bar menu (3 dot button) → Restore from Backup
Expected Outcome: The backup list should appear as much as the file
Verification: Compare with not setting the custom backup location

### Restore backup from custom folder
- Ensure a custom backup location is set.
- Press the action bar menu (3 dot button) → Restore from Backup
- Press one of them to be restored
Expected Outcome: The import run as usual
Verification: Compare with not setting the custom backup location

AnkiDroid Version = 2.21alpha13-debug (6e6c4d1079f81f0e5921ca657d4bcb175116050d)
Backend Version = 0.1.52-anki25.02 (25.02 038d85b1d9e1896e93a3e4a26f600c79ddc33611)
Android Version = 11 (SDK 30)
ProductFlavor = amazon
Device Info = samsung | samsung | r0q | r0qxxx | SM-S901E | qcom
Webview User Agent = Mozilla/5.0 (Linux; Android 11; SM-S901E Build/SP1A.210812.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.120 Mobile Safari/537.36
ACRA UUID = 8283989a-e209-41cd-8ea1-674c69552de4
FSRS = 2.0.3 (Enabled: null)
Crash Reports Enabled = false

## Learning (optional, can help others)
First, I studied the source code and created a Preference for the new settings. Using the built in Preference made it easier to integrate with SharedPreferences, no need to create UI and easy to updates. Even easier when using the EditText or other more specified Preference that have automatic update when saving, which I think not suitable in my case. I initially tried saving the URI as a string in SharedPreferences and converting it back when needed, but this didn’t work because the converted URI was no longer a valid SAF URI.

After seeking advice from Discord and Stack Overflow, I learned to use SAF URIs with persistedUriPermissions via contentResolver.persistedUriPermissions, which worked. However, my implementation isn’t ideal, as it currently relies on persistedUriPermissions[0] / persistedUriPermissions.first(), which could break if the app manages multiple persisted URIs in the future.

Next, I reviewed the backup process in BackendBackups.kt, but I couldn't fully inspect it since it's handled in the backend. It also seems to bypass the backup settings (daily, weekly, monthly to keep and also minutes between backup) from the Preferences. Additionally, I found a BackupManager.createBackup() method that isn’t being used (It is removed recently), which caused some confusion. 

For restoring backups, it also handled in the backend. It requires an absolute file path as a parameter, which isn’t compatible with DocumentFile (SAF URIs). After some LLM researching :3 , I discovered a workaround: which I have described in Approach.