### PR TITLE
fix: Custom study error caused crash report & logcat issues with TagFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -87,6 +87,7 @@ import com.ichi2.utils.title
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.parcelize.Parcelize
+import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
 
 /**
@@ -165,7 +166,11 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         tagsToInclude: List<String> = emptyList(),
         tagsToExclude: List<String> = emptyList(),
     ) {
-        requireActivity().launchCatchingTask {
+        requireActivity().launchCatchingTask(
+            // net.ankiweb.rsdroid.BackendException: No cards matched the criteria you provided.
+            // TODO (Backend#256: make this BackendCustomStudyException)
+            skipCrashReport = { it is BackendException },
+        ) {
             withProgress {
                 try {
                     customStudy(option, cardsAmount, kind, tagsToInclude, tagsToExclude)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -153,13 +153,24 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             if (selectedStatePosition == AdapterView.INVALID_POSITION) return@setFragmentResultListener
             val kind = CustomStudyCardState.entries[selectedStatePosition].kind
             val cardsAmount = userInputValue ?: 100 // the default value
-            requireActivity().launchCatchingTask {
-                withProgress {
-                    try {
-                        customStudy(option, cardsAmount, kind, tagsToInclude, tagsToExclude)
-                    } finally {
-                        requireActivity().dismissAllDialogFragments()
-                    }
+            launchCustomStudy(option, cardsAmount, kind, tagsToInclude, tagsToExclude)
+        }
+    }
+
+    /** @see customStudy */
+    private fun launchCustomStudy(
+        option: ContextMenuOption,
+        cardsAmount: Int,
+        kind: CramKind = CramKind.CRAM_KIND_NEW,
+        tagsToInclude: List<String> = emptyList(),
+        tagsToExclude: List<String> = emptyList(),
+    ) {
+        requireActivity().launchCatchingTask {
+            withProgress {
+                try {
+                    customStudy(option, cardsAmount, kind, tagsToInclude, tagsToExclude)
+                } finally {
+                    requireActivity().dismissAllDialogFragments()
                 }
             }
         }
@@ -357,15 +368,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                     tagsSelectionDialog.show(parentFragmentManager, TagLimitFragment.TAG)
                     return@setOnClickListener
                 }
-                requireActivity().launchCatchingTask {
-                    withProgress {
-                        try {
-                            customStudy(contextMenuOption, n)
-                        } finally {
-                            requireActivity().dismissAllDialogFragments()
-                        }
-                    }
-                }
+                launchCustomStudy(contextMenuOption, n)
             }
         }
 
@@ -383,9 +386,9 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
     private suspend fun customStudy(
         contextMenuOption: ContextMenuOption,
         userEntry: Int,
-        cramKind: CramKind = CramKind.CRAM_KIND_NEW,
-        tagsSelectedForInclude: List<String> = emptyList(),
-        tagsSelectedForExclude: List<String> = emptyList(),
+        cramKind: CramKind,
+        tagsSelectedForInclude: List<String>,
+        tagsSelectedForExclude: List<String>,
     ) {
         Timber.i("Custom study: $contextMenuOption; input = $userEntry")
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
@@ -121,8 +121,8 @@ class TagLimitFragment : DialogFragment() {
                 setFragmentResult(
                     REQUEST_CUSTOM_STUDY_TAGS,
                     bundleOf(
-                        KEY_INCLUDED_TAGS to tagsToInclude,
-                        KEY_EXCLUDED_TAGS to tagsToExclude,
+                        KEY_INCLUDED_TAGS to ArrayList(tagsToInclude),
+                        KEY_EXCLUDED_TAGS to ArrayList(tagsToExclude),
                     ),
                 )
                 dismiss()


### PR DESCRIPTION
## Purpose / Description
A custom study error returned a backend error, but the error should not have been reported to ACRA

## Fixes
* Fixes #18500
* Fixes #18505

## Approach
* define and use `skipCrashReport`
  * ⚠️ on all `BackendException`s for now: backend could provide more granularity, but doesn't
* Pass in ArrayList to fragment result to fix 18505

## How Has This Been Tested?
A log was added for a pending crash report

* new collection
* add a card
* custom study: study ahead
* no cards found

----

For 18505, errors are no longer in logcat

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
