### PR TITLE
Deck toggles should not show when inapplicable in a search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -114,6 +114,7 @@ import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.deckpicker.EmptyCardsResult
+import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.BackupPromptDialog
 import com.ichi2.anki.dialogs.ConfirmationDialog
@@ -1047,7 +1048,7 @@ open class DeckPicker :
                             val selectedDeckId = withCol { decks.current().getLong("id") }
                             dueTree?.let {
                                 adapter.submit(
-                                    data = it.filterAndFlatten(newText),
+                                    data = it.filterAndFlattenDisplay(newText),
                                     hasSubDecks = it.children.any { deckNode -> deckNode.children.any() },
                                     currentDeckId = selectedDeckId,
                                 )
@@ -2330,7 +2331,7 @@ open class DeckPicker :
             return
         }
         deckListAdapter.submit(
-            data = tree.filterAndFlatten(currentFilter),
+            data = tree.filterAndFlattenDisplay(currentFilter),
             hasSubDecks = tree.children.any { it.children.any() },
             currentDeckId = withCol { decks.current().getLong("id") },
         )
@@ -2356,7 +2357,7 @@ open class DeckPicker :
     /**
      * Get the [DeckNode] identified by [did] from [DeckAdapter].
      */
-    private fun DeckPicker.getNodeByDid(did: DeckId): DeckNode = deckListAdapter.currentList[findDeckPosition(did)]
+    private fun DeckPicker.getNodeByDid(did: DeckId): DeckNode = deckListAdapter.currentList[findDeckPosition(did)].deckNode
 
     fun exportDeck(did: DeckId) {
         ExportDialogFragment.newInstance(did).show(supportFragmentManager, "exportOptions")
@@ -2394,7 +2395,7 @@ open class DeckPicker :
 
     /** Disables the shortcut of the deck and the children belonging to it.*/
     private fun disableDeckAndChildrenShortcuts(did: DeckId) {
-        val childDids = dueTree?.find(did)?.filterAndFlatten(null)?.map { it.did.toString() } ?: listOf()
+        val childDids = dueTree?.find(did)?.filterAndFlattenDisplay(null)?.map { it.did.toString() } ?: listOf()
         val deckTreeDids = listOf(did.toString(), *childDids.toTypedArray())
         val errorMessage: CharSequence = getString(R.string.deck_shortcut_doesnt_exist)
         ShortcutManagerCompat.disableShortcuts(this, deckTreeDids, errorMessage)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
@@ -1,0 +1,142 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2025 Gautam Bhetanabhotla <gautamarcturus@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.deckpicker
+
+import android.annotation.SuppressLint
+import androidx.annotation.VisibleForTesting
+import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.sched.DeckNode
+import com.ichi2.libanki.utils.append
+import java.util.Locale
+
+/**
+ * An immutable variant of a [DeckNode]. Instantiated right before
+ * we want to display it. The list being submitted to the [ListViewAdapter]
+ * is a list of [DisplayDeckNode]s. This class only contains the information
+ * needed to display it on the screen, hence no data of a node's children and parent.
+ */
+data class DisplayDeckNode(
+    val did: DeckId,
+    val fullDeckName: String,
+    val lastDeckNameComponent: String,
+    val collapsed: Boolean,
+    val canCollapse: Boolean,
+    val depth: Int,
+    val filtered: Boolean,
+    val newCount: Int,
+    val lrnCount: Int,
+    val revCount: Int,
+) {
+    // DeckNode is mutable, so use a lateinit var so '==' doesn't include it in the comparison
+    lateinit var deckNode: DeckNode
+
+    companion object {
+        fun from(
+            node: DeckNode,
+            matchesSearchOrChild: Boolean,
+        ): DisplayDeckNode =
+            DisplayDeckNode(
+                did = node.did,
+                fullDeckName = node.fullDeckName,
+                lastDeckNameComponent = node.lastDeckNameComponent,
+                collapsed = node.collapsed,
+                canCollapse = node.children.any() && matchesSearchOrChild,
+                depth = node.depth,
+                filtered = node.filtered,
+                newCount = node.newCount,
+                lrnCount = node.lrnCount,
+                revCount = node.revCount,
+            ).apply {
+                this.deckNode = node
+            }
+    }
+}
+
+/** Convert the tree into a flat list of [DisplayDeckNode]s, where matching decks and the children/parents
+ * are included. Decks inside collapsed decks are not considered. */
+fun DeckNode.filterAndFlattenDisplay(filter: CharSequence?): List<DisplayDeckNode> {
+    val filterPattern =
+        if (filter.isNullOrBlank()) {
+            null
+        } else {
+            filter.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
+        }
+    val list = mutableListOf<DisplayDeckNode>()
+    filterAndFlattenDisplayInner(filterPattern, list, false)
+    return list
+}
+
+private fun DeckNode.filterAndFlattenDisplayInner(
+    filter: CharSequence?,
+    list: MutableList<DisplayDeckNode>,
+    parentMatched: Boolean,
+) {
+    if (node.level > 0 && (nameMatchesFilter((filter)) || parentMatched)) {
+        addVisibleToList(list, true)
+        return
+    }
+
+    // When searching, ignore collapsed state and always search children
+    val searching = filter != null
+    if (collapsed && !searching) {
+        return
+    }
+
+    if (node.level > 0) {
+        list.append(DisplayDeckNode.from(this, false))
+    }
+    val startingLen = list.size
+    for (child in children) {
+        child.filterAndFlattenDisplayInner(filter, list, false)
+    }
+    if (node.level > 0 && startingLen == list.size) {
+        // we don't include ourselves if no children matched
+        list.removeAt(list.lastIndex)
+    }
+}
+
+private fun DeckNode.addVisibleToList(
+    list: MutableList<DisplayDeckNode>,
+    matchesSearchOrChild: Boolean,
+) {
+    list.append(DisplayDeckNode.from(this, matchesSearchOrChild))
+    if (!collapsed) {
+        for (child in children) {
+            child.addVisibleToList(list, matchesSearchOrChild)
+        }
+    }
+}
+
+@VisibleForTesting
+fun DeckNode.addVisibleToList(list: MutableList<DeckNode>) {
+    list.append(this)
+    if (!collapsed) {
+        for (child in children) {
+            child.addVisibleToList(list)
+        }
+    }
+}
+
+@SuppressLint("LocaleRootUsage")
+private fun DeckNode.nameMatchesFilter(filter: CharSequence?): Boolean {
+    return if (filter == null) {
+        true
+    } else {
+        return node.name.lowercase(Locale.getDefault()).contains(filter) || node.name.lowercase(Locale.ROOT).contains(filter)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckAdapterFilterTest.kt
@@ -16,6 +16,8 @@
 package com.ichi2.anki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.deckpicker.addVisibleToList
+import com.ichi2.libanki.filterAndFlatten
 import com.ichi2.libanki.sched.DeckNode
 import org.junit.Assert
 import org.junit.Test

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/DeckNodeTest.kt
@@ -18,6 +18,7 @@
 package com.ichi2.libanki
 
 import anki.decks.deckTreeNode
+import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
 import com.ichi2.libanki.sched.DeckNode
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -108,3 +109,5 @@ class DeckNodeTest {
         assertEquals(emptyList<String>(), results.map { it.lastDeckNameComponent })
     }
 }
+
+fun DeckNode.filterAndFlatten(filter: CharSequence?) = this.filterAndFlattenDisplay(filter).map { it.deckNode }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When searching for decks in the main menu, parents of matching decks are also rendered but their expand/collapse toggles were unnecessary as the toggles don't work during a search. This PR aims to not render those toggles at all.

### Before
![image](https://github.com/user-attachments/assets/18dfc4ca-4896-4eab-a870-31dacf5db448)

### After
![image](https://github.com/user-attachments/assets/c6469c6e-deb0-4d74-84ab-0896b8a3a652)

Note that toggles for matching decks and their children are still active and functional.

## Fixes
* Fixes #18278
* Fixes #18379 

## Approach
Created a new property for `DeckNode`, namely `var matchingSearchOrChild: Boolean`. This is set to `true` for all decks matching the search query or having an ancestor which matches the query. Only these decks have active and functioning toggles. The other visible decks will not have their toggles rendered. This requires updating the diff checker for the list adapter to also check for update in the `matchingSearchOrChild` property. Since both lists hold a reference to the same node, the diff checker cannot catch a change in this property. Hence I tracked changes in `DeckNode` itself by adding a `previouslyMatchingSearchOrChild` property. Every time the search query changes, `previouslyMatchingSearchOrChild` takes on the value of `matchingSearchOrChild` and the latter gets adjusted according to the deck's name and the query.

## How Has This Been Tested?

Manual tests on
1. An android device
2. An android emulator (medium phone API 35)

## Learning (optional, can help others)
A significant pitfall I faced in this process was that the `filterAndFlatten` (which returns a list of `DeckNode`s and their children matching the search query) could not be modified to simply return a list of _copies_ of the original `DeckNode`s, as the toggle functionality (when the search bar isn't active) checks the `collapsed` property of the original node. Duplicating it caused problems. On the other hand, simply updating the boolean did not trigger the diff checker, leading to the list not re-rendering to show the correct result. I had also considered inserting a dummy `DeckNode`  right before returning the list to manually trigger the diff checker but decided to go with the 2 boolean approach as described previously.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
