### PR TITLE
feat: add licenses wiki page link

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -91,8 +91,13 @@ class AboutFragment :
         val gplLicenseLink = getString(R.string.licence_wiki)
         val agplLicenseLink = getString(R.string.link_agpl_wiki)
         val sourceCodeLink = getString(R.string.link_source)
+        val dependencyLicenseLink = getString(R.string.dependency_license_wiki)
         view.findViewById<TextView>(R.id.about_license_description).apply {
-            text = getString(R.string.license_description, gplLicenseLink, agplLicenseLink, sourceCodeLink).parseAsHtml()
+            text =
+                (
+                    getString(R.string.license_description, gplLicenseLink, agplLicenseLink, sourceCodeLink) + "<br>" +
+                        getString(R.string.other_licenses, dependencyLicenseLink)
+                ).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
 

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -253,6 +253,7 @@
     <string name="about_contributors_description"><![CDATA[These are our awesome <a href=\"%1$s\">contributors</a>. You can help AnkiDroid too by programming, translating, donating and <a href=\"%2$s\">more</a>!]]></string>
     <string name="license">License</string>
     <string name="license_description"><![CDATA[AnkiDroid is released under the <a href=\"%1$s\">GPL-3.0</a> and <a href=\"%2$s\">AGPL-3.0</a> licenses, with the source code available <a href=\"%3$s\">on GitHub</a>]]></string>
+    <string name="other_licenses"><![CDATA[AnkiDroid also uses third-party libraries and icons, which are licensed under various open source <a href=\"%1$s\">licenses</a>]]></string>
     <string name="donate_description"><![CDATA[You can support AnkiDroid\'s development by <a href=\"%1$s\">donating</a>. Any amount is deeply appreciated.]]></string>
 
     <!-- Controls -->

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -107,6 +107,7 @@
     <string name="link_anki_forum">https://forums.ankiweb.net/</string>
     <string name="link_forum">http://groups.google.com/group/anki-android</string>
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
+    <string name="dependency_license_wiki">https://github.com/ankidroid/Anki-Android/wiki/Licences</string>
     <string name="link_agpl_wiki">https://www.gnu.org/licenses/agpl-3.0.html</string>
     <string name="link_source">https://github.com/ankidroid/Anki-Android</string>
     <string name="link_market">market://details?id=com.ichi2.anki</string>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Created wiki page for AnkiDroid license and its dependencies, and added the link in the about section
- [wiki](https://github.com/ankidroid/Anki-Android/wiki/Licences)

## Fixes
* Fixes #11825

## How Has This Been Tested?
<img width="321" alt="Screenshot 2025-05-16 at 11 55 54 PM" src="https://github.com/user-attachments/assets/e5168fae-43f9-480e-9dec-ff0381d6d9bc" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
