### PR TITLE
feat(preferences): shortcut for 'Display screen shortcuts'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -704,6 +704,11 @@ open class AnkiActivity :
             ShortcutGroup(
                 listOf(
                     shortcut("Ctrl+Z", R.string.undo),
+                    // For 'Controls': to help user discover shortcuts in all screens
+                    // BUG: There is no way to access system shortcuts, so this may not be correct
+                    // This is copied from AOSP, which will be correct in most cases
+                    // https://cs.android.com/android/_/android/platform/frameworks/base/+/1cdfff555f4a21f71ccc978290e2e212e2f8b168:packages/SystemUI/src/com/android/systemui/keyboard/shortcut/data/source/SystemShortcutsSource.kt;l=162-166;bpv=1;bpt=0;drc=697cd49fb770afa8480d4c187b30553645b5879c
+                    shortcut("Meta+/", R.string.shortcut_label_show_shortcuts_for_app),
                 ),
                 R.string.pref_cat_general,
             ).toShortcutGroup(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/input/Shortcut.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/input/Shortcut.kt
@@ -51,7 +51,7 @@ data class Shortcut(
     /**
      * Maps a modifier string to its corresponding KeyEvent meta flag.
      *
-     * @param modifier The modifier string (e.g., "Ctrl", "Alt", "Shift").
+     * @param modifier The modifier string (e.g., "Ctrl", "Alt", "Shift", "Meta").
      * @return The corresponding KeyEvent meta flag.
      */
     private fun getModifier(modifier: String): Int =
@@ -59,6 +59,7 @@ data class Shortcut(
             "Ctrl" -> KeyEvent.META_CTRL_ON
             "Alt" -> KeyEvent.META_ALT_ON
             "Shift" -> KeyEvent.META_SHIFT_ON
+            "Meta" -> KeyEvent.META_META_ON
 
             else -> 0
         }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -407,5 +407,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string name="missing_user_action_dialog_message" comment="%s is the user action number">User action %s is not set in this notetype. Please configure it</string>
 
     <string name="directory_inaccessible_info">Learn more about how to restore access here %s or go to settings to update collection folder.</string>
+
+    <string name="shortcut_label_show_shortcuts_for_app">Display screen shortcuts</string>
 </resources>
 


### PR DESCRIPTION
## Purpose / Description
'Show keyboard shortcuts' was unintuitive: app shortcuts only showed Ctrl+Z

## Fixes
* Fixes #18488

## Approach
This makes the 'Access list of system / apps shortcuts' more prominent by including it in the 'Current app' tab

⚠️ It may be buggy on custom Android systems which change this default shortcut, but should work for the vast majority of systems

## How Has This Been Tested?
API 34 tablet emulator

<img width="975" alt="Screenshot 2025-06-12 at 13 48 59" src="https://github.com/user-attachments/assets/66e90e9f-0260-4455-b1d7-40424508baaa" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
