### PR TITLE
Allow better flexibility in dimensions of deck widget

### DIFF
--- a/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
@@ -2,11 +2,11 @@
      The widths and heights parameters are determined as follows:
      The default is 3 cells in width and 2 in height.
      The height is between 1 and 5 cells.
-     The width is between 3 and 4 cells.
+     The width is between 2 and 12 cells.
      Following https://developer.android.com/develop/ui/views/appwidgets/layouts#anatomy_determining_size
      we used the portrait mode cell size for the width and the landscape mode cell size for the height. Leading to:
-     * height between 50 and 315
-     * width 203 and 276 -->
+     * height between 50 and 800
+     * width 120 and 800 -->
 
 <!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
 
@@ -15,15 +15,15 @@
     android:initialLayout="@layout/widget_deck_picker_large"
     android:configure="com.ichi2.widget.deckpicker.DeckPickerWidgetConfig"
     android:widgetFeatures="reconfigurable"
-    android:minWidth="203dp"
+    android:minWidth="120dp"
     android:minHeight="50dp"
-    android:minResizeWidth="203dp"
+    android:minResizeWidth="120dp"
     android:minResizeHeight="50dp"
-    android:maxResizeWidth="276dp"
-    android:maxResizeHeight="315dp"
+    android:maxResizeWidth="800dp"
+    android:maxResizeHeight="800dp"
     android:previewImage="@drawable/widget_deck_picker_drawable"
     android:previewLayout="@layout/widget_deck_picker_drawable_v31"
     android:resizeMode="horizontal|vertical"
     android:targetCellHeight="2"
-    android:targetCellWidth="4"
+    android:targetCellWidth="12"
     android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Purpose / Description
Allows better flexibility in dimensions of deck widget.

## Fixes
* Fixes #18312

## Approach

Adjusted min and max width, along with changing `targetCellWidth` value to 12.

## How Has This Been Tested?

Manually.

[Screen_recording_20250519_154759.webm](https://github.com/user-attachments/assets/51f36dec-049a-4917-aa0b-9c774c481331)


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
