### PR TITLE
refactor(libanki): begin removing AnkiDroid dependencies from `TestClass` 

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -36,6 +36,7 @@ import com.ichi2.testutils.BackupManagerTestUtilities
 import com.ichi2.testutils.DbUtils
 import com.ichi2.testutils.common.Flaky
 import com.ichi2.testutils.common.OS
+import com.ichi2.testutils.ext.addBasicNoteWithOp
 import com.ichi2.testutils.ext.menu
 import com.ichi2.testutils.grantWritePermissions
 import com.ichi2.testutils.revokeWritePermissions

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -71,6 +71,7 @@ import com.ichi2.testutils.TestClass
 import com.ichi2.testutils.createTransientDirectory
 import com.ichi2.testutils.ensureNoOpsExecuted
 import com.ichi2.testutils.ensureOpsExecuted
+import com.ichi2.testutils.ext.reopenWithLanguage
 import com.ichi2.testutils.mockIt
 import kotlinx.coroutines.flow.first
 import org.hamcrest.MatcherAssert.assertThat

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -17,7 +17,6 @@
 package com.ichi2.testutils
 
 import android.annotation.SuppressLint
-import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.ioDispatcher
 import com.ichi2.anki.isCollectionEmpty
@@ -32,7 +31,6 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
-import com.ichi2.anki.observability.undoableOp
 import com.ichi2.testutils.ext.addNote
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -105,17 +103,6 @@ interface TestClass {
         check(col.addNote(n) != 0) { "Could not add note: {${fields.joinToString(separator = ", ")}}" }
         return n
     }
-
-    suspend fun addBasicNoteWithOp(
-        fields: List<String> = listOf("foo", "bar"),
-        noteType: NotetypeJson = col.notetypes.byName("Basic")!!,
-    ): Note =
-        col.newNote(noteType).also { note ->
-            for ((i, field) in fields.withIndex()) {
-                note.setField(i, field)
-            }
-            undoableOp<OpChanges> { col.addNote(note, Consts.DEFAULT_DECK_ID) }
-        }
 
     /**
      * Create a new note type in the collection.
@@ -244,14 +231,6 @@ interface TestClass {
         col.updateNote(this)
         return this
     }
-
-    /** Helper method to update a note */
-    @SuppressLint("CheckResult")
-    suspend fun Note.updateOp(block: Note.() -> Unit): Note =
-        this.also { note ->
-            block(note)
-            undoableOp<OpChanges> { col.updateNote(note) }
-        }
 
     /** Helper method to all cards of a note */
     fun Note.updateCards(update: Card.() -> Unit): Note {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/TestClass.kt
@@ -17,7 +17,6 @@
 package com.ichi2.testutils
 
 import android.annotation.SuppressLint
-import androidx.appcompat.app.AppCompatDelegate
 import anki.collection.OpChanges
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.ioDispatcher
@@ -35,7 +34,6 @@ import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.testutils.ext.addNote
-import com.ichi2.utils.LanguageUtil
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
@@ -205,20 +203,6 @@ interface TestClass {
     /** Ensures [isCollectionEmpty] returns `false` */
     fun ensureNonEmptyCollection() {
         addNotes(1)
-    }
-
-    /**
-     * Closes and reopens the backend using the provided [language], typically for
-     * [CollectionManager.TR] calls
-     *
-     * This does not set the [application locales][AppCompatDelegate.setApplicationLocales]
-     *
-     * @param language tag in the form: `de` or `zh-CN`
-     */
-    suspend fun Collection.reopenWithLanguage(language: String) {
-        LanguageUtil.setDefaultBackendLanguages(language)
-        CollectionManager.discardBackend()
-        CollectionManager.getColUnsafe()
     }
 
     fun selectDefaultDeck() {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ext/Collection.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ext/Collection.kt
@@ -16,10 +16,28 @@
 
 package com.ichi2.testutils.ext
 
+import androidx.appcompat.app.AppCompatDelegate
+import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Note
+import com.ichi2.utils.LanguageUtil
 
 fun Collection.addNote(note: Note): Int {
     addNote(note, note.notetype.did)
     return note.numberOfCards(this)
+}
+
+/**
+ * Closes and reopens the backend using the provided [language], typically for
+ * [CollectionManager.TR] calls
+ *
+ * This does not set the [application locales][AppCompatDelegate.setApplicationLocales]
+ *
+ * @param language tag in the form: `de` or `zh-CN`
+ */
+@Suppress("UnusedReceiverParameter")
+suspend fun Collection.reopenWithLanguage(language: String) {
+    LanguageUtil.setDefaultBackendLanguages(language)
+    CollectionManager.discardBackend()
+    CollectionManager.getColUnsafe()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ext/TestClass.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ext/TestClass.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.ext
+
+import anki.collection.OpChanges
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.Note
+import com.ichi2.anki.libanki.NotetypeJson
+import com.ichi2.anki.observability.undoableOp
+import com.ichi2.testutils.TestClass
+
+suspend fun TestClass.addBasicNoteWithOp(
+    fields: List<String> = listOf("foo", "bar"),
+    noteType: NotetypeJson = col.notetypes.byName("Basic")!!,
+): Note =
+    col.newNote(noteType).also { note ->
+        for ((i, field) in fields.withIndex()) {
+            note.setField(i, field)
+        }
+        undoableOp<OpChanges> { col.addNote(note, Consts.DEFAULT_DECK_ID) }
+    }

--- a/common/src/main/java/com/ichi2/anki/common/annotations/UseContextParameter.kt
+++ b/common/src/main/java/com/ichi2/anki/common/annotations/UseContextParameter.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.common.annotations
+
+/**
+ * Use when code should be converted to use context parameters (Kotlin 2.2.0)
+ *
+ * Context parameters are not yet supported by AnkiDroid
+ * https://github.com/JLLeitschuh/ktlint-gradle/issues/912
+ *
+ * @param toExtend the name of the class to extend
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class UseContextParameter(
+    val toExtend: String,
+)


### PR DESCRIPTION
I split this out from https://github.com/ankidroid/Anki-Android/pull/18813 to make it an easier review

* https://github.com/ankidroid/Anki-Android/pull/18813

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->