### PR TITLE
Bugfix for #18615 When tapping on a style in the note editor, open the keyboard

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditor.kt
@@ -42,7 +42,6 @@ import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.view.ViewGroup.MarginLayoutParams
 import android.view.WindowManager
-import android.view.inputmethod.InputMethodManager
 import android.widget.AdapterView
 import android.widget.AdapterView.OnItemSelectedListener
 import android.widget.Button
@@ -160,6 +159,7 @@ import com.ichi2.libanki.Notetypes
 import com.ichi2.libanki.Notetypes.Companion.NOT_FOUND_NOTE_TYPE
 import com.ichi2.libanki.Utils
 import com.ichi2.themes.Themes
+import com.ichi2.utils.AndroidUiUtils.showSoftInput
 import com.ichi2.utils.ClipboardUtil
 import com.ichi2.utils.ClipboardUtil.MEDIA_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.hasMedia
@@ -2974,22 +2974,5 @@ class NoteEditor :
             !AnkiDroidApp.instance
                 .sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, true)
-    }
-}
-
-/**
- * Shows the soft keyboard for the current focused view in the activity.
- *
- * It's a good practice to ensure that the `currentFocus` is an
- * appropriate input field (e.g., EditText) before calling this function
- */
-fun Activity?.showSoftInput() {
-    if (this != null) {
-        val currentFocus = this.currentFocus
-        if (currentFocus != null) { // It's good to check if currentFocus is a text field
-            val imm =
-                this.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
-            imm.showSoftInput(currentFocus, InputMethodManager.SHOW_IMPLICIT)
-        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -52,8 +52,8 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.NoteEditor
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.sharedPrefs
-import com.ichi2.anki.showSoftInput
 import com.ichi2.compat.CompatHelper
+import com.ichi2.utils.AndroidUiUtils.showSoftInput
 import com.ichi2.utils.ViewGroupUtils
 import com.ichi2.utils.ViewGroupUtils.getAllChildrenRecursive
 import com.ichi2.utils.dp

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AndroidUiUtils.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.utils
 
+import android.app.Activity
 import android.content.Context
 import android.view.View
 import android.view.Window
@@ -22,6 +23,18 @@ import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 
 object AndroidUiUtils {
+    /**
+     * Shows the soft keyboard for the current focused view in the activity.
+     *
+     * It's a good practice to ensure that the `currentFocus` is an
+     * appropriate input field (e.g., EditText) before calling this function
+     */
+    fun Activity?.showSoftInput() {
+        val currentFocus = this?.currentFocus ?: return
+        val imm = this.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.showSoftInput(currentFocus, InputMethodManager.SHOW_IMPLICIT)
+    }
+
     /**
      * This method is used for setting the focus on an EditText which is used in a dialog
      * and for opening the keyboard.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 When tapping on a style in the note editor, open the keyboard

## Fixes
* Fixes #18615 

## Approach
The onClick functions of both, default and custom buttons in the toolbar have been modified. Whenever the user clicks a button on the tool bar the keyboard is shown.

## How Has This Been Tested?
This change has been tested on an android 15 phone, and an emulator. In both the cases the app functioned as expected