### PR TITLE
fix(previewer): update after IO changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -23,7 +23,6 @@ import android.view.Menu
 import android.view.MenuItem
 import android.view.View
 import android.webkit.WebView
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
@@ -261,15 +260,10 @@ class PreviewerFragment :
         }
     }
 
-    private val editCardLauncher =
-        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            viewModel.handleEditCardResult(result)
-        }
-
     private fun editCard() {
         lifecycleScope.launch {
             val intent = viewModel.getNoteEditorDestination().toIntent(requireContext())
-            editCardLauncher.launch(intent)
+            startActivity(intent)
         }
     }
 


### PR DESCRIPTION
Handle changes with opExecuted instead of using an activity result

Similar to https://github.com/ankidroid/Anki-Android/pull/18273/commits/ad778b9f02042acc92b076231b1d9af2ec3301a4

## Fixes
* Fixes #18405

## How Has This Been Tested?

Emulator 35:
1. Have an Image Occlusion Note
2. Go to the Browser and preview an Image occlusion note
3. Edit the note
4. See the changes

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
