### PR TITLE
Fix: Preserve deck order in DeckPickerWidget configuration screen.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -291,8 +291,10 @@ class DeckPickerWidgetConfig :
         val selectedDeckIds = deckPickerWidgetPreferences.getSelectedDeckIdsFromPreferences(appWidgetId)
         if (selectedDeckIds.isNotEmpty()) {
             val decks = fetchDecks()
-            val selectedDecks = decks.filter { it.deckId in selectedDeckIds }
-            selectedDecks.forEach { deckAdapter.addDeck(it) }
+            val deckMap = decks.associateBy { it.deckId }
+            selectedDeckIds.forEach { deckId ->
+                deckMap[deckId]?.let { deckAdapter.addDeck(it) }
+            }
             updateViewVisibility()
             updateFabVisibility()
             setupDoneButton()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When reconfiguring the DeckPickerWidget, the configuration screen was displaying decks in alphabetical order instead of maintaining the user's previously selected order. While the widget itself correctly displayed the custom order, the configuration screen lost this order when reopened.

## Fixes
* #18523 


## Approach
Modified the `updateViewWithSavedPreferences()` method to preserve the deck order by:
1. Creating a map of decks for quick lookup by ID
2. Iterating through the saved deck IDs in their original order
3. Adding each deck to the adapter in the same order as saved in preferences

## How Has This Been Tested?
### Before
https://github.com/user-attachments/assets/4ce3e4b0-60d7-4bda-91d4-df72f032db7f

### After
https://github.com/user-attachments/assets/a0c671b3-cb88-4cd1-9beb-8aea1d7396a2




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
