### PR TITLE
refactor: reimplement 'htmlEncode' in `common`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
@@ -16,7 +16,7 @@
 
 package com.ichi2.anki.cardviewer
 
-import androidx.core.text.htmlEncode
+import com.ichi2.anki.common.utils.htmlEncode
 import com.ichi2.libanki.AvRef
 import com.ichi2.libanki.SoundOrVideoTag
 import kotlinx.coroutines.CancellableContinuation

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Sound.kt
@@ -25,8 +25,8 @@
 
 package com.ichi2.libanki
 
-import androidx.core.text.htmlEncode
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.common.utils.htmlEncode
 import com.ichi2.anki.preferences.getHidePlayAudioButtons
 import com.ichi2.compat.CompatHelper
 import com.ichi2.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput

--- a/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/HtmlUtils.kt
@@ -15,7 +15,7 @@
  */
 package com.ichi2.utils
 
-import androidx.core.text.htmlEncode
+import com.ichi2.anki.common.utils.htmlEncode
 
 object HtmlUtils {
     // #5188 - compat.fromHtml converts newlines into spaces.

--- a/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
@@ -13,10 +13,28 @@
  You should have received a copy of the GNU General Public License along with
  this program.  If not, see <http://www.gnu.org/licenses/>.
 
+ ----
+
+ This file incorporates code under the following license:
+
+   Copyright (C) 2006 The Android Open Source Project
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
  */
 
 package com.ichi2.anki.common.utils
 
+import com.ichi2.anki.common.annotations.DuplicatedCode
 import com.ichi2.anki.common.annotations.NeedsTest
 import org.jetbrains.annotations.Contract
 import java.util.Locale
@@ -46,3 +64,33 @@ fun String.lastIndexOfOrNull(c: Char): Int? =
 fun emptyStringMutableList(size: Int): MutableList<String> = MutableList(size) { "" }
 
 fun emptyStringArray(size: Int): Array<String> = Array(size) { "" }
+
+/**
+ * Html-encode the string.
+ * @receiver the string to be encoded
+ * @return the encoded string
+ */
+// replaces:
+// androidx.core.text.htmlEncode
+// android.text.TextUtils.htmlEncode
+@DuplicatedCode("copied from android.text.TextUtils.htmlEncode, converted to kotlin extension")
+fun String.htmlEncode(): String {
+    val sb = StringBuilder()
+    var c: Char
+    for (i in 0..<this.length) {
+        c = this[i]
+        when (c) {
+            '<' -> sb.append("&lt;") // $NON-NLS-1$
+            '>' -> sb.append("&gt;") // $NON-NLS-1$
+            '&' -> sb.append("&amp;") // $NON-NLS-1$
+            '\'' -> // http://www.w3.org/TR/xhtml1
+                // The named character reference &apos; (the apostrophe, U+0027) was introduced in
+                // XML 1.0 but does not appear in HTML. Authors should therefore use &#39; instead
+                // of &apos; to work as expected in HTML 4 user agents.
+                sb.append("&#39;") // $NON-NLS-1$
+            '"' -> sb.append("&quot;") // $NON-NLS-1$
+            else -> sb.append(c)
+        }
+    }
+    return sb.toString()
+}


### PR DESCRIPTION
Removes an Android dependency from libAnki

`androidx.core.text.htmlEncode => android.text.TextUtils.htmlEncode`

* Issue #18015
* #18565

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->