### PR TITLE
Converted previewer empty front indicator to text

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -57,11 +57,13 @@ class TemplatePreviewerPage : Fragment(R.layout.template_previewer_container) {
         lifecycleScope.launch {
             val cardsWithEmptyFronts = viewModel.cardsWithEmptyFronts?.await()
             for ((index, templateName) in viewModel.getTemplateNames().withIndex()) {
-                val newTab = tabLayout.newTab().setText(templateName)
-                if (cardsWithEmptyFronts?.get(index) == true) {
-                    val badge = newTab.getOrCreateBadge()
-                    badge.horizontalOffset = -4
-                }
+                val tabTitle =
+                    if (cardsWithEmptyFronts?.get(index) == true) {
+                        getString(R.string.card_previewer_empty_front_indicator, templateName)
+                    } else {
+                        templateName
+                    }
+                val newTab = tabLayout.newTab().setText(tabTitle)
                 tabLayout.addTab(newTab)
             }
             tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -84,6 +84,7 @@
     <string name="field_remapping">%1$s (from “%2$s”)</string>
     <string name="confirm_map_cards_to_nothing">Any cards mapped to nothing will be deleted. If a note has no remaining cards, it will be lost. Are you sure you want to continue?</string>
     <string name="missing_note_type">No note type found</string>
+    <string name="card_previewer_empty_front_indicator" comment="Extra text appended onto a tab title in the card previewer so that the user can see at a glance whether a card has no front.">%1$s (empty)</string>
 
     <!-- Timebox -->
     <string name="timebox_reached_title">Timebox reached</string>


### PR DESCRIPTION
## Purpose / Description
Addresses @user1823's concerns at #18147 by implementing @BrayanDSO's suggestion. When a card's front is empty, the previewer tab now indicates this by appending (empty) to the tab title rather than using an overly-urgent looking red badge. Creates a new string resource and appends it in [TemplatePreviewerPage].

![image](https://github.com/user-attachments/assets/7cfe2865-b424-4040-91d1-b107b4f10a1e)

## Fixes
Continues fixing #18107.

## Approach
Adds a new string resource and appends it onto the tab title.

## How Has This Been Tested?
Text displays properly on my end!

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)