### PR TITLE
fix: lateinit property deckNode has not been initialized

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
@@ -30,7 +30,8 @@ import java.util.Locale
  * is a list of [DisplayDeckNode]s. This class only contains the information
  * needed to display it on the screen, hence no data of a node's children and parent.
  */
-data class DisplayDeckNode(
+@ConsistentCopyVisibility
+data class DisplayDeckNode private constructor(
     val did: DeckId,
     val fullDeckName: String,
     val lastDeckNameComponent: String,
@@ -45,6 +46,11 @@ data class DisplayDeckNode(
 ) {
     // DeckNode is mutable, so use a lateinit var so '==' doesn't include it in the comparison
     lateinit var deckNode: DeckNode
+
+    fun withUpdatedDeckId(deckId: DeckId): DisplayDeckNode =
+        this.copy(isSelected = this.did == deckId).also { updated ->
+            updated.deckNode = this.deckNode
+        }
 
     companion object {
         fun from(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -32,6 +32,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.OnContextAndLongClickListener.Companion.setOnContextAndLongClickListener
 import com.ichi2.anki.R
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.deckpicker.DisplayDeckNode
 import com.ichi2.anki.utils.ext.findViewById
 import com.ichi2.libanki.DeckId
@@ -127,11 +128,10 @@ class DeckAdapter(
      * Update the current selected deck so the adapter shows the proper backgrounds.
      * Calls [notifyDataSetChanged].
      */
+    @NeedsTest("18658: ensure a deck can be selected after this")
     fun updateSelectedDeck(deckId: DeckId) {
         submitList(
-            this.currentList.map {
-                it.copy(isSelected = it.did == deckId)
-            },
+            this.currentList.map { it.withUpdatedDeckId(deckId) },
         )
     }
 


### PR DESCRIPTION
Couldn't reproduce this, but the cause was that `.copy()` didn't copy the lateinit property

Didn't realise this.

## Fixes
* Fixes #18658

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->