### PR TITLE
improve study shortcut

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -453,17 +453,23 @@ abstract class NavigationDrawerActivity :
                 return
             }
             // Review Cards Shortcut
-            val intentReviewCards = Reviewer.getIntent(context)
-            intentReviewCards.action = Intent.ACTION_VIEW
-            intentReviewCards.flags = Intent.FLAG_ACTIVITY_CLEAR_TASK
-            intentReviewCards.putExtra(EXTRA_STARTED_WITH_SHORTCUT, true)
+            val intentReviewCards =
+                Reviewer.getIntent(context).apply {
+                    action = Intent.ACTION_VIEW
+                    flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+                    putExtra(EXTRA_STARTED_WITH_SHORTCUT, true)
+                }
+            val deckPickerIntent =
+                Intent(context, IntentHandler::class.java).apply {
+                    action = Intent.ACTION_VIEW
+                }
             val reviewCardsShortcut =
                 ShortcutInfoCompat
                     .Builder(context, "reviewCardsShortcutId")
                     .setShortLabel(context.getString(R.string.studyoptions_start))
                     .setLongLabel(context.getString(R.string.studyoptions_start))
                     .setIcon(IconCompat.createWithResource(context, R.drawable.review_shortcut))
-                    .setIntent(intentReviewCards)
+                    .setIntents(arrayOf(deckPickerIntent, intentReviewCards))
                     .build()
 
             // Add Shortcut


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

If I open the study shortcut and the deck has no pending cards, the screen closes without any warning nor try to check if there are other decks to review

## Fixes
* Fixes the issue above

## Approach

It adds the deck picker to the task stack in the Study shorcut like the deck specific shortcuts already do

## How Has This Been Tested?

https://github.com/user-attachments/assets/2e0c00e0-4f8d-4837-b27e-655ad22f3141


https://github.com/user-attachments/assets/67400ad2-a8ee-42f2-8ad6-0457ca196dd7


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->