### PR TITLE
Fix: Media Sync PoisonError, and a couple of media sync issues

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.libanki.ChangeManager.notifySubscribersAllValuesChanged
 import com.ichi2.libanki.createBackup
@@ -385,7 +386,7 @@ suspend fun monitorMediaSync(deckPicker: DeckPicker) {
         withContext(Dispatchers.Main) {
             AlertDialog
                 .Builder(deckPicker)
-                .setTitle(TR.syncMediaLogTitle())
+                .setTitle(TR.syncMediaLogTitle().toSentenceCase(deckPicker, R.string.sentence_sync_media_log))
                 .setMessage("")
                 .setPositiveButton(R.string.dialog_continue) { _, _ ->
                     scope.cancel()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -42,6 +42,7 @@ import com.ichi2.libanki.syncCollection
 import com.ichi2.libanki.syncLogin
 import com.ichi2.preferences.VersatileTextWithASwitchPreference
 import com.ichi2.utils.NetworkUtils
+import com.ichi2.utils.dismissSafely
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -416,7 +417,7 @@ suspend fun monitorMediaSync(deckPicker: DeckPicker) {
         } catch (_: Exception) {
             showMessage(TR.syncMediaFailed())
         } finally {
-            dialog.dismiss()
+            dialog.dismissSafely()
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -71,8 +71,10 @@ class SyncMediaWorker(
                     }
                 }
 
+            // The collection must be open, but we should not block collection operations while
+            // `syncMedia` is executing, the app should be usable during a background media sync
+            CollectionManager.getColUnsafe().backend.syncMedia(auth)
             val backend = CollectionManager.getBackend()
-            backend.syncMedia(auth)
 
             delay(1000) // avoid notifications if sync occurs too quickly
             if (backend.mediaSyncStatus().active) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -44,6 +44,7 @@ import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
 import com.ichi2.ui.FixedTextView
+import com.ichi2.utils.HandlerUtils.executeOnMainThread
 import timber.log.Timber
 
 /** Wraps [DialogInterface.OnClickListener] as we don't need the `which` parameter */
@@ -451,5 +452,22 @@ fun AlertDialog.Builder.titleWithHelpIcon(
     customTitleView.findViewById<ImageView>(R.id.help_icon).setOnClickListener { v ->
         Timber.i("dialog help icon click")
         block.onClick(v)
+    }
+}
+
+/** Calls [AlertDialog.dismiss], ignoring errors */
+fun AlertDialog.dismissSafely() {
+    // The exception will be uncaught if not run on the main thread.
+    executeOnMainThread {
+        try {
+            // safer to catch the exception to be sure dismiss() was called
+            dismiss()
+        } catch (e: IllegalArgumentException) {
+            if (window == null || !isShowing) {
+                Timber.d(e, "Dialog not attached to window manager")
+                return@executeOnMainThread
+            }
+            Timber.w(e, "Dialog not attached to window manager")
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HandlerUtils.kt
@@ -88,4 +88,18 @@ object HandlerUtils {
             time,
         )
     }
+
+    /**
+     * Executes a method on the main thread. Either immediately, or via
+     * [HandlerUtils.executeFunctionUsingHandler]
+     *
+     * @param function The function which needs to be executed.
+     */
+    fun executeOnMainThread(function: () -> Unit) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            function()
+        } else {
+            executeFunctionUsingHandler { function() }
+        }
+    }
 }

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -48,5 +48,6 @@ undoActionUndone()
     <string name="sentence_check_media_delete_unused">Delete unused</string>
     <string name="sentence_choose_tags">Choose tags</string>
     <string name="sentence_selective_study">Selective study</string>
+    <string name="sentence_sync_media_log">Media sync log</string>
 
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -39,6 +39,12 @@ class SentenceCaseTest : RobolectricTest() {
             assertThat(TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date), equalTo("Set due date"))
             assertThat(TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study), equalTo("Custom study"))
             assertThat(TR.emptyCardsWindowTitle().toSentenceCase(this, R.string.sentence_empty_cards), equalTo("Empty cards"))
+            assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
+            assertThat(
+                "sentence_sync_media_log",
+                TR.syncMediaLogTitle().toSentenceCase(this, R.string.sentence_sync_media_log),
+                equalTo("Media sync log"),
+            )
 
             assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
             assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))


### PR DESCRIPTION
Special thanks to [Enchantable](https://www.reddit.com/user/Enchantable/) on Reddit for the diagnostic help!

## Purpose / Description

If a media sync is attempted with a closed collection, it raises:

```
Panic at anki/rslib/src/backend/sync.rs:249: called Option::unwrap() on a None
```

Which poisons the collection for all future accesses

```
Result::unwrap() on an Err value: PoisonError { .. }
```

## Fixes
* Fixes #17382
* Fixes #18542
* Fixes Part of #15760

## Approach

Our fix ensures an open collection, and throws if this is not the case, but does NOT use `withCol { }`, as this blocks the queue of operations to the backend until it's completed (even if done in a background thread)

* Dismiss a dialog safely
  *  Fix by a try...catch, which needed to be on the main thread  
* Fix a title
  * Standard `sentence-case` stuff 

## How Has This Been Tested?

**PoisonError**

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt	(revision a107a81149f74fd3651c5d22e1557999a5e4fbe7)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt	(date 1750095023225)
@@ -73,9 +73,9 @@
 
             // The collection must be open, but we should not block collection operations while
             // `syncMedia` is executing, the app should be usable during a background media sync
-            CollectionManager.getColUnsafe().backend.syncMedia(auth)
+            CollectionManager.closeCollectionBlocking()
             val backend = CollectionManager.getBackend()
-
+            backend.syncMedia(auth)
             delay(1000) // avoid notifications if sync occurs too quickly
             if (backend.mediaSyncStatus().active) {
                 Timber.i("Showing SyncMediaWorker's notification")
```

**Media sync started**

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt	(revision a107a81149f74fd3651c5d22e1557999a5e4fbe7)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt	(date 1750095148658)
@@ -73,6 +73,7 @@
 
             // The collection must be open, but we should not block collection operations while
             // `syncMedia` is executing, the app should be usable during a background media sync
+            CollectionManager.closeCollectionBlocking()
             CollectionManager.getColUnsafe().backend.syncMedia(auth)
             val backend = CollectionManager.getBackend()
``` 

----

![image](https://github.com/user-attachments/assets/01584073-0576-49ba-b220-3b2cbada2ac3)

----

Checked logcat for the Fragment detached error; logged and no longer crashes

Do note that the `window == null || !isShowing` checks were passing, so Timber logs this as `w`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
