### PR TITLE
Fixed option to remove hard and easy buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1072,7 +1072,7 @@ open class Reviewer :
             }
         }
 
-        // Check if should hide hard and easy buttons
+        // Check if hard and easy buttons should be removed
         if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
             easeButton2!!.setVisibility(View.GONE)
             easeButton4!!.setVisibility(View.GONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1074,8 +1074,8 @@ open class Reviewer :
 
         // Check if should hide hard and easy buttons
         if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
-            easeButton2!!.setVisibility(View.INVISIBLE)
-            easeButton4!!.setVisibility(View.INVISIBLE)
+            easeButton2!!.setVisibility(View.GONE)
+            easeButton4!!.setVisibility(View.GONE)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -55,6 +55,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
+import androidx.core.view.isVisible
 import androidx.lifecycle.lifecycleScope
 import anki.frontend.SetSchedulingStatesRequest
 import com.google.android.material.color.MaterialColors
@@ -107,6 +108,7 @@ import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.flag
 import com.ichi2.anki.utils.ext.setUserFlagForCards
+import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.navBarNeedsScrim
 import com.ichi2.anki.utils.remainingTime
@@ -1068,6 +1070,12 @@ open class Reviewer :
                 easeButton3!!.nextTime = labels[2]
                 easeButton4!!.nextTime = labels[3]
             }
+        }
+
+        // Check if should hide hard and easy buttons
+        if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
+            easeButton2!!.setVisibility(View.INVISIBLE)
+            easeButton4!!.setVisibility(View.INVISIBLE)
         }
     }
 

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -36,6 +36,11 @@
             android:key="@string/pref_reset_languages_key" />
         <SwitchPreferenceCompat
             android:defaultValue="false"
+            android:key="@string/hide_hard_and_easy_key"
+            android:title="@string/hide_hard_and_easy"
+            />
+    <SwitchPreferenceCompat
+            android:defaultValue="false"
             android:key="@string/double_scrolling_gap_key"
             android:summary="@string/double_scrolling_gap_summ"
             android:title="@string/double_scrolling_gap" />
@@ -114,4 +119,5 @@
         android:key="@string/tts_key"
         android:summary="@string/tts_summ"
         android:title="@string/tts" />
+
 </PreferenceScreen>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Ability to check for removing hard and easy buttons

Thoughts: 

- Better placement in settings
- Remove checking-logic in ReviewerFragment.kt?

## Fixes
Fixed the place where the check and execute logic is placed, from ReviewerFragment.kt to Reviewer.kt

## Approach
It removes the hard and easy buttons from being added

## How Has This Been Tested?

Tested on the following devices:

    Android Studio Emulator: Medium Phone, API 36

    Physical Device: Samsung Galaxy S22, Android 15.0, One UI 7.0

## Learning (optional, can help others)
Gained familiarity with how button rendering is managed across Reviewer.kt and ReviewerFragment.kt, aswell as the layout found in the reviewer.xml and reviewer2.xml files

## Checklist
_Please, go through these checks before submitting the PR._

- [x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x ] You have commented your code, particularly in hard-to-understand areas
- [x ] You have performed a self-review of your own code
- [ x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->
![{2D6E7E28-0906-48C2-A1EF-EC694828B466}](https://github.com/user-attachments/assets/a00aff87-e266-49b0-8bd2-5c73f49858c4)
![{52E5A487-3788-4DFE-A828-9BA8B57DF30E}](https://github.com/user-attachments/assets/cf23651d-8126-42a5-86c0-8962c62b46a7)
