### PR TITLE
fix(field-editor): changes after languageHint crashed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.annotations.NeedsTest
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Fields
 import com.ichi2.libanki.NotetypeJson
@@ -60,6 +61,7 @@ import org.json.JSONException
 import timber.log.Timber
 import java.util.Locale
 
+@NeedsTest("perform one action, then another")
 class NoteTypeFieldEditor : AnkiActivity() {
     // Position of the current field selected
     private var currentPos = 0
@@ -546,6 +548,7 @@ class NoteTypeFieldEditor : AnkiActivity() {
         setLanguageHintForField(getColUnsafe.notetypes, notetype, currentPos, selectedLocale)
         val format = getString(R.string.model_field_editor_language_hint_dialog_success_result, selectedLocale.displayName)
         showSnackbar(format, Snackbar.LENGTH_SHORT)
+        initialize()
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)


### PR DESCRIPTION
## Purpose / Description
If a user tried to make a change after setting the hint, it failed

## Fixes
* Fixes #18501

## Approach
The other methods call `initialize()`, so do it here


## How Has This Been Tested?

* Google Pixel 9 Pro, Android 15
   * Add note type (Clone Basic)
   * set language hint on field
   * Delete Field

No crash

## Learning

This class is very weird, needs rewrite.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
