### PR TITLE
feat(reminders): make ReviewReminder Parcelable

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -33,9 +33,10 @@ import kotlin.time.Duration.Companion.minutes
 
 @JvmInline
 @Serializable
+@Parcelize
 value class ReviewReminderId(
     val id: Int,
-) {
+) : Parcelable {
     companion object {
         /**
          * Get and return the next free reminder ID which can be associated with a new review reminder.
@@ -55,10 +56,11 @@ value class ReviewReminderId(
  * The time of day at which reminders will send a notification.
  */
 @Serializable
+@Parcelize
 data class ReviewReminderTime(
     val hour: Int,
     val minute: Int,
-) {
+) : Parcelable {
     init {
         require(hour in 0..23) { "Hour must be between 0 and 23" }
         require(minute in 0..59) { "Minute must be between 0 and 59" }
@@ -81,9 +83,10 @@ data class ReviewReminderTime(
  */
 @JvmInline
 @Serializable
+@Parcelize
 value class ReviewReminderCardTriggerThreshold(
     val threshold: Int,
-) {
+) : Parcelable {
     init {
         require(threshold >= 0) { "Card trigger threshold must be >= 0" }
     }
@@ -160,6 +163,7 @@ sealed class ReviewReminderScope : Parcelable {
  * @param enabled Whether the review reminder's notifications are active or disabled.
  */
 @Serializable
+@Parcelize
 @ConsistentCopyVisibility
 data class ReviewReminder private constructor(
     val id: ReviewReminderId,
@@ -167,7 +171,7 @@ data class ReviewReminder private constructor(
     val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
     val scope: ReviewReminderScope,
     var enabled: Boolean,
-) {
+) : Parcelable {
     companion object {
         /**
          * Create a new review reminder. This will allocate a new ID for the reminder.


### PR DESCRIPTION
## Purpose / Description
- Makes `ReviewReminder` Parcelable so that it can be passed to and from the AddEditReminderDialog -- the AddEditReminderDialog will receive a `ReviewReminder` to edit via arguments and return one via a FragmentResult, `ReviewReminder` must be Parcelable to allow this to happen

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Annotations!

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->