### PR TITLE
feat(card-browser): add select all/none toggle in header 

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_deselect_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_deselect_white.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright 2025, Google Material Design Icons
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M791,904L567,680L280,680L280,393L56,169L112,112L848,848L791,904ZM360,600L487,600L360,473L360,600ZM680,567L600,487L600,360L473,360L393,280L680,280L680,567ZM200,760L200,840Q167,840 143.5,816.5Q120,793 120,760L200,760ZM120,680L120,600L200,600L200,680L120,680ZM120,520L120,440L200,440L200,520L120,520ZM120,360L120,280L200,280L200,360L120,360ZM280,840L280,760L360,760L360,840L280,840ZM280,200L280,120L360,120L360,200L280,200ZM440,840L440,760L520,760L520,840L440,840ZM440,200L440,120L520,120L520,200L440,200ZM600,840L600,760L680,760L680,840L600,840ZM600,200L600,120L680,120L680,200L600,200ZM760,680L760,600L840,600L840,680L760,680ZM760,520L760,440L840,440L840,520L760,520ZM760,360L760,280L840,280L840,360L760,360ZM760,200L760,120Q793,120 816.5,143.5Q840,167 840,200L760,200Z"/>
+    
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_select_all_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_select_all_white.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="#FFFFFF"
+<vector android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FF000000" android:pathData="M3,5h2L5,3c-1.1,0 -2,0.9 -2,2zM3,13h2v-2L3,11v2zM7,21h2v-2L7,19v2zM3,9h2L5,7L3,7v2zM13,3h-2v2h2L13,3zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM5,21v-2L3,19c0,1.1 0.9,2 2,2zM3,17h2v-2L3,15v2zM9,3L7,3v2h2L9,3zM11,21h2v-2h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2zM19,9h2L21,7h-2v2zM19,17h2v-2h-2v2zM15,21h2v-2h-2v2zM15,5h2L17,3h-2v2zM7,17h10L17,7L7,7v10zM9,9h6v6L9,15L9,9z"/>

--- a/AnkiDroid/src/main/res/layout/cardbrowser.xml
+++ b/AnkiDroid/src/main/res/layout/cardbrowser.xml
@@ -30,6 +30,7 @@
             android:layout_height="wrap_content"
             android:indeterminate="true"
             android:visibility="gone"
+            tools:visbility="visible"
             />
 
         <RelativeLayout
@@ -43,6 +44,7 @@
                 android:overScrollFooter="@color/transparent"
                 android:dividerHeight="0.5dp"
                 android:drawSelectorOnTop="true"
+                tools:listitem="@layout/card_item_browser"
                 />
 
             <com.ichi2.anki.ui.RecyclerFastScroller

--- a/AnkiDroid/src/main/res/layout/cardbrowser.xml
+++ b/AnkiDroid/src/main/res/layout/cardbrowser.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<androidx.coordinatorlayout.widget.CoordinatorLayout
-    android:id="@+id/root_layout"
+<androidx.coordinatorlayout.widget.CoordinatorLayout android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    >
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -14,15 +13,35 @@
         android:orientation="vertical" >
 
         <LinearLayout
-            android:id="@+id/browser_column_headings"
             android:layout_width="match_parent"
-            android:background="@drawable/browser_heading_bottom_divider"
-            android:orientation="horizontal"
-            android:paddingVertical="2dp"
             android:layout_height="wrap_content"
-            android:longClickable="true">
+            android:orientation="horizontal">
 
+
+            <ImageButton
+                android:id="@+id/toggle_row_selections"
+                android:layout_width="48dp"
+                android:layout_height="48dp"
+                android:src="@drawable/ic_select_all_white"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                app:tint="?attr/colorControlNormal"
+                />
+
+
+            <LinearLayout
+                android:id="@+id/browser_column_headings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:longClickable="true">
+            </LinearLayout>
         </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="2dp"
+            android:background="@drawable/browser_heading_bottom_divider"
+            />
 
         <com.google.android.material.progressindicator.LinearProgressIndicator
             android:id="@+id/browser_progress"

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -69,26 +69,16 @@
         android:id="@+id/action_reset_cards_progress"
         android:title="@string/card_editor_reset_card"/>
 
+    <!-- TODO: ankidroid:showAsAction="ifRoom" once 'no hamburger' padding issues are resolved -->
     <item
         android:id="@+id/action_preview"
-        android:title="@string/card_editor_preview_card"/>
+        android:title="@string/card_editor_preview_card"
+        android:icon="@drawable/ic_remove_red_eye_white"
+    />
 
     <item
         android:id="@+id/action_export_selected"
         tools:title="Export cards"/>
-
-    <item
-        ankidroid:showAsAction="ifRoom"
-        android:id="@+id/action_select_all"
-        android:title="@string/card_browser_select_all"
-        android:icon="@drawable/ic_select_all_white"/>
-
-    <!-- For now: don't display 'select none' as action as we don't have an icon -->
-    <item
-        ankidroid:showAsAction="never"
-        android:id="@+id/action_select_none"
-        android:title="@string/card_browser_select_none"
-        android:icon="@drawable/ic_select_all_white"/>
 
     <item
         ankidroid:showAsAction="ifRoom"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -172,28 +172,6 @@ class CardBrowserTest : RobolectricTest() {
         }
 
     @Test
-    fun selectNoneIsVisibleOnceSelectAllCalled() =
-        runTest {
-            val browser = browserWithMultipleNotes
-            selectMenuItem(browser, R.id.action_select_all)
-            assertThat(browser.isShowingSelectNone, equalTo(true))
-        }
-
-    @Test
-    fun selectNoneIsVisibleWhenSelectingOne() {
-        val browser = browserWithMultipleNotes
-        selectOneOfManyCards(browser)
-        assertThat(browser.isShowingSelectNone, equalTo(true))
-    }
-
-    @Test
-    fun selectAllIsVisibleWhenSelectingOne() {
-        val browser = browserWithMultipleNotes
-        selectOneOfManyCards(browser)
-        assertThat(browser.isShowingSelectAll, equalTo(true))
-    }
-
-    @Test
     fun testOnDeckSelected() =
         withBrowser(noteCount = 1) {
             // Arrange
@@ -220,24 +198,6 @@ class CardBrowserTest : RobolectricTest() {
         selectOneOfManyCards(browser)
         assertThat(browser.viewModel.isInMultiSelectMode, equalTo(true))
     }
-
-    @Test
-    @Flaky(os = OS.WINDOWS, "Expected `true`, got `false`")
-    fun browserIsInMultiSelectModeWhenSelectingAll() =
-        runTest {
-            val browser = browserWithMultipleNotes
-            selectMenuItem(browser, R.id.action_select_all)
-            assertThat(browser.viewModel.isInMultiSelectMode, equalTo(true))
-        }
-
-    @Test
-    fun browserIsNotInMultiSelectModeWhenSelectingNone() =
-        runTest {
-            val browser = browserWithMultipleNotes
-            selectMenuItem(browser, R.id.action_select_all)
-            selectMenuItem(browser, R.id.action_select_none)
-            assertThat(browser.viewModel.isInMultiSelectMode, equalTo(false))
-        }
 
     @Test
     fun browserDoesNotFailWhenSelectingANonExistingCard() =
@@ -1717,12 +1677,6 @@ val CardBrowser.isShowingSelectAll: Boolean
     get() {
         waitForAsyncTasksToComplete()
         return actionBarMenu?.findItem(R.id.action_select_all)?.isVisible == true
-    }
-
-val CardBrowser.isShowingSelectNone: Boolean
-    get() {
-        waitForAsyncTasksToComplete()
-        return actionBarMenu?.findItem(R.id.action_select_none)?.isVisible == true
     }
 
 val CardBrowser.columnHeadingViews


### PR DESCRIPTION
## Purpose / Description

There was blank space, it made sense, and it meant we can remove two menu items

<img width="773" alt="Screenshot 2025-06-21 at 05 58 39" src="https://github.com/user-attachments/assets/be043df0-94da-454c-82ef-6708a8a2ccb8" />
<img width="760" alt="Screenshot 2025-06-21 at 05 58 49" src="https://github.com/user-attachments/assets/76f86a89-e278-4b12-9c2a-bc3fe9034f69" />

## Fixes
* Fixes #18572

## Approach

I first added the toggle and removed 'select all' and 'select none' menu items if the user was in 'multi-select' mode

I was then frustrated that 'select none' disabled selection mode: the 'back' button was so close which did the same, so I changed the Card Browser to allow a user to be in selection mode with 0 rows selected.

This then meant a number of menu items were unusable, so I hid them. Only 'preview' remains

## How Has This Been Tested?
Unit tests were added

I have tested on a Google Pixel 9 Pro, and an Emulator 34 tablet

* Focused row functionality feels unchanged on the tablet
* Keyboard shortcuts did nothing (as expected)
* Menu items were removed if 0 items were selected
  * Only 'preview' remains 
  * Tested in cards and notes mode

## Learning

* Preview is still menu-only. if there was only 1 menu item, it didn't look like the margins were correct

![image](https://github.com/user-attachments/assets/96def055-6da7-460f-9691-3a55f254b090)

<details>

<summary>broken patch</summary>

```patch
Subject:
---
Index: AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt	(revision f8cdd32fb8e719d240e0b8f6fcf48d88fb8442cd)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt	(revision dd6263d901e4a5bde0c50ab2b925edd174e3065f)
@@ -1128,6 +1128,11 @@
                     )
             }
         }
+
+        if (actionBarMenu.toList().count { it.isVisible } == 1) {
+            val menuItem = actionBarMenu[0]
+            // TODO: do something here to fix               
+        }
     }
 
     private fun updateFlagForSelectedRows(flag: Flag) =
Index: AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Menu.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Menu.kt b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Menu.kt
new file mode 100644
--- /dev/null	(revision dd6263d901e4a5bde0c50ab2b925edd174e3065f)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Menu.kt	(revision dd6263d901e4a5bde0c50ab2b925edd174e3065f)
@@ -0,0 +1,24 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.view.Menu
+import android.view.MenuItem
+import androidx.core.view.get
+import androidx.core.view.size
+
+fun Menu.toList(): List<MenuItem> = List(size) { idx -> this[idx] }

```

</details>

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Google Material Design Icons | Material design system icons are simple, modern, friendly, and sometimes quirky. Each icon is created using our design guidelines to depict in simple and minimal forms the universal concepts used commonly throughout a UI. Ensuring readability and clarity at both large and small sizes, these icons have been optimized for beautiful display on all common platforms and display resolutions. | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**⚠️ Maintainers: Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging**