### PR TITLE
feat: use `NotificationChannelCompat.Builder` for channel creation 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -180,7 +180,7 @@ open class AnkiDroidApp :
             this,
             preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true),
         )
-        CompatHelper.compat.setupNotificationChannel(applicationContext)
+        setupNotificationChannels(applicationContext)
 
         makeBackendUsable(this)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -49,7 +49,6 @@ import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.FullDraggableContainerFix
-import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.CardId
 import com.ichi2.utils.HandlerUtils
 import com.ichi2.utils.IntentUtil
@@ -276,7 +275,7 @@ abstract class NavigationDrawerActivity :
                 REQUEST_PREFERENCES_UPDATE,
                 result.resultCode,
             )
-            CompatHelper.compat.setupNotificationChannel(applicationContext)
+            setupNotificationChannels(applicationContext)
             // Restart the activity on preference change
             // collection path hasn't been changed so just restart the current activity
             if (this is Reviewer && preferences.getBoolean("tts", false)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -17,53 +17,63 @@
 
 package com.ichi2.anki
 
-import android.app.NotificationChannel
-import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
-import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
-import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationChannelCompat
+import androidx.core.app.NotificationManagerCompat
 import timber.log.Timber
 
-object NotificationChannels {
-    /**
-     * Create or update all the notification channels for the app
-     *
-     * In Oreo and higher, you must create a channel for all notifications.
-     * This will create the channel if it doesn't exist, or if it exists it will update the name.
-     *
-     * Note that once a channel is created, only the name may be changed as long as the application
-     * is installed on the user device. All other settings are fully under user control.
+/**
+ * Create or update all the notification channels for the app
+ *
+ * In Oreo and higher, you must create a channel for all notifications.
+ * This will create the channel if it doesn't exist, or if it exists it will update the name.
+ *
+ * Note that once a channel is created, only the name may be changed as long as the application
+ * is installed on the user device. All other settings are fully under user control.
+ *
+ * TODO should be called in response to [Intent.ACTION_LOCALE_CHANGED]
+ * @param context the context for access to localized strings for channel names
+ */
+fun setupNotificationChannels(context: Context) {
+    val res = context.resources
+    val manager = NotificationManagerCompat.from(context)
 
-     * TODO should be called in response to [Intent.ACTION_LOCALE_CHANGED]
-     * @param context the context for access to localized strings for channel names
-     */
-    @RequiresApi(26)
-    fun setup(context: Context) {
-        val res = context.resources
-        for (channel in Channel.entries) {
-            val id = channel.id
-            val name = channel.getName(res)
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            Timber.i("Creating notification channel with id/name: %s/%s", id, name)
-            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            val notificationChannel = NotificationChannel(id, name, importance)
-            notificationChannel.setShowBadge(true)
-            notificationChannel.lockscreenVisibility = NotificationCompat.VISIBILITY_PUBLIC
-            manager.createNotificationChannel(notificationChannel)
-        }
+    for (channel in Channel.entries) {
+        val id = channel.id
+        val name = channel.getName(res)
+        val importance = NotificationManagerCompat.IMPORTANCE_DEFAULT
+        Timber.i("Creating notification channel with id/name: %s/%s", id, name)
+
+        val notificationChannel =
+            NotificationChannelCompat
+                .Builder(id, importance)
+                .setName(name)
+                .setShowBadge(true)
+                .build()
+
+        manager.createNotificationChannel(notificationChannel)
     }
 }
 
+/**
+ * Defines the available notification channels for the application.
+ *
+ * @property id The unique identifier for the notification channel.
+ * @property nameId The string resource ID for the localized channel name.
+ */
 enum class Channel(
     val id: String,
     @StringRes val nameId: Int,
 ) {
     GENERAL("General Notifications", R.string.app_name),
     SYNC("Synchronization", R.string.sync_title),
-    GLOBAL_REMINDERS("Global Reminders", R.string.widget_minimum_cards_due_notification_ticker_title),
+    GLOBAL_REMINDERS(
+        "Global Reminders",
+        R.string.widget_minimum_cards_due_notification_ticker_title,
+    ),
     DECK_REMINDERS("Deck Reminders", R.string.deck_conf_reminders),
     ;
 

--- a/AnkiDroid/src/main/java/com/ichi2/compat/BaseCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/BaseCompat.kt
@@ -47,10 +47,6 @@ import kotlin.time.Duration
 @KotlinCleanup("add extension method logging file.delete() failure" + "Fix Deprecation")
 @Suppress("Deprecation")
 open class BaseCompat : Compat {
-    // Until API26, ignore notification channels
-    override fun setupNotificationChannel(context: Context) { // pre-API26, do nothing
-    }
-
     // Until API26, tooltips cannot be defined declaratively in layouts
     override fun setTooltipTextByContentDescription(view: View) {
         TooltipCompat.setTooltipText(view, view.contentDescription)

--- a/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/Compat.kt
@@ -76,8 +76,6 @@ import kotlin.time.Duration
  * [CompatV29] in order to use [Environment.DIRECTORY_PICTURES], need not be implemented again in [CompatV26].
  */
 interface Compat {
-    fun setupNotificationChannel(context: Context)
-
     fun setTooltipTextByContentDescription(view: View)
 
     fun vibrate(

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV26.kt
@@ -22,7 +22,6 @@ import android.os.Vibrator
 import android.view.View
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.NotificationChannels
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException
@@ -40,14 +39,6 @@ import kotlin.time.Duration
 /** Implementation of [Compat] for SDK level 26 and higher. Check  [Compat]'s for more detail.  */
 @RequiresApi(26)
 open class CompatV26 : CompatV24() {
-    /**
-     * In Oreo and higher, you must create a channel for all notifications.
-     * This will create the channel if it doesn't exist, or if it exists it will update the name.
-     */
-    override fun setupNotificationChannel(context: Context) {
-        NotificationChannels.setup(context)
-    }
-
     override fun setTooltipTextByContentDescription(view: View) { // Nothing to do API26+
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
We want to remove dependency for notification channel creation from compact module as we will be extracting it out as module, hence I am lifting the old code off and using the new code from androidx

## Approach
Use new `NotificationChannelCompat.Builder`

## How Has This Been Tested?
![Screenshot 2025-04-01 at 9 52 27 PM](https://github.com/user-attachments/assets/8e777e31-c212-490f-8fef-d8d7374d25a1)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
