### PR TITLE
improvement(card-type): add title to rename dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RenameCardTemplateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/RenameCardTemplateDialog.kt
@@ -24,6 +24,7 @@ import com.ichi2.utils.input
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
+import com.ichi2.utils.title
 
 class RenameCardTemplateDialog {
     companion object {
@@ -35,6 +36,7 @@ class RenameCardTemplateDialog {
             AlertDialog
                 .Builder(context)
                 .show {
+                    title(R.string.rename_card_type)
                     positiveButton(R.string.dialog_ok) { }
                     negativeButton(R.string.dialog_cancel)
                     setView(R.layout.dialog_generic_text_input)

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -35,6 +35,7 @@
 
     <!--Rename-->
     <string name="rename_model">Rename note type</string>
+    <string name="rename_card_type">Rename card type</string>
 
     <!--Language Hint-->
     <string name="model_field_editor_language_hint_dialog_success_result">Set language hint to %s</string>


### PR DESCRIPTION

## Fixes
* Fixes #18545

## Approach
Add title: 'Rename card type'

## How Has This Been Tested?
![image](https://github.com/user-attachments/assets/e7c4f727-27ef-4d80-ab37-42828f9bd62b)

## Learning (optional, can help others)
Anki Desktop has `TR.cardTemplatesRenameCardType`: 'Rename Card Type...', but we don't want '...' in a title

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
