### PR TITLE
fix: rename 'play media' -> 'replay media'

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -69,7 +69,6 @@
     <string name="answer_hard" maxLength="41">Answer hard</string>
     <string name="answer_good" maxLength="41">Answer good</string>
     <string name="answer_easy" maxLength="41">Answer easy</string>
-    <string name="gesture_play" maxLength="41">Play media</string>
     <string name="gesture_abort_learning" maxLength="41">Close study screen</string>
     <string name="gesture_flag_red" maxLength="41">Toggle Red Flag</string>
     <string name="gesture_flag_orange" maxLength="41">Toggle Orange Flag</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -153,7 +153,7 @@
     <PreferenceCategory android:title="@string/media">
         <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/play_media_command_key"
-            android:title="@string/gesture_play"
+            android:title="@string/replay_media"
             android:icon="@drawable/ic_play_circle_white"
             />
         <com.ichi2.preferences.ReviewerControlPreference


### PR DESCRIPTION
In controls/gestures

follow on from 040a7ba31a93d8cfdd523e7d731d3ef582932176

Mentioned: https://redirect.github.com/ankidroid/Anki-Android/issues/15760#issuecomment-2998531849

* https://github.com/ankidroid/Anki-Android/pull/18492
* https://github.com/ankidroid/Anki-Android/issues/18442

## How Has This Been Tested?
Untested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
