### PR TITLE
Allow better flexibility in dimensions of card analysis widget

### DIFF
--- a/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
+++ b/AnkiDroid/src/main/res/layout/widget_card_analysis.xml
@@ -1,8 +1,8 @@
 <RelativeLayout android:id="@+id/widget_deck_picker"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
     android:background="@drawable/widget_card_analysis_rounded_background"
     android:clickable="true"
     android:focusable="false"
@@ -25,9 +25,11 @@
         android:id="@+id/cardAnalysisDataHolder"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
         android:background="@drawable/widget_card_analysis_rounded_inner_background"
         android:orientation="horizontal"
-        android:padding="16dp">
+        android:paddingVertical="14dp"
+        android:paddingHorizontal="16dp">
 
         <TextView
             android:id="@+id/deckNew_card_analysis_widget"
@@ -67,12 +69,13 @@
         android:id="@+id/deckNameCardAnalysis"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="64dp"
+        android:layout_below="@id/cardAnalysisDataHolder"
         android:gravity="center"
-        android:padding="15dp"
-        android:paddingBottom="5dp"
+        android:paddingVertical="8dp"
+        android:paddingHorizontal="16dp"
         android:textColor="?android:attr/textColorPrimary"
         android:textSize="24sp"
+        android:textStyle="bold"
         tools:text="Default" />
 
 </RelativeLayout>

--- a/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
@@ -3,8 +3,8 @@
      The default size is 3 cells wide and 2 cells high, but the grid layout typically determines the final dimensions.
      Following https://developer.android.com/develop/ui/views/appwidgets/layouts#anatomy_determining_size
      we used the portrait mode cell size for the width and the landscape mode cell size for the height. Leading to:
-     * height between 102 and 315
-     * width 203 and 276 -->
+     * height between 56 and 800
+     * width 84 and 800 -->
 
 <!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
 
@@ -13,12 +13,12 @@
     android:initialLayout="@layout/widget_card_analysis"
     android:configure="com.ichi2.widget.cardanalysis.CardAnalysisWidgetConfig"
     android:widgetFeatures="reconfigurable"
-    android:minWidth="203dp"
-    android:minHeight="102dp"
-    android:minResizeWidth="203dp"
-    android:minResizeHeight="102dp"
-    android:maxResizeWidth="276dp"
-    android:maxResizeHeight="315dp"
+    android:minWidth="84dp"
+    android:minHeight="56dp"
+    android:minResizeWidth="84dp"
+    android:minResizeHeight="56dp"
+    android:maxResizeWidth="800dp"
+    android:maxResizeHeight="800dp"
     android:previewImage="@drawable/widget_card_analysis_drawable"
     android:previewLayout="@layout/widget_card_analysis_drawable_v31"
     android:resizeMode="horizontal|vertical"


### PR DESCRIPTION
## Purpose / Description
Allows better flexibility in dimensions of card analysis widget

## Fixes
* Fixes #18312 partially

## Approach

Adjusted min and max height and width, along with improving the widget layout.

## How Has This Been Tested?

Manually.

[Screen_recording_20250519_151141.webm](https://github.com/user-attachments/assets/908362d7-eca2-4ff8-b144-51f774484281)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
