### PR TITLE
fix(tags): nesting broken if casing differed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -354,6 +354,7 @@ class TagsArrayAdapter(
      *
      * @param expandTarget The target tag to expand. Do nothing if it is empty or not found.
      */
+    @NeedsTest("#18481 - case insensitivity")
     private fun buildTagTree(expandTarget: String) {
         // init mapping for newly added tags
         filteredList.forEach {
@@ -380,7 +381,7 @@ class TagsArrayAdapter(
         for (tag in filteredList) {
             // root will never be popped
             while (stack.size > 1) {
-                if (!tag.startsWith(stack.peek().tag + "::")) {
+                if (!tag.startsWith(stack.peek().tag + "::", ignoreCase = true)) {
                     stackPopAndPushUp()
                 } else {
                     break


### PR DESCRIPTION
## Purpose / Description

the tags:

```
#AK_Step1_v12::#Pixorize::03_Pharmacology::22_Cardiovascular_(New)::01_Ivabradine
#AK_Step1_V12::#Pixorize::03_Pharmacology::22_Cardiovascular_(New)::02_Nitroprusside
```

Caused `02_Nitroprusside` to be a top level deck, and corrupted the stack calculations

## Fixes
* Fixes #18481

## Approach
Tags are case insensitive, and we forgot a check

Note the two parent tags with different 'v' casing above

```diff
- _v12
+ _V12
```

Use case insensitive compare

## How Has This Been Tested?
API 34 Tablet emulator

<img width="300" alt="Screenshot 2025-06-12 at 00 30 31" src="https://github.com/user-attachments/assets/bc2b4fa8-f046-45c7-b19c-c9982f785f6c" />

<img width="300" alt="Screenshot 2025-06-12 at 00 27 31" src="https://github.com/user-attachments/assets/43d8f054-bda8-4c77-9d70-47023c37de5e" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
