### PR TITLE
Add a dev option to add useless note

### DIFF
--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -204,6 +204,9 @@
     <string name="pref_browser_find_replace">browserFindReplace</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <string name="pref_cat_wip_key">workInProgressDevOptions</string>
+    <!-- Developer options > Create fake notes -->
+    <string name="pref_fill_default_deck_number_key">FillDefaultNumberDeck</string>
+    <string name="pref_fill_default_deck_key">FillDefaultDeck</string>
     <!-- Developer options > Create fake media -->
     <string name="pref_fill_collection_key">fillCollection</string>
     <string name="pref_fill_collection_number_file_key">fillCollectionNumberFile</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -53,6 +53,21 @@
         android:key="@string/new_congrats_screen_pref_key"
         android:defaultValue="false"/>
     <PreferenceCategory
+        android:title="Create meaningless cards notes"
+        >
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+            android:key="@string/pref_fill_default_deck_number_key"
+            android:title="Number of notes to generate"
+            app1:useSimpleSummaryProvider="true"
+            android:defaultValue="200"
+            app:min="1"
+            />
+        <Preference
+            android:key="@string/pref_fill_default_deck_key"
+            android:title="Create notes"
+            />
+    </PreferenceCategory>
+    <PreferenceCategory
         android:title="Create fake media"
         >
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat


### PR DESCRIPTION
This way, if I start a fresh collection to test AnkiDroid, I can ensure it's not empty. Especially useful if I want to fill the card browser and the deck browser

To be specific, I wanted it to test #18165 with a deck with many cards and easy to remember card content