### PR TITLE
fix: Remove 'shake device' maracas emoji [<= API 30]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.cardviewer
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.TapGestureMode.FOUR_POINT
 import com.ichi2.anki.cardviewer.TapGestureMode.NINE_POINT
@@ -30,7 +31,10 @@ const val GESTURE_PREFIX = "\u235D"
 /**
  * https://www.fileformat.info/info/unicode/char/1fa87/index.htm (Maracas)
  */
-const val SHAKE_GESTURE_PREFIX = "\uD83E\uDE87"
+// #17090: maracas emoji is unusable on API 30 or below.
+// androidX emoji2 doesn't work by default on an API 30 emulator.
+// either requires a GMS dependency, or bloats the APK size by 9.8MB
+val SHAKE_GESTURE_PREFIX = if (Build.VERSION.SDK_INT > 30) "\uD83E\uDE87" else "  "
 
 fun interface GestureListener {
     fun onGesture(gesture: Gesture)


### PR DESCRIPTION
## Purpose / Description

Maracas emoji showed a tofu on API 30

## Fixes
* Fixes #17090

## Approach
* Don't show the emoji if unavailable

## How Has This Been Tested?
<img width="240" alt="Screenshot 2025-06-09 at 16 58 27" src="https://github.com/user-attachments/assets/af3cf392-4b5f-4b88-ad41-4ea01f1477f5" />

API 30

## Learning (optional, can help others)
⚠️ EmojiCompat bundle was tested and adds 9.8MB to the app size

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
