### PR TITLE
test: exclude app-bar test issue that shows on macos in CI

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -180,6 +180,7 @@ class ReviewerTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(OS.MACOS, message = "issue #18693 / auto-advance in col prefs")
     fun onlyDisableWhiteboardAppearsInAppBarIfAllAppBarButtonsAreDisabledWithWhiteboard() {
         disableAllReviewerAppBarButtons()
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

I *think* that app bar buttons now may show based on collection preferences not just shared preferences, so the test utility that disables all the buttons (used in this flaky test) needs a fix

however until then this test seems to flake only on macos in CI, so temporarily excluding it there as the narrowest exclusion I can think of

I've seen this cause CI failures twice in the last half hour

## Fixes
* does not fix, but related #18693


## Approach

constrained exclusion should allow CI to continue with good signal-to-noise while underlying issue is fixed

## How Has This Been Tested?

This will only affect CI
