### PR TITLE
Add tooltip in note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -36,6 +36,7 @@ import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.os.ParcelCompat
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.compat.setTooltipTextCompat
 import com.ichi2.ui.AnimationUtil.collapseView
 import com.ichi2.ui.AnimationUtil.expandView
 import java.util.Locale
@@ -62,7 +63,10 @@ class FieldEditLine : FrameLayout {
         LayoutInflater.from(context).inflate(R.layout.card_multimedia_editline, this, true)
         editText = findViewById(R.id.id_note_editText)
         label = findViewById(R.id.id_label)
-        toggleSticky = findViewById(R.id.id_toggle_sticky_button)
+        toggleSticky =
+            findViewById<ImageButton?>(R.id.id_toggle_sticky_button).apply {
+                setTooltipTextCompat(CollectionManager.TR.editingToggleSticky())
+            }
         mediaButton = findViewById(R.id.id_media_button)
         val constraintLayout: ConstraintLayout = findViewById(R.id.constraint_layout)
         expandButton = findViewById(R.id.id_expand_button)

--- a/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/card_multimedia_editline.xml
@@ -37,6 +37,7 @@
         android:layout_height="wrap_content"
         android:gravity="end|center_vertical"
         android:background="@drawable/ic_attachment"
+        android:tooltipText="@string/multimedia_editor_attach_tooltip"
         android:layout_marginEnd="16dp"
         app:layout_constraintEnd_toStartOf="@id/id_expand_button"
         app:layout_constraintTop_toTopOf="parent"/>

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -38,6 +38,7 @@
     <!-- not a good message, when an unexpected error happens -->
     <string name="multimedia_editor_something_wrong">Something went wrong</string>
     <string name="multimedia_editor_png_paste_error">Error converting clipboard image to png: %s</string>
+    <string name="multimedia_editor_attach_tooltip" comment="Appear when holding the finger  on the paperclip icon">Attach multimedia content</string>
     <string name="multimedia_editor_attach_mm_content" comment="used for screen readers. Not visible to the user">Attach multimedia content to the %1$s field</string>
 
     <!-- Audio view -->


### PR DESCRIPTION
This was missing. And the sticky was really not clear. Admittedly, still not clear if you don't know what "sticky" mean but it helps and can be searched online.