### PR TITLE
fix: controls settings being removed after selecting tab

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -76,11 +76,11 @@ class ControlsSettingsFragment :
         setDynamicTitle()
     }
 
-    @NeedsTest("General category is kept and the other elements are removed")
+    @NeedsTest("Only the tab elements are removed")
     override fun onTabUnselected(tab: TabLayout.Tab?) {
         val preferences = preferenceScreen.children.toList()
-        // 0 is the `General` category, which should be kept
-        for (pref in preferences.subList(1, preferences.size)) {
+        val tabsPrefIndex = preferences.indexOfFirst { it is ControlsTabPreference }
+        for (pref in preferences.subList(tabsPrefIndex + 1, preferences.size)) {
             preferenceScreen.removePreference(pref)
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

this issue happened after I removed the `General` settings category on `Controls`


https://github.com/user-attachments/assets/b7b247b5-6f8c-4d19-b126-575df3f123b5

## Approach

Remove only the items after the ControlTabsPreference. I tried to make a test for it, but had some trouble getting a reference to the TabLayout

## How Has This Been Tested?

Emulator API 36:

https://github.com/user-attachments/assets/1ac96aea-523a-4cd8-b17b-28c5d4e2d22f


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->