### PR TITLE
NF: remove variables which are simply `col.notetypes`

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -40,9 +40,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiGetNextTimeTest() =
         runTest {
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
 
@@ -74,9 +73,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiTestCurrentCard() =
         runTest {
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
 
@@ -185,9 +183,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     @Test
     fun ankiJsUiTest() =
         runTest {
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
 
@@ -228,9 +225,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiMarkAndFlagCardTest() =
         runTest {
             // js api test for marking and flagging card
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
 
@@ -289,9 +285,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             // add five notes, four will be buried and suspended
             // count number of notes, if buried or suspended then
             // in scheduling the count will be less than previous scheduling
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
             addBasicNote("baz", "bak")
@@ -358,9 +353,8 @@ class AnkiDroidJsAPITest : RobolectricTest() {
     fun ankiSetCardDueTest() =
         runTest {
             TimeManager.reset()
-            val models = col.notetypes
             val didA = addDeck("Test", setAsSelected = true)
-            val basic = models.byName(BASIC_MODEL_NAME)
+            val basic = col.notetypes.byName(BASIC_MODEL_NAME)
             basic!!.put("did", didA)
             addBasicNote("foo", "bar")
             addBasicNote("baz", "bak")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -69,22 +69,21 @@ class CardTest : JvmTest() {
         col.addNote(note)
         assertEquals(1, note.numberOfCards())
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
         // adding a new template should automatically create cards
         var t =
             Notetypes.newTemplate("rev").apply {
                 qfmt = "{{Front}}1"
                 afmt = ""
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         assertEquals(2, note.numberOfCards())
         // if the template is changed to remove cards, they'll be removed
         t =
             noteType.tmpls[1].apply {
                 qfmt = "{{Back}}"
             }
-        noteTypes.save(noteType)
+        col.notetypes.save(noteType)
         val rep = col.emptyCids()
         col.removeCardsAndOrphanedNotes(rep)
         assertEquals(1, note.numberOfCards())
@@ -121,22 +120,21 @@ class CardTest : JvmTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_gen_or() {
-        val models = col.notetypes
-        val model = models.byName("Basic")
+        val model = col.notetypes.byName("Basic")
         assertNotNull(model)
-        models.renameFieldLegacy(model, model.flds[0], "A")
-        models.renameFieldLegacy(model, model.flds[1], "B")
-        val fld2 = models.newField("C")
+        col.notetypes.renameFieldLegacy(model, model.flds[0], "A")
+        col.notetypes.renameFieldLegacy(model, model.flds[1], "B")
+        val fld2 = col.notetypes.newField("C")
         fld2.setOrd(null)
-        models.addFieldLegacy(model, fld2)
+        col.notetypes.addFieldLegacy(model, fld2)
         model.tmpls[0].qfmt = "{{A}}{{B}}{{C}}"
         // ensure first card is always generated,
         // because at last one card is generated
         val tmpl = Notetypes.newTemplate("AND_OR")
         tmpl.qfmt = "        {{A}}    {{#B}}        {{#C}}            {{B}}        {{/C}}    {{/B}}"
-        models.addTemplate(model, tmpl)
-        models.save(model)
-        models.setCurrent(model)
+        col.notetypes.addTemplate(model, tmpl)
+        col.notetypes.save(model)
+        col.notetypes.setCurrent(model)
         var note = col.newNote()
         note.setItem("A", "foo")
         col.addNote(note)
@@ -169,24 +167,23 @@ class CardTest : JvmTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_gen_not() {
-        val models = col.notetypes
-        val model = models.byName("Basic")
+        val model = col.notetypes.byName("Basic")
         assertNotNull(model)
         val tmpls = model.tmpls
-        models.renameFieldLegacy(model, model.flds[0], "First")
-        models.renameFieldLegacy(model, model.flds[1], "Front")
-        val fld2 = models.newField("AddIfEmpty")
+        col.notetypes.renameFieldLegacy(model, model.flds[0], "First")
+        col.notetypes.renameFieldLegacy(model, model.flds[1], "Front")
+        val fld2 = col.notetypes.newField("AddIfEmpty")
         fld2.name = "AddIfEmpty"
-        models.addFieldLegacy(model, fld2)
+        col.notetypes.addFieldLegacy(model, fld2)
 
         // ensure first card is always generated,
         // because at last one card is generated
         tmpls[0].qfmt = "{{AddIfEmpty}}{{Front}}{{First}}"
         val tmpl = Notetypes.newTemplate("NOT")
         tmpl.qfmt = "    {{^AddIfEmpty}}        {{Front}}    {{/AddIfEmpty}}    "
-        models.addTemplate(model, tmpl)
-        models.save(model)
-        models.setCurrent(model)
+        col.notetypes.addTemplate(model, tmpl)
+        col.notetypes.save(model)
+        col.notetypes.setCurrent(model)
         var note = col.newNote()
         note.setItem("First", "foo")
         note.setItem("AddIfEmpty", "foo")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CollectionTest.kt
@@ -112,12 +112,11 @@ class CollectionTest : JvmTest() {
         assertEquals(1, n)
         // test multiple cards - add another template
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
         val t = Notetypes.newTemplate("Reverse")
         t.qfmt = "{{Back}}"
         t.afmt = "{{Front}}"
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         assertEquals(2, col.cardCount())
         // creating new notes should use both cards
         note = col.newNote()
@@ -192,11 +191,10 @@ class CollectionTest : JvmTest() {
     @Test
     @Ignore("Pending port of media search from Rust code")
     fun test_furigana() {
-        val noteTypes = col.notetypes
-        val noteType = noteTypes.current()
+        val noteType = col.notetypes.current()
         // filter should work
         noteType.tmpls[0].qfmt = "{{kana:Front}}"
-        noteTypes.save(noteType)
+        col.notetypes.save(noteType)
         val n = col.newNote()
         n.setItem("Front", "foo[abc]")
         col.addNote(n)
@@ -209,7 +207,7 @@ class CollectionTest : JvmTest() {
         assertThat("Question «$question» does not contains «anki:play».", question, Matchers.containsString("anki:play"))
         // it shouldn't throw an error while people are editing
         noteType.tmpls[0].qfmt = "{{kana:}}"
-        noteTypes.save(noteType)
+        col.notetypes.save(noteType)
         c.question(true)
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -136,14 +136,13 @@ class FinderTest : JvmTest() {
         val catCard = note.cards()[0]
         var noteType = col.notetypes.current()
         noteType = col.notetypes.copy(noteType)
-        val noteTypes = col.notetypes
         val t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
                 afmt = "{{Front}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         note = col.newNote()
         note.setItem("Front", "test")
         note.setItem("Back", "foo bar")

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/ModelTest.kt
@@ -230,14 +230,13 @@ class NotetypeTest : JvmTest() {
     @Throws(ConfirmModSchemaException::class)
     fun test_templates() {
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
                 afmt = "{{Front}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         val note = col.newNote()
         note.setItem("Front", "1")
         note.setItem("Back", "2")
@@ -268,7 +267,7 @@ class NotetypeTest : JvmTest() {
             Notetypes.newTemplate("template name").apply {
                 qfmt = "{{Front}}1"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
+        col.notetypes.addTemplateModChanged(noteType, t)
         col.notetypes.remTemplate(noteType, noteType.tmpls[0])
         assertEquals(
             0,
@@ -283,7 +282,6 @@ class NotetypeTest : JvmTest() {
     fun test_cloze_ordinals() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
 
         // We replace the default Cloze template
         val t =
@@ -291,8 +289,8 @@ class NotetypeTest : JvmTest() {
                 qfmt = "{{text:cloze:Text}}"
                 afmt = "{{text:cloze:Text}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         col.notetypes.remTemplate(noteType, noteType.tmpls[0])
 
         val note = col.newNote()
@@ -393,7 +391,6 @@ class NotetypeTest : JvmTest() {
     fun test_chained_mods() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
 
         // We replace the default Cloze template
         val t =
@@ -401,8 +398,8 @@ class NotetypeTest : JvmTest() {
                 qfmt = "{{cloze:text:Text}}"
                 afmt = "{{cloze:text:Text}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         col.notetypes.remTemplate(noteType, noteType.tmpls[0])
         val note = col.newNote()
         val q1 = "<span style=\"color:red\">phrase</span>"
@@ -427,14 +424,13 @@ class NotetypeTest : JvmTest() {
         val cloze = col.notetypes.byName("Cloze")
         // enable second template and add a note
         val basic = col.notetypes.current()
-        val noteTypes = col.notetypes
         val t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
                 afmt = "{{Front}}"
             }
-        noteTypes.addTemplateModChanged(basic, t)
-        noteTypes.save(basic)
+        col.notetypes.addTemplateModChanged(basic, t)
+        col.notetypes.save(basic)
         var note = col.newNote()
         note.setItem("Front", "note")
         note.setItem("Back", "b123")
@@ -516,8 +512,7 @@ class NotetypeTest : JvmTest() {
 
     @Test
     fun nonEmptyFieldTest() {
-        val noteTypes = col.notetypes
-        val basic = noteTypes.byName("Basic")
+        val basic = col.notetypes.byName("Basic")
         val s: MutableSet<String> = HashSet<String>()
         assertEquals(s, basic!!.nonEmptyFields(arrayOf("", "")))
         s.add("Front")
@@ -537,8 +532,7 @@ class NotetypeTest : JvmTest() {
 
     @Test
     fun getDid_test() {
-        val noteTypes = col.notetypes
-        val basic = noteTypes.byName("Basic")
+        val basic = col.notetypes.byName("Basic")
         basic!!.put("did", 999L)
 
         val expected = 999L

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -889,20 +889,19 @@ open class SchedulerTest : JvmTest() {
     fun test_ordcycleV2() {
         // add two more templates and set second active
         val noteType = col.notetypes.current()
-        val noteTypes = col.notetypes
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
                 afmt = "{{Front}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
+        col.notetypes.addTemplateModChanged(noteType, t)
         t =
             Notetypes.newTemplate("f2").apply {
                 qfmt = "{{Front}}1"
                 afmt = "{{Back}}"
             }
-        noteTypes.addTemplateModChanged(noteType, t)
-        noteTypes.save(noteType)
+        col.notetypes.addTemplateModChanged(noteType, t)
+        col.notetypes.save(noteType)
         // create a new note; it should have 3 cards
         val note = col.newNote()
         note.setItem("Front", "1")

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -147,9 +147,8 @@ interface TestClass {
         notetype: NotetypeJson,
         name: String,
     ) {
-        val noteTypes = col.notetypes
         try {
-            noteTypes.addFieldLegacy(notetype, noteTypes.newField(name))
+            col.notetypes.addFieldLegacy(notetype, col.notetypes.newField(name))
         } catch (e: ConfirmModSchemaException) {
             throw RuntimeException(e)
         }


### PR DESCRIPTION
David noted that `val noteTypes = col.notetypes` is useless in #18113. I find it simpler to just go over all of them and replace them instead of having to do it everywhere.

This is low priority, don't review if you don't have time for it