### PR TITLE
fix(deck-picker): clicking on an empty filtered deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2118,6 +2118,7 @@ open class DeckPicker :
     }
 
     @NeedsTest("14608: Ensure that the deck options refer to the selected deck")
+    @NeedsTest("18586: handle clicking on an empty filtered deck")
     private suspend fun handleDeckSelection(
         did: DeckId,
         selectionType: DeckSelectionType,
@@ -2157,7 +2158,7 @@ open class DeckPicker :
             return
         }
 
-        if (isDeckAndSubdeckEmpty(did)) {
+        if (!deck.filtered && isDeckAndSubdeckEmpty(did)) {
             showEmptyDeckSnackbar()
             updateUi()
         } else {


### PR DESCRIPTION
... Should not suggest that a user adds cards

## Fixes
* Fixes #18586

## How Has This Been Tested?
* Pixel 9 Pro Emulator, API 36

* Clicking an empty filtered deck now shows the Congrats Screen and allows a user to select options

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
