### PR TITLE
tweak: Remove cancel button in one of "Empty cards" dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.withProgress
 import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.emptyCids
 import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
@@ -152,6 +153,7 @@ class EmptyCardsDialogFragment : DialogFragment() {
                                 keepNotesWithNoValidCards?.isVisible = false
                                 (dialog as? AlertDialog)?.positiveButton?.text =
                                     getString(R.string.dialog_ok)
+                                (dialog as? AlertDialog)?.negativeButton?.visibility = View.GONE
                             } else {
                                 reportScrollView?.updateViewHeight()
                                 reportView?.setText(

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -373,6 +373,8 @@ fun AlertDialog.getInputField() = getInputTextLayout().editText!!
 /** @see AlertDialog.getButton */
 val AlertDialog.positiveButton: Button
     get() = getButton(DialogInterface.BUTTON_POSITIVE)
+val AlertDialog.negativeButton: Button
+    get() = getButton(DialogInterface.BUTTON_NEGATIVE)
 
 /**
  * Extension function for AlertDialog.Builder to set a list of items.


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description

After checking empty cards, "No empty cards" message dialog is shown if there aren't any empty cards.

In this case, the user has nothing to do but close the dialog, and they can do so by its positive button, so the existing "Cancel" button is unnecessary and redundant.
![image](https://github.com/user-attachments/assets/0303e840-47e8-4fee-9527-0b2b040840b5)


## Approach
Hide the cancel button in the "No empty cards" dialog.

## How Has This Been Tested?
Checked in a physical device (Android 11)

Before | After
--- | ---
![image](https://github.com/user-attachments/assets/144485c6-697d-41b3-83b7-78c5a0206a04) | ![image](https://github.com/user-attachments/assets/20c661c6-74ce-4ee3-b743-1136aaab5aa7)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
