### PR TITLE
NF: use File as much as possible

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.tests
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
@@ -42,8 +43,10 @@ object Shared {
         // Provide a string instead of an actual File. Storage.Collection won't populate the DB
         // if the file already exists (it assumes it's an existing DB).
         val path = f.absolutePath
+        val folder = path.substringBeforeLast("/")
+        val name = path.substringAfterLast("/").removeSuffix(".anki2")
         assertTrue(f.delete())
-        return Storage.collection(path)
+        return Storage.collection(CollectionFiles(File(folder), name))
     }
 
     /**

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -103,7 +103,7 @@ class MediaTest : InstrumentedTest() {
     @Throws(IOException::class, EmptyMediaException::class)
     fun testDeckIntegration() {
         // create a media dir
-        testCol!!.media.dir
+        val mediaDir = testCol!!.media.dir
         // Put a file into it
         val file = createNonEmptyFile("fake.png")
         testCol!!.media.addFile(file)
@@ -118,7 +118,7 @@ class MediaTest : InstrumentedTest() {
         f.setField(1, "<img src='fake2.png'>")
         testCol!!.addNote(f)
         // and add another file which isn't used
-        FileOutputStream(File(testCol!!.media.dir, "foo.jpg"), false).use { os ->
+        FileOutputStream(File(mediaDir, "foo.jpg"), false).use { os ->
             os.write("test".toByteArray())
         }
         // check media

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2720,12 +2720,12 @@ abstract class AbstractFlashcardViewer :
          * @param mediaDir media directory path on SD card
          * @return path converted to file URL, properly UTF-8 URL encoded
          */
-        fun getMediaBaseUrl(mediaDir: String): String {
+        fun getMediaBaseUrl(mediaDir: File): String {
             // Use android.net.Uri class to ensure whole path is properly encoded
             // File.toURL() does not work here, and URLEncoder class is not directly usable
             // with existing slashes
-            if (mediaDir.isNotEmpty()) {
-                val mediaDirUri = Uri.fromFile(File(mediaDir))
+            if (mediaDir.absolutePath.isNotEmpty()) {
+                val mediaDirUri = Uri.fromFile(mediaDir)
                 return "$mediaDirUri/"
             }
             return ""

--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -51,7 +51,7 @@ private suspend fun createBackup(force: Boolean) {
     withCol {
         // this two-step approach releases the backend lock after the initial copy
         createBackup(
-            BackupManager.getBackupDirectoryFromCollection(this.path),
+            BackupManager.getBackupDirectoryFromCollection(colDb),
             force,
             waitForCompletion = false,
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionIntegrityStorageCheck.kt
@@ -17,7 +17,6 @@ import android.content.Context
 import android.text.format.Formatter
 import com.ichi2.utils.FileUtil
 import timber.log.Timber
-import java.io.File
 
 /**
  * This currently stores either:
@@ -112,7 +111,7 @@ class CollectionIntegrityStorageCheck {
             val requiredSpaceInBytes = maybeCurrentCollectionSizeInBytes * 2
 
             // We currently use the same directory as the collection for VACUUM/ANALYZE due to the SQLite APIs
-            val collectionFile = File(CollectionHelper.getCollectionPath(context))
+            val collectionFile = CollectionHelper.getCollectionPath(context)
             val freeSpace = FileUtil.getFreeDiskSpace(collectionFile, -1)
             if (freeSpace == -1L) {
                 Timber.w("Error obtaining free space for '%s'", collectionFile.path)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -35,7 +35,6 @@ import net.ankiweb.rsdroid.BackendFactory
 import net.ankiweb.rsdroid.Translations
 import okio.withLock
 import timber.log.Timber
-import java.io.File
 import java.util.concurrent.locks.ReentrantLock
 
 object CollectionManager {
@@ -248,9 +247,9 @@ object CollectionManager {
         ensureBackendInner()
         emulatedOpenFailure?.triggerFailure()
         if (collection == null || collection!!.dbClosed) {
-            val path = collectionPathInValidFolder()
+            val collectionPath = collectionPathInValidFolder()
             collection =
-                collection(path, backend)
+                collection(collectionPath, backend)
         }
     }
 
@@ -263,14 +262,14 @@ object CollectionManager {
 
     fun getCollectionDirectory() =
         // Allow execution if AnkiDroidApp.instance is not initialized
-        File(CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext(AnkiDroidApp.sharedPrefs()) { AnkiDroidApp.instance })
+        CollectionHelper.getCurrentAnkiDroidDirectoryOptionalContext(AnkiDroidApp.sharedPrefs()) { AnkiDroidApp.instance }
 
-    /** Ensures the AnkiDroid directory is created, then returns the path to the collection file
-     * inside it. */
-    fun collectionPathInValidFolder(): String {
-        val dir = getCollectionDirectory().path
+    /** Ensures the AnkiDroid directory is created, then returns the path to the
+     * folder and the name of the collection file inside it. */
+    fun collectionPathInValidFolder(): CollectionFiles {
+        val dir = getCollectionDirectory()
         CollectionHelper.initializeAnkiDroidDirectory(dir)
-        return File(dir, "collection.anki2").absolutePath
+        return CollectionFiles(dir)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1302,7 +1302,7 @@ open class DeckPicker :
         outState.putBoolean("mIsFABOpen", floatingActionMenu.isFABOpen)
         importColpkgListener?.let {
             if (it is DatabaseRestorationListener) {
-                outState.getString("dbRestorationPath", it.newAnkiDroidDirectory)
+                outState.getString("dbRestorationPath", it.newAnkiDroidDirectory.absolutePath)
             }
         }
         exportingDelegate.onSaveInstanceState(outState)
@@ -1314,6 +1314,7 @@ open class DeckPicker :
         super.onRestoreInstanceState(savedInstanceState)
         floatingActionMenu.isFABOpen = savedInstanceState.getBoolean("mIsFABOpen")
         savedInstanceState.getString("dbRestorationPath")?.let { path ->
+            val path = File(path)
             CollectionHelper.ankiDroidDirectoryOverride = path
             importColpkgListener = DatabaseRestorationListener(this, path)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Import.kt
@@ -32,6 +32,7 @@ import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.utils.ImportUtils
 import timber.log.Timber
+import java.io.File
 
 // see also:
 // ImportFileSelectionFragment - selects 'APKG/COLPKG/CSV' and opens a file picker
@@ -98,12 +99,12 @@ fun AnkiActivity.showImportDialog(options: ImportOptions) {
 
 class DatabaseRestorationListener(
     val activity: AnkiActivity,
-    val newAnkiDroidDirectory: String,
+    val newAnkiDroidDirectory: File,
 ) : ImportColpkgListener {
     override fun onImportColpkg(colpkgPath: String?) {
         Timber.i("Database restoration correct")
         activity.sharedPrefs().edit {
-            putString("deckPath", newAnkiDroidDirectory)
+            putString("deckPath", newAnkiDroidDirectory.absolutePath)
         }
         activity.dismissAllDialogFragments()
         activity.importColpkgListener = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MediaRegistration.kt
@@ -178,12 +178,12 @@ object MediaRegistration {
                 bytesWritten = CompatHelper.compat.copyFile(fd, clipCopy.absolutePath)
             }
         }
-        val tempFilePath = clipCopy.absolutePath
+        val tempFilePath = clipCopy
 
         val checkMediaSize = checkMediaSize(bytesWritten, isImage, isVideo, showError)
 
         if (!checkMediaSize) {
-            File(tempFilePath).delete()
+            tempFilePath.delete()
             clipCopy.delete()
             return null
         }
@@ -198,7 +198,7 @@ object MediaRegistration {
         val field = if (isImage) ImageField() else MediaClipField()
 
         field.hasTemporaryMedia = true
-        field.mediaPath = tempFilePath
+        field.mediaFile = tempFilePath
         return field.formattedValue
     }
 
@@ -223,13 +223,13 @@ object MediaRegistration {
     }
 
     @CheckResult
-    fun registerMediaForWebView(mediaPath: String?): Boolean {
+    fun registerMediaForWebView(mediaPath: File?): Boolean {
         if (mediaPath == null) {
             // Nothing to register - continue with execution.
             return true
         }
         Timber.i("Adding media to collection: %s", mediaPath)
-        val f = File(mediaPath)
+        val f = mediaPath
         return try {
             CollectionManager.getColUnsafe().media.addFile(f)
             true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -1974,7 +1974,7 @@ class NoteEditor :
                 ?: return
 
         // Process successful result only if field has data
-        if (field.type != EFieldType.TEXT || field.mediaPath != null) {
+        if (field.type != EFieldType.TEXT || field.mediaFile != null) {
             addMediaFileToField(index, field)
         } else {
             Timber.i("field imagePath and audioPath are both null")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -132,7 +132,6 @@ import com.ichi2.widget.WidgetStatus.updateInBackground
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
-import java.io.File
 import kotlin.coroutines.resume
 
 @Suppress("LeakingThis")
@@ -611,8 +610,7 @@ open class Reviewer :
         if (isRecording) audioRecordingController?.stopAndSaveRecording()
 
         // Remove the temporary audio file
-        tempAudioPath?.let {
-            val tempAudioPathToDelete = File(it)
+        tempAudioPath?.let { tempAudioPathToDelete ->
             if (tempAudioPathToDelete.exists()) {
                 tempAudioPathToDelete.delete()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -309,7 +309,7 @@ private suspend fun handleDownload(
         withCol {
             try {
                 createBackup(
-                    BackupManager.getBackupDirectoryFromCollection(path),
+                    BackupManager.getBackupDirectoryFromCollection(colDb),
                     force = true,
                     waitForCompletion = true,
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -107,7 +107,7 @@ class CardMediaPlayer : Closeable {
         // javascriptEvaluator is wrapped in a lambda so the value in this class propagates down
         this.soundTagPlayer =
             SoundTagPlayer(
-                soundUriBase = getMediaBaseUrl(getMediaDirectory(AnkiDroidApp.instance).path),
+                soundUriBase = getMediaBaseUrl(getMediaDirectory(AnkiDroidApp.instance)),
                 videoPlayer = VideoPlayer { javascriptEvaluator() },
             )
         this.ttsPlayer = scope.async { AndroidTtsPlayer.createInstance(AnkiDroidApp.instance, scope) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -229,8 +229,7 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             }
             DIALOG_RESTORE_BACKUP -> {
                 // Allow user to restore one of the backups
-                val path = CollectionHelper.getCollectionPath(requireContext())
-                backups = BackupManager.getBackups(File(path))
+                backups = BackupManager.getBackups(CollectionHelper.getCollectionPath(requireContext()))
                 if (backups.isEmpty()) {
                     alertDialog
                         .title(R.string.backup_restore)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
@@ -104,7 +104,7 @@ class AudioRecordingFragment : MultimediaFragment(R.layout.fragment_audio_record
                 return@setOnClickListener
             }
 
-            field.mediaPath = viewModel.currentMultimediaPath.value
+            field.mediaFile = viewModel.currentMultimediaPath.value
             field.hasTemporaryMedia = true
 
             val resultData =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
@@ -203,7 +203,7 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
                 Timber.d("Audio or Video length is not valid")
                 return@setOnClickListener
             }
-            field.mediaPath = viewModel.currentMultimediaPath.value
+            field.mediaFile = viewModel.currentMultimediaPath.value
 
             field.hasTemporaryMedia = true
 
@@ -375,7 +375,7 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
             requireContext().contentResolver.openInputStream(selectedMediaClip).use { inputStream ->
                 CompatHelper.compat.copyFile(inputStream!!, clipCopy.absolutePath)
 
-                viewModel.updateCurrentMultimediaPath(clipCopy.path)
+                viewModel.updateCurrentMultimediaPath(clipCopy)
                 viewModel.selectedMediaFileSize = clipCopy.length()
                 mediaFileSize.text = clipCopy.toHumanReadableSize()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaViewModel.kt
@@ -24,19 +24,20 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
+import java.io.File
 
 class MultimediaViewModel : ViewModel() {
     /** Errors or Warnings related to the edit fields that might occur when trying to save note */
     val multimediaAction = MutableSharedFlow<MultimediaBottomSheet.MultimediaAction>()
 
-    private var prevMultimediaPath: String? = null
+    private var prevMultimediaPath: File? = null
     private var prevMultimediaUri: Uri? = null
 
     private val _currentMultimediaUri = MutableStateFlow<Uri?>(null)
     val currentMultimediaUri: StateFlow<Uri?> get() = _currentMultimediaUri
 
-    private val _currentMultimediaPath = MutableStateFlow<String?>(null)
-    val currentMultimediaPath: StateFlow<String?> get() = _currentMultimediaPath
+    private val _currentMultimediaPath = MutableStateFlow<File?>(null)
+    val currentMultimediaPath: StateFlow<File?> get() = _currentMultimediaPath
 
     var selectedMediaFileSize: Long = 0
 
@@ -47,7 +48,7 @@ class MultimediaViewModel : ViewModel() {
     }
 
     fun saveMultimediaForRevert(
-        imagePath: String?,
+        imagePath: File?,
         imageUri: Uri?,
     ) {
         prevMultimediaPath = imagePath
@@ -67,7 +68,11 @@ class MultimediaViewModel : ViewModel() {
         _currentMultimediaUri.value = uri
     }
 
-    fun updateCurrentMultimediaPath(path: String?) {
+    fun updateCurrentMultimediaPath(uri: String) {
+        updateCurrentMultimediaPath(File(uri))
+    }
+
+    fun updateCurrentMultimediaPath(path: File?) {
         _currentMultimediaPath.value = path
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioRecordingController.kt
@@ -128,9 +128,9 @@ class AudioRecordingController(
             val origAudioPath = viewModel?.currentMultimediaPath?.value
             var bExist = false
             if (origAudioPath != null) {
-                val f = File(origAudioPath)
+                val f = origAudioPath
                 if (f.exists()) {
-                    tempAudioPath = f.absolutePath
+                    tempAudioPath = f
                     bExist = true
                 }
             }
@@ -477,7 +477,7 @@ class AudioRecordingController(
     private fun prepareAudioPlayer() {
         audioPlayer = MediaPlayer()
         audioPlayer?.apply {
-            if (tempAudioPath != null) setDataSource(tempAudioPath)
+            tempAudioPath?.let { tempAudioPath -> setDataSource(tempAudioPath.absolutePath) }
             setOnPreparedListener {
                 audioTimeView?.text = DEFAULT_TIME
             }
@@ -606,7 +606,7 @@ class AudioRecordingController(
 
     private fun startRecording(
         context: Context,
-        audioPath: String,
+        audioPath: File,
     ) {
         Timber.i("starting recording")
         try {
@@ -621,9 +621,8 @@ class AudioRecordingController(
 
     private fun saveRecording() {
         viewModel?.updateCurrentMultimediaPath(tempAudioPath)
-        val file = tempAudioPath?.let { File(it) }
-        if (file != null) {
-            viewModel?.updateMediaFileLength(file.length())
+        tempAudioPath?.let { tempAudioPath ->
+            viewModel?.updateMediaFileLength(tempAudioPath.length())
         }
     }
 
@@ -736,24 +735,21 @@ class AudioRecordingController(
         const val DEFAULT_TIME = "00:00.00"
         const val JUMP_VALUE = 500
 
-        fun generateTempAudioFile(context: Context): String? {
-            val tempAudioPath: String? =
-                try {
-                    val storingDirectory = context.cacheDir
-                    File.createTempFile("ankidroid_audiorec", ".3gp", storingDirectory).absolutePath
-                } catch (e: IOException) {
-                    Timber.w(e, "Could not create temporary audio file.")
-                    null
-                }
-            return tempAudioPath
-        }
+        fun generateTempAudioFile(context: Context) =
+            try {
+                val storingDirectory = context.cacheDir
+                File.createTempFile("ankidroid_audiorec", ".3gp", storingDirectory)
+            } catch (e: IOException) {
+                Timber.w(e, "Could not create temporary audio file.")
+                null
+            }
 
         fun setEditorStatus(inEditField: Boolean) {
             this.inEditField = inEditField
         }
 
         /** File of the temporary mic record  */
-        var tempAudioPath: String? = null
+        var tempAudioPath: File? = null
     }
 
     sealed interface RecordingState {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/AudioRecorder.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.media.MediaRecorder
 import com.ichi2.compat.CompatHelper
 import timber.log.Timber
+import java.io.File
 import java.io.IOException
 
 class AudioRecorder {
@@ -33,13 +34,13 @@ class AudioRecorder {
 
     private fun initMediaRecorder(
         context: Context,
-        audioPath: String,
+        audioPath: File,
     ): MediaRecorder {
         val mr = CompatHelper.compat.getMediaRecorder(context)
         mr.setAudioSource(MediaRecorder.AudioSource.MIC)
         mr.setOutputFormat(MediaRecorder.OutputFormat.THREE_GPP)
         onRecordingInitialized()
-        mr.setOutputFile(audioPath) // audioPath could change
+        mr.setOutputFile(audioPath.absolutePath) // audioPath could change
         return mr
     }
 
@@ -51,6 +52,14 @@ class AudioRecorder {
     fun startRecording(
         context: Context,
         audioPath: String,
+    ) {
+        startRecording(context, File(audioPath))
+    }
+
+    @Throws(IOException::class)
+    fun startRecording(
+        context: Context,
+        audioPath: File,
     ) {
         var highSampling = false
         try {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/AudioField.kt
@@ -29,7 +29,7 @@ import java.util.regex.Pattern
 abstract class AudioField :
     FieldBase(),
     IField {
-    override var mediaPath: String? = null
+    override var mediaFile: File? = null
         get() = field
         set(value) {
             field = value
@@ -42,8 +42,7 @@ abstract class AudioField :
 
     override val formattedValue: String
         get() =
-            mediaPath?.let { path ->
-                val file = File(path)
+            mediaFile?.let { file ->
                 if (file.exists()) "[sound:${file.name}]" else ""
             } ?: ""
 
@@ -53,12 +52,11 @@ abstract class AudioField :
     ) {
         val p = Pattern.compile(PATH_REGEX)
         val m = p.matcher(value)
-        var res = ""
+        var mediaFileName = ""
         if (m.find()) {
-            res = m.group(1)!!
+            mediaFileName = m.group(1)!!
         }
-        val mediaDir = col.media.dir + "/"
-        mediaPath = mediaDir + res
+        mediaFile = File(col.collectionFiles.mediaFolder, mediaFileName)
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/IField.kt
@@ -19,6 +19,7 @@
 package com.ichi2.anki.multimediacard.fields
 
 import com.ichi2.libanki.Collection
+import java.io.File
 import java.io.Serializable
 
 /**
@@ -30,7 +31,7 @@ interface IField : Serializable {
     val isModified: Boolean
 
     // Path of the folder containing media used by AnkiDroid.
-    var mediaPath: String?
+    var mediaFile: File?
 
     // For Text type
     var text: String?

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/ImageField.kt
@@ -37,7 +37,7 @@ class ImageField :
     FieldBase(),
     IField {
     @get:JvmName("getImagePath_unused")
-    var extraImagePathRef: String? = null
+    var extraImageFileRef: File? = null
     private var _name: String? = null
 
     override val type: EFieldType = EFieldType.IMAGE
@@ -45,10 +45,10 @@ class ImageField :
     override val isModified: Boolean
         get() = thisModified
 
-    override var mediaPath: String?
-        get() = extraImagePathRef
+    override var mediaFile: File?
+        get() = extraImageFileRef
         set(value) {
-            extraImagePathRef = value
+            extraImageFileRef = value
             thisModified = true
         }
 
@@ -64,7 +64,7 @@ class ImageField :
 
     override val formattedValue: String
         get() {
-            val file = File(mediaPath!!)
+            val file = mediaFile!!
             return formatImageFileName(file)
         }
 
@@ -72,7 +72,7 @@ class ImageField :
         col: Collection,
         value: String,
     ) {
-        extraImagePathRef = getImageFullPath(col, value)
+        extraImageFileRef = getImageFullPath(col, value)
     }
 
     companion object {
@@ -90,13 +90,12 @@ class ImageField :
         fun getImageFullPath(
             col: Collection,
             value: String,
-        ): String {
+        ): File? {
             val path = parseImageSrcFromHtml(value)
-
             return if (path.isNotEmpty()) {
-                "${col.media.dir}/$path"
+                File(col.collectionFiles.mediaFolder, path)
             } else {
-                ""
+                null
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/fields/TextField.kt
@@ -20,6 +20,7 @@
 package com.ichi2.anki.multimediacard.fields
 
 import com.ichi2.libanki.Collection
+import java.io.File
 
 /**
  * Text Field implementation.
@@ -35,7 +36,7 @@ class TextField :
     override val isModified: Boolean
         get() = thisModified
 
-    override var mediaPath: String? = null
+    override var mediaFile: File? = null
 
     override var text: String?
         get() = _text

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.compat.CompatHelper
 import com.ichi2.utils.show
 import timber.log.Timber
+import java.io.File
 
 class AdvancedSettingsFragment : SettingsFragment() {
     override val preferenceResource: Int
@@ -50,7 +51,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
             setOnPreferenceChangeListener { _, newValue: Any? ->
                 val newPath = newValue as String
                 try {
-                    CollectionHelper.initializeAnkiDroidDirectory(newPath)
+                    CollectionHelper.initializeAnkiDroidDirectory(File(newPath))
                     launchCatchingTask {
                         CollectionManager.discardBackend()
                         val deckPicker = Intent(requireContext(), DeckPicker::class.java)
@@ -65,7 +66,7 @@ class AdvancedSettingsFragment : SettingsFragment() {
                         setTitle(R.string.dialog_collection_path_not_dir)
                         setPositiveButton(R.string.dialog_ok) { _, _ -> }
                         setNegativeButton(R.string.reset_custom_buttons) { _, _ ->
-                            text = CollectionHelper.getDefaultAnkiDroidDirectory(requireContext())
+                            text = CollectionHelper.getDefaultAnkiDroidDirectory(requireContext()).absolutePath
                         }
                     }
                     false

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -131,25 +131,25 @@ object NoteService {
         col: Collection,
         field: IField?,
     ) {
-        var tmpMediaPath: String? = null
+        var tmpMediaPath: File? = null
         when (field!!.type) {
-            EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> tmpMediaPath = field.mediaPath
+            EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> tmpMediaPath = field.mediaFile
             EFieldType.TEXT -> {
             }
         }
         if (tmpMediaPath != null) {
             try {
-                val inFile = File(tmpMediaPath)
+                val inFile = tmpMediaPath
                 if (inFile.exists() && inFile.length() > 0) {
                     val fname = col.media.addFile(inFile)
                     val outFile = File(col.media.dir, fname)
                     Timber.v("""File "%s" should be copied to "%s""", fname, outFile)
-                    if (field.hasTemporaryMedia && outFile.absolutePath != tmpMediaPath) {
+                    if (field.hasTemporaryMedia && outFile != tmpMediaPath) {
                         // Delete original
                         inFile.delete()
                     }
                     when (field.type) {
-                        EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> field.mediaPath = outFile.absolutePath
+                        EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> field.mediaFile = outFile
                         else -> {
                         }
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/ScopedStorageService.kt
@@ -37,7 +37,7 @@ object ScopedStorageService {
      *
      * @return `true` if AnkiDroid is storing user data in a Legacy Storage Directory.
      */
-    fun isLegacyStorage(context: Context): Boolean = isLegacyStorage(File(CollectionHelper.getCurrentAnkiDroidDirectory(context)), context)
+    fun isLegacyStorage(context: Context): Boolean = isLegacyStorage(CollectionHelper.getCurrentAnkiDroidDirectory(context), context)
 
     /**
      * Checks if current directory being used by AnkiDroid to store user data is a Legacy Storage Directory.
@@ -58,7 +58,7 @@ object ScopedStorageService {
         ) {
             return null
         }
-        return isLegacyStorage(File(CollectionHelper.getCurrentAnkiDroidDirectory(context)), context)
+        return isLegacyStorage(CollectionHelper.getCurrentAnkiDroidDirectory(context), context)
     }
 
     /**
@@ -176,7 +176,7 @@ object ScopedStorageService {
     }
 
     fun userIsPromptedToDeleteCollectionOnUninstall(context: Context): Boolean =
-        File(CollectionHelper.getCollectionPath(context)).isInsideDirectoriesRemovedWithTheApp(
+        CollectionHelper.getCollectionPath(context).isInsideDirectoriesRemovedWithTheApp(
             context,
         )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/managespace/ManageSpaceFragment.kt
@@ -121,7 +121,7 @@ class ManageSpaceViewModel(
         viewModelScope.launch {
             flowOfDeleteBackupsSize.ifCollectionDirectoryExistsEmit {
                 withCol {
-                    val backupFiles = BackupManager.getBackups(File(this.path)).toList()
+                    val backupFiles = BackupManager.getBackups(colDb).toList()
                     val backupFilesSize = backupFiles.sumOf(::calculateSize)
                     Size.FilesAndBytes(backupFiles, backupFilesSize)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/AndroidPermanentlyRevokedPermissionsDialog.kt
@@ -51,7 +51,7 @@ object AndroidPermanentlyRevokedPermissionsDialog {
             context.getString(
                 R.string.directory_revoked_after_inactivity,
                 "WRITE_EXTERNAL_STORAGE",
-                getCurrentAnkiDroidDirectory(context),
+                getCurrentAnkiDroidDirectoryPath(context),
             )
         AlertDialog.Builder(context).show {
             listItemsAndMessage(
@@ -68,9 +68,9 @@ object AndroidPermanentlyRevokedPermissionsDialog {
         }
     }
 
-    private fun getCurrentAnkiDroidDirectory(context: Context): String =
+    private fun getCurrentAnkiDroidDirectoryPath(context: Context): String =
         try {
-            CollectionHelper.getCurrentAnkiDroidDirectory(context)
+            CollectionHelper.getCurrentAnkiDroidDirectory(context).absolutePath
         } catch (e: Exception) {
             Timber.w(e)
             context.getString(R.string.card_browser_unknown_deck_name)

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
@@ -21,6 +21,7 @@ import anki.import_export.ImportAnkiPackageOptions
 import anki.import_export.ImportResponse
 import anki.import_export.exportAnkiPackageOptions
 import anki.search.SearchNode
+import com.ichi2.anki.CollectionFiles
 import net.ankiweb.rsdroid.Backend
 
 /**
@@ -63,14 +64,14 @@ fun Collection.awaitBackupCompletion() {
  * */
 fun importCollectionPackage(
     backend: Backend,
-    colPath: String,
+    colPath: CollectionFiles,
     colpkgPath: String,
 ) {
     backend.importCollectionPackage(
-        colPath = colPath,
+        colPath = colPath.colDb.absolutePath,
         backupPath = colpkgPath,
-        mediaFolder = colPath.replace(".anki2", ".media"),
-        mediaDb = colPath.replace(".anki2", ".media.db"),
+        mediaFolder = colPath.mediaFolder.absolutePath,
+        mediaDb = colPath.mediaDb.absolutePath,
     )
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,6 +40,7 @@ import anki.search.BrowserRow
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
+import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.ids2str
@@ -65,9 +66,10 @@ import java.io.File
 @WorkerThread
 class Collection(
     /**
-     *  The path to the collection.anki2 database. Must be unicode and openable with [File].
+     *  The path to the folder containing collection.anki2 database. Must be unicode and openable with [File].
      */
-    val path: String,
+
+    val collectionFiles: CollectionFiles,
     /**
      * Outside of libanki, you should not access the backend directly for collection operations.
      * Operations that work on a closed collection (eg importing), or do not require a collection
@@ -75,6 +77,8 @@ class Collection(
      */
     val backend: Backend,
 ) {
+    val colDb = collectionFiles.colDb
+
     /** Access backend translations */
     val tr = backend.tr
 
@@ -150,10 +154,7 @@ class Collection(
         }
     }
 
-    fun name(): String {
-        // TODO:
-        return File(path).name.replace(".anki2", "")
-    }
+    fun name() = collectionFiles.collectionName
 
     /**
      * Scheduler
@@ -209,9 +210,9 @@ class Collection(
 
     /** True if DB was created */
     fun reopen(afterFullSync: Boolean = false): Boolean {
-        Timber.i("(Re)opening Database: %s", path)
+        Timber.i("(Re)opening Database: %s", colDb)
         return if (dbClosed) {
-            val (database, created) = Storage.openDB(path, backend, afterFullSync)
+            val (database, created) = Storage.openDB(colDb, backend, afterFullSync)
             dbInternal = database
             load()
             if (afterFullSync) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.database.AnkiSupportSQLiteDatabase
 import timber.log.Timber
+import java.io.File
 
 /**
  * Database layer for AnkiDroid. Wraps an SupportSQLiteDatabase (provided by either the Rust backend
@@ -239,12 +240,12 @@ class DB(
          */
         fun withAndroidFramework(
             context: Context,
-            path: String,
+            path: File,
         ): DB {
             val db =
                 AnkiSupportSQLiteDatabase.withFramework(
                     context,
-                    path,
+                    path.absolutePath,
                     SupportSQLiteOpenHelperCallback(1),
                 )
             db.disableWriteAheadLogging()

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Media.kt
@@ -32,11 +32,11 @@ import java.io.File
 open class Media(
     private val col: Collection,
 ) {
-    val dir = getCollectionMediaPath(col.path)
+    val dir = col.collectionFiles.mediaFolder
 
     init {
         Timber.v("dir %s", dir)
-        val file = File(dir)
+        val file = dir
         if (!file.exists()) {
             file.mkdirs()
         }
@@ -108,7 +108,7 @@ open class Media(
     open fun have(fname: String): Boolean = File(dir, fname).exists()
 
     open fun forceResync() {
-        col.backend.removeMediaDb(colPath = col.path)
+        col.backend.removeMediaDb(colPath = col.colDb.absolutePath)
     }
 
     /**
@@ -135,5 +135,3 @@ open class Media(
         col.backend.restoreTrash()
     }
 }
-
-fun getCollectionMediaPath(collectionPath: String): String = collectionPath.replaceFirst("\\.anki2$".toRegex(), ".media")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -62,7 +62,7 @@ data class SoundOrVideoTag(
     val filename: String,
 ) : AvTag() {
     @NotInLibAnki
-    fun getType(mediaDir: String): Type {
+    fun getType(mediaDir: File): Type {
         val extension = filename.substringAfterLast(".", "")
         return when (extension) {
             in Sound.VIDEO_ONLY_EXTENSIONS -> Type.VIDEO
@@ -120,7 +120,7 @@ object Sound {
         content: String,
         renderOutput: TemplateRenderOutput,
         showAudioPlayButtons: Boolean,
-        mediaDir: String,
+        mediaDir: File,
     ) = replaceAvRefsWith(content, renderOutput) { tag, playTag ->
         fun asAudio(): String {
             if (!showAudioPlayButtons) return ""
@@ -137,7 +137,7 @@ object Sound {
         }
 
         fun asVideo(tag: SoundOrVideoTag): String {
-            val path = Paths.get(mediaDir, tag.filename).toString()
+            val path = Paths.get(mediaDir.absolutePath, tag.filename).toString()
             val uri = getFileUri(path)
 
             val playsound = "${playTag.side}:${playTag.index}"

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.libanki
 
+import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.time.Time
 import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.anki.getDayStart
@@ -29,31 +30,31 @@ object Storage {
     /**
      *  Open a new or existing collection.
      *
-     * @param path The path to the collection.anki2 database. Should be unicode.
-     * path should be tested with [File.exists] and [File.canWrite] before this is called.
+     * @param collectionFiles: The files of this collection
+     * Files should be tested with [File.exists] and [File.canWrite] before this is called.
      * */
     fun collection(
-        path: String,
+        collectionFiles: CollectionFiles,
         backend: Backend? = null,
     ): Collection {
         val backend2 = backend ?: BackendFactory.getBackend()
-        return Collection(path, backend2)
+        return Collection(collectionFiles, backend2)
     }
 
     /**
      * Called as part of [Collection] initialization. Don't call directly.
      */
     internal fun openDB(
-        path: String,
+        path: File,
         backend: Backend,
         afterFullSync: Boolean,
     ): Pair<DB, Boolean> {
-        val dbFile = File(path)
+        val dbFile = path
         var create = !dbFile.exists()
         if (afterFullSync) {
             create = false
         } else {
-            backend.openCollection(if (isInMemory) ":memory:" else path)
+            backend.openCollection(if (isInMemory) ":memory:" else path.absolutePath)
         }
         val db = DB.withRustBackend(backend)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/jsaddons/TgzPackageExtractTest.kt
@@ -44,7 +44,7 @@ class TgzPackageExtractTest : RobolectricTest() {
         super.setUp()
 
         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(targetContext)
-        ShadowStatFs.markAsNonEmpty(File(currentAnkiDroidDirectory))
+        ShadowStatFs.markAsNonEmpty(currentAnkiDroidDirectory)
         addonPackage = TgzPackageExtract(targetContext)
         addonDir = File(currentAnkiDroidDirectory, "addons")
         tarballPath = getFileResource("valid-ankidroid-js-addon-test-1.0.0.tgz")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NoteServiceTest.kt
@@ -27,7 +27,6 @@ import com.ichi2.testutils.createTransientFile
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.io.FileMatchers.aFileWithAbsolutePath
 import org.hamcrest.io.FileMatchers.anExistingFile
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertThrows
@@ -98,7 +97,7 @@ class NoteServiceTest : RobolectricTest() {
         FileWriter(fileAudio).use { fileWriter -> fileWriter.write("line1") }
 
         val audioField = MediaClipField()
-        audioField.mediaPath = fileAudio.absolutePath
+        audioField.mediaFile = fileAudio
 
         NoteService.importMediaToDirectory(col, audioField)
 
@@ -107,7 +106,7 @@ class NoteServiceTest : RobolectricTest() {
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             outFile,
-            aFileWithAbsolutePath(equalTo(audioField.mediaPath)),
+            equalTo(audioField.mediaFile),
         )
     }
 
@@ -121,7 +120,7 @@ class NoteServiceTest : RobolectricTest() {
         FileWriter(fileImage).use { fileWriter -> fileWriter.write("line1") }
 
         val imgField = ImageField()
-        imgField.extraImagePathRef = fileImage.absolutePath
+        imgField.extraImageFileRef = fileImage
 
         NoteService.importMediaToDirectory(col, imgField)
 
@@ -130,7 +129,7 @@ class NoteServiceTest : RobolectricTest() {
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             outFile,
-            aFileWithAbsolutePath(equalTo(imgField.extraImagePathRef)),
+            equalTo(imgField.extraImageFileRef),
         )
     }
 
@@ -155,16 +154,16 @@ class NoteServiceTest : RobolectricTest() {
         FileWriter(f2).use { fileWriter -> fileWriter.write("2") }
 
         val fld1 = MediaClipField()
-        fld1.mediaPath = f1.absolutePath
+        fld1.mediaFile = f1
 
         val fld2 = MediaClipField()
-        fld2.mediaPath = f2.absolutePath
+        fld2.mediaFile = f2
 
         // third field to test if name is kept after reimporting the same file
         val fld3 = MediaClipField()
-        fld3.mediaPath = f1.absolutePath
+        fld3.mediaFile = f1
 
-        Timber.e("media folder is %s %b", col.media.dir, File(col.media.dir).exists())
+        Timber.e("media folder is %s %b", col.media.dir, col.media.dir.exists())
         NoteService.importMediaToDirectory(col, fld1)
         val o1 = File(col.media.dir, f1.name)
 
@@ -177,17 +176,17 @@ class NoteServiceTest : RobolectricTest() {
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             o1,
-            aFileWithAbsolutePath(equalTo(fld1.mediaPath)),
+            equalTo(fld1.mediaFile),
         )
         assertThat(
             "path should be different to new file made in NoteService.importMediaToDirectory",
             o2,
-            aFileWithAbsolutePath(not(fld2.mediaPath)),
+            not(fld2.mediaFile),
         )
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             o1,
-            aFileWithAbsolutePath(equalTo(fld3.mediaPath)),
+            equalTo(fld3.mediaFile),
         )
     }
 
@@ -204,14 +203,14 @@ class NoteServiceTest : RobolectricTest() {
         FileWriter(f2).use { fileWriter -> fileWriter.write("2") }
 
         val fld1 = ImageField()
-        fld1.extraImagePathRef = f1.absolutePath
+        fld1.extraImageFileRef = f1
 
         val fld2 = ImageField()
-        fld2.extraImagePathRef = f2.absolutePath
+        fld2.extraImageFileRef = f2
 
         // third field to test if name is kept after reimporting the same file
         val fld3 = ImageField()
-        fld3.extraImagePathRef = f1.absolutePath
+        fld3.extraImageFileRef = f1
 
         NoteService.importMediaToDirectory(col, fld1)
         val o1 = File(col.media.dir, f1.name)
@@ -225,17 +224,17 @@ class NoteServiceTest : RobolectricTest() {
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             o1,
-            aFileWithAbsolutePath(equalTo(fld1.extraImagePathRef)),
+            equalTo(fld1.extraImageFileRef),
         )
         assertThat(
             "path should be different to new file made in NoteService.importMediaToDirectory",
             o2,
-            aFileWithAbsolutePath(not(fld2.extraImagePathRef)),
+            not(fld2.extraImageFileRef),
         )
         assertThat(
             "path should be equal to new file made in NoteService.importMediaToDirectory",
             o1,
-            aFileWithAbsolutePath(equalTo(fld3.extraImagePathRef)),
+            equalTo(fld3.extraImageFileRef),
         )
     }
 
@@ -250,7 +249,7 @@ class NoteServiceTest : RobolectricTest() {
 
         val field =
             MediaClipField().apply {
-                mediaPath = file.absolutePath
+                mediaFile = file
                 hasTemporaryMedia = true
             }
 
@@ -266,7 +265,7 @@ class NoteServiceTest : RobolectricTest() {
 
         val field =
             ImageField().apply {
-                extraImagePathRef = file.absolutePath
+                extraImageFileRef = file
                 hasTemporaryMedia = true
             }
 

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/BackupManagerTestUtilities.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import com.ichi2.anki.BackupManager.Companion.enoughDiscSpace
 import com.ichi2.anki.CollectionHelper
 import org.junit.Assert.assertTrue
-import java.io.File
 import java.lang.IllegalStateException
 
 object BackupManagerTestUtilities {
@@ -27,7 +26,7 @@ object BackupManagerTestUtilities {
         val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(context)
 
         val path =
-            File(currentAnkiDroidDirectory).parentFile
+            currentAnkiDroidDirectory.parentFile
                 ?: throw IllegalStateException("currentAnkiDroidDirectory had no parent")
         ShadowStatFs.markAsNonEmpty(path)
 


### PR DESCRIPTION
While trying to understand how media are accessed, I realize that there are some part of the code that are not ideal.

The name of the media folder (and similarly the database) are sometime hard coded as "collection.media", and sometime obtained by taking the collection file, and replacing .anki2 by .media. Which means that code is not even consistent about where the medias are. Admittedly, the database is named "collection.anki2" everywhere except in test, so it's not actually an issue.

Also, I remarked that the code keep alternating between File and String through the code. This is furthermore complexified by the fact that the String can be a URI or a path and this is not always clear from context.

Sometime we have a string, create a File from it, do file operation, and then transform it into a string again. I find it clearer to use File as much as possible and keep strings:
* to fetch and save data in the preferences
* to call back-end function that require a string
* for URI