### PR TITLE
Fixed 'Change Column' does not restore state correctly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnSelectionDialogFragment.kt
@@ -45,7 +45,7 @@ class ColumnSelectionDialogFragment : DialogFragment() {
 
     private var availableColumns: List<ColumnWithSample> = emptyList()
 
-    public override fun onSaveInstanceState(outState: Bundle) {
+    override fun onSaveInstanceState(outState: Bundle) {
         with(outState) {
             outState.putParcelableArrayList(AVAILABLE_COLUMNS, availableColumns.toCollection(ArrayList()))
             super.onSaveInstanceState(this)
@@ -53,7 +53,6 @@ class ColumnSelectionDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
-        super.onCreate(savedInstanceState)
         val listView =
             ListView(requireContext()).apply {
                 setPaddingRelative(
@@ -91,22 +90,17 @@ class ColumnSelectionDialogFragment : DialogFragment() {
         listView.adapter = adapter
         listView.divider = null
 
-        // Load the available columns either from the viewModel or savedInstanceState bundle
-        if (savedInstanceState == null) {
-            lifecycleScope.launch {
+        lifecycleScope.launch {
+            // Load the available columns either from the viewModel or savedInstanceState bundle
+            if (savedInstanceState == null) {
                 availableColumns = viewModel.previewColumnHeadings(viewModel.cardsOrNotes).second
-                adapter.clear()
-                adapter.addAll(availableColumns)
-                adapter.notifyDataSetChanged()
-            }
-        } else {
-            lifecycleScope.launch {
+            } else {
                 availableColumns =
                     BundleCompat.getParcelableArrayList(savedInstanceState, AVAILABLE_COLUMNS, ColumnWithSample::class.java)!!.toList()
-                adapter.clear()
-                adapter.addAll(availableColumns)
-                adapter.notifyDataSetChanged()
             }
+            adapter.clear()
+            adapter.addAll(availableColumns)
+            adapter.notifyDataSetChanged()
         }
 
         listView.setOnItemClickListener { _, _, position, _ ->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Browser: 'Change Column' does not restore state correctly when 'Don't keep Activities' is turned on

## Fixes
* Fixes #18584

## Approach
I used an onSaveInstanceState function to properly save the state of the List of available columns. This list is later on retrieved in the onCreateDialog function

## How Has This Been Tested?
For testing I used my Android 16 phone. To reproduce the issue, the instructions from the linked issue can be used

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->