### PR TITLE
refactor: Move most CardBrowser methods to CardBrowserFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -163,7 +163,6 @@ open class CardBrowser :
     private var saveSearchItem: MenuItem? = null
     private var mySearchesItem: MenuItem? = null
     private var previewItem: MenuItem? = null
-    private var undoSnackbar: Snackbar? = null
 
     // card that was clicked (not marked)
     override var currentCardId
@@ -1028,13 +1027,8 @@ open class CardBrowser :
     @NeedsTest("filter-marked query needs testing")
     @NeedsTest("filter-suspended query needs testing")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        when {
-            drawerToggle.onOptionsItemSelected(item) -> return true
-
-            // dismiss undo-snackbar if shown to avoid race condition
-            // (when another operation will be performed on the model, it will undo the latest operation)
-            undoSnackbar != null && undoSnackbar!!.isShown -> undoSnackbar!!.dismiss()
-        }
+        if (drawerToggle.onOptionsItemSelected(item)) return true
+        cardBrowserFragment.prepareForUndoableOperation()
 
         Flag.entries.find { it.ordinal == item.itemId }?.let { flag ->
             when (item.groupId) {
@@ -1278,13 +1272,6 @@ open class CardBrowser :
         @Suppress("UNUSED_PARAMETER") cardIds: List<CardId>,
     ) {
         updateList()
-    }
-
-    fun showUndoSnackbar(message: CharSequence) {
-        showSnackbar(message) {
-            setAction(R.string.undo) { launchCatchingTask { undoAndShowSnackbar() } }
-            undoSnackbar = this
-        }
     }
 
     private fun refreshAfterUndo() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -82,6 +82,7 @@ import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.browser.toggleBury
 import com.ichi2.anki.browser.toggleMark
 import com.ichi2.anki.browser.toggleSuspendCards
+import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
@@ -1120,27 +1121,12 @@ open class CardBrowser :
         }
     }
 
-    private fun updateFlagForSelectedRows(flag: Flag) =
-        launchCatchingTask {
-            updateSelectedCardsFlag(flag)
-        }
-
-    /**
-     * Sets the flag for selected cards, default norm of flags are as:
-     *
-     * 0: No Flag, 1: RED, 2: ORANGE, 3: GREEN
-     * 4: BLUE, 5: PINK, 6: Turquoise, 7: PURPLE
-     *
-     */
-    @VisibleForTesting
-    suspend fun updateSelectedCardsFlag(flag: Flag) {
-        // list of cards with updated flags
-        val updatedCardIds = withProgress { viewModel.updateSelectedCardsFlag(flag) }
+    fun onCardsUpdated(cardIds: List<CardId>) {
         // TODO: try to offload the cards processing in updateCardsInList() on a background thread,
         // otherwise it could hang the main thread
-        updateCardsInList(updatedCardIds)
+        updateCardsInList(cardIds)
         invalidateOptionsMenu() // maybe the availability of undo changed
-        if (updatedCardIds.any { it == reviewerCardId }) {
+        if (cardIds.any { it == reviewerCardId }) {
             reloadRequired = true
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -72,6 +72,7 @@ import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.registerFindReplaceHandler
+import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -81,8 +82,6 @@ import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog
 import com.ichi2.anki.dialogs.CreateDeckDialog
-import com.ichi2.anki.dialogs.DeckSelectionDialog
-import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DiscardChangesDialog
@@ -113,7 +112,6 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.toSentenceCase
-import com.ichi2.anki.utils.ext.getCurrentDialogFragment
 import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -123,7 +121,6 @@ import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.TagsUtil.getUpdatedTags
 import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
 import com.ichi2.widget.WidgetStatus.updateInBackground
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
@@ -346,17 +343,6 @@ open class CardBrowser :
 
     private fun canPerformMultiSelectEditNote(): Boolean = viewModel.selectedRowCount() == 1
 
-    /**
-     * Change Deck
-     * @param did Id of the deck
-     */
-    @VisibleForTesting
-    fun moveSelectedCardsToDeck(did: DeckId): Job =
-        launchCatchingTask {
-            val changed = withProgress { viewModel.moveSelectedCardsToDeck(did).await() }
-            showUndoSnackbar(TR.browsingCardsUpdated(changed.count))
-        }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -437,15 +423,6 @@ open class CardBrowser :
             )
 
         startLoadingCollection()
-
-        // Selected cards aren't restored on activity recreation,
-        // so it is necessary to dismiss the change deck dialog
-        getCurrentDialogFragment<DeckSelectionDialog>()?.let { dialogFragment ->
-            if (dialogFragment.requireArguments().getBoolean(CHANGE_DECK_KEY, false)) {
-                Timber.d("onCreate(): Change deck dialog dismissed")
-                dialogFragment.dismiss()
-            }
-        }
 
         setupFlows()
         registerOnForgetHandler { viewModel.queryAllSelectedCardIds() }
@@ -1541,36 +1518,6 @@ open class CardBrowser :
         }
     }
 
-    @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
-    fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
-        val dialog =
-            newInstance(
-                getString(R.string.move_all_to_deck),
-                null,
-                false,
-                selectableDecks!!,
-            )
-        // Add change deck argument so the dialog can be dismissed
-        // after activity recreation, since the selected cards will be gone with it
-        dialog.requireArguments().putBoolean(CHANGE_DECK_KEY, true)
-        dialog.deckSelectionListener = DeckSelectionListener { deck: SelectableDeck? -> moveSelectedCardsToDeck(deck!!.deckId) }
-        return dialog
-    }
-
-    private fun showChangeDeckDialog() =
-        launchCatchingTask {
-            if (!viewModel.hasSelectedAnyRows()) {
-                Timber.i("Not showing Change Deck - No Cards")
-                return@launchCatchingTask
-            }
-            val selectableDecks =
-                viewModel
-                    .getAvailableDecks()
-                    .map { d -> SelectableDeck(d) }
-            val dialog = getChangeDeckDialog(selectableDecks)
-            showDialogFragment(dialog)
-        }
-
     private fun addNoteFromCardBrowser() {
         if (fragmented) {
             loadNoteEditorFragmentIfFragmented()
@@ -1792,7 +1739,7 @@ open class CardBrowser :
             showUndoSnackbar(message)
         }
 
-    private fun showUndoSnackbar(message: CharSequence) {
+    fun showUndoSnackbar(message: CharSequence) {
         showSnackbar(message) {
             setAction(R.string.undo) { launchCatchingTask { undoAndShowSnackbar() } }
             undoSnackbar = this
@@ -1892,13 +1839,6 @@ open class CardBrowser :
         get() = cardBrowserFragment.shortcuts
 
     companion object {
-        /**
-         * Argument key to add on change deck dialog,
-         * so it can be dismissed on activity recreation,
-         * since the cards are unselected when this happens
-         */
-        private const val CHANGE_DECK_KEY = "CHANGE_DECK"
-
         // Keys for saving pane weights in SharedPreferences
         private const val PREF_CARD_BROWSER_PANE_WEIGHT = "cardBrowserPaneWeight"
         private const val PREF_NOTE_EDITOR_PANE_WEIGHT = "noteEditorPaneWeight"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -74,6 +74,7 @@ import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
 import com.ichi2.anki.browser.rescheduleSelectedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
+import com.ichi2.anki.browser.showCreateFilteredDeckDialog
 import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.browser.toggleBury
@@ -85,7 +86,6 @@ import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
 import com.ichi2.anki.dialogs.CardBrowserOrderDialog
-import com.ichi2.anki.dialogs.CreateDeckDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DiscardChangesDialog
@@ -1297,24 +1297,6 @@ open class CardBrowser :
             Timber.w("Unexpected onOptionsItemSelected call: %s", item.itemId)
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    private fun showCreateFilteredDeckDialog() {
-        val dialog = CreateDeckDialog(this, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null)
-        dialog.onNewDeckCreated = {
-            startActivity(
-                FilteredDeckOptions.getIntent(
-                    this,
-                    deckId = null,
-                    searchTerms = viewModel.searchTerms,
-                ),
-            )
-        }
-        launchCatchingTask {
-            withProgress {
-                dialog.showFilteredDeckDialog()
-            }
-        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -19,7 +19,6 @@
 package com.ichi2.anki
 
 import android.content.Context
-import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
@@ -67,6 +66,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
+import com.ichi2.anki.browser.changeDisplayOrder
 import com.ichi2.anki.browser.deleteSelectedNotes
 import com.ichi2.anki.browser.exportSelected
 import com.ichi2.anki.browser.onResetProgress
@@ -85,7 +85,6 @@ import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
-import com.ichi2.anki.dialogs.CardBrowserOrderDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DiscardChangesDialog
@@ -101,7 +100,6 @@ import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
-import com.ichi2.anki.model.SortType
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
@@ -1316,16 +1314,6 @@ open class CardBrowser :
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     fun showFindAndReplaceDialog() {
         FindAndReplaceDialogFragment().show(supportFragmentManager, FindAndReplaceDialogFragment.TAG)
-    }
-
-    private fun changeDisplayOrder() {
-        showDialogFragment(
-            // TODO: move this into the ViewModel
-            CardBrowserOrderDialog.newInstance { dialog: DialogInterface, which: Int ->
-                dialog.dismiss()
-                viewModel.changeCardOrder(SortType.fromCardBrowserLabelIndex(which))
-            },
-        )
     }
 
     private fun showSavedSearches() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -76,6 +76,8 @@ import com.ichi2.anki.browser.searchForMarkedNotes
 import com.ichi2.anki.browser.searchForSuspendedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.showCreateFilteredDeckDialog
+import com.ichi2.anki.browser.showEditTagsDialog
+import com.ichi2.anki.browser.showFilterByTagsDialog
 import com.ichi2.anki.browser.showFindAndReplaceDialog
 import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
@@ -92,7 +94,6 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.dialogs.GradeNowDialog
-import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.libanki.CardId
@@ -105,7 +106,6 @@ import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
-import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.PreviewerFragment
 import com.ichi2.anki.scheduling.registerOnForgetHandler
@@ -117,7 +117,6 @@ import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckDropDownAdapter
 import com.ichi2.ui.CardBrowserSearchView
 import com.ichi2.utils.LanguageUtil
-import com.ichi2.utils.TagsUtil.getUpdatedTags
 import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
 import com.ichi2.widget.WidgetStatus.updateInBackground
 import kotlinx.coroutines.launch
@@ -161,11 +160,6 @@ open class CardBrowser :
             throw UnsupportedOperationException()
         }
 
-    private enum class TagsDialogListenerAction {
-        FILTER,
-        EDIT_TAGS,
-    }
-
     lateinit var viewModel: CardBrowserViewModel
 
     lateinit var cardBrowserFragment: CardBrowserFragment
@@ -179,7 +173,7 @@ open class CardBrowser :
 
     private var searchView: CardBrowserSearchView? = null
 
-    private lateinit var tagsDialogFactory: TagsDialogFactory
+    lateinit var tagsDialogFactory: TagsDialogFactory
     private var searchItem: MenuItem? = null
     private var saveSearchItem: MenuItem? = null
     private var mySearchesItem: MenuItem? = null
@@ -192,9 +186,6 @@ open class CardBrowser :
         set(value) {
             viewModel.currentCardId = value
         }
-
-    // DEFECT: Doesn't need to be a local
-    private var tagsDialogListenerAction: TagsDialogListenerAction? = null
 
     private var onEditCardActivityResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
@@ -1356,36 +1347,6 @@ open class CardBrowser :
     private val reviewerCardId: CardId
         get() = intent.getLongExtra("currentCard", -1)
 
-    private fun showEditTagsDialog() {
-        if (!viewModel.hasSelectedAnyRows()) {
-            Timber.d("showEditTagsDialog: called with empty selection")
-        }
-        tagsDialogListenerAction = TagsDialogListenerAction.EDIT_TAGS
-        lifecycleScope.launch {
-            val noteIds = viewModel.queryAllSelectedNoteIds()
-            val dialog =
-                tagsDialogFactory.newTagsDialog().withArguments(
-                    this@CardBrowser,
-                    type = TagsDialog.DialogType.EDIT_TAGS,
-                    noteIds = noteIds,
-                )
-            showDialogFragment(dialog)
-        }
-    }
-
-    private fun showFilterByTagsDialog() {
-        launchCatchingTask {
-            tagsDialogListenerAction = TagsDialogListenerAction.FILTER
-            val dialog =
-                tagsDialogFactory.newTagsDialog().withArguments(
-                    context = this@CardBrowser,
-                    type = TagsDialog.DialogType.FILTER_BY_TAG,
-                    noteIds = emptyList(),
-                )
-            showDialogFragment(dialog)
-        }
-    }
-
     public override fun onSaveInstanceState(outState: Bundle) {
         // Save current search terms
         outState.putString("mSearchTerms", viewModel.searchTerms)
@@ -1491,45 +1452,7 @@ open class CardBrowser :
         indeterminateTags: List<String>,
         stateFilter: CardStateFilter,
     ) {
-        when (tagsDialogListenerAction) {
-            TagsDialogListenerAction.FILTER -> filterByTags(selectedTags, stateFilter)
-            TagsDialogListenerAction.EDIT_TAGS ->
-                launchCatchingTask {
-                    editSelectedCardsTags(selectedTags, indeterminateTags)
-                }
-            else -> {}
-        }
-    }
-
-    /**
-     * Updates the tags of selected/checked notes and saves them to the disk
-     * @param selectedTags list of checked tags
-     * @param indeterminateTags a list of tags which can checked or unchecked, should be ignored if not expected
-     * For more info on [selectedTags] and [indeterminateTags] see [com.ichi2.anki.dialogs.tags.TagsDialogListener.onSelectedTags]
-     */
-    private suspend fun editSelectedCardsTags(
-        selectedTags: List<String>,
-        indeterminateTags: List<String>,
-    ) = withProgress {
-        val selectedNoteIds = viewModel.queryAllSelectedNoteIds().distinct()
-        undoableOp {
-            val selectedNotes =
-                selectedNoteIds
-                    .map { noteId -> getNote(noteId) }
-                    .onEach { note ->
-                        val previousTags: List<String> = note.tags
-                        val updatedTags = getUpdatedTags(previousTags, selectedTags, indeterminateTags)
-                        note.setTagsFromStr(this@undoableOp, tags.join(updatedTags))
-                    }
-            updateNotes(selectedNotes)
-        }
-    }
-
-    private fun filterByTags(
-        selectedTags: List<String>,
-        cardState: CardStateFilter,
-    ) = launchCatchingTask {
-        viewModel.filterByTags(selectedTags, cardState)
+        cardBrowserFragment.onSelectedTags(selectedTags, indeterminateTags, stateFilter)
     }
 
     /** Updates search terms to only show cards with selected flag.  */
@@ -1617,13 +1540,6 @@ open class CardBrowser :
         ),
         defaultViewModelCreationExtras,
     )[CardBrowserViewModel::class.java]
-
-    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
-    fun filterByTag(vararg tags: String) {
-        tagsDialogListenerAction = TagsDialogListenerAction.FILTER
-        onSelectedTags(tags.toList(), emptyList(), CardStateFilter.ALL_CARDS)
-        filterByTags(tags.toList(), CardStateFilter.ALL_CARDS)
-    }
 
     override fun opExecuted(
         changes: OpChanges,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -74,6 +74,9 @@ import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
+import com.ichi2.anki.browser.toggleBury
+import com.ichi2.anki.browser.toggleMark
+import com.ichi2.anki.browser.toggleSuspendCards
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
@@ -844,16 +847,6 @@ open class CardBrowser :
             }
         updateFlagForSelectedRows(flag)
     }
-
-    /** All the notes of the selected cards will be marked
-     * If one or more card is unmarked, all will be marked,
-     * otherwise, they will be unmarked  */
-    @NeedsTest("Test that the mark get toggled as expected for a list of selected cards")
-    @VisibleForTesting
-    fun toggleMark() =
-        launchCatchingTask {
-            withProgress { viewModel.toggleMark() }
-        }
 
     /** Opens the note editor for a card.
      * We use the Card ID to specify the preview target  */
@@ -1723,21 +1716,6 @@ open class CardBrowser :
     ) {
         updateList()
     }
-
-    private fun toggleSuspendCards() = launchCatchingTask { withProgress { viewModel.toggleSuspendCards().join() } }
-
-    /** @see CardBrowserViewModel.toggleBury */
-    private fun toggleBury() =
-        launchCatchingTask {
-            val result = withProgress { viewModel.toggleBury() } ?: return@launchCatchingTask
-            // show a snackbar as there's currently no colored background for buried cards
-            val message =
-                when (result.wasBuried) {
-                    true -> TR.studyingCardsBuried(result.count)
-                    false -> resources.getQuantityString(R.plurals.unbury_cards_feedback, result.count, result.count)
-                }
-            showUndoSnackbar(message)
-        }
 
     fun showUndoSnackbar(message: CharSequence) {
         showSnackbar(message) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -73,6 +73,8 @@ import com.ichi2.anki.browser.onResetProgress
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
 import com.ichi2.anki.browser.rescheduleSelectedCards
+import com.ichi2.anki.browser.searchForMarkedNotes
+import com.ichi2.anki.browser.searchForSuspendedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.showCreateFilteredDeckDialog
 import com.ichi2.anki.browser.showOptionsDialog
@@ -1295,20 +1297,6 @@ open class CardBrowser :
             Timber.w("Unexpected onOptionsItemSelected call: %s", item.itemId)
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    /**
-     * @see CardBrowserViewModel.searchForSuspendedCards
-     */
-    private fun searchForSuspendedCards() {
-        launchCatchingTask { viewModel.searchForSuspendedCards() }
-    }
-
-    /**
-     * @see CardBrowserViewModel.searchForMarkedNotes
-     */
-    private fun searchForMarkedNotes() {
-        launchCatchingTask { viewModel.searchForMarkedNotes() }
     }
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -65,11 +65,8 @@ import com.ichi2.anki.browser.CardOrNoteId
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
-import com.ichi2.anki.browser.deleteSelectedNotes
 import com.ichi2.anki.browser.registerFindReplaceHandler
-import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
-import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
@@ -645,7 +642,7 @@ open class CardBrowser :
                     return false
                 } else {
                     Timber.i("Delete pressed - Delete Selected Note")
-                    deleteSelectedNotes()
+                    cardBrowserFragment.deleteSelectedNotes()
                     return true
                 }
             }
@@ -711,7 +708,7 @@ open class CardBrowser :
                 KeyEvent.KEYCODE_7 -> Flag.PURPLE
                 else -> return
             }
-        updateFlagForSelectedRows(flag)
+        cardBrowserFragment.updateFlagForSelectedRows(flag)
     }
 
     /** Opens the note editor for a card.
@@ -1015,7 +1012,7 @@ open class CardBrowser :
     fun warnUserIfInNotesOnlyMode(): Boolean {
         if (viewModel.cardsOrNotes != NOTES) return false
         showSnackbar(R.string.card_browser_unavailable_when_notes_mode) {
-            setAction(R.string.error_handling_options) { showOptionsDialog() }
+            setAction(R.string.error_handling_options) { cardBrowserFragment.showOptionsDialog() }
         }
         return true
     }
@@ -1029,7 +1026,7 @@ open class CardBrowser :
         Flag.entries.find { it.ordinal == item.itemId }?.let { flag ->
             when (item.groupId) {
                 Mode.SINGLE_SELECT.value -> filterByFlag(flag)
-                Mode.MULTI_SELECT.value -> updateFlagForSelectedRows(flag)
+                Mode.MULTI_SELECT.value -> cardBrowserFragment.updateFlagForSelectedRows(flag)
                 else -> return@let
             }
             return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -53,8 +53,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.android.input.ShortcutGroup
-import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.browser.BrowserRowCollection
 import com.ichi2.anki.browser.CardBrowserFragment
 import com.ichi2.anki.browser.CardBrowserLaunchOptions
@@ -128,7 +126,6 @@ import com.ichi2.widget.WidgetStatus.updateInBackground
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.RustCleanup
-import net.ankiweb.rsdroid.Translations
 import timber.log.Timber
 
 @Suppress("LeakingThis")
@@ -174,6 +171,8 @@ open class CardBrowser :
     }
 
     lateinit var viewModel: CardBrowserViewModel
+
+    lateinit var cardBrowserFragment: CardBrowserFragment
 
     /**
      * The frame containing the NoteEditor. Non null only in layout x-large.
@@ -416,11 +415,12 @@ open class CardBrowser :
         // must be called once we have an accessible collection
         viewModel = createViewModel(launchOptions, fragmented)
 
-        if (supportFragmentManager.findFragmentById(R.id.card_browser_frame) == null) {
-            supportFragmentManager.commit {
-                replace(R.id.card_browser_frame, CardBrowserFragment())
+        cardBrowserFragment = supportFragmentManager.findFragmentById(R.id.card_browser_frame) as? CardBrowserFragment
+            ?: CardBrowserFragment().also { fragment ->
+                supportFragmentManager.commit {
+                    replace(R.id.card_browser_frame, fragment)
+                }
             }
-        }
 
         // initialize the lateinit variables
         // Load reference to action bar title
@@ -1889,42 +1889,7 @@ open class CardBrowser :
     }
 
     override val shortcuts
-        get() =
-            ShortcutGroup(
-                listOf(
-                    shortcut("Ctrl+Shift+A", R.string.edit_tags_dialog),
-                    shortcut("Ctrl+A", R.string.card_browser_select_all),
-                    shortcut("Ctrl+Shift+E", Translations::exportingExport),
-                    shortcut("Ctrl+E", R.string.menu_add_note),
-                    shortcut("E", R.string.cardeditor_title_edit_card),
-                    shortcut("Ctrl+D", R.string.card_browser_change_deck),
-                    shortcut("Ctrl+K", Translations::browsingToggleMark),
-                    shortcut("Ctrl+Alt+R", Translations::browsingReschedule),
-                    shortcut("DEL", R.string.delete_card_title),
-                    shortcut("Ctrl+Alt+N", R.string.reset_card_dialog_title),
-                    shortcut("Ctrl+Alt+T", R.string.toggle_cards_notes),
-                    shortcut("Ctrl+T", R.string.card_browser_search_by_tag),
-                    shortcut("Ctrl+Shift+S", Translations::actionsReposition),
-                    shortcut("Ctrl+Alt+S", R.string.card_browser_list_my_searches),
-                    shortcut("Ctrl+S", R.string.card_browser_list_my_searches_save),
-                    shortcut("Alt+S", R.string.card_browser_show_suspended),
-                    shortcut("Ctrl+Shift+G", Translations::actionsGradeNow),
-                    shortcut("Ctrl+Shift+J", Translations::browsingToggleBury),
-                    shortcut("Ctrl+J", Translations::browsingToggleSuspend),
-                    shortcut("Ctrl+Shift+I", Translations::actionsCardInfo),
-                    shortcut("Ctrl+O", R.string.show_order_dialog),
-                    shortcut("Ctrl+M", R.string.card_browser_show_marked),
-                    shortcut("Esc", R.string.card_browser_select_none),
-                    shortcut("Ctrl+1", R.string.gesture_flag_red),
-                    shortcut("Ctrl+2", R.string.gesture_flag_orange),
-                    shortcut("Ctrl+3", R.string.gesture_flag_green),
-                    shortcut("Ctrl+4", R.string.gesture_flag_blue),
-                    shortcut("Ctrl+5", R.string.gesture_flag_pink),
-                    shortcut("Ctrl+6", R.string.gesture_flag_turquoise),
-                    shortcut("Ctrl+7", R.string.gesture_flag_purple),
-                ),
-                R.string.card_browser_context_menu,
-            )
+        get() = cardBrowserFragment.shortcuts
 
     companion object {
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -65,25 +65,10 @@ import com.ichi2.anki.browser.CardOrNoteId
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
-import com.ichi2.anki.browser.changeDisplayOrder
 import com.ichi2.anki.browser.deleteSelectedNotes
-import com.ichi2.anki.browser.exportSelected
-import com.ichi2.anki.browser.onResetProgress
 import com.ichi2.anki.browser.registerFindReplaceHandler
-import com.ichi2.anki.browser.repositionSelectedCards
-import com.ichi2.anki.browser.rescheduleSelectedCards
-import com.ichi2.anki.browser.searchForMarkedNotes
-import com.ichi2.anki.browser.searchForSuspendedCards
-import com.ichi2.anki.browser.showChangeDeckDialog
-import com.ichi2.anki.browser.showCreateFilteredDeckDialog
-import com.ichi2.anki.browser.showEditTagsDialog
-import com.ichi2.anki.browser.showFilterByTagsDialog
-import com.ichi2.anki.browser.showFindAndReplaceDialog
 import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
-import com.ichi2.anki.browser.toggleBury
-import com.ichi2.anki.browser.toggleMark
-import com.ichi2.anki.browser.toggleSuspendCards
 import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
@@ -626,27 +611,16 @@ open class CardBrowser :
         keyCode: Int,
         event: KeyEvent,
     ): Boolean {
+        if (cardBrowserFragment.onKeyUp(keyCode, event)) {
+            return true
+        }
+
         // This method is called even when the user is typing in the search text field.
         // So we must ensure that all shortcuts uses a modifier.
         // A shortcut without modifier would be triggered while the user types, which is not what we want.
         when (keyCode) {
-            KeyEvent.KEYCODE_A -> {
-                if (event.isCtrlPressed && event.isShiftPressed) {
-                    Timber.i("Ctrl+Shift+A - Show edit tags dialog")
-                    showEditTagsDialog()
-                    return true
-                } else if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+A - Select All")
-                    viewModel.selectAll()
-                    return true
-                }
-            }
             KeyEvent.KEYCODE_E -> {
-                if (event.isCtrlPressed && event.isShiftPressed) {
-                    Timber.i("Ctrl+Shift+E: Export selected cards")
-                    exportSelected()
-                    return true
-                } else if (event.isCtrlPressed) {
+                if (event.isCtrlPressed) {
                     Timber.i("Ctrl+E: Add Note")
                     launchCatchingTask { addNoteFromCardBrowser() }
                     return true
@@ -659,27 +633,6 @@ open class CardBrowser :
                     Timber.i("E: Character added")
                     // search box might be available and receiving input so treat this as usual text
                     return false
-                }
-            }
-            KeyEvent.KEYCODE_D -> {
-                if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+D: Change Deck")
-                    showChangeDeckDialog()
-                    return true
-                }
-            }
-            KeyEvent.KEYCODE_K -> {
-                if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+K: Toggle Mark")
-                    toggleMark()
-                    return true
-                }
-            }
-            KeyEvent.KEYCODE_R -> {
-                if (event.isCtrlPressed && event.isAltPressed) {
-                    Timber.i("Ctrl+Alt+R - Reschedule")
-                    rescheduleSelectedCards()
-                    return true
                 }
             }
             KeyEvent.KEYCODE_G -> {
@@ -702,11 +655,6 @@ open class CardBrowser :
                 }
             }
             KeyEvent.KEYCODE_F -> {
-                if (event.isCtrlPressed && event.isAltPressed) {
-                    Timber.i("CTRL+ALT+F - Find and replace")
-                    showFindAndReplaceDialog()
-                    return true
-                }
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+F - Find notes")
                     searchItem?.expandActionView()
@@ -720,51 +668,14 @@ open class CardBrowser :
                     return true
                 }
             }
-            KeyEvent.KEYCODE_N -> {
-                if (event.isCtrlPressed && event.isAltPressed) {
-                    Timber.i("Ctrl+Alt+N: Reset card progress")
-                    onResetProgress()
-                    return true
-                }
-            }
-            KeyEvent.KEYCODE_T -> {
-                if (event.isCtrlPressed && event.isAltPressed) {
-                    Timber.i("Ctrl+Alt+T: Toggle cards/notes")
-                    showOptionsDialog()
-                    return true
-                } else if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+T: Show filter by tags dialog")
-                    showFilterByTagsDialog()
-                    return true
-                }
-            }
             KeyEvent.KEYCODE_S -> {
-                if (event.isCtrlPressed && event.isShiftPressed) {
-                    Timber.i("Ctrl+Shift+S: Reposition selected cards")
-                    repositionSelectedCards()
-                    return true
-                } else if (event.isCtrlPressed && event.isAltPressed) {
+                if (event.isCtrlPressed && event.isAltPressed) {
                     Timber.i("Ctrl+Alt+S: Show saved searches")
                     showSavedSearches()
                     return true
                 } else if (event.isCtrlPressed) {
                     Timber.i("Ctrl+S: Save search")
                     openSaveSearchView()
-                    return true
-                } else if (event.isAltPressed) {
-                    Timber.i("Alt+S: Show suspended cards")
-                    searchForSuspendedCards()
-                    return true
-                }
-            }
-            KeyEvent.KEYCODE_J -> {
-                if (event.isCtrlPressed && event.isShiftPressed) {
-                    Timber.i("Ctrl+Shift+J: Toggle bury cards")
-                    toggleBury()
-                    return true
-                } else if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+J: Toggle suspended cards")
-                    toggleSuspendCards()
                     return true
                 }
             }
@@ -775,31 +686,12 @@ open class CardBrowser :
                     return true
                 }
             }
-            KeyEvent.KEYCODE_O -> {
-                if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+O: Show order dialog")
-                    changeDisplayOrder()
-                    return true
-                }
-            }
-            KeyEvent.KEYCODE_M -> {
-                if (event.isCtrlPressed) {
-                    Timber.i("Ctrl+M: Search marked notes")
-                    searchForMarkedNotes()
-                    return true
-                }
-            }
             KeyEvent.KEYCODE_Z -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+Z: Undo")
                     onUndo()
                     return true
                 }
-            }
-            KeyEvent.KEYCODE_ESCAPE -> {
-                Timber.i("ESC: Select none")
-                viewModel.selectNone()
-                return true
             }
             in KeyEvent.KEYCODE_1..KeyEvent.KEYCODE_7 -> {
                 if (event.isCtrlPressed) {
@@ -1154,10 +1046,6 @@ open class CardBrowser :
         }
 
         when (item.itemId) {
-            android.R.id.home -> {
-                viewModel.endMultiSelectMode(SingleSelectCause.NavigateBack)
-                return true
-            }
             R.id.action_add_note_from_card_browser -> {
                 addNoteFromCardBrowser()
                 return true
@@ -1170,72 +1058,13 @@ open class CardBrowser :
                 showSavedSearches()
                 return true
             }
-            R.id.action_sort_by_size -> {
-                changeDisplayOrder()
-                return true
-            }
-            R.id.action_show_marked -> {
-                searchForMarkedNotes()
-                return true
-            }
-            R.id.action_show_suspended -> {
-                searchForSuspendedCards()
-                return true
-            }
-            R.id.action_search_by_tag -> {
-                showFilterByTagsDialog()
-                return true
-            }
-            R.id.action_delete_card -> {
-                deleteSelectedNotes()
-                return true
-            }
-            R.id.action_mark_card -> {
-                toggleMark()
-                return true
-            }
-            R.id.action_suspend_card -> {
-                toggleSuspendCards()
-                return true
-            }
-            R.id.action_toggle_bury -> {
-                toggleBury()
-                return true
-            }
-            R.id.action_change_deck -> {
-                showChangeDeckDialog()
-                return true
-            }
             R.id.action_undo -> {
                 Timber.w("CardBrowser:: Undo pressed")
                 onUndo()
                 return true
             }
-            R.id.action_select_all -> {
-                viewModel.selectAll()
-                return true
-            }
             R.id.action_preview -> {
                 onPreview()
-                return true
-            }
-            R.id.action_reset_cards_progress -> {
-                Timber.i("NoteEditor:: Reset progress button pressed")
-                onResetProgress()
-                return true
-            }
-            R.id.action_grade_now -> {
-                Timber.i("CardBrowser:: Grade now button pressed")
-                openGradeNow()
-                return true
-            }
-            R.id.action_reschedule_cards -> {
-                Timber.i("CardBrowser:: Reschedule button pressed")
-                rescheduleSelectedCards()
-                return true
-            }
-            R.id.action_reposition_cards -> {
-                repositionSelectedCards()
                 return true
             }
             R.id.action_edit_note -> {
@@ -1246,27 +1075,9 @@ open class CardBrowser :
                 displayCardInfo()
                 return true
             }
-            R.id.action_edit_tags -> {
-                showEditTagsDialog()
-                return true
-            }
-            R.id.action_open_options -> {
-                showOptionsDialog()
-                return true
-            }
-            R.id.action_export_selected -> {
-                exportSelected()
-                return true
-            }
-            R.id.action_create_filtered_deck -> {
-                showCreateFilteredDeckDialog()
-                return true
-            }
-            R.id.action_find_replace -> {
-                showFindAndReplaceDialog()
-                return true
-            }
         }
+
+        // TODO: make better use of MenuProvider
         if (fragment?.onMenuItemSelected(item) == true) {
             return true
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -68,6 +68,7 @@ import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.deleteSelectedNotes
+import com.ichi2.anki.browser.onResetProgress
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
 import com.ichi2.anki.browser.rescheduleSelectedCards
@@ -106,7 +107,6 @@ import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.PreviewerFragment
-import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
@@ -1397,11 +1397,6 @@ open class CardBrowser :
         launchCatchingTask {
             undoAndShowSnackbar()
         }
-    }
-
-    private fun onResetProgress() {
-        if (warnUserIfInNotesOnlyMode()) return
-        showDialogFragment(ForgetCardsDialog())
     }
 
     private fun onPreview() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -135,7 +135,7 @@ open class CardBrowser :
 
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let {
-            launchCatchingTask { selectDeckAndSave(deck.deckId) }
+            launchCatchingTask { viewModel.setDeckId(deck.deckId) }
         }
     }
 
@@ -600,10 +600,6 @@ open class CardBrowser :
                 )
             }
         }
-    }
-
-    suspend fun selectDeckAndSave(deckId: DeckId) {
-        viewModel.setDeckId(deckId)
     }
 
     override fun onKeyUp(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -62,7 +62,6 @@ import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
 import com.ichi2.anki.browser.CardOrNoteId
-import com.ichi2.anki.browser.FindAndReplaceDialogFragment
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
@@ -77,6 +76,7 @@ import com.ichi2.anki.browser.searchForMarkedNotes
 import com.ichi2.anki.browser.searchForSuspendedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.showCreateFilteredDeckDialog
+import com.ichi2.anki.browser.showFindAndReplaceDialog
 import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.browser.toggleBury
@@ -1283,11 +1283,6 @@ open class CardBrowser :
             Timber.w("Unexpected onOptionsItemSelected call: %s", item.itemId)
         }
         return super.onOptionsItemSelected(item)
-    }
-
-    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
-    fun showFindAndReplaceDialog() {
-        FindAndReplaceDialogFragment().show(supportFragmentManager, FindAndReplaceDialogFragment.TAG)
     }
 
     private fun showSavedSearches() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -68,6 +68,7 @@ import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.deleteSelectedNotes
+import com.ichi2.anki.browser.exportSelected
 import com.ichi2.anki.browser.onResetProgress
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
@@ -92,7 +93,6 @@ import com.ichi2.anki.dialogs.GradeNowDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
-import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
@@ -1385,11 +1385,6 @@ open class CardBrowser :
                 startActivity(intent)
             }
         }
-    }
-
-    private fun exportSelected() {
-        val (type, selectedIds) = viewModel.querySelectionExportData() ?: return
-        ExportDialogFragment.newInstance(type, selectedIds).show(supportFragmentManager, "exportDialog")
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -67,6 +67,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment
 import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
+import com.ichi2.anki.browser.deleteSelectedNotes
 import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
 import com.ichi2.anki.browser.rescheduleSelectedCards
@@ -111,7 +112,6 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.internationalization.toSentenceCase
-import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.widgets.DeckDropDownAdapter
 import com.ichi2.ui.CardBrowserSearchView
@@ -1391,16 +1391,6 @@ open class CardBrowser :
         val (type, selectedIds) = viewModel.querySelectionExportData() ?: return
         ExportDialogFragment.newInstance(type, selectedIds).show(supportFragmentManager, "exportDialog")
     }
-
-    private fun deleteSelectedNotes() =
-        launchCatchingTask {
-            withProgress(R.string.deleting_selected_notes) {
-                viewModel.deleteSelectedNotes()
-            }.ifNotZero { noteCount ->
-                val deletedMessage = resources.getQuantityString(R.plurals.card_browser_cards_deleted, noteCount, noteCount)
-                showUndoSnackbar(deletedMessage)
-            }
-        }
 
     @VisibleForTesting
     fun onUndo() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -72,6 +72,7 @@ import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.registerFindReplaceHandler
+import com.ichi2.anki.browser.rescheduleSelectedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.browser.toggleBury
@@ -109,7 +110,6 @@ import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.PreviewerFragment
 import com.ichi2.anki.scheduling.ForgetCardsDialog
-import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
@@ -1161,7 +1161,7 @@ open class CardBrowser :
     /**
      * @return `false` if the user may proceed; `true` if a warning is shown due to being in [NOTES]
      */
-    private fun warnUserIfInNotesOnlyMode(): Boolean {
+    fun warnUserIfInNotesOnlyMode(): Boolean {
         if (viewModel.cardsOrNotes != NOTES) return false
         showSnackbar(R.string.card_browser_unavailable_when_notes_mode) {
             setAction(R.string.error_handling_options) { showOptionsDialog() }
@@ -1497,19 +1497,6 @@ open class CardBrowser :
         index: Int,
         idsFile: IdsFile,
     ): Intent = PreviewerDestination(index, idsFile).toIntent(this)
-
-    private fun rescheduleSelectedCards() {
-        if (!viewModel.hasSelectedAnyRows()) {
-            Timber.i("Attempted reschedule - no cards selected")
-            return
-        }
-        if (warnUserIfInNotesOnlyMode()) return
-
-        launchCatchingTask {
-            val allCardIds = viewModel.queryAllSelectedCardIds()
-            showDialogFragment(SetDueDateDialog.newInstance(allCardIds))
-        }
-    }
 
     private fun addNoteFromCardBrowser() {
         if (fragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -74,13 +74,13 @@ import com.ichi2.anki.browser.registerFindReplaceHandler
 import com.ichi2.anki.browser.repositionSelectedCards
 import com.ichi2.anki.browser.rescheduleSelectedCards
 import com.ichi2.anki.browser.showChangeDeckDialog
+import com.ichi2.anki.browser.showOptionsDialog
 import com.ichi2.anki.browser.toCardBrowserLaunchOptions
 import com.ichi2.anki.browser.toggleBury
 import com.ichi2.anki.browser.toggleMark
 import com.ichi2.anki.browser.toggleSuspendCards
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
-import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.CardBrowserMySearchesDialog.MySearchesDialogListener
@@ -1445,11 +1445,6 @@ open class CardBrowser :
                 )
             showDialogFragment(dialog)
         }
-    }
-
-    private fun showOptionsDialog() {
-        val dialog = BrowserOptionsDialog.newInstance(viewModel.cardsOrNotes, viewModel.isTruncated)
-        dialog.show(supportFragmentManager, "browserOptionsDialog")
     }
 
     public override fun onSaveInstanceState(outState: Bundle) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1464,6 +1464,7 @@ class NoteEditorFragment :
         }
 
     override fun onMenuItemSelected(item: MenuItem): Boolean {
+        Timber.d("NoteEditor::onMenuItemSelected")
         when (item.itemId) {
             R.id.action_preview -> {
                 Timber.i("NoteEditor:: Preview button pressed")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import anki.collection.OpChangesAfterUndo
 import com.google.android.material.snackbar.Snackbar
@@ -44,6 +45,11 @@ suspend fun FragmentActivity.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH
             }
         showSnackbar(message, duration)
     }
+}
+
+/** If there's an action pending in the review queue, undo it and show a snackbar */
+suspend fun Fragment.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) {
+    requireActivity().undoAndShowSnackbar(duration)
 }
 
 suspend fun FragmentActivity.redoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -499,6 +499,20 @@ class CardBrowserFragment :
         )
     }
 
+    /**
+     * @see CardBrowserViewModel.searchForSuspendedCards
+     */
+    fun searchForSuspendedCards() {
+        launchCatchingTask { viewModel.searchForSuspendedCards() }
+    }
+
+    /**
+     * @see CardBrowserViewModel.searchForMarkedNotes
+     */
+    fun searchForMarkedNotes() {
+        launchCatchingTask { viewModel.searchForMarkedNotes() }
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -650,3 +664,7 @@ fun CardBrowser.showOptionsDialog() = cardBrowserFragment.showOptionsDialog()
 fun CardBrowser.showCreateFilteredDeckDialog() = cardBrowserFragment.showCreateFilteredDeckDialog()
 
 fun CardBrowser.changeDisplayOrder() = cardBrowserFragment.changeDisplayOrder()
+
+fun CardBrowser.searchForMarkedNotes() = cardBrowserFragment.searchForMarkedNotes()
+
+fun CardBrowser.searchForSuspendedCards() = cardBrowserFragment.searchForSuspendedCards()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -67,6 +67,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.requireAnkiActivity
+import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
@@ -450,6 +451,11 @@ class CardBrowserFragment :
             }
         }
 
+    fun onResetProgress() {
+        if (ankiActivity.warnUserIfInNotesOnlyMode()) return
+        showDialogFragment(ForgetCardsDialog())
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -591,3 +597,5 @@ fun CardBrowser.rescheduleSelectedCards() = cardBrowserFragment.rescheduleSelect
 fun CardBrowser.repositionSelectedCards() = cardBrowserFragment.repositionSelectedCards()
 
 fun CardBrowser.deleteSelectedNotes() = cardBrowserFragment.deleteSelectedNotes()
+
+fun CardBrowser.onResetProgress() = cardBrowserFragment.onResetProgress()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -224,11 +224,11 @@ class CardBrowserFragment :
                             return true
                         }
                         R.id.action_show_marked -> {
-                            searchForMarkedNotes()
+                            activityViewModel.searchForMarkedNotes()
                             return true
                         }
                         R.id.action_show_suspended -> {
-                            searchForSuspendedCards()
+                            activityViewModel.searchForSuspendedCards()
                             return true
                         }
                         R.id.action_search_by_tag -> {
@@ -520,7 +520,7 @@ class CardBrowserFragment :
                     // Ctrl+Alt+S / Ctrl+S in the activity take priority
                 } else if (!event.isCtrlPressed && event.isAltPressed) {
                     Timber.i("Alt+S: Show suspended cards")
-                    searchForSuspendedCards()
+                    activityViewModel.searchForSuspendedCards()
                     return true
                 }
             }
@@ -545,7 +545,7 @@ class CardBrowserFragment :
             KeyEvent.KEYCODE_M -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+M: Search marked notes")
-                    searchForMarkedNotes()
+                    activityViewModel.searchForMarkedNotes()
                     return true
                 }
             }
@@ -741,20 +741,6 @@ class CardBrowserFragment :
                 activityViewModel.changeCardOrder(SortType.fromCardBrowserLabelIndex(which))
             },
         )
-    }
-
-    /**
-     * @see CardBrowserViewModel.searchForSuspendedCards
-     */
-    fun searchForSuspendedCards() {
-        launchCatchingTask { activityViewModel.searchForSuspendedCards() }
-    }
-
-    /**
-     * @see CardBrowserViewModel.searchForMarkedNotes
-     */
-    fun searchForMarkedNotes() {
-        launchCatchingTask { activityViewModel.searchForMarkedNotes() }
     }
 
     fun updateFlagForSelectedRows(flag: Flag) =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -987,11 +987,3 @@ class CardBrowserFragment :
         private const val CHANGE_DECK_KEY = "CHANGE_DECK"
     }
 }
-
-fun CardBrowser.deleteSelectedNotes() = cardBrowserFragment.deleteSelectedNotes()
-
-fun CardBrowser.showOptionsDialog() = cardBrowserFragment.showOptionsDialog()
-
-fun CardBrowser.updateFlagForSelectedRows(flag: Flag) = cardBrowserFragment.updateFlagForSelectedRows(flag)
-
-fun CardBrowser.showFindAndReplaceDialog() = cardBrowserFragment.showFindAndReplaceDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -522,6 +522,11 @@ class CardBrowserFragment :
             ankiActivity.onCardsUpdated(updatedCardIds)
         }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun showFindAndReplaceDialog() {
+        FindAndReplaceDialogFragment().show(parentFragmentManager, FindAndReplaceDialogFragment.TAG)
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -679,3 +684,5 @@ fun CardBrowser.searchForMarkedNotes() = cardBrowserFragment.searchForMarkedNote
 fun CardBrowser.searchForSuspendedCards() = cardBrowserFragment.searchForSuspendedCards()
 
 fun CardBrowser.updateFlagForSelectedRows(flag: Flag) = cardBrowserFragment.updateFlagForSelectedRows(flag)
+
+fun CardBrowser.showFindAndReplaceDialog() = cardBrowserFragment.showFindAndReplaceDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -35,8 +35,12 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import anki.collection.OpChanges
 import com.google.android.material.progressindicator.LinearProgressIndicator
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.AnkiActivityProvider
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
+import com.ichi2.anki.android.input.ShortcutGroup
+import com.ichi2.anki.android.input.shortcut
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.MultiSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
@@ -50,6 +54,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_N
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.utils.ext.visibleItemPositions
@@ -57,6 +62,7 @@ import com.ichi2.utils.HandlerUtils
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import net.ankiweb.rsdroid.Translations
 import timber.log.Timber
 
 // Minor BUG: 'don't keep activities' and huge selection
@@ -64,8 +70,12 @@ import timber.log.Timber
 // This occurred on a Pixel 9 Pro, Android 15
 class CardBrowserFragment :
     Fragment(R.layout.cardbrowser),
+    AnkiActivityProvider,
     ChangeManager.Subscriber {
     val viewModel: CardBrowserViewModel by activityViewModels()
+
+    override val ankiActivity: AnkiActivity
+        get() = requireAnkiActivity()
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     lateinit var cardsAdapter: BrowserMultiColumnAdapter
@@ -327,4 +337,41 @@ class CardBrowserFragment :
             }
         }
     }
+
+    val shortcuts get() =
+        ShortcutGroup(
+            listOf(
+                shortcut("Ctrl+Shift+A", R.string.edit_tags_dialog),
+                shortcut("Ctrl+A", R.string.card_browser_select_all),
+                shortcut("Ctrl+Shift+E", Translations::exportingExport),
+                shortcut("Ctrl+E", R.string.menu_add_note),
+                shortcut("E", R.string.cardeditor_title_edit_card),
+                shortcut("Ctrl+D", R.string.card_browser_change_deck),
+                shortcut("Ctrl+K", Translations::browsingToggleMark),
+                shortcut("Ctrl+Alt+R", Translations::browsingReschedule),
+                shortcut("DEL", R.string.delete_card_title),
+                shortcut("Ctrl+Alt+N", R.string.reset_card_dialog_title),
+                shortcut("Ctrl+Alt+T", R.string.toggle_cards_notes),
+                shortcut("Ctrl+T", R.string.card_browser_search_by_tag),
+                shortcut("Ctrl+Shift+S", Translations::actionsReposition),
+                shortcut("Ctrl+Alt+S", R.string.card_browser_list_my_searches),
+                shortcut("Ctrl+S", R.string.card_browser_list_my_searches_save),
+                shortcut("Alt+S", R.string.card_browser_show_suspended),
+                shortcut("Ctrl+Shift+G", Translations::actionsGradeNow),
+                shortcut("Ctrl+Shift+J", Translations::browsingToggleBury),
+                shortcut("Ctrl+J", Translations::browsingToggleSuspend),
+                shortcut("Ctrl+Shift+I", Translations::actionsCardInfo),
+                shortcut("Ctrl+O", R.string.show_order_dialog),
+                shortcut("Ctrl+M", R.string.card_browser_show_marked),
+                shortcut("Esc", R.string.card_browser_select_none),
+                shortcut("Ctrl+1", R.string.gesture_flag_red),
+                shortcut("Ctrl+2", R.string.gesture_flag_orange),
+                shortcut("Ctrl+3", R.string.gesture_flag_green),
+                shortcut("Ctrl+4", R.string.gesture_flag_blue),
+                shortcut("Ctrl+5", R.string.gesture_flag_pink),
+                shortcut("Ctrl+6", R.string.gesture_flag_turquoise),
+                shortcut("Ctrl+7", R.string.gesture_flag_purple),
+            ),
+            R.string.card_browser_context_menu,
+        )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.browser
 
+import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -60,6 +61,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
+import com.ichi2.anki.dialogs.CardBrowserOrderDialog
 import com.ichi2.anki.dialogs.CreateDeckDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
@@ -68,6 +70,7 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.model.SortType
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.requireAnkiActivity
@@ -486,6 +489,16 @@ class CardBrowserFragment :
         }
     }
 
+    fun changeDisplayOrder() {
+        showDialogFragment(
+            // TODO: move this into the ViewModel
+            CardBrowserOrderDialog.newInstance { dialog: DialogInterface, which: Int ->
+                dialog.dismiss()
+                viewModel.changeCardOrder(SortType.fromCardBrowserLabelIndex(which))
+            },
+        )
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -635,3 +648,5 @@ fun CardBrowser.exportSelected() = cardBrowserFragment.exportSelected()
 fun CardBrowser.showOptionsDialog() = cardBrowserFragment.showOptionsDialog()
 
 fun CardBrowser.showCreateFilteredDeckDialog() = cardBrowserFragment.showCreateFilteredDeckDialog()
+
+fun CardBrowser.changeDisplayOrder() = cardBrowserFragment.changeDisplayOrder()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.AnkiActivityProvider
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.FilteredDeckOptions
+import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
@@ -513,6 +514,14 @@ class CardBrowserFragment :
         launchCatchingTask { viewModel.searchForMarkedNotes() }
     }
 
+    fun updateFlagForSelectedRows(flag: Flag) =
+        launchCatchingTask {
+            // list of cards with updated flags
+            val updatedCardIds = withProgress { viewModel.updateSelectedCardsFlag(flag) }
+
+            ankiActivity.onCardsUpdated(updatedCardIds)
+        }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -668,3 +677,5 @@ fun CardBrowser.changeDisplayOrder() = cardBrowserFragment.changeDisplayOrder()
 fun CardBrowser.searchForMarkedNotes() = cardBrowserFragment.searchForMarkedNotes()
 
 fun CardBrowser.searchForSuspendedCards() = cardBrowserFragment.searchForSuspendedCards()
+
+fun CardBrowser.updateFlagForSelectedRows(flag: Flag) = cardBrowserFragment.updateFlagForSelectedRows(flag)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -62,6 +62,7 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.requireAnkiActivity
+import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
@@ -368,6 +369,19 @@ class CardBrowserFragment :
             ankiActivity.showUndoSnackbar(message)
         }
 
+    fun rescheduleSelectedCards() {
+        if (!viewModel.hasSelectedAnyRows()) {
+            Timber.i("Attempted reschedule - no cards selected")
+            return
+        }
+        if (ankiActivity.warnUserIfInNotesOnlyMode()) return
+
+        launchCatchingTask {
+            val allCardIds = viewModel.queryAllSelectedCardIds()
+            showDialogFragment(SetDueDateDialog.newInstance(allCardIds))
+        }
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -481,3 +495,5 @@ fun CardBrowser.toggleMark() = cardBrowserFragment.toggleMark()
 fun CardBrowser.toggleSuspendCards() = cardBrowserFragment.toggleSuspendCards()
 
 fun CardBrowser.toggleBury() = cardBrowserFragment.toggleBury()
+
+fun CardBrowser.rescheduleSelectedCards() = cardBrowserFragment.rescheduleSelectedCards()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
+import com.ichi2.anki.dialogs.BrowserOptionsDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -462,6 +463,11 @@ class CardBrowserFragment :
         ExportDialogFragment.newInstance(type, selectedIds).show(parentFragmentManager, "exportDialog")
     }
 
+    fun showOptionsDialog() {
+        val dialog = BrowserOptionsDialog.newInstance(viewModel.cardsOrNotes, viewModel.isTruncated)
+        dialog.show(parentFragmentManager, "browserOptionsDialog")
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -607,3 +613,5 @@ fun CardBrowser.deleteSelectedNotes() = cardBrowserFragment.deleteSelectedNotes(
 fun CardBrowser.onResetProgress() = cardBrowserFragment.onResetProgress()
 
 fun CardBrowser.exportSelected() = cardBrowserFragment.exportSelected()
+
+fun CardBrowser.showOptionsDialog() = cardBrowserFragment.showOptionsDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -63,6 +63,7 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
 import com.ichi2.anki.dialogs.DeckSelectionDialog.SelectableDeck
 import com.ichi2.anki.dialogs.SimpleMessageDialog
+import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.ChangeManager
@@ -456,6 +457,11 @@ class CardBrowserFragment :
         showDialogFragment(ForgetCardsDialog())
     }
 
+    fun exportSelected() {
+        val (type, selectedIds) = viewModel.querySelectionExportData() ?: return
+        ExportDialogFragment.newInstance(type, selectedIds).show(parentFragmentManager, "exportDialog")
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -599,3 +605,5 @@ fun CardBrowser.repositionSelectedCards() = cardBrowserFragment.repositionSelect
 fun CardBrowser.deleteSelectedNotes() = cardBrowserFragment.deleteSelectedNotes()
 
 fun CardBrowser.onResetProgress() = cardBrowserFragment.onResetProgress()
+
+fun CardBrowser.exportSelected() = cardBrowserFragment.exportSelected()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -39,6 +39,7 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivityProvider
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.FilteredDeckOptions
 import com.ichi2.anki.R
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
@@ -59,6 +60,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.BrowserOptionsDialog
+import com.ichi2.anki.dialogs.CreateDeckDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DeckSelectionDialog.Companion.newInstance
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DeckSelectionListener
@@ -80,8 +82,6 @@ import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.visibleItemPositions
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.HandlerUtils
-import com.ichi2.utils.dp
-import com.ichi2.utils.updatePaddingRelative
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
@@ -468,6 +468,24 @@ class CardBrowserFragment :
         dialog.show(parentFragmentManager, "browserOptionsDialog")
     }
 
+    fun showCreateFilteredDeckDialog() {
+        val dialog = CreateDeckDialog(ankiActivity, R.string.new_deck, CreateDeckDialog.DeckDialogType.FILTERED_DECK, null)
+        dialog.onNewDeckCreated = {
+            startActivity(
+                FilteredDeckOptions.getIntent(
+                    context = requireContext(),
+                    deckId = null,
+                    searchTerms = viewModel.searchTerms,
+                ),
+            )
+        }
+        launchCatchingTask {
+            withProgress {
+                dialog.showFilteredDeckDialog()
+            }
+        }
+    }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -615,3 +633,5 @@ fun CardBrowser.onResetProgress() = cardBrowserFragment.onResetProgress()
 fun CardBrowser.exportSelected() = cardBrowserFragment.exportSelected()
 
 fun CardBrowser.showOptionsDialog() = cardBrowserFragment.showOptionsDialog()
+
+fun CardBrowser.showCreateFilteredDeckDialog() = cardBrowserFragment.showCreateFilteredDeckDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -71,6 +71,7 @@ import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
+import com.ichi2.anki.utils.ext.ifNotZero
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.visibleItemPositions
@@ -439,6 +440,16 @@ class CardBrowserFragment :
         return true
     }
 
+    fun deleteSelectedNotes() =
+        launchCatchingTask {
+            withProgress(R.string.deleting_selected_notes) {
+                viewModel.deleteSelectedNotes()
+            }.ifNotZero { noteCount ->
+                val deletedMessage = resources.getQuantityString(R.plurals.card_browser_cards_deleted, noteCount, noteCount)
+                ankiActivity.showUndoSnackbar(deletedMessage)
+            }
+        }
+
     @KotlinCleanup("DeckSelectionListener is almost certainly a bug - deck!!")
     @VisibleForTesting
     internal fun getChangeDeckDialog(selectableDecks: List<SelectableDeck>?): DeckSelectionDialog {
@@ -578,3 +589,5 @@ fun CardBrowser.toggleBury() = cardBrowserFragment.toggleBury()
 fun CardBrowser.rescheduleSelectedCards() = cardBrowserFragment.rescheduleSelectedCards()
 
 fun CardBrowser.repositionSelectedCards() = cardBrowserFragment.repositionSelectedCards()
+
+fun CardBrowser.deleteSelectedNotes() = cardBrowserFragment.deleteSelectedNotes()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragmentViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragmentViewModel.kt
@@ -1,0 +1,21 @@
+/*
+ *  Copyright (c) 2023 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.lifecycle.ViewModel
+
+class CardBrowserFragmentViewModel : ViewModel()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -975,20 +975,22 @@ class CardBrowserViewModel(
     /**
      * Searches for all marked notes and replaces the current search results with these marked notes.
      */
-    suspend fun searchForMarkedNotes() {
-        // only intended to be used if the user has no selection
-        if (hasSelectedAnyRows()) return
-        setFilterQuery("tag:marked")
-    }
+    fun searchForMarkedNotes() =
+        viewModelScope.launch {
+            // only intended to be used if the user has no selection
+            if (hasSelectedAnyRows()) return@launch
+            setFilterQuery("tag:marked")
+        }
 
     /**
      * Searches for all suspended cards and replaces the current search results with these suspended cards.
      */
-    suspend fun searchForSuspendedCards() {
-        // only intended to be used if the user has no selection
-        if (hasSelectedAnyRows()) return
-        setFilterQuery("is:suspended")
-    }
+    fun searchForSuspendedCards() =
+        viewModelScope.launch {
+            // only intended to be used if the user has no selection
+            if (hasSelectedAnyRows()) return@launch
+            setFilterQuery("is:suspended")
+        }
 
     suspend fun setFlagFilter(flag: Flag) {
         Timber.i("filtering to flag: %s", flag)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.utils.ext
 
 import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.AnkiActivity
@@ -59,3 +60,9 @@ fun FragmentActivity.dismissAllDialogFragments() {
  */
 inline fun <reified T : DialogFragment> FragmentActivity.getCurrentDialogFragment(): T? =
     supportFragmentManager.findFragmentByTag(DIALOG_FRAGMENT_TAG) as? T?
+
+/**
+ * @return The last fragment added by [showDialogFragment], only  if it is the provided type.
+ * `null` if the type does not match, or if a dialog has not been shown
+ */
+inline fun <reified T : DialogFragment> Fragment.getCurrentDialogFragment(): T? = requireActivity().getCurrentDialogFragment()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -324,7 +324,7 @@ class CardBrowserTest : RobolectricTest() {
             }
 
             // act
-            assertDoesNotThrow { b.moveSelectedCardsToDeck(deckIdToChangeTo) }
+            assertDoesNotThrow { b.cardBrowserFragment.moveSelectedCardsToDeck(deckIdToChangeTo) }
 
             // assert
             for (cardId in cardIds) {
@@ -344,7 +344,7 @@ class CardBrowserTest : RobolectricTest() {
 
             val cardIds = b.viewModel.queryAllSelectedCardIds()
 
-            b.moveSelectedCardsToDeck(dynId).join()
+            b.cardBrowserFragment.moveSelectedCardsToDeck(dynId).join()
 
             for (cardId in cardIds) {
                 assertThat("Deck should not be changed", col.getCard(cardId).did, not(dynId))
@@ -728,7 +728,7 @@ class CardBrowserTest : RobolectricTest() {
     fun change_deck_dialog_is_dismissed_on_activity_recreation() {
         val cardBrowser = browserWithNoNewCards
 
-        val dialog = cardBrowser.getChangeDeckDialog(listOf())
+        val dialog = cardBrowser.cardBrowserFragment.getChangeDeckDialog(listOf())
         cardBrowser.showDialogFragment(dialog)
 
         val shownDialog: Fragment? = cardBrowser.getCurrentDialogFragment()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -73,6 +73,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.TAGS_AS_FIE
 import com.ichi2.anki.browser.column1
 import com.ichi2.anki.browser.selectRowAtPosition
 import com.ichi2.anki.browser.setColumn
+import com.ichi2.anki.browser.showFindAndReplaceDialog
 import com.ichi2.anki.browser.toRowSelection
 import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.time.TimeManager

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -73,9 +73,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.TAGS_AS_FIE
 import com.ichi2.anki.browser.column1
 import com.ichi2.anki.browser.selectRowAtPosition
 import com.ichi2.anki.browser.setColumn
-import com.ichi2.anki.browser.showFindAndReplaceDialog
 import com.ichi2.anki.browser.toRowSelection
-import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
@@ -385,7 +383,7 @@ class CardBrowserTest : RobolectricTest() {
             )
 
             // flag the selected card
-            cardBrowser.updateFlagForSelectedRows(Flag.RED)
+            cardBrowser.cardBrowserFragment.updateFlagForSelectedRows(Flag.RED)
             // check if card is red
             assertThat(
                 "Card should be flagged",
@@ -394,7 +392,7 @@ class CardBrowserTest : RobolectricTest() {
             )
 
             // unflag the selected card
-            cardBrowser.updateFlagForSelectedRows(Flag.NONE)
+            cardBrowser.cardBrowserFragment.updateFlagForSelectedRows(Flag.NONE)
             // check if card flag is removed
             assertThat(
                 "Card flag should be removed",
@@ -406,7 +404,7 @@ class CardBrowserTest : RobolectricTest() {
             cardBrowser.viewModel.selectNone()
             cardBrowser.viewModel.selectAll()
             // flag all the cards as Green
-            cardBrowser.updateFlagForSelectedRows(Flag.GREEN)
+            cardBrowser.cardBrowserFragment.updateFlagForSelectedRows(Flag.GREEN)
             // check if all card flags turned green
             assertThat(
                 "All cards should be flagged",
@@ -1688,3 +1686,5 @@ fun CardBrowser.searchCards(search: String? = null) {
     }
     runBlocking { viewModel.searchJob?.join() }
 }
+
+fun CardBrowser.showFindAndReplaceDialog() = cardBrowserFragment.showFindAndReplaceDialog()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1169,7 +1169,7 @@ class CardBrowserTest : RobolectricTest() {
             val secondDeckId = requireNotNull(col.decks.idForName("Second"))
 
             browserWithNoNewCards.apply {
-                selectDeckAndSave(secondDeckId)
+                viewModel.setDeckId(secondDeckId)
                 assertThat(viewModel.deckId, equalTo(secondDeckId))
                 finish()
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -74,6 +74,7 @@ import com.ichi2.anki.browser.column1
 import com.ichi2.anki.browser.selectRowAtPosition
 import com.ichi2.anki.browser.setColumn
 import com.ichi2.anki.browser.toRowSelection
+import com.ichi2.anki.browser.updateFlagForSelectedRows
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.isRunningAsUnitTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
@@ -383,7 +384,7 @@ class CardBrowserTest : RobolectricTest() {
             )
 
             // flag the selected card
-            cardBrowser.updateSelectedCardsFlag(Flag.RED)
+            cardBrowser.updateFlagForSelectedRows(Flag.RED)
             // check if card is red
             assertThat(
                 "Card should be flagged",
@@ -392,7 +393,7 @@ class CardBrowserTest : RobolectricTest() {
             )
 
             // unflag the selected card
-            cardBrowser.updateSelectedCardsFlag(Flag.NONE)
+            cardBrowser.updateFlagForSelectedRows(Flag.NONE)
             // check if card flag is removed
             assertThat(
                 "Card flag should be removed",
@@ -404,7 +405,7 @@ class CardBrowserTest : RobolectricTest() {
             cardBrowser.viewModel.selectNone()
             cardBrowser.viewModel.selectAll()
             // flag all the cards as Green
-            cardBrowser.updateSelectedCardsFlag(Flag.GREEN)
+            cardBrowser.updateFlagForSelectedRows(Flag.GREEN)
             // check if all card flags turned green
             assertThat(
                 "All cards should be flagged",

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1630,7 +1630,7 @@ suspend fun CardBrowser.searchCardsSync(query: String) {
 }
 
 suspend fun CardBrowser.filterByTagSync(vararg tags: String) {
-    filterByTag(*tags)
+    cardBrowserFragment.filterByTag(*tags)
     viewModel.searchJob?.join()
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -707,7 +707,12 @@ class CardBrowserTest : RobolectricTest() {
                 equalTo("1"),
             )
 
-            b.repositionCardsNoValidation(2, 1, shuffle = false, shift = false)
+            b.cardBrowserFragment.repositionCardsNoValidation(
+                2,
+                1,
+                shuffle = false,
+                shift = false,
+            )
 
             assertThat(
                 "Position of checked card after reposition",

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -57,7 +57,6 @@ import com.ichi2.anki.browser.CardBrowserColumn.DECK
 import com.ichi2.anki.browser.CardBrowserColumn.QUESTION
 import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserColumn.TAGS
-import com.ichi2.anki.browser.CardBrowserFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModelTest
 import com.ichi2.anki.browser.CardOrNoteId
@@ -1682,6 +1681,3 @@ fun CardBrowser.searchCards(search: String? = null) {
     }
     runBlocking { viewModel.searchJob?.join() }
 }
-
-val CardBrowser.cardBrowserFragment: CardBrowserFragment
-    get() = supportFragmentManager.findFragmentById(R.id.card_browser_frame) as CardBrowserFragment


### PR DESCRIPTION
When I was looking into 

* https://github.com/ankidroid/Anki-Android/issues/18709

I found that I wanted to:

1. Move the menu state to a ViewModel
2. Split the ViewModel into a Fragment-level, and an Activity-level ViewModel
    * When we added the NoteEditor (https://github.com/ankidroid/Anki-Android/pull/16764 ), a lot of bugs were introduced due to the complexity
    * The panes are an activity-level concern, and would be easier to focus on with a smaller class
    * Most of the rest of the logic is CardBrowserFragment-based
3. Introduce the `SearchBar`/`SearchView` 

These changes have been done on a branch for (1) and (3), but it feels like a 'huge' functional chance that I'll struggle to get reviewed with the Browser in its current state.

This PR moves us closer to (2), and closer to:
* a separation of concerns, adding in a `CardBrowserFragmentViewModel`
* splitting out a PR of (1) - as it would move the menu state into the future `CardBrowserFragmentViewModel`

## Fixes
* #17901 (follow-on)

## Approach
* Go through method by method and move them to the fragment
* Once a sufficient number of methods were moved, move both `onKeyUp` and `onOptionsItemSelected` for these methods into the `CardBrowserFragment`, removing 


## How Has This Been Tested?

CI

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->