### PR TITLE
Replace "reviewer" by "Study screen" in string

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/ChangeManager.kt
@@ -22,7 +22,7 @@
  * The optional handler argument can be used so that the initiator of an action can tell when a
  * OpChanges action was caused by itself. This can be useful when the default change behaviour
  * should be ignored, in favour of specific handling (eg the UI wishes to directly update the
- * displayed flag, without redrawing the entire review screen).
+ * displayed flag, without redrawing the entire study screen).
  */
 
 package com.ichi2.libanki

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -70,7 +70,7 @@
 
 
     <!-- flashcard_portrait.xml -->
-    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in Reviewer. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)" maxLength="28">Undo stroke</string>
+    <string name="undo_action_whiteboard_last_stroke" comment="One of the display patterns of 'Undo' item on the action menu in the Study Screen. It is shown as the title of the item when the whiteboard (handwriting) feature is enabled and visible and has any strokes (handwritten lines)" maxLength="28">Undo stroke</string>
     <string name="move_all_to_deck">Move all to deck</string>
     <string name="unbury" maxLength="28">Unbury</string>
     <string name="rename_deck" maxLength="28">Rename deck</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -38,7 +38,7 @@
     <string name="no_tags">You haven’t added any tags yet</string>
     <string name="updated_version">Updated to version %s</string>
 
-    <!-- Reviewer.kt -->
+    <!-- Reviewer.kt (Study Screen) -->
     <string name="save_whiteboard" maxLength="28">Save whiteboard</string>
     <string name="enable_stylus" maxLength="28">Enable stylus writing</string>
     <string name="disable_stylus">Disable stylus writing</string>
@@ -184,7 +184,7 @@
 
     <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
 
-    <!-- Whiteboard save image message in Reviewer -->
+    <!-- Whiteboard save image message in the Study Screen -->
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>
 
@@ -275,7 +275,7 @@
     <string name="external_storage_unavailable">Download aborted, the external storage is not available</string>
     <string name="home" maxLength="28">Home</string>
 
-    <!-- Reviewer actions
+    <!-- Study Screen actions
     Each of these strings ends with a period, following the notation of Anki Desktop -->
     <string name="card_buried">Card buried.</string>
     <plurals name="note_suspended">

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -183,13 +183,13 @@
         >Toggle backside only</string>
 
     <!-- Appearance settings -->
-    <string name="pref_cat_reviewer" maxLength="41">Reviewer</string>
+    <string name="pref_cat_reviewer" maxLength="41">Study Screen</string>
     <string name="show_deck_title" maxLength="41">Show deck title</string>
     <string name="accessibility" maxLength="41">Accessibility</string>
     <!-- Paste clipboard image as png option -->
     <string name="paste_as_png" maxLength="41">Paste clipboard images as PNG</string>
     <string name="exit_via_double_tap_back" maxLength="41">Press back twice to go back/exit</string>
-    <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the reviewer or the app</string>
+    <string name="exit_via_double_tap_back_summ">To avoid accidentally leaving the study screen or the app</string>
     <!-- Allow all files in media imports -->
     <string name="media_import_allow_all_files" maxLength="41">Allow all files in media imports</string>
     <string name="media_import_allow_all_files_summ">If Android doesn’t recognize a media file</string>
@@ -243,7 +243,7 @@
     <string name="note_editor_replace_newlines_summ">In the Note Editor, convert any instances of &lt;br&gt; to newlines when editing a card.</string>
     
     <string name="type_in_answer_focus" maxLength="41">Focus ‘type in answer’</string>
-    <string name="type_in_answer_focus_summ">Automatically focus the ‘type in answer’ field in the reviewer</string>
+    <string name="type_in_answer_focus_summ">Automatically focus the ‘type in answer’ field in the study screen</string>
 
     <!-- About -->
     <string name="open_changelog">Open Changelog</string>
@@ -262,7 +262,7 @@
     <string name="binding_add_axis">Add joystick/motion controller</string>
     <string name="axis_picker_move_joystick">Move a joystick/motion controller</string>
     <string name="user_actions" maxLength="41">User actions</string>
-    <string name="user_actions_summary" maxLength="41">Trigger JavaScript from the review screen</string>
+    <string name="user_actions_summary" maxLength="41">Trigger JavaScript from the study screen</string>
     <string name="user_action_1" maxLength="28">User action 1</string>
     <string name="user_action_2" maxLength="28">User action 2</string>
     <string name="user_action_3" maxLength="28">User action 3</string>
@@ -442,9 +442,9 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <string name="hide_answer_buttons" maxLength="41">Hide answer buttons</string>
     <string name="hide_hard_and_easy" maxLength="41">Hide ‘Hard’ and ‘Easy’ buttons</string>
     <string name="reviewer_frame_style" maxLength="41">Frame style</string>
-    <string name="reviewer_frame_style_card" maxLength="41" comment="Style name of the 'Card' card frame of the Reviewer"
+    <string name="reviewer_frame_style_card" maxLength="41" comment="Style name of the 'Card' card frame of the Study Screen"
         >Card</string>
-    <string name="reviewer_frame_style_box" maxLength="41" comment="Style name of the 'Box' card frame of the Reviewer"
+    <string name="reviewer_frame_style_box" maxLength="41" comment="Style name of the 'Box' card frame of the Study Screen"
         >Box</string>
 
     <!--Keyboard shortcuts dialog-->

--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -70,7 +70,7 @@
     <string name="answer_good" maxLength="41">Answer good</string>
     <string name="answer_easy" maxLength="41">Answer easy</string>
     <string name="gesture_play" maxLength="41">Play media</string>
-    <string name="gesture_abort_learning" maxLength="41">Close reviewer</string>
+    <string name="gesture_abort_learning" maxLength="41">Close study screen</string>
     <string name="gesture_flag_red" maxLength="41">Toggle Red Flag</string>
     <string name="gesture_flag_orange" maxLength="41">Toggle Orange Flag</string>
     <string name="gesture_flag_green" maxLength="41">Toggle Green Flag</string>
@@ -81,7 +81,7 @@
     <string name="gesture_flag_remove" maxLength="41">Remove Flag</string>
     <string name="gesture_page_up" maxLength="41">Page Up</string>
     <string name="gesture_page_down" maxLength="41">Page Down</string>
-    <string name="gesture_abort_sync" maxLength="41">Close reviewer and Sync</string>
+    <string name="gesture_abort_sync" maxLength="41">Close study screen and Sync</string>
     <string name="gesture_toggle_whiteboard" maxLength="41">Toggle Whiteboard</string>
     <string name="gesture_show_hint" maxLength="41">Show Hint</string>
     <string name="gesture_show_all_hints" maxLength="41">Show All Hints</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -96,7 +96,7 @@
     <attr name="reviewCountColor" format="color"/>
     <attr name="zeroCountColor" format="color"/>
     <attr name="buryCountColor" format="color"/>
-    <!-- Reviewer button backgrounds -->
+    <!-- Study Screen button backgrounds -->
     <attr name="answerButtonBackground" format="color"/>
     <attr name="againButtonBackground" format="color"/>
     <attr name="hardButtonBackground" format="color"/>
@@ -112,7 +112,7 @@
     <attr name="hardButtonRippleRef" format="reference"/>
     <attr name="goodButtonRippleRef" format="reference"/>
     <attr name="easyButtonRippleRef" format="reference"/>
-    <!-- Reviewer button text colors-->
+    <!-- Study Screen button text colors-->
     <attr name="answerButtonTextColor" format="color"/>
     <attr name="againButtonTextColor" format="color"/>
     <attr name="hardButtonTextColor" format="color"/>
@@ -120,7 +120,7 @@
     <attr name="easyButtonTextColor" format="color"/>
     <!-- Card Browser Colors -->
     <attr name="cardBrowserDivider" format="color"/>
-    <!-- Reviewer other colors -->
+    <!-- Study Screen other colors -->
     <attr name="topBarColor" format="color"/>
     <attr name="maxTimerColor" format="color"/>
     <attr name="alternativeBackgroundColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -225,7 +225,7 @@
     <string name="pref_weekly_backups_to_keep_key">weekly_backups_to_keep</string>
     <string name="pref_monthly_backups_to_keep_key">monthly_backups_to_keep</string>
 
-    <!-- Reviewer options -->
+    <!-- Study Screen options -->
     <string name="hide_system_bars_key">hideSystemBars</string>
     <string name="ignore_display_cutout_key">ignoreDisplayCutout</string>
     <string name="hide_answer_buttons_key">hideAnswerButtons</string>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -41,7 +41,7 @@
         <item name="reviewCountColor">@color/material_green_400</item>
         <item name="buryCountColor">@color/disabled_gray_dark</item>
         <item name="zeroCountColor">#202020</item>
-        <!-- Reviewer colors -->
+        <!-- Study Screen colors -->
         <item name="showAnswerColor">@color/theme_black_primary</item>
         <item name="topBarColor">@color/theme_black_primary</item>
         <item name="maxTimerColor">@color/material_red_300</item>
@@ -51,7 +51,7 @@
         <item name="goodButtonTextColor">@color/material_green_400</item>
         <item name="easyButtonTextColor">@color/material_blue_700</item>
         <item name="alternativeBackgroundColor">#101010</item>
-        <!-- Reviewer button drawables -->
+        <!-- Study Screen button drawables -->
         <item name="againButtonRef">@drawable/footer_button_all_black</item>
         <item name="hardButtonRef">@drawable/footer_button_all_black</item>
         <item name="goodButtonRef">@drawable/footer_button_all_black</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -64,7 +64,7 @@
         <item name="reviewCountColor">@color/material_green_200</item>
         <item name="buryCountColor">@color/disabled_gray_dark</item>
         <item name="zeroCountColor">#404040</item>
-        <!-- Reviewer colors -->
+        <!-- Study Screen colors -->
         <item name="againButtonBackground">@color/material_red_800</item>
         <item name="hardButtonBackground">@color/material_blue_grey_800</item>
         <item name="goodButtonBackground">@color/material_green_800</item>
@@ -77,7 +77,7 @@
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
         <item name="alternativeBackgroundColor">#2a2a2a</item>
-        <!-- Reviewer button drawables -->
+        <!-- Study Screen button drawables -->
         <item name="showAnswerColor">@color/material_blue_grey_800</item>
         <item name="againButtonRef">@drawable/footer_button_again_dark</item>
         <item name="hardButtonRef">@drawable/footer_button_hard_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -56,7 +56,7 @@
         <item name="reviewCountColor">@color/material_green_700</item>
         <item name="buryCountColor">@color/disabled_gray_light</item>
         <item name="zeroCountColor">#1f000000</item>
-        <!-- Reviewer colors -->
+        <!-- Study Screen colors -->
         <item name="againButtonBackground">@color/material_red_700</item>
         <item name="hardButtonBackground">@color/material_blue_grey_700</item>
         <item name="goodButtonBackground">@color/material_green_500</item>
@@ -69,7 +69,7 @@
         <item name="goodButtonTextColor">@color/white</item>
         <item name="easyButtonTextColor">@color/white</item>
         <item name="alternativeBackgroundColor">#f4f5f9</item>
-        <!-- Reviewer button drawables -->
+        <!-- Study Screen button drawables -->
         <item name="showAnswerColor">@color/material_blue_grey_700</item>
         <item name="againButtonRef">@drawable/footer_button_again</item>
         <item name="hardButtonRef">@drawable/footer_button_hard</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -23,9 +23,9 @@
         <!-- Tab layout -->
         <item name="tabLayoutBackgroundColor">@color/theme_plain_primary</item>
         <item name="tabActiveIconColor">@color/white</item>
-        <!-- Reviewer colors -->
+        <!-- Study Screen colors -->
         <item name="topBarColor">@color/theme_plain_primary_light</item>
-        <!-- Reviewer button drawables -->
+        <!-- Study Screen button drawables -->
         <item name="showAnswerColor">@color/theme_plain_primary</item>
         <item name="againButtonRef">@drawable/footer_button_all_plain</item>
         <item name="hardButtonRef">@drawable/footer_button_all_plain</item>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -96,11 +96,11 @@
         android:summary="Only for testing. Not suited for use. Don't create reports about them">
 
         <SwitchPreferenceCompat
-            android:title="New reviewer"
+            android:title="New study screen"
             android:key="@string/new_reviewer_pref_key"
             android:defaultValue="false"/>
         <Preference
-            android:title="New reviewer options"
+            android:title="New study screen options"
             android:key="@string/new_reviewer_options_key"
             android:dependency="@string/new_reviewer_pref_key"
             android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"/>


### PR DESCRIPTION
Those strings were found by looking for "reviewer" (case insensitive) in the values folder. And also trying to look at experimental settings for the new reviewer.

This is consistent with Anki documentation. And more consistent with English it seems.

It may be worth waiting for
https://github.com/ankitects/anki-manual/issues/341 to be resolved by Dae in case we want to rename the screen to Study screen.

I must note that changing a string comment don't require a new translation. So the translators will only have to retranslate the strings that actually changed.

Also, given how badly "reviewer" was translated in French, (And I suspect in other language) a new translation will certainly be an improvement.
