### PR TITLE
test: ignore flaky tests

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1425,6 +1425,7 @@ class CardBrowserTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(OS.ALL)
     fun `FindReplace - replaces text based on regular expression`() {
         val note0 = createFindReplaceTestNote("A", "kart", "ki1logram")
         val note1 = createFindReplaceTestNote("B", "pink", "chicken")


### PR DESCRIPTION
CardBrowserTest > FindReplace - replaces text based on regular expression FAILED
    androidx.test.espresso.NoMatchingViewException: No views in hierarchy found matching: an instance of android.widget.TextView and view.getText() with or without transformation to match: is "⁨1⁩ note updated."
    If the target view is not part of the view hierarchy, you may need to use Espresso.onData to load it from one of the following AdapterViews:androidx.appcompat.widget.AppCompatSpinner{37dd5091 VFED..CL. ......ID 56,0-232,64 #7f0a04e6 app:id/toolbar_spinner}

Follow on from 
* 4c5bf718a7c8f170f741553b5e9d5a8b7ff6d80e => PR #18093 
* Cause: https://github.com/ankidroid/Anki-Android/pull/17897
