### PR TITLE
fix(card-browser): note editor fragment updated browser deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -44,7 +44,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
-import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.showThemedToast
 import com.ichi2.annotations.NeedsTest
@@ -247,23 +246,22 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             if (field != null) {
                 return field
             }
+            val parentFragment = parentFragment
+            if (parentFragment is DeckSelectionListener) {
+                return parentFragment
+            }
             val activity: Activity = requireActivity()
             if (activity is DeckSelectionListener) {
                 return activity
             }
-            val parentFragment = parentFragment
-            if (parentFragment is DeckSelectionListener) {
-                return parentFragment
-            } else {
-                // try to find inside the activity an active fragment that is a DeckSelectionListener
-                val foundAvailableFragments =
-                    parentFragmentManager.fragments.filter {
-                        it.isResumed && it is DeckSelectionListener
-                    }
-                if (foundAvailableFragments.isNotEmpty()) {
-                    // if we found at least one resumed candidate fragment use it
-                    return foundAvailableFragments[0] as DeckSelectionListener
+            // try to find inside the activity an active fragment that is a DeckSelectionListener
+            val foundAvailableFragments =
+                parentFragmentManager.fragments.filter {
+                    it.isResumed && it is DeckSelectionListener
                 }
+            if (foundAvailableFragments.isNotEmpty()) {
+                // if we found at least one resumed candidate fragment use it
+                return foundAvailableFragments[0] as DeckSelectionListener
             }
             throw IllegalStateException("Neither activity or any fragment in the activity were a selection listener")
         }


### PR DESCRIPTION
## Fixes
* Fixes #18462

## Approach
Prefer the parent fragment over the activity when finding `DeckSelectionListener`

## How Has This Been Tested?
API 34 tablet emulator

## Learning (optional, can help others)
I have a more involved fix, but this was really easy after https://github.com/ankidroid/Anki-Android/pull/18463 was merged

* https://github.com/ankidroid/Anki-Android/pull/18463

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
