### PR TITLE
fix: remove duplicate bindings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -73,9 +73,13 @@ class ReviewerControlPreference : ControlPreference {
         binding: Binding,
         side: CardSide,
     ) {
+        val bindings = ReviewerBinding.fromPreferenceString(value).toMutableList()
+        // remove duplicate bindings
+        bindings.firstOrNull { it.binding == binding }?.let {
+            bindings.remove(it)
+        }
         val newBinding = ReviewerBinding(binding, side)
         getPreferenceAssignedTo(binding)?.removeMappableBinding(newBinding)
-        val bindings = ReviewerBinding.fromPreferenceString(value).toMutableList()
         bindings.add(newBinding)
         value = bindings.toPreferenceString()
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

## Fixes
* Fixes #18841

## Approach

Instead of combining the bindings, I let it override the binding because I think it is more expected.

## How Has This Been Tested?

With an Android 11 emulator, I assigned the same gesture, but with different card sides to see if the side would get overriden.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->