### PR TITLE
Developer option for review reminders

### DIFF
--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -202,6 +202,7 @@
     <string name="new_reviewer_pref_key">newReviewer</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
     <string name="pref_browser_find_replace">browserFindReplace</string>
+    <string name="pref_new_notifications">newNotifications</string>
     <string name="dev_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <string name="pref_cat_wip_key">workInProgressDevOptions</string>
     <!-- Developer options > Create fake notes -->

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -109,5 +109,9 @@
             android:summary="Caution, this can be very destructive for your collection!"
             android:key="@string/pref_browser_find_replace"
             android:defaultValue="false"/>
+        <SwitchPreferenceCompat
+            android:title="Enable new notifications"
+            android:key="@string/pref_new_notifications"
+            android:defaultValue="false"/>
     </com.ichi2.anki.preferences.ExtendedPreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
- Created a "New notifications" developer toggle in settings

## Fixes
- For GSoC 2025: Review Reminders

## Approach
- This is a simple toggle to facilitate further development on this project. New notification features (such as [this PR](https://github.com/ankidroid/Anki-Android/pull/18318)) will be locked behind this toggle until the system is stable by the end of August.

## How Has This Been Tested?
- The developer setting can be toggled on and off. The state persists between app sessions.
- Tested on a physical Samsung S23, API 34.

## Learning
- This is a subchange of [this PR](https://github.com/ankidroid/Anki-Android/pull/18318).

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)