### PR TITLE
refactor: move `Ease` to `libAnki` module

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -26,7 +26,6 @@ import android.database.CursorWindow
 import android.net.Uri
 import anki.notetypes.StockNotetype
 import com.ichi2.anki.CollectionManager
-import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.common.utils.emptyStringArray
@@ -48,6 +47,7 @@ import com.ichi2.libanki.addNotetypeLegacy
 import com.ichi2.libanki.backend.BackendUtils
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.getStockNotetype
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.common.assertThrows
 import kotlinx.serialization.json.Json

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -144,6 +144,7 @@ import com.ichi2.libanki.Sound.getAvTag
 import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.TTSTag
 import com.ichi2.libanki.Utils
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.undoableOp
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.getResFromAttr

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidJsAPI.kt
@@ -48,6 +48,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.Note
 import com.ichi2.libanki.SortOrder
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.utils.NetworkUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -114,6 +114,7 @@ import com.ichi2.libanki.Collection
 import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.CurrentQueueState
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.undoableOp
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.currentTheme

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -34,7 +34,6 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CrashReportService
-import com.ichi2.anki.Ease
 import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -58,6 +57,7 @@ import com.ichi2.libanki.Utils
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.exception.EmptyMediaException
 import com.ichi2.libanki.sched.DeckNode
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.FileUtil.internalizeUri
 import com.ichi2.utils.Permissions.arePermissionsDefinedInManifest

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
@@ -24,8 +24,8 @@ import android.widget.TextView
 import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import com.ichi2.anki.AbstractFlashcardViewer
-import com.ichi2.anki.Ease
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.libanki.sched.Ease
 
 /**
  * The UI of an ease button

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PreviousAnswerIndicator.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/PreviousAnswerIndicator.kt
@@ -17,8 +17,8 @@
 package com.ichi2.anki.reviewer
 
 import android.widget.TextView
-import com.ichi2.anki.Ease
 import com.ichi2.anki.R
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.utils.HandlerUtils.newHandler
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -31,7 +31,6 @@ import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_NO_MORE_CARDS
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.Ease
 import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.asyncIO
@@ -65,6 +64,7 @@ import com.ichi2.libanki.NoteId
 import com.ichi2.libanki.redo
 import com.ichi2.libanki.sched.Counts
 import com.ichi2.libanki.sched.CurrentQueueState
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.undo
 import com.ichi2.libanki.undoableOp
 import kotlinx.coroutines.CompletableDeferred

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DummyScheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/DummyScheduler.kt
@@ -18,10 +18,8 @@
 
 package com.ichi2.libanki.sched
 
-import com.ichi2.anki.Ease
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
-import java.lang.Exception
 
 class DummyScheduler(
     col: Collection,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Ease.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Ease.kt
@@ -13,7 +13,8 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.anki
+
+package com.ichi2.libanki.sched
 
 /**
  * [value] should be kept in sync with the [com.ichi2.anki.api.Ease] enum.

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/sched/Scheduler.kt
@@ -41,7 +41,6 @@ import anki.scheduler.SchedulingStates
 import anki.scheduler.UnburyDeckRequest
 import anki.scheduler.cardAnswer
 import anki.scheduler.scheduleCardsAsNewRequest
-import com.ichi2.anki.Ease
 import com.ichi2.anki.common.time.SECONDS_PER_DAY
 import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.libanki.Card

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.reviewer.AutomaticAnswer
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.AutomaticAnswerSettings
 import com.ichi2.anki.servicelayer.LanguageHintService
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.undoableOp
 import com.ichi2.testutils.AnkiAssert.assertDoesNotThrow
 import com.ichi2.testutils.common.Flaky

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Storage
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.testutils.BackendEmulatingOpenConflict
 import com.ichi2.testutils.BackupManagerTestUtilities
 import com.ichi2.testutils.DbUtils

--- a/AnkiDroid/src/test/java/com/ichi2/anki/EaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/EaseTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import com.ichi2.libanki.sched.Ease
 import org.junit.Assert.assertEquals
 import org.junit.Test
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerKeyboardInputTest.kt
@@ -35,10 +35,6 @@ import androidx.annotation.CheckResult
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ibm.icu.impl.Assert
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
-import com.ichi2.anki.Ease.AGAIN
-import com.ichi2.anki.Ease.EASY
-import com.ichi2.anki.Ease.GOOD
-import com.ichi2.anki.Ease.HARD
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.reviewer.Binding.Companion.keyCode
@@ -48,6 +44,11 @@ import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.utils.ext.addBinding
 import com.ichi2.libanki.Card
+import com.ichi2.libanki.sched.Ease
+import com.ichi2.libanki.sched.Ease.AGAIN
+import com.ichi2.libanki.sched.Ease.EASY
+import com.ichi2.libanki.sched.Ease.GOOD
+import com.ichi2.libanki.sched.Ease.HARD
 import kotlinx.coroutines.Job
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerNoParamTest.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.reviewer.ReviewerBinding
 import com.ichi2.anki.utils.ext.addBinding
 import com.ichi2.libanki.Consts
 import com.ichi2.libanki.DeckId
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
 import com.ichi2.themes.Theme

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -46,6 +46,7 @@ import com.ichi2.libanki.NotetypeJson
 import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.QueueType
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.undoableOp
 import com.ichi2.testutils.MockTime
 import com.ichi2.testutils.common.Flaky

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/AbstractSchedTest.kt
@@ -16,8 +16,8 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.Ease
 import com.ichi2.libanki.sched.Counts
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/CardTest.kt
@@ -18,8 +18,8 @@ package com.ichi2.libanki
 import android.annotation.SuppressLint
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.Ease
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote
 import org.hamcrest.Matchers.containsString

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/FinderTest.kt
@@ -16,10 +16,10 @@
 package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.Ease
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.libanki.QueueType.Suspended
 import com.ichi2.libanki.exception.ConfirmModSchemaException
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.libanki.sched.Scheduler
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -17,7 +17,6 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.scheduler.UnburyDeckRequest
-import com.ichi2.anki.Ease
 import com.ichi2.anki.common.time.SECONDS_PER_DAY
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.TimeManager.time
@@ -27,6 +26,7 @@ import com.ichi2.libanki.Consts.LEECH_SUSPEND
 import com.ichi2.libanki.Consts.STARTING_FACTOR
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.libanki.sched.Counts
+import com.ichi2.libanki.sched.Ease
 import com.ichi2.testutils.AnkiAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote


### PR DESCRIPTION
Removes a cyclic dependency: libAnki <-> AnkiDroid

Better than moving to `CardAnswer.Rating` due to
`CardAnswer.Rating.UNRECOGNIZED`

* #18015
* https://github.com/ankidroid/Anki-Android/pull/18565

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->