### PR TITLE
Bug Fix : MathJax subscript rendering issue.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -121,7 +121,7 @@ class Toolbar : FrameLayout {
         setupButtonWrappingText(R.id.note_editor_toolbar_button_bold, "<b>", "</b>")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_italic, "<i>", "</i>")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_underline, "<u>", "</u>")
-        setupButtonWrappingText(R.id.note_editor_toolbar_button_insert_mathjax, "\\(", "\\)")
+        setupButtonWrappingText(R.id.note_editor_toolbar_button_insert_mathjax, "\\[", "\\]")
         setupButtonWrappingText(R.id.note_editor_toolbar_button_horizontal_rule, "<hr>", "")
         findViewById<View>(R.id.note_editor_toolbar_button_font_size).setOnClickListener { displayFontSizeDialog() }
         findViewById<View>(R.id.note_editor_toolbar_button_title).setOnClickListener { displayInsertHeadingDialog() }


### PR DESCRIPTION
## Purpose / Description
Fixed the MathJax subscript rendering issue.

## Fixes
* Fixes #18215


## Approach
 Updated `setupButtonWrappingText` for the `insert_mathjax` toolbar button from `"\\(", "\\)"` to `"\\[", "\\]"` .

## How Has This Been Tested?
Device : Emulator Pixel 9 Pro
| *State*  | *Screenshot* |
|------------|--------------|
| *Before* | <img src="https://github.com/user-attachments/assets/abef5cc5-8e89-4c9e-b89d-290b77d324dc" width="300"> |
| *After*  | <img src="https://github.com/user-attachments/assets/5bc10a9d-341f-4408-b14d-49a3c0abf937" width="300"> |




## Checklist
Please, go through these checks before submitting the PR.

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
