### PR TITLE
fix(new reviewer): answer button size

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -175,6 +175,8 @@ object Prefs {
     val ignoreDisplayCutout by booleanPref(R.string.ignore_display_cutout_key, false)
     val autoFocusTypeAnswer by booleanPref(R.string.type_in_answer_focus_key, true)
 
+    val newStudyScreenAnswerButtonSize by intPref(R.string.answer_button_size_pref_key, defaultValue = 100)
+
     val frameStyle: FrameStyle
         get() = getEnum(R.string.reviewer_frame_style_key, FrameStyle.CARD)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -372,8 +372,8 @@ class ReviewerFragment :
             easyButton.isVisible = false
         }
 
-        val buttonsHeight = Prefs.answerButtonsSize
-        if (buttonsHeight != 100) {
+        val buttonsHeight = Prefs.newStudyScreenAnswerButtonSize
+        if (buttonsHeight > 100) {
             answerButtonsLayout.post {
                 answerButtonsLayout.updateLayoutParams {
                     height = answerButtonsLayout.measuredHeight * buttonsHeight / 100

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -162,6 +162,7 @@
     <string name="card_zoom_preference">cardZoom</string>
     <string name="image_zoom_preference">imageZoom</string>
     <string name="answer_button_size_preference">answerButtonSize</string>
+    <string name="answer_button_size_pref_key">answerBtnSize</string>
     <string name="show_large_answer_buttons_preference">showLargeAnswerButtons</string>
     <string name="pref_card_minimal_click_time">showCardAnswerButtonTime</string>
     <!-- Custom sync server -->

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -80,9 +80,9 @@
 
         <com.ichi2.preferences.SliderPreference
             android:title="@string/button_size"
-            android:key="@string/answer_button_size_preference"
+            android:key="@string/answer_button_size_pref_key"
             android:defaultValue="100"
-            android:valueFrom="10"
+            android:valueFrom="100"
             android:valueTo="200"
             android:stepSize="10"
             app:displayFormat="@string/percentage"/>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -93,6 +93,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.hide_system_bars_key, // hideSystemBars
             R.string.ignore_display_cutout_key, // ignoreDisplayCutout
             R.string.reviewer_toolbar_position_key, // reviewerToolbarPosition
+            R.string.answer_button_size_pref_key, // answerBtnSize
         ).toStringResourceSet()
 
     @Test


### PR DESCRIPTION
it doesn't make sense to go below the minimum value

for now, the setting becomes distinct from the one in `Accessibility` to avoid changes in the old reviewer

## How Has This Been Tested?

1. Go to settings
2. Check if `Answer button size` from the "Acessibility" and "New study screen" are independent
3. Check if the new study screen answer buttons size setting is reflected in the new reviewer

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->