### PR TITLE
refactor(card-browser): Convert to fragment (and fix a few issues)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -170,9 +170,6 @@ open class CardBrowser :
 
     lateinit var viewModel: CardBrowserViewModel
 
-    val cardBrowserFragment: CardBrowserFragment
-        get() = supportFragmentManager.findFragmentById(R.id.card_browser_frame) as CardBrowserFragment
-
     /**
      * The frame containing the NoteEditor. Non null only in layout x-large.
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -59,7 +59,6 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.browser.BrowserColumnSelectionFragment
-import com.ichi2.anki.browser.BrowserMultiColumnAdapter
 import com.ichi2.anki.browser.BrowserRowCollection
 import com.ichi2.anki.browser.CardBrowserFragment
 import com.ichi2.anki.browser.CardBrowserLaunchOptions
@@ -192,10 +191,6 @@ open class CardBrowser :
     @VisibleForTesting
     val browserColumnHeadings: ViewGroup
         get() = cardBrowserFragment.browserColumnHeadings
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    val cardsAdapter: BrowserMultiColumnAdapter
-        get() = cardBrowserFragment.cardsAdapter
 
     private lateinit var tagsDialogFactory: TagsDialogFactory
     private var searchItem: MenuItem? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -518,11 +518,6 @@ open class CardBrowser :
         }
     }
 
-    fun notifyDataSetChanged() {
-        cardsAdapter.notifyDataSetChanged()
-        refreshSubtitle()
-    }
-
     private fun refreshSubtitle() {
         (findViewById<Spinner>(R.id.toolbar_spinner)?.adapter as? BaseAdapter)?.notifyDataSetChanged()
     }
@@ -672,6 +667,7 @@ open class CardBrowser :
         viewModel.flowOfDeckId.launchCollectionInLifecycleScope(::onDeckIdChanged)
         viewModel.flowOfCanSearch.launchCollectionInLifecycleScope(::onCanSaveChanged)
         viewModel.flowOfIsInMultiSelectMode.launchCollectionInLifecycleScope(::isInMultiSelectModeChanged)
+        viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
         viewModel.flowOfColumnHeadings.launchCollectionInLifecycleScope(::onColumnNamesChanged)
         viewModel.cardSelectionEventFlow.launchCollectionInLifecycleScope(::onSelectedCardUpdated)
@@ -1706,7 +1702,7 @@ open class CardBrowser :
         updateMultiselectMenu()
         actionBarMenu?.findItem(R.id.action_select_all)?.isVisible = !hasSelectedAllCards()
         actionBarMenu?.findItem(R.id.action_select_none)?.isVisible = viewModel.hasSelectedAnyRows()
-        notifyDataSetChanged()
+        refreshSubtitle()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -919,7 +919,6 @@ open class CardBrowser :
     fun toggleMark() =
         launchCatchingTask {
             withProgress { viewModel.toggleMark() }
-            notifyDataSetChanged()
         }
 
     /** Opens the note editor for a card.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -49,8 +49,6 @@ import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import anki.collection.OpChanges
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
@@ -183,9 +181,6 @@ open class CardBrowser :
 
     private lateinit var deckSpinnerSelection: DeckSpinnerSelection
 
-    @VisibleForTesting
-    val cardsListView: RecyclerView
-        get() = cardBrowserFragment.cardsListView
     private var searchView: CardBrowserSearchView? = null
 
     @VisibleForTesting
@@ -561,7 +556,6 @@ open class CardBrowser :
                 // Due to the ripple on long press, we set padding
                 browserColumnHeadings.updatePaddingRelative(start = 48.dp)
                 multiSelectOnBackPressedCallback.isEnabled = true
-                autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
             } else {
                 Timber.d("end multiselect mode")
                 refreshSubtitle()
@@ -569,7 +563,6 @@ open class CardBrowser :
                 actionBarTitle.visibility = View.GONE
                 browserColumnHeadings.updatePaddingRelative(start = 0.dp)
                 multiSelectOnBackPressedCallback.isEnabled = false
-                autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
             }
             // reload the actionbar using the multi-select mode actionbar
             invalidateOptionsMenu()
@@ -967,7 +960,6 @@ open class CardBrowser :
     override fun onResume() {
         super.onResume()
         selectNavigationItem(R.id.nav_browser)
-        autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
         searchView?.post {
             hideKeyboard()
         }
@@ -1944,13 +1936,6 @@ open class CardBrowser :
             viewModel: CardBrowserViewModel,
             inFragmentedActivity: Boolean = false,
         ): NoteEditorLauncher = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel, inFragmentedActivity)
-    }
-
-    private fun autoScrollTo(
-        newPosition: Int,
-        offset: Int,
-    ) {
-        (cardsListView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(newPosition, offset)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1822,7 +1822,7 @@ open class CardBrowser :
         // reload whole view
         forceRefreshSearch()
         viewModel.endMultiSelectMode()
-        notifyDataSetChanged()
+        refreshSubtitle()
         updatePreviewMenuItem()
         invalidateOptionsMenu() // maybe the availability of undo changed
     }
@@ -1892,12 +1892,10 @@ open class CardBrowser :
             return
         }
 
-        if ((
-                changes.browserSidebar ||
-                    changes.browserTable ||
-                    changes.noteText ||
-                    changes.card
-            )
+        if (changes.browserSidebar ||
+            changes.browserTable ||
+            changes.noteText ||
+            changes.card
         ) {
             refreshAfterUndo()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1657,7 +1657,7 @@ open class CardBrowser :
             // Hide note editor frame if deck is empty and fragmented
             noteEditorFrame?.visibility =
                 if (fragmented && !isDeckEmpty) {
-                    viewModel.currentCardId = (cardsAdapter.focusedRow ?: viewModel.cards[0]).toCardId(viewModel.cardsOrNotes)
+                    viewModel.currentCardId = (viewModel.focusedRow ?: viewModel.cards[0]).toCardId(viewModel.cardsOrNotes)
                     loadNoteEditorFragmentIfFragmented()
                     View.VISIBLE
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -60,7 +60,7 @@ abstract class NavigationDrawerActivity :
     /**
      * Navigation Drawer
      */
-    var fragmented = false
+    open var fragmented = false
         protected set
     private var navButtonGoesBack = false
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -63,8 +63,6 @@ class BrowserMultiColumnAdapter(
     private val onLongPress: (CardOrNoteId) -> Unit,
     private val onTap: (CardOrNoteId) -> Unit,
 ) : RecyclerView.Adapter<BrowserMultiColumnAdapter.MultiColumnViewHolder>() {
-    var focusedRow: CardOrNoteId? = null
-
     val fontSizeScalePercent =
         sharedPrefs().getInt("relativeCardBrowserFontSize", DEFAULT_FONT_SIZE_RATIO)
 
@@ -249,7 +247,7 @@ class BrowserMultiColumnAdapter(
             }
             holder.setIsSelected(isSelected)
             val rowColor =
-                if (focusedRow == id) {
+                if (viewModel.focusedRow == id) {
                     ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
                 } else {
                     backendColorToColor(row.color)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -128,7 +128,6 @@ class CardBrowserFragment :
         fun onSelectedRowsChanged(rows: Set<Any>) = cardsAdapter.notifyDataSetChanged()
 
         fun onSelectedRowUpdated(id: CardOrNoteId?) {
-            cardsAdapter.focusedRow = id
             if (!viewModel.isInMultiSelectMode || viewModel.lastSelectedId == null) {
                 viewModel.oldCardTopOffset =
                     calculateTopOffset(viewModel.lastSelectedPosition)
@@ -170,7 +169,7 @@ class CardBrowserFragment :
     @VisibleForTesting
     fun onTap(id: CardOrNoteId) =
         launchCatchingTask {
-            cardsAdapter.focusedRow = id
+            viewModel.focusedRow = id
             if (viewModel.isInMultiSelectMode) {
                 val wasSelected = viewModel.selectedRows.contains(id)
                 viewModel.toggleRowSelection(id)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -133,12 +133,17 @@ class CardBrowserFragment :
             }
         }
 
+        fun onCardsMarkedEvent(unit: Unit) {
+            cardsAdapter.notifyDataSetChanged()
+        }
+
         viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
         viewModel.flowOfActiveColumns.launchCollectionInLifecycleScope(::onColumnsChanged)
         viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         viewModel.flowOfIsInMultiSelectMode.launchCollectionInLifecycleScope(::isInMultiSelectModeChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
         viewModel.rowLongPressFocusFlow.launchCollectionInLifecycleScope(::onSelectedRowUpdated)
+        viewModel.flowOfCardsMarkedEvent.launchCollectionInLifecycleScope(::onCardsMarkedEvent)
     }
 
     override fun opExecuted(
@@ -196,9 +201,6 @@ class CardBrowserFragment :
             lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
                 this@launchCollectionInLifecycleScope.collect {
                     if (isRobolectric) {
-                        // hack: lifecycleScope/runOnUiThread do not handle our
-                        // test dispatcher overriding both IO and Main
-                        // in tests, waitForAsyncTasksToComplete may be required.
                         HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
                     } else {
                         block(it)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1,0 +1,189 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.os.Bundle
+import android.view.View
+import android.view.ViewGroup
+import androidx.annotation.VisibleForTesting
+import androidx.core.content.ContextCompat
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.R
+import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
+import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
+import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
+import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.ui.attachFastScroller
+import com.ichi2.utils.HandlerUtils
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import timber.log.Timber
+
+class CardBrowserFragment : Fragment(R.layout.cardbrowser) {
+    val viewModel: CardBrowserViewModel by activityViewModels()
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    lateinit var cardsAdapter: BrowserMultiColumnAdapter
+
+    @VisibleForTesting
+    lateinit var cardsListView: RecyclerView
+
+    @VisibleForTesting
+    lateinit var browserColumnHeadings: ViewGroup
+
+    private lateinit var progressIndicator: LinearProgressIndicator
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        cardsListView =
+            view.findViewById<RecyclerView?>(R.id.card_browser_list).apply {
+                attachFastScroller(R.id.browser_scroller)
+            }
+        DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL).apply {
+            setDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.browser_divider)!!)
+            cardsListView.addItemDecoration(this)
+        }
+        cardsAdapter =
+            BrowserMultiColumnAdapter(
+                requireContext(),
+                viewModel,
+                onTap = ::onTap,
+                onLongPress = viewModel::handleRowLongPress,
+            )
+        cardsListView.adapter = cardsAdapter
+        cardsAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY
+        val layoutManager = LinearLayoutManager(requireContext())
+        cardsListView.layoutManager = layoutManager
+        cardsListView.addItemDecoration(DividerItemDecoration(requireContext(), layoutManager.orientation))
+
+        this.browserColumnHeadings = view.findViewById(R.id.browser_column_headings)
+
+        progressIndicator = view.findViewById(R.id.browser_progress)
+
+        setupFlows()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        if (::cardsListView.isInitialized) {
+            cardsListView.adapter = null
+        }
+    }
+
+    @Suppress("UNUSED_PARAMETER", "unused")
+    private fun setupFlows() {
+        fun onIsTruncatedChanged(isTruncated: Boolean) = cardsAdapter.notifyDataSetChanged()
+
+        fun cardsUpdatedChanged(unit: Unit) = cardsAdapter.notifyDataSetChanged()
+
+        fun onColumnsChanged(columnCollection: BrowserColumnCollection) {
+            Timber.d("columns changed")
+            cardsAdapter.notifyDataSetChanged()
+        }
+
+        fun isInMultiSelectModeChanged(inMultiSelect: Boolean) {
+            // update adapter to remove check boxes
+            cardsAdapter.notifyDataSetChanged()
+        }
+
+        fun searchStateChanged(searchState: SearchState) {
+            cardsAdapter.notifyDataSetChanged()
+            progressIndicator.isVisible = searchState == Initializing || searchState == Searching
+        }
+
+        fun onSelectedRowUpdated(id: CardOrNoteId?) {
+            cardsAdapter.focusedRow = id
+            if (!viewModel.isInMultiSelectMode || viewModel.lastSelectedId == null) {
+                viewModel.oldCardTopOffset =
+                    calculateTopOffset(viewModel.lastSelectedPosition)
+            }
+        }
+
+        viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
+        viewModel.flowOfActiveColumns.launchCollectionInLifecycleScope(::onColumnsChanged)
+        viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
+        viewModel.flowOfIsInMultiSelectMode.launchCollectionInLifecycleScope(::isInMultiSelectModeChanged)
+        viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
+        viewModel.rowLongPressFocusFlow.launchCollectionInLifecycleScope(::onSelectedRowUpdated)
+    }
+
+    // TODO: Move this to ViewModel and test
+    @VisibleForTesting
+    fun onTap(id: CardOrNoteId) =
+        launchCatchingTask {
+            cardsAdapter.focusedRow = id
+            if (viewModel.isInMultiSelectMode) {
+                val wasSelected = viewModel.selectedRows.contains(id)
+                viewModel.toggleRowSelection(id)
+                viewModel.saveScrollingState(id)
+                viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
+                // Load NoteEditor on trailing side if card is selected
+                if (wasSelected) {
+                    viewModel.currentCardId = id.toCardId(viewModel.cardsOrNotes)
+                    requireCardBrowserActivity().loadNoteEditorFragmentIfFragmented()
+                }
+            } else {
+                viewModel.lastSelectedPosition = (cardsListView.layoutManager as LinearLayoutManager).findFirstVisibleItemPosition()
+                viewModel.oldCardTopOffset = calculateTopOffset(viewModel.lastSelectedPosition)
+                val cardId = viewModel.queryDataForCardEdit(id)
+                requireCardBrowserActivity().openNoteEditorForCard(cardId)
+            }
+        }
+
+    private fun calculateTopOffset(cardPosition: Int): Int {
+        val layoutManager = cardsListView.layoutManager as LinearLayoutManager
+        val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+        val view = cardsListView.getChildAt(cardPosition - firstVisiblePosition)
+        return view?.top ?: 0
+    }
+
+    private fun requireCardBrowserActivity(): CardBrowser = requireActivity() as CardBrowser
+
+    // TODO: Move this to an extension method once we have context parameters
+    private fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                this@launchCollectionInLifecycleScope.collect {
+                    if (isRobolectric) {
+                        // hack: lifecycleScope/runOnUiThread do not handle our
+                        // test dispatcher overriding both IO and Main
+                        // in tests, waitForAsyncTasksToComplete may be required.
+                        HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
+                    } else {
+                        block(it)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -125,6 +125,8 @@ class CardBrowserFragment :
             progressIndicator.isVisible = searchState == Initializing || searchState == Searching
         }
 
+        fun onSelectedRowsChanged(rows: Set<Any>) = cardsAdapter.notifyDataSetChanged()
+
         fun onSelectedRowUpdated(id: CardOrNoteId?) {
             cardsAdapter.focusedRow = id
             if (!viewModel.isInMultiSelectMode || viewModel.lastSelectedId == null) {
@@ -138,12 +140,13 @@ class CardBrowserFragment :
         }
 
         viewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
+        viewModel.flowOfSelectedRows.launchCollectionInLifecycleScope(::onSelectedRowsChanged)
         viewModel.flowOfActiveColumns.launchCollectionInLifecycleScope(::onColumnsChanged)
         viewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         viewModel.flowOfIsInMultiSelectMode.launchCollectionInLifecycleScope(::isInMultiSelectModeChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
         viewModel.rowLongPressFocusFlow.launchCollectionInLifecycleScope(::onSelectedRowUpdated)
-        viewModel.flowOfCardsMarkedEvent.launchCollectionInLifecycleScope(::onCardsMarkedEvent)
+        viewModel.flowOfCardStateChanged.launchCollectionInLifecycleScope(::onCardsMarkedEvent)
     }
 
     override fun opExecuted(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -97,6 +97,11 @@ class CardBrowserFragment :
         setupFlows()
     }
 
+    override fun onResume() {
+        super.onResume()
+        autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         if (::cardsListView.isInitialized) {
@@ -118,6 +123,7 @@ class CardBrowserFragment :
         fun isInMultiSelectModeChanged(inMultiSelect: Boolean) {
             // update adapter to remove check boxes
             cardsAdapter.notifyDataSetChanged()
+            autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
         }
 
         fun searchStateChanged(searchState: SearchState) {
@@ -193,6 +199,13 @@ class CardBrowserFragment :
         val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
         val view = cardsListView.getChildAt(cardPosition - firstVisiblePosition)
         return view?.top ?: 0
+    }
+
+    private fun autoScrollTo(
+        newPosition: Int,
+        offset: Int,
+    ) {
+        (cardsListView.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(newPosition, offset)
     }
 
     private fun requireCardBrowserActivity(): CardBrowser = requireActivity() as CardBrowser

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -207,6 +207,8 @@ class CardBrowserViewModel(
 
     val cardSelectionEventFlow = MutableSharedFlow<Unit>()
 
+    val flowOfCardsMarkedEvent = MutableSharedFlow<Unit>()
+
     suspend fun queryAllSelectedCardIds() = selectedRows.queryCardIds(this.cardsOrNotes)
 
     suspend fun queryAllSelectedNoteIds() = selectedRows.queryNoteIds(this.cardsOrNotes)
@@ -477,6 +479,7 @@ class CardBrowserViewModel(
                 tags.bulkRemove(noteIds, "marked")
             }
         }
+        flowOfCardsMarkedEvent.emit(Unit)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -971,7 +971,7 @@ class CardBrowserViewModel(
 
     suspend fun updateSelectedCardsFlag(flag: Flag): List<CardId> {
         val idsToChange = queryAllSelectedCardIds()
-        undoableOp { setUserFlagForCards(cids = idsToChange, flag = flag) }
+        undoableOp(this) { setUserFlagForCards(cids = idsToChange, flag = flag) }
         flowOfCardStateChanged.emit(Unit)
         return idsToChange
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -212,6 +212,8 @@ class CardBrowserViewModel(
      */
     val flowOfCardStateChanged = MutableSharedFlow<Unit>()
 
+    var focusedRow: CardOrNoteId? = null
+
     suspend fun queryAllSelectedCardIds() = selectedRows.queryCardIds(this.cardsOrNotes)
 
     suspend fun queryAllSelectedNoteIds() = selectedRows.queryNoteIds(this.cardsOrNotes)
@@ -445,6 +447,7 @@ class CardBrowserViewModel(
                 saveScrollingState(id)
                 toggleRowSelection(id)
             }
+            focusedRow = id
             rowLongPressFocusFlow.emit(id)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -207,7 +207,10 @@ class CardBrowserViewModel(
 
     val cardSelectionEventFlow = MutableSharedFlow<Unit>()
 
-    val flowOfCardsMarkedEvent = MutableSharedFlow<Unit>()
+    /**
+     * If cards are marked or flagged
+     */
+    val flowOfCardStateChanged = MutableSharedFlow<Unit>()
 
     suspend fun queryAllSelectedCardIds() = selectedRows.queryCardIds(this.cardsOrNotes)
 
@@ -479,7 +482,7 @@ class CardBrowserViewModel(
                 tags.bulkRemove(noteIds, "marked")
             }
         }
-        flowOfCardsMarkedEvent.emit(Unit)
+        flowOfCardStateChanged.emit(Unit)
     }
 
     /**
@@ -966,6 +969,7 @@ class CardBrowserViewModel(
     suspend fun updateSelectedCardsFlag(flag: Flag): List<CardId> {
         val idsToChange = queryAllSelectedCardIds()
         undoableOp { setUserFlagForCards(cids = idsToChange, flag = flag) }
+        flowOfCardStateChanged.emit(Unit)
         return idsToChange
     }
 

--- a/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
     <LinearLayout
@@ -13,7 +14,8 @@
             android:layout_height="match_parent"
             android:background="?android:attr/colorBackground"
             android:orientation="horizontal">
-            <include layout="@layout/cardbrowser"
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/card_browser_frame"
                 android:layout_width="1dip"
                 android:layout_weight="3"
                 android:layout_height="match_parent"/>

--- a/AnkiDroid/src/main/res/layout/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser.xml
@@ -7,6 +7,9 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
         <include layout="@layout/toolbar" />
-        <include layout="@layout/cardbrowser" />
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/card_browser_frame"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1698,8 +1698,14 @@ fun TestClass.flagCardForNote(
 
 fun CardBrowser.getVisibleRows() =
     sequence {
+        val cardsListView = cardBrowserFragment.cardsListView
         for (i in 0 until (cardsListView.childCount)) {
-            val row = cardsListView.getChildViewHolder(cardsListView.getChildAt(i))
+            val row =
+                cardsListView.getChildViewHolder(
+                    cardsListView.getChildAt(
+                        i,
+                    ),
+                )
             yield(row as BrowserMultiColumnAdapter.MultiColumnViewHolder)
         }
     }.toList().also {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1639,7 +1639,7 @@ class CardBrowserTest : RobolectricTest() {
 }
 
 private fun CardBrowser.rerenderAllCards() {
-    cardsAdapter.notifyDataSetChanged()
+    cardBrowserFragment.cardsAdapter.notifyDataSetChanged()
     waitForAsyncTasksToComplete()
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.browser.CardBrowserColumn.DECK
 import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
 import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserColumn.TAGS
+import com.ichi2.anki.browser.CardBrowserFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModelTest
 import com.ichi2.anki.browser.CardOrNoteId
@@ -1742,3 +1743,6 @@ fun CardBrowser.searchCards(search: String? = null) {
     }
     runBlocking { viewModel.searchJob?.join() }
 }
+
+val CardBrowser.cardBrowserFragment: CardBrowserFragment
+    get() = supportFragmentManager.findFragmentById(R.id.card_browser_frame) as CardBrowserFragment

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1726,7 +1726,7 @@ val CardBrowser.isShowingSelectNone: Boolean
 
 val CardBrowser.columnHeadingViews
     get() =
-        this.browserColumnHeadings.children
+        this.cardBrowserFragment.browserColumnHeadings.children
             .filterIsInstance<TextView>()
             .toList()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1662,7 +1662,7 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     }
 }
 
-fun CardBrowser.clickRowAtPosition(pos: Int) = onTap(viewModel.cards[pos])
+fun CardBrowser.clickRowAtPosition(pos: Int) = cardBrowserFragment.onTap(viewModel.cards[pos])
 
 fun CardBrowser.longClickRowAtPosition(pos: Int) = viewModel.handleRowLongPress(viewModel.cards[pos])
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -588,7 +588,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `suspend - notes - some cards suspended`() =
         runViewModelNotesTest(notes = 2) {
             // this suspends o single cid from a nid
-            suspend(cards.first().toCardId(cardsOrNotes))
+            suspend(cards.first().toCardId(cardsOrNotes) as CardId)
             ensureOpsExecuted(1) {
                 selectAll()
                 toggleSuspendCards()
@@ -1054,6 +1054,7 @@ class CardBrowserViewModelTest : JvmTest() {
                 cacheDir = createTransientDirectory(),
                 options = null,
                 preferences = AnkiDroidApp.sharedPreferencesProvider,
+                isFragmented = false,
                 manualInit = manualInit,
             )
         // makes ignoreValuesFromViewModelLaunch work under test
@@ -1078,6 +1079,7 @@ class CardBrowserViewModelTest : JvmTest() {
                 cacheDir = createTransientDirectory(),
                 options = null,
                 preferences = AnkiDroidApp.sharedPreferencesProvider,
+                isFragmented = false,
                 manualInit = manualInit,
             )
         // makes ignoreValuesFromViewModelLaunch work under test
@@ -1107,7 +1109,13 @@ class CardBrowserViewModelTest : JvmTest() {
             }
 
             val cache = File(createTempDirectory().pathString)
-            return CardBrowserViewModel(lastDeckIdRepository, cache, intent, AnkiDroidApp.sharedPreferencesProvider).apply {
+            return CardBrowserViewModel(
+                lastDeckIdRepository = lastDeckIdRepository,
+                cacheDir = cache,
+                options = intent,
+                isFragmented = false,
+                preferences = AnkiDroidApp.sharedPreferencesProvider,
+            ).apply {
                 invokeInitialSearch()
             }
         }


### PR DESCRIPTION
## Purpose / Description
Requested by @BrayanDSO

## Fixes
* Fixes #17901

## Approach
See commits:

1. Create fragment and move UI elements there
2. define accessors for UI elements via `cardBrowserFragment`
3. Go through each usage of accessors and move inside fragment
4. finally, remove the `cardBrowserFragment`, it became test only

----

* fix: maintain selection after selecting flag
* fix: don't show focused row if non-fragmented

## How Has This Been Tested?
* Unit tests
* Google Pixel 9 Pro
* API 34 tablet
  * One bug, also present in `main` : https://github.com/ankidroid/Anki-Android/issues/18462

## Learning (optional, can help others)

Easier than expected. There's more rounds if we want to tackle the menu 

I feel I did something wrong....

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
