### PR TITLE
refactor: make DeckDropDownAdapter SubtitleListener cast safe

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckDropDownAdapter.kt
@@ -87,7 +87,7 @@ class DeckDropDownAdapter(
             val deckName = deck.name
             deckNameView!!.text = deckName
         }
-        deckCountsView!!.text = (context as SubtitleListener).subtitleText
+        deckCountsView!!.text = (context as? SubtitleListener)?.subtitleText ?: ""
         return convertView
     }
 


### PR DESCRIPTION
## Purpose / Description
- I found that DeckDropDownAdapter requires an active context to be a SubtitleListener, meaning it has to have a subtitleText field. This is used in screens like the card browser to show the deck selected in the toolbar, but I don’t need this. I noticed NoteEditor doesn’t need it either and the way it gets around this requirement is that… it implements SubtitleListener and just creates a useless subtitleText field that always returns “”. That felt a bit hacky to copy, what do you think about this little edit I’ve done to DeckDropDownAdapter in this PR to make the cast to SubtitleListener null-safe? It’s the most minimal change I can make, anything more would probably require a large refactor that I feel a bit nervous about undertaking. Should I just copy NoteEditor and make a dummy subtitleText field?

```
// The hacky method in NoteEditor:
override val subtitleText: String
    get() = ""
```

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- I need to be able to add a DeckDropDownAdapter for the DeckSpinner in the AddEditReminderDialog.

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->