### PR TITLE
feat(card-browser): two-taps to change columns

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -81,6 +81,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
 import net.ankiweb.rsdroid.BackendException
 import org.jetbrains.annotations.VisibleForTesting
 import timber.log.Timber
@@ -276,6 +277,7 @@ class CardBrowserViewModel(
             activeColumns.columns.map {
                 ColumnHeading(
                     label = allColumns[it.ankiColumnKey]!!.getLabel(cardsOrNotes),
+                    ankiColumnKey = it.ankiColumnKey,
                 )
             }
             // stateIn is required for tests
@@ -1068,6 +1070,18 @@ class CardBrowserViewModel(
             }
         }
 
+    fun updateSelectedColumn(
+        selectedColumn: ColumnHeading,
+        newColumn: ColumnWithSample,
+    ) = viewModelScope.launch {
+        val replacementKey = selectedColumn.ankiColumnKey
+        val replacements =
+            activeColumns.toMutableList().apply {
+                replaceAll { if (it.ankiColumnKey == replacementKey) newColumn.columnType else it }
+            }
+        updateActiveColumns(replacements, cardsOrNotes)
+    }
+
     companion object {
         fun factory(
             lastDeckIdRepository: LastDeckIdRepository,
@@ -1221,6 +1235,8 @@ sealed class RepositionCardsRequest {
 
 fun BrowserColumns.Column.getLabel(cardsOrNotes: CardsOrNotes): String = if (cardsOrNotes == CARDS) cardsModeLabel else notesModeLabel
 
+@Parcelize
 data class ColumnHeading(
     val label: String,
-)
+    val ankiColumnKey: String,
+) : Parcelable

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2025 Siddhesh Jondhale <jondhale2004@gmail.com>
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.browser
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.LinearLayout
+import android.widget.ListView
+import android.widget.TextView
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.R
+import com.ichi2.utils.dp
+import com.ichi2.utils.setPaddingRelative
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class ColumnSelectionDialogFragment : DialogFragment() {
+    private val viewModel: CardBrowserViewModel by activityViewModels()
+    private val columnToReplace: ColumnHeading
+        get() =
+            requireNotNull(
+                BundleCompat.getParcelable(requireArguments(), SELECTED_COLUMN, ColumnHeading::class.java),
+            )
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
+        val listView =
+            ListView(requireContext()).apply {
+                setPaddingRelative(
+                    start = 0.dp,
+                    end = 0.dp,
+                    top = 24.dp,
+                    bottom = 0.dp,
+                )
+            }
+
+        val adapter =
+            object : ArrayAdapter<ColumnWithSample>(
+                requireContext(),
+                R.layout.item_column_selection,
+                mutableListOf(),
+            ) {
+                override fun getView(
+                    position: Int,
+                    convertView: View?,
+                    parent: ViewGroup,
+                ): View {
+                    val view = convertView ?: layoutInflater.inflate(R.layout.item_column_selection, parent, false)
+
+                    val column = getItem(position)
+
+                    view.findViewById<TextView>(R.id.column_title).text =
+                        column?.label ?: getString(R.string.no_columns_available)
+
+                    view.findViewById<TextView>(R.id.column_example).text =
+                        if (column?.sampleValue.isNullOrBlank()) "-" else column.sampleValue
+
+                    return view
+                }
+            }
+        listView.adapter = adapter
+        listView.divider = null
+
+        // Fetch columns
+        lifecycleScope.launch {
+            val (_, availableColumns) = viewModel.previewColumnHeadings(viewModel.cardsOrNotes)
+            adapter.clear()
+            adapter.addAll(availableColumns)
+            adapter.notifyDataSetChanged()
+        }
+
+        listView.setOnItemClickListener { _, _, position, _ ->
+            val selected = adapter.getItem(position)
+            if (selected == null || selected.label == getString(R.string.no_columns_available)) {
+                Timber.d("Ignoring click on 'No Columns Available'")
+                return@setOnItemClickListener
+            }
+            viewModel.updateSelectedColumn(columnToReplace, selected)
+            dismissAllowingStateLoss()
+        }
+
+        val container =
+            LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                addView(listView)
+            }
+
+        return AlertDialog
+            .Builder(requireActivity())
+            .setTitle(getString(R.string.chane_browser_column))
+            .setView(container)
+            .setNegativeButton(android.R.string.cancel) { _, _ -> dismissAllowingStateLoss() }
+            .create()
+    }
+
+    companion object {
+        const val TAG = "ColumnSelectionDialog"
+
+        private const val SELECTED_COLUMN = "selected_column"
+
+        fun newInstance(selectedColumn: ColumnHeading): ColumnSelectionDialogFragment =
+            ColumnSelectionDialogFragment().apply {
+                arguments = bundleOf(SELECTED_COLUMN to selectedColumn)
+            }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/item_column_selection.xml
+++ b/AnkiDroid/src/main/res/layout/item_column_selection.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?attr/listPreferredItemHeight"
+    android:orientation="vertical"
+    android:paddingVertical="8dp"
+    android:paddingStart="?android:attr/listPreferredItemPaddingStart"
+    android:paddingEnd="?android:attr/listPreferredItemPaddingEnd"
+    android:background="?android:attr/selectableItemBackground">
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/column_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBodyLarge"
+        android:textColor="?attr/colorOnSurface"
+        android:textStyle="bold"/>
+
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/column_example"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?attr/textAppearanceBodyMedium"
+        android:textColor="?attr/colorOnSurfaceVariant"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:singleLine="true"/>
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -66,6 +66,8 @@
         <item>By lapses</item>
         <item>By deck name</item>
     </string-array>
+    <string name="chane_browser_column">Change column</string>
+    <string name="no_columns_available">No columns available</string>
     <string name="card_browser_select_all" maxLength="28">Select all</string>
     <string name="card_browser_select_none" maxLength="28">Select none</string>
     <string name="card_browser_no_cards_in_deck">No cards found in deck ‘%s’</string>


### PR DESCRIPTION
> [!WARNING]
> This is a fixup of the following PR, I've briefly tested and reviewed the code, but copy/pasted the PR message with brief changes
> * https://github.com/ankidroid/Anki-Android/pull/17920 

<!--- Please fill the necessary details below -->
## Purpose / Description
Added dialog on single-click of column name to show available columns for change, as mentioned in the issue.


## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/17910

## Approach
- **Added a single-tap listener** to each column heading (`TextView` inside `browser_column_headings`) to open a dialog.  
- **Dialog now displays:**
  - The **title** with the name of the currently selected column.
  - **A list of available columns** (those not currently in use).
- **On column selection:**
  - Calls `updateActiveColumns()` from `CardBrowserViewModel.kt` to apply the change **without reloading all columns**.

## How Has This Been Tested?
Tested by long-pressing the column heading to open the manage columns dialog and single-clicking to change columns, both functioning as expected. Physical Device: (Samsung Galaxy A6+)

**David: Screenshot**
<img width="547" alt="Screenshot 2025-05-17 at 05 13 37" src="https://github.com/user-attachments/assets/ad92b84a-91f5-42a9-821d-9a17ff524ec3" />

Video: 



old video: https://github.com/user-attachments/assets/0af661ac-d02a-4702-a30b-b5216777b058

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens.
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).
