### PR TITLE
fix(card-browser): crash on swipe if no rows 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -192,6 +192,8 @@ class RecyclerFastScroller
                         event: MotionEvent,
                     ): Boolean {
                         val recyclerView = requireNotNull(recyclerView)
+                        val recyclerViewAdapter = recyclerView.adapter
+                        if (recyclerViewAdapter == null || recyclerViewAdapter.itemCount == 0) return false
 
                         onHandleTouchListener?.onTouch(v, event)
                         if (event.actionMasked == MotionEvent.ACTION_DOWN) {
@@ -214,9 +216,9 @@ class RecyclerFastScroller
 
                             val scrollProportion = newHandlePressedYAdjustedToInitial / initialBarHeight
                             val targetPosition =
-                                (scrollProportion * recyclerView.adapter!!.itemCount)
+                                (scrollProportion * recyclerViewAdapter.itemCount)
                                     .toInt()
-                                    .coerceIn(0, recyclerView.adapter!!.itemCount - 1)
+                                    .coerceIn(0, recyclerViewAdapter.itemCount - 1)
 
                             try {
                                 recyclerView.scrollToPosition(targetPosition)


### PR DESCRIPTION
cause: https://github.com/ankidroid/Anki-Android/commit/ebdc57629454c4bc04528328fc498b29679c293a

`coerceIn(0, recyclerView.adapter!!.itemCount - 1)` crashed if there was 0 items

This occurred when performing a 'back' gesture

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
