### PR TITLE
NF: Comment DeckNode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -399,8 +399,10 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         private fun hasSubDecks(node: DeckNode): Boolean = node.children.isNotEmpty()
 
         private fun isViewable(deck: DeckNode): Boolean {
-            val parentNode = deck.parent ?: return true
-            return !parentNode.get()?.collapsed!! && isViewable(parentNode.get()!!)
+            val parentNodeRef = deck.parent ?: return true
+            // The parent belongs to the tree retained by [allDecksList], so should still exists.
+            val parentNode = parentNodeRef.get()!!
+            return !parentNode.collapsed && isViewable(parentNode)
         }
 
         override fun getItemCount(): Int = currentlyDisplayedDecks.size

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -22,14 +22,43 @@ import com.ichi2.libanki.utils.append
 import java.lang.ref.WeakReference
 import java.util.Locale
 
+/**
+ * An object of this class represent a [com.ichi2.libanki.Deck], with all information that may be useful for its usage, such as its subdecks and the number of cards to review today.
+ * This object can also represent the root of the tree, of depth -1, that is the parent of all top-level decks. All non-root decks are called read decks.
+ * No change to this object are retained in the collection. Any change must be made through collections methods such as the ones of [com.ichi2.libanki.Decks].
+ *
+ * Objects of this type should not be retained, as this could cause them to outlive their parent. The only exception being the above-mentioned root deck that has no parent.
+ *
+ * The hierarchy is exactly the same as the one returned by [net.ankiweb.rsdroid.Backend.deckTree].
+ */
 data class DeckNode(
     val node: DeckTreeNode,
     val fullDeckName: String,
+    /**
+     * Non-null for real decks. The parent of a top-level deck is the root of the tree.
+     */
     val parent: WeakReference<DeckNode>? = null,
 ) : Iterable<DeckNode> {
+    /**
+     * Whether or not the deck should appear as collapsed in the deck picker.
+     * Change to this variable is not retained in the collection. The caller must change the [com.ichi2.libanki.Deck] object with the same id and save it.
+     */
     var collapsed = node.collapsed
+
+    /**
+     * Number of review cards to review today, as displayed in the deck picker, including count of subdecks.
+     */
     val revCount = node.reviewCount
+
+    /**
+     * Number of new cards to review today, as displayed in the deck picker, including count of subdecks.
+     */
     val newCount = node.newCount
+
+    /**
+     * Number of cards in learning to review today, as displayed in the deck picker, including count of subdecks.
+     * Note that this value will quite often be smaller than the value that would be returned by the back-end. This is because a card in learning may be due at any second.
+     */
     val lrnCount = node.learnCount
     val did = node.deckId
     val filtered = node.filtered
@@ -58,6 +87,12 @@ data class DeckNode(
      */
     val depth = node.level - 1
 
+    /**
+     * True if this node corresponds to an actual deck that the user can interact with.
+     * False if this is the root of the deck tree.
+     */
+    private val isRealDeck = node.level > 0
+
     override fun toString(): String =
         String.format(
             Locale.US,
@@ -69,8 +104,17 @@ data class DeckNode(
             newCount,
         )
 
+    /**
+     * Whether we expect that tapping on this deck would allow to start reviewing.
+     * Note that this value may have false-negative, because [lrnCount] can increase virtually at any time.
+     * False positive are virtually impossible; unless the API is used in the background.
+     * Indeed, any other action that would cause a card to be reviewed or deleted should cause the owner of this tree to refresh it.
+     */
     fun hasCardsReadyToStudy(): Boolean = revCount > 0 || newCount > 0 || lrnCount > 0
 
+    /**
+     * The node with [did] [deckId], if it is either this node or a descendant.
+     */
     fun find(deckId: DeckId): DeckNode? {
         if (node.deckId == deckId) {
             return this
@@ -81,8 +125,11 @@ data class DeckNode(
         return null
     }
 
+    /**
+     * Run [fn] on this node (unless its the root) and its descendants.
+     */
     fun forEach(fn: (DeckNode) -> Unit) {
-        if (node.level > 0) {
+        if (isRealDeck) {
             fn(this)
         }
         for (child in children) {
@@ -90,14 +137,17 @@ data class DeckNode(
         }
     }
 
+    /**
+     * An iterator returning this deck (unless it's the root) and all descendant.
+     */
     override fun iterator(): Iterator<DeckNode> =
         sequence {
-            if (node.level > 0) yield(this@DeckNode)
+            if (isRealDeck) yield(this@DeckNode)
             for (child in children) yieldAll(child)
         }.iterator()
 
-    /** Convert the tree into a flat list, where matching decks and the children/parents
-     * are included. Decks inside collapsed decks are not considered. */
+    /**
+     * The list of all decks displayed in the deck picker containing the string [filter]. That is, all real decks excepts the descendant of collapsed decks. */
     fun filterAndFlatten(filter: CharSequence?): List<DeckNode> {
         val filterPattern =
             if (filter.isNullOrBlank()) {
@@ -110,33 +160,43 @@ data class DeckNode(
         return list
     }
 
+    /**
+     * Add this deck (if its not the root of the tree) and its visible descendants, to [list]
+     * @param filter: if non-null, restricts the list to visible decks matching whose name contains [filter] as a case-independent substring, and the ancestors of those decks.
+     */
     private fun filterAndFlattenInner(
         filter: CharSequence?,
         list: MutableList<DeckNode>,
     ) {
-        if (node.level > 0 && nameMatchesFilter(filter)) {
-            // if this deck matched, all children are included
+        if (isRealDeck && nameMatchesFilter(filter)) {
+            // if this deck matched, all visible descendant are included.
             addVisibleToList(list)
             return
         }
 
         if (collapsed) {
+            // We don't show non-visible subdecks even when its name matches the filter.
             return
         }
 
-        if (node.level > 0) {
+        if (isRealDeck) {
             list.append(this)
         }
         val startingLen = list.size
         for (child in children) {
             child.filterAndFlattenInner(filter, list)
         }
-        if (node.level > 0 && startingLen == list.size) {
+        if (isRealDeck && startingLen == list.size) {
             // we don't include ourselves if no children matched
             list.removeAt(list.lastIndex)
         }
     }
 
+    /**
+     * Whether the base name of the deck (not including the name of its parent) matches [filter].
+     * if [filter] is [none], returns [true] as every deck matchs the empty filter.
+     * otherwise, [filter] must be a substring (case-insensitive) of the deck name.
+     */
     @SuppressLint("LocaleRootUsage")
     private fun nameMatchesFilter(filter: CharSequence?): Boolean {
         return if (filter == null) {
@@ -146,6 +206,10 @@ data class DeckNode(
         }
     }
 
+    /**
+     * Add this deck and all visible descendants to [list].
+     * A descendant is visible if none of its parents are collapsed.
+     */
     fun addVisibleToList(list: MutableList<DeckNode>) {
         list.append(this)
         if (!collapsed) {


### PR DESCRIPTION
I found DeckNode slightly hard to use, as it was not clear exactly what each value was and what each function does.

For example, I would not have guessed that the parent of the top-level deck is a root DeckNode that is not actually a deck. Or that the counts included the cards to review in children decks.

I also modified an access to the parent to explain why `get()!!` is safe.

Admittedly, I don't think that we should have used a WeakReference for the parent here. The whole tree should have the same lifespan. If it's not the case and a children outlive its parents, it's already an issue and being able to release its parent may not save thas much memory overall.