### PR TITLE
fix: multimedia URI `SecurityException`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -163,6 +163,7 @@ import com.ichi2.utils.ClipboardUtil
 import com.ichi2.utils.ClipboardUtil.MEDIA_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.hasMedia
 import com.ichi2.utils.ClipboardUtil.items
+import com.ichi2.utils.ContentResolverUtil
 import com.ichi2.utils.HashUtil
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.IntentUtil.resolveMimeType
@@ -598,9 +599,28 @@ class NoteEditor :
             } else {
                 data.data
             }
-        Timber.d("Image Uri : $imageUri")
-        // ImageIntentManager.saveImageUri(imageUri)
-        // the field won't exist so it will always be a new card
+
+        if (imageUri == null) {
+            Timber.d("NoteEditor:: Image Uri is null")
+            showSnackbar(R.string.something_wrong)
+            return
+        }
+
+        try {
+            requireContext().contentResolver.takePersistableUriPermission(imageUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            Timber.d("Persisted URI permission for $imageUri")
+        } catch (e: SecurityException) {
+            Timber.w(e, "Unable to persist URI permission")
+        }
+
+        val cachedImagePath = copyUriToInternalCache(imageUri)
+        if (cachedImagePath == null) {
+            Timber.w("Failed to cache image")
+            showSnackbar(R.string.something_wrong)
+            return
+        }
+        val cachedUri = Uri.fromFile(File(requireContext().cacheDir, cachedImagePath))
+
         val note = getCurrentMultimediaEditableNote()
         if (note.isEmpty) {
             Timber.w("Note is null, returning")
@@ -610,8 +630,50 @@ class NoteEditor :
             fieldIndex = 0,
             field = ImageField(),
             multimediaNote = note,
-            imageUri = imageUri,
+            imageUri = cachedUri,
         )
+    }
+
+    /**
+     * Copies a given [Uri] to the app's internal cache directory.
+     *
+     * This is necessary because URIs provided by other apps (e.g., WhatsApp, gallery apps) via
+     * `Intent` are usually content URIs with temporary permissions that are only valid
+     * in the originating context (like an Activity). Once passed to other components (like Fragments),
+     * these permissions may be lost, resulting in a SecurityException.
+     *
+     * By caching the file in internal storage and referencing it via a file URI,
+     * we ensure persistent access to the image without relying on external content providers.
+     *
+     * @param uri The [Uri] pointing to the external image content.
+     * @return The name of the cached file, or `null` if the operation failed.
+     */
+    private fun copyUriToInternalCache(uri: Uri): String? {
+        return try {
+            val inputStream = requireContext().contentResolver.openInputStream(uri) ?: return null
+
+            val fileName = ContentResolverUtil.getFileName(requireContext().contentResolver, uri) ?: return null
+            val cacheDir = requireContext().cacheDir
+            val destFile = File(cacheDir, fileName)
+
+            val canonicalCacheDir = cacheDir.canonicalFile
+            val canonicalDestFile = destFile.canonicalFile
+
+            if (!canonicalDestFile.path.startsWith(canonicalCacheDir.path)) {
+                Timber.w("Rejected path due to directory traversal risk: $fileName")
+                return null
+            }
+
+            destFile.outputStream().use { output ->
+                inputStream.copyTo(output)
+            }
+
+            Timber.d("copyUriToInternalCache() copied to ${destFile.absolutePath}")
+            destFile.name
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to copy URI to internal cache")
+            null
+        }
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When app like WhatsApp shares a file using an Intent, it typically passes a content:// URI (from its ContentProvider) and grants temporary URI permissions for:
- The specific component receiving the intent.
- Only during that activity's lifecycle — not globally or across app components like fragments in our case the MultimediaImageFragment

Its(Whatsapp) MediaProvider is not exported — meaning no other app can directly query it unless explicitly granted permission via intent.

So to fix this we needed to immediately internalizing the URI  in the Activity that received the intent.

## Fixes
* Fixes  #18660

## Approach
By copying the image to internal storage (file://), we ensure persistent access without permission issues across fragments and then in fragment(MultimediaImageFragment) we check if we need to internalize it or not to avoid internalizing it again

## How Has This Been Tested?
Vivo V338

## Learning (optional, can help others)
That we either need to pass the permission or cache the uri where(to activity or fragment recieving it) the image is shared 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->