### PR TITLE
refactor: move time utils to common

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -25,6 +25,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.testutil.addNote
 import com.ichi2.anki.utils.EnsureAllFilesAccessRule
 import com.ichi2.annotations.DuplicatedCode
@@ -33,7 +34,6 @@ import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.QueueType
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.common.IgnoreFlakyTestsInCIRule
 import kotlinx.coroutines.runBlocking
 import net.ankiweb.rsdroid.BackendException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -17,11 +17,11 @@
 package com.ichi2.anki
 
 import android.text.format.DateFormat
+import com.ichi2.anki.common.time.Time
+import com.ichi2.anki.common.time.Time.Companion.utcOffset
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Utils
-import com.ichi2.libanki.utils.Time
-import com.ichi2.libanki.utils.Time.Companion.utcOffset
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.FileUtil.getFreeDiskSpace
 import timber.log.Timber
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -26,11 +26,11 @@ import androidx.webkit.WebViewCompat
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.analytics.UsageAnalytics.sendAnalyticsException
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.exception.UserSubmittedException
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.ThrowableFilterService
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.WebViewDebugging.setDataDirectorySuffix
 import org.acra.ACRA
 import org.acra.ReportField

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -108,6 +108,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
@@ -174,7 +175,6 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.DeckNode
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.ui.BadgeDrawableBuilder
 import com.ichi2.utils.AdaptionUtil

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingActivity.kt
@@ -26,7 +26,7 @@ import android.widget.LinearLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuItemCompat
 import androidx.core.view.isGone
-import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.themes.Themes
 import com.ichi2.utils.iconAlpha
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -64,6 +64,7 @@ import com.ichi2.anki.Whiteboard.Companion.createInstance
 import com.ichi2.anki.Whiteboard.OnPaintColorChangeListener
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.multimedia.audio.AudioRecordingController
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.generateTempAudioFile
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.isAudioRecordingSaved
@@ -112,7 +113,6 @@ import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.CurrentQueueState
 import com.ichi2.libanki.undoableOp
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.currentTheme
 import com.ichi2.utils.HandlerUtils.executeFunctionWithDelay

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -29,6 +29,7 @@ import anki.sync.syncAuth
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.SyncErrorDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
@@ -39,7 +40,6 @@ import com.ichi2.libanki.createBackup
 import com.ichi2.libanki.fullUploadOrDownload
 import com.ichi2.libanki.syncCollection
 import com.ichi2.libanki.syncLogin
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.preferences.VersatileTextWithASwitchPreference
 import com.ichi2.utils.NetworkUtils
 import kotlinx.coroutines.CancellationException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.util.DisplayMetrics
 import android.widget.Toast
 import androidx.annotation.StringRes
-import com.ichi2.libanki.utils.Time
+import com.ichi2.anki.common.time.Time
 import java.util.Calendar
 
 fun showThemedToast(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt
@@ -40,12 +40,12 @@ import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
 import androidx.core.graphics.scale
+import com.ichi2.anki.common.time.Time
 import com.ichi2.anki.dialogs.WhiteBoardWidthDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.getTimestamp
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
-import com.ichi2.libanki.utils.Time
 import com.ichi2.themes.Themes.currentTheme
 import com.ichi2.utils.DisplayUtils.getDisplayDimensions
 import com.mrudultora.colorpicker.ColorPickerPopUp

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BackupPromptDialog.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.isLoggedIn
 import com.ichi2.anki.millisecondsSinceLastSync
 import com.ichi2.anki.preferences.sharedPrefs
@@ -32,7 +33,6 @@ import com.ichi2.anki.servicelayer.ScopedStorageService.collectionWillBeMadeInac
 import com.ichi2.anki.servicelayer.ScopedStorageService.userIsPromptedToDeleteCollectionOnUninstall
 import com.ichi2.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.compat.PackageInfoFlagsCompat
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.checkBoxPrompt

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.DatabaseRestorationListener
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.LocalizedUnambiguousBackupTimeFormatter
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_CONFIRM_DATABASE_CHECK
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_CONFIRM_RESTORE_BACKUP
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_DB_ERROR
@@ -60,7 +61,6 @@ import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.showImportDialog
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.libanki.Consts
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.UiUtil.makeBold
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.copyToClipboard

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ActivityExportingDelegate.kt
@@ -30,6 +30,7 @@ import androidx.core.content.edit
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.ExportReadyDialog.ExportReadyDialogListener
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.preferences.sharedPrefs
@@ -40,7 +41,6 @@ import com.ichi2.anki.withProgress
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.utils.TimeManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -43,6 +43,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.exportApkgPackage
 import com.ichi2.anki.exportCollectionPackage
 import com.ichi2.anki.exportSelectedCards
@@ -53,7 +54,6 @@ import com.ichi2.annotations.NeedsTest
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import kotlinx.coroutines.launch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaUtils.kt
@@ -27,8 +27,8 @@ import android.provider.MediaStore
 import androidx.core.content.ContentResolverCompat
 import androidx.core.net.toUri
 import com.ichi2.anki.CrashReportService
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.utils.getTimestamp
-import com.ichi2.libanki.utils.TimeManager
 import timber.log.Timber
 import java.io.File
 import java.io.IOException

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -28,6 +28,7 @@ import anki.notetypes.StockNotetype
 import anki.notetypes.copy
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.withProgress
 import com.ichi2.libanki.Utils
@@ -37,7 +38,6 @@ import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.getNotetype
 import com.ichi2.libanki.getNotetypeNames
 import com.ichi2.libanki.getStockNotetype
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -30,13 +30,13 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.utils.getTimestamp
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.BundleUtils.getNullableLong
 
 class Statistics :

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/NotificationsSettingsFragment.kt
@@ -22,9 +22,9 @@ import androidx.core.app.PendingIntentCompat
 import androidx.preference.ListPreference
 import androidx.preference.SwitchPreferenceCompat
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
 import com.ichi2.anki.services.NotificationService
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.AdaptionUtil
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -20,11 +20,11 @@ import androidx.annotation.VisibleForTesting
 import anki.config.copy
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.undoableOp
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.preferences.SliderPreference
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.utils.ext.description
 import com.ichi2.libanki.Card
@@ -55,7 +56,6 @@ import com.ichi2.libanki.Utils
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.libanki.sched.DeckNode
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.FileUtil.internalizeUri
 import com.ichi2.utils.Permissions.arePermissionsDefinedInManifest

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -9,13 +9,13 @@ import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.R
+import com.ichi2.anki.common.time.Time
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.showThemedToast
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
-import com.ichi2.libanki.utils.Time
-import com.ichi2.libanki.utils.TimeManager
 import timber.log.Timber
 import java.util.Calendar
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.asyncIO
 import com.ichi2.anki.cardviewer.CardMediaPlayer
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.pages.AnkiServer
@@ -61,7 +62,6 @@ import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.CurrentQueueState
 import com.ichi2.libanki.undo
 import com.ichi2.libanki.undoableOp
-import com.ichi2.libanki.utils.TimeManager
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.delay

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
@@ -19,7 +19,7 @@ import android.content.Context
 import android.media.MediaPlayer
 import android.os.Handler
 import com.ichi2.anki.R
-import com.ichi2.libanki.utils.Time
+import com.ichi2.anki.common.time.Time
 import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.math.max

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV29.kt
@@ -24,7 +24,7 @@ import android.os.Environment
 import android.provider.MediaStore
 import android.util.Size
 import androidx.annotation.RequiresApi
-import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.anki.common.time.TimeManager
 import java.io.File
 import java.io.IOException
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -19,12 +19,12 @@ package com.ichi2.libanki
 
 import androidx.annotation.VisibleForTesting
 import anki.cards.FsrsMemoryState
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.utils.ext.ifZero
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.libanki.utils.TimeManager
 import net.ankiweb.rsdroid.RustCleanup
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,6 +40,7 @@ import anki.search.BrowserRow
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.ids2str
 import com.ichi2.libanki.backend.model.toBackendNote
@@ -50,7 +51,6 @@ import com.ichi2.libanki.sched.DummyScheduler
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.libanki.utils.TimeManager
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -42,6 +42,7 @@ import anki.notetypes.StockNotetype
 import anki.notetypes.restoreNotetypeToStockRequest
 import com.google.protobuf.ByteString
 import com.ichi2.anki.CrashReportService
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
@@ -50,7 +51,6 @@ import com.ichi2.libanki.backend.BackendUtils.toJsonBytes
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.libanki.utils.append
 import com.ichi2.utils.len
 import net.ankiweb.rsdroid.RustCleanup

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
@@ -15,9 +15,9 @@
  */
 package com.ichi2.libanki
 
+import com.ichi2.anki.common.time.Time
+import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.anki.getDayStart
-import com.ichi2.libanki.utils.Time
-import com.ichi2.libanki.utils.TimeManager.time
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.BackendFactory
 import java.io.File

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -42,6 +42,7 @@ import anki.scheduler.UnburyDeckRequest
 import anki.scheduler.cardAnswer
 import anki.scheduler.scheduleCardsAsNewRequest
 import com.ichi2.anki.Ease
+import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardId
@@ -55,7 +56,6 @@ import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.Utils
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.libanki.utils.TimeManager.time
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
 import kotlin.math.ceil

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/utils/Time.kt
@@ -15,13 +15,11 @@
  */
 package com.ichi2.libanki.utils
 
-import com.ichi2.libanki.DB
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.Locale
 import java.util.TimeZone
-import kotlin.math.max
 import java.sql.Date as SqlDate
 import java.util.Date as UtilDate
 
@@ -41,35 +39,6 @@ abstract class Time {
         val cal = Calendar.getInstance()
         cal.time = currentDate
         return cal
-    }
-
-    /** Gregorian calendar for this date  */
-    fun gregorianCalendar(): GregorianCalendar {
-        val cal = GregorianCalendar()
-        cal.time = currentDate
-        return cal
-    }
-
-    /** Return a non-conflicting timestamp for table.  */
-    fun timestampID(
-        db: DB,
-        table: String,
-    ): Long {
-        // be careful not to create multiple objects without flushing them, or they
-        // may share an ID.
-        var t = intTimeMS()
-        while (db.queryScalar("SELECT id FROM $table WHERE id = ?", t) != 0) {
-            t += 1
-        }
-        return t
-    }
-
-    /** Return the first safe ID to use.  */
-    fun maxID(db: DB): Long {
-        var now = intTimeMS()
-        now = max(now, db.queryLongScalar("SELECT MAX(id) FROM cards"))
-        now = max(now, db.queryLongScalar("SELECT MAX(id) FROM notes"))
-        return now + 1
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
@@ -17,7 +17,7 @@
 package com.ichi2.utils
 
 import androidx.annotation.CheckResult
-import com.ichi2.libanki.utils.TimeManager
+import com.ichi2.anki.common.time.TimeManager
 import timber.log.Timber
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -21,9 +21,9 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.SUCCESS_KEY
 import com.ichi2.anki.AnkiDroidJsAPI.Companion.VALUE_KEY
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.utils.ext.CardExt.setFlag
 import com.ichi2.libanki.CardType
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.utils.BASIC_NOTE_TYPE_NAME
 import net.ankiweb.rsdroid.withoutUnicodeIsolation
 import org.hamcrest.CoreMatchers.equalTo

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -72,6 +72,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.REQUEST_FIN
 import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.TAGS_AS_FIELD
 import com.ichi2.anki.browser.column1
 import com.ichi2.anki.browser.setColumn
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.model.CardsOrNotes.CARDS
@@ -90,7 +91,6 @@ import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.QueueType
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.TestClass

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -14,6 +14,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
@@ -25,7 +26,6 @@ import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Storage
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.BackendEmulatingOpenConflict
 import com.ichi2.testutils.BackupManagerTestUtilities
 import com.ichi2.testutils.DbUtils

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand.FLIP_OR_ANSWER_EASE1
 import com.ichi2.anki.cardviewer.ViewerCommand.MARK
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.PreferenceTestUtils
@@ -46,7 +47,6 @@ import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.undoableOp
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS

--- a/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/RobolectricTest.kt
@@ -33,6 +33,7 @@ import androidx.work.Configuration
 import androidx.work.testing.SynchronousExecutor
 import androidx.work.testing.WorkManagerTestInitHelper
 import com.ichi2.anki.CollectionManager.CollectionOpenFailure
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.dialogs.DialogHandler
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.customtabs.CustomTabActivityHelper
@@ -41,7 +42,6 @@ import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Storage
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.TaskSchedulerRule

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -17,10 +17,10 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Ease
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.libanki.QueueType.Suspended
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.Scheduler
-import com.ichi2.libanki.utils.TimeManager
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -18,6 +18,8 @@ package com.ichi2.libanki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.scheduler.UnburyDeckRequest
 import com.ichi2.anki.Ease
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.utils.SECONDS_PER_DAY
 import com.ichi2.libanki.CardType.Relearning
@@ -25,8 +27,6 @@ import com.ichi2.libanki.Consts.LEECH_SUSPEND
 import com.ichi2.libanki.Consts.STARTING_FACTOR
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.Counts
-import com.ichi2.libanki.utils.TimeManager
-import com.ichi2.libanki.utils.TimeManager.time
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JvmTest.kt
@@ -19,10 +19,10 @@ package com.ichi2.testutils
 import android.annotation.SuppressLint
 import androidx.annotation.CallSuper
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Storage
-import com.ichi2.libanki.utils.TimeManager
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.resetMain

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/MockTime.kt
@@ -16,7 +16,7 @@
 package com.ichi2.testutils
 
 import android.annotation.SuppressLint
-import com.ichi2.libanki.utils.Time
+import com.ichi2.anki.common.time.Time
 import java.util.Calendar
 import java.util.GregorianCalendar
 import java.util.TimeZone

--- a/common/src/main/java/com/ichi2/anki/common/time/SystemTime.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/SystemTime.kt
@@ -13,7 +13,9 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.libanki.utils
+package com.ichi2.anki.common.time
+
+import com.ichi2.anki.common.time.Time
 
 class SystemTime : Time() {
     override fun intTimeMS(): Long = System.currentTimeMillis()

--- a/common/src/main/java/com/ichi2/anki/common/time/Time.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/Time.kt
@@ -13,7 +13,7 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.libanki.utils
+package com.ichi2.anki.common.time
 
 import java.text.SimpleDateFormat
 import java.util.Calendar

--- a/common/src/main/java/com/ichi2/anki/common/time/TimeManager.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/TimeManager.kt
@@ -14,7 +14,7 @@
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package com.ichi2.libanki.utils
+package com.ichi2.anki.common.time
 
 import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Follow up to separate libanki as a module, time utils are used in compat and other places hence moving them to `common`


## Approach
- Moving the files to `common` then I will move the `compat` to `common` module and finally peeling out 'libanki' as a separate module
- Removing the unused methods from the files

## How Has This Been Tested?
Local build, no extensive testing needed as the files are moved and imports are updated 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
