### PR TITLE
chore(card-browser): move 'fragmented' mode to dev-only

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -387,7 +387,9 @@ open class CardBrowser :
          * [fragmented] will be true if the view size is large otherwise false
          */
         // TODO: Consider refactoring by storing noteEditorFrame and similar views in a sealed class (e.g., FragmentAccessor).
-        val fragmented = noteEditorFrame?.visibility == View.VISIBLE
+        val fragmented =
+            Prefs.devIsCardBrowserFragmented &&
+                noteEditorFrame?.visibility == View.VISIBLE
         Timber.i("Using split Browser: %b", fragmented)
 
         if (fragmented) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -209,6 +209,9 @@ object Prefs {
     val isNewStudyScreenEnabled: Boolean
         get() = getBoolean(R.string.new_reviewer_pref_key, false) && getBoolean(R.string.new_reviewer_options_key, false)
 
+    val devIsCardBrowserFragmented: Boolean
+        get() = getBoolean(R.string.dev_card_browser_fragmented, false)
+
     // **************************************** UI Config *************************************** //
 
     private const val UI_CONFIG_PREFERENCES_NAME = "ui-config"

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -211,6 +211,7 @@
     <string name="pref_cat_wip_key">workInProgressDevOptions</string>
     <string name="reviewer_port_pref_key">reviewerPort</string>
     <string name="use_fixed_port_pref_key">useFixedPort</string>
+    <string name="dev_card_browser_fragmented">cardBrowserFragmented</string>
     <!-- Developer options > Create fake notes -->
     <string name="pref_fill_default_deck_number_key">FillDefaultNumberDeck</string>
     <string name="pref_fill_default_deck_key">FillDefaultDeck</string>

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -100,6 +100,10 @@
             android:key="@string/new_reviewer_pref_key"
             android:defaultValue="false"/>
         <SwitchPreferenceCompat
+            android:title="[Tablet] Side-by-side Browser and Editor"
+            android:key="@string/dev_card_browser_fragmented"
+            android:defaultValue="false"/>
+        <SwitchPreferenceCompat
             android:title="Find and replace in browser"
             android:summary="Caution, this can be very destructive for your collection!"
             android:key="@string/pref_browser_find_replace"


### PR DESCRIPTION
Merged in 

* https://github.com/ankidroid/Anki-Android/pull/16764

But not yet stable enough for a release:

* Add note didn't work
* Focused row management
   * Can't see the flagged state of the focused row
* Issues with "dismiss changes" appearing too often
* Issues when notes are deleted
* Issues when notes are modified outside the screen

## Testing

* Opened browser
* tapped a note
* long pressed some notes
* edited one note via the menu
* Enabled the dev setting
* Moved in & out of the card browser: split mode now visible

<img width="1275" alt="Screenshot 2025-07-02 at 20 35 37" src="https://github.com/user-attachments/assets/2ba62f23-9007-487e-a680-767f3d572e96" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)