### PR TITLE
fix: Can't create IO note if image filename contains special chars

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.View
 import android.webkit.WebView
@@ -127,16 +128,16 @@ class ImageOcclusion : PageFragment(R.layout.image_occlusion) {
         ): Intent {
             val suffix =
                 if (kind == "edit") {
-                    "/$noteOrNotetypeId"
+                    noteOrNotetypeId
                 } else {
-                    imagePath
+                    Uri.encode(imagePath)
                 }
             val arguments =
                 bundleOf(
                     ARG_KEY_KIND to kind,
                     ARG_KEY_ID to noteOrNotetypeId,
                     ARG_KEY_PATH to imagePath,
-                    PATH_ARG_KEY to "image-occlusion$suffix",
+                    PATH_ARG_KEY to "image-occlusion/$suffix",
                     ARG_KEY_EDITOR_DECK_ID to editorWorkingDeckId,
                 )
             return SingleFragmentActivity.getIntent(context, ImageOcclusion::class, arguments)


### PR DESCRIPTION
## Fixes
* Fixes #18173

## Approach

https://github.com/ankidroid/Anki-Android/pull/18193#issuecomment-2781225140

## How Has This Been Tested?

Tested on an emulator and on my phone

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
