### PR TITLE
fix(preferences): fragment back stack being reset

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -169,6 +169,9 @@ class PreferencesFragment :
 
         parentFragmentManager.addOnBackStackChangedListener(parentBackStackListener)
         childFragmentManager.addOnBackStackChangedListener(childBackStackListener)
+
+        childFragmentOnBackPressedCallback.isEnabled = !settingsIsSplit && childFragmentManager.backStackEntryCount > 0
+        parentFragmentOnBackPressedCallback.isEnabled = parentFragmentManager.backStackEntryCount > 0
     }
 
     private fun setFragmentTitleOnToolbar(fragment: Fragment) {


### PR DESCRIPTION
the backPressed callbacks are disabled when the fragment is created, and get enabled when the backstack changes with the backstack listeners

The issue was that after an activity recreation, the callbacks weren't being enabled because there was no backstack change

So, enabling them manually when the view is created fix that

## Fixes
* Fixes #18580

## How Has This Been Tested?

Same steps of the issue in an SDK 35 emulator

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
