### PR TITLE
fix(filtered-decks): handle duplicate name on creation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -195,12 +195,26 @@ class CreateDeckDialog(
     }
 
     fun createFilteredDeck(deckName: String): Boolean {
+        fun validFilteredDeckName(initialName: String): String {
+            for (i in 0..10) {
+                val name = initialName + "+".repeat(i)
+                if (getColUnsafe.decks.byName(name) == null) return name
+            }
+            throw IllegalStateException("Could not generate valid name")
+        }
+
         try {
             // create filtered deck
             Timber.i("CreateDeckDialog::createFilteredDeck...")
-            val newDeckId = getColUnsafe.decks.newFiltered(deckName)
+            val newDeckId = getColUnsafe.decks.newFiltered(validFilteredDeckName(deckName))
             Timber.d("Created filtered deck '%s'; id: %d", deckName, newDeckId)
             onNewDeckCreated(newDeckId)
+        } catch (ex: IllegalStateException) {
+            if (ex.message != "Could not generate valid name") {
+                throw ex
+            }
+            displayFeedback(ex.localizedMessage ?: ex.message ?: "", Snackbar.LENGTH_LONG)
+            return false
         } catch (ex: BackendDeckIsFilteredException) {
             displayFeedback(ex.localizedMessage ?: ex.message ?: "", Snackbar.LENGTH_LONG)
             return false


### PR DESCRIPTION
In Anki Desktop, creating a filtered deck suffixes a "+" if the deck name is already found.

Before this change, AnkiDroid edited the provided deck, rather than creating a new one

We now perform the same operation

* Fixes #18761

Tested via unit tests

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->