### PR TITLE
Add modern progress dialog implementation using DialogFragment instead of ProgressDialog

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -388,7 +388,13 @@ dependencies {
     implementation libs.kotlinx.serialization.json
     implementation libs.seismic
 
-    debugImplementation libs.androidx.fragment.testing.manifest
+    // Fragment testing infrastructure has to be available during testing,
+    // and we test release builds sometimes - include in main APK if so
+    if (rootProject.testReleaseBuild) {
+        implementation libs.androidx.fragment.testing.manifest
+    } else {
+        debugImplementation libs.androidx.fragment.testing.manifest
+    }
 
     // Backend libraries
 

--- a/AnkiDroid/src/androidTest/AndroidManifest.xml
+++ b/AnkiDroid/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <!-- Needed for FragmentScenario.launchInContainer -->
+        <activity
+            android:name="androidx.fragment.app.testing.EmptyFragmentActivity"
+            android:exported="true" />
+    </application>
+
+</manifest>

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/AnkiProgressDialogFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/AnkiProgressDialogFragmentTest.kt
@@ -1,0 +1,378 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import androidx.fragment.app.testing.FragmentScenario
+import androidx.fragment.app.testing.launchFragmentInContainer
+import androidx.lifecycle.Lifecycle
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.AnkiProgressDialogFragment.Companion.newInstance
+import org.hamcrest.CoreMatchers.not
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.atomic.AtomicBoolean
+
+/** Tests [AnkiProgressDialogFragment] */
+@RunWith(AndroidJUnit4::class)
+class AnkiProgressDialogFragmentTest {
+    private lateinit var scenario: FragmentScenario<TestHostFragment>
+
+    @Before
+    fun setUp() {
+        scenario = launchFragmentInContainer(themeResId = R.style.Theme_Light)
+        scenario.moveToState(Lifecycle.State.RESUMED)
+    }
+
+    @After
+    fun tearDown() {
+        if (::scenario.isInitialized) {
+            scenario.close()
+        }
+    }
+
+    @Test
+    fun testDialogCreationWithDefaultValues() {
+        val message = "Loading..."
+
+        scenario.onFragment { fragment ->
+            val dialogFragment = newInstance(message)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Wait until the dialog's message appears
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(message)))
+
+        // Check that indeterminate progress bar is visible
+        onView(withId(R.id.indeterminate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        // Check that determinate progress bar is hidden
+        onView(withId(R.id.determinate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun testDialogCreationWithCustomParameters() {
+        val message = "Processing..."
+        val cancelable = true
+        val cancelButtonText = "Cancel"
+        val cancelCalled = AtomicBoolean(false)
+
+        scenario.onFragment { fragment ->
+            val dialogFragment =
+                newInstance(
+                    message = message,
+                    cancellationConfig =
+                        ProgressDialogCancellationConfig(
+                            cancelableViaBackButton = cancelable,
+                            cancelButtonText = cancelButtonText,
+                        ) {
+                            cancelCalled.set(true)
+                        },
+                )
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Wait until the dialog's message appears
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(message)))
+
+        // Check cancel button exists with correct text
+        onView(withText(cancelButtonText))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        // Click cancel button and verify callback is called
+        onView(withText(cancelButtonText))
+            .inRoot(isDialog())
+            .perform(click())
+
+        assertTrue("Cancel callback should be called", cancelCalled.get())
+    }
+
+    @Test
+    fun testMessageUpdate() {
+        val initialMessage = "Initial message"
+        val updatedMessage = "Updated message"
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment = newInstance(initialMessage)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Verify initial message
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(initialMessage)))
+
+        scenario.onFragment {
+            dialogFragment.updateMessage(updatedMessage)
+        }
+
+        // Verify updated message
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(updatedMessage)))
+    }
+
+    @Test
+    fun testProgressUpdateFromIndeterminateToDeterminate() {
+        val message = "Processing..."
+        val current = 30
+        val max = 100
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment = newInstance(message)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Initially, indeterminate progress bar should be visible
+        onView(withId(R.id.indeterminate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.determinate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(not(isDisplayed())))
+
+        onView(withId(R.id.progress_counter))
+            .inRoot(isDialog())
+            .check(matches(not(isDisplayed())))
+
+        // Update progress to switch to determinate mode
+        scenario.onFragment {
+            dialogFragment.updateProgress(current, max)
+        }
+
+        // Verify determinate progress bar and counter appear with correct values
+        onView(withId(R.id.determinate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withId(R.id.indeterminate_progress_bar))
+            .inRoot(isDialog())
+            .check(matches(not(isDisplayed())))
+
+        onView(withId(R.id.progress_counter))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+            .check(matches(withText("$current / $max")))
+    }
+
+    @Test
+    fun testMultipleProgressUpdates() {
+        val message = "Processing..."
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment = newInstance(message)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // First update - switches to determinate mode
+        scenario.onFragment {
+            dialogFragment.updateProgress(10, 100)
+        }
+
+        // Second update
+        scenario.onFragment {
+            dialogFragment.updateProgress(25, 100)
+        }
+
+        // Third update
+        scenario.onFragment {
+            dialogFragment.updateProgress(40, 100)
+        }
+
+        // Check final progress counter displays correct values
+        onView(withId(R.id.progress_counter))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+            .check(matches(withText("40 / 100")))
+    }
+
+    @Test
+    fun testCancellationViaBackButton() {
+        val message = "Processing..."
+        val cancelCalled = AtomicBoolean(false)
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment =
+                newInstance(
+                    message = message,
+                    cancellationConfig =
+                        ProgressDialogCancellationConfig(
+                            cancelableViaBackButton = true,
+                            onCancel = { cancelCalled.set(true) },
+                        ),
+                )
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Wait until the dialog's message appears
+        onView(withText(message))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        Espresso.pressBack()
+
+        assertTrue("Cancel callback should be called on back press", cancelCalled.get())
+    }
+
+    @Test
+    fun testConfigurationChangeDuringProgress() {
+        val message = "Configuration Change Test"
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment = newInstance(message)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Update progress before recreation
+        scenario.onFragment {
+            dialogFragment.updateProgress(45, 100)
+        }
+
+        // Simulate configuration change by recreating the activity
+        scenario.recreate()
+
+        // Check if the dialog is still showing after recreate
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun testQuickMultipleUpdates() {
+        val message = "Multiple updates"
+        lateinit var dialogFragment: AnkiProgressDialogFragment
+
+        scenario.onFragment { fragment ->
+            dialogFragment = newInstance(message)
+            dialogFragment.show(fragment.childFragmentManager, "test_tag")
+        }
+
+        // Switch to determinate mode and perform quick updates
+        scenario.onFragment {
+            dialogFragment.updateProgress(0, 100)
+            for (i in 1..10) {
+                dialogFragment.updateMessage("Update $i of 10")
+                dialogFragment.updateProgress(i * 10, 100)
+            }
+        }
+
+        // Check final state after quick updates
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText("Update 10 of 10")))
+
+        onView(withId(R.id.progress_counter))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+            .check(matches(withText("100 / 100")))
+    }
+
+    @Test
+    fun testMessagePreservationAfterConfigurationChange() {
+        val initialMessage = "Initial message before configuration change"
+        val dialogTag = "config_change_test"
+
+        scenario.onFragment { fragment ->
+            val dialogFragment = newInstance(initialMessage)
+            dialogFragment.show(fragment.childFragmentManager, dialogTag)
+        }
+
+        // Verify initial message is displayed
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(initialMessage)))
+
+        // Simulate configuration change by recreating the activity
+        scenario.recreate()
+
+        // Verify message is preserved after configuration change
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(initialMessage)))
+    }
+
+    @Test
+    fun testUpdatedMessagePreservationAfterConfigurationChange() {
+        val initialMessage = "Initial message"
+        val updatedMessage = "Updated message before config change"
+        val dialogTag = "message_preservation_test"
+
+        var childFragmentManager: androidx.fragment.app.FragmentManager? = null
+
+        scenario.onFragment { fragment ->
+            childFragmentManager = fragment.childFragmentManager
+            val dialogFragment = newInstance(initialMessage)
+            dialogFragment.show(fragment.childFragmentManager, dialogTag)
+        }
+
+        // Verify initial message is displayed
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(initialMessage)))
+
+        scenario.onFragment {
+            val dialogFragment =
+                childFragmentManager?.findFragmentByTag(dialogTag) as? AnkiProgressDialogFragment
+            dialogFragment?.updateMessage(updatedMessage)
+        }
+
+        // Verify message was updated
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(updatedMessage)))
+
+        // Simulate configuration change by recreating the activity
+        scenario.recreate()
+
+        // Verify updated message is preserved after configuration change
+        onView(withId(R.id.progress_message))
+            .inRoot(isDialog())
+            .check(matches(withText(updatedMessage)))
+    }
+}
+
+/**
+ * Host fragment to contain the dialog fragment for testing
+ */
+class TestHostFragment : androidx.fragment.app.Fragment()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -224,14 +224,14 @@ private suspend fun handleNormalSync(
     Timber.i("Sync: Normal collection sync")
     var auth2 = auth
     val output =
-        deckPicker.withProgress(
+        deckPicker.withProgressV2(
             extractProgress = {
                 if (progress.hasNormalSync()) {
                     text = progress.normalSync.run { "$added\n$removed" }
                 }
             },
             onCancel = ::cancelSync,
-            manualCancelButton = R.string.dialog_cancel,
+            manualCancelButtonText = deckPicker.getString(R.string.dialog_cancel),
         ) {
             withCol {
                 syncCollection(auth2, media = false) // media is synced by SyncMediaWorker
@@ -306,7 +306,7 @@ private suspend fun handleDownload(
     mediaUsn: Int?,
 ) {
     Timber.i("Sync: Full collection download requested")
-    deckPicker.withProgress(
+    deckPicker.withProgressV2(
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
         onCancel = ::cancelSync,
     ) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressDialogFragment.kt
@@ -1,0 +1,279 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import android.app.Dialog
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.View
+import android.widget.ProgressBar
+import android.widget.TextView
+import androidx.annotation.VisibleForTesting
+import androidx.appcompat.app.AlertDialog
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.ichi2.anki.R
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * A DialogFragment implementation for showing progress indicators.
+ */
+open class AnkiProgressDialogFragment : DialogFragment() {
+    @VisibleForTesting
+    val viewModel: AnkiProgressDialogViewModel by viewModels()
+
+    private var progressMessageView: TextView? = null
+    private lateinit var indeterminateProgressBar: ProgressBar
+    private lateinit var determinateProgressBar: ProgressBar
+    private lateinit var progressCounterView: TextView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setupViewModelFromArguments()
+    }
+
+    private fun setupViewModelFromArguments() {
+        if (viewModel.message.value.isNotBlank()) {
+            // Already configured (e.g., after config change)
+            return
+        }
+        arguments?.let { args ->
+            val message = args.getString(ARG_MESSAGE, "")
+            val cancelable = args.getBoolean(ARG_CANCELABLE, false)
+            val cancelButtonText = args.getString(ARG_CANCEL_BUTTON_TEXT, null)
+
+            Timber.d("Setting up ViewModel with message: '%s'", message)
+            viewModel.setup(
+                message = message,
+                cancelableViaBackButton = cancelable,
+                cancelButtonText = cancelButtonText,
+                onCancelListener = cancelListener,
+            )
+            cancelListener = null
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val view = layoutInflater.inflate(R.layout.new_anki_progress_dialog, null)
+        initializeViews(view)
+        updateUiFromViewModel()
+
+        return MaterialAlertDialogBuilder(requireContext())
+            .setView(view)
+            .create()
+            .apply {
+                setCanceledOnTouchOutside(false)
+                setupCancelButton(this)
+            }
+    }
+
+    private fun initializeViews(view: View) {
+        progressMessageView = view.findViewById(R.id.progress_message)
+        indeterminateProgressBar = view.findViewById(R.id.indeterminate_progress_bar)
+        determinateProgressBar = view.findViewById(R.id.determinate_progress_bar)
+        progressCounterView = view.findViewById(R.id.progress_counter)
+    }
+
+    private fun setupCancelButton(dialog: AlertDialog) {
+        viewModel.cancelButtonText.value?.let { buttonText ->
+            dialog.setButton(
+                DialogInterface.BUTTON_NEGATIVE,
+                buttonText,
+            ) { _, _ ->
+                Timber.i("Progress dialog cancelled via cancel button")
+                viewModel.cancel()
+            }
+        }
+    }
+
+    /**
+     * Sets up the initial UI state from the ViewModel's values
+     */
+    private fun updateUiFromViewModel() {
+        try {
+            updateMessageUi(viewModel.message.value)
+            updateProgressUi(viewModel.progress.value)
+            updateCancelableState(viewModel.cancelableViaBackButton.value)
+        } catch (e: Exception) {
+            Timber.w(e, "Error in updateUiFromViewModel")
+        }
+    }
+
+    private fun updateMessageUi(message: String) {
+        progressMessageView?.let {
+            it.text = message
+        } ?: Timber.w("progressMessageView is null during message update")
+    }
+
+    private fun updateProgressUi(progress: AnkiProgressDialogViewModel.Progress?) {
+        val isIndeterminate = progress == null
+
+        if (isIndeterminate) {
+            showIndeterminateProgress()
+        } else {
+            showDeterminateProgress(progress!!.currentProgress, progress.maxProgress)
+        }
+    }
+
+    private fun showIndeterminateProgress() {
+        indeterminateProgressBar.visibility = View.VISIBLE
+        determinateProgressBar.visibility = View.GONE
+        progressCounterView.visibility = View.GONE
+    }
+
+    private fun showDeterminateProgress(
+        current: Int,
+        max: Int,
+    ) {
+        indeterminateProgressBar.visibility = View.GONE
+        determinateProgressBar.visibility = View.VISIBLE
+        progressCounterView.visibility = View.VISIBLE
+
+        determinateProgressBar.max = max
+        determinateProgressBar.progress = current
+        updateProgressCounter()
+    }
+
+    private fun updateCancelableState(cancelable: Boolean) {
+        isCancelable = cancelable
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        setupStateFlowCollectors()
+    }
+
+    private fun setupStateFlowCollectors() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.CREATED) {
+                launch {
+                    viewModel.message.collectLatest { message ->
+                        updateMessageUi(message)
+                    }
+                }
+
+                launch {
+                    viewModel.progress.collect { progress ->
+                        updateProgressUi(progress)
+                    }
+                }
+
+                launch {
+                    viewModel.cancelableViaBackButton.collectLatest { cancelable ->
+                        updateCancelableState(cancelable)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateProgressCounter() {
+        val progress = viewModel.progress.value ?: return
+        progressCounterView.visibility = View.VISIBLE
+        progressCounterView.text = "${progress.currentProgress} / ${progress.maxProgress}"
+    }
+
+    override fun onCancel(dialog: DialogInterface) {
+        super.onCancel(dialog)
+        viewModel.cancel()
+    }
+
+    fun updateMessage(newMessage: String) {
+        if (newMessage.isBlank()) {
+            Timber.w("Empty message provided to updateMessage, keeping existing message")
+            return
+        }
+
+        try {
+            viewModel.updateMessage(newMessage)
+
+            progressMessageView?.let { textView ->
+                if (isAdded && !isDetached) {
+                    activity?.runOnUiThread {
+                        textView.text = newMessage
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Exception while updating message in progress dialog")
+        }
+    }
+
+    fun updateProgress(
+        current: Int,
+        max: Int,
+    ) {
+        try {
+            viewModel.updateProgress(current, max)
+
+            if (isAdded && !isDetached) {
+                activity?.runOnUiThread {
+                    indeterminateProgressBar.visibility = View.GONE
+                    determinateProgressBar.visibility = View.VISIBLE
+                    progressCounterView.visibility = View.VISIBLE
+
+                    determinateProgressBar.max = max
+                    determinateProgressBar.progress = current
+                    progressCounterView.text = "$current / $max"
+                }
+            }
+        } catch (e: Exception) {
+            Timber.w(e, "Exception while updating progress in progress dialog")
+        }
+    }
+
+    fun setOnCancelListener(listener: (() -> Unit)?) {
+        viewModel.setOnCancelListener(listener)
+    }
+
+    companion object {
+        const val TAG = "AnkiProgressDialogFragment"
+
+        private const val ARG_MESSAGE = "arg_message"
+        private const val ARG_CANCELABLE = "arg_cancelable"
+        private const val ARG_CANCEL_BUTTON_TEXT = "arg_cancel_button_text"
+
+        private var cancelListener: (() -> Unit)? = null
+
+        fun newInstance(
+            message: String,
+            cancellationConfig: ProgressDialogCancellationConfig = ProgressDialogCancellationConfig(),
+        ): AnkiProgressDialogFragment =
+            AnkiProgressDialogFragment().apply {
+                arguments =
+                    Bundle().apply {
+                        putString(ARG_MESSAGE, message)
+                        putBoolean(ARG_CANCELABLE, cancellationConfig.cancelableViaBackButton)
+                        cancellationConfig.cancelButtonText?.let {
+                            putString(ARG_CANCEL_BUTTON_TEXT, it)
+                        }
+                    }
+
+                cancelListener = cancellationConfig.onCancel
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressDialogViewModel.kt
@@ -1,0 +1,110 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.parcelize.Parcelize
+
+/**
+ * ViewModel for [AnkiProgressDialogFragment] that manages dialog state using StateFlow pattern.
+ *
+ * The ViewModel:
+ * - Survives configuration changes automatically
+ * - Can be easily tested in isolation
+ * - Encapsulates dialog state logic
+ * - Uses StateFlow/SharedFlow for reactive UI updates
+ */
+class AnkiProgressDialogViewModel(
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    @Parcelize
+    data class Progress(
+        val currentProgress: Int,
+        val maxProgress: Int,
+    ) : Parcelable
+
+    val message = MutableStateFlow(savedStateHandle.get<String>(KEY_MESSAGE) ?: "")
+
+    val cancelableViaBackButton = MutableStateFlow(savedStateHandle.get<Boolean>(KEY_CANCELABLE) ?: false)
+
+    val cancelButtonText = MutableStateFlow(savedStateHandle.get<String>(KEY_CANCEL_BUTTON_TEXT))
+
+    val progress = MutableStateFlow(savedStateHandle.get<Progress>(KEY_PROGRESS))
+
+    private var onCancelListener: (() -> Unit)? = null
+
+    fun updateMessage(newMessage: String) {
+        if (newMessage.isNotBlank()) {
+            savedStateHandle[KEY_MESSAGE] = newMessage
+            message.value = newMessage
+        }
+    }
+
+    fun updateProgress(
+        current: Int,
+        max: Int,
+    ) {
+        val newProgress = Progress(current, max)
+        progress.value = newProgress
+        savedStateHandle[KEY_PROGRESS] = newProgress
+    }
+
+    fun cancel() {
+        onCancelListener?.invoke()
+    }
+
+    fun setOnCancelListener(listener: (() -> Unit)?) {
+        onCancelListener = listener
+        savedStateHandle[KEY_HAS_CANCEL_LISTENER] = listener != null
+    }
+
+    fun setCancelable(cancelable: Boolean) {
+        savedStateHandle[KEY_CANCELABLE] = cancelable
+        cancelableViaBackButton.value = cancelable
+    }
+
+    fun setCancelButtonText(text: String?) {
+        savedStateHandle[KEY_CANCEL_BUTTON_TEXT] = text
+        cancelButtonText.value = text
+    }
+
+    fun hasCancelListener(): Boolean = onCancelListener != null
+
+    fun setup(
+        message: String,
+        cancelableViaBackButton: Boolean = false,
+        cancelButtonText: String? = null,
+        onCancelListener: (() -> Unit)? = null,
+    ) {
+        updateMessage(message)
+        setCancelable(cancelableViaBackButton)
+        setCancelButtonText(cancelButtonText)
+        setOnCancelListener(onCancelListener)
+    }
+
+    companion object {
+        private const val KEY_MESSAGE = "message"
+        private const val KEY_CANCELABLE = "cancelableViaBackButton"
+        private const val KEY_CANCEL_BUTTON_TEXT = "cancelButtonText"
+        private const val KEY_PROGRESS = "progress"
+        private const val KEY_HAS_CANCEL_LISTENER = "hasCancelListener"
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AnkiProgressManager.kt
@@ -1,0 +1,119 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import android.view.WindowManager
+import androidx.fragment.app.FragmentActivity
+import com.ichi2.utils.dismissSafely
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.lang.ref.WeakReference
+
+/**
+ * Manages showing and hiding progress dialogs.
+ *
+ * If a dialog is already showing when a new dialog is requested, the new dialog will not be displayed
+ * and a warning is logged. This is tracked by the boolean progressDialogShown.
+ *
+ * This implementation uses AnkiProgressDialogFragment, which is based on DialogFragment because:
+ * - DialogFragment survives configuration changes (e.g., screen rotation)
+ * - DialogFragment follows Material Design guidelines
+ * - DialogFragment allows for a customizable UI with lifecycle management
+ *
+ * @see AnkiProgressDialogFragment
+ */
+object AnkiProgressManager {
+    private var dialogJob: Job? = null
+    private var dialog: WeakReference<AnkiProgressDialogFragment>? = null
+
+    /** Used to avoid showing extra progress dialogs when one already shown. */
+    private var progressDialogShown = false
+
+    /**
+     * Checks if a progress dialog is currently being shown.
+     * @return true if a progress dialog is being shown, false otherwise.
+     */
+    fun isProgressDialogShown(): Boolean = progressDialogShown
+
+    /**
+     * Sets the state of whether a progress dialog is being shown.
+     * @param shown true if a progress dialog is being shown, false otherwise.
+     */
+    fun setProgressDialogShown(shown: Boolean) {
+        progressDialogShown = shown
+    }
+
+    /**
+     * Shows a progress dialog and executes the given operation.
+     * The dialog is shown after a delay and dismissed when the operation completes.
+     *
+     * Progress info is polled from the backend via the
+     * monitorProgress method in CoroutineHelpers
+     *
+     * Starts the progress dialog after a delay (default value is 600 ms)
+     * so that quick operations don't just show flashes of a dialog.
+     *
+     * @param activity The FragmentActivity where the dialog will be shown
+     * @param message The message to display in the progress dialog
+     * @param cancellationConfig Configuration parameters for the dialog: cancelability, button text, cancel callback
+     * @param delayMillis Delay before showing the dialog (to avoid flashing for quick operations)
+     * @param op The operation to execute while showing the progress dialog
+     */
+    suspend fun <T> withProgress(
+        activity: FragmentActivity,
+        message: String,
+        cancellationConfig: ProgressDialogCancellationConfig = ProgressDialogCancellationConfig(),
+        delayMillis: Long = 600,
+        op: suspend (AnkiProgressDialogFragment) -> T,
+    ): T =
+        coroutineScope {
+            val dialog = AnkiProgressDialogFragment.newInstance(message = message, cancellationConfig = cancellationConfig)
+            this@AnkiProgressManager.dialog = WeakReference(dialog)
+
+            activity.window.setFlags(
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+                WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE,
+            )
+
+            dialogJob =
+                launch {
+                    delay(delayMillis)
+                    if (!isProgressDialogShown()) {
+                        Timber.i("Displaying progress dialog: ${delayMillis}ms elapsed")
+                        dialog.show(activity.supportFragmentManager, AnkiProgressDialogFragment.TAG)
+                        setProgressDialogShown(true)
+                    } else {
+                        // TODO: It would be a bug if a progress dialog is shown when one is
+                        //  already displayed. Handle this in a better way.
+                        Timber.w("A progress dialog is already displayed, not displaying another")
+                    }
+                }
+
+            try {
+                op(dialog)
+            } finally {
+                dialogJob?.cancel()
+                dialog.dismissSafely()
+                setProgressDialogShown(false)
+                activity.window.clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
+            }
+        }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ProgressDialogCancellationConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ProgressDialogCancellationConfig.kt
@@ -1,0 +1,31 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+/**
+ * Data class to encapsulate dialog cancellation config parameters for AnkiProgressDialog
+ *
+ * @param cancelableViaBackButton Whether the dialog can be canceled by the user via back button
+ * @param cancelButtonText Optional custom cancel button text
+ * @param onCancel Optional callback to invoke when dialog is canceled
+ */
+data class ProgressDialogCancellationConfig(
+    val cancelableViaBackButton: Boolean = false,
+    val cancelButtonText: String? = null,
+    val onCancel: (() -> Unit)? = null,
+)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -37,6 +37,7 @@ import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -475,6 +476,22 @@ fun AlertDialog.dismissSafely() {
             dismiss()
         } catch (e: IllegalArgumentException) {
             if (window == null || !isShowing) {
+                Timber.d(e, "Dialog not attached to window manager")
+                return@executeOnMainThread
+            }
+            Timber.w(e, "Dialog not attached to window manager")
+        }
+    }
+}
+
+fun DialogFragment.dismissSafely() {
+    // The exception will be uncaught if not run on the main thread.
+    executeOnMainThread {
+        try {
+            // safer to catch the exception to be sure dismiss() was called
+            dismiss()
+        } catch (e: IllegalArgumentException) {
+            if (dialog?.window == null || dialog?.isShowing == false) {
                 Timber.d(e, "Dialog not attached to window manager")
                 return@executeOnMainThread
             }

--- a/AnkiDroid/src/main/res/layout/new_anki_progress_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/new_anki_progress_dialog.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingHorizontal="24dp"
+    android:paddingVertical="20dp"
+    android:minHeight="72dp">
+    
+    <FrameLayout
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical">
+        
+        <!-- Indeterminate progress bar (visible by default) -->
+        <ProgressBar
+            android:id="@+id/indeterminate_progress_bar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:visibility="visible" />
+            
+        <!-- Determinate progress bar (hidden by default) -->
+        <ProgressBar
+            android:id="@+id/determinate_progress_bar"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_gravity="center"
+            android:indeterminate="false"
+            android:rotation="270"
+            android:visibility="gone" />
+    </FrameLayout>
+
+    <LinearLayout
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_marginStart="16dp"
+        android:orientation="vertical"
+        android:layout_gravity="center_vertical">
+
+        <TextView
+            android:id="@+id/progress_message"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody1" />
+
+        <TextView
+            android:id="@+id/progress_counter"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:visibility="gone" />
+    </LinearLayout>
+</LinearLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AnkiProgressDialogViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/AnkiProgressDialogViewModelTest.kt
@@ -1,0 +1,259 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.anki.dialogs
+
+import androidx.lifecycle.SavedStateHandle
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
+import junit.framework.TestCase.assertNotNull
+import junit.framework.TestCase.assertNull
+import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/** Unit tests for [AnkiProgressDialogViewModel] */
+@ExperimentalCoroutinesApi
+class AnkiProgressDialogViewModelTest {
+    private lateinit var viewModel: AnkiProgressDialogViewModel
+    private lateinit var savedStateHandle: SavedStateHandle
+    private val testDispatcher = StandardTestDispatcher()
+
+    private var cancelCallbackCalled = false
+    private val testCancelListener: () -> Unit = { cancelCallbackCalled = true }
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        savedStateHandle = SavedStateHandle()
+        viewModel = AnkiProgressDialogViewModel(savedStateHandle)
+        cancelCallbackCalled = false
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has default values`() =
+        runTest {
+            // Assert default values
+            assertEquals("", viewModel.message.value)
+            assertNull(viewModel.progress.value) // No progress set initially
+            assertFalse(viewModel.cancelableViaBackButton.value)
+            assertNull(viewModel.cancelButtonText.value)
+            assertFalse(viewModel.hasCancelListener())
+        }
+
+    @Test
+    fun `setup properly initializes values`() =
+        runTest {
+            val initialMessage = "Initial Test Message"
+            val cancelable = true
+            val buttonText = "Cancel"
+
+            viewModel.setup(
+                message = initialMessage,
+                cancelableViaBackButton = cancelable,
+                cancelButtonText = buttonText,
+                onCancelListener = testCancelListener,
+            )
+
+            // Verify all values were set correctly
+            assertEquals(initialMessage, viewModel.message.value)
+            assertEquals(cancelable, viewModel.cancelableViaBackButton.value)
+            assertEquals(buttonText, viewModel.cancelButtonText.value)
+            assertTrue(viewModel.hasCancelListener())
+        }
+
+    @Test
+    fun `updateMessage updates valid messages`() =
+        runTest {
+            val initialMessage = "Initial message"
+            val newMessage = "Updated message"
+
+            // Start with initial message
+            viewModel.updateMessage(initialMessage)
+            assertEquals(initialMessage, viewModel.message.value)
+            assertEquals(initialMessage, savedStateHandle.get<String>("message"))
+
+            // Update with new message
+            viewModel.updateMessage(newMessage)
+            assertEquals(newMessage, viewModel.message.value)
+            assertEquals(newMessage, savedStateHandle.get<String>("message"))
+        }
+
+    @Test
+    fun `updateMessage handles empty messages`() =
+        runTest {
+            val initialMessage = "Initial message"
+
+            // Set initial message
+            viewModel.updateMessage(initialMessage)
+            assertEquals(initialMessage, viewModel.message.value)
+
+            // Try updating with empty message - should keep initial message
+            viewModel.updateMessage("")
+            assertEquals(initialMessage, viewModel.message.value)
+
+            // Try updating with blank message (spaces) - should keep initial message
+            viewModel.updateMessage("   ")
+            assertEquals(initialMessage, viewModel.message.value)
+        }
+
+    @Test
+    fun `updateProgress sets determinate progress values`() =
+        runTest {
+            // Initial state should be null progress (indeterminate)
+            assertNull(viewModel.progress.value)
+
+            // Update progress
+            viewModel.updateProgress(30, 100)
+
+            // Should now have a Progress object with correct values
+            val progress = viewModel.progress.value
+            assertNotNull(progress)
+            assertEquals(30, progress!!.currentProgress)
+            assertEquals(100, progress.maxProgress)
+
+            // Progress should be saved to savedStateHandle
+            val savedProgress = savedStateHandle.get<AnkiProgressDialogViewModel.Progress>("progress")
+            assertNotNull(savedProgress)
+            assertEquals(30, savedProgress!!.currentProgress)
+            assertEquals(100, savedProgress.maxProgress)
+        }
+
+    @Test
+    fun `cancel method emits cancel event and calls listener`() =
+        runTest {
+            // Set up cancel listener
+            viewModel.setOnCancelListener(testCancelListener)
+
+            // Initially not called
+            assertFalse(cancelCallbackCalled)
+
+            // Trigger cancel
+            viewModel.cancel()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Verify callback was called
+            assertTrue(cancelCallbackCalled)
+        }
+
+    @Test
+    fun `state is preserved through SavedStateHandle`() =
+        runTest {
+            // Set initial state
+            viewModel.setup(
+                message = "Test Message",
+                cancelableViaBackButton = true,
+                cancelButtonText = "OK",
+                onCancelListener = testCancelListener,
+            )
+            viewModel.updateProgress(50, 200)
+
+            // Create new ViewModel with same SavedStateHandle to simulate recreation
+            val restoredViewModel = AnkiProgressDialogViewModel(savedStateHandle)
+
+            // Verify state is restored
+            assertEquals("Test Message", restoredViewModel.message.value)
+            assertEquals(true, restoredViewModel.cancelableViaBackButton.value)
+            assertEquals("OK", restoredViewModel.cancelButtonText.value)
+
+            // Verify progress state is restored
+            val progress = restoredViewModel.progress.value
+            assertNotNull(progress)
+            assertEquals(50, progress!!.currentProgress)
+            assertEquals(200, progress.maxProgress)
+
+            // Note: The cancel listener can't be persisted through SavedStateHandle
+            // so we have separate handling for that in the Fragment
+        }
+
+    @Test
+    fun `setCancelable updates cancelable state`() =
+        runTest {
+            // Initial state
+            assertFalse(viewModel.cancelableViaBackButton.value)
+
+            // Update cancelable
+            viewModel.setCancelable(true)
+
+            // Verify updated
+            assertTrue(viewModel.cancelableViaBackButton.value)
+            assertEquals(true, savedStateHandle.get<Boolean>("cancelableViaBackButton"))
+        }
+
+    @Test
+    fun `setCancelButtonText updates button text`() =
+        runTest {
+            // Initial state
+            assertNull(viewModel.cancelButtonText.value)
+
+            // Update button text
+            viewModel.setCancelButtonText("Cancel")
+
+            // Verify updated
+            assertEquals("Cancel", viewModel.cancelButtonText.value)
+            assertEquals("Cancel", savedStateHandle.get<String>("cancelButtonText"))
+        }
+
+    @Test
+    fun `updateMessage with empty string preserves non-empty initial message`() =
+        runTest {
+            // Set up a non-empty initial message
+            val initialMessage = "Initial message"
+            viewModel.updateMessage(initialMessage)
+
+            // Update with an empty string
+            viewModel.updateMessage("")
+
+            // The initial message should be preserved
+            assertEquals(initialMessage, viewModel.message.value)
+        }
+
+    @Test
+    fun `setup preserves message in SavedStateHandle`() =
+        runTest {
+            val testMessage = "Test message"
+
+            viewModel.setup(message = testMessage)
+
+            // Message should be in SavedStateHandle
+            assertEquals(testMessage, savedStateHandle.get<String>("message"))
+        }
+
+    @Test
+    fun `multiple rapid message updates are processed correctly`() =
+        runTest {
+            // Set multiple messages in quick succession
+            for (i in 1..5) {
+                viewModel.updateMessage("Message $i")
+            }
+
+            // The final message should be the one that's displayed
+            assertEquals("Message 5", viewModel.message.value)
+        }
+}


### PR DESCRIPTION
This replaces the deprecated `ProgressDialog` with a `DialogFragment`-based implementation that

* Survives config changes  
* Follows Material Design  
* Avoids window leaks  
* Delivers a uniform UI across Android versions  

`ProgressDialog` was deprecated in API level 26 (Android 8.0) because it:

* Fails to handle config changes (e.g. screen rotation)  
* Does not follow Material Design guidelines  
* Can cause window-leak errors in some cases  

### Benefits of the `DialogFragment` Implementation

* **Handles config changes** automatically  
* **Material Design compliant** via `MaterialAlertDialogBuilder`  
* **Prevents memory leaks** via proper lifecycle management  
* **Consistent UI** on all Android versions  

Here, only the usage in `Sync.kt` has been updated. All other `ProgressDialog` usages will be updated in follow-up pull requests.

## Demo

**Before (ProgressDialog):**

[ProgressDialog.webm](https://github.com/user-attachments/assets/e4bbcb65-c1c4-40c4-a214-e0f80685fa51)

**After (DialogFragment):**

<table>
  <tr>
    <td align="center">
      <video
        src="https://github.com/user-attachments/assets/bfd3beb9-513a-4a40-a8f3-833de122657c"
        controls
        width="320"
        style="border:1px solid #ddd; border-radius:4px;">
        Your browser does not support the video tag.
      </video>
    </td>
    <td align="center">
      <video
        src="https://github.com/user-attachments/assets/47526573-c0f9-498f-9144-54840fa7b66b"
        controls
        width="320"
        style="border:1px solid #ddd; border-radius:4px;">
        Your browser does not support the video tag.
      </video>
    </td>
  </tr>
</table>
