### PR TITLE
build(deps): 0.1.53-anki25.02.7 / display panics in ACRA

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.1"
-ankiBackend = '0.1.52-anki25.02.7'
+ankiBackend = '0.1.53-anki25.02.7'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION
When you see this, please:

* replicate a panic in the emulator
* merge + publish an alpha 

## Fixes
* Fixes #18512

## Approach
* https://github.com/ankidroid/Anki-Android-Backend/pull/530

## How Has This Been Tested?


```
2025-06-14 23:26:57.589  6629-6914  rsdroid::logging        com.ichi2.anki.debug                 E  Panic at anki/rslib/src/storage/note/mod.rs:73: assertion `left == right` failed
                                                                                                      left: 1749940017552
                                                                                                     right: 0
2025-06-14 23:26:57.591  6629-6914  rsdroid::logging        com.ichi2.anki.debug                 E  Panic at anki/rslib/src/backend/mod.rs:122: called `Result::unwrap()` on an `Err` value: PoisonError { .. }
2025-06-14 23:26:57.593  6629-6629  rsdroid::logging        com.ichi2.anki.debug                 E  Panic at anki/rslib/src/backend/mod.rs:122: called `Result::unwrap()` on an `Err` value: PoisonError { .. }
2025-06-14 23:26:57.606  6629-6629  ACRA                    com.ichi2.anki.debug                 E  ACRA caught a BackendFatalError for com.ichi2.anki.debug
                                                                                                    net.ankiweb.rsdroid.BackendException$BackendFatalError: called `Result::unwrap()` on an `Err` value: PoisonError { .. }

```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
