### PR TITLE
fix: axis picker

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
@@ -15,49 +15,38 @@
   -->
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <LinearLayout
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/axis_picker_selected_axis"
+        app:layout_constraintDimensionRatio="w,1:1"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:gravity="center"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintDimensionRatio="w,1:1"
-        app:layout_constraintWidth_max="320dp"
+        android:textSize="24sp"
+        android:textAlignment="center"
+        android:text="@string/axis_picker_move_joystick"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <com.ichi2.ui.FixedTextView
-            android:id="@+id/axis_picker_selected_axis"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:focusable="true"
-            android:focusableInTouchMode="true"
-            android:text="@string/axis_picker_move_joystick"
-            android:textAlignment="center"
-            android:textSize="24sp" />
-
-    </LinearLayout>
 
     <ScrollView
         android:id="@+id/axis_picker_scrollview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:visibility="gone"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
+        >
         <LinearLayout
             android:id="@+id/axis_picker_available_axes"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="vertical" />
+            android:orientation="vertical"
+            android:layout_height="0dp"/>
     </ScrollView>
-
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_axis_picker.xml
@@ -22,7 +22,7 @@
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/axis_picker_selected_axis"
-        app:layout_constraintDimensionRatio="w,1:1"
+        app:layout_constraintDimensionRatio="1:1"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:gravity="center"
@@ -33,6 +33,7 @@
         android:focusableInTouchMode="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The axis picker is broken since 2.19beta5 (nobody noticing it reveals that it isn't popular). Noticed after working on adding the joystick controller detection to the new reviewer

## Fixes
* Fixes #17026

## Approach

1. Find the cause with git blame -> 3d6ac834
2. Revert it
3. Fix back the original issue (#17026)

## How Has This Been Tested?

1. Check in Android Studio layout preview if the picker works in landscape mode (#17026)

Android 14 tablet with a Dualshock 4 controller:
1. Settings > Controls > Add joystick/motion controller
2. Move the joyticks

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
