### PR TITLE
Fix: Enter triggers OK without extra press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -169,7 +169,7 @@ suspend fun <T> FragmentActivity.runCatching(
             is BackendNetworkException, is BackendSyncException, is StorageAccessException -> {
                 // these exceptions do not generate worthwhile crash reports
                 Timber.i("Showing error dialog but not sending a crash report.")
-                showError(this, exc.localizedMessage!!, exc, false)
+                showError(this, exc.localizedMessage!!, exc, false, enableEnterKeyHandler = true)
             }
             is BackendException -> {
                 Timber.e(exc, errorMessage)
@@ -263,11 +263,12 @@ fun showError(
     msg: String,
     exception: Throwable,
     crashReport: Boolean = true,
+    enableEnterKeyHandler: Boolean = false,
 ) {
     if (throwOnShowError) throw IllegalStateException("throwOnShowError: $msg", exception)
     Timber.i("Error dialog displayed")
     try {
-        AlertDialog.Builder(context).show {
+        AlertDialog.Builder(context).show(enableEnterKeyHandler = enableEnterKeyHandler) {
             title(R.string.vague_error)
             message(text = msg)
             positiveButton(R.string.dialog_ok)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.content.DialogInterface.OnClickListener
 import android.text.InputFilter
+import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ArrayAdapter
@@ -142,9 +143,36 @@ fun AlertDialog.Builder.cancelable(cancelable: Boolean): AlertDialog.Builder = t
  * Executes the provided block, then creates an [AlertDialog] with the arguments supplied
  * and immediately displays the dialog
  */
-inline fun AlertDialog.Builder.show(block: AlertDialog.Builder.() -> Unit): AlertDialog {
+inline fun AlertDialog.Builder.show(
+    enableEnterKeyHandler: Boolean = false, // Make it opt-in
+    block: AlertDialog.Builder.() -> Unit,
+): AlertDialog {
     this.apply { block() }
-    return this.show()
+    val dialog = this.show()
+    return if (enableEnterKeyHandler) {
+        dialog.setupEnterKeyHandler()
+    } else {
+        dialog
+    }
+}
+
+/**
+ * Extension function to configure an AlertDialog to handle the Enter key press event.
+ * This will make the Enter key directly trigger the positive button action instead of just selecting it.
+ */
+fun AlertDialog.setupEnterKeyHandler(): AlertDialog {
+    this.setOnKeyListener { dialog, keyCode, event ->
+        if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP) {
+            // Get the positive button and simulate a click
+            val positiveButton = (dialog as AlertDialog).getButton(DialogInterface.BUTTON_POSITIVE)
+            if (positiveButton != null && positiveButton.isEnabled) {
+                positiveButton.performClick()
+                return@setOnKeyListener true
+            }
+        }
+        false
+    }
+    return this
 }
 
 /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When an alert dialog appears after entering incorrect credentials in the sync page, pressing the Enter key only selects the "OK" button instead of triggering it. This PR modifies the behavior so that pressing Enter directly triggers the positive button action, making the user experience more intuitive.

## Fixes
* Fixes #18340

## Approach

Added an extension function setupEnterKeyHandler() to handle Enter key presses in AlertDialogs
Modified the existing show() extension function to apply this handler to all dialogs created through the builder pattern
The handler detects Enter key presses and simulates a click on the positive button if it exists and is enabled

## How Has This Been Tested?

Manually verified with the following steps:

Without an AnkiWeb account on AnkiDroid
Attempted to sync
From the sync page, entered an email and wrong password
When error message appeared, pressed Enter key

#### 🎥 Before the Fix
<details>
  <summary>Click to expand</summary>

[failure.webm](https://github.com/user-attachments/assets/742512ca-e722-4be7-a097-119e5e430614)

</details>

#### 🎥 After the Fix
<details>
  <summary>Click to expand</summary>

https://github.com/user-attachments/assets/303ec6ee-bc26-41f1-9ab5-dc3e5f2df881

</details>

Before the fix, Enter key only selected the "OK" button requiring a second press.
After the fix, Enter key immediately dismisses the dialog.

## Learning
The default behavior of AlertDialogs in Android is to only select but not trigger buttons when Enter is pressed. This is a common UI pattern that needs explicit handling to improve user experience

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
