### PR TITLE
perf: speed up i18nResourcesRaw

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -121,6 +121,13 @@ val uiMethods =
                 }
             }
         },
+        "i18nResources" to { bytes ->
+            lifecycleScope.async {
+                withContext(Dispatchers.IO) {
+                    CollectionManager.getBackend().i18nResourcesRaw(bytes)
+                }
+            }
+        },
         "importCsv" to { bytes -> lifecycleScope.async { importCsvRaw(bytes) } },
         "importAnkiPackage" to { bytes -> lifecycleScope.async { importAnkiPackageUndoable(bytes) } },
         "addImageOcclusionNote" to { bytes ->


### PR DESCRIPTION
No longer blocks the collection

Noticed while looking into https://github.com/ankidroid/Anki-Android/issues/18660

* https://github.com/ankidroid/Anki-Android/issues/18660

## How Has This Been Tested?

Briefly opened Image Occlusion, added a logcat entry to prove the call was made and still works

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->