### PR TITLE
feat(new reviewer): answer timer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimer.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.con>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer
+
+import android.content.Context
+import android.os.Parcelable
+import android.os.SystemClock
+import android.util.AttributeSet
+import android.widget.Chronometer
+import androidx.appcompat.widget.ThemeUtils
+import com.ichi2.anki.R
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Improved version of a [Chronometer] aimed at handling Anki Decks' `Timer` configurations.
+ *
+ * Compared to a default [Chronometer], it can:
+ * - Restore its status after configuration changes
+ * - Stop the timer after [limitInMs] is reached.
+ */
+class AnswerTimer(
+    context: Context,
+    attributeSet: AttributeSet?,
+) : Chronometer(context, attributeSet) {
+    var limitInMs = Int.MAX_VALUE
+    private var elapsedMillisBeforeStop = 0L
+    private var isRunning = false
+
+    init {
+        setOnChronometerTickListener {
+            if (hasReachedLimit()) {
+                setTextColor(ThemeUtils.getThemeAttrColor(context, R.attr.maxTimerColor))
+                stop()
+            }
+        }
+    }
+
+    override fun start() {
+        super.start()
+        isRunning = true
+    }
+
+    override fun stop() {
+        elapsedMillisBeforeStop = SystemClock.elapsedRealtime() - base
+        super.stop()
+        isRunning = false
+    }
+
+    fun resume() {
+        base = SystemClock.elapsedRealtime() - elapsedMillisBeforeStop
+        start()
+    }
+
+    fun restart() {
+        elapsedMillisBeforeStop = 0
+        base = SystemClock.elapsedRealtime()
+        setTextColor(ThemeUtils.getThemeAttrColor(context, android.R.attr.textColor))
+        start()
+    }
+
+    private fun hasReachedLimit() = SystemClock.elapsedRealtime() - base >= limitInMs
+
+    override fun onSaveInstanceState(): Parcelable {
+        val elapsedMillis = if (isRunning) SystemClock.elapsedRealtime() - base else elapsedMillisBeforeStop
+        return SavedState(
+            state = super.onSaveInstanceState(),
+            elapsedMs = elapsedMillis,
+            isRunning = isRunning,
+            limitInMs = limitInMs,
+        )
+    }
+
+    override fun onRestoreInstanceState(state: Parcelable?) {
+        if (state !is SavedState) {
+            super.onRestoreInstanceState(state)
+            return
+        }
+        super.onRestoreInstanceState(state.superState)
+
+        elapsedMillisBeforeStop = state.elapsedMs
+        isRunning = state.isRunning
+        limitInMs = state.limitInMs
+
+        base = SystemClock.elapsedRealtime() - elapsedMillisBeforeStop
+        if (isRunning && !hasReachedLimit()) {
+            super.start()
+        }
+    }
+
+    @Parcelize
+    private data class SavedState(
+        val state: Parcelable?,
+        val elapsedMs: Long,
+        val isRunning: Boolean,
+        val limitInMs: Int,
+    ) : BaseSavedState(state)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimerStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimerStatus.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.con>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer
+
+import kotlin.random.Random
+
+sealed interface AnswerTimerStatus {
+    data class Running(
+        val limitInMs: Int,
+    ) : AnswerTimerStatus {
+        // allows emitting the same value in MutableStateFlow
+        override fun equals(other: Any?): Boolean = false
+
+        override fun hashCode(): Int = Random.nextInt()
+    }
+
+    data object Stopped : AnswerTimerStatus
+}

--- a/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
@@ -106,10 +106,6 @@
                 android:textColor="?attr/newCountColor"
                 android:paddingEnd="4dp"
                 android:textSize="16sp"
-                app:layout_constraintTop_toTopOf="@id/back_button"
-                app:layout_constraintBottom_toBottomOf="@id/back_button"
-                app:layout_constraintStart_toEndOf="@id/back_button"
-                app:layout_constraintEnd_toStartOf="@id/lrn_count"
                 tools:text="127"
                 />
 
@@ -120,10 +116,6 @@
                 android:textColor="?attr/learnCountColor"
                 android:paddingHorizontal="4dp"
                 android:textSize="16sp"
-                app:layout_constraintTop_toTopOf="@id/back_button"
-                app:layout_constraintBottom_toBottomOf="@id/back_button"
-                app:layout_constraintStart_toEndOf="@id/new_count"
-                app:layout_constraintEnd_toStartOf="@id/rev_count"
                 tools:text="381"
                 />
 
@@ -134,10 +126,32 @@
                 android:textColor="?attr/reviewCountColor"
                 android:paddingStart="4dp"
                 android:textSize="16sp"
-                app:layout_constraintTop_toTopOf="@id/back_button"
-                app:layout_constraintBottom_toBottomOf="@id/back_button"
-                app:layout_constraintStart_toEndOf="@id/lrn_count"
                 tools:text="954"
+                />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/counts_flow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="new_count,lrn_count,rev_count"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintBottom_toTopOf="@id/timer"
+                />
+
+            <!-- Timer below counts means UI elements may jump if timer is selectively enabled.
+              This was a considered decision vs other options. Current thinking is the selectively-
+              enabled timer case will be very rare, so UI element motion should also be rare. -->
+            <com.ichi2.anki.ui.windows.reviewer.AnswerTimer
+                android:id="@+id/timer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/counts_flow"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/counts_flow"
+                app:layout_constraintStart_toStartOf="@id/counts_flow"
+                android:visibility="gone"
+                tools:visibility="visible"
                 />
 
             <FrameLayout

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -18,59 +18,84 @@
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/tools_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            >
+            android:minHeight="?actionBarSize">
 
             <androidx.appcompat.widget.AppCompatImageButton
                 android:id="@+id/back_button"
                 style="?actionButtonStyle"
                 android:layout_width="?minTouchTargetSize"
                 android:layout_height="?actionBarSize"
-                android:src="?attr/homeAsUpIndicator"
                 android:layout_marginStart="4dp"
                 android:contentDescription="@string/abc_action_bar_up_description"
-                android:tooltipText="@string/abc_action_bar_up_description"
+                android:src="?attr/homeAsUpIndicator"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <androidx.constraintlayout.helper.widget.Flow
+                android:id="@+id/counts_flow"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:constraint_referenced_ids="new_count,lrn_count,rev_count"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintBottom_toTopOf="@id/timer"
                 />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/new_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="?attr/newCountColor"
                 android:paddingEnd="4dp"
-                tools:text="127"
-                />
+                android:textColor="?attr/newCountColor"
+                tools:text="127" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/lrn_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="?attr/learnCountColor"
                 android:paddingHorizontal="4dp"
-                tools:text="381"
-                />
+                android:textColor="?attr/learnCountColor"
+                tools:text="381" />
 
             <com.google.android.material.textview.MaterialTextView
                 android:id="@+id/rev_count"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="?attr/reviewCountColor"
                 android:paddingStart="4dp"
-                tools:text="954"
+                android:textColor="?attr/reviewCountColor"
+                tools:text="954" />
+
+            <!-- Timer below counts means UI elements may jump if timer is selectively enabled.
+              This was a considered decision vs other options. Current thinking is the selectively-
+              enabled timer case will be very rare, so UI element motion should also be rare. -->
+            <com.ichi2.anki.ui.windows.reviewer.AnswerTimer
+                android:id="@+id/timer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintTop_toBottomOf="@id/counts_flow"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="@id/counts_flow"
+                app:layout_constraintStart_toStartOf="@id/counts_flow"
+                android:visibility="gone"
+                tools:visibility="visible"
                 />
 
             <com.ichi2.anki.preferences.reviewer.ReviewerMenuView
                 android:id="@+id/reviewer_menu_view"
-                android:layout_width="match_parent"
-                android:layout_height="?actionBarSize"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
                 android:layout_marginStart="12dp"
-                />
-        </LinearLayout>
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/rev_count"
+                app:layout_constraintTop_toTopOf="parent" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/webview_container"


### PR DESCRIPTION
localized below the Count numbers to avoid losing screen space

## Approach
1. Add an improved subclass of `Chronometer` to handle configuration changes properly
2. Add the Timer below the Count numbers
3. Setup the timer

## How Has This Been Tested?

Emulator SDK 35:

https://github.com/user-attachments/assets/9a2a7f1c-00cc-4fe3-bafd-85ce80480e19

Android 15 phone (Galaxy S23):

https://github.com/user-attachments/assets/5aae8232-eec6-47fd-ad79-1980f6f119f2

## Learning (optional, can help others)

1. Had heard before about ConstraintLayout [Flow](https://developer.android.com/reference/kotlin/androidx/constraintlayout/helper/widget/Flow), but never used it until now
2. You can force the emission of the same value in MutableStateFlow by overriding equals() and hashCode() https://stackoverflow.com/questions/62331931/mutablestateflow-is-not-emitting-values-after-1st-emit-kotlin-coroutine


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
