### PR TITLE
fix(browser): maybe fix crash after editing note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -1101,6 +1101,12 @@ class CardBrowserViewModel(
         updateActiveColumns(replacements, cardsOrNotes)
     }
 
+    // TODO: Do a selective update, and accept a noteId as parameter
+    fun onCurrentNoteEdited() {
+        Timber.i("Reloading search due to note edit")
+        launchSearchForCards()
+    }
+
     companion object {
         fun createCardSelector(viewModel: CardBrowserViewModel) =
             { cardId: CardId, fragmented: Boolean ->


### PR DESCRIPTION
This is experimental:

I believe this is a race condition between `saveEditedCard` and `forceRefreshSearch` - `saveEditedCard` performs `updateList` -> `notifyDataSetChanged()`

If we refresh the search, then the results may be cleared while this is occurring via `clearCardsList()`

## Fixes
* Fixes #17759 (hopefully)

## Approach

Updating the search is now lightning-fast, so just rerun it

## How Has This Been Tested?
Pixel 9 Pro

* edited a note in cards mode by tapping the row
* edited a note in cards mode by long pressing -> edit note  
* edited a note: filled in a field, and more cards were added to the list

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->