### PR TITLE
Allow search to show subdecks if they match the searched term

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -113,9 +113,13 @@ data class DeckNode(
             return
         }
 
-        if (collapsed) {
+        // When searching, ignore collapsed state and always search children
+        val searching = filter != null
+        if (collapsed && !searching) {
             return
         }
+        // TODO: Fix collapse/uncollapse icons showing during search even when they are not usable.
+        //       See issue #18379 for more details.
 
         if (node.level > 0) {
             list.append(this)

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DeckNodeTest.kt
@@ -1,0 +1,110 @@
+/****************************************************************************************
+ *                                                                                      *
+ * Copyright (c) 2025 Shridhar Goel <shridhar.goel@gmail.com>                           *
+ *                                                                                      *
+ * This program is free software; you can redistribute it and/or modify it under        *
+ * the terms of the GNU General Public License as published by the Free Software        *
+ * Foundation; either version 3 of the License, or (at your option) any later           *
+ * version.                                                                             *
+ *                                                                                      *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY      *
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A      *
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.             *
+ *                                                                                      *
+ * You should have received a copy of the GNU General Public License along with         *
+ * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
+ ****************************************************************************************/
+
+package com.ichi2.libanki
+
+import anki.decks.deckTreeNode
+import com.ichi2.libanki.sched.DeckNode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DeckNodeTest {
+    private fun makeNode(
+        name: String,
+        deckId: Long,
+        level: Int,
+        collapsed: Boolean = false,
+        children: List<DeckNode> = emptyList(),
+    ): DeckNode {
+        val treeNode =
+            deckTreeNode {
+                this.name = name
+                this.deckId = deckId
+                this.level = level
+                this.collapsed = collapsed
+                children.forEach { this.children.add(it.node) }
+                this.reviewCount = 0
+                this.newCount = 0
+                this.learnCount = 0
+                this.filtered = false
+            }
+        return DeckNode(treeNode, name)
+    }
+
+    @Test
+    fun `search finds subdeck even if parent collapsed`() {
+        // Science::Math::Algebra::Group
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = true, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results1 = science.filterAndFlatten("group")
+        assertEquals(listOf("Science", "Math", "Algebra", "Group"), results1.map { it.lastDeckNameComponent })
+
+        val results2 = science.filterAndFlatten("math")
+        assertEquals(listOf("Science", "Math"), results2.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `collapsed parent hides children when not searching`() {
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = true, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = math.filterAndFlatten(null)
+        assertEquals(1, results.size)
+        assertEquals("Math", results[0].lastDeckNameComponent)
+    }
+
+    @Test
+    fun `search for non-matching term returns no results`() {
+        // Science::Math::Algebra::Group
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = true, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = science.filterAndFlatten("complex")
+        assertEquals(emptyList<String>(), results.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `search for algebra shows all decks in the path`() {
+        // Science::Math::Algebra::Group
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = science.filterAndFlatten("algebra")
+        assertEquals(listOf("Science", "Math", "Algebra", "Group"), results.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `search for non-existent path pattern returns no results`() {
+        // Science::Math::Algebra::Group
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = science.filterAndFlatten("th::alg")
+        assertEquals(emptyList<String>(), results.map { it.lastDeckNameComponent })
+    }
+}


### PR DESCRIPTION
## Purpose / Description

This addresses a bug where searching for a sub-deck in the deck picker would fail to return the expected deck if one of its ancestor decks was collapsed. For example, if a user has the deck structure `Science::Math::Algebra::Group` and the Math deck is collapsed, searching for "Group" would not yield the `Science::Math::Algebra::Group` deck. This is not ideal, as users should not need to remember the collapsed state of parent decks when searching for a specific sub-deck.

## Fixes
* Fixes #18287 

## Approach

When searching, we'll ignore collapsed state and always search sub-decks.

## How Has This Been Tested?

Manual testing + unit tests.

## Demo

[Screen_recording_20250511_010042.webm](https://github.com/user-attachments/assets/86415584-6675-487d-917b-70ef18704b98)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
