### PR TITLE
Fix for deck expander icon not updating correctly for bottom deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -159,7 +159,9 @@ class DeckAdapter(
         if (node.children.isNotEmpty()) {
             holder.deckExpander.setOnClickListener {
                 onDeckChildrenToggled(node.did)
-                notifyItemChanged(position) // Ensure UI updates
+                // Force a complete redraw to ensure all expanders update correctly
+                // This fixes issues with bottom deck expander icon not updating
+                notifyDataSetChanged()
             }
         } else {
             holder.deckExpander.isClickable = false


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When opening AnkiDroid, the deck expander icon for the bottom deck sometimes fails to update visually after clicking it. This issue only occurs when first opening the app, and disappears after navigating to another screen and returning to the deck picker.

## Fixes
* Fixes #18247

## Approach
The fix modifies the DeckAdapter.onBindViewHolder() method to use notifyDataSetChanged() instead of the more targeted notifyItemChanged(position) when a deck's collapsed state is toggled.

## How Has This Been Tested?

Emulator 

https://github.com/user-attachments/assets/cdeee3a6-e47e-440e-a84c-eec16c6b761e

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)