### PR TITLE
Created ReviewRemindersDatabase and ReviewReminder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -1,0 +1,238 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.os.Parcelable
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.libanki.DeckId
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import java.util.Locale
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@JvmInline
+@Serializable
+value class ReviewReminderId(
+    val id: Int,
+) {
+    companion object {
+        /**
+         * Get and return the next free reminder ID which can be associated with a new review reminder.
+         * Also increment the next free reminder ID stored in SharedPreferences.
+         * @return The next free reminder ID.
+         */
+        fun getAndIncrementNextFreeReminderId(): ReviewReminderId {
+            val nextFreeId = Prefs.reviewReminderNextFreeId
+            Prefs.reviewReminderNextFreeId = nextFreeId + 1
+            Timber.d("Generated next free review reminder ID: $nextFreeId")
+            return ReviewReminderId(nextFreeId)
+        }
+    }
+}
+
+/**
+ * The time of day at which reminders will send a notification.
+ */
+@Serializable
+data class ReviewReminderTime(
+    val hour: Int,
+    val minute: Int,
+) {
+    init {
+        require(hour in 0..23) { "Hour must be between 0 and 23" }
+        require(minute in 0..59) { "Minute must be between 0 and 59" }
+    }
+
+    override fun toString(): String =
+        LocalTime
+            .of(hour, minute)
+            .format(
+                DateTimeFormatter
+                    .ofLocalizedTime(FormatStyle.SHORT)
+                    .withLocale(Locale.getDefault()),
+            )
+
+    fun toSecondsFromMidnight(): Long = (hour.hours + minute.minutes).inWholeSeconds
+}
+
+/**
+ * Types of snooze behaviour that can be present on notifications sent by review reminders.
+ * If a reminder is snoozed repeatedly until it overlaps with another notification from the reminder firing the next day,
+ * the snoozing instance of the reminder from the previous day will be cancelled.
+ */
+@Serializable
+sealed class ReviewReminderSnoozeAmount {
+    /**
+     * The snooze button will never appear on notifications set by this review reminder.
+     */
+    @Serializable
+    data object Disabled : ReviewReminderSnoozeAmount()
+
+    /**
+     * The snooze button will always be available on notifications sent by this review reminder.
+     */
+    @Serializable
+    data class Infinite(
+        val interval: Duration,
+    ) : ReviewReminderSnoozeAmount() {
+        init {
+            require(interval >= 1.minutes) { "Snooze time interval must be >= 1 minute" }
+            require(interval < 24.hours) { "Snooze time interval must be < 24 hours" }
+        }
+    }
+
+    /**
+     * The snooze button can be pressed a maximum amount of times on notifications sent by this review reminder.
+     * After it has been pressed that many times, the button will no longer appear.
+     */
+    @Serializable
+    data class SetAmount(
+        val interval: Duration,
+        val maxSnoozes: Int,
+    ) : ReviewReminderSnoozeAmount() {
+        init {
+            require(interval >= 1.minutes) { "Snooze time interval must be >= 1 minute" }
+            require(interval < 24.hours) { "Snooze time interval must be < 24 hours" }
+            require(maxSnoozes >= 1) { "Max snoozes must be >= 1" }
+        }
+    }
+}
+
+/**
+ * If, at the time of the reminder, less than this many cards are due, the notification is not triggered.
+ */
+@JvmInline
+@Serializable
+value class ReviewReminderCardTriggerThreshold(
+    val threshold: Int,
+) {
+    init {
+        require(threshold >= 0) { "Card trigger threshold must be >= 0" }
+    }
+}
+
+/**
+ * An indicator of whether a review reminders feature is associated with every deck in the user's
+ * collection or if it is associated with a single deck. For example, the [ScheduleReminders] fragment
+ * can be triggered in either global or deck-specific editing mode. A [ReviewReminder] can be associated
+ * with either all decks or a specific deck.
+ *
+ * This class is marked with @Parcelize so that it can be passed into [ScheduleReminders.getIntent].
+ * This class is marked with @Serializable so that it can be a field of [ReviewReminder]s, which are stored as JSON strings.
+ */
+@Serializable
+@Parcelize
+sealed class ReviewReminderScope : Parcelable {
+    /**
+     * This represents all decks in the user's collection.
+     */
+    @Serializable
+    data object Global : ReviewReminderScope()
+
+    /**
+     * This represents a specific deck in the user's collection.
+     */
+    @Serializable
+    data class DeckSpecific(
+        val did: DeckId,
+    ) : ReviewReminderScope() {
+        @IgnoredOnParcel
+        private var cachedDeckName: String? = null
+
+        /**
+         * Gets the deck name associated with this [DeckSpecific] review reminder's [did] from the collection.
+         * Caches the resultant deck name to minimize calls to the collection.
+         * Should not be called if [did] is no longer a valid deck ID. If [did] is invalid, this method will return "[no deck]".
+         */
+        suspend fun getDeckName(): String = cachedDeckName ?: withCol { decks.name(did) }.also { cachedDeckName = it }
+    }
+}
+
+/**
+ * A "review reminder" is a recurring scheduled notification that reminds the user
+ * to review their Anki cards. Individual instances of a review reminder firing and showing up
+ * on the user's phone are called "notifications".
+ *
+ * Below, a public way of creating review reminders is exposed via a companion object so that
+ * reminders with invalid IDs are never created. This class is annotated
+ * with @ConsistentCopyVisibility to ensure copy() is private too and does not leak the constructor.
+ *
+ * About the old schema migration process:
+ *
+ * To any developer who changes this class in the future, note that these review reminders are stored
+ * by [ReviewRemindersDatabase] inside SharedPreferences. Modifying this schema means that existing
+ * stored review reminders on user devices will no longer be able to be read, as decoding them to the new
+ * [ReviewReminder] schema will cause a serialization exception.
+ * You must specify a schema migration mapping for users who already have review reminders set on their devices
+ * so that [ReviewRemindersDatabase.attemptSchemaMigration] can migrate their reminders to the new schema.
+ * Use an [OldReviewReminderSchema] to store the old schema and to define a method for migrating to the new schema.
+ * Your method will be called from [ScheduleReminders.catchDatabaseExceptions]. To inform [ScheduleReminders.catchDatabaseExceptions]
+ * that some users may have review reminders in the form of your old schema, add your [OldReviewReminderSchema]
+ * to [ScheduleReminders.oldReviewReminderSchemasForMigration]. We store a list of old schemas since there may be
+ * multiple old schemas, and users do not always update their app from
+ * version A -> B -> C but may sometimes jump from A -> C.
+ * [ScheduleReminders.catchDatabaseExceptions] will attempt to migrate from all old schemas present in the list.
+ *
+ * TODO: add remaining fields planned for GSoC 2025.
+ *
+ * @param id Unique, auto-incremented ID of the review reminder.
+ * @param time See [ReviewReminderTime].
+ * @param snoozeAmount See [ReviewReminderSnoozeAmount].
+ * @param cardTriggerThreshold See [ReviewReminderCardTriggerThreshold].
+ * @param scope See [ReviewReminderScope].
+ * @param enabled Whether the review reminder's notifications are active or disabled.
+ */
+@Serializable
+@ConsistentCopyVisibility
+data class ReviewReminder private constructor(
+    val id: ReviewReminderId,
+    val time: ReviewReminderTime,
+    val snoozeAmount: ReviewReminderSnoozeAmount,
+    val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
+    val scope: ReviewReminderScope,
+    var enabled: Boolean,
+) {
+    companion object {
+        /**
+         * Create a new review reminder. This will allocate a new ID for the reminder.
+         * @return A new [ReviewReminder] object.
+         * @see [ReviewReminder]
+         */
+        fun createReviewReminder(
+            time: ReviewReminderTime,
+            snoozeAmount: ReviewReminderSnoozeAmount,
+            cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
+            scope: ReviewReminderScope = ReviewReminderScope.Global,
+            enabled: Boolean = true,
+        ) = ReviewReminder(
+            id = ReviewReminderId.getAndIncrementNextFreeReminderId(),
+            time,
+            snoozeAmount,
+            cardTriggerThreshold,
+            scope,
+            enabled,
+        )
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -1,0 +1,280 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.edit
+import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.libanki.DeckId
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+
+/**
+ * Manages the storage and retrieval of [ReviewReminder]s in SharedPreferences.
+ *
+ * [ReviewReminder]s can either be tied to a specific deck and trigger based on the number of cards
+ * due in that deck, or they can be app-wide reminders that trigger based on the total number
+ * of cards due across all decks. See [ReviewReminderScope].
+ *
+ * Calls to methods in this class should be wrapped by [ScheduleReminders.catchDatabaseExceptions].
+ */
+class ReviewRemindersDatabase {
+    companion object {
+        /**
+         * Key in SharedPreferences for retrieving deck-specific reminders.
+         * Should have deck ID appended to its end, ex. "review_reminders_deck_12345".
+         * Its value is a HashMap<[ReviewReminderId], [ReviewReminder]> serialized as a JSON String.
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val DECK_SPECIFIC_KEY = "review_reminders_deck_"
+
+        /**
+         * Key in SharedPreferences for retrieving app-wide reminders.
+         * Its value is a HashMap<[ReviewReminderId], [ReviewReminder]> serialized as a JSON String.
+         */
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val APP_WIDE_KEY = "review_reminders_app_wide"
+    }
+
+    /**
+     * Decode an encoded HashMap<[ReviewReminderId], [ReviewReminder]> JSON string.
+     * @see Json.decodeFromString
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    private fun decodeJson(jsonString: String): HashMap<ReviewReminderId, ReviewReminder> =
+        Json.decodeFromString<HashMap<ReviewReminderId, ReviewReminder>>(jsonString)
+
+    /**
+     * Encode a Map<[ReviewReminderId], [ReviewReminder]> as a JSON string.
+     * @see Json.encodeToString
+     * @throws SerializationException If the string is not a valid JSON string.
+     */
+    private fun encodeJson(reminders: Map<ReviewReminderId, ReviewReminder>): String = Json.encodeToString(reminders)
+
+    /**
+     * Get the [ReviewReminder]s for a specific key.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    private fun getRemindersForKey(key: String): HashMap<ReviewReminderId, ReviewReminder> {
+        val jsonString = AnkiDroidApp.sharedPrefs().getString(key, null) ?: return hashMapOf()
+        return decodeJson(jsonString)
+    }
+
+    /**
+     * Get the [ReviewReminder]s for a specific deck.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun getRemindersForDeck(did: DeckId): HashMap<ReviewReminderId, ReviewReminder> = getRemindersForKey(DECK_SPECIFIC_KEY + did)
+
+    /**
+     * Get the app-wide [ReviewReminder]s.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun getAllAppWideReminders(): HashMap<ReviewReminderId, ReviewReminder> = getRemindersForKey(APP_WIDE_KEY)
+
+    /**
+     * Get all [ReviewReminder]s that are associated with a specific deck, grouped by deck ID.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    private fun getAllDeckSpecificRemindersGrouped(): Map<DeckId, HashMap<ReviewReminderId, ReviewReminder>> {
+        return AnkiDroidApp
+            .sharedPrefs()
+            .all
+            .filterKeys { it.startsWith(DECK_SPECIFIC_KEY) }
+            .mapNotNull { (key, value) ->
+                val did = key.removePrefix(DECK_SPECIFIC_KEY).toLongOrNull() ?: return@mapNotNull null
+                val reminders = decodeJson(value.toString())
+                did to reminders
+            }.toMap()
+    }
+
+    /**
+     * Get all [ReviewReminder]s that are associated with a specific deck, all in a single flattened map.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun getAllDeckSpecificReminders(): HashMap<ReviewReminderId, ReviewReminder> = getAllDeckSpecificRemindersGrouped().flatten()
+
+    /**
+     * Edit the [ReviewReminder]s for a specific key.
+     * @param key
+     * @param reminderEditor A lambda that takes the current map and returns the updated map.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    private fun editRemindersForKey(
+        key: String,
+        reminderEditor: (HashMap<ReviewReminderId, ReviewReminder>) -> Map<ReviewReminderId, ReviewReminder>,
+    ) {
+        val existingReminders = getRemindersForKey(key)
+        val updatedReminders = reminderEditor(existingReminders)
+        AnkiDroidApp.sharedPrefs().edit {
+            putString(key, encodeJson(updatedReminders))
+        }
+    }
+
+    /**
+     * Edit the [ReviewReminder]s for a specific deck.
+     * This assumes the resulting map contains only reminders of scope [ReviewReminderScope.DeckSpecific].
+     * @param did
+     * @param reminderEditor A lambda that takes the current map and returns the updated map.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun editRemindersForDeck(
+        did: DeckId,
+        reminderEditor: (HashMap<ReviewReminderId, ReviewReminder>) -> Map<ReviewReminderId, ReviewReminder>,
+    ) = editRemindersForKey(DECK_SPECIFIC_KEY + did, reminderEditor)
+
+    /**
+     * Edit the app-wide [ReviewReminder]s.
+     * This assumes the resulting map contains only reminders of scope [ReviewReminderScope.Global].
+     * @param reminderEditor A lambda that takes the current map and returns the updated map.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun editAllAppWideReminders(reminderEditor: (HashMap<ReviewReminderId, ReviewReminder>) -> Map<ReviewReminderId, ReviewReminder>) =
+        editRemindersForKey(APP_WIDE_KEY, reminderEditor)
+
+    /**
+     * Edit all [ReviewReminder]s that are associated with a specific deck by operating on a single mutable map.
+     * This assumes the resulting map contains only reminders of scope [ReviewReminderScope.DeckSpecific].
+     * @param reminderEditor A lambda that takes the current map and returns the updated map.
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    fun editAllDeckSpecificReminders(reminderEditor: (HashMap<ReviewReminderId, ReviewReminder>) -> Map<ReviewReminderId, ReviewReminder>) {
+        val existingRemindersGrouped = getAllDeckSpecificRemindersGrouped()
+        val existingRemindersFlattened = existingRemindersGrouped.flatten()
+
+        val updatedRemindersFlattened = reminderEditor(existingRemindersFlattened)
+        val updatedRemindersGrouped = updatedRemindersFlattened.groupByDeckId()
+
+        val existingKeys = existingRemindersGrouped.keys.map { DECK_SPECIFIC_KEY + it }
+
+        AnkiDroidApp.sharedPrefs().edit {
+            // Clear existing review reminder keys in SharedPreferences
+            existingKeys.forEach { remove(it) }
+            // Add the updated ones back in
+            updatedRemindersGrouped.forEach { (did, reminders) ->
+                putString(DECK_SPECIFIC_KEY + did, encodeJson(reminders))
+            }
+        }
+    }
+
+    /**
+     * Utility function for flattening maps of deck-specific [ReviewReminder]s grouped by deck ID into a single map.
+     */
+    private fun Map<DeckId, HashMap<ReviewReminderId, ReviewReminder>>.flatten(): HashMap<ReviewReminderId, ReviewReminder> =
+        hashMapOf<ReviewReminderId, ReviewReminder>().apply {
+            this@flatten.forEach { (_, reminders) ->
+                putAll(reminders)
+            }
+        }
+
+    /**
+     * Utility function for grouping maps of deck-specific [ReviewReminder]s by deck ID.
+     * Should only be called on deck-specific [ReviewReminder]s and will throw an [IllegalArgumentException] otherwise.
+     */
+    private fun Map<ReviewReminderId, ReviewReminder>.groupByDeckId(): Map<DeckId, HashMap<ReviewReminderId, ReviewReminder>> =
+        hashMapOf<DeckId, HashMap<ReviewReminderId, ReviewReminder>>().apply {
+            this@groupByDeckId.forEach { (id, reminder) ->
+                when (val scope = reminder.scope) {
+                    is ReviewReminderScope.Global -> throw IllegalArgumentException("Global reminders found in deck-specific map")
+                    is ReviewReminderScope.DeckSpecific -> getOrPut(scope.did) { hashMapOf() }[id] = reminder
+                }
+            }
+        }
+
+    /**
+     * Helper method for getting all SharedPreferences that represent app-wide or deck-specific reminder HashMaps.
+     * For example, may be used for constructing a backup of all review reminders pending a potentially-destructive migration operation.
+     * Does not return the next-free-ID preference for review reminders used by [ReviewReminder.getAndIncrementNextFreeReminderId].
+     */
+    fun getAllReviewReminderSharedPrefsAsMap(): Map<String, Any?> =
+        AnkiDroidApp.sharedPrefs().all.filter {
+            it.key.startsWith(DECK_SPECIFIC_KEY) ||
+                it.key.startsWith(APP_WIDE_KEY)
+        }
+
+    /**
+     * Helper method for deleting all SharedPreferences that represent app-wide or deck-specific reminder HashMaps.
+     * Does not delete the next-free-ID preference for review reminders used by [ReviewReminder.getAndIncrementNextFreeReminderId].
+     *
+     * For example, may be used when a potentially-destructive operation, like a failed migration, has been applied to all review reminders.
+     * This method can be used to delete all potentially-corrupted review reminder shared preferences so that backed-up
+     * review reminders can be restored.
+     *
+     * For developers debugging review reminder issues during development or writing tests:
+     * call this when you need to hard-reset the review reminders database.
+     */
+    fun deleteAllReviewReminderSharedPrefs() {
+        AnkiDroidApp.sharedPrefs().edit {
+            AnkiDroidApp
+                .sharedPrefs()
+                .all
+                .keys
+                .filter { it.startsWith(DECK_SPECIFIC_KEY) || it.startsWith(APP_WIDE_KEY) }
+                .forEach { remove(it) }
+        }
+    }
+
+    /**
+     * Schema update method for migrating old review reminders to new ones.
+     * Use when [ReviewReminder] is updated and existing users who already have review reminders set up on their devices
+     * need to have their data ported to the new schema.
+     * @param serializer The serializer for the old schema of type [T] implementing [OldReviewReminderSchema]
+     * @see [OldReviewReminderSchema]
+     * @throws SerializationException If the string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded object is not a HashMap<[ReviewReminderId], [T]>.
+     */
+    fun <T : OldReviewReminderSchema> attemptSchemaMigration(serializer: KSerializer<T>) {
+        val mapSerializer = MapSerializer(ReviewReminderId.serializer(), serializer)
+        AnkiDroidApp.sharedPrefs().edit {
+            getAllReviewReminderSharedPrefsAsMap().forEach { (key, value) ->
+                val old: Map<ReviewReminderId, T> = Json.decodeFromString(mapSerializer, value.toString())
+                val new =
+                    old
+                        .map { (_, value) ->
+                            val updatedReminder = value.migrate()
+                            updatedReminder.id to updatedReminder
+                        }.toMap()
+                putString(key, Json.encodeToString(new))
+                Timber.d("Migrated review reminders from $key")
+            }
+        }
+    }
+}
+
+/**
+ * When [ReviewReminder] is updated by a developer, implement this interface in a new data class which
+ * has the same fields as the old version of [ReviewReminder], then implement the [migrate] method which
+ * transforms old [ReviewReminder]s to new [ReviewReminder]s. Data classes implementing this interface
+ * should be marked as @Serializable.
+ * @see [ReviewRemindersDatabase.attemptSchemaMigration].
+ */
+interface OldReviewReminderSchema {
+    fun migrate(): ReviewReminder
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -170,6 +170,13 @@ object Prefs {
     var username by stringPref(R.string.username_key)
     var hkey by stringPref(R.string.hkey_key)
 
+    // ************************************** Review Reminders ********************************** //
+
+    /**
+     * Review reminder IDs are unique, starting at 0 and climbing upwards by one each time a new one is created.
+     */
+    var reviewReminderNextFreeId by intPref(R.string.review_reminders_next_free_id, defaultValue = 0)
+
     // **************************************** Reviewer **************************************** //
 
     val ignoreDisplayCutout by booleanPref(R.string.ignore_display_cutout_key, false)

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -196,6 +196,7 @@
     <string name="pref_notifications_blink_key">widgetBlink</string>
     <!-- Review reminders -->
     <string name="pref_review_reminders_screen_key">reviewRemindersScreen</string>
+    <string name="review_reminders_next_free_id">reviewRemindersNextFreeId</string>
     <!-- Developer options -->
     <string name="pref_dev_options_screen_key">devOptionsKey</string>
     <string name="pref_trigger_crash_key">trigger_crash_preference</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.preferences.sharedPrefs
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+class ReviewReminderTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        // Reset the database after each test
+        targetContext.sharedPrefs().edit { clear() }
+    }
+
+    @Test
+    fun `getAndIncrementNextFreeReminderId should increment IDs correctly`() {
+        for (i in 0..10) {
+            val reminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(12, 30),
+                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 3),
+                    ReviewReminderCardTriggerThreshold(0),
+                    ReviewReminderScope.DeckSpecific(5),
+                )
+            assertThat(reminder.id, equalTo(ReviewReminderId(i)))
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -1,0 +1,314 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.preferences.sharedPrefs
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.anEmptyMap
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.equalTo
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+class ReviewRemindersDatabaseTest : RobolectricTest() {
+    private lateinit var reviewRemindersDatabase: ReviewRemindersDatabase
+
+    private val did1 = 12345L
+    private val did2 = 67890L
+    private val did3 = 13579L
+
+    private val dummyDeckSpecificRemindersForDeckOne =
+        mapOf(
+            ReviewReminderId(0) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 2),
+                    ReviewReminderCardTriggerThreshold(5),
+                    ReviewReminderScope.DeckSpecific(did1),
+                    false,
+                ),
+            ReviewReminderId(1) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(10, 30),
+                    ReviewReminderSnoozeAmount.Infinite(15.minutes),
+                    ReviewReminderCardTriggerThreshold(10),
+                    ReviewReminderScope.DeckSpecific(did1),
+                ),
+        )
+    private val dummyDeckSpecificRemindersForDeckTwo =
+        mapOf(
+            ReviewReminderId(2) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(10, 30),
+                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 2),
+                    ReviewReminderCardTriggerThreshold(10),
+                    ReviewReminderScope.DeckSpecific(did2),
+                    true,
+                ),
+            ReviewReminderId(3) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(12, 30),
+                    ReviewReminderSnoozeAmount.Disabled,
+                    ReviewReminderCardTriggerThreshold(20),
+                    ReviewReminderScope.DeckSpecific(did2),
+                ),
+        )
+    private val dummyAppWideReminders =
+        mapOf(
+            ReviewReminderId(4) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderSnoozeAmount.SetAmount(30.minutes, 1),
+                    ReviewReminderCardTriggerThreshold(5),
+                ),
+            ReviewReminderId(5) to
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(10, 30),
+                    ReviewReminderSnoozeAmount.Infinite(60.minutes),
+                    ReviewReminderCardTriggerThreshold(10),
+                ),
+        )
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        reviewRemindersDatabase = ReviewRemindersDatabase()
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        // Reset the database after each test
+        targetContext.sharedPrefs().edit { clear() }
+    }
+
+    @Test
+    fun `getRemindersForDeck should return empty map when no reminders exist`() {
+        val reminders = reviewRemindersDatabase.getRemindersForDeck(did1)
+        assertThat(reminders, anEmptyMap())
+    }
+
+    @Test
+    fun `editRemindersForDeck and getRemindersForDeck should read and write reminders correctly`() {
+        reviewRemindersDatabase.editRemindersForDeck(did1) { dummyDeckSpecificRemindersForDeckOne }
+        val storedReminders = reviewRemindersDatabase.getRemindersForDeck(did1)
+        assertThat(storedReminders, equalTo(dummyDeckSpecificRemindersForDeckOne))
+    }
+
+    @Test
+    fun `getAllDeckSpecificReminders should return empty map when no reminders exist`() {
+        val reminders = reviewRemindersDatabase.getAllDeckSpecificReminders()
+        assertThat(reminders, anEmptyMap())
+    }
+
+    @Test
+    fun `getAllDeckSpecificReminders should return all reminders across decks`() {
+        reviewRemindersDatabase.editRemindersForDeck(did1) { dummyDeckSpecificRemindersForDeckOne }
+        reviewRemindersDatabase.editRemindersForDeck(did2) { dummyDeckSpecificRemindersForDeckTwo }
+        val allReminders = reviewRemindersDatabase.getAllDeckSpecificReminders()
+        assertThat(
+            allReminders,
+            equalTo(dummyDeckSpecificRemindersForDeckOne + dummyDeckSpecificRemindersForDeckTwo),
+        )
+    }
+
+    @Test
+    fun `getAllAppWideReminders should return empty map when no reminders exist`() {
+        val reminders = reviewRemindersDatabase.getAllAppWideReminders()
+        assertThat(reminders, anEmptyMap())
+    }
+
+    @Test
+    fun `editAllAppWideReminders and getAllAppWideReminders should read and write reminders correctly`() {
+        reviewRemindersDatabase.editAllAppWideReminders { dummyAppWideReminders }
+        val storedReminders = reviewRemindersDatabase.getAllAppWideReminders()
+        assertThat(storedReminders, equalTo(dummyAppWideReminders))
+    }
+
+    @Test
+    fun `editAllDeckSpecificReminders should update all reminders across decks`() {
+        val reminders1Old =
+            mapOf(
+                ReviewReminderId(0) to
+                    ReviewReminder.createReviewReminder(
+                        ReviewReminderTime(9, 0),
+                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
+                        ReviewReminderCardTriggerThreshold(5),
+                        ReviewReminderScope.DeckSpecific(did1),
+                    ),
+            )
+        val reminders2Old =
+            mapOf(
+                ReviewReminderId(1) to
+                    ReviewReminder.createReviewReminder(
+                        ReviewReminderTime(10, 30),
+                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
+                        ReviewReminderCardTriggerThreshold(10),
+                        ReviewReminderScope.DeckSpecific(did2),
+                    ),
+            )
+        val reminders2New =
+            mapOf(
+                ReviewReminderId(2) to
+                    ReviewReminder.createReviewReminder(
+                        ReviewReminderTime(10, 45),
+                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
+                        ReviewReminderCardTriggerThreshold(10),
+                        ReviewReminderScope.DeckSpecific(did2),
+                    ),
+            )
+        val reminders3New =
+            mapOf(
+                ReviewReminderId(3) to
+                    ReviewReminder.createReviewReminder(
+                        ReviewReminderTime(11, 0),
+                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
+                        ReviewReminderCardTriggerThreshold(25),
+                        ReviewReminderScope.DeckSpecific(did3),
+                    ),
+            )
+
+        reviewRemindersDatabase.editRemindersForDeck(did1) { reminders1Old }
+        reviewRemindersDatabase.editRemindersForDeck(did2) { reminders2Old }
+
+        reviewRemindersDatabase.editAllDeckSpecificReminders { reminders2New + reminders3New }
+
+        val storedReminders1 = reviewRemindersDatabase.getRemindersForDeck(did1)
+        val storedReminders2 = reviewRemindersDatabase.getRemindersForDeck(did2)
+        val storedReminders3 = reviewRemindersDatabase.getRemindersForDeck(did3)
+        val allStoredReminders = reviewRemindersDatabase.getAllDeckSpecificReminders()
+
+        assertThat(storedReminders1, anEmptyMap())
+        assertThat(storedReminders2, equalTo(reminders2New))
+        assertThat(storedReminders3, equalTo(reminders3New))
+        assertThat(
+            allStoredReminders,
+            equalTo(reminders2New + reminders3New),
+        )
+    }
+
+    @Test(expected = SerializationException::class)
+    fun `getRemindersForDeck should throw SerializationException if JSON string is corrupted`() {
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, "corrupted_and_invalid_json_string")
+        }
+        reviewRemindersDatabase.getRemindersForDeck(did1)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getRemindersForDeck should throw IllegalArgumentException if JSON string is not a ReviewReminder`() {
+        val randomObject = Pair("not a map of", "review reminders")
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, Json.encodeToString(randomObject))
+        }
+        reviewRemindersDatabase.getRemindersForDeck(did1)
+    }
+
+    @Test(expected = SerializationException::class)
+    fun `getAllAppWideReminders should throw SerializationException if JSON string is corrupted`() {
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.APP_WIDE_KEY, "corrupted_and_invalid_json_string")
+        }
+        reviewRemindersDatabase.getAllAppWideReminders()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getAllAppWideReminders should throw IllegalArgumentException if JSON string is not a ReviewReminder`() {
+        val randomObject = Pair("not a map of", "review reminders")
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.APP_WIDE_KEY, Json.encodeToString(randomObject))
+        }
+        reviewRemindersDatabase.getAllAppWideReminders()
+    }
+
+    @Test(expected = SerializationException::class)
+    fun `getAllDeckSpecificReminders should throw SerializationException if JSON string is corrupted`() {
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, "corrupted_and_invalid_json_string")
+        }
+        reviewRemindersDatabase.getAllDeckSpecificReminders()
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `getAllDeckSpecificReminders should throw IllegalArgumentException if JSON string is not a ReviewReminder`() {
+        val randomObject = Pair("not a map of", "review reminders")
+        targetContext.sharedPrefs().edit {
+            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, Json.encodeToString(randomObject))
+        }
+        reviewRemindersDatabase.getAllDeckSpecificReminders()
+    }
+
+    @Test
+    fun `getAllReviewReminderSharedPrefsAsMap should return empty map if no reminders exist`() {
+        val sharedPrefs = reviewRemindersDatabase.getAllReviewReminderSharedPrefsAsMap()
+        assertThat(sharedPrefs, anEmptyMap())
+    }
+
+    @Test
+    fun `getAllReviewReminderSharedPrefsAsMap should return only review reminder shared preferences`() {
+        reviewRemindersDatabase.editRemindersForDeck(did1) { dummyDeckSpecificRemindersForDeckOne }
+        reviewRemindersDatabase.editAllAppWideReminders { dummyAppWideReminders }
+
+        targetContext.sharedPrefs().edit {
+            putString("unrelated shared preference", "that should not be returned")
+        }
+
+        val reviewReminderSharedPrefs =
+            reviewRemindersDatabase
+                .getAllReviewReminderSharedPrefsAsMap()
+                .values
+                .toList()
+                .map { Json.decodeFromString<Map<ReviewReminderId, ReviewReminder>>(it as String) }
+
+        assertThat(reviewReminderSharedPrefs, containsInAnyOrder(dummyDeckSpecificRemindersForDeckOne, dummyAppWideReminders))
+    }
+
+    @Test
+    fun `deleteAllReviewReminderSharedPrefs should do nothing if there are no review reminder shared preferences`() {
+        targetContext.sharedPrefs().edit {
+            putString("unrelated shared preference", "that should not be deleted")
+        }
+        val sharedPrefsBefore = targetContext.sharedPrefs().all
+        reviewRemindersDatabase.deleteAllReviewReminderSharedPrefs()
+        val sharedPrefsAfter = targetContext.sharedPrefs().all
+        assertThat(sharedPrefsBefore, equalTo(sharedPrefsAfter))
+    }
+
+    @Test
+    fun `deleteAllReviewReminderSharedPrefs should delete all review reminder shared preferences`() {
+        targetContext.sharedPrefs().edit {
+            putString("unrelated shared preference", "that should not be deleted")
+        }
+        val sharedPrefsBefore = targetContext.sharedPrefs().all
+
+        reviewRemindersDatabase.editRemindersForDeck(did1) { dummyDeckSpecificRemindersForDeckOne }
+        reviewRemindersDatabase.editAllAppWideReminders { dummyAppWideReminders }
+        reviewRemindersDatabase.deleteAllReviewReminderSharedPrefs()
+
+        val sharedPrefsAfter = targetContext.sharedPrefs().all
+        assertThat(sharedPrefsBefore, equalTo(sharedPrefsAfter))
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Review Reminders database system.

- Created `ReviewRemindersDatabase`, which contains methods for reading and writing to a Preferences Datastore instance for storing review reminder data
- Created `ReviewReminder`, which defines the review reminder data class
- Created Robolectric unit tests for `ReviewRemindersDatabase` and `ReviewReminder`

## Fixes
- For GSoC 2025: Review Reminders

## Approach
Using Preferences Datastore was the original method I proposed for storing review reminder data in my original project proposal: see [[1]](https://docs.google.com/document/d/1KMjnm6ol1M_VMAsg9V5Qb4XRZnEON-39gkzLkFe8q2Y/edit?tab=t.0#heading=h.o472euuadswv)

Why did I initially choose Preferences Datastore for storing review reminder data?
1. Google recommends using it over Shared Preferences: see [[2]](https://android-developers.googleblog.com/2020/09/prefer-storing-data-with-jetpack.html)
2. It has been used before. Past attempts at creating a review reminders system (see [[3]](https://github.com/ankidroid/Anki-Android/pull/11487)) used Preferences Datastore.

However, we've now chosen to use SharedPreferences instead. It's consistent with what the rest of AnkiDroid uses and doesn't necessitate a whole new import. It's also a lot simpler and straightforward.

## How Has This Been Tested?
- `ReviewRemindersDatabaseTest` directly or indirectly exercises all methods within `ReviewRemindersDatabase`.
- `ReviewReminderTest` exercises the ID allocation method of `ReviewReminder`
- On a physical Samsung S23, API 34., buttons to add, edit, and delete reminders (coming soon in a later PR) cause expected changes to the database and the database changes persist between app sessions.

## Learning
I've tried my best to make my code clean and safe. In particular, allocating and deallocating IDs is handled internally and any developer creating a new `ReviewReminder` should be unable to manually forge an ID.

Originally, I planned to create different types of review reminders. I've now abandoned that in favour of a simpler approach involving snooze functionality.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)