### PR TITLE
refactor: move `CollectionFiles` to `libAnki` module

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/Shared.kt
@@ -18,10 +18,10 @@ package com.ichi2.anki.tests
 import android.annotation.SuppressLint
 import android.content.Context
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
-import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.Collection
+import com.ichi2.libanki.CollectionFiles
 import com.ichi2.libanki.Storage
 import org.hamcrest.CoreMatchers.containsString
 import org.hamcrest.CoreMatchers.not

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.exception.UnknownDatabaseVersionException
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.libanki.Collection
+import com.ichi2.libanki.CollectionFiles
 import com.ichi2.libanki.DB
 import com.ichi2.preferences.getOrSetString
 import timber.log.Timber
@@ -330,13 +331,4 @@ object CollectionHelper {
             db?.close()
         }
     }
-}
-
-class CollectionFiles(
-    folderPath: File,
-    val collectionName: String = "collection",
-) {
-    val colDb = File(folderPath, "$collectionName.anki2")
-    val mediaFolder = File(folderPath, "$collectionName.media")
-    val mediaDb = File(folderPath, "$collectionName.media.db")
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionManager.kt
@@ -22,6 +22,7 @@ import androidx.annotation.WorkerThread
 import anki.backend.backendError
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.libanki.Collection
+import com.ichi2.libanki.CollectionFiles
 import com.ichi2.libanki.Storage.collection
 import com.ichi2.libanki.importCollectionPackage
 import com.ichi2.utils.Threads

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/BackendImportExport.kt
@@ -21,7 +21,6 @@ import anki.import_export.ImportAnkiPackageOptions
 import anki.import_export.ImportResponse
 import anki.import_export.exportAnkiPackageOptions
 import anki.search.SearchNode
-import com.ichi2.anki.CollectionFiles
 import net.ankiweb.rsdroid.Backend
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -40,7 +40,6 @@ import anki.search.BrowserRow
 import anki.search.SearchNode
 import anki.sync.SyncAuth
 import anki.sync.SyncStatusResponse
-import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.libanki.Utils.ids2str

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionFiles.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/CollectionFiles.kt
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2025 Arthur Milchior <arthur@milchior.fr>
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.libanki
+
+import com.ichi2.libanki.utils.NotInLibAnki
+import java.io.File
+
+@NotInLibAnki
+class CollectionFiles(
+    folderPath: File,
+    val collectionName: String = "collection",
+) {
+    val colDb = File(folderPath, "$collectionName.anki2")
+    val mediaFolder = File(folderPath, "$collectionName.media")
+    val mediaDb = File(folderPath, "$collectionName.media.db")
+}

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Storage.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.libanki
 
-import com.ichi2.anki.CollectionFiles
 import com.ichi2.anki.common.time.Time
 import com.ichi2.anki.common.time.TimeManager.time
 import com.ichi2.anki.common.time.getDayStart


### PR DESCRIPTION
Removes a cyclic dependency: libAnki <-> AnkiDroid


## Fixes
* Issue #18015
* #18565

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->