### PR TITLE
fix(card-template-editor): change Ctrl+A to Ctrl+N

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -815,6 +815,10 @@ open class CardTemplateEditor :
         }
 
         fun addCardTemplate() {
+            if (templateEditor.tempNoteType!!.notetype.isCloze) {
+                Timber.w("addCardTemplate attempted on cloze note type")
+                return
+            }
             // Show confirmation dialog
             val ordinal = templateEditor.viewPager.currentItem
             // isOrdinalPendingAdd method will check if there are any new card types added or not,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -380,8 +380,8 @@ open class CardTemplateEditor :
                 Timber.i("Ctrl+I: Insert field from keypress")
                 currentFragment.showInsertFieldDialog()
             }
-            KeyEvent.KEYCODE_A -> {
-                Timber.i("Ctrl+A: Add card template from keypress")
+            KeyEvent.KEYCODE_N -> {
+                Timber.i("Ctrl+N: Add card template from keypress")
                 currentFragment.addCardTemplate()
             }
             KeyEvent.KEYCODE_R -> {


### PR DESCRIPTION
Ctrl+A is standardised as 'select all'

Also stops the new command working on a cloze note

Added in 87e2a79b676c6309496317141340d6db52e82fa5

* Fixes #18271

## How Has This Been Tested?
⚠️  untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
