### PR TITLE
fix: freeze when syncing when notifications permission is missing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -180,6 +180,10 @@ object Permissions {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R &&
             context.arePermissionsDefinedInAnkiDroidManifest(MANAGE_EXTERNAL_STORAGE)
     }
+
+    fun canPostNotifications(context: Context): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
+            ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
 }
 
 fun Fragment.hasAnyOfPermissionsBeenDenied(permissions: Collection<String>): Boolean {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

In Android 13+, it's necessary to get the user permission in order to send notifications.

The issue is that we use foreground services for syncing, and they use notifications.

## Fixes
* Fixes #17493 

## Approach

Make the NotificationManager of the workers `null` if the app can't post notifications, so no notifications are sent

## How Has This Been Tested?

Emulator 35:
1. Log-in into some account
2. Add some fake media in Dev options
3. Sync
(couldn't reproduce the original issue, but these steps test that sync is still working)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
