### PR TITLE
In card template editor, set the cursor at the start

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -787,8 +787,8 @@ open class CardTemplateEditor :
         ) {
             currentEditorViewId = id
             editorEditText.setText(editorContent)
-            editorEditText.setSelection(cursorPosition)
             editorEditText.requestFocus()
+            editorEditText.setSelection(cursorPosition)
         }
 
         override fun onViewCreated(


### PR DESCRIPTION
In card template editor, set the cursor at the start

Before: when opening the template editor, the cursor is at the end of
the template. If the template is too big, the cursor don't happen and
the user don't see this is an editable field.


https://github.com/user-attachments/assets/e49829f9-af85-4523-b0de-cda1403bd2bf



After: the cursor is at character 0, so its always seen by the user.


https://github.com/user-attachments/assets/137a17eb-f1b4-427a-a9a1-4e00c17789c0



Testing on simulator, it seems that `setSelection` was ignored unless
the view already had the focus.

Fixes #18637