### PR TITLE
Escape quotes in the deck name for card browser's search syntax

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -125,7 +125,10 @@ class CardBrowserViewModel(
 
     var searchTerms = ""
         private set
-    private var restrictOnDeck: String = ""
+
+    @VisibleForTesting
+    var restrictOnDeck: String = ""
+        private set
 
     /** text in the search box (potentially unsubmitted) */
     // this does not currently bind to the value in the UI and is only used for posting
@@ -232,7 +235,9 @@ class CardBrowserViewModel(
                 ""
             } else {
                 val deckName = withCol { decks.name(deckId) }
-                "deck:\"$deckName\" "
+                // Escape any quotes in the deck name to prevent search syntax errors
+                val escapedDeckName = deckName.replace("\"", "\\\"")
+                "deck:\"$escapedDeckName\""
             }
         flowOfDeckId.update { deckId }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1011,6 +1011,19 @@ class CardBrowserViewModelTest : JvmTest() {
             assertThat("German", firstHeading(), equalTo("Sortierfeld"))
         }
 
+    @Test
+    fun `deck name with quotes is properly escaped in search query`() =
+        runViewModelTest {
+            val deckWithQuotes = addDeck("Test\"Quotes\"In\"Deck")
+            setDeckId(deckWithQuotes)
+
+            assertThat(
+                "Quotes in deck name should be escaped with backslashes",
+                restrictOnDeck,
+                equalTo("deck:\"Test\\\"Quotes\\\"In\\\"Deck\""),
+            )
+        }
+
     private fun assertDate(str: String?) {
         // 2025-01-09 @ 18:06
         assertNotNull(str)


### PR DESCRIPTION
## Purpose / Description
This ensures that quotes in the deck name for card browser's search syntax are escaped before they are used.

## Fixes
Fixes #18265 

## Approach

- This modifies the `setDeckId` method in `CardBrowserViewModel` to escape quotes in deck names when constructing the search query.
- The fix replaces all double quotes with escaped double quotes (\") in the deck name.

## How Has This Been Tested?

Manually and added a new unit test.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
