### PR TITLE
fix(reviewer): allow disabling 'voice playback' if app bar button removed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -867,6 +867,8 @@ open class Reviewer :
         val voicePlaybackIcon = menu.findItem(R.id.action_toggle_mic_tool_bar)
         if (isMicToolBarVisible) {
             voicePlaybackIcon.setTitle(R.string.menu_disable_voice_playback)
+            // #18477: always show 'disable', even if 'enable' was invisible
+            voicePlaybackIcon.isVisible = true
         } else {
             voicePlaybackIcon.setTitle(R.string.menu_enable_voice_playback)
         }


### PR DESCRIPTION
If the menu item was removed, but a keyboard shortcut was pressed there was no way to disable the control

* Fixes #18477

## How Has This Been Tested?

API 34 tablet emulator

* 'disable voice playback' menu item is visible after 'shift+v'
* 'enable voice playback' menu item is removed once clicked
  * This is because we invalidate options 


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
