### PR TITLE
fix(release): Unable to start activity: MultimediaActivity

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -25,6 +25,9 @@
 
 # Used through Reflection
 -keep class com.ichi2.anki.**.*Fragment { *; }
+# 18712: MultimediaActivity: android.os.BadParcelableException
+# TODO: this is brittle; IMultimediaEditableNote should implement Parcelable
+-keep class com.ichi2.anki.**.multimediacard.** { *; }
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 -keep class androidx.core.app.ActivityCompat$* { *; }
 -keep class androidx.concurrent.futures.** { *; }


### PR DESCRIPTION
Pending: https://github.com/ankidroid/Anki-Android/actions/workflows/compare_apk_size.yml

----

We got the following truncated stack trace due to proguard/minify

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.multimedia.MultimediaActivity}: android.os.BadParcelableException: Parcelable encountered IOException reading a Serializable object (name = com.ichi2.anki.multimedia.f)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4377)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4574)
	...
	at android.os.Looper.loop(Looper.java:393)
	at android.app.ActivityThread.main(ActivityThread.java:9549)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)
Caused by: android.os.BadParcelableException: Parcelable encountered IOException reading a Serializable object (name = com.ichi2.anki.multimedia.f)
	at android.os.Parcel.readSerializableInternal(Parcel.java:5410)
	at android.os.Parcel.readValue(Parcel.java:4928)
	at android.os.Parcel.readValue(Parcel.java:4625)
	...
	at android.os.Bundle.getSerializable(Bundle.java:1283)
	at com.ichi2.compat.CompatV33.getSerializable(CompatV33.kt:47)
	at com.ichi2.compat.CompatHelper$Companion.getSerializableCompat(CompatHelper.java:85)
	at com.ichi2.anki.multimedia.MultimediaActivity.getMultimediaArgsExtra(MultimediaActivity.kt:66)
	at com.ichi2.anki.multimedia.MultimediaActivity.onCreate(MultimediaActivity.kt:96)
	at android.app.Activity.performCreate(Activity.java:9196)
Caused by: java.io.InvalidClassException: m4.d; no valid constructor
	at java.io.ObjectStreamClass$ExceptionInfo.newInvalidClassException(ObjectStreamClass.java:163)
	at java.io.ObjectStreamClass.checkDeserialize(ObjectStreamClass.java:832)
```

## Fixes
* Hopefully fixes #18712

## How Has This Been Tested?

⚠️ I was unable to reproduce this issue locally, and it's easier to ignore a few classes, since we're close to a public release and this is a blocker

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->