### PR TITLE
Fixed: Gesture picker is mirrored in rtl languages

### DIFF
--- a/AnkiDroid/src/main/res/layout/gesture_picker.xml
+++ b/AnkiDroid/src/main/res/layout/gesture_picker.xml
@@ -21,6 +21,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
+    <!-- 18781: Don't mirror the gesture display for rtl languages -->
     <com.ichi2.ui.GestureDisplay
         android:id="@+id/gestureDisplay"
         android:layout_width="0dp"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Gesture picker is mirrored in rtl languages

## Fixes
* Fixes #18781

## Approach
I added a single line of code that forces the Gesture Display to always display in a left-to-right layout direction

## How Has This Been Tested?
For testing I used my Android 16 phone. To reproduce the issue, the instructions from the linked issue can be used

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->