### PR TITLE
build(deps): adopt anki 25.07.1 on release branch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -91,10 +91,11 @@ val collectionMethods =
         "setSchedulingStates" to { bytes -> setSchedulingStatesRaw(bytes) },
         "getChangeNotetypeInfo" to { bytes -> getChangeNotetypeInfoRaw(bytes) },
         "changeNotetype" to { bytes -> changeNotetypeRaw(bytes) },
-        "importJsonString" to { bytes -> importJsonStringRaw(bytes) },
         "importJsonFile" to { bytes -> importJsonFileRaw(bytes) },
         "congratsInfo" to { bytes -> congratsInfoRaw(bytes) },
         "getImageOcclusionFields" to { bytes -> getImageOcclusionFieldsRaw(bytes) },
+        "getIgnoredBeforeCount" to { bytes -> getIgnoredBeforeCountRaw(bytes) },
+        "getRetentionWorkload" to { bytes -> getRetentionWorkloadRaw(bytes) },
     )
 
 suspend fun handleCollectionPostRequest(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -39,7 +39,6 @@ import com.ichi2.libanki.getImportAnkiPackagePresetsRaw
 import com.ichi2.libanki.getNotetypeNamesRaw
 import com.ichi2.libanki.sched.computeFsrsParamsRaw
 import com.ichi2.libanki.sched.computeOptimalRetentionRaw
-import com.ichi2.libanki.sched.evaluateParamsRaw
 import com.ichi2.libanki.sched.simulateFsrsReviewRaw
 import com.ichi2.libanki.stats.cardStatsRaw
 import com.ichi2.libanki.stats.getGraphPreferencesRaw
@@ -82,7 +81,7 @@ val collectionMethods =
         "getDeckConfigsForUpdate" to { bytes -> getDeckConfigsForUpdateRaw(bytes) },
         "computeOptimalRetention" to { bytes -> computeOptimalRetentionRaw(bytes) },
         "computeFsrsParams" to { bytes -> computeFsrsParamsRaw(bytes) },
-        "evaluateParams" to { bytes -> evaluateParamsRaw(bytes) },
+        "evaluateParamsLegacy" to { bytes -> evaluateParamsLegacyRaw(bytes) },
         "simulateFsrsReview" to { bytes -> simulateFsrsReviewRaw(bytes) },
         "getImageForOcclusion" to { bytes -> getImageForOcclusionRaw(bytes) },
         "getImageOcclusionNote" to { bytes -> getImageOcclusionNoteRaw(bytes) },
@@ -91,6 +90,7 @@ val collectionMethods =
         "setSchedulingStates" to { bytes -> setSchedulingStatesRaw(bytes) },
         "getChangeNotetypeInfo" to { bytes -> getChangeNotetypeInfoRaw(bytes) },
         "changeNotetype" to { bytes -> changeNotetypeRaw(bytes) },
+        "importJsonString" to { bytes -> importJsonStringRaw(bytes) },
         "importJsonFile" to { bytes -> importJsonFileRaw(bytes) },
         "congratsInfo" to { bytes -> congratsInfoRaw(bytes) },
         "getImageOcclusionFields" to { bytes -> getImageOcclusionFieldsRaw(bytes) },

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Card.kt
@@ -91,6 +91,7 @@ open class Card : Cloneable {
     var flags = 0
     private var memoryState: FsrsMemoryState? = null
     private var desiredRetention: Float? = null
+    private var decay: Float? = null
 
     var renderOutput: TemplateRenderOutput? = null
     var note: Note? = null
@@ -139,6 +140,7 @@ open class Card : Cloneable {
         customData = card.customData
         memoryState = if (card.hasMemoryState()) card.memoryState else null
         desiredRetention = if (card.hasDesiredRetention()) card.desiredRetention else null
+        decay = if (card.hasDecay()) card.decay else null
     }
 
     @LibAnkiAlias("_to_backend_card")
@@ -163,6 +165,7 @@ open class Card : Cloneable {
             this@Card.originalPosition?.let { originalPosition = it }
             this@Card.memoryState?.let { memoryState = it }
             this@Card.desiredRetention?.let { desiredRetention = it }
+            this@Card.decay?.let { decay = it }
         }
 
     @LibAnkiAlias("question")

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -647,6 +647,10 @@ class Collection(
 
     fun importJsonFileRaw(input: ByteArray): ByteArray = backend.importJsonFileRaw(input = input)
 
+    fun getIgnoredBeforeCountRaw(input: ByteArray): ByteArray = backend.getIgnoredBeforeCountRaw(input = input)
+
+    fun getRetentionWorkloadRaw(input: ByteArray): ByteArray = backend.getRetentionWorkloadRaw(input = input)
+
     fun compareAnswer(
         expected: String,
         provided: String,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Collection.kt
@@ -651,6 +651,8 @@ class Collection(
 
     fun getRetentionWorkloadRaw(input: ByteArray): ByteArray = backend.getRetentionWorkloadRaw(input = input)
 
+    fun evaluateParamsLegacyRaw(input: ByteArray): ByteArray = backend.evaluateParamsLegacyRaw(input = input)
+
     fun compareAnswer(
         expected: String,
         provided: String,

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/TemplateManager.kt
@@ -56,13 +56,13 @@ class TemplateManager {
     data class PartiallyRenderedCard(
         val qnodes: TemplateReplacementList,
         val anodes: TemplateReplacementList,
+        val isEmpty: Boolean,
     ) {
         companion object {
             fun fromProto(out: anki.card_rendering.RenderCardResponse): PartiallyRenderedCard {
                 val qnodes = nodesFromProto(out.questionNodesList)
                 val anodes = nodesFromProto(out.answerNodesList)
-
-                return PartiallyRenderedCard(qnodes, anodes)
+                return PartiallyRenderedCard(qnodes, anodes, out.isEmpty)
             }
 
             fun nodesFromProto(nodes: List<anki.card_rendering.RenderedTemplateNode>): TemplateReplacementList {

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/SchedulerTest.kt
@@ -631,7 +631,7 @@ open class SchedulerTest : JvmTest() {
                     Ease.EASY,
                 ),
             ),
-            Matchers.equalTo("10.8mo"),
+            Matchers.equalTo("10.7mo"),
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.1"
-ankiBackend = '0.1.54-anki25.02.7'
+ankiBackend = '0.1.56-anki25.06b6'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.1"
-ankiBackend = '0.1.56-anki25.06b6'
+ankiBackend = '0.1.57-anki25.07.1'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

As discussed on Discord, we believe these things:

- upstream hasn't necessarily fully qualified this, it may be considered a release candidate upstream. It may be fine, but it's still more of a "wide testing" release. So we're not 100% into merging this, yet.
- on the other hand, it's...mostly just worked for us here in AnkiDroid, so...perhaps it will be fine upstream and fine here, and could be suitable for a 2.21.1 or similar? Or maybe not.

So this PR continues the theme of "feasibility check" for the anki-25.05/6/7 releases that we've been doing. It could work, and be useful in the future, or it could go nowhere and close unmerged.

Either way, we'll have CI feedback, and will do whatever seems right based on a future consensus

It is a cherry-pick of these two PRs:

- #18490 
- #18782