### PR TITLE
UX Improvements: Set Due Date

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -238,6 +238,20 @@ fun FragmentActivity.launchCatchingTask(
         runCatching(errorMessage, skipCrashReport = skipCrashReport) { block() }
     }
 
+/**
+ * Launch a job that catches any uncaught errors and reports them to the user.
+ * Errors from the backend contain localized text that is often suitable to show to the user as-is.
+ * Other errors should ideally be handled in the block.
+ */
+fun <T> FragmentActivity.asyncCatching(
+    errorMessage: String? = null,
+    skipCrashReport: ((Exception) -> Boolean)? = null,
+    block: suspend CoroutineScope.() -> T,
+): Deferred<T?> =
+    lifecycle.coroutineScope.async {
+        runCatching(errorMessage, skipCrashReport = skipCrashReport) { block() }
+    }
+
 /** See [FragmentActivity.launchCatchingTask] */
 fun Fragment.launchCatchingTask(
     errorMessage: String? = null,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -25,6 +25,7 @@ import android.view.ViewGroup
 import android.view.WindowManager.LayoutParams.FLAG_ALT_FOCUSABLE_IM
 import android.view.WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
 import android.view.inputmethod.EditorInfo
+import android.widget.EditText
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.core.content.ContextCompat
@@ -295,6 +296,7 @@ class SetDueDateDialog : DialogFragment() {
                             false
                         }
                     }
+                    selectAllWhenFocused()
                 }
             }
             view.findViewById<TextView>(R.id.date_single_label).text =
@@ -331,6 +333,7 @@ class SetDueDateDialog : DialogFragment() {
                             resources.getQuantityString(R.plurals.set_due_date_label_suffix, value ?: 0)
                     }
                     suffixText = resources.getQuantityString(R.plurals.set_due_date_label_suffix, 0)
+                    selectAllWhenFocused()
                 }
             }
             view.findViewById<TextInputLayout>(R.id.date_range_end_layout).apply {
@@ -353,6 +356,7 @@ class SetDueDateDialog : DialogFragment() {
                             false
                         }
                     }
+                    selectAllWhenFocused()
                 }
             }
             view.findViewById<TextView>(R.id.date_range_label).text =
@@ -363,8 +367,8 @@ class SetDueDateDialog : DialogFragment() {
             super.onResume()
             this.requireView().requestLayout() // update the height of the ViewPager
 
-            val rangeStartLayout = requireView().findViewById<TextInputLayout>(R.id.date_range_start_layout)
-            AndroidUiUtils.setFocusAndOpenKeyboard(rangeStartLayout.editText!!)
+            val editText = requireView().findViewById<TextInputLayout>(R.id.date_range_start_layout).editText!!
+            AndroidUiUtils.setFocusAndOpenKeyboard(editText)
         }
     }
 }
@@ -393,3 +397,11 @@ private fun AnkiActivity.updateDueDate(
         showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
         return@asyncCatching cardsUpdated
     }
+
+private fun EditText.selectAllWhenFocused() {
+    setOnFocusChangeListener({ _, hasFocus ->
+        if (hasFocus) {
+            selectAll()
+        }
+    })
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -43,7 +43,6 @@ import com.google.android.material.tabs.TabLayoutMediator
 import com.google.android.material.textfield.TextInputLayout
 import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.AnkiActivity
-import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
@@ -57,6 +56,7 @@ import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.libanki.CardId
 import com.ichi2.libanki.sched.Scheduler
+import com.ichi2.utils.AndroidUiUtils
 import com.ichi2.utils.create
 import com.ichi2.utils.dp
 import com.ichi2.utils.negativeButton
@@ -119,7 +119,7 @@ class SetDueDateDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog =
         MaterialAlertDialogBuilder(requireContext())
             .create {
-                title(text = CollectionManager.TR.actionsSetDueDate().toSentenceCase(this@SetDueDateDialog, R.string.sentence_set_due_date))
+                title(text = TR.actionsSetDueDate().toSentenceCase(this@SetDueDateDialog, R.string.sentence_set_due_date))
                 positiveButton(R.string.dialog_ok) { launchUpdateDueDate() }
                 negativeButton(R.string.dialog_cancel)
                 neutralButton(R.string.help)
@@ -277,6 +277,9 @@ class SetDueDateDialog : DialogFragment() {
         override fun onResume() {
             super.onResume()
             this.requireView().requestLayout() // update the height of the ViewPager
+
+            val editText = requireView().findViewById<TextInputLayout>(R.id.set_due_date_single_day_text).editText!!
+            AndroidUiUtils.setFocusAndOpenKeyboard(editText)
         }
     }
 
@@ -322,6 +325,9 @@ class SetDueDateDialog : DialogFragment() {
         override fun onResume() {
             super.onResume()
             this.requireView().requestLayout() // update the height of the ViewPager
+
+            val rangeStartLayout = requireView().findViewById<TextInputLayout>(R.id.date_range_start_layout)
+            AndroidUiUtils.setFocusAndOpenKeyboard(rangeStartLayout.editText!!)
         }
     }
 }

--- a/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
@@ -49,7 +49,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:inputType="number"
-            android:maxLength="5" />
+            android:maxLength="5"
+            android:imeOptions="actionNext"
+            android:nextFocusForward="@id/date_range_end" />
     </com.google.android.material.textfield.TextInputLayout>
 
 
@@ -62,6 +64,7 @@
         app:layout_constraintEnd_toStartOf="@+id/date_range_end_layout"
         app:layout_constraintStart_toEndOf="@+id/date_range_start_layout"
         app:layout_constraintTop_toTopOf="@+id/date_range_start_layout"
+        android:focusable="false"
         />
 
     <com.google.android.material.textfield.TextInputLayout

--- a/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout-w340dp/set_due_date_range.xml
@@ -83,7 +83,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:inputType="number"
-            android:maxLength="5" />
+            android:maxLength="5"
+            android:imeOptions="actionDone" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout/set_due_date_range.xml
@@ -70,7 +70,8 @@
             android:layout_height="wrap_content"
             android:hint="@string/set_due_date_range_end"
             android:inputType="number"
-            android:maxLength="5" />
+            android:maxLength="5"
+            android:imeOptions="actionDone" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/set_due_date_range.xml
+++ b/AnkiDroid/src/main/res/layout/set_due_date_range.xml
@@ -49,7 +49,10 @@
             android:layout_height="wrap_content"
             android:hint="@string/set_due_date_range_start"
             android:inputType="number"
-            android:maxLength="5" />
+            android:maxLength="5"
+            android:imeOptions="actionNext"
+            android:nextFocusForward="@id/date_range_end"
+            />
     </com.google.android.material.textfield.TextInputLayout>
 
     <com.google.android.material.textfield.TextInputLayout

--- a/AnkiDroid/src/main/res/layout/set_due_date_single.xml
+++ b/AnkiDroid/src/main/res/layout/set_due_date_single.xml
@@ -52,7 +52,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:inputType="number"
-            tools:text="2" />
+            tools:text="2"
+            android:imeOptions="actionDone" />
     </com.google.android.material.textfield.TextInputLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AnkiDroid/src/main/res/layout/set_due_date_single.xml
+++ b/AnkiDroid/src/main/res/layout/set_due_date_single.xml
@@ -44,8 +44,9 @@
         app:layout_constraintStart_toStartOf="@+id/date_single_label"
         app:layout_constraintTop_toBottomOf="@+id/date_single_label"
         app:expandedHintEnabled="false"
-        tools:helperText="Today is ‘0 days’, tomorrow is ‘1 day’, etc…">
-        tools:suffixText="days">
+        tools:helperText="Today is ‘0 days’, tomorrow is ‘1 day’, etc…"
+        tools:suffixText="days"
+        >
 
         <com.google.android.material.textfield.TextInputEditText
             android:layout_width="match_parent"


### PR DESCRIPTION
## Purpose / Description
* When each tab is focused, the field is focused, with all text selected
* The IME action is changed to 'next field' if selecting a range
* The IME 'done' action now submits the dialog

## Fixes
* Fixes beta feedback: https://forums.ankiweb.net/t/ankidroid-2-21-beta-feedback/62992/8

> It probably happened before. When selecting the “set due date” function, there is no focus on the input field. The function remembers the past input data, but does not remember the “show card in” “show card in range” section. When you enter and confirm the minimum interval in the “show card in range”, the focus disappears from the field. Expected behavior: The focus should switch to the maximum time interval field.

## How Has This Been Tested?
Google Pixel 9 Pro:

* tab works
* submit works
* submit doesn't show an error if used when 'OK' is disabled

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
