### PR TITLE
ReviewRemindersScope for ScheduleReminders entry

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -46,6 +46,7 @@ import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
@@ -286,8 +287,7 @@ class StudyOptionsFragment :
                 val intent =
                     ScheduleReminders.getIntent(
                         requireContext(),
-                        false,
-                        col!!.decks.current().id,
+                        ReviewReminderScope.DeckSpecific(col!!.decks.current().id),
                     )
                 startActivity(intent)
                 return true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -181,7 +181,7 @@ class DeckPickerViewModel :
 
     fun scheduleReviewReminders(deckId: DeckId) =
         viewModelScope.launch {
-            flowOfDestination.emit(ScheduleRemindersDestination(false, deckId))
+            flowOfDestination.emit(ScheduleRemindersDestination(deckId))
         }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.toSentenceCase
@@ -64,7 +65,7 @@ class HeaderFragment : SettingsFragment() {
         requirePreference<HeaderPreference>(R.string.pref_review_reminders_screen_key)
             .setOnPreferenceClickListener {
                 Timber.i("HeaderFragment:: edit review reminders button pressed")
-                val intent = ScheduleReminders.getIntent(requireContext(), true)
+                val intent = ScheduleReminders.getIntent(requireContext(), ReviewReminderScope.Global)
                 startActivity(intent)
                 true
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -43,6 +43,7 @@ import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.preferences.HeaderFragment.Companion.getHeaderKeyForFragment
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.isWindowCompact
@@ -115,7 +116,7 @@ class PreferencesFragment :
     override fun onSearchResultClicked(result: SearchPreferenceResult) {
         if (result.key == getString(R.string.pref_review_reminders_screen_key)) {
             Timber.i("Preferences:: edit review reminders button pressed")
-            val intent = ScheduleReminders.getIntent(requireContext(), true)
+            val intent = ScheduleReminders.getIntent(requireContext(), ReviewReminderScope.Global)
             startActivity(intent)
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersDestination.kt
@@ -22,8 +22,11 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.utils.Destination
 
 class ScheduleRemindersDestination(
-    private val isInGlobalScope: Boolean,
-    private val did: DeckId? = null,
+    private val did: DeckId,
 ) : Destination {
-    override fun toIntent(context: Context): Intent = ScheduleReminders.getIntent(context, isInGlobalScope, did)
+    override fun toIntent(context: Context): Intent =
+        ScheduleReminders.getIntent(
+            context,
+            ReviewReminderScope.DeckSpecific(did),
+        )
 }


### PR DESCRIPTION
## Purpose / Description
- Refactored ScheduleReminders to take a ReviewReminderScope as an argument in `getIntent` to better enforce that callers should either trigger ScheduleReminders in deck-specific or global mode rather than leaving open the possibility of passing an incorrect deckId, etc. This was recommended by David.
- Made toolbar title use ReviewReminderScope to follow the above change
- Modified review reminder entry points to pass a ReviewReminderScope rather than the old `getIntent` arguments

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- I'm actually quite happy with this change, it feels very elegant. Both ReviewReminder and ScheduleReminders are now using the same sealed class to communicate a "scope", whereas previously they were each using slightly different methods to accomplish the same "scoping" functionality. This commit unifies the "scope" feature.

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->