### PR TITLE
improvement(browse): remove bottom padding

### DIFF
--- a/AnkiDroid/src/main/res/layout/cardbrowser.xml
+++ b/AnkiDroid/src/main/res/layout/cardbrowser.xml
@@ -38,8 +38,6 @@
             android:layout_height="match_parent"
             android:background="?android:attr/colorBackground"
             android:overScrollFooter="@color/transparent"
-            android:clipToPadding="false"
-            android:paddingBottom="72dp"
             android:drawSelectorOnTop="true"
             tools:listitem="@layout/card_item_browser"
             />


### PR DESCRIPTION
Added in f0e4ceb6237002ed3c9ab21b99081fc744b930fd for flags 

This was reverted, but the padding remained

This caused blank space after scrolling to the bottom of the list in the Browse window

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
