### PR TITLE
Fix Android Studio warnings in `PageFragment.kt`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -79,10 +79,10 @@ open class PageFragment(
             return
         }
         webView.addJavascriptInterface(
-            object : Object() {
+            object : Any() {
                 @JavascriptInterface
                 fun bridgeCommandImpl(request: String) {
-                    bridgeCommands.orEmpty().getOrDefault(request) {
+                    bridgeCommands.getOrDefault(request) {
                         Timber.d("Unknown request received %s", request)
                     }()
                 }


### PR DESCRIPTION
## Purpose / Description
- Remove unnecessary `orEmpty` call.
- Replace `java.lang.Object` to the Kotlin equivalent `kotlin.Any`

## Fixes
* Fixes #13282 

## Approach
Removed unnecessary calls and replaced Java code with Kotlin equivalent as recommended by Android Studio.

## How Has This Been Tested?
By running the code on a physical device.

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
