### PR TITLE
chore: improve logging of invalid index issue in new reviewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
@@ -73,6 +73,12 @@ object GestureParser {
 
         val row = getGridIndex(tapY, scrollY, measuredHeight, scale)
         val column = getGridIndex(tapX, scrollX, measuredWidth, scale)
+        // FIXME fix the source of values that result in an invalid index
+        if (row !in 0..2 || column !in 0..2) {
+            throw IllegalArgumentException(
+                "Gesture parsing error: uri $uri - isScrolling $isScrolling - scale $scale - scrollX $scrollX - scrollY $scrollY - measuredWidth $measuredWidth - measuredHeight $measuredHeight",
+            )
+        }
         return gestureGrid[row][column]
     }
 


### PR DESCRIPTION
## Fixes
* Fixes part of #18559

## Approach
I suspect that getting an index of `4` in an scenario where only `0, 1 or 2` should be returned is caused by the `WebView` scale initial value not being set.
To avoid deeper bugs (like a gesture mapped incorrectly), and also taking advantage of the fact that the new reviewer is a developer option, I'm keeping the offensive programming approach of failing fast, but now with improved logging.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
