### PR TITLE
Bindings for "show answer" and "answer XXX" are single side only

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -27,12 +27,18 @@ import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.ReviewerBinding
 
 /** Abstraction: Discuss moving many of these to 'Reviewer'  */
-enum class ViewerCommand : MappableAction<ReviewerBinding> {
-    SHOW_ANSWER,
-    FLIP_OR_ANSWER_EASE1,
-    FLIP_OR_ANSWER_EASE2,
-    FLIP_OR_ANSWER_EASE3,
-    FLIP_OR_ANSWER_EASE4,
+enum class ViewerCommand(
+    /**
+     * [CardSide.BOTH] if the command can be executed on both question and answer.
+     * Otherwise, the side on which the command can be executed.
+     */
+    val potentialSides: CardSide = CardSide.BOTH
+) : MappableAction<ReviewerBinding> {
+    SHOW_ANSWER(potentialSides = CardSide.QUESTION),
+    FLIP_OR_ANSWER_EASE1(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE2(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE3(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE4(potentialSides = CardSide.ANSWER),
     UNDO,
     REDO,
     EDIT,
@@ -215,5 +221,12 @@ enum class ViewerCommand : MappableAction<ReviewerBinding> {
             which: ViewerCommand,
             fromGesture: Gesture?,
         ): Boolean
+    }
+
+    companion object {
+        /**
+         * The command whose key is [preferenceKey] if it exists.
+         */
+        fun fromPreferenceKey(preferenceKey: String) = ViewerCommand.entries.firstOrNull { it.preferenceKey == preferenceKey }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/ViewerCommand.kt
@@ -28,11 +28,7 @@ import com.ichi2.anki.reviewer.ReviewerBinding
 
 /** Abstraction: Discuss moving many of these to 'Reviewer'  */
 enum class ViewerCommand(
-    /**
-     * [CardSide.BOTH] if the command can be executed on both question and answer.
-     * Otherwise, the side on which the command can be executed.
-     */
-    val potentialSides: CardSide = CardSide.BOTH
+    override val potentialSides: CardSide = CardSide.BOTH,
 ) : MappableAction<ReviewerBinding> {
     SHOW_ANSWER(potentialSides = CardSide.QUESTION),
     FLIP_OR_ANSWER_EASE1(potentialSides = CardSide.ANSWER),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardSideSelectionDialog.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki.dialogs
 
-import android.annotation.SuppressLint
 import android.content.Context
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.R
@@ -26,7 +25,6 @@ import com.ichi2.utils.title
 /** Allows selecting between [CardSide.QUESTION], [CardSide.ANSWER] or [CardSide.BOTH] */
 class CardSideSelectionDialog {
     companion object {
-        @SuppressLint("CheckResult")
         fun displayInstance(
             ctx: Context,
             callback: (c: CardSide) -> Unit,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -47,6 +47,7 @@ enum class ViewerAction(
     @StringRes val titleRes: Int = R.string.empty_string,
     val defaultDisplayType: MenuDisplayType? = null,
     val parentMenu: ViewerAction? = null,
+    override val potentialSides: CardSide = CardSide.BOTH,
 ) : MappableAction<ReviewerBinding> {
     // Always
     UNDO(R.id.action_undo, R.drawable.ic_undo_white, R.string.undo, ALWAYS),
@@ -90,11 +91,11 @@ enum class ViewerAction(
     FLAG_PURPLE(Flag.PURPLE.id, Flag.PURPLE.drawableRes, parentMenu = FLAG_MENU),
 
     // Command only
-    SHOW_ANSWER,
-    FLIP_OR_ANSWER_EASE1,
-    FLIP_OR_ANSWER_EASE2,
-    FLIP_OR_ANSWER_EASE3,
-    FLIP_OR_ANSWER_EASE4,
+    SHOW_ANSWER(potentialSides = CardSide.QUESTION),
+    FLIP_OR_ANSWER_EASE1(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE2(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE3(potentialSides = CardSide.ANSWER),
+    FLIP_OR_ANSWER_EASE4(potentialSides = CardSide.ANSWER),
     TOGGLE_FLAG_RED,
     TOGGLE_FLAG_ORANGE,
     TOGGLE_FLAG_GREEN,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerAction.kt
@@ -20,6 +20,7 @@ import android.view.KeyEvent
 import com.ichi2.anki.reviewer.Binding.Companion.keyCode
 import com.ichi2.anki.reviewer.Binding.Companion.unicode
 import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.ctrl
+import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.MappableBinding
 
@@ -39,6 +40,8 @@ enum class PreviewerAction : MappableAction<MappableBinding> {
     TOGGLE_FLAG_PURPLE,
     UNSET_FLAG,
     ;
+
+    override val potentialSides = CardSide.BOTH
 
     override val preferenceKey = "previewer_$name"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/MappableBinding.kt
@@ -36,7 +36,10 @@ open class MappableBinding(
 
     override fun hashCode(): Int = Objects.hash(binding)
 
-    open fun toDisplayString(context: Context): String = binding.toDisplayString(context)
+    open fun toDisplayString(
+        context: Context,
+        potentialSides: CardSide,
+    ): String = binding.toDisplayString(context)
 
     open fun toPreferenceString(): String? = binding.toString()
 
@@ -83,6 +86,11 @@ open class MappableBinding(
  */
 interface MappableAction<B : MappableBinding> {
     val preferenceKey: String
+
+    /**
+     *  The side(s) on which this binding can be executed
+     */
+    val potentialSides: CardSide
 
     fun getBindings(prefs: SharedPreferences): List<B>
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerBinding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ReviewerBinding.kt
@@ -58,12 +58,20 @@ class ReviewerBinding(
         return s.toString()
     }
 
-    override fun toDisplayString(context: Context): String {
+    override fun toDisplayString(
+        context: Context,
+        potentialSides: CardSide,
+    ): String {
+        val bindingDisplayString = binding.toDisplayString(context)
+        if (potentialSides != CardSide.BOTH) {
+            // No need to show "Q: " or "A: " given that the command can be executed on a single side.
+            return bindingDisplayString
+        }
         val formatString =
             when (side) {
                 CardSide.QUESTION -> context.getString(R.string.display_binding_card_side_question)
                 CardSide.ANSWER -> context.getString(R.string.display_binding_card_side_answer)
-                CardSide.BOTH -> context.getString(R.string.display_binding_card_side_both) // intentionally no prefix
+                CardSide.BOTH -> return bindingDisplayString // intentionally no prefix
             }
         return String.format(formatString, binding.toDisplayString(context))
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.preferences.SettingsFragment
 import com.ichi2.anki.preferences.allPreferences
 import com.ichi2.anki.preferences.requirePreference
 import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.ui.AxisPicker
@@ -73,6 +74,11 @@ open class ControlPreference :
     @Suppress("unused")
     constructor(context: Context) : super(context)
 
+    /**
+     * The sides on which the command on which this action can be executed.
+     */
+    open val potentialSides = CardSide.BOTH
+
     open fun getMappableBindings(): List<MappableBinding> = MappableBinding.fromPreferenceString(value)
 
     protected open fun onKeySelected(binding: Binding): Unit = addBinding(binding)
@@ -105,7 +111,7 @@ open class ControlPreference :
             }
         }
 
-    override fun getSummary(): CharSequence = getMappableBindings().joinToString(", ") { it.toDisplayString(context) }
+    override fun getSummary(): CharSequence = getMappableBindings().joinToString(", ") { it.toDisplayString(context, potentialSides) }
 
     override fun makeDialogFragment(): DialogFragment = ControlPreferenceDialogFragment()
 
@@ -274,7 +280,7 @@ class ControlPreferenceDialogFragment : DialogFragment() {
         }
         val titles =
             bindings.map {
-                getString(R.string.binding_remove_binding, it.toDisplayString(requireContext()))
+                getString(R.string.binding_remove_binding, it.toDisplayString(requireContext(), preference.potentialSides))
             }
         listView.apply {
             adapter = ArrayAdapter(requireContext(), R.layout.control_preference_list_item, titles)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -18,6 +18,7 @@ package com.ichi2.preferences
 import android.content.Context
 import android.util.AttributeSet
 import com.ichi2.anki.cardviewer.GestureProcessor
+import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.CardSide
@@ -42,25 +43,47 @@ class ReviewerControlPreference : ControlPreference {
     @Suppress("unused")
     constructor(context: Context) : super(context)
 
+    /**
+     * The command associated to this preference.
+     */
+    private val viewerCommand = ViewerCommand.fromPreferenceKey(key)!!
+    /**
+     *  The side(s) on which this preference can be executed
+     */
+    private val potentialSides = viewerCommand.potentialSides
+
     override val areGesturesEnabled: Boolean
         get() = sharedPreferences?.getBoolean(GestureProcessor.PREF_KEY, false) ?: false
+
+    /**
+     * If this command can be executed on a single side, execute the callback on this side.
+     * Otherwise, ask the suer to select one or two side(s) and execute the callback on them.
+     */
+    private fun selectSide(callback: (c: CardSide) -> Unit) {
+        val potentialSides = potentialSides
+        if (potentialSides != CardSide.BOTH) {
+            callback(potentialSides)
+        } else {
+            CardSideSelectionDialog.displayInstance(context, callback)
+        }
+    }
 
     override fun getMappableBindings(): List<ReviewerBinding> = ReviewerBinding.fromPreferenceString(value).toList()
 
     override fun onKeySelected(binding: Binding) {
-        CardSideSelectionDialog.displayInstance(context) { side ->
+        selectSide { side ->
             addBinding(binding, side)
         }
     }
 
     override fun onGestureSelected(binding: Binding) {
         CardSideSelectionDialog.displayInstance(context) { side ->
-            addBinding(binding, side)
+            addBinding(binding, potentialSides)
         }
     }
 
     override fun onAxisSelected(binding: Binding) {
-        CardSideSelectionDialog.displayInstance(context) { side ->
+        selectSide { side ->
             addBinding(binding, side)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -22,6 +22,7 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.CardSide
+import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.anki.reviewer.ReviewerBinding
 
@@ -46,18 +47,19 @@ class ReviewerControlPreference : ControlPreference {
     /**
      * The command associated to this preference.
      */
-    private val viewerCommand = ViewerCommand.fromPreferenceKey(key)!!
+    private val viewerCommand: MappableAction<*> = ViewerCommand.fromPreferenceKey(key)!!
+
     /**
      *  The side(s) on which this preference can be executed
      */
-    private val potentialSides = viewerCommand.potentialSides
+    override val potentialSides = viewerCommand.potentialSides
 
     override val areGesturesEnabled: Boolean
         get() = sharedPreferences?.getBoolean(GestureProcessor.PREF_KEY, false) ?: false
 
     /**
      * If this command can be executed on a single side, execute the callback on this side.
-     * Otherwise, ask the suer to select one or two side(s) and execute the callback on them.
+     * Otherwise, ask the user to select one or two side(s) and execute the callback on them.
      */
     private fun selectSide(callback: (c: CardSide) -> Unit) {
         val potentialSides = potentialSides

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -283,8 +283,6 @@
 this formatter is used if the bind only applies to the question">Q: %s</string>
     <string name="display_binding_card_side_answer" comment="When displaying a key bind on a preference
 this formatter is used if the bind only applies to the answer">A: %s</string>
-    <string name="display_binding_card_side_both" comment="When displaying a key bind on a preference
-this formatter is used if the bind only applies to both the question and the answer">%s</string>
 
     <!-- Binding Preference -->
     <string name="binding_remove_binding" comment="The parameter is the name of the key/gesture.


### PR DESCRIPTION
It seemed absurd to ask the user which side "show answer" binding should be applied to, while only the question side makes sense. Reciprocally, "answer XXX" should only be used on answer side.

The user can set the same binding to multiple action, so in particular, they can set a binding to both "Show answer" and "answer XXX" if they want, which would allow to control whether the answer binding also cause a flip.