### PR TITLE
improvement(debug-info): improve newlines

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/DebugInfoService.kt
@@ -50,6 +50,9 @@ object DebugInfoService {
             FSRS = ${BackendBuildConfig.FSRS_VERSION} (Enabled: $isFSRSEnabled)
             Crash Reports Enabled = ${isSendingCrashReports(info)}
             """.trimIndent()
+            // A Markdown newline is two spaces followed by '\n', this avoids the need for
+            // code fences
+            .replace("\n", "  \n")
     }
 
     private fun isSendingCrashReports(context: Context): Boolean = CrashReportService.isAcraEnabled(context, false)


### PR DESCRIPTION
In Markdown, a line break is 2 spaces followed by a newline

This makes them look a little better if a user doesn't add a code fence

## How Has This Been Tested?

AnkiDroid Version = 2.21alpha20-debug (b734b2aee0df6da15dbca001768e4e5de0cdaeec)  
Backend Version = 0.1.54-anki25.02.7 (25.02.7 98253c81cb3c4d203acec48d6eae6b488bf484d0)  
Android Version = 15 (SDK 35)  
ProductFlavor = play  
Device Info = Google | google | caiman | caiman | Pixel 9 Pro | caiman  
Webview User Agent = Mozilla/5.0 (Linux; Android 15; Pixel 9 Pro Build/BP1A.250505.005.A1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/137.0.7151.88 Mobile Safari/537.36  
ACRA UUID = 5ae2ce0e-ed23-43f7-9219-b2a8050e754e  
FSRS = 2.0.3 (Enabled: true)  
Crash Reports Enabled = false

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
