### PR TITLE
Improve tags

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2624,12 +2624,11 @@ abstract class AbstractFlashcardViewer :
         get() = displayAnswer
 
     internal fun showTagsDialog() {
-        val tags = ArrayList(getColUnsafe.tags.all())
-        val selTags = ArrayList(currentCard!!.note(getColUnsafe).tags)
+        val noteId = currentCard!!.note(getColUnsafe).id
         val dialog =
             tagsDialogFactory!!
                 .newTagsDialog()
-                .withArguments(this, TagsDialog.DialogType.EDIT_TAGS, selTags, tags)
+                .withArguments(this, TagsDialog.DialogType.EDIT_TAGS, noteIds = listOf(noteId))
         showDialogFragment(dialog)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -68,7 +68,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
 import com.ichi2.anki.browser.CardOrNoteId
 import com.ichi2.anki.browser.ColumnHeading
 import com.ichi2.anki.browser.FindAndReplaceDialogFragment
-import com.ichi2.anki.browser.PreviewerIdsFile
+import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.RepositionCardFragment
 import com.ichi2.anki.browser.RepositionCardFragment.Companion.REQUEST_REPOSITION_NEW_CARDS
 import com.ichi2.anki.browser.RepositionCardsRequest.ContainsNonNewCardsError
@@ -1437,14 +1437,14 @@ open class CardBrowser :
     private fun onPreview() {
         launchCatchingTask {
             val intentData = viewModel.queryPreviewIntentData()
-            onPreviewCardsActivityResult.launch(getPreviewIntent(intentData.currentIndex, intentData.previewerIdsFile))
+            onPreviewCardsActivityResult.launch(getPreviewIntent(intentData.currentIndex, intentData.idsFile))
         }
     }
 
     private fun getPreviewIntent(
         index: Int,
-        previewerIdsFile: PreviewerIdsFile,
-    ): Intent = PreviewerDestination(index, previewerIdsFile).toIntent(this)
+        idsFile: IdsFile,
+    ): Intent = PreviewerDestination(index, idsFile).toIntent(this)
 
     private fun rescheduleSelectedCards() {
         if (!viewModel.hasSelectedAnyRows()) {
@@ -1950,8 +1950,8 @@ suspend fun searchForRows(
 
 class PreviewerDestination(
     val currentIndex: Int,
-    val previewerIdsFile: PreviewerIdsFile,
+    val idsFile: IdsFile,
 )
 
 @CheckResult
-fun PreviewerDestination.toIntent(context: Context) = PreviewerFragment.getIntent(context, previewerIdsFile, currentIndex)
+fun PreviewerDestination.toIntent(context: Context) = PreviewerFragment.getIntent(context, idsFile, currentIndex)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -120,7 +120,6 @@ import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.DeckNameId
-import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.SortOrder
 import com.ichi2.libanki.undoableOp
 import com.ichi2.ui.CardBrowserSearchView
@@ -130,10 +129,8 @@ import com.ichi2.utils.dp
 import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
 import com.ichi2.utils.updatePaddingRelative
 import com.ichi2.widget.WidgetStatus.updateInBackground
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.Translations
 import timber.log.Timber
@@ -1503,84 +1500,16 @@ open class CardBrowser :
         if (!viewModel.hasSelectedAnyRows()) {
             Timber.d("showEditTagsDialog: called with empty selection")
         }
-
-        var progressMax: Int? = null // this can be made null to blank the dialog
-        var progress = 0
-
-        fun onProgress(progressContext: ProgressContext) {
-            val max = progressMax
-            if (max == null) {
-                progressContext.amount = null
-                progressContext.text = getString(R.string.dialog_processing)
-            } else {
-                progressContext.amount = Pair(progress, max)
-            }
-        }
-        launchCatchingTask {
-            withProgress(extractProgress = ::onProgress) {
-                val allTags = withCol { tags.all() }
-                val selectedNoteIds = viewModel.queryAllSelectedNoteIds()
-
-                progressMax = selectedNoteIds.size * 2
-                // TODO!! This is terribly slow on AnKing
-                val checkedTags =
-                    withCol {
-                        selectedNoteIds
-                            .asSequence() // reduce memory pressure
-                            .flatMap { nid ->
-                                progress++
-                                getNote(nid).tags // requires withCol
-                            }.distinct()
-                            .toList()
-                    }
-
-                if (selectedNoteIds.size == 1) {
-                    Timber.d("showEditTagsDialog: edit tags for one note")
-                    tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
-                    val dialog =
-                        tagsDialogFactory.newTagsDialog().withArguments(
-                            this@CardBrowser,
-                            type = TagsDialog.DialogType.EDIT_TAGS,
-                            checkedTags = checkedTags,
-                            allTags = allTags,
-                        )
-                    showDialogFragment(dialog)
-                    return@withProgress
-                }
-                // TODO!! This is terribly slow on AnKing
-                // PERF: This MUST be combined with the above sequence - this becomes O(2n) on a
-                // database operation performed over 30k times
-                val uncheckedTags =
-                    withCol {
-                        selectedNoteIds
-                            .asSequence() // reduce memory pressure
-                            .flatMap { nid: NoteId ->
-                                progress++
-                                val note = getNote(nid) // requires withCol
-                                val noteTags = note.tags.toSet()
-                                allTags.filter { t: String? -> !noteTags.contains(t) }
-                            }.distinct()
-                            .toList()
-                    }
-
-                progressMax = null
-
-                Timber.d("showEditTagsDialog: edit tags for multiple note")
-                tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
-
-                // withArguments performs IO, can be 18 seconds
-                val dialog =
-                    withContext(Dispatchers.IO) {
-                        tagsDialogFactory.newTagsDialog().withArguments(
-                            context = this@CardBrowser,
-                            type = TagsDialog.DialogType.EDIT_TAGS,
-                            checkedTags = checkedTags,
-                            uncheckedTags = uncheckedTags,
-                            allTags = allTags,
-                        )
-                    }
-                showDialogFragment(dialog)
-            }
+        tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
+        lifecycleScope.launch {
+            val noteIds = viewModel.queryAllSelectedNoteIds()
+            val dialog =
+                tagsDialogFactory.newTagsDialog().withArguments(
+                    this@CardBrowser,
+                    type = TagsDialog.DialogType.EDIT_TAGS,
+                    noteIds = noteIds,
+                )
+            showDialogFragment(dialog)
         }
     }
 
@@ -1591,8 +1520,7 @@ open class CardBrowser :
                 tagsDialogFactory.newTagsDialog().withArguments(
                     context = this@CardBrowser,
                     type = TagsDialog.DialogType.FILTER_BY_TAG,
-                    checkedTags = ArrayList(0),
-                    allTags = withCol { tags.all() },
+                    noteIds = emptyList(),
                 )
             showDialogFragment(dialog)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1605,18 +1605,13 @@ class NoteEditor :
     }
 
     private fun showTagsDialog() {
-        if (selectedTags == null) {
-            selectedTags = ArrayList(0)
-        }
-        val tags = ArrayList(getColUnsafe.tags.all())
-        val selTags = ArrayList(selectedTags!!)
+        val selTags = selectedTags?.let { ArrayList(it) } ?: arrayListOf()
         val dialog =
             with(requireContext()) {
                 tagsDialogFactory!!.newTagsDialog().withArguments(
                     context = this,
                     type = TagsDialog.DialogType.EDIT_TAGS,
                     checkedTags = selTags,
-                    allTags = tags,
                 )
             }
         showDialogFragment(dialog)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -881,11 +881,11 @@ class CardBrowserViewModel(
     suspend fun queryPreviewIntentData(): PreviewerDestination {
         // If in NOTES mode, we show one Card per Note, as this matches Anki Desktop
         return if (selectedRowCount() > 1) {
-            PreviewerDestination(currentIndex = 0, PreviewerIdsFile(cacheDir, queryAllSelectedCardIds()))
+            PreviewerDestination(currentIndex = 0, IdsFile(cacheDir, queryAllSelectedCardIds()))
         } else {
             // Preview all cards, starting from the one that is currently selected
             val startIndex = indexOfFirstCheckedCard() ?: 0
-            PreviewerDestination(startIndex, PreviewerIdsFile(cacheDir, queryOneCardIdPerNote()))
+            PreviewerDestination(startIndex, IdsFile(cacheDir, queryOneCardIdPerNote()))
         }
     }
 
@@ -1135,26 +1135,28 @@ enum class SaveSearchResult {
 }
 
 /**
- * Temporary file containing the IDs of the cards to be displayed at the previewer
+ * Temporary file containing cards or note IDs to be passed in a Bundle.
+ *
+ * It avoids [android.os.TransactionTooLargeException] when passing a big amount of data.
  */
-class PreviewerIdsFile(
+class IdsFile(
     path: String,
 ) : File(path),
     Parcelable {
     /**
      * @param directory parent directory of the file. Generally it should be the cache directory
-     * @param cardIds ids of the cards to be displayed
+     * @param ids ids to store
      */
-    constructor(directory: File, cardIds: List<CardId>) : this(createTempFile("previewerIds", ".tmp", directory).path) {
+    constructor(directory: File, ids: List<Long>) : this(createTempFile("ids", ".tmp", directory).path) {
         DataOutputStream(FileOutputStream(this)).use { outputStream ->
-            outputStream.writeInt(cardIds.size)
-            for (id in cardIds) {
+            outputStream.writeInt(ids.size)
+            for (id in ids) {
                 outputStream.writeLong(id)
             }
         }
     }
 
-    fun getCardIds(): List<Long> =
+    fun getIds(): List<Long> =
         DataInputStream(FileInputStream(this)).use { inputStream ->
             val size = inputStream.readInt()
             List(size) { inputStream.readLong() }
@@ -1173,10 +1175,10 @@ class PreviewerIdsFile(
         @JvmField
         @Suppress("unused")
         val CREATOR =
-            object : Parcelable.Creator<PreviewerIdsFile> {
-                override fun createFromParcel(source: Parcel?): PreviewerIdsFile = PreviewerIdsFile(source!!.readString()!!)
+            object : Parcelable.Creator<IdsFile> {
+                override fun createFromParcel(source: Parcel?): IdsFile = IdsFile(source!!.readString()!!)
 
-                override fun newArray(size: Int): Array<PreviewerIdsFile> = arrayOf()
+                override fun newArray(size: Int): Array<IdsFile> = arrayOf()
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki.dialogs.tags
 
-import android.content.res.Resources
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -45,7 +44,6 @@ import java.util.TreeSet
  */
 class TagsArrayAdapter(
     private val tags: TagsList,
-    private val resources: Resources,
 ) : RecyclerView.Adapter<TagsArrayAdapter.ViewHolder>(),
     Filterable {
     class ViewHolder(
@@ -302,7 +300,7 @@ class TagsArrayAdapter(
             // do not add padding if there is no visible nested tag
             holder.expandButton.visibility = View.GONE
         }
-        holder.expandButton.contentDescription = resources.getString(R.string.expand_tag, holder.node.tag.replace("::", " "))
+        holder.expandButton.contentDescription = holder.itemView.context.getString(R.string.expand_tag, holder.node.tag.replace("::", " "))
 
         holder.textView.text = TagsUtil.getTagParts(holder.node.tag).last()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -173,7 +173,7 @@ class TagsDialog : AnalyticsDialogFragment {
         tagsListRecyclerView?.requestFocus()
         val tagsListLayout: RecyclerView.LayoutManager = LinearLayoutManager(activity)
         tagsListRecyclerView?.layoutManager = tagsListLayout
-        tagsArrayAdapter = TagsArrayAdapter(tags!!, resources)
+        tagsArrayAdapter = TagsArrayAdapter(tags!!)
         tagsListRecyclerView?.adapter = tagsArrayAdapter
         noTagsTextView = tagsDialogView.findViewById(R.id.tags_dialog_no_tags_textview)
         val noTagsTextView: TextView? = noTagsTextView

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.con>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.dialogs.tags
+
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.asyncIO
+import com.ichi2.libanki.NoteId
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+/**
+ * @param noteIds IDs of notes whose tags should bfe retrieved and marked as "checked"
+ * @param checkedTags additional list of checked tags.
+ *  They are joined with the tags retrieved from noteIds
+ */
+class TagsDialogViewModel(
+    noteIds: Collection<NoteId> = emptyList(),
+    checkedTags: Collection<String> = emptyList(),
+) : ViewModel() {
+    val tags: Deferred<TagsList>
+
+    private val _initProgress = MutableStateFlow<InitProgress>(InitProgress.Processing)
+    val initProgress = _initProgress.asStateFlow()
+
+    init {
+        tags =
+            asyncIO {
+                val allTags = withCol { tags.all() }.toSet()
+                val allCheckedTags =
+                    noteIds
+                        .flatMapIndexedTo(mutableSetOf()) { index, nid ->
+                            _initProgress.emit(InitProgress.FetchingNoteTags(index + 1, noteIds.size))
+                            withCol { getNote(nid) }.tags
+                        }.apply {
+                            addAll(checkedTags)
+                        }
+                _initProgress.emit(InitProgress.Processing)
+                val uncheckedTags = allTags - allCheckedTags
+                TagsList(
+                    allTags = allTags,
+                    checkedTags = allCheckedTags,
+                    uncheckedTags = uncheckedTags,
+                ).also {
+                    _initProgress.emit(InitProgress.Finished)
+                }
+            }
+    }
+
+    sealed interface InitProgress {
+        data object Processing : InitProgress
+
+        class FetchingNoteTags(
+            val noteNumber: Int,
+            val noteCount: Int,
+        ) : InitProgress
+
+        data object Finished : InitProgress
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -35,14 +35,14 @@ import java.util.TreeSet
  * @param uncheckedTags a list containing the currently unselected tags. Any duplicates will be ignored.
  */
 class TagsList(
-    allTags: List<String>,
-    checkedTags: List<String>,
-    uncheckedTags: List<String>? = null,
+    allTags: Collection<String>,
+    checkedTags: Collection<String>,
+    uncheckedTags: Collection<String>? = null,
 ) : Iterable<String> {
     /**
      * A Set containing the currently selected tags
      */
-    private val checkedTags: MutableSet<String>
+    private val checkedTags: MutableSet<String> = TreeSet(java.lang.String.CASE_INSENSITIVE_ORDER)
 
     /**
      * A Set containing the tags with indeterminate state
@@ -55,7 +55,6 @@ class TagsList(
     private val allTags: UniqueArrayList<String>
 
     init {
-        this.checkedTags = TreeSet(java.lang.String.CASE_INSENSITIVE_ORDER)
         this.checkedTags.addAll(checkedTags)
         this.allTags = from(allTags, java.lang.String.CASE_INSENSITIVE_ORDER)
         this.allTags.addAll(this.checkedTags)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -39,7 +39,7 @@ import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
-import com.ichi2.anki.browser.PreviewerIdsFile
+import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.reviewer.BindingProcessor
 import com.ichi2.anki.reviewer.MappableBinding
@@ -59,12 +59,12 @@ class PreviewerFragment :
     DispatchKeyEventListener,
     BindingProcessor<MappableBinding, PreviewerAction> {
     override val viewModel: PreviewerViewModel by viewModels {
-        val previewerIdsFile =
-            requireNotNull(BundleCompat.getParcelable(requireArguments(), CARD_IDS_FILE_ARG, PreviewerIdsFile::class.java)) {
+        val idsFile =
+            requireNotNull(BundleCompat.getParcelable(requireArguments(), CARD_IDS_FILE_ARG, IdsFile::class.java)) {
                 "$CARD_IDS_FILE_ARG is required"
             }
         val currentIndex = requireArguments().getInt(CURRENT_INDEX_ARG, 0)
-        PreviewerViewModel.factory(previewerIdsFile, currentIndex, CardMediaPlayer())
+        PreviewerViewModel.factory(idsFile, currentIndex, CardMediaPlayer())
     }
     override val webView: WebView
         get() = requireView().findViewById(R.id.webview)
@@ -282,18 +282,18 @@ class PreviewerFragment :
         /** Index of the card to be first displayed among the IDs provided by [CARD_IDS_FILE_ARG] */
         const val CURRENT_INDEX_ARG = "currentIndex"
 
-        /** Argument key to a [PreviewerIdsFile] with the IDs of the cards to be displayed */
+        /** Argument key to a [IdsFile] with the IDs of the cards to be displayed */
         const val CARD_IDS_FILE_ARG = "cardIdsFile"
 
         fun getIntent(
             context: Context,
-            previewerIdsFile: PreviewerIdsFile,
+            idsFile: IdsFile,
             currentIndex: Int,
         ): Intent {
             val arguments =
                 bundleOf(
                     CURRENT_INDEX_ARG to currentIndex,
-                    CARD_IDS_FILE_ARG to previewerIdsFile,
+                    CARD_IDS_FILE_ARG to idsFile,
                 )
             return CardViewerActivity.getIntent(context, PreviewerFragment::class, arguments)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -24,7 +24,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.asyncIO
-import com.ichi2.anki.browser.PreviewerIdsFile
+import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.launchCatchingIO
@@ -46,7 +46,7 @@ import kotlinx.coroutines.flow.update
 import timber.log.Timber
 
 class PreviewerViewModel(
-    previewerIdsFile: PreviewerIdsFile,
+    idsFile: IdsFile,
     firstIndex: Int,
     cardMediaPlayer: CardMediaPlayer,
 ) : CardViewerViewModel(cardMediaPlayer),
@@ -55,7 +55,7 @@ class PreviewerViewModel(
     val backSideOnly = MutableStateFlow(false)
     val isMarked = MutableStateFlow(false)
     val flag: MutableStateFlow<Flag> = MutableStateFlow(Flag.NONE)
-    private val selectedCardIds: List<Long> = previewerIdsFile.getCardIds()
+    private val selectedCardIds: List<Long> = idsFile.getIds()
     val isBackButtonEnabled =
         combine(currentIndex, showingAnswer, backSideOnly) { index, showingAnswer, isBackSideOnly ->
             index != 0 || (showingAnswer && !isBackSideOnly)
@@ -249,13 +249,13 @@ class PreviewerViewModel(
 
     companion object {
         fun factory(
-            previewerIdsFile: PreviewerIdsFile,
+            idsFile: IdsFile,
             currentIndex: Int,
             cardMediaPlayer: CardMediaPlayer,
         ): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
-                    PreviewerViewModel(previewerIdsFile, currentIndex, cardMediaPlayer)
+                    PreviewerViewModel(idsFile, currentIndex, cardMediaPlayer)
                 }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -150,7 +150,7 @@ class UniqueArrayList<E> /**
              * @param comparator used to judge uniqueness
              */
             fun <E> from(
-                source: List<E>,
+                source: Collection<E>,
                 comparator: Comparator<in E>? = null,
             ): UniqueArrayList<E> {
                 val set: Set<E> =

--- a/AnkiDroid/src/main/res/layout/tags_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog.xml
@@ -37,13 +37,40 @@
             android:text="@string/tags_dialog_option_due_cards"/>
     </RadioGroup>
 
+    <LinearLayout
+        android:id="@+id/loading_container"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:layout_centerInParent="true"
+        android:visibility="gone"
+        tools:visibility="visible" >
+
+        <com.google.android.material.progressindicator.CircularProgressIndicator
+            android:id="@+id/progress_indicator"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            />
+        <TextView
+            android:id="@+id/progress_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text=""
+            tools:text="Loading..."
+            android:layout_marginStart="8dp"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+    </LinearLayout>
+
+
     <androidx.recyclerview.widget.RecyclerView android:id="@+id/tags_dialog_tags_list"
-                                               android:scrollbars="vertical"
-                                               android:layout_width="match_parent"
-                                               android:layout_height="wrap_content"
-                                               android:layout_above="@id/tags_dialog_options_radiogroup"
-                                               android:layout_below="@id/tags_dialog_toolbar"
-                                               tools:listitem="@layout/tags_item_list_dialog" />
+        android:scrollbars="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/tags_dialog_options_radiogroup"
+        android:layout_below="@id/tags_dialog_toolbar"
+        tools:listitem="@layout/tags_item_list_dialog" />
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="wrap_content"

--- a/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
+++ b/AnkiDroid/src/main/res/layout/tags_dialog_title.xml
@@ -8,5 +8,6 @@
     android:layout_alignParentTop="true"
     android:theme="@style/ActionBarStyle"
     android:background="?attr/appBarColor"
-    app:popupTheme="@style/ActionBar.Popup">
+    app:popupTheme="@style/ActionBar.Popup"
+    app:menu="@menu/tags_dialog_menu">
 </androidx.appcompat.widget.Toolbar>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -525,7 +525,7 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("before: index", previewIntent.currentIndex, equalTo(0))
             assertThat(
                 "before: cards",
-                previewIntent.previewerIdsFile.getCardIds(),
+                previewIntent.idsFile.getIds(),
                 equalTo(listOf(cid1, cid2)),
             )
 
@@ -537,7 +537,7 @@ class CardBrowserTest : RobolectricTest() {
             assertThat("after: index", intentAfterReverse.currentIndex, equalTo(0))
             assertThat(
                 "after: cards",
-                intentAfterReverse.previewerIdsFile.getCardIds(),
+                intentAfterReverse.idsFile.getIds(),
                 equalTo(listOf(cid2, cid1)),
             )
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -769,7 +769,7 @@ class CardBrowserViewModelTest : JvmTest() {
             val data = queryPreviewIntentData()
             assertThat(data.currentIndex, equalTo(0))
 
-            data.previewerIdsFile.getCardIds().also { actualCardIds ->
+            data.idsFile.getIds().also { actualCardIds ->
                 assertThat("previewing a note previews cards", actualCardIds, hasSize(5))
 
                 val firstCardIds =
@@ -793,7 +793,7 @@ class CardBrowserViewModelTest : JvmTest() {
         runViewModelTest(notes = 2) {
             val data = queryPreviewIntentData()
             assertThat(data.currentIndex, equalTo(0))
-            assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+            assertThat(data.idsFile.getIds(), hasSize(2))
         }
 
     @Test
@@ -802,7 +802,7 @@ class CardBrowserViewModelTest : JvmTest() {
             selectRowsWithPositions(0).also {
                 val data = queryPreviewIntentData()
                 assertThat(data.currentIndex, equalTo(0))
-                assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+                assertThat(data.idsFile.getIds(), hasSize(2))
             }
 
             selectNone()
@@ -811,7 +811,7 @@ class CardBrowserViewModelTest : JvmTest() {
             selectRowsWithPositions(1).also {
                 val data = queryPreviewIntentData()
                 assertThat(data.currentIndex, equalTo(1))
-                assertThat(data.previewerIdsFile.getCardIds(), hasSize(2))
+                assertThat(data.idsFile.getIds(), hasSize(2))
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -18,15 +18,12 @@ package com.ichi2.anki.dialogs.tags
 import android.os.Bundle
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.BundleCompat
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.dialogs.utils.AnKingTags
-import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import com.ichi2.testutils.ParametersUtils
 import com.ichi2.testutils.RecyclerViewUtils
 import com.ichi2.ui.CheckBoxTriStates
@@ -47,7 +44,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_AddNewTag_shouldBeVisibleInRecyclerView_andSortedCorrectly() {
         val type = TagsDialog.DialogType.EDIT_TAGS
         val allTags = listOf("a", "b", "d", "e")
-        val checkedTags = listOf("a", "b")
+        val checkedTags = arrayListOf("a", "b")
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -81,7 +78,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_AddNewTag_existingTag_shouldBeSelectedAndSorted() {
         val type = TagsDialog.DialogType.EDIT_TAGS
         val allTags = listOf("a", "b", "d", "e")
-        val checkedTags = listOf("a", "b")
+        val checkedTags = arrayListOf("a", "b")
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -114,14 +111,13 @@ class TagsDialogTest : RobolectricTest() {
     fun test_checked_unchecked_indeterminate() {
         val type = TagsDialog.DialogType.EDIT_TAGS
         val expectedAllTags = listOf("a", "b", "d", "e")
-        val checkedTags = listOf("a", "b")
-        val uncheckedTags = listOf("b", "d")
-        val expectedCheckedTags = listOf("a")
+        val checkedTags = arrayListOf("a", "b")
+        val expectedCheckedTags = listOf("a", "b")
         val expectedUncheckedTags = listOf("d", "e")
-        val expectedIndeterminate = listOf("b")
+        val expectedIndeterminate = emptyList<String>()
         val args =
             TagsDialog(ParametersUtils.whatever())
-                .withTestArguments(type, checkedTags, uncheckedTags, expectedAllTags)
+                .withTestArguments(type, checkedTags, expectedAllTags)
                 .requireArguments()
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -170,7 +166,7 @@ class TagsDialogTest : RobolectricTest() {
                 "book",
             )
         val checkedTags =
-            listOf(
+            arrayListOf(
                 "fruit::pear::big",
                 "sport::tennis",
             )
@@ -218,7 +214,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_AddNewTag_newHierarchicalTag_pathToItShouldBeExpanded() {
         val type = TagsDialog.DialogType.EDIT_TAGS
         val allTags = listOf("common::speak", "common::speak::daily", "common::sport::tennis", "common::sport::football")
-        val checkedTags = listOf("common::speak::daily", "common::sport::tennis")
+        val checkedTags = arrayListOf("common::speak::daily", "common::sport::tennis")
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -271,7 +267,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_AddNewTag_newHierarchicalTag_willUniformHierarchicalTag() {
         val type = TagsDialog.DialogType.EDIT_TAGS
         val allTags = listOf("common")
-        val checkedTags = listOf("common")
+        val checkedTags = arrayListOf("common")
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -316,7 +312,7 @@ class TagsDialogTest : RobolectricTest() {
                 "common::sport::football::small",
             )
         val checkedTags =
-            listOf(
+            arrayListOf(
                 "common::speak::tennis",
                 "common::sport::tennis",
                 "common::sport::football::small",
@@ -360,7 +356,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_SearchTag_willInheritExpandState() {
         val type = TagsDialog.DialogType.FILTER_BY_TAG
         val allTags = listOf("common::speak", "common::sport::tennis")
-        val checkedTags = emptyList<String>()
+        val checkedTags = arrayListOf<String>()
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -407,7 +403,7 @@ class TagsDialogTest : RobolectricTest() {
                 "common::sport::football",
                 "common::sport::football::small",
             )
-        val checkedTags = emptyList<String>()
+        val checkedTags = arrayListOf<String>()
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -524,7 +520,7 @@ class TagsDialogTest : RobolectricTest() {
     fun test_SearchTag_spaceWillBeFilteredCorrectly() {
         val type = TagsDialog.DialogType.FILTER_BY_TAG
         val allTags = listOf("hello::world")
-        val checkedTags = emptyList<String>()
+        val checkedTags = arrayListOf<String>()
         val args =
             TagsDialog(ParametersUtils.whatever())
                 .withTestArguments(type, checkedTags, allTags)
@@ -568,7 +564,7 @@ class TagsDialogTest : RobolectricTest() {
 
         val args =
             TagsDialog(ParametersUtils.whatever())
-                .withTestArguments(type, emptyList(), allTags)
+                .withTestArguments(type, arrayListOf(), allTags)
                 .arguments
         val mockListener = Mockito.mock(TagsDialogListener::class.java)
         val factory = TagsDialogFactory(mockListener)
@@ -578,61 +574,22 @@ class TagsDialogTest : RobolectricTest() {
         }
     }
 
-    @Test
-    fun `huge number of tags`() {
-        val type = TagsDialog.DialogType.FILTER_BY_TAG
-        val allTags = AnKingTags.value
-
-        val args =
-            TagsDialog(ParametersUtils.whatever())
-                .withTestArguments(type, emptyList(), allTags)
-                .arguments
-        val mockListener = Mockito.mock(TagsDialogListener::class.java)
-        val factory = TagsDialogFactory(mockListener)
-        FragmentScenario.launch(TagsDialog::class.java, args, R.style.Theme_Light, factory).use { scenario ->
-            scenario.moveToState(Lifecycle.State.STARTED)
-            scenario.onFragment { f ->
-                val tagsFile =
-                    requireNotNull(
-                        BundleCompat.getParcelable(
-                            f.requireArguments(),
-                            "tagsFile",
-                            TagsFile::class.java,
-                        ),
-                    )
-
-                val dataFromArguments = tagsFile.getData()
-
-                assertThat(dataFromArguments.allTags, containsInAnyOrder(allTags))
-            }
-        }
-    }
-
     // these are called 'withTestArguments' due to "extension is shadowed by a member" warnings
     // this is needed so we can pass in 'targetContext' for context.cacheDir
     private fun TagsDialog.withTestArguments(
         type: TagsDialog.DialogType,
-        checkedTags: List<String>,
-        allTags: List<String>,
-    ) = withArguments(
-        context = targetContext,
-        type = type,
-        checkedTags = checkedTags,
-        allTags = allTags,
-    )
-
-    private fun TagsDialog.withTestArguments(
-        type: TagsDialog.DialogType,
-        checkedTags: List<String>,
-        uncheckedTags: List<String>?,
-        allTags: List<String>,
-    ) = withArguments(
-        context = targetContext,
-        type = type,
-        checkedTags = checkedTags,
-        uncheckedTags = uncheckedTags,
-        allTags = allTags,
-    )
+        checkedTags: ArrayList<String>,
+        allTags: Collection<String>,
+    ): TagsDialog {
+        val note = col.newNote()
+        col.tags.bulkAdd(listOf(note.id), allTags.joinToString(separator = " "))
+        col.addNote(note, 0L)
+        return withArguments(
+            context = targetContext,
+            type = type,
+            checkedTags = checkedTags,
+        )
+    }
 
     private fun runTagsDialogScenario(
         args: Bundle,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerFragmentTest.kt
@@ -21,7 +21,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.espresso.Espresso
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.browser.PreviewerIdsFile
+import com.ichi2.anki.browser.IdsFile
 import com.ichi2.testutils.createTransientDirectory
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -36,7 +36,7 @@ class PreviewerFragmentTest : RobolectricTest() {
         val intent =
             PreviewerFragment.getIntent(
                 targetContext,
-                previewerIdsFile = PreviewerIdsFile(createTransientDirectory(), note.cardIds(col)),
+                idsFile = IdsFile(createTransientDirectory(), note.cardIds(col)),
                 currentIndex = 0,
             )
 


### PR DESCRIPTION
## Purpose / Description

This PR improves the initialization time of the Tags Dialog. In small and medium sized collections, there won't be a significant difference because they load fast anyway. But in large ones, with many tags and notes as Anking, there is a big difference when editting the notes of a lot of cards.

This only fixes most of the initialization slowdown caused by #16356. While investigating the tags loading process, I found that several improvements could be done in `TagsList` and `TagsArrayAdapter` (I guess at least 4 times faster when filtering by tags). There's also the new backend `tags.tree()` method that may be useful. But, those are fairly complex classes (which solve the fairly complex issue of building a tags tree) and dealing with them would take a lot of time.

## Fixes
* Fixes #16473

## Approach

1. Fetch the note tags only once
2. Write only the note IDs into a file, instead of all the tags
3. Use a ViewModel to load the tags

## How Has This Been Tested?

Tested in two scenarios in an API 35 emulator. Both used the Anking V11 deck.

The "default" scenario is using "filter by tag", without fetching any note tags

The "worst" scenario is fetching all the 43.000+ notes in Anking

## Default scenario


https://github.com/user-attachments/assets/54802101-6d32-44a4-8b7c-ca4b95f65826


https://github.com/user-attachments/assets/59d10a1c-db07-4249-a1f2-47d389a62cff


## Worst scenario

https://github.com/user-attachments/assets/931101ed-1967-4f71-9246-5a98118015b2

https://github.com/user-attachments/assets/1daf284e-99e1-4a02-a711-4b9fdb975fd4


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
