### PR TITLE
fix(new reviewer): keybinds triggered when using type answer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -266,7 +266,12 @@ class ReviewerFragment :
         webView.settings.loadWithOverviewMode = true
     }
 
-    override fun dispatchKeyEvent(event: KeyEvent): Boolean = viewModel.dispatchKeyEvent(event)
+    override fun dispatchKeyEvent(event: KeyEvent): Boolean {
+        if (view?.findViewById<TextInputEditText>(R.id.type_answer_edit_text)?.isFocused == true) {
+            return false
+        }
+        return viewModel.dispatchKeyEvent(event)
+    }
 
     override fun onMenuItemClick(item: MenuItem): Boolean = viewModel.onMenuItemClick(item)
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I haven't paid attention to the interaction with `type-in answer` when I implemented keybinds for the new reviewer. 

Reproduction steps
1. Start reviewing a `type-in answer` card
2. While focusing the type answer input, type a letter assigned to a keybind (e.g. the default `E` shortcut for editting a note)

This doesn't affect the old reviewer

## Approach

Check if the type answer container is focused when a key is captured, like the old reviewer does

## How Has This Been Tested?

Emulator API 35 with the steps above

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
