### PR TITLE
Use TR for [no deck]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Decks.kt
@@ -36,6 +36,7 @@ import anki.decks.DeckTreeNode
 import anki.decks.FilteredDeckForUpdate
 import anki.decks.SetDeckCollapsedRequest
 import anki.decks.copy
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import com.ichi2.libanki.backend.BackendUtils
@@ -446,8 +447,7 @@ class Decks(
      *************************************************************
      */
 
-    @RustCleanup("use TR")
-    fun name(did: DeckId): String = get(did)?.name ?: "[no deck]"
+    fun name(did: DeckId): String = get(did)?.name ?: TR.decksNoDeck()
 
     @RustCleanup("implement and make public")
     @LibAnkiAlias("name_if_exists")


### PR DESCRIPTION
- Retrieved the "[no deck]" error string returned when `decks.name()` fails via TR rather than hardcoding it

## Purpose / Description
- This way, if an error occurs when `decks.name()` runs, it can be read in any language.

## Approach
I used TR.

## How Has This Been Tested?
Tests pass. Runs fine on a physical Samsung S23, API 34.

## Learning (optional, can help others)
Found in the process of making https://github.com/ankidroid/Anki-Android/pull/18364

* https://github.com/ankidroid/Anki-Android/pull/18364

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->