### PR TITLE
Deprecate noteId var from getNoteTags in Js-API

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/js-api.js
+++ b/AnkiDroid/src/main/assets/scripts/js-api.js
@@ -129,7 +129,7 @@ Object.keys(jsApiList).forEach(method => {
         return;
     }
     if (method === "ankiSetNoteTags") {
-        AnkiDroidJS.prototype[method] = async function (noteId, tags) {
+        AnkiDroidJS.prototype[method] = async function (tags) {
             let hasSpaces = false;
             for (let i = 0; i < tags.length; i++) {
                 tags[i] = tags[i].trim();
@@ -142,15 +142,7 @@ Object.keys(jsApiList).forEach(method => {
                 console.warn("Spaces in tags have been converted to underscores");
             }
             const endpoint = jsApiList[method];
-            const data = JSON.stringify({ noteId, tags });
-            return await this.handleRequest(endpoint, data);
-        };
-        return;
-    }
-    if (method === "ankiGetNoteTags") {
-        AnkiDroidJS.prototype[method] = async function (noteId) {
-            const endpoint = jsApiList[method];
-            const data = JSON.stringify({ noteId });
+            const data = JSON.stringify({ tags });
             return await this.handleRequest(endpoint, data);
         };
         return;

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -380,7 +380,7 @@ open class AnkiDroidJsAPI(
 
             "setNoteTags" -> {
                 val jsonObject = JSONObject(apiParams)
-                val noteId = jsonObject.getLong("noteId")
+                val noteId = currentCard.nid
                 val tags = jsonObject.getJSONArray("tags")
                 withCol {
                     fun Note.setTagsFromList(tagList: List<String>) {
@@ -403,8 +403,7 @@ open class AnkiDroidJsAPI(
             }
 
             "getNoteTags" -> {
-                val jsonObject = JSONObject(apiParams)
-                val noteId = jsonObject.getLong("noteId")
+                val noteId = currentCard.nid
                 val noteTags =
                     withCol {
                         getNote(noteId).tags

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AnkiDroidJsAPITest.kt
@@ -428,7 +428,7 @@ class AnkiDroidJsAPITest : RobolectricTest() {
 
             // test get tags for note
             val expectedTags = n.tags
-            val response = getDataFromRequest("getNoteTags", jsapi, jsonObjectOf("noteId" to n.id))
+            val response = getDataFromRequest("getNoteTags", jsapi)
             val jsonResponse = JSONObject(response)
             val actualTags = JSONArray(jsonResponse.getString("value"))
 
@@ -471,21 +471,5 @@ class AnkiDroidJsAPITest : RobolectricTest() {
             jsAPI
                 .handleJsApiRequest(methodName, jsApiContract(apiData), false)
                 .decodeToString()
-
-        suspend fun getDataFromRequest(
-            methodName: String,
-            jsAPI: AnkiDroidJsAPI,
-            apiData: JSONObject,
-        ): String =
-            jsAPI
-                .handleJsApiRequest(methodName, jsApiContract(apiData.toString()), false)
-                .decodeToString()
     }
 }
-
-private fun jsonObjectOf(vararg pairs: Pair<String, Any>): JSONObject =
-    JSONObject().apply {
-        for ((key, value) in pairs) {
-            put(key, value)
-        }
-    }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/JsonUtils.kt
@@ -71,3 +71,10 @@ class IsJsonHolderEqual(
 }
 
 fun isJsonHolderEqual(expectedValue: String) = IsJsonHolderEqual(JSONObject(expectedValue))
+
+private fun jsonObjectOf(vararg pairs: Pair<String, Any>): JSONObject =
+    JSONObject().apply {
+        for ((key, value) in pairs) {
+            put(key, value)
+        }
+    }


### PR DESCRIPTION
## Purpose / Description
- get and set NoteTags does not need a noteId var anymore

## Fixes
* Fixes #17716

## How Has This Been Tested?
Fixed UnitTests

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
