### PR TITLE
fix(card-browser): [tablet] menu crashed when no note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1306,7 +1306,13 @@ open class CardBrowser :
                 return true
             }
         }
-        return fragmented && fragment!!.onMenuItemSelected(item)
+        if (fragment?.onMenuItemSelected(item) == true) {
+            return true
+        }
+        if (fragment == null) {
+            Timber.w("Unexpected onOptionsItemSelected call: %s", item.itemId)
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     private fun showCreateFilteredDeckDialog() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1287,18 +1287,23 @@ open class CardBrowser :
             }
             R.id.action_edit_tags -> {
                 showEditTagsDialog()
+                return true
             }
             R.id.action_open_options -> {
                 showOptionsDialog()
+                return true
             }
             R.id.action_export_selected -> {
                 exportSelected()
+                return true
             }
             R.id.action_create_filtered_deck -> {
                 showCreateFilteredDeckDialog()
+                return true
             }
             R.id.action_find_replace -> {
                 showFindAndReplaceDialog()
+                return true
             }
         }
         return fragmented && fragment!!.onMenuItemSelected(item)


### PR DESCRIPTION
## Fixes
* Fixes #18752

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)