### PR TITLE
Fix export last step after an activity restore

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -161,10 +161,6 @@ open class AnkiActivity :
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
             window.navigationBarColor = getColor(R.color.transparent)
         }
-        if (savedInstanceState != null) {
-            val restoredValue = savedInstanceState.getString(KEY_EXPORT_FILE_NAME) ?: return
-            fileExportPath = restoredValue
-        }
         supportFragmentManager.setFragmentResultListener(REQUEST_EXPORT_SAVE, this) { _, bundle ->
             saveExportFile(
                 bundle.getString(KEY_EXPORT_PATH) ?: error("Missing required exportPath!"),
@@ -174,6 +170,10 @@ open class AnkiActivity :
             shareFile(
                 bundle.getString(KEY_EXPORT_PATH) ?: error("Missing required exportPath!"),
             )
+        }
+        if (savedInstanceState != null) {
+            val restoredValue = savedInstanceState.getString(KEY_EXPORT_FILE_NAME) ?: return
+            fileExportPath = restoredValue
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

There was a check(after an activity restore) that was cancelling setting the export related fragment results(and in the last export step nothing was being done).

## Fixes
* Fixes #18640

## How Has This Been Tested?

Checked the behavior with the mentioned reproduction steps.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

