### PR TITLE
fix(automatic-answer): don't show if menu is 'never show'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -882,6 +882,7 @@ open class Reviewer :
             }
         }
         menu.findItem(R.id.action_toggle_auto_advance).apply {
+            if (actionButtons.status.autoAdvanceMenuIsNeverShown()) return@apply
             // always show if enabled (to allow disabling)
             // otherwise show if it will have an effect
             isVisible = automaticAnswer.isEnabled() || automaticAnswer.isUsable()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/ActionButtonStatus.kt
@@ -115,6 +115,8 @@ class ActionButtonStatus {
 
     fun flagsIsOverflown(): Boolean = customButtons[R.id.action_flag] == SHOW_AS_ACTION_NEVER
 
+    fun autoAdvanceMenuIsNeverShown(): Boolean = customButtons[R.id.action_toggle_auto_advance] == MENU_DISABLED
+
     companion object {
         const val SHOW_AS_ACTION_NEVER = MenuItem.SHOW_AS_ACTION_NEVER
         const val SHOW_AS_ACTION_IF_ROOM = MenuItem.SHOW_AS_ACTION_IF_ROOM


### PR DESCRIPTION
A user manually enabled the feature and explicitly set the menu item to 'never show', we should respect their wishes rather than try to be helpful

introduced in 1788e223a1165edecbaa05d35f32d81c9a5931f2

## Fixes
* Fixes #18693

## Approach
* Skip the `isVisible` check if disabled in 'app bar buttons'

## How Has This Been Tested?
Pixel 9 Pro

* Toggle Auto Advance appeared if settings were set on the deck
* After disabling the feature (show: 'never'), the menu item didn't appear
* After toggling auto advance on via gesture, the menu still didn't appear

## Learning (optional, can help others)
We could have done with better testing for the old reviewer, I thought we caught this case

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->