### PR TITLE
Fix two ui issues when using the black theme

### DIFF
--- a/AnkiDroid/src/main/res/drawable/black_round_alert_dialog_background.xml
+++ b/AnkiDroid/src/main/res/drawable/black_round_alert_dialog_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/theme_black_primary_light"/>
+    <corners android:radius="@dimen/m3_alert_dialog_corner_size" />
+</shape>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -119,6 +119,6 @@
     </style>
 
     <style name="ThemeOverlay.AnkiDroid.AlertDialog.Black" parent="ThemeOverlay.AnkiDroid.AlertDialog">
-        <item name="android:background">@color/theme_black_primary_light</item>
+        <item name="android:windowBackground">@drawable/black_round_alert_dialog_background</item>
     </style>
 </resources>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -102,6 +102,8 @@
         <!-- Introduction -->
         <item name="introductionLogoTransparent">#55111111</item>
 
+        <!-- Card-->
+        <item name="cardViewStyle">@style/BlackCardBackground</item>
 
         <!-- ProgressDialog-->
         <item name="dialogBackground">@color/theme_black_primary_light</item>
@@ -110,6 +112,10 @@
 
     <style name="SnackbarTextStyleBlack" parent="@style/Widget.MaterialComponents.Snackbar.TextView">
         <item name="android:textColor">@color/white</item>
+    </style>
+
+    <style name="BlackCardBackground" parent="CardView">
+        <item name="cardBackgroundColor">@color/theme_black_primary_light</item>
     </style>
 
     <style name="ThemeOverlay.AnkiDroid.AlertDialog.Black" parent="ThemeOverlay.AnkiDroid.AlertDialog">


### PR DESCRIPTION
## Purpose / Description
Besides the linked issue this(first commit) also fixes a ui issue in manage notetypes. See images below:

Manage notetypes issue in black theme:
<details>
<summary>
Before the fix
</summary>
<img src="https://github.com/user-attachments/assets/aca5361e-45b0-417e-ad88-c292975d6801" width="300" height="720"/>
</details>


<details>
<summary>
After the fix
</summary>
<img src="https://github.com/user-attachments/assets/0dcd2f83-76e0-47f6-b3b4-19b523d53213" width="300" height="720"/><img src="https://github.com/user-attachments/assets/3849fd6c-7881-4cff-bc0c-d342a96756a8" width="300" height="720"/>
<img src="https://github.com/user-attachments/assets/fe4ef8a9-a3ea-4a3b-a15a-aae727133b04" width="300" height="720"/><img src="https://github.com/user-attachments/assets/a61f7b83-b45b-4fd6-85e7-220fcafde815" width="300" height="720"/>
</details>

How some of the alert dialogs look after applying the fix:

<details>
<summary>
New dialogs images
</summary>
<img src="https://github.com/user-attachments/assets/3036e31a-a343-4bbf-a3cc-8ecd646a092b" width="300" height="720"/><img src="https://github.com/user-attachments/assets/be1a36d0-928e-4538-9b53-d7b32df4381a" width="300" height="720"/>


<img src="https://github.com/user-attachments/assets/66a046a7-4064-41dd-afa3-7be19eafd1ab" width="300" height="720"/><img src="https://github.com/user-attachments/assets/46029791-ada9-4da2-9c6e-ac3beb2990bd" width="300" height="720"/>
<img src="https://github.com/user-attachments/assets/8ad15165-7a9f-4452-bbba-9e7137c5b14e" width="300" height="720"/><img src="https://github.com/user-attachments/assets/2ef8359b-caa6-43e0-9166-790efab89437" width="300" height="720"/>
<img src="https://github.com/user-attachments/assets/16915920-a1a8-4654-85d8-c28810604808" width="300" height="720"/><img src="https://github.com/user-attachments/assets/06d932e7-7319-41d7-9f37-d155fff07f33" width="300" height="720"/>
<img src="https://github.com/user-attachments/assets/feac12c0-3ed5-4ceb-bcce-70f7830d9058" width="300" height="720"/>
</details>

## Fixes
* Fixes #18535

## How Has This Been Tested?

Checked the app dialogs.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

