### PR TITLE
fix(filtered-decks): [API33+] rebuild after 'back' press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AppCompatPreferenceActivity.kt
@@ -26,6 +26,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.res.Configuration
+import android.os.Build
 import android.os.Bundle
 import android.preference.PreferenceActivity
 import android.view.KeyEvent
@@ -33,6 +34,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
+import android.window.OnBackInvokedDispatcher.PRIORITY_OVERLAY
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AlertDialog
@@ -228,6 +230,13 @@ abstract class AppCompatPreferenceActivity<PreferenceHack : AppCompatPreferenceA
         delegate.onCreate(savedInstanceState)
         super.onCreate(savedInstanceState)
         this.col = CollectionManager.getColUnsafe()
+        // HACK: PreferenceActivity does not have a back dispatcher
+        // on API <= 32, onKeyDown is called; on API 33+, this is needed
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(PRIORITY_OVERLAY) {
+                tryCloseWithResult()
+            }
+        }
     }
 
     override fun onPostCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
## Purpose / Description

On API 33+, `onKeyDown(KEY_BACK)` was no longer fired, so `tryCloseWithResult `was not called

`onKeyDown(KEY_BACK)` was still called on API 32


## Fixes
* Fixes #18627
* Related to https://github.com/ankidroid/Anki-Android/issues/14558

## Approach
To fix this, add API 33+ specific code to handle the
 Android back button/swipe gestures

We won't keep the activity around forever, so it wasn't worthwhile rewriting it

## How Has This Been Tested?
Emulators: Pixel 6 Pro: SDK 32 and 33

  * Add card with content: 'd' 
  * Make filtered deck
  * search: 'd'
  * Physical back button

----

* Broken on SDK 33 before patch
* Passed on SDK 32 before patch

----

* Passed on SDK 33 after patch
* Passed on SDK 32 after patch


## Learning (optional, can help others)

Broken in 0657cdb8deb45cc3f8e63ea25e97011c5829c84e enableOnBackInvokedCallback

https://developer.android.com/guide/navigation/custom-back/predictive-back-gesture#opt-predictive

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->