### PR TITLE
refactor: remove granular snooze settings

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
@@ -26,7 +26,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 class ReviewReminderTest : RobolectricTest() {
@@ -48,7 +47,6 @@ class ReviewReminderTest : RobolectricTest() {
             val reminder =
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(12, 30),
-                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 3),
                     ReviewReminderCardTriggerThreshold(0),
                     ReviewReminderScope.DeckSpecific(5),
                 )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -30,7 +30,6 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 class ReviewRemindersDatabaseTest : RobolectricTest() {
@@ -45,7 +44,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewReminderId(0) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(9, 0),
-                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 2),
                     ReviewReminderCardTriggerThreshold(5),
                     ReviewReminderScope.DeckSpecific(did1),
                     false,
@@ -53,7 +51,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewReminderId(1) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(10, 30),
-                    ReviewReminderSnoozeAmount.Infinite(15.minutes),
                     ReviewReminderCardTriggerThreshold(10),
                     ReviewReminderScope.DeckSpecific(did1),
                 ),
@@ -63,7 +60,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewReminderId(2) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(10, 30),
-                    ReviewReminderSnoozeAmount.SetAmount(15.minutes, 2),
                     ReviewReminderCardTriggerThreshold(10),
                     ReviewReminderScope.DeckSpecific(did2),
                     true,
@@ -71,7 +67,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewReminderId(3) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(12, 30),
-                    ReviewReminderSnoozeAmount.Disabled,
                     ReviewReminderCardTriggerThreshold(20),
                     ReviewReminderScope.DeckSpecific(did2),
                 ),
@@ -81,13 +76,11 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             ReviewReminderId(4) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(9, 0),
-                    ReviewReminderSnoozeAmount.SetAmount(30.minutes, 1),
                     ReviewReminderCardTriggerThreshold(5),
                 ),
             ReviewReminderId(5) to
                 ReviewReminder.createReviewReminder(
                     ReviewReminderTime(10, 30),
-                    ReviewReminderSnoozeAmount.Infinite(60.minutes),
                     ReviewReminderCardTriggerThreshold(10),
                 ),
         )
@@ -155,7 +148,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 ReviewReminderId(0) to
                     ReviewReminder.createReviewReminder(
                         ReviewReminderTime(9, 0),
-                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
                         ReviewReminderCardTriggerThreshold(5),
                         ReviewReminderScope.DeckSpecific(did1),
                     ),
@@ -165,7 +157,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 ReviewReminderId(1) to
                     ReviewReminder.createReviewReminder(
                         ReviewReminderTime(10, 30),
-                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
                         ReviewReminderCardTriggerThreshold(10),
                         ReviewReminderScope.DeckSpecific(did2),
                     ),
@@ -175,7 +166,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 ReviewReminderId(2) to
                     ReviewReminder.createReviewReminder(
                         ReviewReminderTime(10, 45),
-                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
                         ReviewReminderCardTriggerThreshold(10),
                         ReviewReminderScope.DeckSpecific(did2),
                     ),
@@ -185,7 +175,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 ReviewReminderId(3) to
                     ReviewReminder.createReviewReminder(
                         ReviewReminderTime(11, 0),
-                        ReviewReminderSnoozeAmount.SetAmount(15.minutes, 1),
                         ReviewReminderCardTriggerThreshold(25),
                         ReviewReminderScope.DeckSpecific(did3),
                     ),


### PR DESCRIPTION
## Purpose / Description
- Removed `ReviewReminderSnoozeAmount` as we will now be providing snooze settings at the app-wide level rather than the reminder-specific level; this reduces the complexity of the review reminders system for the user -- it is unlikely that a user will need to customize snoozing on a per-reminder basis
- Updated unit tests to adhere to this change

## Fixes
* For GSoC 2025: Review Reminders.

## Approach
- Deletion!

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.
- Unit tests pass.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->