### PR TITLE
Refactor: move extensions to `common` module

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -27,6 +27,7 @@ import anki.notetypes.StockNotetype
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.provider.pureAnswer
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
@@ -48,7 +49,6 @@ import com.ichi2.libanki.getStockNotetypeLegacy
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.common.assertThrows
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.emptyStringArray
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/NotificationChannelTest.kt
@@ -23,9 +23,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SdkSuppress
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.Channel
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.testutil.GrantStoragePermission
 import com.ichi2.compat.CompatHelper.Companion.sdkVersion
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.greaterThanOrEqualTo
 import org.junit.Before

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
@@ -18,10 +18,10 @@ package com.ichi2.anki.tests
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not
 import org.junit.Assert.assertTrue

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -56,6 +56,7 @@ import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.CustomExceptionData
@@ -77,7 +78,6 @@ import com.ichi2.libanki.Collection
 import com.ichi2.themes.Themes
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.HandlerUtils
-import com.ichi2.utils.KotlinCleanup
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -38,6 +38,7 @@ import anki.collection.OpChanges
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
 import com.ichi2.anki.contextmenu.CardBrowserContextMenu
@@ -58,7 +59,6 @@ import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.ChangeManager
 import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ExceptionUtil
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.Permissions
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.AnkiDroidJsAPIConstants.ANKI_JS_ERROR_CODE_SUSPEND_NOTE
 import com.ichi2.anki.AnkiDroidJsAPIConstants.flagCommands
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.common.utils.ext.stringIterable
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.servicelayer.rescheduleCards
 import com.ichi2.anki.servicelayer.resetCards
@@ -48,7 +49,6 @@ import com.ichi2.libanki.Decks
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.SortOrder
 import com.ichi2.utils.NetworkUtils
-import com.ichi2.utils.stringIterable
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -77,6 +77,7 @@ import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
@@ -122,7 +123,6 @@ import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.SortOrder
 import com.ichi2.libanki.undoableOp
 import com.ichi2.ui.CardBrowserSearchView
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.TagsUtil.getUpdatedTags
 import com.ichi2.utils.dp

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -64,6 +64,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -99,7 +100,6 @@ import com.ichi2.libanki.undoableOp
 import com.ichi2.themes.Themes
 import com.ichi2.ui.FixedEditText
 import com.ichi2.ui.FixedTextView
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.listItems
 import com.ichi2.utils.show

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -22,6 +22,7 @@ import android.os.Bundle
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.core.os.bundleOf
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.async.saveModel
 import com.ichi2.compat.CompatHelper.Companion.compat
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -29,7 +30,6 @@ import com.ichi2.libanki.CardTemplate
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -108,6 +108,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
@@ -178,7 +179,6 @@ import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ClipboardUtil.IMPORT_MIME_TYPES
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.ImportUtils.ImportResult
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
 import com.ichi2.utils.SyncStatus

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -26,6 +26,7 @@ import androidx.annotation.MainThread
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckCreationListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
@@ -36,7 +37,6 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
 import com.ichi2.utils.FragmentManagerSupplier
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.asFragmentManagerSupplier
 import timber.log.Timber
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -35,9 +35,9 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.os.ParcelCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.ui.AnimationUtil.collapseView
 import com.ichi2.ui.AnimationUtil.expandView
-import com.ichi2.utils.KotlinCleanup
 import java.util.Locale
 
 @KotlinCleanup("replace _name with `field`")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -29,6 +29,7 @@ import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.annotation.VisibleForTesting
 import com.google.android.material.color.MaterialColors
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.snackbar.showSnackbar
@@ -37,7 +38,6 @@ import com.ichi2.utils.ClipboardUtil.getDescription
 import com.ichi2.utils.ClipboardUtil.getPlainText
 import com.ichi2.utils.ClipboardUtil.getUri
 import com.ichi2.utils.ClipboardUtil.hasMedia
-import com.ichi2.utils.KotlinCleanup
 import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 import java.util.Locale

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -28,13 +28,13 @@ import android.preference.Preference
 import android.preference.PreferenceCategory
 import androidx.core.content.edit
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.common.utils.ext.stringIterable
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.preferences.StepsPreference.Companion.convertFromJSON
 import com.ichi2.preferences.StepsPreference.Companion.convertToJSON
 import com.ichi2.themes.Themes
 import com.ichi2.ui.AppCompatPreferenceActivity
-import com.ichi2.utils.stringIterable
 import org.json.JSONArray
 import org.json.JSONException
 import org.json.JSONObject

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -7,11 +7,11 @@ import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteException
 import androidx.annotation.WorkerThread
 import androidx.core.database.sqlite.transaction
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.model.WhiteboardPenColor
 import com.ichi2.anki.model.WhiteboardPenColor.Companion.default
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.libanki.DeckId
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.widget.SmallWidgetStatus
 import timber.log.Timber
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -35,6 +35,7 @@ import androidx.core.net.toUri
 import androidx.core.view.isVisible
 import com.google.android.material.textfield.TextInputEditText
 import com.google.android.material.textfield.TextInputLayout
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.help.HelpDialog
 import com.ichi2.anki.pages.RemoveAccountFragment
 import com.ichi2.anki.settings.Prefs
@@ -42,7 +43,6 @@ import com.ichi2.anki.utils.ext.removeFragmentFromContainer
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.ui.TextInputEditField
 import com.ichi2.utils.AdaptionUtil.isUserATestClient
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions
 import timber.log.Timber
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -91,6 +91,7 @@ import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.bottomsheet.ImageOcclusionBottomSheetFragment
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.ConfirmationDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
@@ -168,7 +169,6 @@ import com.ichi2.utils.HashUtil
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.IntentUtil.resolveMimeType
 import com.ichi2.utils.KeyUtils
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.MapUtil
 import com.ichi2.utils.NoteFieldDecorator
 import com.ichi2.utils.TextViewUtil

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -29,9 +29,9 @@ import com.brsanthu.googleanalytics.request.DefaultRequest
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.utils.DisplayUtils
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.WebViewDebugging.hasSetDataDirectory
 import org.acra.ACRA
 import org.acra.util.Installation

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.OnContextAndLongClickListener.Companion.setOnContextAndLongClickListener
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.launchCatchingTask
@@ -51,7 +52,6 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
 import com.ichi2.libanki.sched.DeckNode
 import com.ichi2.ui.AccessibleSearchView
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.TypedFilter
 import com.ichi2.utils.create
 import com.ichi2.utils.customView

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_NEW
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_REV
@@ -67,7 +68,6 @@ import com.ichi2.libanki.Deck
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.undoableOp
 import com.ichi2.utils.BundleUtils.getNullableInt
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.bundleOfNotNull
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.customView

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogListener.kt
@@ -18,9 +18,9 @@ package com.ichi2.anki.dialogs.tags
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
-import com.ichi2.utils.KotlinCleanup
 import java.util.ArrayList
 
 @KotlinCleanup("make selectedTags and indeterminateTags non-null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -47,6 +47,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CustomActionModeCallback
 import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.launchCatchingTask
@@ -58,7 +59,6 @@ import com.ichi2.libanki.NotetypeJson
 import com.ichi2.themes.setTransparentBackground
 import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.AssetHelper.TEXT_PLAIN
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -22,9 +22,9 @@ package com.ichi2.anki.multimediacard.fields
 import android.net.Uri
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
-import com.ichi2.utils.KotlinCleanup
 import org.jsoup.Jsoup
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -22,10 +22,10 @@ import android.view.View
 import com.ichi2.anki.FieldEditLine
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Field
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.MapUtil.getKeyByValue
 import java.util.ArrayList
 import kotlin.math.min

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.utils.ext.description
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardTemplate
@@ -57,7 +58,6 @@ import com.ichi2.libanki.sched.DeckNode
 import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.FileUtil.internalizeUri
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.Permissions.arePermissionsDefinedInManifest
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import org.json.JSONArray

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
@@ -25,7 +25,7 @@ import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.Ease
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 
 /**
  * The UI of an ease button

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/NoteType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/NoteType.kt
@@ -17,9 +17,9 @@
 package com.ichi2.anki.utils.ext
 
 import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_IMAGE_OCCLUSION_VALUE
+import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import com.ichi2.anki.utils.CardTemplateJson
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.utils.jsonObjectIterable
 import org.json.JSONException
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
@@ -19,7 +19,7 @@
  ****************************************************************************************/
 
 package com.ichi2.anki.web
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient

--- a/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/async/CollectionOperations.kt
@@ -17,9 +17,9 @@
 package com.ichi2.async
 
 import com.ichi2.anki.CardTemplateNotetype
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NotetypeJson
-import com.ichi2.utils.KotlinCleanup
 import timber.log.Timber
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/compat/BaseCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/BaseCompat.kt
@@ -31,7 +31,7 @@ import android.os.Vibrator
 import android.provider.MediaStore
 import android.view.View
 import androidx.appcompat.widget.TooltipCompat
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CardTemplate.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.libanki
 
+import com.ichi2.anki.common.utils.ext.deepClone
 import com.ichi2.utils.JSONObjectHolder
 import com.ichi2.utils.deepClone
 import net.ankiweb.rsdroid.RustCleanup

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,6 +40,7 @@ import anki.search.BrowserRow
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.ids2str
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.backend.model.toProtoBuf
@@ -50,7 +51,6 @@ import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -28,8 +28,8 @@ import androidx.annotation.WorkerThread
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService.sendExceptionReport
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
-import com.ichi2.utils.KotlinCleanup
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.database.AnkiSupportSQLiteDatabase
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -36,6 +36,7 @@ import anki.decks.DeckTreeNode
 import anki.decks.FilteredDeckForUpdate
 import anki.decks.SetDeckCollapsedRequest
 import anki.decks.copy
+import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.BackendUtils.toJsonBytes
@@ -43,7 +44,6 @@ import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.append
 import com.ichi2.libanki.utils.len
-import com.ichi2.utils.jsonObjectIterable
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -20,11 +20,11 @@ package com.ichi2.libanki
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import anki.notes.NoteFieldsCheckResponse
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Consts.DEFAULT_DECK_ID
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.emptyStringArray
 import java.util.regex.Pattern
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -17,8 +17,8 @@
 package com.ichi2.libanki
 
 import androidx.annotation.CheckResult
+import com.ichi2.anki.common.utils.ext.toStringList
 import com.ichi2.utils.deepClonedInto
-import com.ichi2.utils.toStringList
 import org.intellij.lang.annotations.Language
 import org.json.JSONArray
 import org.json.JSONObject

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/PythonExtensions.kt
@@ -16,7 +16,7 @@
 
 package com.ichi2.libanki.utils
 
-import com.ichi2.utils.jsonObjectIterable
+import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import org.json.JSONArray
 import org.json.JSONObject
 import java.util.Optional

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreference.kt
@@ -24,7 +24,7 @@ import android.view.ViewGroup
 import android.widget.Button
 import android.widget.LinearLayout
 import com.ichi2.anki.R
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 
 // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5019 : use IncrementerNumberRangePreferenceCompat
 @Suppress("deprecation", "OVERRIDE_DEPRECATION")

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -22,8 +22,8 @@ import android.util.AttributeSet
 import android.view.View
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.ext.stringIterable
 import com.ichi2.anki.showThemedToast
-import com.ichi2.utils.stringIterable
 import org.json.JSONArray
 import org.json.JSONException
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -41,12 +41,12 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.receiver.SdCardReceiver
 import com.ichi2.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Deck
 import com.ichi2.utils.HashUtil
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.message
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -22,7 +22,7 @@ import android.util.AttributeSet
 import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.appcompat.widget.AppCompatCheckBox
 import com.ichi2.anki.R
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 
 /**
  * Based on https://gist.github.com/kevin-barrientos/d75a5baa13a686367d45d17aaec7f030.

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HashUtil.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.ichi2.utils
 
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import java.util.HashMap
 import java.util.HashSet
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONArray.kt
@@ -41,6 +41,7 @@
  */
 package com.ichi2.utils
 
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/JSONContainer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/JSONContainer.kt
@@ -17,6 +17,7 @@
 package com.ichi2.utils
 
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.common.utils.ext.jsonObjectIterator
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.append
 import com.ichi2.libanki.utils.index

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -18,6 +18,7 @@
 
 package com.ichi2.utils
 
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import org.apache.commons.collections4.list.SetUniqueList
 import java.util.Arrays
 import java.util.Spliterator

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -14,6 +14,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
 import com.ichi2.anki.dialogs.DeckPickerContextMenu
@@ -32,7 +33,6 @@ import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.grantWritePermissions
 import com.ichi2.testutils.revokeWritePermissions
-import com.ichi2.utils.KotlinCleanup
 import com.ichi2.utils.ResourceLoader
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand.FLIP_OR_ANSWER_EASE1
 import com.ichi2.anki.cardviewer.ViewerCommand.MARK
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.PreferenceTestUtils
 import com.ichi2.anki.preferences.sharedPrefs
@@ -51,7 +52,6 @@ import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.testutils.ext.addNote
 import com.ichi2.utils.BASIC_MODEL_NAME
-import com.ichi2.utils.KotlinCleanup
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertTrue

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/AnalyticsConstantsTest.kt
@@ -12,7 +12,7 @@
  */
 package com.ichi2.anki.analytics
 
-import com.ichi2.utils.KotlinCleanup
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/ActionButtonStatusTest.kt
@@ -18,8 +18,8 @@ package com.ichi2.anki.reviewer
 import android.content.SharedPreferences
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.preferences.PreferenceTestUtils
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -16,11 +16,11 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.stripHTML
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.endsWith

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/PythonExtensionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/PythonExtensionsTest.kt
@@ -17,8 +17,8 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import com.ichi2.libanki.utils.insert
-import com.ichi2.utils.jsonObjectIterable
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.collection.IsIterableContainingInOrder.contains

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.libanki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.scheduler.UnburyDeckRequest
 import com.ichi2.anki.Ease
+import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.CardType.Relearning
 import com.ichi2.libanki.Consts.LEECH_SUSPEND
@@ -29,7 +30,6 @@ import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.KotlinCleanup
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers

--- a/common/src/main/java/com/ichi2/anki/common/utils/annotation/KotlinCleanup.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/annotation/KotlinCleanup.kt
@@ -18,7 +18,7 @@
         "@RunWith(AndroidJUnit4::class) to speed up tests (if no other Android references)",
 )
 
-package com.ichi2.utils
+package com.ichi2.anki.common.utils.annotation
 
 /** Use when code can be changed after further conversion to Kotlin */
 @Target(

--- a/common/src/main/java/com/ichi2/anki/common/utils/ext/JSONArray.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/ext/JSONArray.kt
@@ -39,9 +39,10 @@
  *    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  *    SOFTWARE.
  */
-package com.ichi2.utils
+package com.ichi2.anki.common.utils.ext
 
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.utils.deepClone
 import org.json.JSONArray
 import org.json.JSONObject
 

--- a/common/src/main/java/com/ichi2/anki/common/utils/ext/JSONObject.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/ext/JSONObject.kt
@@ -43,6 +43,7 @@ package com.ichi2.utils
 
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.common.utils.ext.deepClone
 import org.json.JSONArray
 import org.json.JSONObject
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
We want to move `libanki` to a separate module so its a part of #18015

## Fixes
N/A

## Approach
Moved Kotlin clean up then json ext, the commits explain it 

## How Has This Been Tested?
Local build successful 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
