### PR TITLE
fix: Updated visibility for buried card counts in Study Options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -610,29 +610,27 @@ class StudyOptionsFragment :
             newCountText.text = result.newCardsToday.toString()
             learningCountText.text = result.lrnCardsToday.toString()
             reviewCountText.text = result.revCardsToday.toString()
+
             // set bury numbers
             buryInfoLabel.isVisible = result.buriedNew > 0 || result.buriedLearning > 0 || result.buriedReview > 0
-            newBuryText.text =
-                requireContext().resources.getQuantityString(
-                    R.plurals.studyoptions_buried_count,
-                    result.buriedNew,
-                    result.buriedNew,
-                )
-            newBuryText.isVisible = result.buriedNew != 0
-            learningBuryText.text =
-                requireContext().resources.getQuantityString(
-                    R.plurals.studyoptions_buried_count,
-                    result.buriedLearning,
-                    result.buriedLearning,
-                )
-            learningBuryText.isVisible = result.buriedLearning != 0
-            reviewBuryText.text =
-                requireContext().resources.getQuantityString(
-                    R.plurals.studyoptions_buried_count,
-                    result.buriedReview,
-                    result.buriedReview,
-                )
-            reviewBuryText.isVisible = result.buriedReview != 0
+
+            fun TextView.updateBuryText(count: Int) {
+                this.isVisible = count > 0
+                this.text =
+                    when {
+                        count > 0 ->
+                            requireContext().resources.getQuantityString(
+                                R.plurals.studyoptions_buried_count,
+                                count,
+                                count,
+                            )
+                        // #18094 - potential race condition: view may be visible with a count of 0
+                        else -> ""
+                    }
+            }
+            newBuryText.updateBuryText(result.buriedNew)
+            learningBuryText.updateBuryText(result.buriedLearning)
+            reviewBuryText.updateBuryText(result.buriedReview)
             totalNewCardsCount.text = result.totalNewCards.toString()
             totalCardsCount.text = result.numberOfCardsInDeck.toString()
             // Rebuild the options menu


### PR DESCRIPTION
> [!IMPORTANT]
> I copied the description from #18098, as the user deleted their account
> * #18098

## Purpose / Description

- Problem: The Study Options screen incorrectly displays "+0 buried" for New, Learning, and/or Review card categories even when those categories have no buried cards.

- Impact: This misleadingly suggests there are buried cards when there aren't, confusing users about their study status.

- Problem: When there are buried cards in the review category, the value displayed is "+0" instead of the correct one. To improve the accuracy and clarity of the Study Options screen, providing users with correct information about their buried cards.

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/18094#issue-2919291007
Uploading solved18094.mp4…

## Approach

- Modified the **rebuildUi** function in **StudyOptionsFragment**.
- Added conditional logic to set the **text** property of the buried card count TextViews (**newBuryText**, **learningBuryText**, **reviewBuryText**) only when there are actually buried cards in the corresponding category.
- Ensured the **buryInfoLabel** is visible when there are any buried cards, and invisible when there aren't any.
- Verified that the visibility of the TextViews are correctly set, hiding them when there are no buried cards.
- This approach prevents the erroneous display of "+0 buried" by not setting the text property when there are no buried cards.

## How Has This Been Tested?

- This issue has been tested on a physical device running on Android 15, as well as on Android Emulator (API 35 )

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)