### PR TITLE
fix:bottom alignment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -57,6 +57,7 @@ import anki.notetypes.StockNotetype
 import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_UNKNOWN_VALUE
 import anki.notetypes.notetypeId
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import com.google.android.material.button.MaterialButton
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -101,6 +102,7 @@ import com.ichi2.ui.FixedEditText
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.copyToClipboard
+import com.ichi2.utils.dp
 import com.ichi2.utils.listItems
 import com.ichi2.utils.show
 import kotlinx.coroutines.launch
@@ -238,6 +240,16 @@ open class CardTemplateEditor :
             val fragment = TemplatePreviewerFragment.newInstance(args, backgroundColor)
             supportFragmentManager.commitNow {
                 replace(R.id.fragment_container, fragment)
+            }
+
+            // Modify the "Show Answer" button height to 80dp to maintain visual consistency with the BottomNavigationView,
+            // which has a default height of 80dp.
+            fragment.view?.post {
+                val showAnswerButton = fragment.view?.findViewById<MaterialButton>(R.id.show_answer)
+                showAnswerButton?.let { button ->
+                    button.layoutParams.height = 80.dp.toPx(button.context)
+                    button.requestLayout()
+                }
             }
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Bottom Alignment Issue `Show answer`

## Approach
set bottom `show answer` height to `80dp`

## How Has This Been Tested?
Medium Tablet API 33

### Before
![image](https://github.com/user-attachments/assets/d85f5104-897e-4b50-833e-31fdd97ba15c)

### After
![image](https://github.com/user-attachments/assets/241683b1-9c9e-4de6-80fa-dfffed45b21e)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)