### PR TITLE
fix: Image cropper screen action bar color is inconsistent with the preceding screen's one

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/imagecropper/ImageCropper.kt
@@ -119,15 +119,13 @@ class ImageCropper :
         menu: Menu,
         menuInflater: MenuInflater,
     ) {
-        menu.clear()
-        // TODO make our own menu, we shouldn't rely on third party menu files
-        menuInflater.inflate(com.canhub.cropper.R.menu.crop_image_menu, menu)
+        menuInflater.inflate(R.menu.image_cropper_menu, menu)
     }
 
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean =
         when (menuItem.itemId) {
-            com.canhub.cropper.R.id.crop_image_menu_crop -> {
-                Timber.d("Crop image clicked")
+            R.id.action_done -> {
+                Timber.d("Done clicked")
                 val imageFormat = cropImageView.imageUri?.let { getImageCompressFormat(it) }
                 Timber.d("Compress format: $imageFormat")
                 if (imageFormat != null) {
@@ -138,20 +136,19 @@ class ImageCropper :
                 true
             }
 
-            com.canhub.cropper.R.id.ic_rotate_right_24 -> {
-                Timber.d("Rotate right clicked")
+            R.id.action_rotate -> {
+                Timber.d("Rotate clicked")
                 cropImageView.rotateImage(90)
                 true
             }
 
-            com.canhub.cropper.R.id.ic_flip_24_horizontally -> {
+            R.id.action_flip_horizontally -> {
                 Timber.d("Flip horizontally clicked")
-
                 cropImageView.flipImageHorizontally()
                 true
             }
 
-            com.canhub.cropper.R.id.ic_flip_24_vertically -> {
+            R.id.action_flip_vertically -> {
                 Timber.d("Flip vertically clicked")
                 cropImageView.flipImageVertically()
                 true

--- a/AnkiDroid/src/main/res/drawable/ic_flip_horizontal.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_flip_horizontal.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15,21h2v-2h-2v2zM19,9h2L21,7h-2v2zM3,5v14c0,1.1 0.9,2 2,2h4v-2L5,19L5,5h4L9,3L5,3c-1.1,0 -2,0.9 -2,2zM19,3v2h2c0,-1.1 -0.9,-2 -2,-2zM11,23h2L13,1h-2v22zM19,17h2v-2h-2v2zM15,5h2L17,3h-2v2zM19,13h2v-2h-2v2zM19,21c1.1,0 2,-0.9 2,-2h-2v2z" />
+</vector>

--- a/AnkiDroid/src/main/res/drawable/ic_rotate_right.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_rotate_right.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+  <path
+      android:fillColor="@android:color/white"
+      android:pathData="M15.55,5.55L11,1v3.07C7.06,4.56 4,7.92 4,12s3.05,7.44 7,7.93v-2.02c-2.84,-0.48 -5,-2.94 -5,-5.91s2.16,-5.43 5,-5.91L11,10l4.55,-4.45zM19.93,11c-0.17,-1.39 -0.72,-2.73 -1.62,-3.89l-1.42,1.42c0.54,0.75 0.88,1.6 1.02,2.47h2.02zM13,17.9v2.02c1.39,-0.17 2.74,-0.71 3.9,-1.61l-1.44,-1.44c-0.75,0.54 -1.59,0.89 -2.46,1.03zM16.89,15.48l1.42,1.41c0.9,-1.16 1.45,-2.5 1.62,-3.89h-2.02c-0.14,0.87 -0.48,1.72 -1.02,2.48z" />
+</vector>

--- a/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_image_cropper.xml
@@ -31,8 +31,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:minHeight="?attr/actionBarSize"
-            android:background="?attr/appBarColor"
-            android:theme="@style/ActionBarStyle"
             app:layout_constraintTop_toTopOf="parent"/>
 
         <com.canhub.cropper.CropImageView

--- a/AnkiDroid/src/main/res/menu/image_cropper_menu.xml
+++ b/AnkiDroid/src/main/res/menu/image_cropper_menu.xml
@@ -1,0 +1,32 @@
+<!-- res/menu/image_cropper_menu.xml -->
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_rotate"
+        android:title="@string/image_cropper_action_rotate"
+        android:icon="@drawable/ic_rotate_right"
+        app:showAsAction="always" />
+
+    <!-- Flip parent with submenu -->
+    <item
+        android:id="@+id/action_flip"
+        android:title="@string/image_cropper_action_flip"
+        android:icon="@drawable/ic_flip_horizontal"
+        app:showAsAction="always">
+
+        <menu>
+            <item
+                android:id="@+id/action_flip_horizontally"
+                android:title="@string/image_cropper_action_flip_horizontally" />
+            <item
+                android:id="@+id/action_flip_vertically"
+                android:title="@string/image_cropper_action_flip_vertically" />
+        </menu>
+    </item>
+    
+    <item
+        android:id="@+id/action_done"
+        android:title="@string/multimedia_editor_field_editing_done"
+        android:icon="@drawable/ic_done"
+        app:showAsAction="always" />
+</menu>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -88,6 +88,12 @@
     <string name="missing_note_type">No note type found</string>
     <string name="card_previewer_empty_front_indicator" comment="Extra text appended onto a tab title in the card previewer so that the user can see at a glance whether a card has no front.">%1$s (empty)</string>
 
+    <!-- Image cropper -->
+    <string name="image_cropper_action_rotate" maxLength="28" comment="Action in image cropper screen">Rotate</string>
+    <string name="image_cropper_action_flip" maxLength="28" comment="Action in image cropper screen">Flip</string>
+    <string name="image_cropper_action_flip_horizontally" maxLength="28" comment="Submenu action in image cropper screen">Flip horizontally</string>
+    <string name="image_cropper_action_flip_vertically" maxLength="28" comment="Submenu action in image cropper screen">Flip vertically</string>
+
     <!-- Timebox -->
     <string name="timebox_reached_title">Timebox reached</string>
     <plurals name="timebox_reached">

--- a/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
+++ b/AnkiDroid/src/main/res/values/16-multimedia-editor.xml
@@ -23,7 +23,7 @@
     <!-- Field editing general -->
     <!-- these are button names to convert field type -->
     <string name="multimedia_editor_field_editing_audio">Audio recording</string>
-    <string name="multimedia_editor_field_editing_done" comment="Label of a button to tell the app that the current action is 'Done'.">Done</string>
+    <string name="multimedia_editor_field_editing_done" maxLength="28" comment="Label of a button to tell the app that the current action is 'Done'.">Done</string>
 
     <!-- Multimedia card editor activity -->
     <!-- for buttons -->


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
The image clopper screen's action bar color is inconsistent with the color of the status bar and the preceding screen ("Add image"). This PR intends to fix the inconsistency.

## Fixes
* Fixes #18832

## Approach
- Remove the codes regarding the action bar color
- Change the icon references from the current icons (hard-coded in white color) managed in CanHub repository to the new icons managed in AnkiDroid repository.
- Use Google Material Icons for the new icons
    - [Rotate](https://fonts.google.com/icons?selected=Material+Icons+Outlined:rotate_right:&icon.set=Material+Icons&icon.size=24&icon.color=%235f6368&icon.query=rotate)
    - [Flip](https://fonts.google.com/icons?selected=Material+Icons+Outlined:flip:&icon.set=Material+Icons&icon.size=24&icon.color=%235f6368&icon.query=rotate)

## How Has This Been Tested?

Checked in a physical device (Android 11)


**Before** 
<img src="https://github.com/user-attachments/assets/b4dc8f84-b671-459c-a511-6bcdb3536375" width="320px"><img src="https://github.com/user-attachments/assets/17534a45-3f49-4726-b4ad-27b28f017296" width="320px">


**After**
<img src="https://github.com/user-attachments/assets/07c078cd-f5aa-4e5d-b465-0695752ee351" width="320px"><img src="https://github.com/user-attachments/assets/2dd827b7-d828-48ee-8e65-8e66786e86bd" width="320px">

https://github.com/user-attachments/assets/6c80f513-df98-47d8-be82-e2108d6b35d1

<details>
<summary>Other themes</summary>
<img src="https://github.com/user-attachments/assets/2e07d955-c441-4a9d-a783-1ccd964387f2" width="320px"><img src="https://github.com/user-attachments/assets/c2c40e5e-0384-4058-b230-5182418d197d" width="320px">

<img src="https://github.com/user-attachments/assets/c31e1c6c-7c2e-4496-b782-9bda010f42df" width="320px"><img src="https://github.com/user-attachments/assets/f4a5fa5d-6832-43cd-93da-a0eab47dc448" width="320px">

<img src="https://github.com/user-attachments/assets/c7e97a76-243c-4baa-9926-a72eb06441cf" width="320px">
<img src="https://github.com/user-attachments/assets/a3e15c26-4f6a-4604-8552-92f98d38ca50" width="320px">
</details>

## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->