### PR TITLE
fix(new reviewer): gestures crash when scrolled

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid.js
@@ -40,8 +40,8 @@ globalThis.ankidroid.showAllHints = function () {
                 return;
             }
             isSingleTouch = true;
-            startX = event.touches[0].clientX;
-            startY = event.touches[0].clientY;
+            startX = event.touches[0].pageX;
+            startY = event.touches[0].pageY;
         },
         { passive: true },
     );
@@ -59,8 +59,8 @@ globalThis.ankidroid.showAllHints = function () {
                 return;
             }
 
-            const endX = event.changedTouches[0].clientX;
-            const endY = event.changedTouches[0].clientY;
+            const endX = event.changedTouches[0].pageX;
+            const endY = event.changedTouches[0].pageY;
             const scrollDirection = getScrollDirection(event.target);
             const params = new URLSearchParams({
                 x: Math.round(endX),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
@@ -59,8 +59,8 @@ object GestureParser {
         if (isScrolling) return null
         if (uri.host == "doubleTap") return Gesture.DOUBLE_TAP
 
-        val tapX = uri.getIntQuery("x") ?: return null
-        val tapY = uri.getIntQuery("y") ?: return null
+        val pageX = uri.getIntQuery("x") ?: return null
+        val pageY = uri.getIntQuery("y") ?: return null
         val deltaX = uri.getIntQuery("deltaX") ?: return null
         val deltaY = uri.getIntQuery("deltaY") ?: return null
         val absDeltaX = abs(deltaX)
@@ -72,12 +72,12 @@ object GestureParser {
             return determineSwipeGesture(deltaX, deltaY, absDeltaX, absDeltaY, scrollDirection)
         }
 
-        val row = getGridIndex(tapY, scrollY, measuredHeight, scale)
-        val column = getGridIndex(tapX, scrollX, measuredWidth, scale)
+        val row = getGridIndex(pageY, scrollY, measuredHeight, scale)
+        val column = getGridIndex(pageX, scrollX, measuredWidth, scale)
         // FIXME fix the source of values that result in an invalid index
         if (row !in 0..2 || column !in 0..2) {
             throw IllegalArgumentException(
-                "Gesture parsing error: row $row - column $column - uri $uri - isScrolling $isScrolling - scale $scale - tapX $tapX - tapY $tapY - scrollX $scrollX - scrollY $scrollY - measuredWidth $measuredWidth - measuredHeight $measuredHeight",
+                "Gesture parsing error: row $row - column $column - uri $uri - isScrolling $isScrolling - scale $scale - pageX $pageX - pageY $pageY - scrollX $scrollX - scrollY $scrollY - measuredWidth $measuredWidth - measuredHeight $measuredHeight",
             )
         }
         return gestureGrid[row][column]


### PR DESCRIPTION
## Fixes
* Fixes part of #18559
    - some traces still haven't been diagnosed. 562788464650b4391ad6e254fc7b6e974f49b598 should shed a light after it goes to a beta

## Approach
Use pageX/Y instead of clientX/Y to handle the scrolling

## How Has This Been Tested?

Galaxy S23, Android 15

1. Have a deck with content enough to demand being scrolled down
2. Scroll down
3. Tap in the bottom row

Also checked the same thing with the screen zoomed in

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
