### PR TITLE
refactor: move `android.text.HtmlCompat` out of `libanki`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -85,6 +85,7 @@ import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
+import com.ichi2.anki.backend.stripHTMLAndSpecialFields
 import com.ichi2.anki.cardviewer.AndroidCardRenderContext
 import com.ichi2.anki.cardviewer.AndroidCardRenderContext.Companion.createInstance
 import com.ichi2.anki.cardviewer.CardMediaPlayer
@@ -144,7 +145,6 @@ import com.ichi2.libanki.DeckId
 import com.ichi2.libanki.Decks
 import com.ichi2.libanki.SoundOrVideoTag
 import com.ichi2.libanki.TTSTag
-import com.ichi2.libanki.Utils
 import com.ichi2.libanki.sched.Ease
 import com.ichi2.themes.Themes
 import com.ichi2.themes.Themes.getResFromAttr
@@ -797,7 +797,7 @@ abstract class AbstractFlashcardViewer :
                 text =
                     resources.getString(
                         R.string.delete_note_message,
-                        Utils.stripHTMLAndSpecialFields(currentCard!!.question(getColUnsafe, true)).trim(),
+                        stripHTMLAndSpecialFields(currentCard!!.question(getColUnsafe, true)).trim(),
                     ),
             )
             positiveButton(R.string.dialog_positive_delete) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -40,6 +40,7 @@ import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.backend.stripHTMLScriptAndStyleTags
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewreminders.ScheduleReminders
@@ -50,7 +51,6 @@ import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.libanki.ChangeManager
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.Decks
-import com.ichi2.libanki.Utils
 import com.ichi2.utils.HtmlUtils.convertNewlinesToHtml
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -726,7 +726,7 @@ class StudyOptionsFragment :
         ): Spanned {
             // #5715: In deck description, ignore what is in style and script tag
             // Since we don't currently execute the JS/CSS, it's not worth displaying.
-            val withStrippedTags = Utils.stripHTMLScriptAndStyleTags(desc)
+            val withStrippedTags = stripHTMLScriptAndStyleTags(desc)
             // #5188 - fromHtml displays newlines as " "
             val withFixedNewlines = convertNewlinesToHtml(withStrippedTags)
             return HtmlCompat.fromHtml(withFixedNewlines!!, HtmlCompat.FROM_HTML_MODE_LEGACY)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/backend/HtmlUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/backend/HtmlUtils.kt
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.backend
+
+import androidx.core.text.HtmlCompat
+import java.util.regex.Matcher
+import java.util.regex.Pattern
+
+// Regex pattern used in removing tags from text before diff
+private val commentPattern = Pattern.compile("(?s)<!--.*?-->")
+private val stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>")
+private val scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>")
+private val tagPattern = Pattern.compile("(?s)<.*?>")
+private val typePattern = Pattern.compile("(?s)\\[\\[type:.+?]]")
+private val avRefPattern = Pattern.compile("(?s)\\[anki:play:.:\\d+?]")
+private val htmlEntitiesPattern = Pattern.compile("&#?\\w+;")
+
+/**
+ * Strip special fields like `[[type:...]]` and `[anki:play...]` from a string.
+ * @param input The text to be cleaned.
+ * @return The text without special fields.
+ */
+fun stripSpecialFields(input: String): String {
+    val s = typePattern.matcher(input).replaceAll("")
+    return avRefPattern.matcher(s).replaceAll("")
+}
+
+/**
+ * Strip HTML and special fields from a string.
+ * @param input The text to be cleaned.
+ * @return The text without HTML and special fields.
+ */
+fun stripHTMLAndSpecialFields(input: String): String {
+    val s = stripHTML(input)
+    return stripSpecialFields(s)
+}
+
+/**
+ * Strips a text from <style>...</style>, <script>...</script> and <_any_tag_> HTML tags.
+ * @param inputParam The HTML text to be cleaned.
+ * @return The text without the aforementioned tags.
+ */
+fun stripHTML(inputParam: String): String {
+    var s = commentPattern.matcher(inputParam).replaceAll("")
+    s = stripHTMLScriptAndStyleTags(s)
+    s = tagPattern.matcher(s).replaceAll("")
+    return entsToTxt(s)
+}
+
+/**
+ * Strips <style>...</style> and <script>...</script> HTML tags and content from a string.
+ * @param inputParam The HTML text to be cleaned.
+ * @return The text without the aforementioned tags.
+ */
+fun stripHTMLScriptAndStyleTags(inputParam: String): String {
+    var htmlMatcher = stylePattern.matcher(inputParam)
+    val s = htmlMatcher.replaceAll("")
+    htmlMatcher = scriptPattern.matcher(s)
+    return htmlMatcher.replaceAll("")
+}
+
+/**
+ * Takes a string and replaces all the HTML symbols in it with their unescaped representation.
+ * This should only affect substrings of the form `&something;` and not tags.
+ * Internet rumour says that Html.fromHtml() doesn't cover all cases, but it doesn't get less
+ * vague than that.
+ * @param htmlInput The HTML escaped text
+ * @return The text with its HTML entities unescaped.
+ */
+private fun entsToTxt(htmlInput: String): String {
+    // entitydefs defines nbsp as \xa0 instead of a standard space, so we
+    // replace it first
+    val html = htmlInput.replace("&nbsp;", " ")
+    val htmlEntities = htmlEntitiesPattern.matcher(html)
+    val sb = StringBuffer()
+    while (htmlEntities.find()) {
+        val spanned =
+            HtmlCompat.fromHtml(htmlEntities.group(), HtmlCompat.FROM_HTML_MODE_LEGACY)
+        val replacement = Matcher.quoteReplacement(spanned.toString())
+        htmlEntities.appendReplacement(sb, replacement)
+    }
+    htmlEntities.appendTail(sb)
+    return sb.toString()
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/TTS.kt
@@ -22,12 +22,12 @@ import android.content.Context
 import com.ichi2.anki.CardUtils
 import com.ichi2.anki.R
 import com.ichi2.anki.ReadText
+import com.ichi2.anki.backend.stripHTML
 import com.ichi2.anki.provider.pureAnswer
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.libanki.Card
 import com.ichi2.libanki.Collection
 import com.ichi2.libanki.TTSTag
-import com.ichi2.libanki.Utils
 import com.ichi2.libanki.template.TemplateFilters
 
 class TTS {
@@ -97,7 +97,7 @@ class TTS {
     ): String {
         val clozeReplacement = context.getString(R.string.reviewer_tts_cloze_spoken_replacement)
         val clozeReplaced = text.replace(TemplateFilters.CLOZE_DELETION_REPLACEMENT, clozeReplacement)
-        return Utils.stripHTML(clozeReplaced)
+        return stripHTML(clozeReplaced)
     }
 
     fun initialize(

--- a/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/libanki/Utils.kt
@@ -18,7 +18,6 @@
  ****************************************************************************************/
 package com.ichi2.libanki
 
-import androidx.core.text.HtmlCompat
 import com.ichi2.libanki.Consts.FIELD_SEPARATOR
 import timber.log.Timber
 import java.io.UnsupportedEncodingException
@@ -26,96 +25,11 @@ import java.math.BigInteger
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
 import java.util.Locale
-import java.util.regex.Matcher
-import java.util.regex.Pattern
 
 // TODO switch to standalone functions and properties and remove Utils container
 object Utils {
     // Used to format doubles with English's decimal separator system
     val ENGLISH_LOCALE = Locale("en_US")
-
-    // Regex pattern used in removing tags from text before diff
-    private val commentPattern = Pattern.compile("(?s)<!--.*?-->")
-    private val stylePattern = Pattern.compile("(?si)<style.*?>.*?</style>")
-    private val scriptPattern = Pattern.compile("(?si)<script.*?>.*?</script>")
-    private val tagPattern = Pattern.compile("(?s)<.*?>")
-    private val typePattern = Pattern.compile("(?s)\\[\\[type:.+?]]")
-    private val avRefPattern = Pattern.compile("(?s)\\[anki:play:.:\\d+?]")
-    private val htmlEntitiesPattern = Pattern.compile("&#?\\w+;")
-
-    /*
-     * HTML
-     * ***********************************************************************************************
-     */
-
-    /**
-     * Strips a text from <style>...</style>, <script>...</script> and <_any_tag_> HTML tags.
-     * @param inputParam The HTML text to be cleaned.
-     * @return The text without the aforementioned tags.
-     </_any_tag_> */
-    fun stripHTML(inputParam: String): String {
-        var s = commentPattern.matcher(inputParam).replaceAll("")
-        s = stripHTMLScriptAndStyleTags(s)
-        s = tagPattern.matcher(s).replaceAll("")
-        return entsToTxt(s)
-    }
-
-    /**
-     * Strips <style>...</style> and <script>...</script> HTML tags and content from a string.
-     * @param inputParam The HTML text to be cleaned.
-     * @return The text without the aforementioned tags.
-     */
-    fun stripHTMLScriptAndStyleTags(inputParam: String): String {
-        var htmlMatcher = stylePattern.matcher(inputParam)
-        val s = htmlMatcher.replaceAll("")
-        htmlMatcher = scriptPattern.matcher(s)
-        return htmlMatcher.replaceAll("")
-    }
-
-    /**
-     * Takes a string and replaces all the HTML symbols in it with their unescaped representation.
-     * This should only affect substrings of the form `&something;` and not tags.
-     * Internet rumour says that Html.fromHtml() doesn't cover all cases, but it doesn't get less
-     * vague than that.
-     * @param htmlInput The HTML escaped text
-     * @return The text with its HTML entities unescaped.
-     */
-    // TODO see if method can be refactored to remove the reference to HtmlCompat
-    private fun entsToTxt(htmlInput: String): String {
-        // entitydefs defines nbsp as \xa0 instead of a standard space, so we
-        // replace it first
-        val html = htmlInput.replace("&nbsp;", " ")
-        val htmlEntities = htmlEntitiesPattern.matcher(html)
-        val sb = StringBuffer()
-        while (htmlEntities.find()) {
-            val spanned =
-                HtmlCompat.fromHtml(htmlEntities.group(), HtmlCompat.FROM_HTML_MODE_LEGACY)
-            val replacement = Matcher.quoteReplacement(spanned.toString())
-            htmlEntities.appendReplacement(sb, replacement)
-        }
-        htmlEntities.appendTail(sb)
-        return sb.toString()
-    }
-
-    /**
-     * Strip special fields like `[[type:...]]` and `[anki:play...]` from a string.
-     * @param input The text to be cleaned.
-     * @return The text without special fields.
-     */
-    fun stripSpecialFields(input: String): String {
-        val s = typePattern.matcher(input).replaceAll("")
-        return avRefPattern.matcher(s).replaceAll("")
-    }
-
-    /**
-     * Strip HTML and special fields from a string.
-     * @param input The text to be cleaned.
-     * @return The text without HTML and special fields.
-     */
-    fun stripHTMLAndSpecialFields(input: String): String {
-        val s = stripHTML(input)
-        return stripSpecialFields(s)
-    }
 
     /*
      * IDs

--- a/AnkiDroid/src/test/java/com/ichi2/anki/backend/HtmlUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/backend/HtmlUtilsTest.kt
@@ -1,0 +1,90 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.backend
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class HtmlUtilsTest {
+    @Test
+    fun test_stripHTML_will_remove_tags() {
+        val strings =
+            listOf(
+                "<>",
+                "<1>",
+                "<foo>",
+                "<\n>",
+                "<\\qwq>",
+                "<aa\nsd\nas\n?\n>",
+            )
+        for (s in strings) {
+            assertEquals(
+                s.replace("\n", "\\n") + " should be removed.",
+                "",
+                stripHTML(s),
+            )
+        }
+    }
+
+    @Test
+    fun test_stripHTML_will_remove_comments() {
+        val strings =
+            listOf(
+                "<!---->",
+                "<!--dd-->",
+                "<!--asd asd asd-->",
+                "<!--\n-->",
+                "<!--\nsd-->",
+                "<!--lkl\nklk\n-->",
+            )
+        for (s in strings) {
+            assertEquals(
+                s.replace("\n", "\\n") + " should be removed.",
+                "",
+                stripHTML(s),
+            )
+        }
+    }
+
+    @Test
+    fun test_stripSpecialFields_will_remove_type() {
+        val input = "test\n\n[[type:Back]]"
+        val output = stripSpecialFields(input)
+        assertEquals(
+            "type field should be removed",
+            "test\n\n",
+            output,
+        )
+    }
+
+    @Test
+    fun test_stripSpecialFields_will_remove_avRef() {
+        val input = "test\n\n[anki:play:q:0]"
+        val output = stripSpecialFields(input)
+        assertEquals(
+            "avRef field should be removed",
+            "test\n\n",
+            output,
+        )
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/NoteTypeTest.kt
@@ -17,8 +17,8 @@ package com.ichi2.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import anki.notetypes.copy
+import com.ichi2.anki.backend.stripHTML
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
-import com.ichi2.libanki.Utils.stripHTML
 import com.ichi2.libanki.exception.ConfirmModSchemaException
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.ext.addNote

--- a/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/libanki/UtilsTest.kt
@@ -16,78 +16,13 @@
 
 package com.ichi2.libanki
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertEquals
 import org.junit.Test
-import org.junit.runner.RunWith
 
-@RunWith(AndroidJUnit4::class)
 class UtilsTest {
     @Test
     fun testSplit() {
         assertEquals(listOf("foo", "bar"), Utils.splitFields("foobar"))
         assertEquals(listOf("", "foo", "", "", ""), Utils.splitFields("foo"))
-    }
-
-    @Test
-    fun test_stripHTML_will_remove_tags() {
-        val strings =
-            listOf(
-                "<>",
-                "<1>",
-                "<foo>",
-                "<\n>",
-                "<\\qwq>",
-                "<aa\nsd\nas\n?\n>",
-            )
-        for (s in strings) {
-            assertEquals(
-                s.replace("\n", "\\n") + " should be removed.",
-                "",
-                Utils.stripHTML(s),
-            )
-        }
-    }
-
-    @Test
-    fun test_stripHTML_will_remove_comments() {
-        val strings =
-            listOf(
-                "<!---->",
-                "<!--dd-->",
-                "<!--asd asd asd-->",
-                "<!--\n-->",
-                "<!--\nsd-->",
-                "<!--lkl\nklk\n-->",
-            )
-        for (s in strings) {
-            assertEquals(
-                s.replace("\n", "\\n") + " should be removed.",
-                "",
-                Utils.stripHTML(s),
-            )
-        }
-    }
-
-    @Test
-    fun test_stripSpecialFields_will_remove_type() {
-        val input = "test\n\n[[type:Back]]"
-        val output = Utils.stripSpecialFields(input)
-        assertEquals(
-            "type field should be removed",
-            "test\n\n",
-            output,
-        )
-    }
-
-    @Test
-    fun test_stripSpecialFields_will_remove_avRef() {
-        val input = "test\n\n[anki:play:q:0]"
-        val output = Utils.stripSpecialFields(input)
-        assertEquals(
-            "avRef field should be removed",
-            "test\n\n",
-            output,
-        )
     }
 }


### PR DESCRIPTION
to `com.ichi2.anki.backend.HtmlUtils`

and made the tests a little faster

* Issue #18015

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->