### PR TITLE
refactor(libanki): make typealiases public

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/PythonTypes.kt
@@ -21,11 +21,11 @@ package com.ichi2.libanki
  * https://youtrack.jetbrains.com/issue/KT-24700 is fixed
  */
 
-internal typealias DeckId = Long
-internal typealias CardId = Long
-internal typealias DeckConfigId = Long
-internal typealias NoteId = Long
-internal typealias NoteTypeId = Long
+typealias DeckId = Long
+typealias CardId = Long
+typealias DeckConfigId = Long
+typealias NoteId = Long
+typealias NoteTypeId = Long
 
 /**
  * The number of non-leap seconds which have elapsed since the


### PR DESCRIPTION
We will move the affected files to a 'libanki' module in order to reduce build times

These aliases need to be accessed outside the module

* Issue #18015
* #18565

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)