### PR TITLE
Ensure latest notetype data is used after updates

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTypeTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.notetypes.copy
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.stripHTML
 import com.ichi2.libanki.exception.ConfirmModSchemaException
@@ -546,5 +547,28 @@ class NotetypeTest : JvmTest() {
             expected2,
             basic.did,
         )
+    }
+
+    @Test
+    fun test_updateNotetype_clears_cache() {
+        val noteType = col.notetypes.current()
+        val originalName = noteType.name
+        val noteTypeId = noteType.id
+
+        val cached1 = col.notetypes.get(noteTypeId)!!
+        assertEquals("Cached notetype should have original name", originalName, cached1.name)
+
+        val renamedNotetype =
+            col.getNotetype(noteTypeId).copy {
+                this.name = "${originalName}_renamed"
+            }
+        col.updateNotetype(renamedNotetype)
+
+        val cached2 = col.notetypes.get(noteTypeId)!!
+        assertEquals("Cached notetype should be cleared and show new name", "${originalName}_renamed", cached2.name)
+
+        val allNotetypes = col.notetypes.all()
+        val foundNotetype = allNotetypes.find { it.id == noteTypeId }!!
+        assertEquals("Notetype in all() should have new name", "${originalName}_renamed", foundNotetype.name)
     }
 }


### PR DESCRIPTION
## Purpose / Description
Ensure latest notetype data is used after updates. This is done to fix an issue where old notes name was still showing while creating a card after updating a note type's name.

## Fixes
* Fixes #18394

## Approach

The bug occurred because when a notetype was renamed via updateNotetype(), the old cached version with the original name remained in memory, causing UI components to show stale data until app restart.

With this new approach:

- removeFromCache(specificId) removes the updated notetype from cache.
- Next access to that notetype fetches fresh data from backend with new name.

## How Has This Been Tested?

Manual testing + unit test.

[Screen_recording_20250531_170034.webm](https://github.com/user-attachments/assets/6f69b0b8-687b-48d6-9aaa-1bc97bb25635)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
