### PR TITLE
feat(settings): change fragment transition

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -115,7 +115,7 @@ class PreferencesFragment :
         fragment.arguments = pref.extras
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment::class.jvmName)
-            setOpenTransition(this)
+            setFadeTransition(this)
             addToBackStack(null)
         }
         return true
@@ -127,7 +127,7 @@ class PreferencesFragment :
         parentFragmentManager.popBackStack() // clear the search fragment from the backstack
         childFragmentManager.commit {
             replace(R.id.settings_container, fragment, fragment.javaClass.name)
-            setOpenTransition(this)
+            setFadeTransition(this)
             addToBackStack(fragment.javaClass.name)
         }
 
@@ -142,9 +142,9 @@ class PreferencesFragment :
         view?.findViewById<MaterialToolbar>(R.id.toolbar)?.title = title
     }
 
-    private fun setOpenTransition(fragmentTransaction: FragmentTransaction) {
+    private fun setFadeTransition(fragmentTransaction: FragmentTransaction) {
         if (!sharedPrefs().getBoolean("safeDisplay", false)) {
-            fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_OPEN)
+            fragmentTransaction.setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
         }
     }
 


### PR DESCRIPTION
the default 'open' transition is too quick in some devices

## Fixes
* Fixes #18324

## Approach

Replace the old transition with the Android's standard `Fade` transition

## How Has This Been Tested?

Emulator API 35

https://github.com/user-attachments/assets/bf8e503c-2008-4f3e-acba-4b4d9d18cd0b


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
