### PR TITLE
Fix lint warnings related to trim() function

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -1344,7 +1344,7 @@ open class CardTemplateEditor :
                 if (!m.find()) {
                     afmt.replace("{{FrontSide}}", "")
                 } else {
-                    m.group(2)!!.trim { it <= ' ' }
+                    m.group(2)!!.trim()
                 }
             template.afmt = "{{FrontSide}}\n\n<hr id=answer>\n\n$qfmt"
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MyAccount.kt
@@ -129,7 +129,7 @@ open class MyAccount : AnkiActivity() {
     }
 
     private fun attemptLogin() {
-        val username = username.text.toString().trim { it <= ' ' } // trim spaces, issue 1586
+        val username = username.text.toString().trim() // trim spaces, issue 1586
         val password = password.text.toString()
         if (username.isEmpty() || password.isEmpty()) {
             Timber.i("Auto-login cancelled - username/password missing")
@@ -143,7 +143,7 @@ open class MyAccount : AnkiActivity() {
         // Hide soft keyboard
         val inputMethodManager = getSystemService(INPUT_METHOD_SERVICE) as InputMethodManager
         inputMethodManager.hideSoftInputFromWindow(username.windowToken, 0)
-        val username = username.text.toString().trim { it <= ' ' } // trim spaces, issue 1586
+        val username = username.text.toString().trim() // trim spaces, issue 1586
         val password = password.text.toString()
         handleNewLogin(username, password, notificationPermissionLauncher)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -2565,7 +2565,7 @@ class NoteEditor :
                 R.string.CardEditorTags,
                 getColUnsafe.tags
                     .join(getColUnsafe.tags.canonify(selectedTags!!))
-                    .trim { it <= ' ' }
+                    .trim()
                     .replace(" ", ", "),
             )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -178,7 +178,7 @@ class NoteTypeFieldEditor : AnkiActivity() {
             }
             offset++
         }
-        input = input.substring(offset).trim { it <= ' ' }
+        input = input.substring(offset).trim()
         if (input.isEmpty()) {
             showThemedToast(this, resources.getString(R.string.toast_empty_name), true)
             return null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -414,7 +414,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
                 constraint: CharSequence,
                 items: List<DeckNode>,
             ): List<DeckNode> {
-                val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
+                val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim()
                 return items.filter {
                     it.fullDeckName.lowercase(Locale.getDefault()).contains(filterPattern)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -436,7 +436,7 @@ class TagsArrayAdapter(
             items: List<String>,
         ): List<String> {
             val shownTags = TreeSet<String>()
-            val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
+            val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim()
             val crucialTags =
                 items.filter {
                     it.lowercase(Locale.getDefault()).contains(filterPattern)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -320,14 +320,14 @@ class CardContentProvider : ContentProvider() {
                         try {
                             // check if value is a placeholder ("?"), if so replace with the next value of selectionArgs
                             val value =
-                                if ("?" == keyAndValue[1].trim { it <= ' ' }) {
+                                if ("?" == keyAndValue[1].trim()) {
                                     selectionArgs!![selectionArgIndex++]
                                 } else {
                                     keyAndValue[1]
                                 }
-                            if ("limit" == keyAndValue[0].trim { it <= ' ' }) {
+                            if ("limit" == keyAndValue[0].trim()) {
                                 limit = value.toInt()
-                            } else if ("deckID" == keyAndValue[0].trim { it <= ' ' }) {
+                            } else if ("deckID" == keyAndValue[0].trim()) {
                                 deckIdOfTemporarilySelectedDeck = value.toLong()
                                 if (!selectDeckWithCheck(col, deckIdOfTemporarilySelectedDeck)) {
                                     return rv // if the provided deckID is wrong, return empty cursor.
@@ -1364,7 +1364,7 @@ fun Card.pureAnswer(col: Collection): String {
     for (target in arrayOf("<hr id=answer>", "<hr id=\"answer\">")) {
         val pos = s.indexOf(target)
         if (pos == -1) continue
-        return s.substring(pos + target.length).trim { it <= ' ' }
+        return s.substring(pos + target.length).trim()
     }
     // neither found
     return s

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/DB.kt
@@ -189,7 +189,7 @@ class DB(
         sql: String,
         vararg `object`: Any?,
     ) {
-        val s = sql.trim { it <= ' ' }.lowercase()
+        val s = sql.trim().lowercase()
         // mark modified?
         for (mo in MOD_SQL_STATEMENTS) {
             if (s.startsWith(mo)) {

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -669,7 +669,7 @@ class Decks(
         const val DECK_SEPARATOR = "::"
 
         @NotInLibAnki
-        fun isValidDeckName(deckName: String): Boolean = deckName.trim { it <= ' ' }.isNotEmpty()
+        fun isValidDeckName(deckName: String): Boolean = deckName.trim().isNotEmpty()
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/NotetypeJson.kt
@@ -121,7 +121,7 @@ value class NotetypeJson(
         sfld
             .zip(fieldsNames)
             // filter to the fields which are non-empty
-            .filter { (sfld, _) -> sfld.trim { it <= ' ' }.isNotEmpty() }
+            .filter { (sfld, _) -> sfld.trim().isNotEmpty() }
             .mapTo(HashSet()) { (_, fieldName) -> fieldName }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DeckNode.kt
@@ -103,7 +103,7 @@ data class DeckNode(
             if (filter.isNullOrBlank()) {
                 null
             } else {
-                filter.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
+                filter.toString().lowercase(Locale.getDefault()).trim()
             }
         val list = mutableListOf<DeckNode>()
         filterAndFlattenInner(filterPattern, list)

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -100,7 +100,7 @@ class StepsPreference :
             for (step in stepsAr.stringIterable()) {
                 sb.append(step).append(" ")
             }
-            sb.toString().trim { it <= ' ' }
+            sb.toString().trim()
         }
     }
 
@@ -120,7 +120,7 @@ class StepsPreference :
             for (s in a.stringIterable()) {
                 sb.append(s).append(" ")
             }
-            return sb.toString().trim { it <= ' ' }
+            return sb.toString().trim()
         }
 
         /**
@@ -132,7 +132,7 @@ class StepsPreference :
          */
         fun convertToJSON(steps: String): JSONArray? {
             val stepsAr = JSONArray()
-            val stepsTrim = steps.trim { it <= ' ' }
+            val stepsTrim = steps.trim()
             if (steps.isEmpty()) {
                 return stepsAr
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -74,10 +74,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertTrue("Note type did not change after edit?", testEditor.noteTypeHasChanged())
         assertEquals(
             "Change already in database?",
-            collectionBasicNoteTypeOriginal.toString().trim {
-                it <= ' '
-            },
-            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+            collectionBasicNoteTypeOriginal.toString().trim(),
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
         )
 
         // Kill and restart the Activity, make sure note type edit is preserved
@@ -97,10 +95,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertTrue("note type change not preserved across activity lifecycle?", testEditor.noteTypeHasChanged())
         assertEquals(
             "Change already in database?",
-            collectionBasicNoteTypeOriginal.toString().trim {
-                it <= ' '
-            },
-            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+            collectionBasicNoteTypeOriginal.toString().trim(),
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
         )
 
         // Make sure we get a confirmation dialog if we hit the back button
@@ -143,10 +139,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Previewer not started?", CardViewerActivity::class.java.name, shadowIntent.intentClass.name)
         assertEquals(
             "Change already in database?",
-            collectionBasicNoteTypeOriginal.toString().trim {
-                it <= ' '
-            },
-            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+            collectionBasicNoteTypeOriginal.toString().trim(),
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
         )
         shadowTestEditor.receiveResult(startedIntent, Activity.RESULT_OK, Intent())
 
@@ -159,10 +153,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
             "note type did not save?",
-            testEditorNoteTypeEdited.toString().trim {
-                it <= ' '
-            },
-            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
+            testEditorNoteTypeEdited.toString().trim(),
+            collectionBasicNoteTypeCopyEdited.toString().trim(),
         )
         assertTrue("Note type does not have our change?", collectionBasicNoteTypeCopyEdited.toString().contains(testNoteTypeQfmtEdit))
     }
@@ -207,10 +199,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         )
         assertEquals(
             "Change already in database?",
-            collectionBasicNoteTypeOriginal.toString().trim {
-                it <= ' '
-            },
-            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+            collectionBasicNoteTypeOriginal.toString().trim(),
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
         )
 
         // Save the change to the database and make sure there's only one template after
@@ -221,10 +211,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
             "Note type did not save?",
-            testEditorNoteTypeEdited.toString().trim {
-                it <= ' '
-            },
-            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
+            testEditorNoteTypeEdited.toString().trim(),
+            collectionBasicNoteTypeCopyEdited.toString().trim(),
         )
     }
 
@@ -266,10 +254,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertEquals("Previewer not started?", CardViewerActivity::class.java.name, shadowIntent.intentClass.name)
         assertEquals(
             "Change already in database?",
-            collectionBasicNoteTypeOriginal.toString().trim {
-                it <= ' '
-            },
-            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+            collectionBasicNoteTypeOriginal.toString().trim(),
+            getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
         )
 
         // Save the change to the database and make sure there are two templates after
@@ -280,10 +266,8 @@ class CardTemplateEditorTest : RobolectricTest() {
         assertNotEquals("Note type is unchanged?", collectionBasicNoteTypeOriginal, collectionBasicNoteTypeCopyEdited)
         assertEquals(
             "Note type did not save?",
-            testEditorNoteTypeEdited.toString().trim {
-                it <= ' '
-            },
-            collectionBasicNoteTypeCopyEdited.toString().trim { it <= ' ' },
+            testEditorNoteTypeEdited.toString().trim(),
+            collectionBasicNoteTypeCopyEdited.toString().trim(),
         )
     }
 
@@ -366,10 +350,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             )
             assertEquals(
                 "Change already in database?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertFalse("Ordinal pending add?", testEditor.tempNoteType.isOrdinalPendingAdd(0))
             assertEquals("Change incorrectly added to list?", 0, testEditor.templateChangeCount)
@@ -453,10 +435,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no change?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertEquals("Note type should have 2 templates still", 2, testEditor.tempNoteType?.templateCount)
 
@@ -549,10 +529,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertNull("Can delete all templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1, 2))
             assertEquals(
                 "Change already in database?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertEquals(
                 "Change added but not adjusted correctly?",
@@ -576,10 +554,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             advanceRobolectricLooperWithSleep()
             assertNotEquals(
                 "Change not in database?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertEquals("Note type should have 2 templates now", 2, getCurrentDatabaseNoteTypeCopy(noteTypeName).templates.length())
             assertEquals("should be two cards", 2, getNoteTypeCardCount(collectionBasicNoteTypeOriginal))
@@ -639,10 +615,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no save?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertEquals("Note type should have 1 template", 1, testEditor.tempNoteType?.templateCount)
 
@@ -675,10 +649,8 @@ class CardTemplateEditorTest : RobolectricTest() {
             assertNull("Can delete both templates?", collectionBasicNoteTypeOriginal.getCardIds(0, 1))
             assertEquals(
                 "Change in database despite no save?",
-                collectionBasicNoteTypeOriginal.toString().trim {
-                    it <= ' '
-                },
-                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim { it <= ' ' },
+                collectionBasicNoteTypeOriginal.toString().trim(),
+                getCurrentDatabaseNoteTypeCopy(noteTypeName).toString().trim(),
             )
             assertEquals("Note type should have 1 template", 1, testEditor.tempNoteType?.templateCount)
 

--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -52,7 +52,7 @@ internal object Utils {
         return tags.joinToString(" ")
     }
 
-    fun splitTags(tags: String): Array<String> = tags.trim { it <= ' ' }.split("\\s+".toRegex()).toTypedArray()
+    fun splitTags(tags: String): Array<String> = tags.trim().split("\\s+".toRegex()).toTypedArray()
 
     fun fieldChecksum(data: String): Long {
         val strippedData = stripHTMLMedia(data)

--- a/lint-rules/src/main/java/com/ichi2/anki/lint/utils/StringFormatDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/utils/StringFormatDetector.kt
@@ -44,7 +44,7 @@ object StringFormatDetector {
     ) {
         val nodeType = node.nodeType
         if (nodeType == Node.TEXT_NODE || nodeType == Node.CDATA_SECTION_NODE) {
-            sb.append(stripQuotes(node.nodeValue.trim { it <= ' ' }))
+            sb.append(stripQuotes(node.nodeValue.trim()))
         } else {
             val childNodes = node.childNodes
             var i = 0


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Small fix for a lint warning related to the usage of the trim() function. I did this mostly because when the code quality action fails these warnings appear and I have to scroll through all of them to see the actual errors(ex. strings issues). See a [failed action run](https://github.com/ankidroid/Anki-Android/actions/runs/15511609111/job/43673269978).

## How Has This Been Tested?

Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
