### PR TITLE
fix(new reviewer): don't discard touches

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid.js
@@ -50,7 +50,6 @@ globalThis.ankidroid.showAllHints = function () {
         "touchend",
         event => {
             if (!isSingleTouch || isTextSelected() || isInteractable(event)) return;
-            event.preventDefault();
 
             if (tapTimer != null) {
                 clearTimeout(tapTimer);
@@ -78,7 +77,7 @@ globalThis.ankidroid.showAllHints = function () {
                 tapTimer = null;
             }, DOUBLE_TAP_TIMEOUT);
         },
-        { passive: false },
+        { passive: true },
     );
 
     /**

--- a/AnkiDroid/src/main/assets/scripts/ankidroid.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid.js
@@ -82,24 +82,22 @@ globalThis.ankidroid.showAllHints = function () {
 
     /**
      * Checks if the target element or its parents are interactive.
-     * @param {HTMLElement} target
+     * @param {TouchEvent} event
      * @returns {boolean}
      */
-    function isInteractable(e) {
-        let node = e.target;
+    function isInteractable(event) {
+        let node = event.target;
         while (node && node !== document) {
-            const res =
+            if (
                 node.nodeName === "A" ||
                 node.onclick ||
                 node.nodeName === "BUTTON" ||
                 node.nodeName === "VIDEO" ||
                 node.nodeName === "SUMMARY" ||
                 node.nodeName === "INPUT" ||
-                node.getAttribute("contentEditable");
-            if (res) {
-                return true;
-            }
-            if (node.classList && node.classList.contains("tappable")) {
+                node.getAttribute("contentEditable") ||
+                (node.classList && node.classList.contains("tappable"))
+            ) {
                 return true;
             }
             node = node.parentNode;


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Some cards may have tappable elements that were factored in an unusual way that `isInteractable` isn't able to catch (nor it is supposed to).

One example is the notetype created by this [addon](https://ankiweb.net/shared/info/1990296174), which seems to be popular

After some thought, I believe that `event.preventDefault();` may not be necessary here (although AnkiMobile has it).

After the fix, the unusually factored tappable elements now work, despite also triggering gestures (which needs the notetypes devs to add the [`tappable` class](https://docs.ankimobile.net/more.html#javascript) to make it mobile friendly)


## How Has This Been Tested?

Emulator API 35:

### Before

https://github.com/user-attachments/assets/27b3f3c6-f367-4fe1-bdb6-42155f385375

### After

https://github.com/user-attachments/assets/29d22feb-2aec-4ee6-98c4-31ea6ce44602

Tapping links and buttons still don't trigger gestures:

https://github.com/user-attachments/assets/1a5d5de6-8d25-4308-8c55-e0a5d8250355

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->