### PR TITLE
NF: Introduce 13-feature-in-progress.xml

### DIFF
--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -14,7 +14,17 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 -->
-<!-- This contains strings that are used to test the translation process. They should not be used in actual code -->
+<!--
+This contains strings that are used to test the translation process.
+They should not be used in actual code.
+
+Those strings still appear as untranslated to crowdin translators.
+
+If you want to use a string in your code that can't be translated, please use:
+* constants.xml if the string must be a constant, such as the name of someone or a URL
+* 13-feature-in-progress.xml if the string should not be translated because it belongs to a feature in progress.
+
+-->
 <resources>
     <!--
     Adding or removing new line at the start/end of the string cause crowdin to require a new translation. Let's check if a comment before lead to a translation need!

--- a/AnkiDroid/src/main/res/values/13-feature-in-progress.xml
+++ b/AnkiDroid/src/main/res/values/13-feature-in-progress.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+This file contains strings that are used by feature in progress.
+That is, the feature is hidden behind a developer option and a normal user won't see this string.
+Once this feature is launched, the related string resources must be moved to other xml file.
+
+Please create one subsection per feature with XML comment and add your strings in the relevant subsection,
+so that it's easy to see which strings to move when the feature is enabled.
+
+ Strings in this files are not uploaded to crowdin. They won't be translated.
+ Please add to this file only strings that are protected by a developer options.
+ -->
+<resources>
+  <!-- Strings for the review reminder feature -->
+
+  <!-- Strings for the multiprofile feature -->
+
+</resources>


### PR DESCRIPTION
The issue with 12-dont-translate.xml is that the translators will still see the warning that there are untranslated strings. While a feature is in progress, I'd prefer that user don't see any untranslated strings.

It's expected behavior for 12 as I used this file to test when crowdin consider a string to need translation and when it does not.

In order to solve this issue, I introduce 13-feature-in-progress where I expect strings to go.