### PR TITLE
refactor(libanki): inline unnecessary methods

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1507,14 +1507,14 @@ class ContentProviderTest : InstrumentedTest() {
     ): String {
         val noteType = col.notetypes.new(name)
         for (field in fields) {
-            col.notetypes.addFieldInNewNoteType(noteType, col.notetypes.newField(field))
+            col.notetypes.addFieldLegacy(noteType, col.notetypes.newField(field))
         }
         val t =
             Notetypes.newTemplate("Card 1").also { t ->
                 t.qfmt = qfmt
                 t.afmt = afmt
             }
-        col.notetypes.addTemplateInNewNoteType(noteType, t)
+        col.notetypes.addTemplate(noteType, t)
         col.notetypes.add(noteType)
         return name
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -852,7 +852,7 @@ class CardContentProvider : ContentProvider() {
                     // Add the fields
                     val allFields = Utils.splitFields(fieldNames)
                     for (f: String? in allFields) {
-                        col.notetypes.addFieldInNewNoteType(newNoteType, col.notetypes.newField(f!!))
+                        col.notetypes.addFieldLegacy(newNoteType, col.notetypes.newField(f!!))
                     }
                     // Add some empty card templates
                     var idx = 0
@@ -865,7 +865,7 @@ class CardContentProvider : ContentProvider() {
                             answerField = allFields[1]
                         }
                         t.afmt = "{{FrontSide}}\\n\\n<hr id=answer>\\n\\n{{$answerField}}"
-                        col.notetypes.addTemplateInNewNoteType(newNoteType, t)
+                        col.notetypes.addTemplate(newNoteType, t)
                         idx++
                     }
                     // Add the CSS if specified

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Notetypes.kt
@@ -41,14 +41,12 @@ import anki.notetypes.NotetypeNameIdUseCount
 import anki.notetypes.StockNotetype
 import anki.notetypes.restoreNotetypeToStockRequest
 import com.google.protobuf.ByteString
-import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.libanki.Utils.checksum
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.backend.BackendUtils.fromJsonBytes
 import com.ichi2.libanki.backend.BackendUtils.toJsonBytes
-import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
 import com.ichi2.libanki.utils.append
@@ -422,43 +420,6 @@ class Notetypes(
     ) {
         renameField(notetype, field, newName)
         save(notetype)
-    }
-
-    /**
-     * similar to Anki's addField; but thanks to assumption that
-     * model is new, it never has to throw
-     * [ConfirmModSchemaException]
-     */
-    @RustCleanup("Since Kotlin doesn't have throws, this may not be needed")
-    fun addFieldInNewNoteType(
-        notetype: NotetypeJson,
-        field: Field,
-    ) {
-        check(isModelNew(notetype)) { "Model was assumed to be new, but is not" }
-        try {
-            addFieldLegacy(notetype, field)
-        } catch (e: ConfirmModSchemaException) {
-            Timber.w(e, "Unexpected mod schema")
-            CrashReportService.sendExceptionReport(e, "addFieldInNewModel: Unexpected mod schema")
-            throw IllegalStateException("ConfirmModSchemaException should not be thrown", e)
-        }
-    }
-
-    fun addTemplateInNewNoteType(
-        notetype: NotetypeJson,
-        template: CardTemplate,
-    ) {
-        // similar to addTemplate, but doesn't throw exception;
-        // asserting the model is new.
-        check(isModelNew(notetype)) { "Model was assumed to be new, but is not" }
-
-        try {
-            addTemplate(notetype, template)
-        } catch (e: ConfirmModSchemaException) {
-            Timber.w(e, "Unexpected mod schema")
-            CrashReportService.sendExceptionReport(e, "addTemplateInNewModel: Unexpected mod schema")
-            throw IllegalStateException("ConfirmModSchemaException should not be thrown", e)
-        }
     }
 
     fun addFieldModChanged(

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -32,7 +32,6 @@ import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
-import com.ichi2.libanki.utils.set
 import com.ichi2.testutils.ext.addNote
 import com.ichi2.utils.LanguageUtil
 import kotlinx.coroutines.Dispatchers
@@ -123,14 +122,14 @@ interface TestClass {
     ): String {
         val noteType = col.notetypes.new(name)
         for (field in fields) {
-            col.notetypes.addFieldInNewNoteType(noteType, col.notetypes.newField(field))
+            col.notetypes.addFieldLegacy(noteType, col.notetypes.newField(field))
         }
         val t =
             Notetypes.newTemplate("Card 1").also { tmpl ->
                 tmpl.qfmt = qfmt
                 tmpl.afmt = afmt
             }
-        col.notetypes.addTemplateInNewNoteType(noteType, t)
+        col.notetypes.addTemplate(noteType, t)
         col.notetypes.add(noteType)
         return name
     }


### PR DESCRIPTION
Since we moved to Kotlin, we no longer need to worry about `@throws`, therefore can inline:

* addTemplateInNewNoteType -> addTemplate
* addFieldInNewNoteType -> addFieldLegacy

Removes a cyclic dependency: libAnki <-> AnkiDroid

* Issue #18015
* https://github.com/ankidroid/Anki-Android/pull/18565

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
