### PR TITLE
feat(previewer): motion controllers

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/reviewer/PeripheralKeymapTest.kt
@@ -34,10 +34,10 @@ class PeripheralKeymapTest : InstrumentedTest() {
         val processed: MutableList<ViewerCommand> = ArrayList()
 
         val sharedPrefs = testContext.sharedPrefs()
-        val peripheralKeymap =
-            PeripheralKeymap(sharedPrefs, ViewerCommand.entries) { e: ViewerCommand, _ -> processed.add(e) }
+        val bindingMap =
+            BindingMap(sharedPrefs, ViewerCommand.entries) { e: ViewerCommand, _ -> processed.add(e) }
 
-        peripheralKeymap.onKeyDown(
+        bindingMap.onKeyDown(
             getNumpadEvent(KeyEvent.KEYCODE_NUMPAD_1),
         )
         assertThat<List<ViewerCommand>>(processed, hasSize(1))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -120,7 +120,6 @@ import com.ichi2.anki.reviewer.EaseButton
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.DEFAULT
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.fromPreference
-import com.ichi2.anki.reviewer.MotionEventHandler
 import com.ichi2.anki.reviewer.PreviousAnswerIndicator
 import com.ichi2.anki.servicelayer.LanguageHintService.applyLanguageHint
 import com.ichi2.anki.servicelayer.NoteService.isMarked
@@ -269,9 +268,6 @@ abstract class AbstractFlashcardViewer :
     protected val gestureProcessor = GestureProcessor(this)
 
     // needs to be lateinit due to a reliance on Context
-
-    /** Handle joysticks/pedals */
-    protected lateinit var motionEventHandler: MotionEventHandler
 
     val server = AnkiServer(this).also { it.start() }
 
@@ -548,7 +544,6 @@ abstract class AbstractFlashcardViewer :
         restorePreferences()
         tagsDialogFactory = TagsDialogFactory(this).attachToActivity<TagsDialogFactory>(this)
         super.onCreate(savedInstanceState)
-        motionEventHandler = MotionEventHandler.createInstance(this)
 
         // Issue 14142: The reviewer had a focus highlight after answering using a keyboard.
         // This theme removes the highlight, but there is likely a better way.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -82,13 +82,13 @@ import com.ichi2.anki.reviewer.AnswerButtons.Companion.getTextColors
 import com.ichi2.anki.reviewer.AnswerTimer
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.reviewer.BindingMap
 import com.ichi2.anki.reviewer.BindingProcessor
 import com.ichi2.anki.reviewer.CardMarker
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.FullScreenMode
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.fromPreference
 import com.ichi2.anki.reviewer.FullScreenMode.Companion.isFullScreenReview
-import com.ichi2.anki.reviewer.PeripheralKeymap
 import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.reviewer.ReviewerUi
 import com.ichi2.anki.scheduling.ForgetCardsDialog
@@ -204,7 +204,7 @@ open class Reviewer :
     private lateinit var toolbar: Toolbar
 
     @VisibleForTesting
-    protected open lateinit var processor: PeripheralKeymap<ReviewerBinding, ViewerCommand>
+    protected open lateinit var processor: BindingMap<ReviewerBinding, ViewerCommand>
 
     private val addNoteLauncher =
         registerForActivityResult(
@@ -229,7 +229,7 @@ open class Reviewer :
         textBarReview = findViewById(R.id.review_number)
         toolbar = findViewById(R.id.toolbar)
         micToolBarLayer = findViewById(R.id.mic_tool_bar_layer)
-        processor = PeripheralKeymap(sharedPrefs(), ViewerCommand.entries, this)
+        processor = BindingMap(sharedPrefs(), ViewerCommand.entries, this)
         if (sharedPrefs().getString("answerButtonPosition", "bottom") == "bottom" && !navBarNeedsScrim) {
             setNavigationBarColor(R.attr.showAnswerColor)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -922,7 +922,7 @@ open class Reviewer :
     }
 
     override fun onGenericMotionEvent(event: MotionEvent?): Boolean {
-        if (motionEventHandler.onGenericMotionEvent(event)) {
+        if (processor.onGenericMotionEvent(event)) {
             return true
         }
         return super.onGenericMotionEvent(event)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -25,6 +25,7 @@ import android.view.View
 import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
@@ -46,6 +47,7 @@ import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.PeripheralKeymap
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.utils.ext.collectIn
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.performClickIfEnabled
@@ -177,6 +179,16 @@ class PreviewerFragment :
 
         previousButton.setOnClickListener {
             viewModel.onPreviousButtonClick()
+        }
+
+        view.setOnGenericMotionListener { _, event ->
+            bindingMap.onGenericMotionEvent(event)
+        }
+
+        viewModel.showingAnswer.collectIn(lifecycleScope) {
+            // focus on the whole layout so motion controllers can be captured
+            // without navigating the other View elements
+            view.findViewById<CoordinatorLayout>(R.id.root_layout).requestFocus()
         }
 
         view.findViewById<MaterialToolbar>(R.id.toolbar).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Axis.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Axis.kt
@@ -16,66 +16,8 @@
 
 package com.ichi2.anki.reviewer
 
-import android.content.Context
 import android.view.MotionEvent
-import com.ichi2.anki.AbstractFlashcardViewer
-import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.cardviewer.ViewerCommand
-import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
-import timber.log.Timber
-
-/**
- * Handles motion events, such as joystick/pedal input and converts them to [ViewerCommand]s
- *
- * A [MotionEvent] is a **batched** collection of [actions][MotionEvent.getAction] ond [axes][Axis]
- *
- * Axes can either be bidirectional, or unidirectional. AnkiDroid allows a user to define an action
- * which occurs if the extreme of an axis [-1, 1] is met
- */
-class MotionEventHandler(
-    private val commandProcessor: ViewerCommand.CommandProcessor,
-    private val detectors: List<SingleAxisDetector>,
-) {
-    /**
-     * Accepts a [MotionEvent] and determines if one or more commands need to be executed
-     * @return whether one or more commands were executed
-     */
-    fun onGenericMotionEvent(ev: MotionEvent?): Boolean {
-        if (ev == null || !detectors.any()) return false
-
-        var processed = false
-        for (detector in detectors) {
-            val command = detector.getCommand(ev) ?: continue
-            processed = true
-            Timber.v("executing command: %s due to %s", command, detector.toDisplayString(AnkiDroidApp.instance))
-            this.commandProcessor.executeCommand(command, null)
-        }
-        return processed
-    }
-
-    companion object {
-        fun createInstance(viewer: AbstractFlashcardViewer): MotionEventHandler {
-            val handlers = getAxisButtonBindings(viewer).toList()
-            Timber.d("setting up %d motion handlers", handlers.size)
-            return MotionEventHandler(viewer, handlers)
-        }
-
-        private fun getAxisButtonBindings(context: Context) =
-            sequence {
-                for ((command, bindings) in ViewerCommand.entries
-                    .map {
-                        Pair(it, ReviewerBinding.fromPreference(context.sharedPrefs(), it))
-                    }) {
-                    for (binding in bindings
-                        .map { it.binding }
-                        .filterIsInstance<Binding.AxisButtonBinding>()) {
-                        yield(SingleAxisDetector(command, binding))
-                    }
-                }
-            }
-    }
-}
 
 /**
  * A type of movement, typically a Joystick/Trigger on a gamepad

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/BindingMap.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/BindingMap.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.reviewer
 
 import android.content.SharedPreferences
 import android.view.KeyEvent
-import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.Binding.Companion.possibleKeyBindings
 
 /**
@@ -26,12 +25,12 @@ import com.ichi2.anki.reviewer.Binding.Companion.possibleKeyBindings
  *
  * That way, [onKeyDown] can be used to detect key presses and trigger their actions.
  */
-class PeripheralKeymap<B : MappableBinding, A : MappableAction<B>>(
+class BindingMap<B : MappableBinding, A : MappableAction<B>>(
     sharedPrefs: SharedPreferences,
     actions: List<A>,
     private var processor: BindingProcessor<B, A>? = null,
 ) {
-    private val bindingMap = HashMap<Binding, List<Pair<A, B>>>()
+    private val keyMap = HashMap<Binding, List<Pair<A, B>>>()
 
     init {
         for (action in actions) {
@@ -39,10 +38,10 @@ class PeripheralKeymap<B : MappableBinding, A : MappableAction<B>>(
             for (mappableBinding in mappableBindings) {
                 if (!mappableBinding.isKey) continue
                 val binding = mappableBinding.binding
-                if (binding in bindingMap) {
-                    (bindingMap[binding] as MutableList).add(action to mappableBinding)
+                if (binding in keyMap) {
+                    (keyMap[binding] as MutableList).add(action to mappableBinding)
                 } else {
-                    bindingMap[binding] = mutableListOf(action to mappableBinding)
+                    keyMap[binding] = mutableListOf(action to mappableBinding)
                 }
             }
         }
@@ -58,7 +57,7 @@ class PeripheralKeymap<B : MappableBinding, A : MappableAction<B>>(
         }
         val bindings = possibleKeyBindings(event)
         for (binding in bindings) {
-            val actionAndMappableBindings = bindingMap[binding] ?: continue
+            val actionAndMappableBindings = keyMap[binding] ?: continue
             for ((action, mappableBinding) in actionAndMappableBindings) {
                 if (processor?.processAction(action, mappableBinding) == true) return true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MotionEventHandler.kt
@@ -37,57 +37,6 @@ class MotionEventHandler(
     private val commandProcessor: ViewerCommand.CommandProcessor,
     private val detectors: List<SingleAxisDetector>,
 ) {
-    data class SingleAxisDetector(
-        val axis: Axis,
-        val command: ViewerCommand,
-        val threshold: Float,
-    ) {
-        constructor(command: ViewerCommand, binding: Binding.AxisButtonBinding) : this(
-            command = command,
-            axis = binding.axis,
-            threshold = binding.threshold,
-        )
-
-        /** If the command has been executed and we have not returned lower than the threshold */
-        private var sentCommand: Boolean = false
-
-        /**
-         * If multiple events above the threshold are obtained, only return 1 command
-         * until the value is under the threshold
-         */
-        private val debouncedCommand: ViewerCommand?
-            get() {
-                if (sentCommand) return null
-                sentCommand = true
-                return command
-            }
-
-        /**
-         * Given a [MotionEvent], determine whether we've reached [threshold].
-         *
-         * If we have, and [command] has not been sent in the period that we reached the threshold
-         * then send the command once and wait for the value to go back under the threshold
-         *
-         * @return [command] or `null`
-         */
-        fun getCommand(ev: MotionEvent): ViewerCommand? {
-            // TODO: We may need to handle historical events as well
-            val value = ev.getAxisValue(axis.motionEventValue)
-            when {
-                threshold > 0 -> {
-                    if (value >= threshold) return debouncedCommand
-                }
-                threshold < 0 -> {
-                    if (value <= threshold) return debouncedCommand
-                }
-            }
-            sentCommand = false
-            return null
-        }
-
-        fun toDisplayString(context: Context) = Binding.AxisButtonBinding(axis, threshold).toDisplayString(context)
-    }
-
     /**
      * Accepts a [MotionEvent] and determines if one or more commands need to be executed
      * @return whether one or more commands were executed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/SingleAxisDetector.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/SingleAxisDetector.kt
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.reviewer
+
+import android.content.Context
+import android.view.MotionEvent
+import com.ichi2.anki.cardviewer.ViewerCommand
+
+data class SingleAxisDetector(
+    val axis: Axis,
+    val command: ViewerCommand,
+    val threshold: Float,
+) {
+    constructor(command: ViewerCommand, binding: Binding.AxisButtonBinding) : this(
+        command = command,
+        axis = binding.axis,
+        threshold = binding.threshold,
+    )
+
+    /** If the command has been executed and we have not returned lower than the threshold */
+    private var sentCommand: Boolean = false
+
+    /**
+     * If multiple events above the threshold are obtained, only return 1 command
+     * until the value is under the threshold
+     */
+    private val debouncedCommand: ViewerCommand?
+        get() {
+            if (sentCommand) return null
+            sentCommand = true
+            return command
+        }
+
+    /**
+     * Given a [MotionEvent], determine whether we've reached [threshold].
+     *
+     * If we have, and [command] has not been sent in the period that we reached the threshold
+     * then send the command once and wait for the value to go back under the threshold
+     *
+     * @return [command] or `null`
+     */
+    fun getCommand(ev: MotionEvent): ViewerCommand? {
+        // TODO: We may need to handle historical events as well
+        val value = ev.getAxisValue(axis.motionEventValue)
+        when {
+            threshold > 0 -> {
+                if (value >= threshold) return debouncedCommand
+            }
+            threshold < 0 -> {
+                if (value <= threshold) return debouncedCommand
+            }
+        }
+        sentCommand = false
+        return null
+    }
+
+    fun toDisplayString(context: Context) = Binding.AxisButtonBinding(axis, threshold).toDisplayString(context)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -35,6 +35,7 @@ import androidx.appcompat.view.menu.SubMenuBuilder
 import androidx.appcompat.widget.ActionMenuView
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.getSystemService
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
@@ -116,6 +117,10 @@ class ReviewerFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
 
+        view.setOnGenericMotionListener { _, event ->
+            viewModel.onGenericMotionEvent(event)
+        }
+
         view.findViewById<AppCompatImageButton>(R.id.back_button).setOnClickListener {
             requireActivity().finish()
         }
@@ -148,6 +153,9 @@ class ReviewerFragment :
 
         viewModel.showingAnswer.collectIn(lifecycleScope) {
             resetZoom()
+            // focus on the whole layout so motion controllers can be captured
+            // without navigating the other View elements
+            view.findViewById<CoordinatorLayout>(R.id.root_layout).requestFocus()
         }
 
         viewModel.destinationFlow.collectIn(lifecycleScope) { destination ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -72,7 +72,7 @@ import com.ichi2.anki.preferences.reviewer.ViewerAction.SUSPEND_NOTE
 import com.ichi2.anki.preferences.reviewer.ViewerAction.UNDO
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.previewer.CardViewerFragment
-import com.ichi2.anki.reviewer.PeripheralKeymap
+import com.ichi2.anki.reviewer.BindingMap
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.FrameStyle
 import com.ichi2.anki.settings.enums.HideSystemBars
@@ -93,7 +93,7 @@ class ReviewerFragment :
     ActionMenuView.OnMenuItemClickListener,
     DispatchKeyEventListener {
     override val viewModel: ReviewerViewModel by viewModels {
-        ReviewerViewModel.factory(CardMediaPlayer(), PeripheralKeymap(sharedPrefs(), ViewerAction.entries))
+        ReviewerViewModel.factory(CardMediaPlayer(), BindingMap(sharedPrefs(), ViewerAction.entries))
     }
 
     override val webView: WebView

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.ui.windows.reviewer
 import android.text.style.RelativeSizeSpan
 import android.view.KeyEvent
 import android.view.MenuItem
+import android.view.MotionEvent
 import androidx.core.text.buildSpannedString
 import androidx.core.text.inSpans
 import androidx.lifecycle.ViewModelProvider
@@ -194,6 +195,8 @@ class ReviewerViewModel(
         if (event.action != KeyEvent.ACTION_DOWN) return false
         return bindingMap.onKeyDown(event)
     }
+
+    fun onGenericMotionEvent(event: MotionEvent?): Boolean = bindingMap.onGenericMotionEvent(event)
 
     private suspend fun toggleMark() {
         val card = currentCard.await()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -43,9 +43,9 @@ import com.ichi2.anki.preferences.getShowIntervalOnButtons
 import com.ichi2.anki.preferences.reviewer.ViewerAction
 import com.ichi2.anki.previewer.CardViewerViewModel
 import com.ichi2.anki.previewer.TypeAnswer
+import com.ichi2.anki.reviewer.BindingMap
 import com.ichi2.anki.reviewer.BindingProcessor
 import com.ichi2.anki.reviewer.CardSide
-import com.ichi2.anki.reviewer.PeripheralKeymap
 import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.servicelayer.MARKED_TAG
 import com.ichi2.anki.servicelayer.NoteService
@@ -70,7 +70,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 
 class ReviewerViewModel(
     cardMediaPlayer: CardMediaPlayer,
-    private val keyMap: PeripheralKeymap<ReviewerBinding, ViewerAction>,
+    private val bindingMap: BindingMap<ReviewerBinding, ViewerAction>,
 ) : CardViewerViewModel(cardMediaPlayer),
     ChangeManager.Subscriber,
     BindingProcessor<ReviewerBinding, ViewerAction> {
@@ -123,7 +123,7 @@ class ReviewerViewModel(
         }
 
     init {
-        keyMap.setProcessor(this)
+        bindingMap.setProcessor(this)
         ChangeManager.subscribe(this)
         launchCatchingIO {
             updateUndoAndRedoLabels()
@@ -192,7 +192,7 @@ class ReviewerViewModel(
 
     fun dispatchKeyEvent(event: KeyEvent): Boolean {
         if (event.action != KeyEvent.ACTION_DOWN) return false
-        return keyMap.onKeyDown(event)
+        return bindingMap.onKeyDown(event)
     }
 
     private suspend fun toggleMark() {
@@ -578,11 +578,11 @@ class ReviewerViewModel(
     companion object {
         fun factory(
             soundPlayer: CardMediaPlayer,
-            keyMap: PeripheralKeymap<ReviewerBinding, ViewerAction>,
+            bindingMap: BindingMap<ReviewerBinding, ViewerAction>,
         ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
-                    ReviewerViewModel(soundPlayer, keyMap)
+                    ReviewerViewModel(soundPlayer, bindingMap)
                 }
             }
 

--- a/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
@@ -3,10 +3,12 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/alternativeBackgroundColor"
     android:fitsSystemWindows="true"
+    android:focusableInTouchMode="true"
     tools:context=".ui.windows.reviewer.ReviewerFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -3,10 +3,12 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout  xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="?attr/alternativeBackgroundColor"
     android:fitsSystemWindows="true"
+    android:focusableInTouchMode="true"
     tools:context=".ui.windows.reviewer.ReviewerFragment">
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -43,8 +43,8 @@ import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.Binding.Companion.keyCode
 import com.ichi2.anki.reviewer.Binding.ModifierKeys
+import com.ichi2.anki.reviewer.BindingMap
 import com.ichi2.anki.reviewer.CardSide
-import com.ichi2.anki.reviewer.PeripheralKeymap
 import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.utils.ext.addBinding
 import com.ichi2.libanki.Card
@@ -260,8 +260,8 @@ class ReviewerKeyboardInputTest : RobolectricTest() {
             displayAnswer = true
         }
 
-        override var processor: PeripheralKeymap<ReviewerBinding, ViewerCommand> =
-            PeripheralKeymap(sharedPrefs(), ViewerCommand.entries, this)
+        override var processor: BindingMap<ReviewerBinding, ViewerCommand> =
+            BindingMap(sharedPrefs(), ViewerCommand.entries, this)
 
         override fun answerFieldIsFocused(): Boolean = focusTextField
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingMapTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/BindingMapTest.kt
@@ -25,13 +25,13 @@ import org.junit.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 
-class PeripheralKeymapTest {
+class BindingMapTest {
     @Test
     fun flagAndAnswerDoNotConflict() {
         val processed: MutableList<ViewerCommand> = ArrayList()
 
         val sharedPrefs = SPMockBuilder().createSharedPreferences()
-        val peripheralKeymap = PeripheralKeymap(sharedPrefs, ViewerCommand.entries) { e: ViewerCommand, _ -> processed.add(e) }
+        val bindingMap = BindingMap(sharedPrefs, ViewerCommand.entries) { e: ViewerCommand, _ -> processed.add(e) }
         val event = mock(KeyEvent::class.java)
         whenever(event.unicodeChar).thenReturn(0)
         whenever(event.isCtrlPressed).thenReturn(true)
@@ -40,7 +40,7 @@ class PeripheralKeymapTest {
 
         assertThat(event.unicodeChar.toChar(), equalTo('\u0000'))
         assertThat(event.getUnicodeChar(0).toChar(), equalTo('1'))
-        peripheralKeymap.onKeyDown(event)
+        bindingMap.onKeyDown(event)
 
         assertThat<List<ViewerCommand>>(processed, hasSize(1))
         assertThat(processed[0], equalTo(ViewerCommand.TOGGLE_FLAG_RED))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Adds joystick/motion controllers to the previewer

Blocked by / on top of #18210

## Approach

Just start listening to the motion controllers.

## How Has This Been Tested?

0. Set some joystick controllers in the settings
1. Go to browser > Preview
2. Trigger the joystick controllers

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
