### PR TITLE
Fix AlertDialog background color for black theme

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -83,6 +83,7 @@
         <item name="navDrawerImage">@drawable/nav_drawer_logo_black_theme</item>
         <!-- Dialog styles -->
         <item name="android:listPreferredItemHeight">56dip</item>
+        <item name="alertDialogTheme">@style/ThemeOverlay.AnkiDroid.AlertDialog.Black</item>
         <!--Custom Tabs colors-->
         <item name="customTabNavBarColor">#000000</item>
         <item name="popupBackgroundColor">@color/popup_background_theme_black</item>
@@ -107,5 +108,9 @@
 
     <style name="SnackbarTextStyleBlack" parent="@style/Widget.MaterialComponents.Snackbar.TextView">
         <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="ThemeOverlay.AnkiDroid.AlertDialog.Black" parent="ThemeOverlay.AnkiDroid.AlertDialog">
+        <item name="android:background">@color/theme_black_primary_light</item>
     </style>
 </resources>


### PR DESCRIPTION
## Purpose / Description

The fix consists in extending the style that was used for AlertDialogs and update it with a new color just for the black theme. This shouldn't produce changes outside of the black theme(I looked at dialogs in other themes). Feel free to propose a different color.

See images below(before/after) for some AlertDialogs:

<img src="https://github.com/user-attachments/assets/9edad576-3cd0-4592-9a63-0252d1d0dc54" width="320" height="720"/><img src="https://github.com/user-attachments/assets/52382d38-70d0-4dad-b455-057d082056fe" width="320" height="720"/>


<img src="https://github.com/user-attachments/assets/71cbe24c-11db-4544-b86e-cfc7ec2bde1e" width="320" height="720"/><img src="https://github.com/user-attachments/assets/485eb2df-8ace-4e59-95fb-85c2fe77030e" width="320" height="720"/>

<img src="https://github.com/user-attachments/assets/c0892056-f94f-42a4-ba31-090f17a01cc3" width="320" height="720"/>
<img src="https://github.com/user-attachments/assets/27708677-e487-4307-a606-b646ac2a6e1a" width="320" height="720"/>
<img src="https://github.com/user-attachments/assets/3077c7f1-9ed4-4588-aa58-911e2ad7eeae" width="320" height="720"/><img src="https://github.com/user-attachments/assets/bccfe7aa-dcb4-4ab4-b324-b61833e522d7" width="320" height="720"/>

## Fixes
* Fixes #15241

## How Has This Been Tested?

Checked some dialogs in black theme.

## Learning (optional, can help others)

We need to stop using MaterialAlertDialogBuilder as it has a distinct look.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
