### PR TITLE
feat: display user-facing FSRS version

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.Info
 import com.ichi2.anki.R
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.scheduling.Fsrs
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.showThemedToast
@@ -72,7 +73,9 @@ class AboutFragment : Fragment(R.layout.about_layout) {
             "(anki " + BackendBuildConfig.ANKI_DESKTOP_VERSION + " / " + BackendBuildConfig.ANKI_COMMIT_HASH.subSequence(0, 8) + ")"
 
         // FSRS version text
-        view.findViewById<TextView>(R.id.about_fsrs).text = "(FSRS ${BackendBuildConfig.FSRS_VERSION})"
+        view.findViewById<TextView>(R.id.about_fsrs).text = Fsrs.displayVersion ?.let { version ->
+            "($version)"
+        } ?: ""
 
         // Logo secret
         view

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.scheduling
+
+import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
+
+/**
+ * Functionality for [FSRS](https://github.com/open-spaced-repetition/)
+ */
+object Fsrs {
+    val version = FsrsVersion(BackendBuildConfig.FSRS_VERSION)
+
+    /**
+     * A user-facing string for the FSRS version.
+     *
+     * The underlying library version is not typically known to Anki users
+     *
+     * `null` is unexpected
+     */
+    val displayVersion: String?
+        get() = version.displayString
+}
+
+@JvmInline
+value class FsrsVersion(
+    val libraryVersion: String,
+) {
+    val displayString: String? get() =
+        when (libraryVersion) {
+            "0.6.4" -> "FSRS 4.5"
+            "4.1.1" -> "FSRS 6"
+            else -> null
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/FsrsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/scheduling/FsrsTest.kt
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.scheduling
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+
+class FsrsTest {
+    @Test
+    fun `FSRS version is mapped to user-facing version`() {
+        assertThat("FSRS ${Fsrs.version.libraryVersion} should be mapped to a user-facing version", Fsrs.displayVersion, not(nullValue()))
+    }
+}


### PR DESCRIPTION
This was causing confusion for users

* Fixes #18825

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->