### PR TITLE
style(lint): continue de-fuzzing via `--warning-mode all` on gradle builds

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -12,7 +12,7 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    maven { url "https://jitpack.io" }
+    maven { url = "https://jitpack.io" }
 }
 
 keeper {
@@ -39,9 +39,9 @@ static def gitCommitHash() {
 }
 
 android {
-    namespace "com.ichi2.anki"
+    namespace = "com.ichi2.anki"
 
-    compileSdk libs.versions.compileSdk.get().toInteger()
+    compileSdk = libs.versions.compileSdk.get().toInteger()
 
     buildFeatures {
         buildConfig = true
@@ -49,13 +49,13 @@ android {
     }
 
     if (rootProject.testReleaseBuild) {
-        testBuildType "release"
+        testBuildType = "release"
     } else {
-        testBuildType "debug"
+        testBuildType = "debug"
     }
 
     defaultConfig {
-        applicationId "com.ichi2.anki"
+        applicationId = "com.ichi2.anki"
         buildConfigField "Boolean", "CI", (System.getenv("CI") == "true").toString()
         buildConfigField "String", "ACRA_URL", '"https://ankidroid.org/acra/report"'
         buildConfigField "String", "BACKEND_VERSION", "\"${libs.versions.ankiBackend.get()}\""
@@ -87,13 +87,13 @@ android {
         // needed for upgrades to be offered correctly.
         versionCode=22100116
         versionName="2.21alpha16"
-        minSdk libs.versions.minSdk.get().toInteger()
+        minSdk = libs.versions.minSdk.get().toInteger()
 
         // After #13695: change .tests_emulator.yml
-        targetSdk libs.versions.targetSdk.get().toInteger()
-        testApplicationId "com.ichi2.anki.tests"
+        targetSdk = libs.versions.targetSdk.get().toInteger()
+        testApplicationId = "com.ichi2.anki.tests"
         vectorDrawables.useSupportLibrary = true
-        testInstrumentationRunner 'com.ichi2.testutils.NewCollectionPathTestRunner'
+        testInstrumentationRunner = 'com.ichi2.testutils.NewCollectionPathTestRunner'
     }
     signingConfigs {
         release {
@@ -124,7 +124,7 @@ android {
                 localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
                 // #6009 Allow optional disabling of JaCoCo for general build (assembleDebug).
                 // jacocoDebug task was slow, hung, and wasn't required unless I wanted coverage
-                testCoverageEnabled localProperties['enable_coverage'] != "false"
+                testCoverageEnabled = localProperties['enable_coverage'] != "false"
                 // not profiled: optimization for build times
                 if (localProperties['enable_languages'] == "false") {
                     android.defaultConfig.resConfigs "en"
@@ -150,7 +150,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
             testProguardFile 'proguard-test-rules.pro'
             splits.abi.universalApk = universalApkEnabled // Build universal APK for release with `-Duniversal-apk=true`
-            signingConfig signingConfigs.release
+            signingConfig = signingConfigs.release
 
             // syntax: assembleRelease -PcustomSuffix="suffix" -PcustomName="New name"
             if (project.hasProperty("customSuffix")) {
@@ -205,7 +205,7 @@ android {
     splits {
         abi {
             reset()
-            enable enableSeparateBuildPerCPUArchitecture
+            enable = enableSeparateBuildPerCPUArchitecture
             //universalApk enableUniversalApk  // set in debug + release config blocks above
             include "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
         }
@@ -238,7 +238,7 @@ android {
     }
 
     testOptions {
-        animationsDisabled true
+        animationsDisabled = true
         kotlinOptions {
             freeCompilerArgs += [
                     '-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
@@ -249,7 +249,7 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
-        coreLibraryDesugaringEnabled true
+        coreLibraryDesugaringEnabled = true
     }
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_11

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -10,7 +10,7 @@ jacoco {
 
 android {
     testCoverage {
-        jacocoVersion libs.versions.jacoco.get()
+        jacocoVersion = libs.versions.jacoco.get()
     }
 }
 

--- a/lint.gradle
+++ b/lint.gradle
@@ -2,15 +2,15 @@
 
 android {
     lint {
-        abortOnError true
-        checkReleaseBuilds true
-        checkTestSources true
-        explainIssues false
-        lintConfig file('../lint-release.xml')
-        showAll true
+        abortOnError = true
+        checkReleaseBuilds = true
+        checkTestSources = true
+        explainIssues = false
+        lintConfig = file('../lint-release.xml')
+        showAll = true
         // To output the lint report to stdout set textReport=true, and leave textOutput unset.
-        textReport true
-        warningsAsErrors true
+        textReport = true
+        warningsAsErrors = true
 
         if (System.getenv("CI") == "true") {
             // 14853: we want this to appear in the IDE, but it adds noise to CI


### PR DESCRIPTION

this is just conforming to the new gradle requirement of explicit assignment - that is "you have to use an equals sign for assignment"

example spam in terminal while building, before these changes:

```
mike@isabela:~/work/ankidroid/Anki-Android (main) % ./gradlew assemblePlayDebug lintVitalPlayRelease --warning-mode all

> Configure project :AnkiDroid
Build file '/Users/mike/work/ankidroid/Anki-Android/AnkiDroid/build.gradle': line 15
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('url = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.2/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
        at build_303qwemy4iflr113x9z3vi02v$_run_closure1$_closure14.doCall$original(/Users/mike/work/ankidroid/Anki-Android/AnkiDroid/build.gradle:15)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_303qwemy4iflr113x9z3vi02v$_run_closure1.doCall$original(/Users/mike/work/ankidroid/Anki-Android/AnkiDroid/build.gradle:15)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Build file '/Users/mike/work/ankidroid/Anki-Android/AnkiDroid/build.gradle': line 42
Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated. This is scheduled to be removed in Gradle 10.0. Use assignment ('namespace = <value>') instead. Consult the upgrading guide for further information: https://docs.gradle.org/8.14.2/userguide/upgrading_version_8.html#groovy_space_assignment_syntax
```

with this PR you can run with `--warning-mode all` and it is quiet again except some deprecation which will break our build in gradle 10 (semver major n+2) and doesn't have any good location information


