### PR TITLE
fix: Auto advance doesn't work until the card is flipped once

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1675,8 +1675,8 @@ open class Reviewer :
 
     private fun toggleAutoAdvance() {
         if (automaticAnswer.isDisabled) {
-            Timber.i("Enabling auto advance")
-            automaticAnswer.enable()
+            Timber.i("Re-enabling auto advance")
+            automaticAnswer.reEnable(isDisplayingAnswer)
             showSnackbar(TR.actionsAutoAdvanceActivated())
         } else {
             Timber.i("Disabling auto advance")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/AutomaticAnswer.kt
@@ -164,6 +164,19 @@ class AutomaticAnswer(
         stopShowQuestionTask()
     }
 
+    fun reEnable(isDisplayingAnswer: Boolean) {
+        isDisabled = false
+        // required for the schedule methods below to work
+        hasPlayedSounds = false
+
+        // Schedule automatic display
+        if (isDisplayingAnswer) {
+            scheduleAutomaticDisplayQuestion()
+        } else {
+            scheduleAutomaticDisplayAnswer()
+        }
+    }
+
     /** Stop any "Automatic show answer" tasks in order to avoid race conditions */
     fun onDisplayQuestion() {
         if (!settings.autoAdvanceIfShowingQuestion) return


### PR DESCRIPTION



<!--- Please fill the necessary details below -->
## Purpose / Description
On 2.21.0beta4 or higher (2.22alpha1), Auto advance feature doesn't work (start) until the user manually flips the card once.

This PR intends to fix the issue.

## Fixes
* Fixes #18705

## Approach
Add auto advance scheduling process into "toggle auto advance" action

## How Has This Been Tested?

Checked on a physical device (Android 11)

**Before**

https://github.com/user-attachments/assets/93d3775b-b69e-4d6b-be3e-20c7ae0ff5eb

------

**After**


https://github.com/user-attachments/assets/4c889dd6-e0b2-4f52-9643-de65cef22f33




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->