### PR TITLE
Fix the handling of quotes while renaming a deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -245,16 +245,15 @@ class CreateDeckDialog(
     }
 
     fun renameDeck(newDeckName: String) {
-        val newName = newDeckName.replace("\"".toRegex(), "")
-        if (!Decks.isValidDeckName(newName)) {
+        if (!Decks.isValidDeckName(newDeckName)) {
             Timber.w("CreateDeckDialog::renameDeck not renaming deck to invalid name")
-            Timber.d("invalid deck name: %s", newName)
+            Timber.d("invalid deck name: %s", newDeckName)
             displayFeedback(context.getString(R.string.invalid_deck_name), Snackbar.LENGTH_LONG)
-        } else if (newName != previousDeckName) {
+        } else if (newDeckName != previousDeckName) {
             try {
                 val decks = getColUnsafe.decks
                 val deckId = decks.id(previousDeckName!!)
-                decks.rename(decks.get(deckId)!!, newName)
+                decks.rename(decks.get(deckId)!!, newDeckName)
                 onNewDeckCreated(deckId)
                 // 11668: Display feedback if a deck is renamed
                 displayFeedback(context.getString(R.string.deck_renamed))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -106,6 +106,23 @@ class CreateDeckDialogTest : RobolectricTest() {
     }
 
     @Test
+    fun testCreateDeckWithQuotes() {
+        val deckNameWithQuotes = "New \"Quoted\" Deck"
+        ensureExecutionOfScenario(DeckDialogType.DECK) { createDeckDialog, assertionCalled ->
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
+                // Verify that quotes are preserved in deck names when creating
+                assertThat(
+                    "Quotes should be preserved in deck names when creating",
+                    col.decks.name(id),
+                    equalTo(deckNameWithQuotes),
+                )
+                assertionCalled()
+            }
+            createDeckDialog.createDeck(deckNameWithQuotes)
+        }
+    }
+
+    @Test
     fun testRenameDeckFunction() {
         val deckName = "Deck Name"
         val deckNewName = "New Deck Name"
@@ -117,6 +134,25 @@ class CreateDeckDialogTest : RobolectricTest() {
                 assertionCalled()
             }
             createDeckDialog.renameDeck(deckNewName)
+        }
+    }
+
+    @Test
+    fun testRenameDeckWithQuotes() {
+        val deckName = "Deck Name"
+        val deckNewNameWithQuotes = "New \"Quoted\" Deck Name"
+        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { createDeckDialog, assertionCalled ->
+            createDeckDialog.deckName = deckName
+            createDeckDialog.onNewDeckCreated = { id: DeckId ->
+                // Verify that the quotes are preserved in the renamed deck
+                assertThat(
+                    "Quotes should be preserved in deck names when renaming",
+                    col.decks.name(id),
+                    equalTo(deckNewNameWithQuotes),
+                )
+                assertionCalled()
+            }
+            createDeckDialog.renameDeck(deckNewNameWithQuotes)
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

Fixes the handling of quotes while renaming a deck.

## Fixes
Fixes #18266

## Approach
There was an unnecessary removal of `"` happening before the renaming logic. This was also inconsistent with the deck creation logic.

## How Has This Been Tested?

Manual testing + unit tests.