### PR TITLE
Limit size of image that can be used in the crop editor

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
@@ -18,6 +18,7 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_height="match_parent">
 
@@ -42,6 +43,21 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"/>
+
+        <TextView
+            android:id="@+id/crop_image_size_notice"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="24dp"
+            android:visibility="gone"
+            android:textAppearance="@style/TextAppearance.Material3.BodyMedium"
+            android:text="@string/crop_image_size_notice"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/toolbar"
+            tools:visibility="visible"
+            />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -52,6 +52,7 @@
     <string name="save_dialog_content">Current image size is %sMB. Default image size limit is 1MB. Do you want to compress it?</string>
     <string name="select_image_failed">"Select image failed, Please retry"</string>
     <string name="audio_recording_field_list" comment="Displays a list of the field data in the note editor while audio recording is taking place">Field Contents</string>
+    <string name="crop_image_size_notice">The image is too big to be handled by the crop editor. Please resize it and try again!</string>
 
     <string name="reselect" maxLength="28">Reselect</string>
 


### PR DESCRIPTION
## Purpose / Description

Check the image size before starting the async loading of the image for cropping. The limit was chosen by looking at the acra exceptions, the smallest value that triggered it was just above 100_000_000.

<img src="https://github.com/user-attachments/assets/1f1d1cef-ae3a-46c4-82fc-d1be054b0542" width="300" heigh="720"/>


## Fixes
* Fixes #17378

## How Has This Been Tested?

Ran the tests, checked crop editor.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
