### PR TITLE
Refactoring Card editor [Deprecate editorTitle, wrap in CardView, show focus]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -668,6 +668,14 @@ open class CardTemplateEditor :
                 insets
             }
 
+            /**
+             * We focus on the editText to indicate it's editable, but we don't automatically
+             * show the keyboard. This is intentional - the keyboard should only appear
+             * when the user taps on the edit field, not every time the fragment loads.
+             */
+            editorEditText.post {
+                editorEditText.requestFocus()
+            }
             return mainView
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -102,7 +102,6 @@ import com.ichi2.libanki.restoreNotetypeToStock
 import com.ichi2.libanki.undoableOp
 import com.ichi2.themes.Themes
 import com.ichi2.ui.FixedEditText
-import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.dp
 import com.ichi2.utils.listItems
@@ -510,7 +509,6 @@ open class CardTemplateEditor :
 
     class CardTemplateFragment : Fragment() {
         private val refreshFragmentHandler = Handler(Looper.getMainLooper())
-        private var currentEditorTitle: FixedTextView? = null
         private lateinit var editorEditText: FixedEditText
 
         var currentEditorViewId = 0
@@ -539,7 +537,6 @@ open class CardTemplateEditor :
                     return mainView
                 }
 
-            currentEditorTitle = mainView.findViewById(R.id.title_edit)
             editorEditText = mainView.findViewById(R.id.editor_editText)
             cursorPosition = requireArguments().getInt(CURSOR_POSITION_KEY)
 
@@ -550,14 +547,9 @@ open class CardTemplateEditor :
                 val currentSelectedId = item.itemId
                 templateEditor.tabToViewId[cardIndex] = currentSelectedId
                 when (currentSelectedId) {
-                    R.id.styling_edit -> setCurrentEditorView(currentSelectedId, tempModel.css, R.string.card_template_editor_styling)
-                    R.id.back_edit ->
-                        setCurrentEditorView(
-                            currentSelectedId,
-                            template.afmt,
-                            R.string.card_template_editor_back,
-                        )
-                    else -> setCurrentEditorView(currentSelectedId, template.qfmt, R.string.card_template_editor_front)
+                    R.id.styling_edit -> setCurrentEditorView(currentSelectedId, tempModel.css)
+                    R.id.back_edit -> setCurrentEditorView(currentSelectedId, template.afmt)
+                    else -> setCurrentEditorView(currentSelectedId, template.qfmt)
                 }
                 // contents of menu have changed and menu should be redrawn
                 templateEditor.invalidateOptionsMenu()
@@ -734,11 +726,9 @@ open class CardTemplateEditor :
         fun setCurrentEditorView(
             id: Int,
             editorContent: String,
-            editorTitleId: Int,
         ) {
             currentEditorViewId = id
             editorEditText.setText(editorContent)
-            currentEditorTitle!!.text = resources.getString(editorTitleId)
             editorEditText.setSelection(cursorPosition)
             editorEditText.requestFocus()
         }

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -10,13 +10,6 @@
     android:paddingTop="12dp">
 
     <!-- Editor -->
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/title_edit"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="5dp"
-        android:focusable="true"
-        android:text="@string/card_template_editor_front" />
     <ScrollView
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
+++ b/AnkiDroid/src/main/res/layout/card_template_editor_item.xml
@@ -11,6 +11,7 @@
 
     <!-- Editor -->
     <ScrollView
+        android:id="@+id/card_template_editor_scroll_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -704,14 +704,10 @@ class CardTemplateEditorTest : RobolectricTest() {
         val cardTemplateFragment = testEditor.currentFragment
         val tempNoteType = testEditor.tempNoteType
         // set Bottom Navigation View to Style
-        cardTemplateFragment!!.setCurrentEditorView(R.id.styling_edit, tempNoteType!!.css, R.string.card_template_editor_styling)
+        cardTemplateFragment!!.setCurrentEditorView(R.id.styling_edit, tempNoteType!!.css)
 
         // set Bottom Navigation View to Front
-        cardTemplateFragment.setCurrentEditorView(
-            R.id.front_edit,
-            tempNoteType.getTemplate(0).qfmt,
-            R.string.card_template_editor_front,
-        )
+        cardTemplateFragment.setCurrentEditorView(R.id.front_edit, tempNoteType.getTemplate(0).qfmt)
 
         // check if current content is updated or not
         assumeThat(templateEditText.text.toString(), Matchers.equalTo(updatedFrontContent))
@@ -746,7 +742,7 @@ class CardTemplateEditorTest : RobolectricTest() {
         assumeThat(cardTemplateFragment!!.currentEditorViewId, Matchers.equalTo(R.id.front_edit))
 
         // set Bottom Navigation View to Style
-        cardTemplateFragment.setCurrentEditorView(R.id.styling_edit, tempNoteType.css, R.string.card_template_editor_styling)
+        cardTemplateFragment.setCurrentEditorView(R.id.styling_edit, tempNoteType.css)
 
         // check if current view is changed or not
         assumeThat(templateEditText.text.toString(), Matchers.equalTo(tempNoteType.css))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Deprecate the editor title
- Wrap `CardTemplateEditor` screen inside a MaterialCardView when fragmented.
- Launch focus when `CardTemplateEditor` is opened.

## Fixes
* For GSoC 2025: Tablet & Chromebook UI
* #18511 
* #18560
## Approach
This PR consists of 3 Commits:
1. The first commit contains deprecates the editor title in `CardTemplateEditor`:
   - Removed from setCurrentEditorView
   - Updated all instances of setCurrentEditorView being called from both `CardTemplateEditor.kt` and `CardTemplateEditorTest.kt` 
   - Removed title_edit FixedTextView from `card_template_editor_item.xml` and all references to it.
2. The second commit Wraps the `CardTemplateEditor` edit area in a MaterialCardView:
   - Checks if editor is fragmented, and injects the edit area ScrollView into a MaterialCardView
   - Sets the top margin of `TemplatePreviewer` to match `CardTemplateEditor`
3. The third commit uses focus to show the edit area is editable:
   - Uses requestFocus() to focus to the editText


## How Has This Been Tested?
Tested on the following Android Emulators:
Pixel Tablet API 35
Large Desktop API 34

Tested on the following phones:
Samsung SM-918B (S23 Ultra) - API 35

Screenshots of affected screens in different themes on Large Screens:
1. Black Theme:
![tblack](https://github.com/user-attachments/assets/b7ca31d9-9190-464c-9a17-c1f5d27ed832)

2. Plain Theme:
![tplain](https://github.com/user-attachments/assets/5a3f4d0e-19da-4595-99c7-dc06d2a0b6ac)

3. Default Light Theme:
![tlight](https://github.com/user-attachments/assets/72cb02ea-c659-414c-b6ee-8b1e40eaf2a5)

4. Default Dark Theme:
![tdark](https://github.com/user-attachments/assets/7824d36b-a88b-4e5f-b147-aff24a41ee81)

Screenshots of affected screens in different themes on Mobile Screens:
1. Black Theme:
![pblack](https://github.com/user-attachments/assets/db500025-d3a9-4bd5-a514-275d9ce9d92f)

2. Plain Theme:
![pplain](https://github.com/user-attachments/assets/5fd563df-eaf2-4750-89bf-26a86232f27a)

3. Default Light Theme:
![plight](https://github.com/user-attachments/assets/5e9217ac-f854-445f-acca-0bd471b1f685)

4. Default Dark Theme:
![pdark](https://github.com/user-attachments/assets/c176ecab-77cc-428a-b2ca-24d4342d4ba0)


Emulator Test on Pixel Tablet API 35:
https://github.com/user-attachments/assets/9f6286f4-5326-4fce-a7d7-f51855894b3f

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
