### PR TITLE
refactor: move `StringUtil` to `common` module

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.anki.common.utils.emptyStringArray
 import com.ichi2.anki.provider.pureAnswer
 import com.ichi2.anki.testutil.DatabaseUtils.cursorFillWindow
 import com.ichi2.anki.testutil.GrantStoragePermission.storagePermission
@@ -49,7 +50,6 @@ import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.getStockNotetype
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.common.assertThrows
-import com.ichi2.utils.emptyStringArray
 import kotlinx.serialization.json.Json
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -27,6 +27,7 @@ import androidx.core.app.TaskStackBuilder
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.utils.trimToLength
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
 import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.preferences.sharedPrefs
@@ -46,7 +47,6 @@ import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.Permissions.hasLegacyStorageAccessPermission
 import com.ichi2.utils.copyToClipboard
-import com.ichi2.utils.trimToLength
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/Binding.kt
@@ -19,9 +19,9 @@ import android.content.Context
 import android.view.KeyEvent
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.common.utils.StringUtils
+import com.ichi2.anki.common.utils.lastIndexOfOrNull
 import com.ichi2.anki.utils.ext.ifNotZero
-import com.ichi2.utils.StringUtil
-import com.ichi2.utils.lastIndexOfOrNull
 import timber.log.Timber
 import java.util.Objects
 
@@ -94,7 +94,7 @@ sealed interface Binding {
                 append(modifierKeys.toString())
                 val keyCodeString = KeyEvent.keyCodeToString(keycode)
                 // replace "Button" as we use the gamepad icon
-                append(StringUtil.toTitleCase(keyCodeString.replace("KEYCODE_", "").replace("BUTTON_", "").replace('_', ' ')))
+                append(StringUtils.toTitleCase(keyCodeString.replace("KEYCODE_", "").replace("BUTTON_", "").replace('_', ' ')))
             }
 
         override fun toString() =

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Note.kt
@@ -21,11 +21,11 @@ import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import anki.notes.NoteFieldsCheckResponse
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.anki.common.utils.emptyStringArray
 import com.ichi2.libanki.Consts.DEFAULT_DECK_ID
 import com.ichi2.libanki.backend.model.toBackendNote
 import com.ichi2.libanki.utils.LibAnkiAlias
 import com.ichi2.libanki.utils.NotInLibAnki
-import com.ichi2.utils.emptyStringArray
 import java.util.regex.Pattern
 
 @KotlinCleanup("lots to do")

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -55,7 +55,8 @@ dependencies {
     implementation(libs.jakewharton.timber)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.vintage.engine)
-    testRuntimeOnly(libs.junit.platform.launcher)
+    testImplementation(libs.hamcrest)
+    testImplementation(libs.junit.platform.launcher)
     androidTestImplementation(libs.androidx.test.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
@@ -15,14 +15,17 @@
 
  */
 
-package com.ichi2.utils
+package com.ichi2.anki.common.utils
 
+import com.ichi2.anki.common.annotations.NeedsTest
 import org.jetbrains.annotations.Contract
 import java.util.Locale
 import kotlin.math.min
 
-object StringUtil {
+@NeedsTest("all except toTitleCase is untested")
+object StringUtils {
     /** Converts the string to where the first letter is uppercase, and the rest of the string is lowercase  */
+    // TODO(low): some libAnki functions can use this instead of capitalize() alternatives
     @Contract("null -> null; !null -> !null")
     fun toTitleCase(s: String?): String? {
         if (s == null) return null

--- a/common/src/test/java/com/ichi2/anki/common/utils/StringUtilsTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/utils/StringUtilsTest.kt
@@ -13,15 +13,17 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.utils
 
-import com.ichi2.utils.StringUtil.toTitleCase
+package com.ichi2.anki.common.utils
+
+import com.ichi2.anki.common.utils.StringUtils.toTitleCase
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
 
-class StringUtilTest {
+/** Test of [toTitleCase] */
+class StringUtilsTest {
     @Test
     fun toTitleCase_null_is_null() {
         assertThat(toTitleCase(null), nullValue())


### PR DESCRIPTION
primarily for:

* emptyStringArray

Removes a cyclic dependency: libAnki <-> AnkiDroid

* Issue #18015
*  #18565

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->