### PR TITLE
chore: Update Apache changelog URLs to new structure

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ colorpicker = "1.2.0"
 commonsCollections4 = "4.5.0"
 # https://commons.apache.org/proper/commons-compress/changes-report.html
 commonsCompress = "1.27.1"
-# https://commons.apache.org/proper/commons-io/changes-report.html
+# https://commons.apache.org/proper/commons-io/changes.html
 commonsIo = "2.19.0"
 coroutines = '1.10.2'
 desugar-jdk-libs-nio = "2.1.5"


### PR DESCRIPTION
## Purpose / Description
Update outdated Apache changelog URLs in `gradle/libs.versions.toml` to reflect the new structure (`changes-report.html` → `changes.html`).

## Fixes
* Fixes AnkiDroid/Anki-Android#18368

## Approach
Replaced Apache changelog URLs ending in `changes-report.html` with `changes.html` wherever required in the `toml` file.

## How Has This Been Tested?
- This is a metadata-only change.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
