### PR TITLE
refactor: clean up ReviewReminderScope.DeckSpecific.getDeckName

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -45,7 +45,7 @@ value class ReviewReminderId(
         fun getAndIncrementNextFreeReminderId(): ReviewReminderId {
             val nextFreeId = Prefs.reviewReminderNextFreeId
             Prefs.reviewReminderNextFreeId = nextFreeId + 1
-            Timber.d("Generated next free review reminder ID: $nextFreeId")
+            Timber.d("Generated next free review reminder ID: %s", nextFreeId)
             return ReviewReminderId(nextFreeId)
         }
     }
@@ -122,7 +122,13 @@ sealed class ReviewReminderScope : Parcelable {
          * Caches the resultant deck name to minimize calls to the collection.
          * Should not be called if [did] is no longer a valid deck ID. If [did] is invalid, this method will return "[no deck]".
          */
-        suspend fun getDeckName(): String = cachedDeckName ?: withCol { decks.name(did) }.also { cachedDeckName = it }
+        suspend fun getDeckName(): String {
+            cachedDeckName?.let { return it }
+            val retrievedDeckName = withCol { decks.name(did) }
+            Timber.d("Retrieved deck name for review reminder: %s", retrievedDeckName)
+            cachedDeckName = retrievedDeckName
+            return retrievedDeckName
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose / Description
- Makes `ReviewReminderScope.DeckSpecific.getDeckName()` more readable
- Adds a logger for debugging purposes

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- It's a little refactor! Didn't really belong with any of the other atomic PRs I'm planning. Might as well get it in quickly.

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->