### PR TITLE
Potential fix for Softlock in the deck options when trying to view the manual offline

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -76,6 +76,12 @@ class DeckOptions : PageFragment() {
                         //  * A 'discard changes' dialog may be shown, using confirm()
                         //  * if no changes, or changes discarded, `deckOptionsRequireClose` is called
                         //    which PostRequestHandler handles and calls on this fragment
+
+                        // Used to handle an edge-case when the page could not be fully loaded and therefore the anki-call is unavailable
+                        value ->
+                        if (value == "null") {
+                            actuallyClose()
+                        }
                     }
                 } else {
                     // The webview is not yet loaded, no change could have occurred, we can safely close it.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Softlock in the deck options when trying to view the manual offline

## Fixes
* Fixes #18526

## Approach
I added a check inside `webView.evaluateJavascript("anki.deckOptionsPendingChanges()")` that calls `actuallyClose()` if the page could not be loaded

## How Has This Been Tested?

For testing I used my Android 16 phone. To reproduce the issue, the instructions from the linked issue can be used

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)