### PR TITLE
 refactor: use `CheckMediaResponse` instead of custom data class

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -124,11 +124,11 @@ class MediaTest : InstrumentedTest() {
         // check media
         val ret = testCol!!.media.check()
         var expected = setOf("fake2.png")
-        var actual = ret.missingFileNames.toMutableList()
+        var actual = ret.missingList.toMutableList()
         actual.retainAll(expected)
         assertEquals(expected.size, actual.size)
         expected = setOf("foo.jpg")
-        actual = ret.unusedFileNames.toMutableList()
+        actual = ret.unusedList.toMutableList()
         actual.retainAll(expected)
         assertEquals(expected.size, actual.size)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -27,6 +27,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.RecyclerView
+import anki.media.CheckMediaResponse
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.button.MaterialButton
 import com.ichi2.anki.CollectionManager.TR
@@ -35,7 +36,6 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.withProgress
-import com.ichi2.libanki.MediaCheckResult
 import com.ichi2.utils.cancelable
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
@@ -86,11 +86,11 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
         lifecycleScope.launch {
             viewModel.mediaCheckResult.collectLatest { result ->
                 view.findViewById<TextView>(R.id.unused_media_count)?.apply {
-                    text = (TR.mediaCheckUnusedCount(result?.unusedFileNames?.size ?: 0))
+                    text = (TR.mediaCheckUnusedCount(result?.unusedCount ?: 0))
                 }
 
                 view.findViewById<TextView>(R.id.missing_media_count)?.apply {
-                    text = (TR.mediaCheckMissingCount(result?.missingMediaNotes?.size ?: 0))
+                    text = (TR.mediaCheckMissingCount(result?.missingCount ?: 0))
                 }
 
                 result?.let { files ->
@@ -107,19 +107,19 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
      *
      * @param mediaCheckResult The result containing missing and unused media file names.
      */
-    private fun handleMediaResult(mediaCheckResult: MediaCheckResult) {
+    private fun handleMediaResult(mediaCheckResult: CheckMediaResponse) {
         val fileList =
             buildList {
-                if (mediaCheckResult.missingFileNames.isNotEmpty()) {
+                if (mediaCheckResult.missingCount != 0) {
                     tagMissingButton.visibility = View.VISIBLE
                     add(TR.mediaCheckMissingHeader())
-                    addAll(mediaCheckResult.missingFileNames.map(TR::mediaCheckMissingFile))
+                    addAll(mediaCheckResult.missingList.map(TR::mediaCheckMissingFile))
                 }
-                if (mediaCheckResult.unusedFileNames.isNotEmpty()) {
+                if (mediaCheckResult.unusedCount != 0) {
                     deleteMediaButton.visibility = View.VISIBLE
                     if (isNotEmpty()) add("\n")
                     add(TR.mediaCheckUnusedHeader())
-                    addAll(mediaCheckResult.unusedFileNames.map(TR::mediaCheckUnusedFile))
+                    addAll(mediaCheckResult.unusedList.map(TR::mediaCheckUnusedFile))
                 }
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckViewModel.kt
@@ -19,10 +19,10 @@ package com.ichi2.anki.mediacheck
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import anki.media.CheckMediaResponse
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.async.deleteMedia
-import com.ichi2.libanki.MediaCheckResult
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -31,8 +31,8 @@ import kotlinx.coroutines.launch
 
 @NeedsTest("Test the media check process i.e. the buttons and views")
 class MediaCheckViewModel : ViewModel() {
-    private val _mediaCheckResult = MutableStateFlow<MediaCheckResult?>(null)
-    val mediaCheckResult: StateFlow<MediaCheckResult?> = _mediaCheckResult
+    private val _mediaCheckResult = MutableStateFlow<CheckMediaResponse?>(null)
+    val mediaCheckResult: StateFlow<CheckMediaResponse?> = _mediaCheckResult
 
     private val deletedFilesCount: MutableStateFlow<Int> = MutableStateFlow(0)
     private val taggedFilesCount: MutableStateFlow<Int> = MutableStateFlow(0)
@@ -48,7 +48,7 @@ class MediaCheckViewModel : ViewModel() {
         viewModelScope.launch {
             val taggedNotes =
                 undoableOp {
-                    tags.bulkAdd(_mediaCheckResult.value?.missingMediaNotes ?: listOf(), tag)
+                    tags.bulkAdd(_mediaCheckResult.value?.missingMediaNotesList ?: listOf(), tag)
                 }
             taggedFilesCount.value = taggedNotes.count
         }
@@ -62,7 +62,7 @@ class MediaCheckViewModel : ViewModel() {
     // TODO: investigate: the underlying implementation exposes progress, which we do not yet handle.
     fun deleteUnusedMedia(): Job =
         viewModelScope.launch {
-            val deletedMedia = withCol { deleteMedia(this@withCol, _mediaCheckResult.value?.unusedFileNames ?: listOf()) }
+            val deletedMedia = withCol { deleteMedia(this@withCol, _mediaCheckResult.value?.unusedList ?: listOf()) }
             deletedFilesCount.value = deletedMedia
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -18,6 +18,7 @@
 package com.ichi2.libanki
 
 import androidx.annotation.WorkerThread
+import anki.media.CheckMediaResponse
 import com.google.protobuf.kotlin.toByteString
 import com.ichi2.libanki.exception.EmptyMediaException
 import timber.log.Timber
@@ -75,7 +76,7 @@ open class Media(
                 it.soundOrVideo
             }
 
-    fun findUnusedMediaFiles(): List<File> = check().unusedFileNames.map { File(dir, it) }
+    fun findUnusedMediaFiles(): List<File> = check().unusedList.map { File(dir, it) }
 
     /**
      * [IRI](https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier) encodes media
@@ -98,14 +99,7 @@ open class Media(
      */
 
     // FIXME: this also provides trash count, but UI can not handle it yet
-    fun check(): MediaCheckResult {
-        val out = col.backend.checkMedia()
-        return MediaCheckResult(
-            missingFileNames = out.missingList,
-            unusedFileNames = out.unusedList,
-            missingMediaNotes = out.missingMediaNotesList,
-        )
-    }
+    fun check(): CheckMediaResponse = col.backend.checkMedia()
 
     /**
      * Copying on import
@@ -143,9 +137,3 @@ open class Media(
 }
 
 fun getCollectionMediaPath(collectionPath: String): String = collectionPath.replaceFirst("\\.anki2$".toRegex(), ".media")
-
-data class MediaCheckResult(
-    val missingFileNames: List<String>,
-    val unusedFileNames: List<String>,
-    val missingMediaNotes: List<Long>,
-)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Remove the custom data class that we created for media result and use the result given by backend directly as I am working on the feature to show trash count and then empty or restore trash if needed just like Anki desktop, hence this PR removes the extra step needed to add the val in data class and then use it

## Fixes
* Sets things up for #17993

## Approach
Use the `CheckMediaResponse` type instead of the custom data class we created

## How Has This Been Tested?
Tested on API 31 and POCO API 35, and ran the tests locally

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
