### PR TITLE
NF: Correct NoteType cache

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -75,12 +75,11 @@ class Notetypes(
     #############################################################
      */
 
-    @Suppress("ktlint:standard:backing-property-naming")
-    private var _cache: HashMap<int, NotetypeJson> = HashMap()
-
-    init {
-        _cache = HashMap()
-    }
+    /**
+     * Associating a note type id to its note type.
+     */
+    @LibAnkiAlias("_cache")
+    private val cache = HashMap<NoteTypeId, NotetypeJson>()
 
     /** Save changes made to provided note type. */
     fun save(notetype: NotetypeJson) {
@@ -103,20 +102,20 @@ class Notetypes(
 
     @LibAnkiAlias("_update_cache")
     private fun updateCache(nt: NotetypeJson) {
-        _cache[nt.id] = nt
+        cache[nt.id] = nt
     }
 
     @LibAnkiAlias("_remove_from_cache")
     private fun removeFromCache(ntid: int) {
-        _cache.remove(ntid)
+        cache.remove(ntid)
     }
 
     @LibAnkiAlias("_get_cached")
-    private fun getCached(ntid: int): NotetypeJson? = _cache[ntid]
+    private fun getCached(ntid: int): NotetypeJson? = cache[ntid]
 
     @NeedsTest("14827: styles are updated after syncing style changes")
     @LibAnkiAlias("_clear_cache")
-    fun clearCache() = _cache.clear()
+    fun clearCache() = cache.clear()
 
     /*
     # Listing note types


### PR DESCRIPTION
There was no reason:
* to have as input a int, while the ID is a long
* initialize the HashMap twice
* have a name starting with _ while we can use LibAnkiAlias

Admittedly, this is a purely theoretical concern. The chance of two distinct id having the same int value would be 1 over 2^32 (assuming that time is correctly counted in milisecond.), that is, one over 4 billion. And I am too lazy to apply the birthday paradox formula to find the risk of actual collision in one collection and over all collections

