### PR TITLE
fix(reposition-dialog): adds ScrollView to dialog

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
@@ -1,7 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+<androidx.constraintlayout.widget.ConstraintLayout
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:padding="16dp"
@@ -86,3 +91,4 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/randomize_order_check"/>
 </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>


### PR DESCRIPTION
## Purpose / Description
Allows scrolling in Reposition dialog especially useful for split screen 

## Fixes
* Fixes #18317 

## Approach
Wraps the the layout with ScrollView

## How Has This Been Tested?
- Physical device: Pixel 7 pro

## Screenshots
![WhatsApp Image 2025-05-16 at 8 12 24 PM](https://github.com/user-attachments/assets/f4f0c099-83af-42b2-84d8-2e5ae83206be)
![WhatsApp Image 2025-05-16 at 8 12 23 PM](https://github.com/user-attachments/assets/5c87b66a-4396-4000-a241-215717580ec8)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
