### PR TITLE
Cause gesture to ask on which side it is executed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -53,7 +53,11 @@ class ReviewerControlPreference : ControlPreference {
         }
     }
 
-    override fun onGestureSelected(binding: Binding) = addBinding(binding, CardSide.BOTH)
+    override fun onGestureSelected(binding: Binding) {
+        CardSideSelectionDialog.displayInstance(context) { side ->
+            addBinding(binding, side)
+        }
+    }
 
     override fun onAxisSelected(binding: Binding) {
         CardSideSelectionDialog.displayInstance(context) { side ->


### PR DESCRIPTION
This ensure the behavior is consistent with other bindings. More importantly for me, it'll allow to ensure that the "answer XXX" gesture does not also trigger a flip, which is a problem I currently have when I need to scroll to see the entire card and ends up flipping the card by accident.