### PR TITLE
Fix crash on notetype field deletion after applying language hint

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Fields
+import com.ichi2.libanki.NoteTypeId
 import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.ui.FixedEditText
@@ -78,6 +79,9 @@ class NoteTypeFieldEditor : AnkiActivity() {
 
     // WARN: this should be lateinit, but this can't yet be done on an inline class
     private var noteFields: Fields = Fields(JSONArray())
+
+    private val noteTypeID: NoteTypeId
+        get() = intent.getLongExtra("noteTypeID", 0)
 
     // ----------------------------------------------------------------------------
     // ANDROID METHODS
@@ -139,7 +143,6 @@ class NoteTypeFieldEditor : AnkiActivity() {
      * to finish the activity.
      */
     private fun initialize() {
-        val noteTypeID = intent.getLongExtra("noteTypeID", 0)
         val collectionModel = getColUnsafe.notetypes.get(noteTypeID)
         if (collectionModel == null) {
             showThemedToast(this, R.string.field_editor_model_not_available, true)
@@ -535,6 +538,11 @@ class NoteTypeFieldEditor : AnkiActivity() {
      */
     private fun addFieldLocaleHint(selectedLocale: Locale) {
         setLanguageHintForField(getColUnsafe.notetypes, notetype, currentPos, selectedLocale)
+        // update the note fields list so the (possible) new field's "ad-hint-locale" property is
+        // seen and doesn't break any potential equality checks(like for removal of the fields)
+        getColUnsafe.notetypes.get(noteTypeID)?.let {
+            noteFields = it.fields
+        }
         val format = getString(R.string.model_field_editor_language_hint_dialog_success_result, selectedLocale.displayName)
         showSnackbar(format, Snackbar.LENGTH_SHORT)
     }


### PR DESCRIPTION
## Purpose / Description

Setting a locale hint for a notetype field adds a new property "ad-locale-hint" to the json object, this would then break the removal of that field because the deletion code would try to find the field to delete by doing an equality check(and failing due to the new property).

The fix just updates the working copy of the fields list after setting a field locale hint. 


## Fixes
* Fixes #18501

## How Has This Been Tested?

Checked the behavior, ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
