### PR TITLE
Remove not working long touch gesture

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -295,9 +295,6 @@ abstract class AbstractFlashcardViewer :
     // ----------------------------------------------------------------------------
     // LISTENERS
     // ----------------------------------------------------------------------------
-    private val longClickHandler = newHandler()
-    private val startLongClickAction = Runnable { gestureProcessor.onLongTap() }
-
     // Handler for the "show answer" button
     private val flipCardListener =
         View.OnClickListener {
@@ -608,7 +605,6 @@ abstract class AbstractFlashcardViewer :
         if (this::cardMediaPlayer.isInitialized) {
             cardMediaPlayer.isEnabled = false
         }
-        longClickHandler.removeCallbacks(startLongClickAction)
         // Prevent loss of data in Cookies
         CookieManager.getInstance().flush()
     }
@@ -1894,7 +1890,6 @@ abstract class AbstractFlashcardViewer :
     protected open fun closeReviewer(result: Int) {
         automaticAnswer.disable()
         previousAnswerIndicator!!.stopAutomaticHide()
-        longClickHandler.removeCallbacks(startLongClickAction)
         this@AbstractFlashcardViewer.setResult(result)
         finish()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -45,7 +45,6 @@ enum class Gesture(
     SWIPE_DOWN(R.string.gestures_swipe_down),
     SWIPE_LEFT(R.string.gestures_swipe_left),
     SWIPE_RIGHT(R.string.gestures_swipe_right),
-    LONG_TAP(R.string.gestures_long_tap),
     DOUBLE_TAP(R.string.gestures_double_tap),
     TAP_TOP_LEFT(R.string.gestures_corner_tap_top_left),
     TAP_TOP(R.string.gestures_tap_top),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/GestureProcessor.kt
@@ -28,7 +28,6 @@ class GestureProcessor(
     }
 
     private var gestureDoubleTap: ViewerCommand? = null
-    private var gestureLongclick: ViewerCommand? = null
     private var gestureSwipeUp: ViewerCommand? = null
     private var gestureSwipeDown: ViewerCommand? = null
     private var gestureSwipeLeft: ViewerCommand? = null
@@ -65,7 +64,6 @@ class GestureProcessor(
             }
         }
         gestureDoubleTap = associatedCommands[Gesture.DOUBLE_TAP]
-        gestureLongclick = associatedCommands[Gesture.LONG_TAP]
         gestureSwipeUp = associatedCommands[Gesture.SWIPE_UP]
         gestureSwipeDown = associatedCommands[Gesture.SWIPE_DOWN]
         gestureSwipeLeft = associatedCommands[Gesture.SWIPE_LEFT]
@@ -98,8 +96,6 @@ class GestureProcessor(
     }
 
     fun onDoubleTap(): Boolean? = execute(Gesture.DOUBLE_TAP)
-
-    fun onLongTap(): Boolean? = execute(Gesture.LONG_TAP)
 
     fun onFling(
         dx: Float,
@@ -137,7 +133,6 @@ class GestureProcessor(
             Gesture.TAP_BOTTOM_LEFT -> gestureTapBottomLeft
             Gesture.TAP_BOTTOM_RIGHT -> gestureTapBottomRight
             Gesture.DOUBLE_TAP -> gestureDoubleTap
-            Gesture.LONG_TAP -> gestureLongclick
             Gesture.SHAKE -> gestureShake
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -330,7 +330,6 @@ object PreferenceUpgradeService {
                 upgradeGestureToBinding(preferences, "gestureSwipeDown", Gesture.SWIPE_DOWN)
                 upgradeGestureToBinding(preferences, "gestureSwipeLeft", Gesture.SWIPE_LEFT)
                 upgradeGestureToBinding(preferences, "gestureSwipeRight", Gesture.SWIPE_RIGHT)
-                upgradeGestureToBinding(preferences, "gestureLongclick", Gesture.LONG_TAP)
                 upgradeGestureToBinding(preferences, "gestureDoubleTap", Gesture.DOUBLE_TAP)
                 upgradeGestureToBinding(preferences, "gestureTapTopLeft", Gesture.TAP_TOP_LEFT)
                 upgradeGestureToBinding(preferences, "gestureTapTop", Gesture.TAP_TOP)

--- a/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/GesturePicker.kt
@@ -34,8 +34,8 @@ import timber.log.Timber
 // This class exists as elements resized when adding in the spinner to GestureDisplay.kt
 
 /** [View] which allows selection of a gesture either via taps/swipes, or via a [Spinner]
- * The spinner aids discoverability of [Gesture.DOUBLE_TAP] and [Gesture.LONG_TAP]
- * as they're not explained in [GestureDisplay].
+ * The spinner aids discoverability of [Gesture.DOUBLE_TAP]
+ * as it is not explained in [GestureDisplay].
  *
  * Current use is via [com.ichi2.anki.dialogs.GestureSelectionDialogBuilder]
  */

--- a/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/OnGestureListener.kt
@@ -39,10 +39,6 @@ class OnGestureListener(
         return true
     }
 
-    override fun onLongPress(e: MotionEvent) {
-        consumer.accept(Gesture.LONG_TAP)
-    }
-
     override fun onFling(
         e1: MotionEvent?,
         e2: MotionEvent,
@@ -81,6 +77,11 @@ class OnGestureListener(
             consumer.accept(gesture)
         }
         return true
+    }
+
+    override fun onLongPress(e: MotionEvent) {
+        // selecting stuff in a WebView takes priority over gesture detection
+        // so, do nothing in the method
     }
 
     companion object {

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -84,7 +84,6 @@
     <string name="gestures_swipe_left" maxLength="41">Swipe left</string>
     <string name="gestures_swipe_right" maxLength="41">Swipe right</string>
     <string name="gestures_double_tap" maxLength="41">Double touch</string>
-    <string name="gestures_long_tap" maxLength="41">Long touch</string>
     <string name="gestures_tap_top" maxLength="41">Touch top</string>
     <string name="gestures_tap_left" maxLength="41">Touch left</string>
     <string name="gestures_tap_right" maxLength="41">Touch right</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -199,7 +199,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     @Test
     fun testEditCardProvidesInverseTransition() {
         val viewer: NonAbstractFlashcardViewer = getViewer(true)
-        val gestures = listOf(Gesture.SWIPE_LEFT, Gesture.SWIPE_UP, Gesture.LONG_TAP)
+        val gestures = listOf(Gesture.SWIPE_LEFT, Gesture.SWIPE_UP, Gesture.DOUBLE_TAP)
 
         gestures.forEach { gesture ->
             val expectedAnimation =

--- a/AnkiDroid/src/test/java/com/ichi2/ui/BindingPreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/ui/BindingPreferenceTest.kt
@@ -42,7 +42,7 @@ class BindingPreferenceTest {
     fun test_serialisation_does_not_change() {
         // If this changes, we have introduced a breaking change in the serialization
         //
-        val expected = "1/r✅a2|r✅ 1|r⍝LONG_TAP2|r⌨122"
+        val expected = "1/r✅a2|r✅ 1|r⍝DOUBLE_TAP2|r⌨122"
 
         assertEquals(expected, getSampleBindings().toPreferenceString())
     }
@@ -53,7 +53,7 @@ class BindingPreferenceTest {
             ReviewerBinding(Binding.unicode(' '), CardSide.ANSWER),
             // this one is important: ensure that "|" as a unicode char can't be used
             ReviewerBinding(Binding.unicode(Binding.FORBIDDEN_UNICODE_CHAR), CardSide.QUESTION),
-            ReviewerBinding(Binding.gesture(Gesture.LONG_TAP), CardSide.BOTH),
+            ReviewerBinding(Binding.gesture(Gesture.DOUBLE_TAP), CardSide.BOTH),
             ReviewerBinding(Binding.keyCode(12), CardSide.BOTH),
         )
 }


### PR DESCRIPTION
## Purpose / Description

It doesn't work, AFAICT never worked, and there isn't a reliable way to differentiate between selecting something in the webview and "long touching".

If someone is able to **reproduce it working**, please share it. Otherwise, I vote to remove it since AFAIK there is a good way to implement it·

## How Has This Been Tested?

Emulator 35:
1. Go to settings > controls
2. Enable gestures
3. Check if `Long touch` is on the gesture list (it shouldn't be)

![image](https://github.com/user-attachments/assets/6814e223-0de4-4b4b-beda-cc122ae85b2e)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
