### PR TITLE
feat(reminders): add ScheduleReminders DeckSpinner init method

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -152,6 +152,39 @@ class DeckSpinnerSelection(
         }
     }
 
+    @MainThread // spinner.adapter
+    suspend fun initializeScheduleRemindersDeckSpinner() {
+        withCol {
+            decks.allNamesAndIds(includeFiltered = showFilteredDecks, skipEmptyDefault = true)
+        }.toMutableList().let { decks ->
+            dropDownDecks = decks
+            val deckNames = decks.map { it.name }
+            val noteDeckAdapter: ArrayAdapter<String?> =
+                object :
+                    ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {
+                    override fun getDropDownView(
+                        position: Int,
+                        convertView: View?,
+                        parent: ViewGroup,
+                    ): View {
+                        // Cast the drop down items (popup items) as text view
+                        val tv = super.getDropDownView(position, convertView, parent) as TextView
+
+                        // If this item is selected
+                        if (position == spinner.selectedItemPosition) {
+                            tv.setBackgroundColor(context.getColor(R.color.note_editor_selected_item_background))
+                            tv.setTextColor(context.getColor(R.color.note_editor_selected_item_text))
+                        }
+
+                        // Return the modified view
+                        return tv
+                    }
+                }
+            spinner.adapter = noteDeckAdapter
+            setSpinnerListener()
+        }
+    }
+
     /** @return All decks.  */
     suspend fun computeDropDownDecks(includeFiltered: Boolean): List<DeckNameId> = withCol { computeDropDownDecks(this, includeFiltered) }
 


### PR DESCRIPTION
## Purpose / Description
- When initializing the deck spinner in AddEditReminderDialog, I wanted to use initializeNoteEditorDeckSpinner, but it was annotated with MainThread which meant I couldn’t use withCol and would have had to use getColUnsafe, which I think we’re not supposed to use anymore? I wasn’t sure if I was allowed to refactor everything, so I created a new method that calls withCol internally and tried to copy-paste the format of the other initialization methods. Are these methods supposed to be annotated with MainThread? There’s an annotation at the top of the file marked “this class is a mess…” so I assume it’s due for a refactoring?

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Adds a new method. Basically a copy-paste of other methods in this class. Attempts to conform to the existing code style rather than undertake refactoring.

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->