### PR TITLE
fix: controls settings crash in landscape mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -16,8 +16,6 @@
 package com.ichi2.anki.preferences
 
 import android.content.res.Configuration
-import android.os.Bundle
-import android.view.View
 import androidx.annotation.StringRes
 import androidx.annotation.XmlRes
 import androidx.preference.Preference
@@ -44,7 +42,7 @@ class ControlsSettingsFragment :
         get() = "prefs.controls"
 
     override fun initSubscreen() {
-        requirePreference<Preference>(R.string.pref_controls_tab_layout_key).setViewId(R.id.tab_layout)
+        requirePreference<ControlsTabPreference>(R.string.pref_controls_tab_layout_key).setOnTabSelectedListener(this)
         val initialScreen = ControlPreferenceScreen.entries.first()
         addPreferencesFromResource(initialScreen.xmlRes)
         // TODO replace the preference with something dismissible. This is meant only to improve
@@ -68,22 +66,6 @@ class ControlsSettingsFragment :
             .filterIsInstance<ControlPreference>()
             .filter { pref -> pref.value == null }
             .forEach { pref -> commands[pref.key]?.getBindings(prefs)?.toPreferenceString()?.let { pref.value = it } }
-    }
-
-    override fun onViewCreated(
-        view: View,
-        savedInstanceState: Bundle?,
-    ) {
-        super.onViewCreated(view, savedInstanceState)
-
-        listView.post {
-            val tabLayout = listView.findViewById<TabLayout>(R.id.tab_layout)
-            for (screen in ControlPreferenceScreen.entries) {
-                val tab = tabLayout.newTab().setText(screen.titleRes)
-                tabLayout.addTab(tab)
-            }
-            tabLayout.addOnTabSelectedListener(this)
-        }
     }
 
     override fun onTabSelected(tab: TabLayout.Tab) {
@@ -147,10 +129,9 @@ class ControlsSettingsFragment :
 
 enum class ControlPreferenceScreen(
     @XmlRes val xmlRes: Int,
-    @StringRes val titleRes: Int,
 ) {
-    REVIEWER(R.xml.preferences_reviewer_controls, R.string.pref_controls_reviews_tab),
-    PREVIEWER(R.xml.preferences_previewer_controls, R.string.pref_controls_previews_tab),
+    REVIEWER(R.xml.preferences_reviewer_controls),
+    PREVIEWER(R.xml.preferences_previewer_controls),
     ;
 
     fun getActions(): List<MappableAction<*>> =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsTabPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsTabPreference.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.con>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.preferences
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.preference.Preference
+import androidx.preference.PreferenceViewHolder
+import com.google.android.material.tabs.TabLayout
+import com.ichi2.anki.R
+
+class ControlsTabPreference
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = androidx.preference.R.attr.preferenceStyle,
+        defStyleRes: Int = androidx.preference.R.style.Preference,
+    ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
+        init {
+            layoutResource = R.layout.controls_tab_layout
+        }
+
+        private var tabLayout: TabLayout? = null
+        private var onTabSelectedListener: TabLayout.OnTabSelectedListener? = null
+
+        fun setOnTabSelectedListener(listener: TabLayout.OnTabSelectedListener) {
+            onTabSelectedListener?.let { oldListener ->
+                tabLayout?.removeOnTabSelectedListener(oldListener)
+            }
+            onTabSelectedListener = listener
+            tabLayout?.addOnTabSelectedListener(listener)
+        }
+
+        override fun onBindViewHolder(holder: PreferenceViewHolder) {
+            super.onBindViewHolder(holder)
+            tabLayout = holder.itemView as? TabLayout
+            onTabSelectedListener?.let { listener ->
+                tabLayout?.removeOnTabSelectedListener(listener)
+                tabLayout?.addOnTabSelectedListener(listener)
+            }
+        }
+    }

--- a/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
+++ b/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.tabs.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/tab_layout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    style="@style/Widget.Material3.TabLayout"
+    app:tabMode="fixed">
+
+    <com.google.android.material.tabs.TabItem
+        android:id="@+id/reviews_tab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_controls_reviews_tab"
+        />
+
+    <com.google.android.material.tabs.TabItem
+        android:id="@+id/previews_tab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/pref_controls_previews_tab"
+        />
+
+</com.google.android.material.tabs.TabLayout>

--- a/AnkiDroid/src/main/res/layout/tab_layout.xml
+++ b/AnkiDroid/src/main/res/layout/tab_layout.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<com.google.android.material.tabs.TabLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    style="@style/Widget.Material3.TabLayout"
-    app:tabMode="fixed"
-    />

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -59,9 +59,8 @@
         android:icon="@drawable/ic_keyboard"
         />
 
-        <Preference
+        <com.ichi2.anki.preferences.ControlsTabPreference
             android:key="@string/pref_controls_tab_layout_key"
-            android:layout="@layout/tab_layout"
             />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
since Preferences are RecyclerView items, if the tab layout isn't visible when the view is created, its view won't exist and that leads to a crash.

to configure a preference view dynamically, the alternative is to create an individual preference class

## Fixes
* Fixes #18498

## How Has This Been Tested?

Emulator 35

https://github.com/user-attachments/assets/14452e58-74f2-4d02-84e4-ce9cf9004ae6

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
