### PR TITLE
build(deps): adopt Anki-Android-Backend 0.1.58-anki25.07.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.2"
-ankiBackend = '0.1.57-anki25.07.1'
+ankiBackend = '0.1.58-anki25.07.2'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION
Per [discussion here ](https://github.com/ankidroid/Anki-Android-Backend/pull/551#issuecomment-3066000871)- plan is:

- adopt this so we have current anki which will likely go live
- start pushing betas from main with a 2.22.0 release goal


(close and reopen once 0.1.58-anki25.07.2 is available [on maven here](https://repo1.maven.org/maven2/io/github/david-allison/anki-android-backend/))