### PR TITLE
fix(api): reimplement 'empty_cards'

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.anki.tests
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import androidx.test.espresso.ViewAssertion
@@ -33,6 +34,7 @@ import com.ichi2.libanki.Card
 import com.ichi2.libanki.CardType
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Note
+import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.QueueType
 import com.ichi2.testutils.common.IgnoreFlakyTestsInCIRule
 import kotlinx.coroutines.runBlocking
@@ -180,6 +182,33 @@ abstract class InstrumentedTest {
         check(col.addNote(n) != 0) { "Could not add note: {${fields.joinToString(separator = ", ")}}" }
         return n
     }
+
+    @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
+    fun addClozeNote(
+        text: String,
+        extra: String = "Extra",
+    ): Note =
+        col.newNote(col.notetypes.byName("Cloze")!!).apply {
+            setItem("Text", text)
+            col.addNote(this)
+        }
+
+    @DuplicatedCode("This is copied from RobolectricTest. This will be refactored into a shared library later")
+    /** Helper method to update a note */
+    @SuppressLint("CheckResult")
+    fun Note.update(block: Note.() -> Unit): Note {
+        block(this)
+        col.updateNote(this)
+        return this
+    }
+
+    val notetypes get() = col.notetypes
+
+    val Notetypes.basic
+        get() = byName("Basic")!!
+
+    val Notetypes.cloze
+        get() = byName("Cloze")!!
 }
 
 /**


### PR DESCRIPTION
## Purpose / Description

* Added in: #4178 => a9e4cde46724a9b5d1425bcef2b307e4e7fefdf3
* Removed in https://github.com/ankitects/Anki-Android/commit/aad61a0b5601fbbe45f2601294376a6707e7c9c6
  * #14171 (squashed into 7a65160e0e23e20080091a30abdd4c05fc610e06)

> Also breaks an "empty cards" action in CardContentProvider,
> as I was not sure what it was trying to accomplish.

Implementer requested that this was re-added:

> I can't see any info on how to migrate away from this.
>
> I use `enabler` fields to enable cards of any given note.
When the user requests to remove the cards of a certain type (`enabler`), I clear all the corresponding field for all notes, and then run the `empty_cards` deletion.

## Fixes
* Fixes #18435
* Fixes #9355

## Approach
Reimplement the functionality

## How Has This Been Tested?
Unit tested

## Learning (optional, can help others)
There was a questionable decision in the previous implementation: instead of returning `removeCardsAndOrphanedNotes(cardIds).count`, `cardIds.length` was returned.

This is almost certainly fine, but would not have handled duplicates properly

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
