### PR TITLE
fix(custom-study): stop disabling 'extend' options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -637,12 +637,14 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             val availableInChildren: Int,
         ) {
             /**
+             * **Temporarily Disabled** - logic may be incorrect
+             *
              * "Extend" only has an effect if there are pending cards in the target deck
              *
              * The number of pending cards in child decks is only informative
              */
             val isUsable
-                get() = available > 0
+                get() = true // TODO: Confirm `available > 0` is correct; user feedback states subdecks are taken into account
 
             /**
              * A string representing the count of cards which have exceeded a deck limit

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -49,6 +49,7 @@ import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -145,6 +146,7 @@ class CustomStudyDialogTest : RobolectricTest() {
     }
 
     @Test
+    @Ignore("disabled while we confirm/diagnose issues")
     @Config(qualifiers = "en")
     fun `'increase new limit' is shown when there are new cards`() {
         val studyDefaults = customStudyDefaultsResponse { availableNew = 1 }
@@ -158,6 +160,7 @@ class CustomStudyDialogTest : RobolectricTest() {
     }
 
     @Test
+    @Ignore("disabled while we confirm/diagnose issues")
     @Config(qualifiers = "en")
     fun `'increase new limit' is not shown when there are no new cards`() {
         val studyDefaults = customStudyDefaultsResponse { availableNew = 0 }
@@ -171,6 +174,7 @@ class CustomStudyDialogTest : RobolectricTest() {
     }
 
     @Test
+    @Ignore("disabled while we confirm/diagnose issues")
     @Config(qualifiers = "en")
     fun `'increase review limit' is shown when there are new cards`() {
         val studyDefaults = customStudyDefaultsResponse { availableReview = 1 }
@@ -184,6 +188,7 @@ class CustomStudyDialogTest : RobolectricTest() {
     }
 
     @Test
+    @Ignore("disabled while we confirm/diagnose issues")
     @Config(qualifiers = "en")
     fun `'increase review limit' is not shown when there are no new cards`() {
         val studyDefaults = customStudyDefaultsResponse { availableReview = 0 }


### PR DESCRIPTION
We have user feedback that our logic is incorrect

I have not looked into this deeply, and the outcome was unintuitive, so disable it for now

https://forums.ankiweb.net/t/ankidroid-2-21-beta-feedback/62992/2

## How Has This Been Tested?
Minimal: trivial change; Briefly opened to ensure the screen still worked and items were no longer disabled on a new deck with 1 due card

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
