### PR TITLE
fix: allow rsdroid tagged logs in logcat filter

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -61,6 +61,7 @@ object CrashReportService {
             "ActivityManager:I",
             "SQLiteLog:W",
             AnkiDroidApp.TAG + ":D",
+            "rsdroid:E",
             "*:S",
         )
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.1"
-ankiBackend = '0.1.53-anki25.02.7'
+ankiBackend = '0.1.54-anki25.02.7'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

The backend PR for rsdroid log tagging is required for this, but once available in maven central, this will work in concert with that PR to allow logging from the backend to get through our logcat filters in production releases and hopefully make it in to ACRA

- https://github.com/ankidroid/Anki-Android-Backend/pull/532

Related: 

- #18512

Close and reopen this when it's here:

https://repo1.maven.org/maven2/io/github/david-allison/anki-android-backend/