### PR TITLE
Fix DeckSelectionDialog not attached exception

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -28,6 +28,7 @@ import android.widget.Filter
 import android.widget.Filterable
 import android.widget.ImageButton
 import android.widget.TextView
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -38,6 +39,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import anki.decks.deckTreeNode
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.DeckSpinnerSelection
 import com.ichi2.anki.OnContextAndLongClickListener.Companion.setOnContextAndLongClickListener
 import com.ichi2.anki.R
@@ -223,8 +225,14 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
     }
 
     /** Updates the list and simulates a click on the newly created deck */
-    private fun onNewDeckCreated(id: DeckId) {
+    @VisibleForTesting
+    fun onNewDeckCreated(id: DeckId) {
         // a deck/subdeck was created
+        if (!isAdded) {
+            Timber.d("Fragment not added to the activity")
+            CrashReportService.sendExceptionReport("Fragment is not added to activity", "DeckSelectionDialog")
+            return
+        }
         launchCatchingTask {
             val name = withCol { decks.name(id) }
             val deck = SelectableDeck(id, name)


### PR DESCRIPTION
## Purpose / Description
This change aims to fix an exception caused by DeckSelectionDialog not being attached to an activity on creating a new deck.

## Fixes
* Fixes #18530 

## Approach

`launchCatchingTask` uses `requireActivity`. When `launchCatchingTask` is called via `onNewDeckCreated`, if the fragment is in a detached state, then it throws an exception (which is expected behaviour of requireActivity).

Hence, we can check if the fragment "is added", before we launch the coroutine. 

## How Has This Been Tested?

Added a unit test.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
