### PR TITLE
refactor: delete bulk deletion, use separate prefs file

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
@@ -19,7 +19,6 @@ package com.ichi2.anki.reviewreminders
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.preferences.sharedPrefs
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
@@ -32,13 +31,13 @@ class ReviewReminderTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
-        // Reset the database after each test
-        targetContext.sharedPrefs().edit { clear() }
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -37,7 +37,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
 
     private val did1 = 12345L
     private val did2 = 67890L
-    private val did3 = 13579L
 
     private val dummyDeckSpecificRemindersForDeckOne =
         mapOf(
@@ -139,64 +138,6 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
         reviewRemindersDatabase.editAllAppWideReminders { dummyAppWideReminders }
         val storedReminders = reviewRemindersDatabase.getAllAppWideReminders()
         assertThat(storedReminders, equalTo(dummyAppWideReminders))
-    }
-
-    @Test
-    fun `editAllDeckSpecificReminders should update all reminders across decks`() {
-        val reminders1Old =
-            mapOf(
-                ReviewReminderId(0) to
-                    ReviewReminder.createReviewReminder(
-                        ReviewReminderTime(9, 0),
-                        ReviewReminderCardTriggerThreshold(5),
-                        ReviewReminderScope.DeckSpecific(did1),
-                    ),
-            )
-        val reminders2Old =
-            mapOf(
-                ReviewReminderId(1) to
-                    ReviewReminder.createReviewReminder(
-                        ReviewReminderTime(10, 30),
-                        ReviewReminderCardTriggerThreshold(10),
-                        ReviewReminderScope.DeckSpecific(did2),
-                    ),
-            )
-        val reminders2New =
-            mapOf(
-                ReviewReminderId(2) to
-                    ReviewReminder.createReviewReminder(
-                        ReviewReminderTime(10, 45),
-                        ReviewReminderCardTriggerThreshold(10),
-                        ReviewReminderScope.DeckSpecific(did2),
-                    ),
-            )
-        val reminders3New =
-            mapOf(
-                ReviewReminderId(3) to
-                    ReviewReminder.createReviewReminder(
-                        ReviewReminderTime(11, 0),
-                        ReviewReminderCardTriggerThreshold(25),
-                        ReviewReminderScope.DeckSpecific(did3),
-                    ),
-            )
-
-        reviewRemindersDatabase.editRemindersForDeck(did1) { reminders1Old }
-        reviewRemindersDatabase.editRemindersForDeck(did2) { reminders2Old }
-
-        reviewRemindersDatabase.editAllDeckSpecificReminders { reminders2New + reminders3New }
-
-        val storedReminders1 = reviewRemindersDatabase.getRemindersForDeck(did1)
-        val storedReminders2 = reviewRemindersDatabase.getRemindersForDeck(did2)
-        val storedReminders3 = reviewRemindersDatabase.getRemindersForDeck(did3)
-        val allStoredReminders = reviewRemindersDatabase.getAllDeckSpecificReminders()
-
-        assertThat(storedReminders1, anEmptyMap())
-        assertThat(storedReminders2, equalTo(reminders2New))
-        assertThat(storedReminders3, equalTo(reminders3New))
-        assertThat(
-            allStoredReminders,
-            equalTo(reminders2New + reminders3New),
-        )
     }
 
     @Test(expected = SerializationException::class)


### PR DESCRIPTION
## Purpose / Description
- Since we are removing bulk-deletion functionality, we can delete the database methods that were added to facilitate it: `getAllDeckSpecificRemindersGrouped` and `editAllDeckSpecificReminders`
- Rewrote `getAllDeckSpecificReminders` to not rely on helper methods and be a little more functional in style
- Removed related tests
- Stops writing to the default SharedPreferences when storing review reminders, instead uses a new file
- Cleans up logic for backing up review reminders in the Database file into three methods: `getAllReviewReminderSharedPrefsAsMap`, `deleteAllReviewReminderSharedPrefs`, and `writeAllReviewReminderSharedPrefsFromMap`; these methods will be used by ScheduleReminders when the schema migration code is pushed
- Refactored tests to comply with the above changes

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Deletion!

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->