### PR TITLE
fix(copy-debug-info): crash if Context is null 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
@@ -15,6 +15,7 @@
  ****************************************************************************************/
 package com.ichi2.anki.dialogs
 
+import android.content.Context
 import android.content.res.Resources
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -41,5 +42,17 @@ abstract class AsyncDialogFragment : AnalyticsDialogFragment() {
         } catch (e: Exception) {
             Timber.w(e, "resources failure. Returning AnkiDroidApp resources as fallback.")
             AnkiDroidApp.appResources
+        }
+
+    /**
+     * Return the {@link Context} this fragment is currently associated with.
+     * Uses [AnkiDroidApp.instance] if [requireContext] fails
+     */
+    protected fun getSafeContext(): Context =
+        try {
+            requireContext()
+        } catch (e: Exception) {
+            Timber.w(e, "Error getting context; using AnkiDroidApp")
+            AnkiDroidApp.instance
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -420,13 +420,14 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
      * and copies the combines information to the Android clipboard.
      */
     private suspend fun copyStackTraceAndDebugInfo() {
+        val context = getSafeContext()
         val combinedInfo =
             listOfNotNull(
                 exceptionData?.toHumanReadableString(),
-                DebugInfoService.getDebugInfo(requireContext()),
+                DebugInfoService.getDebugInfo(context),
             ).joinToString(separator = "\n")
 
-        requireContext().copyToClipboard(
+        context.copyToClipboard(
             combinedInfo,
             failureMessageId = R.string.about_ankidroid_error_copy_debug_info,
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -53,6 +53,7 @@ import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_RESTORE_BACKUP
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.DIALOG_STORAGE_UNAVAILABLE_AFTER_UNINSTALL
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType.INCOMPATIBLE_DB_VERSION
+import com.ichi2.anki.dialogs.DatabaseErrorDialog.UninstallListItem.Companion.createList
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ImportOptions
 import com.ichi2.anki.isLoggedIn
 import com.ichi2.anki.launchCatchingTask
@@ -420,11 +421,10 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
      */
     private suspend fun copyStackTraceAndDebugInfo() {
         val combinedInfo =
-            listOf(
+            listOfNotNull(
                 exceptionData?.toHumanReadableString(),
                 DebugInfoService.getDebugInfo(requireContext()),
-            ).filterNotNull()
-                .joinToString(separator = "\n")
+            ).joinToString(separator = "\n")
 
         requireContext().copyToClipboard(
             combinedInfo,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/servicemodel/PreferenceUpgradeServiceTest.kt
@@ -101,7 +101,7 @@ class PreferenceUpgradeServiceTest : RobolectricTest() {
 
         assertThat(
             "Different count of nested classes ($nestedClassCount) and upgrades ($upgradeCount). \n" +
-                "nested classes:\n ${nestedClasses.map { it.simpleName }.joinToString("\n")}",
+                "nested classes:\n ${nestedClasses.joinToString("\n") { it.simpleName.toString() }}",
             nestedClassCount,
             equalTo(upgradeCount),
         )


### PR DESCRIPTION
## Fixes
* Fixes #18527

## Approach
use `AnkiDroidApp.context`

## How Has This Been Tested?

* Tested copy debug info
* Tested with the following, still copies

```patch
Subject: [PATCH] fix(copy-debug-info): crash if Context is null

Fixes 18527
---
Index: AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt	(revision bdf1b3eb5a1c5eeec293fa67380476ede1d73d18)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/AsyncDialogFragment.kt	(date 1750164167116)
@@ -50,7 +50,7 @@
      */
     protected fun getSafeContext(): Context =
         try {
-            requireContext()
+            AnkiDroidApp.instance
         } catch (e: Exception) {
             Timber.w(e, "Error getting context; using AnkiDroidApp")
             AnkiDroidApp.instance
Index: AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt	(revision bdf1b3eb5a1c5eeec293fa67380476ede1d73d18)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt	(date 1750164157928)
@@ -175,6 +175,8 @@
                 bundle.getString(KEY_EXPORT_PATH) ?: error("Missing required exportPath!"),
             )
         }
+
+        showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_ERROR, CustomExceptionData("AA"))
     }
 
     override fun onStart() {
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
