### PR TITLE
Make cardBrowser Resizable and refactor shared pref of resizable screens into seperate shared pref

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -30,6 +30,7 @@ import android.view.View
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.BaseAdapter
+import android.widget.LinearLayout
 import android.widget.Spinner
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
@@ -102,6 +103,7 @@ import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.ifNotZero
@@ -382,6 +384,24 @@ open class CardBrowser :
         // TODO: Consider refactoring by storing noteEditorFrame and similar views in a sealed class (e.g., FragmentAccessor).
         val fragmented = noteEditorFrame?.visibility == View.VISIBLE
         Timber.i("Using split Browser: %b", fragmented)
+
+        if (fragmented) {
+            val parentLayout = findViewById<LinearLayout>(R.id.card_browser_xl_view)
+            val divider = findViewById<View>(R.id.card_browser_resizing_divider)
+            val leftPane = findViewById<View>(R.id.card_browser_frame)
+            val rightPane = findViewById<View>(R.id.note_editor_frame)
+            if (parentLayout != null && divider != null && leftPane != null && rightPane != null) {
+                ResizablePaneManager(
+                    parentLayout = parentLayout,
+                    divider = divider,
+                    leftPane = leftPane,
+                    rightPane = rightPane,
+                    sharedPrefs = this.sharedPrefs(),
+                    leftPaneWeightKey = PREF_CARD_BROWSER_PANE_WEIGHT,
+                    rightPaneWeightKey = PREF_NOTE_EDITOR_PANE_WEIGHT,
+                )
+            }
+        }
 
         // must be called once we have an accessible collection
         viewModel = createViewModel(launchOptions, fragmented)
@@ -1863,6 +1883,10 @@ open class CardBrowser :
          * since the cards are unselected when this happens
          */
         private const val CHANGE_DECK_KEY = "CHANGE_DECK"
+
+        // Keys for saving pane weights in SharedPreferences
+        private const val PREF_CARD_BROWSER_PANE_WEIGHT = "cardBrowserPaneWeight"
+        private const val PREF_NOTE_EDITOR_PANE_WEIGHT = "noteEditorPaneWeight"
 
         // Values related to persistent state data
         fun clearLastDeckId() = SharedPreferencesLastDeckIdRepository.clearLastDeckId()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -102,6 +102,7 @@ import com.ichi2.anki.previewer.PreviewerFragment
 import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.toSentenceCase
@@ -396,7 +397,7 @@ open class CardBrowser :
                     divider = divider,
                     leftPane = leftPane,
                     rightPane = rightPane,
-                    sharedPrefs = this.sharedPrefs(),
+                    sharedPrefs = Prefs.getUiConfig(this),
                     leftPaneWeightKey = PREF_CARD_BROWSER_PANE_WEIGHT,
                     rightPaneWeightKey = PREF_NOTE_EDITOR_PANE_WEIGHT,
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -79,10 +79,10 @@ import com.ichi2.anki.dialogs.InsertFieldDialog
 import com.ichi2.anki.dialogs.InsertFieldDialog.Companion.REQUEST_FIELD_INSERT
 import com.ichi2.anki.notetype.RenameCardTemplateDialog
 import com.ichi2.anki.notetype.RepositionCardTemplateDialog
-import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.TemplatePreviewerArguments
 import com.ichi2.anki.previewer.TemplatePreviewerFragment
 import com.ichi2.anki.previewer.TemplatePreviewerPage
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -224,7 +224,7 @@ open class CardTemplateEditor :
                     divider = divider,
                     leftPane = leftPane,
                     rightPane = rightPane,
-                    sharedPrefs = this.sharedPrefs(),
+                    sharedPrefs = Prefs.getUiConfig(this),
                     leftPaneWeightKey = PREF_TEMPLATE_EDITOR_PANE_WEIGHT,
                     rightPaneWeightKey = PREF_TEMPLATE_PREVIEWER_PANE_WEIGHT,
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -544,7 +544,7 @@ open class DeckPicker :
                     divider = resizingDivider,
                     leftPane = deckPickerPane,
                     rightPane = studyOptionsPane,
-                    sharedPrefs = this.sharedPrefs(),
+                    sharedPrefs = Prefs.getUiConfig(this),
                     leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
                     rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.settings
 
+import android.content.SharedPreferences
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit
@@ -204,4 +205,14 @@ object Prefs {
     var isDevOptionsEnabled: Boolean
         get() = getBoolean(R.string.dev_options_enabled_by_user_key, false) || BuildConfig.DEBUG
         set(value) = putBoolean(R.string.dev_options_enabled_by_user_key, value)
+
+    // **************************************** UI Config *************************************** //
+
+    private const val UI_CONFIG_PREFERENCES_NAME = "ui-config"
+
+    /**
+     * Get the SharedPreferences used for UI configuration such as Resizable layouts
+     */
+    fun getUiConfig(context: android.content.Context): SharedPreferences =
+        context.getSharedPreferences(UI_CONFIG_PREFERENCES_NAME, android.content.Context.MODE_PRIVATE)
 }

--- a/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
@@ -19,6 +19,18 @@
                 android:layout_width="1dip"
                 android:layout_weight="3"
                 android:layout_height="match_parent"/>
+            <FrameLayout
+                android:id="@+id/card_browser_resizing_divider"
+                android:layout_width="8dp"
+                android:layout_height="match_parent"
+                android:background="@color/idle_divider_color">
+                <View
+                    android:id="@+id/card_browser_divider_handle"
+                    android:layout_width="3dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center"
+                    android:background="@drawable/divider_handle_background" />
+            </FrameLayout>
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/note_editor_frame"
                 android:layout_weight="2"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Make cardBrowser Resizable

## Fixes
* For GSoC 2025: Tablet & Chromebook UI

## Approach
Consists of two commits:-
1. The first commit makes cardBrowser Resizable:
- Implements the ResizablePaneManager util class similar to other resizable screens
2. The second commit refactors all resizable screens:
- Uses seperate shared prefrences for all resizable screens called 'dev-ui' to avoid crowding existing shared pref.

## How Has This Been Tested?
Tested on the following Android Emulators:
Pixel Tablet API 35
Large Desktop API 34

Screenshots of affected screen in different themes:
1. Black Theme:
![cbblack](https://github.com/user-attachments/assets/19a8a8d3-e4f8-4bd1-a4a1-66414448cf39)

2. Plain Theme:
![cpplain](https://github.com/user-attachments/assets/e99a9081-40b3-4022-a589-1f55f4144dae)

3. Default Light Theme:
![cblight](https://github.com/user-attachments/assets/21f3ee07-c65e-4091-9209-1d6501e39985)

4. Default Dark Theme:
![cbdark](https://github.com/user-attachments/assets/b78e795e-4d44-4355-9a44-d4419f3a8410)


Commit 2 Test:
[sharedperf.webm](https://github.com/user-attachments/assets/a5644816-f106-481f-8615-d5db3a560807)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
