### PR TITLE
fix(new reviewer): timer showing on tablets if Hide answer buttons is enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -179,11 +179,12 @@ object Prefs {
 
     // **************************************** Reviewer **************************************** //
 
-    val doubleTapInterval by intPref(R.string.double_tap_timeout_pref_key, defaultValue = 200)
     val ignoreDisplayCutout by booleanPref(R.string.ignore_display_cutout_key, false)
     val autoFocusTypeAnswer by booleanPref(R.string.type_in_answer_focus_key, true)
     val showAnswerFeedback by booleanPref(R.string.show_answer_feedback_key, defaultValue = true)
+    val hideAnswerButtons by booleanPref(R.string.hide_answer_buttons_key, false)
 
+    val doubleTapInterval by intPref(R.string.double_tap_timeout_pref_key, defaultValue = 200)
     val newStudyScreenAnswerButtonSize by intPref(R.string.answer_button_size_pref_key, defaultValue = 100)
 
     val swipeSensitivity: Float

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -677,6 +677,9 @@ class ReviewerFragment :
                 )
                 applyTo(constraintLayout)
             }
+            // applying a ConstraintSet resets the visibility of counts_flow, which includes
+            // the timer, so check again if it should be visible.
+            timer?.isVisible = viewModel.answerTimerStatusFlow.value != null
             return
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -394,9 +394,8 @@ class ReviewerFragment :
     }
 
     private fun setupAnswerButtons(view: View) {
-        val prefs = sharedPrefs()
         val answerArea = view.findViewById<FrameLayout>(R.id.answer_area)
-        if (prefs.getBoolean(getString(R.string.hide_answer_buttons_key), false)) {
+        if (Prefs.hideAnswerButtons) {
             answerArea.isVisible = false
             return
         }
@@ -462,7 +461,7 @@ class ReviewerFragment :
             }
         }
 
-        if (prefs.getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
+        if (sharedPrefs().getBoolean(getString(R.string.hide_hard_and_easy_key), false)) {
             hardButton.isVisible = false
             easyButton.isVisible = false
         }
@@ -663,7 +662,7 @@ class ReviewerFragment :
      * of [Prefs.toolbarPosition] and `Hide answer buttons`
      */
     private fun setupMargins(view: View) {
-        val hideAnswerButtons = sharedPrefs().getBoolean(getString(R.string.hide_answer_buttons_key), false)
+        val hideAnswerButtons = Prefs.hideAnswerButtons
         // In big screens, let the menu expand if there are no answer buttons
         if (hideAnswerButtons && !resources.isWindowCompact()) {
             val constraintLayout = view.findViewById<ConstraintLayout>(R.id.tools_layout)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -672,13 +672,13 @@ class ReviewerFragment :
                 connect(
                     R.id.reviewer_menu_view,
                     ConstraintSet.START,
-                    R.id.guideline_counts,
+                    R.id.counts_flow,
                     ConstraintSet.END,
                 )
                 applyTo(constraintLayout)
             }
-            // applying a ConstraintSet resets the visibility of counts_flow, which includes
-            // the timer, so check again if it should be visible.
+            // applying a ConstraintSet resets the visibility of counts_flow,
+            // which includes the timer, so set again its visibility.
             timer?.isVisible = viewModel.answerTimerStatusFlow.value != null
             return
         }

--- a/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
@@ -106,14 +106,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="8dp"
+            android:layout_marginHorizontal="@dimen/reviewer_side_margin"
             >
-
-            <androidx.constraintlayout.widget.Guideline
-                android:id="@+id/guideline_counts"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                app:layout_constraintGuide_percent="0.16"/>
 
             <androidx.constraintlayout.widget.Guideline
                 android:id="@+id/guideline_menu"
@@ -129,7 +123,6 @@
                 android:layout_width="?minTouchTargetSize"
                 android:layout_height="?minTouchTargetSize"
                 android:src="?attr/homeAsUpIndicator"
-                android:layout_marginStart="@dimen/reviewer_side_margin"
                 app:layout_constraintStart_toStartOf="parent"
                 android:contentDescription="@string/abc_action_bar_up_description"
                 android:tooltipText="@string/abc_action_bar_up_description"
@@ -201,8 +194,8 @@
                 android:layout_height="wrap_content"
                 app:layout_constraintWidth_percent="0.52"
                 app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintStart_toEndOf="@id/guideline_counts"
-                app:layout_constraintEnd_toStartOf="@id/reviewer_menu_view">
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
 
                 <com.google.android.material.button.MaterialButton
                     android:id="@+id/show_answer"
@@ -282,7 +275,6 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintBottom_toBottomOf="parent"
-                android:layout_marginEnd="@dimen/reviewer_side_margin"
                 />
         </androidx.constraintlayout.widget.ConstraintLayout>
     </LinearLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

If you were using a tablet and set `Hide answer buttons` to true, the timer would show up despite it not being enabled

## Fixes
* Fixes ☝️

## Approach

In the commits

## How Has This Been Tested?

<details><summary>Emulator API 36</summary>

![result](https://github.com/user-attachments/assets/75be682e-f86b-4776-bee0-ae356d7337fa)
![Screenshot_20250706_210835](https://github.com/user-attachments/assets/bf403022-9e92-465a-9d33-7613879472e1)

</details>


## Learning (optional, can help others)

Changing ContraintLayouts programatically has its issues

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->