### PR TITLE
improvement(settings): add icons to controls tabs

### DIFF
--- a/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
+++ b/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
@@ -12,6 +12,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/pref_controls_reviews_tab"
+        android:icon="@drawable/ic_cards_star"
         />
 
     <com.google.android.material.tabs.TabItem
@@ -19,6 +20,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/pref_controls_previews_tab"
+        android:icon="@drawable/ic_remove_red_eye_white"
         />
 
 </com.google.android.material.tabs.TabLayout>


### PR DESCRIPTION
There was feedback stating that the tabs weren't very noticeable.

I don't think that matters much, they don't need any kind of special attention.

But I thought that adding icons to them would be okay

## How Has This Been Tested?

Emulator API 35

![Screenshot_20250629_160043](https://github.com/user-attachments/assets/e5f1646b-bcbd-4d1c-bad8-346e5bafdf18)
![Screenshot_20250629_160208](https://github.com/user-attachments/assets/ce5132c9-0fc3-47ab-b210-5946ffad6bdc)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->