### PR TITLE
Handle long tap gesture

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2051,6 +2051,12 @@ abstract class AbstractFlashcardViewer :
             return false
         }
 
+        override fun onLongPress(e: MotionEvent) {
+            if (gesturesEnabled) {
+                gestureProcessor.onLongTap()
+            }
+        }
+
         private fun isTouchingEdge(e1: MotionEvent): Boolean {
             val height = touchLayer!!.height
             val width = touchLayer!!.width


### PR DESCRIPTION
## Purpose / Description

This change aims to handle the long tap gesture in AbstractFlashcardViewer.

## Fixes

* Fixes #18326

## Approach

Added the missing `onLongPress()` method to `MyGestureDetector`.

This implementation simply checks if gestures are enabled and then calls the gesture processor to handle the long tap action. It is similar to how `onDoubleTap` is handled.

## How Has This Been Tested?

Manual testing.

[Screen_recording_20250518_164323.webm](https://github.com/user-attachments/assets/323f79ed-8477-4518-9253-b66d80ea98d2)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
