### PR TITLE
Fix crash when using the study keyboard shortcut on an empty collection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1449,7 +1449,7 @@ open class DeckPicker :
             KeyEvent.KEYCODE_S -> {
                 Timber.i("Study from keypress")
                 launchCatchingTask {
-                    handleDeckSelection(getColUnsafe.decks.selected(), DeckSelectionType.SKIP_STUDY_OPTIONS)
+                    handleDeckSelection(withCol { decks.selected() }, DeckSelectionType.SKIP_STUDY_OPTIONS)
                 }
                 return true
             }
@@ -2102,6 +2102,12 @@ open class DeckPicker :
         did: DeckId,
         selectionType: DeckSelectionType,
     ) {
+        // ignore requests(ex: from keyboard shortcuts) when the collection is empty(and
+        // adapter has no decks)
+        if (deckListAdapter.itemCount <= 0) {
+            return
+        }
+
         fun showEmptyDeckSnackbar() =
             showSnackbar(R.string.empty_deck) {
                 setAction(R.string.menu_add) { addNote(did) }


### PR DESCRIPTION
## Purpose / Description

The exception was happening because the user started the study process using the keyboard shortcut when the collection was empty. With the fix applied studying will be allowed only when decks are present(the decks adapter is not empty).

## Fixes
* Fixes #18234

## How Has This Been Tested?

Used the _S_ keyboard shortcut to start studying on a empty/non-empty collection. Also, checked other shortcuts with an empty collection.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
