### PR TITLE
chore: use same icon for 'Replay media'

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_previewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_previewer_controls.xml
@@ -27,7 +27,7 @@
     <com.ichi2.preferences.ControlPreference
         android:key="@string/previewer_replay_media_key"
         android:title="@string/replay_media"
-        android:icon="@drawable/ic_replay"
+        android:icon="@drawable/ic_play_circle_white"
         />
     <com.ichi2.preferences.ControlPreference
         android:key="@string/previewer_backside_only_action_key"


### PR DESCRIPTION
use same icon for 'Replay media' in the `Reviews` and `Previews` tabs of Controls

## How Has This Been Tested?

Saw the layout previews in Android Studio

![image](https://github.com/user-attachments/assets/29d5fa65-7b9f-4a46-a786-5c4a59b3977b)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->