### PR TITLE
fix: instant editor cloze number incrementing on undo

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -173,13 +173,14 @@ class InstantEditorViewModel :
     private fun shouldResetClozeNumber(number: Int) {
         intClozeList.remove(number)
 
-        // Reset cloze number if the list is empty
-        if (intClozeList.isEmpty()) {
-            _currentClozeNumber.value = 1
-        } else {
-            // not null for sure
-            _currentClozeNumber.value = intClozeList.maxOrNull()!! + 1
-        }
+        _currentClozeNumber.value =
+            when {
+                // Reset cloze number if the list is empty
+                intClozeList.isEmpty() -> 1
+                currentClozeMode.value == InstantNoteEditorActivity.ClozeMode.INCREMENT ->
+                    (intClozeList.maxOrNull() ?: 0) + 1
+                else -> _currentClozeNumber.value
+            }
     }
 
     /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The cloze number should be incremented only in the increment mode, so when undoing it was incremented this PR fixes that behaviour 

## Fixes
* Fixes  #18811

## Approach
NA

## How Has This Been Tested?
Pixel fold API35
[Screen_recording_20250710_000607.webm](https://github.com/user-attachments/assets/1df8d216-bea9-4e71-b684-57ff0124c8f2)

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->