### PR TITLE
lint: ensure strings do not contain trailing spaces

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -136,8 +136,7 @@ class TranslationTypo :
             element.reportIssue("should not be empty")
         }
 
-        // TODO(14903): remove "values" check once lint passes without it
-        if ("values" == context.file.parentFile.name && element.textContent.trim() != element.textContent) {
+        if (element.textContent.trim() != element.textContent) {
             var isValid = true
             element.childNodes.forEach {
                 if (it is CDATASection) {


### PR DESCRIPTION
> [!NOTE]
> Blocked on:
> * https://github.com/ankidroid/Anki-Android/pull/18485

We only checked 'values', now translations (`values-af`) are checked

Follow-on from b073f41a0dfc51abfd4fbe1a8a6aa22295dd2dcb

## Fixes
* Fixes #14903

## How Has This Been Tested?
rebased on `i18n-sync` and it passed

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
