### PR TITLE
fix(new reviewer): default keybinds

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.preferences.reviewer.MenuDisplayType.ALWAYS
 import com.ichi2.anki.preferences.reviewer.MenuDisplayType.DISABLED
 import com.ichi2.anki.preferences.reviewer.MenuDisplayType.MENU_ONLY
 import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.reviewer.Binding.AppDefinedModifierKeys
 import com.ichi2.anki.reviewer.Binding.ModifierKeys
 import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.ctrl
 import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.shift
@@ -234,7 +235,7 @@ enum class ViewerAction(
 
     private fun unicode(
         unicodeChar: Char,
-        keys: ModifierKeys = ModifierKeys.none(),
+        keys: ModifierKeys = AppDefinedModifierKeys.allowShift(),
         side: CardSide = CardSide.BOTH,
     ): ReviewerBinding {
         val binding = Binding.unicode(unicodeChar, keys)


### PR DESCRIPTION
default keybinds like *, ! and @, which needs a combination of shift+another key in most keyboards, weren't working in the new reviewer

this fixes it by using `allowShift()` like the old reviewer does

## How Has This Been Tested?

With an Android 14 tablet, by testing if the mentioned keybinds work in a new installation of AnkiDroid

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
