### PR TITLE
build: retain latest 2.19 release when doing new releases

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -278,10 +278,10 @@ play {
                 221603300L, // (2.16.3, minSdk 21, ABI x86)
                 321603300L, // (2.16.3, minSdk 21, ABI arm64-v8a)
                 421603300L, // (2.16.3, minSdk 21, ABI x86_64)
-                121904300L, // (2.19.4, minSdk 23, ABI armeabi-v7a)
-                221904300L, // (2.19.4, minSdk 23, ABI x86)
-                321904300L, // (2.19.4, minSdk 23, ABI arm64-v8a)
-                421904300L, // (2.19.4, minSdk 23, ABI x86_64)
+                121905300L, // (2.19.5, minSdk 23, ABI armeabi-v7a)
+                221905300L, // (2.19.5, minSdk 23, ABI x86)
+                321905300L, // (2.19.5, minSdk 23, ABI arm64-v8a)
+                421905300L, // (2.19.5, minSdk 23, ABI x86_64)
         ])
     }
 


### PR DESCRIPTION
this keeps minSdk 23 APKs available for folks

Part of the release work today