### PR TITLE
fix(release): Unable to start activity: MultimediaActivity

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -25,9 +25,6 @@
 
 # Used through Reflection
 -keep class com.ichi2.anki.**.*Fragment { *; }
-# 18712: MultimediaActivity: android.os.BadParcelableException
-# TODO: this is brittle; IMultimediaEditableNote should implement Parcelable
--keep class com.ichi2.anki.**.multimediacard.** { *; }
 -keep class * extends com.google.protobuf.GeneratedMessageLite { *; }
 -keep class androidx.core.app.ActivityCompat$* { *; }
 -keep class androidx.concurrent.futures.** { *; }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimediacard/impl/MultimediaEditableNote.kt
@@ -19,18 +19,42 @@
 
 package com.ichi2.anki.multimediacard.impl
 
+import android.os.Parcel
+import android.os.Parcelable
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.anki.utils.ext.readSerializableList
+import com.ichi2.anki.utils.ext.writeSerializableList
+import com.ichi2.compat.readBooleanCompat
+import com.ichi2.compat.writeBooleanCompat
 import com.ichi2.libanki.NoteTypeId
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
 import org.acra.util.IOUtils
-import java.util.ArrayList
 
 /**
  * Implementation of the editable note.
- * <p>
+ *
  * Has to be translate to and from anki db format.
+ *
+ * All variables must be handled manually by Parcelable
  */
-class MultimediaEditableNote : IMultimediaEditableNote {
+@Parcelize
+class MultimediaEditableNote() :
+    IMultimediaEditableNote,
+    Parcelable {
+    internal constructor(
+        isModified: Boolean,
+        noteTypeId: Long,
+        initialFields: List<IField?>?,
+        fields: List<IField?>?,
+    ) : this() {
+        this.isModified = isModified
+        this.noteTypeId = noteTypeId
+        this.initialFields = initialFields?.let { ArrayList(it) }
+        this.fields = fields?.let { ArrayList(it) }
+    }
+
     override var isModified = false
         private set
     private var fields: ArrayList<IField?>? = null
@@ -106,4 +130,24 @@ class MultimediaEditableNote : IMultimediaEditableNote {
 
     val isEmpty: Boolean
         get() = fields.isNullOrEmpty()
+
+    companion object : Parceler<MultimediaEditableNote> {
+        override fun create(parcel: Parcel): MultimediaEditableNote =
+            MultimediaEditableNote(
+                isModified = parcel.readBooleanCompat(),
+                noteTypeId = parcel.readLong(),
+                initialFields = parcel.readSerializableList<IField>(),
+                fields = parcel.readSerializableList<IField>(),
+            )
+
+        override fun MultimediaEditableNote.write(
+            parcel: Parcel,
+            flags: Int,
+        ) {
+            parcel.writeBooleanCompat(isModified)
+            parcel.writeLong(noteTypeId)
+            parcel.writeSerializableList<IField>(initialFields)
+            parcel.writeSerializableList<IField>(fields)
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ParcelableUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ParcelableUtils.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.os.Parcel
+import androidx.core.os.ParcelCompat
+import java.io.Serializable
+
+fun <T : Serializable> Parcel.writeSerializableList(list: List<T?>?) {
+    if (list == null) {
+        writeInt(-1)
+        return
+    }
+    writeInt(list.size)
+    for (item in list) {
+        if (item == null) {
+            writeInt(0)
+            continue
+        }
+        writeInt(1)
+        writeSerializable(item)
+    }
+}
+
+inline fun <reified T : Serializable> Parcel.readSerializableList(): List<T?>? {
+    val size = readInt()
+    if (size == -1) return null
+    return List(size = size) {
+        if (readInt() == 0) {
+            null
+        } else {
+            ParcelCompat.readSerializable(
+                this,
+                T::class.java.classLoader,
+                T::class.java,
+            )
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/CompatV28.kt
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.compat
+
+import android.os.Parcel
+
+// writeBoolean requires API level 29
+fun Parcel.writeBooleanCompat(value: Boolean) {
+    writeByte(if (value) 1 else 0)
+}
+
+// readBoolean requires API level 29
+fun Parcel.readBooleanCompat() = readByte() != 0.toByte()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ParcelableUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ParcelableUtilsTest.kt
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.os.Parcel
+import androidx.test.espresso.matcher.ViewMatchers.assertThat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest
+import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest.Companion.write
+import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest.User
+import com.ichi2.testutils.EmptyApplication
+import kotlinx.parcelize.Parceler
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.Serializable
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class ParcelableUtilsTest {
+    @Test
+    fun `serializableList - valid`() {
+        val withData =
+            UnderTest().apply {
+                list =
+                    listOf(
+                        User(1, "david"),
+                        null,
+                        User(2, "dave"),
+                    )
+            }
+
+        val clonedList = withData.cloneAsParcel().list!!
+
+        assertThat(clonedList, hasSize(3))
+        clonedList[0]!!.let {
+            assertThat(it.id, equalTo(1))
+            assertThat(it.name, equalTo("david"))
+        }
+        assertThat(clonedList[1], nullValue())
+        clonedList[2]!!.let {
+            assertThat(it.id, equalTo(2))
+            assertThat(it.name, equalTo("dave"))
+        }
+    }
+
+    @Test
+    fun `serializableList - null list`() {
+        val withData =
+            UnderTest().apply {
+                list = null
+            }
+
+        assertThat(withData.cloneAsParcel().list, nullValue())
+    }
+
+    class UnderTest {
+        var list: List<User?>? = null
+
+        data class User(
+            val id: Int,
+            val name: String,
+        ) : Serializable
+
+        companion object : Parceler<UnderTest> {
+            override fun create(parcel: Parcel): UnderTest =
+                UnderTest().apply {
+                    list = parcel.readSerializableList<User>()
+                }
+
+            override fun UnderTest.write(
+                parcel: Parcel,
+                flags: Int,
+            ) {
+                parcel.writeSerializableList(list)
+            }
+        }
+    }
+}
+
+fun UnderTest.cloneAsParcel(): UnderTest {
+    val parcel = Parcel.obtain()
+    this.write(parcel, 0)
+    parcel.setDataPosition(0)
+    return UnderTest.create(parcel).apply {
+        parcel.recycle()
+    }
+}


### PR DESCRIPTION
Reverts b73ac85ea22f641b8bc3700ff8d36e0c18be97d9

We got the following truncated stack trace due to proguard/minify

Fix it via implementing Parcelize/Parcelable

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.multimedia.MultimediaActivity}: android.os.BadParcelableException: Parcelable encountered IOException reading a Serializable object (name = com.ichi2.anki.multimedia.f)
    at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4377)
    at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4574)
    ...
    at android.os.Looper.loop(Looper.java:393)
    at android.app.ActivityThread.main(ActivityThread.java:9549)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:600)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)
Caused by: android.os.BadParcelableException: Parcelable encountered IOException reading a Serializable object (name = com.ichi2.anki.multimedia.f)
    at android.os.Parcel.readSerializableInternal(Parcel.java:5410)
    at android.os.Parcel.readValue(Parcel.java:4928)
    at android.os.Parcel.readValue(Parcel.java:4625)
    ...
    at android.os.Bundle.getSerializable(Bundle.java:1283)
    at com.ichi2.compat.CompatV33.getSerializable(CompatV33.kt:47)
    at com.ichi2.compat.CompatHelper$Companion.getSerializableCompat(CompatHelper.java:85)
    at com.ichi2.anki.multimedia.MultimediaActivity.getMultimediaArgsExtra(MultimediaActivity.kt:66)
    at com.ichi2.anki.multimedia.MultimediaActivity.onCreate(MultimediaActivity.kt:96)
    at android.app.Activity.performCreate(Activity.java:9196)
Caused by: java.io.InvalidClassException: m4.d; no valid constructor
    at java.io.ObjectStreamClass$ExceptionInfo.newInvalidClassException(ObjectStreamClass.java:163)
    at java.io.ObjectStreamClass.checkDeserialize(ObjectStreamClass.java:832)
```

## Fixes
* Fixes #18712

## How Has This Been Tested?

API 34 tablet emulator: `fullRelease` on `release-2.21`

* Clicking 'Gallery' fails on `release-2.21`
* Passes after this patch is applied

## Learning (optional, can help others)
* `Parceler<MultimediaEditableNote>` interface is much better than `CREATOR`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->