### PR TITLE
fix: "x cards shown" snackbar isn't automatically dismissed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1638,7 +1638,7 @@ open class CardBrowser :
                     } else {
                         subtitleText
                     }
-                showSnackbar(message, Snackbar.LENGTH_INDEFINITE) {
+                showSnackbar(message, Snackbar.LENGTH_SHORT) {
                     setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
                 }
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
"X cards shown" snackbar in the card browser stayed open indefinitely.

## Fixes
* Fixes #18686

## Approach
Changed the snackbar duration from `LENGTH_INDEFINITE` to `LENGTH_SHORT`. Similar to the other snackbars. 

## How Has This Been Tested?
Emulator API 35

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x]  You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->