### PR TITLE
Refactor $PRE_RELEASE to $RELEASE_TYPE & fix SC2088

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,11 +39,6 @@ jobs:
 
       - name: Install Release Utilities
         run: |
-          mkdir ~/bin/
-          curl -L -o ~/bin/github-release.bz2 https://github.com/github-release/github-release/releases/download/v0.10.0/linux-amd64-github-release.bz2
-          cd ~/bin
-          bunzip2 github-release.bz2
-          chmod 755 ~/bin/github-release
           sudo chown -R $USER /var/lib/gems/
           sudo chown -R $USER /usr/local/bin
           gem install asciidoctor


### PR DESCRIPTION
## Purpose / Description
Refactored github-releases in favor of gh cli and fixed a minor SC2088 violation in export PATH.

## Fixes
* Fixes #18110 

## Approach
Refactored to use gh cli, updated the publish.yml to use gh cli.

## How Has This Been Tested?
Will have to test on the fly.

## Learning (optional, can help others)
Checked the github cli documentation:
https://cli.github.com/manual/gh_release_create

Also went through usages of gh cli in code search because documentation is spotty.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
