### PR TITLE
fix(custom-study): defer loading of 'customStudyDefaults'

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.dialogs.utils.performPositiveClick
 import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Consts
+import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiFragmentScenario
 import com.ichi2.testutils.isJsonEqual
@@ -217,20 +218,28 @@ class CustomStudyDialogTest : RobolectricTest() {
                 }
         }
 
-    private fun argumentsDisplayingSubscreen(subscreen: ContextMenuOption) =
-        requireNotNull(
+    private fun argumentsDisplayingSubscreen(subscreen: ContextMenuOption): Bundle {
+        @Suppress("RedundantValueArgument")
+        fun setupDefaultValuesSingleton() {
+            withCustomStudyFragment(argumentsDisplayingMainScreen(deckId = Consts.DEFAULT_DECK_ID)) { }
+        }
+
+        setupDefaultValuesSingleton()
+
+        return requireNotNull(
             CustomStudyDialog
-                .createInstance(
+                .createSubDialog(
                     deckId = Consts.DEFAULT_DECK_ID,
                     contextMenuAttribute = subscreen,
                 ).arguments,
         )
+    }
 
-    private fun argumentsDisplayingMainScreen() =
+    private fun argumentsDisplayingMainScreen(deckId: DeckId = Consts.DEFAULT_DECK_ID) =
         requireNotNull(
             CustomStudyDialog
                 .createInstance(
-                    deckId = Consts.DEFAULT_DECK_ID,
+                    deckId = deckId,
                 ).arguments,
         )
 


### PR DESCRIPTION
## Purpose / Description

Speeds up dialog appearance

This takes > 100ms on my phone, and was reported to take >1s on larger collections

## Fixes
* Fixes #18416

## Approach
* load 'defaults' async
  * if it loads before we build the initial dialog, no change
  * if it loads after the initial dialog, if appropriate, update the UI to disable 'increase limit' options
* if a 'increase limit' option is clicked
  * wait for defaults to load, and inform the user if unavailable

## How Has This Been Tested?
Tested with `delay(5_000)` inside loadCustomStudyDefaults

* menu items were made unavailable
* Clicking the item worked if valid
* Clicking the item showed a snackbar if invalid, dialog was still usable


## Learning (optional, can help others)
Issue introduced in caadde7034cd4bc559f5e424e8a786f7ba1ecca1

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
