### PR TITLE
Replace dp conversion utilities with Dp class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -190,6 +190,7 @@ import com.ichi2.utils.checkBoxPrompt
 import com.ichi2.utils.checkWebviewVersion
 import com.ichi2.utils.configureView
 import com.ichi2.utils.customView
+import com.ichi2.utils.dp
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
@@ -866,10 +867,10 @@ open class DeckPicker :
             title(R.string.directory_inaccessible)
             customView(
                 contentView,
-                convertDpToPixel(16F, this@DeckPicker).toInt(),
+                16.dp.toPx(this@DeckPicker),
                 0,
-                convertDpToPixel(32F, this@DeckPicker).toInt(),
-                convertDpToPixel(32F, this@DeckPicker).toInt(),
+                32.dp.toPx(this@DeckPicker),
+                32.dp.toPx(this@DeckPicker),
             )
             positiveButton(R.string.open_settings) {
                 val settingsIntent = PreferencesActivity.getIntent(this@DeckPicker, AdvancedSettingsFragment::class)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/UIUtils.kt
@@ -3,7 +3,6 @@
 package com.ichi2.anki
 
 import android.content.Context
-import android.util.DisplayMetrics
 import android.widget.Toast
 import androidx.annotation.StringRes
 import com.ichi2.anki.common.time.Time
@@ -49,19 +48,3 @@ fun getDayStart(time: Time): Long {
     cal[Calendar.MILLISECOND] = 0
     return cal.timeInMillis
 }
-
-/**
- * This method converts dp unit to equivalent pixels, depending on device density.
- *
- * @param dp A value in dp (density independent pixels) unit.
- * @param context Context to get resources and device specific display metrics.
- * @return A float value to represent px value which is equivalent to the passed dp value.
- */
-fun convertDpToPixel(
-    dp: Float,
-    context: Context,
-): Float =
-    dp * (
-        context.resources.displayMetrics.densityDpi
-            .toFloat() / DisplayMetrics.DENSITY_DEFAULT
-    )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -34,13 +34,13 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.analytics.UsageAnalytics.Actions
 import com.ichi2.anki.analytics.UsageAnalytics.Category
-import com.ichi2.anki.convertDpToPixel
 import com.ichi2.anki.dialogs.help.HelpItem.Action.OpenUrl
 import com.ichi2.anki.dialogs.help.HelpItem.Action.OpenUrlResource
 import com.ichi2.anki.dialogs.help.HelpItem.Action.Rate
 import com.ichi2.anki.dialogs.help.HelpItem.Action.SendReport
 import com.ichi2.utils.createAndApply
 import com.ichi2.utils.customView
+import com.ichi2.utils.dp
 import com.ichi2.utils.title
 
 /**
@@ -190,7 +190,6 @@ class HelpPageFragment : Fragment(R.layout.fragment_help_page) {
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-        val drawablePadding = convertDpToPixel(16F, requireContext()).toInt()
         val pageContentLayout = view.findViewById<LinearLayout>(R.id.page_content)
         requireArgsHelpEntries().forEach { menuItem ->
             val contentRow =
@@ -207,7 +206,7 @@ class HelpPageFragment : Fragment(R.layout.fragment_help_page) {
                     0,
                     0,
                 )
-                compoundDrawablePadding = drawablePadding
+                compoundDrawablePadding = 16.dp.toPx(requireContext())
                 setOnClickListener {
                     UsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, menuItem.analyticsId)
                     parentFragmentManager.setFragmentResult(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -51,11 +51,11 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
-import com.ichi2.anki.convertDpToPixel
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.ViewGroupUtils
 import com.ichi2.utils.ViewGroupUtils.getAllChildrenRecursive
+import com.ichi2.utils.dp
 import com.ichi2.utils.show
 import com.ichi2.utils.title
 import timber.log.Timber
@@ -100,7 +100,7 @@ class Toolbar : FrameLayout {
         LayoutInflater.from(context).inflate(R.layout.note_editor_toolbar, this, true)
         stringPaint =
             Paint(Paint.ANTI_ALIAS_FLAG).apply {
-                textSize = convertDpToPixel(24F, context)
+                textSize = 24.dp.toPx(context).toFloat()
                 color = Color.BLACK
                 textAlign = Paint.Align.CENTER
             }
@@ -210,7 +210,7 @@ class Toolbar : FrameLayout {
         context.theme.resolveAttribute(android.R.attr.selectableItemBackground, background, true)
         button.setBackgroundResource(background.resourceId)
         // Use layout size from R.style.note_editor_toolbar_button
-        val buttonSize = convertDpToPixel(44F, context).toInt()
+        val buttonSize = 44.dp.toPx(context)
         val params = LinearLayout.LayoutParams(buttonSize, buttonSize)
         params.gravity = Gravity.CENTER
         button.layoutParams = params
@@ -231,7 +231,7 @@ class Toolbar : FrameLayout {
 
         // Hack - items are truncated from the scrollview
         val v = findViewById<View>(R.id.toolbar_layout)
-        val expectedWidth = getVisibleItemCount(toolbar) * convertDpToPixel(48F, context)
+        val expectedWidth = getVisibleItemCount(toolbar) * 48.dp.toPx(context)
         val width = screenWidth
         val p = LayoutParams(v.layoutParams)
         p.gravity =
@@ -350,7 +350,7 @@ class Toolbar : FrameLayout {
     private fun getVisibleItemCount(layout: LinearLayout): Int = ViewGroupUtils.getAllChildren(layout).count { it.isVisible }
 
     private fun addViewToToolbar(button: AppCompatImageButton) {
-        val expectedWidth = getVisibleItemCount(toolbar) * convertDpToPixel(48F, context)
+        val expectedWidth = getVisibleItemCount(toolbar) * 48.dp.toPx(context)
         val width = screenWidth
         if (expectedWidth <= width) {
             toolbar.addView(button, toolbar.childCount)
@@ -359,7 +359,7 @@ class Toolbar : FrameLayout {
         var spaceLeft = false
         if (rows.isNotEmpty()) {
             val row = rows.last()
-            val expectedRowWidth = getVisibleItemCount(row) * convertDpToPixel(48F, context)
+            val expectedRowWidth = getVisibleItemCount(row) * 48.dp.toPx(context)
             if (expectedRowWidth <= width) {
                 row.addView(button, row.childCount)
                 spaceLeft = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.scheduling
 
 import android.app.Dialog
-import android.content.Context
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.View
@@ -58,6 +57,7 @@ import com.ichi2.anki.withProgress
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.utils.create
+import com.ichi2.utils.dp
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
@@ -181,7 +181,7 @@ class SetDueDateDialog : DialogFragment() {
         // The dialog is too wide on tablets
         // Select either 450dp (tablets)
         // or 100% of the screen width (smaller phones)
-        val intendedWidth = min(MAX_WIDTH_DP.dpToPx(this.requireContext()), resources.displayMetrics.widthPixels)
+        val intendedWidth = min(MAX_WIDTH_DP.dp.toPx(this.requireContext()), resources.displayMetrics.widthPixels)
         Timber.d("updating width to %d", intendedWidth)
         this.dialog?.window?.setLayout(
             intendedWidth,
@@ -324,6 +324,3 @@ private fun AnkiActivity.updateDueDate(viewModel: SetDueDateViewModel) =
         }
         showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
     }
-
-// TODO: better to use 16.dp ... toPx(context)
-fun Float.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density + 0.5f).toInt()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/SensibleSwipeDismissBehavior.kt
@@ -25,7 +25,7 @@ import androidx.customview.widget.ViewDragHelper
 import com.google.android.material.snackbar.BaseTransientBottomBar
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.convertDpToPixel
+import com.ichi2.utils.dp
 import kotlin.math.absoluteValue
 import kotlin.math.sign
 
@@ -210,7 +210,6 @@ open class SensibleSwipeDismissBehavior : BaseTransientBottomBar.Behavior() {
 
 @VisibleForTesting enum class Dismiss { DoNotDismiss, ToTheLeft, ToTheRight }
 
-private val FLING_TO_DISMISS_SPEED_THRESHOLD =
-    convertDpToPixel(1000f, AnkiDroidApp.instance.applicationContext)
+private val FLING_TO_DISMISS_SPEED_THRESHOLD = 1000.dp.toPx(AnkiDroidApp.instance.applicationContext)
 
 private const val DRAG_TO_DISMISS_DISTANCE_RATIO = .5f

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisValueDisplay.kt
@@ -24,7 +24,7 @@ import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
 import com.google.android.material.color.MaterialColors
-import com.ichi2.utils.dpToPixels
+import com.ichi2.utils.dp
 import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.max
@@ -82,14 +82,14 @@ class AxisValueDisplay(
     private val textPaint =
         Paint().apply {
             textAlign = Paint.Align.CENTER
-            textSize = dpToPixels(20f).toFloat()
+            textSize = 20.dp.toPx(context).toFloat()
             color = MaterialColors.getColor(context, android.R.attr.textColor, 0)
         }
 
     /** stores text dimensions, used for centering text */
     private val textBounds = Rect()
 
-    private val controlHeight = dpToPixels(40f)
+    private val controlHeight = 40.dp.toPx(context)
 
     override fun onMeasure(
         widthMeasureSpec: Int,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/DisplayUtils.kt
@@ -23,8 +23,6 @@ import android.os.Build
 import android.view.Window
 import android.view.WindowInsets
 import android.view.WindowManager
-import com.ichi2.anki.AnkiDroidApp
-import kotlin.math.roundToInt
 
 object DisplayUtils {
     @Suppress("DEPRECATION") // #9333: defaultDisplay & getSize
@@ -59,9 +57,4 @@ object DisplayUtils {
     fun resizeWhenSoftInputShown(window: Window) {
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE)
     }
-}
-
-fun dpToPixels(dp: Float): Int {
-    val scale = AnkiDroidApp.instance.resources.displayMetrics.density
-    return (dp * scale).roundToInt()
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/MenuUtils.kt
@@ -24,7 +24,6 @@ import androidx.appcompat.view.menu.MenuItemImpl
 import androidx.core.view.forEach
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
-import com.ichi2.anki.convertDpToPixel
 
 private fun Menu.forEachOverflowItemRecursive(block: (MenuItem) -> Unit) {
     (this as? MenuBuilder)?.flagActionItems()
@@ -42,7 +41,7 @@ private fun Menu.forEachOverflowItemRecursive(block: (MenuItem) -> Unit) {
  * Has no effect for items that have no icon, or for items this has processed before.
  */
 fun Context.increaseHorizontalPaddingOfOverflowMenuIcons(menu: Menu) {
-    val extraPadding = convertDpToPixel(5f, this).toInt()
+    val extraPadding = 5.dp.toPx(this)
 
     class Wrapper(
         drawable: Drawable,

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ViewUtils.kt
@@ -23,7 +23,6 @@ import android.view.MotionEvent
 import android.view.View
 import androidx.core.view.OnReceiveContentListener
 import androidx.draganddrop.DropHelper
-import com.ichi2.anki.scheduling.dpToPx
 
 /** @see View.performClick */
 fun View.performClickIfEnabled() {
@@ -131,6 +130,9 @@ fun View.updatePaddingRelative(
 val Int.dp
     get() = Dp(dp = this.toFloat())
 
+val Float.dp
+    get() = Dp(dp = this)
+
 val Double.dp
     get() = Dp(dp = this.toFloat())
 
@@ -144,3 +146,5 @@ value class Dp(
     // TODO: improve once we have context parameters
     fun toPx(context: Context) = dp.dpToPx(context)
 }
+
+private fun Float.dpToPx(context: Context): Int = (this * context.resources.displayMetrics.density + 0.5f).toInt()


### PR DESCRIPTION
## Purpose / Description

Removes two utility methods to convert dp units and replaces them with the _Dp_ class that we recently introduced.

## How Has This Been Tested?

Checked the dialogs where the utilities were used. Didn't checked AxisValueDisplay in settings.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
