### PR TITLE
move 'Full screen navigation drawer' setting

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -33,13 +33,6 @@
         android:key="@string/gestures_corner_touch_preference"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
-    <SwitchPreferenceCompat
-        android:defaultValue="false"
-        android:dependency="@string/gestures_preference"
-        android:disableDependentsState="false"
-        android:key="@string/nav_drawer_gesture_key"
-        android:summary="@string/gestures_fullscreen_nav_drawer_summary"
-        android:title="@string/gestures_full_screen_nav_drawer" />
     <com.ichi2.preferences.SliderPreference
         android:key="@string/pref_swipe_sensitivity_key"
         android:dependency="@string/gestures_preference"

--- a/AnkiDroid/src/main/res/xml/preferences_general.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_general.xml
@@ -44,6 +44,11 @@
             android:key="@string/analytics_opt_in_key"
             android:summary="@string/analytics_summ"
             android:title="@string/analytics_title" />
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="@string/nav_drawer_gesture_key"
+            android:summary="@string/gestures_fullscreen_nav_drawer_summary"
+            android:title="@string/gestures_full_screen_nav_drawer" />
     <PreferenceCategory android:title="@string/pref_cat_editing">
         <SwitchPreferenceCompat
             android:defaultValue="true"


### PR DESCRIPTION
from 'Controls' to 'General'

It made sense to be in 'Controls', when it was called 'Gestures', there were no key or joystick support, and there were no support for other screens like the previewer.

Now, it feel displaced in the 'Controls' category because it isn't related to any control.

Also, the dependency to 'Enable gestures' is soft, because disabling 'Enable gestures' doesn't remove the full screen navigation drawer behavior.

So, that dependency ends up being unnecessary.

## How Has This Been Tested?

<details><summary>Emulator API 36</summary>


https://github.com/user-attachments/assets/0917fe98-8940-4813-b7fd-3ac1127b6b94



</details>


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->