### PR TITLE
improvement: 'auto advance' menu visibility

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_buttons.xml
@@ -125,7 +125,7 @@ TODO: Add a unit test
             android:title="@string/menu_enable_voice_playback"
             app:useSimpleSummaryProvider="true"/>
         <ListPreference
-            android:defaultValue="2"
+            android:defaultValue="0"
             android:entries="@array/custom_button_labels"
             android:entryValues="@array/custom_button_values"
             android:key="@string/custom_button_toggle_auto_advance"


### PR DESCRIPTION
'always show' -> 'menu only'

I missed that 0 was the value, and not the index
I believed the index and the value matched

<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Follow up from #18645
* Issue #17701

## Approach
Fix the default value

## How Has This Been Tested?
Pixel 9 Pro: uninstalled the app, reinstalled and `Menu Only` was the default in app bar buttons

## Learning
I'd refactor the control to make it obvious, but we'll be getting rid of it soon

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->