### PR TITLE
Avoid context leak in TTS Player by using ApplicationContext

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AndroidTtsPlayer.kt
@@ -36,7 +36,6 @@ import timber.log.Timber
 import kotlin.coroutines.resume
 
 class AndroidTtsPlayer(
-    private val context: Context,
     private val voices: List<TtsVoice>,
 ) : TtsPlayer() {
     private lateinit var scope: CoroutineScope
@@ -55,7 +54,7 @@ class AndroidTtsPlayer(
     suspend fun init(scope: CoroutineScope) {
         this.scope = scope
         this.tts =
-            TtsVoices.createTts(context)?.apply {
+            TtsVoices.createTts()?.apply {
                 setOnUtteranceProgressListener(
                     object : UtteranceProgressListenerCompat() {
                         override fun onStart(utteranceId: String?) {
@@ -161,12 +160,9 @@ class AndroidTtsPlayer(
         }
 
         @CheckResult
-        suspend fun createInstance(
-            context: Context,
-            scope: CoroutineScope,
-        ): AndroidTtsPlayer {
+        suspend fun createInstance(scope: CoroutineScope): AndroidTtsPlayer {
             val voices = TtsVoices.allTtsVoices().toList()
-            return AndroidTtsPlayer(context, voices).apply {
+            return AndroidTtsPlayer(voices).apply {
                 init(scope)
                 Timber.v("TTS creation: initialized player instance")
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -22,7 +22,6 @@
 
 package com.ichi2.anki
 
-import android.content.Context
 import android.icu.util.ULocale
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
@@ -191,7 +190,7 @@ object TtsVoices {
      * @return a usable [TextToSpeech] instance, or `null` if the [TextToSpeech.OnInitListener]
      * returns [TextToSpeech.ERROR]
      */
-    suspend fun createTts(context: Context = AnkiDroidApp.instance) =
+    suspend fun createTts() =
         suspendCancellableCoroutine { continuation ->
             var textToSpeech: TextToSpeech? = null
             continuation.invokeOnCancellation {
@@ -201,7 +200,10 @@ object TtsVoices {
             }
             Timber.v("begin TTS creation")
             textToSpeech =
-                TextToSpeech(context) { status ->
+                // TextToSpeech retains the context. So we can't give it any context that
+                // may be expected to disappear, as it would cause a memory leak. Hence
+                // we pass it the application as context.
+                TextToSpeech(AnkiDroidApp.instance) { status ->
                     if (status == TextToSpeech.SUCCESS) {
                         Timber.v("TTS creation success")
                         ttsEngine = textToSpeech?.defaultEngine

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -110,7 +110,7 @@ class CardMediaPlayer : Closeable {
                 soundUriBase = getMediaBaseUrl(getMediaDirectory(AnkiDroidApp.instance).path),
                 videoPlayer = VideoPlayer { javascriptEvaluator() },
             )
-        this.ttsPlayer = scope.async { AndroidTtsPlayer.createInstance(AnkiDroidApp.instance, scope) }
+        this.ttsPlayer = scope.async { AndroidTtsPlayer.createInstance(scope) }
     }
 
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -398,7 +398,7 @@ class CardMediaPlayer : Closeable {
             val scope = viewer.lifecycleScope
             val soundErrorListener = viewer.createSoundErrorListener()
             // tts can take a long time to init, this defers the operation until it's needed
-            val tts = scope.async(Dispatchers.IO) { AndroidTtsPlayer.createInstance(viewer, viewer.lifecycleScope) }
+            val tts = scope.async(Dispatchers.IO) { AndroidTtsPlayer.createInstance(viewer.lifecycleScope) }
 
             val soundPlayer = SoundTagPlayer(soundUriBase, VideoPlayer { viewer.webViewClient!! })
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/viewmodel/TtsVoicesViewModel.kt
@@ -152,7 +152,7 @@ class TtsVoicesViewModel : ViewModel() {
         viewModelScope.launch(Dispatchers.IO) {
             ttsEngineStatus.emit(TtsEngineStatus.Loading)
             val player =
-                AndroidTtsPlayer.createInstance(context = AnkiDroidApp.instance, viewModelScope)
+                AndroidTtsPlayer.createInstance(viewModelScope)
             ttsEngineStatus.emit(TtsEngineStatus.Success(player))
         }
         viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
## Purpose / Description
LeakCanary reported that the TextToSpeech (TTS) instance was retaining a reference to the Context and causing it to outlive its intended lifecycle.

## Fixes
* Fixes a memory Leak caused be TTS Instances in Reviewer instances (more accurately CardMediaPlayer)

## Approach

To prevent context leaks, TTS should be initialized with a Context that has the longest possible lifetime — typically the application context. Fortunately, the createTts function already defaults to using the application context, so we can fix the leak simply by no longer explicitly passing a shorter-lived context.

## How Has This Been Tested?

Before
https://drive.google.com/file/d/1McuB-l8J3NvxyE7sziTffac5yVwuUJkg/view?usp=sharing

After
https://drive.google.com/file/d/1MNfin0v-G3gcgbIUmPO2XTU0LuPmWSIt/view?usp=sharing

This can be verified by adding {{tts en_US:Front}} to a card’s front, then opening and closing the reviewer.
Before this change: LeakCanary reports a memory leak in the reviewer.
After this change: No leak is detected by LeakCanary.

## Learning (optional, can help others)

https://stackoverflow.com/questions/62195373/resolving-tts-memory-leak-detected-with-leakcanary
https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/speech/tts/TextToSpeech.java

## Checklist

- [ ✅] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ✅] You have commented your code, particularly in hard-to-understand areas
- [ ✅] You have performed a self-review of your own code
