### PR TITLE
Prefetch medias

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -535,6 +535,7 @@ abstract class AbstractFlashcardViewer :
         // set the correct mark/unmark icon on action bar
         refreshActionBar()
         focusDefaultLayout()
+        prefetchAnswerMedia()
     }
 
     private fun focusDefaultLayout() {
@@ -1301,6 +1302,12 @@ abstract class AbstractFlashcardViewer :
         }
     }
 
+    private suspend fun prefetchAnswerMedia() {
+        withCol { currentCard?.answer(this) }?.let { html ->
+            ViewerResourceHandler.prefetch(baseContext, html)
+        }
+    }
+
     open fun displayCardQuestion() {
         Timber.d("displayCardQuestion()")
         displayAnswer = false
@@ -1315,7 +1322,8 @@ abstract class AbstractFlashcardViewer :
         } else {
             answerField?.visibility = View.GONE
         }
-        val content = cardRenderContext!!.renderCard(getColUnsafe, currentCard!!, SingleCardSide.FRONT)
+        val col = getColUnsafe
+        val content = cardRenderContext!!.renderCard(col, currentCard!!, SingleCardSide.FRONT)
         automaticAnswer.onDisplayQuestion()
         launchCatchingTask {
             if (!automaticAnswerShouldWaitForAudio()) {


### PR DESCRIPTION
Prefetch 20 media which are at most 10mb to prepare the answer side

Sometime, the answer side's image are slow to load, and I find it
frustrating as the images were already on the front side. I'm not sure
there is a good way to prepare the answer side webview because of the
javascript part, but we certainly can prepare the media.

This is what I do in a currently very naive heuristic. That is, I
search for `src="..."`, and if the part inside the quote corresponds
to a media that exists, and it weigths at most 10mb, I prefetch it so
that there is no need for file access later. Only the first 20 media
are fetched, in order to limit the memory impact. I expect that:
* most cards would actually contains less than 20 media and most media
of less than 10mb, so probably would still improve most cards,
* the memory usage is probably reasonable as it's already the usage in
the webview.

If this works well and don't cause any issue, I'd love to do the same
thing for the question side. But I'd need a back-end method that
allows to fetch the potential future question. So I want to experiment
with answer side first.

Also, when the same media appear in both side, it may be interesting
to avoid reading the file twice and instead saving the file during the
first read. This improvement would make sense to do if this experiment
is a success.

If so, doing the same thing for audio can be interesting too.
