### PR TITLE
Added a toast message when a card is created

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1260,6 +1260,9 @@ class NoteEditorFragment :
         }
 
         if (closeEditorAfterSave) {
+            if (caller == NoteEditorCaller.NOTEEDITOR_INTENT_ADD || aedictIntent) {
+                showThemedToast(requireContext(), R.string.note_message, shortLength = true)
+            }
             closeNoteEditor(closeIntent ?: Intent())
         } else {
             // Reset check for changes to fields

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -22,7 +22,7 @@
     <!-- Navigation drawer strings -->
     <string name="drawer_open">Open drawer</string>
     <string name="drawer_close">Close drawer</string>
-
+    <string name="note_message">Note saved</string>
     <string name="CardEditorCardDeck">Card deck:</string>
     <string name="CardEditorNoteDeck">Deck:</string>
     <string name="CardEditorModel">Type:</string>


### PR DESCRIPTION
## Purpose / Description

Add a toast message ("Note saved") when the user saves a note and the app was launched via an external intent (e.g. from Chrome or Aedict).  
This improves the user experience by confirming the action before the activity closes.

## Fixes

* Fixes #18773 

## Approach

- Checked for `NOTEEDITOR_INTENT_ADD` or `aedictIntent` in `onNoteAdded()`.
- Called `showThemedToast()` before `closeNoteEditor()` to ensure the toast appears before the activity is destroyed.
- Ensured the toast is shown only for externally-triggered note adds (not for standard app usage).

## How Has This Been Tested?

- Manually tested on a physical Android device:
  - Opened Chrome, selected text, shared to AnkiDroid.
  - Verified toast appears when note is saved and app closes.
  - Also tested adding a note within the app to confirm toast does not appear in that flow.
- Used [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor) to validate no accessibility regressions.

## Checklist
_Please, go through these checks before submitting the PR._

- [✔️] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✔️] You have performed a self-review of your own code.
- [✔️] UI changes: included screenshots of all affected screens (if applicable).
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).

### Screenshot
| Scenario | Screenshot |
|----------|------------|
| Toast after intent save |
![f9f698c3-2432-4840-90e4-295b3cb069d4](https://github.com/user-attachments/assets/e1635895-3b66-4281-ad99-d1a9829fe0f0)

