### PR TITLE
fix: img max width in previewers and new reviewer

### DIFF
--- a/AnkiDroid/src/main/assets/ankidroid.css
+++ b/AnkiDroid/src/main/assets/ankidroid.css
@@ -2,6 +2,11 @@ video {
     max-width: 100%;
 }
 
+img {
+    max-width: 100%;
+    max-height: 100%;
+}
+
 @font-face {
     font-family: "Noto Sans Mono";
     src: url("file:///android_asset/fonts/noto/NotoSansMono.ttf")


### PR DESCRIPTION
## Fixes
* Fixes a report from the forums https://forums.ankiweb.net/t/new-study-screen/63230/17 (also applies to the previewers)

## How Has This Been Tested?

Android 15, Galaxy S23:

<details>

![Screenshot_20250702_161956_AnkiDroid](https://github.com/user-attachments/assets/d883ae16-f773-446e-9286-42fd2fffbfe5)
![Screenshot_20250702_161951_AnkiDroid](https://github.com/user-attachments/assets/e336c3e5-c906-4f15-9ae8-5c8f02025323)
![Screenshot_20250702_162011_AnkiDroid](https://github.com/user-attachments/assets/e403314a-89cc-4852-a807-a6d577a20b80)
![Screenshot_20250702_162008_AnkiDroid](https://github.com/user-attachments/assets/6c9517b9-be0f-4897-9dd3-e05b3658b2c7)

</details>

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->