### PR TITLE
tweak: Remove front spaces of "Shake device" label (<= API 30)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/Gesture.kt
@@ -34,7 +34,7 @@ const val GESTURE_PREFIX = "\u235D"
 // #17090: maracas emoji is unusable on API 30 or below.
 // androidX emoji2 doesn't work by default on an API 30 emulator.
 // either requires a GMS dependency, or bloats the APK size by 9.8MB
-val SHAKE_GESTURE_PREFIX = if (Build.VERSION.SDK_INT > 30) "\uD83E\uDE87" else "  "
+val SHAKE_GESTURE_PREFIX = if (Build.VERSION.SDK_INT > 30) "\uD83E\uDE87" else ""
 
 fun interface GestureListener {
     fun onGesture(gesture: Gesture)
@@ -61,7 +61,16 @@ enum class Gesture(
     TAP_BOTTOM_RIGHT(R.string.gestures_corner_tap_bottom_right),
     ;
 
-    fun toDisplayString(context: Context): String = displayPrefix + ' ' + context.getString(resourceId)
+    fun toDisplayString(context: Context): String =
+        if (displayPrefix.isNotEmpty()) {
+            displayPrefix + ' ' + context.getString(resourceId)
+            // e.g., (maracas emoji) + (space) + "Shake device"
+        } else {
+            context.getString(resourceId)
+            // e.g., "Shake device"
+            // (Not only the empty prefix (""), but also the space in the middle (" ") is not shown.)
+            // Related to #17090
+        }
 }
 
 /**


### PR DESCRIPTION




<!--- Please fill the necessary details below -->
## Purpose / Description

Related to: [#17090](https://github.com/ankidroid/Anki-Android/issues/17090)
- https://github.com/ankidroid/Anki-Android/issues/17090

Now on API 30 or below, the maracas emoji is removed from the "Shake device" label, but the prefix space for its replacement ("`  `") and the next space (placed between the prefix and the string) ("` `") are still shown. As a result, the label looks, if anything, missing something or a bit broken.
![image](https://github.com/user-attachments/assets/946cc0e2-bfcf-4b7e-8d09-e1694c735904)


This PR intends to remove the two kind of spaces on API 30 or below.






## Approach

- Replace the current prefix space ("`  `") with an empty string ("")
- Don't use the middle space ("` `") if the prefix string is empty  

## How Has This Been Tested?
Checked on a physical device (Android 11)

Before  | After
---| ---
![image](https://github.com/user-attachments/assets/467815d5-cc1e-49a3-9028-9524dc858ef5) | ![image](https://github.com/user-attachments/assets/442bfedf-6bb4-46ac-94aa-cb7e6e12fff9)
![image](https://github.com/user-attachments/assets/ceba9e23-3fa9-4281-879b-42e11a73b137) | ![image](https://github.com/user-attachments/assets/546b0ee6-f71d-472a-8583-423eeed06cff)



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)