### PR TITLE
fix(widget): disable "material you" if using MIUI

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.tests
 
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.view.LayoutInflater
@@ -104,7 +105,12 @@ class LayoutValidationTest : InstrumentedTest() {
                 listOf(
                     com.ichi2.anki.R.layout.activity_manage_space,
                     com.ichi2.anki.R.layout.introduction_activity,
-                )
+                ) +
+                    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+                        listOf(com.ichi2.anki.R.layout.widget_small_unthemed)
+                    } else {
+                        emptyList()
+                    }
 
             return layout::class.java.fields
                 .map { arrayOf(it.getInt(layout), it.name) }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -17,6 +17,7 @@ package com.ichi2.utils
 
 import android.annotation.SuppressLint
 import android.app.ActivityManager
+import android.content.ComponentName
 import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
@@ -140,4 +141,40 @@ object AdaptionUtil {
             val manufacturer = Build.MANUFACTURER ?: return false
             return manufacturer.lowercase(Locale.ROOT) == "vivo"
         }
+
+    val isMiui: Boolean by lazy {
+        val ctx: Context = AnkiDroidApp.instance
+
+        // https://stackoverflow.com/questions/47610456/how-to-detect-miui-rom-programmatically-in-android
+        fun isIntentResolved(intent: Intent): Boolean =
+            (ctx.packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null)
+
+        return@lazy try {
+            isIntentResolved(
+                Intent("miui.intent.action.OP_AUTO_START").addCategory(Intent.CATEGORY_DEFAULT),
+            ) ||
+                isIntentResolved(
+                    Intent().setComponent(
+                        ComponentName(
+                            "com.miui.securitycenter",
+                            "com.miui.permcenter.autostart.AutoStartManagementActivity",
+                        ),
+                    ),
+                ) ||
+                isIntentResolved(
+                    Intent("miui.intent.action.POWER_HIDE_MODE_APP_LIST").addCategory(Intent.CATEGORY_DEFAULT),
+                ) ||
+                isIntentResolved(
+                    Intent().setComponent(
+                        ComponentName(
+                            "com.miui.securitycenter",
+                            "com.miui.powercenter.PowerSettings",
+                        ),
+                    ),
+                )
+        } catch (e: Exception) {
+            Timber.w(e)
+            false
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -28,6 +28,7 @@ import android.os.IBinder
 import android.util.TypedValue
 import android.view.View
 import android.widget.RemoteViews
+import androidx.annotation.LayoutRes
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
@@ -96,9 +97,16 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
             manager.updateAppWidget(thisWidget, updateViews)
         }
 
+        @get:LayoutRes
+        private val widgetSmallLayout: Int
+            get() {
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return R.layout.widget_small
+                return if (disableMaterialYouDynamicColor) R.layout.widget_small_unthemed else R.layout.widget_small
+            }
+
         private fun buildUpdate(context: Context): RemoteViews {
             Timber.d("buildUpdate")
-            val updateViews = RemoteViews(context.packageName, R.layout.widget_small)
+            val updateViews = RemoteViews(context.packageName, widgetSmallLayout)
             val mounted = AnkiDroidApp.isSdCardMounted
             if (!mounted) {
                 updateViews.setViewVisibility(R.id.widget_due, View.INVISIBLE)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetUtils.kt
@@ -18,6 +18,7 @@ package com.ichi2.widget
 
 import android.appwidget.AppWidgetManager
 import android.content.Context
+import com.ichi2.utils.AdaptionUtil
 
 /**
  * @return An [AppWidgetManager] for the provided context, or `null`
@@ -30,3 +31,10 @@ fun getAppWidgetManager(context: Context): AppWidgetManager? {
     // the result is assumed to be non-null in Kotlin
     return AppWidgetManager.getInstance(context)
 }
+
+/** Whether 'Material You' dynamic color should be used for widgets */
+val disableMaterialYouDynamicColor: Boolean
+    // #18869: MIUI 14 (Android 13) doesn't support Material You well - the color is
+    // based on the system background color, with no means to disable it.
+    // unconfirmed if this is fixed in future MIUI versions
+    get() = AdaptionUtil.isMiui

--- a/AnkiDroid/src/main/res/drawable-v31/ic_anki_unthemed.xml
+++ b/AnkiDroid/src/main/res/drawable-v31/ic_anki_unthemed.xml
@@ -1,0 +1,115 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+    <path
+        android:pathData="M142,161c0,6.6 -5.4,12 -12,12H34.3c-6.6,0 -12,-5.4 -12,-12V24c0,-6.6 5.4,-12 12,-12H130c6.6,0 12,5.4 12,12V161z"
+        android:fillColor="#2F3036"/>
+    <path
+        android:pathData="M127.7,14.6H36.5C22,14.6 22.3,24 22.3,24c0,-6.6 5.4,-12 12,-12H130c6.6,0 12,5.4 12,12C142,24 141.7,14.6 127.7,14.6z"
+        android:fillColor="#E2E2E9"
+        android:fillAlpha="0.1"/>
+    <path
+        android:pathData="M36.5,167h91.2c14.5,0 14.3,-6 14.3,-6c0,6.6 -5.4,12 -12,12H34.2c-6.6,0 -12,-5.4 -12,-12C22.2,161 22.5,167 36.5,167z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3" />
+
+    <path
+        android:pathData="M35.8,104.2h40v6h-40z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M35.8,126.9h20v6h-20z"
+        android:fillColor="#5D5E64" />
+
+    <path
+        android:pathData="M35.3,148.4h42v6h-42z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M35.8,104.2h40v6h-40z"
+        android:fillColor="#1A1B20" />
+
+    <path
+        android:pathData="M35.8,126.9h20v6h-20z"
+        android:fillColor="#1A1B20" />
+    <path
+        android:pathData="M35.3,148.4h42v6h-42z"
+        android:fillColor="#1A1B20" />
+    <path
+        android:pathData="M35.8,27.9h69.5v6h-69.5z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M35.8,48.7h22.4v6h-22.4z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M36.3,70.2h36.8v6h-36.8z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M65.9,48.7h22.4v6h-22.4z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M35.8,27.9h69.5v6h-69.5z"
+        android:strokeAlpha="0.2"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M35.8,48.7h22.4v6h-22.4z"
+        android:strokeAlpha="0.2"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M36.3,70.2h36.8v6h-36.8z"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M65.9,48.7h22.4v6h-22.4z"
+        android:strokeAlpha="0.2"
+        android:fillColor="#5D5E64" />
+    <path
+        android:pathData="M106.2,59.6c-1,0 -2.1,0.1 -3.1,0.4c-4.2,1.4 -6.3,5.4 -7.3,9.1s-1.2,7.8 -1.3,11.9c-0.1,4.1 -0.2,8.3 -0.5,11.7c-0.3,3.4 -1.2,5.9 -1.7,6.6s-2.7,2.3 -5.8,3.6c-3.1,1.4 -7,2.7 -10.9,4.1s-7.7,2.9 -11,4.9c-3.2,2 -6.4,5.2 -6.4,9.7s3.1,7.6 6.4,9.7s7,3.5 10.9,5c3.9,1.4 7.8,2.7 10.9,4.1c3.1,1.4 5.3,2.9 5.8,3.6c0.5,0.7 1.3,3.3 1.6,6.7c0.3,3.4 0.4,7.5 0.5,11.7c0.1,4.1 0.4,8.2 1.3,11.9s3,7.7 7.2,9.1c4.2,1.4 8.2,-0.6 11.2,-3.1s5.6,-5.6 8.1,-8.8s5,-6.6 7.3,-9.1s4.4,-4.2 5.3,-4.4c0.8,-0.3 3.5,-0.2 6.8,0.5s7.3,2 11.2,3.1c4,1.1 7.9,2.2 11.7,2.4s8.2,-0.5 10.9,-4.1c2.6,-3.6 2,-8 0.6,-11.6s-3.6,-7 -5.9,-10.4c-2.3,-3.4 -4.7,-6.8 -6.4,-9.7c-1.7,-2.9 -2.6,-5.5 -2.6,-6.4c0,-1 1.1,-4 3.3,-7.4c2.1,-3.4 5,-7.3 7.5,-11.1c2,-3 3.7,-6.1 4.8,-9.2c1,-3.2 1.3,-7.1 -1,-10.3c-2.6,-3.6 -7,-4.3 -10.9,-4.1c-3.8,0.2 -7.8,1.3 -11.8,2.4s-7.9,2.4 -11.2,3.1s-6,0.7 -6.8,0.5s-3,-1.9 -5.3,-4.4c-2.3,-2.6 -4.7,-5.9 -7.2,-9.2c-2.5,-3.3 -5.1,-6.4 -8.1,-8.9C112,61.3 109.2,59.7 106.2,59.6L106.2,59.6z"
+        android:fillColor="#D9E2FF"/>
+  <path
+      android:pathData="M105.7,68.2c0.4,-0.1 1.2,-0.1 3.1,1.5s4.3,4.4 6.8,7.5c2.4,3.1 4.9,6.6 7.6,9.5c2.6,3 5.2,5.7 9,6.9c4,1.3 8,0.7 11.4,-0.3c3.9,-0.9 7.9,-2.1 11.7,-3.2s7.4,-2 9.9,-2.1c2.5,-0.2 3.2,0.3 3.4,0.6c0.2,0.3 0.4,0.8 -0.2,2.6s-2,4.5 -3.8,7.2c-2.3,3.5 -5.1,7.4 -7.5,11.2c-2.4,3.8 -4.6,7.5 -4.6,12c0,4 1.8,7.3 3.8,10.7s4.5,6.9 6.7,10.2s4.1,6.4 5.1,8.8c0.9,2.3 0.7,3.1 0.5,3.4c-0.2,0.3 -0.9,0.7 -3.4,0.6c-2.5,-0.2 -6.1,-1 -9.9,-2.1c-3.8,-1.1 -7.9,-2.4 -11.7,-3.3c-3.9,-0.9 -7.6,-1.5 -11.4,-0.3c-3.8,1.2 -6.4,3.9 -9,6.9s-5.2,6.4 -7.6,9.5s-4.9,5.9 -6.8,7.5s-2.7,1.7 -3.1,1.5c-0.4,-0.1 -1,-0.6 -1.6,-3.1s-0.9,-6.1 -1,-10.1s-0.2,-8.2 -0.5,-12.2c-0.4,-4 -0.9,-7.7 -3.2,-10.9c-2.3,-3.2 -5.7,-4.9 -9.3,-6.5s-7.7,-2.9 -11.4,-4.3c-3.7,-1.4 -7.1,-2.8 -9.3,-4.1c-2.1,-1.4 -2.4,-2.1 -2.4,-2.5s0.3,-1.1 2.4,-2.4c2.2,-1.4 5.7,-2.9 9.3,-4.1c3.7,-1.4 7.8,-2.7 11.4,-4.3c3.6,-1.6 7,-3.2 9.3,-6.4c2.3,-3.2 2.9,-7 3.3,-10.9s0.4,-8.2 0.6,-12.2c0.1,-4 0.4,-7.6 1.1,-10.1C104.7,68.8 105.3,68.3 105.7,68.2L105.7,68.2z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="98.7147"
+          android:startX="79.9001"
+          android:endY="151.12"
+          android:endX="170.6686"
+          android:type="linear">
+        <item android:offset="0" android:color="#94AAE4"/>
+      <item android:offset="1" android:color="#6076AC"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M142.3,160.5c0,6.6 -5.4,12 -12,12H34.6c-6.6,0 -12,-5.4 -12,-12v-137c0,-6.6 5.4,-12 12,-12h95.7c6.6,0 12,5.4 12,12L142.3,160.5L142.3,160.5z"
+      android:strokeAlpha="0.1"
+      android:fillAlpha="0.1">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="25.35"
+          android:startX="15.8"
+          android:endY="158.65"
+          android:endX="149.1"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFFFFF"/>
+        <item android:offset="1" android:color="#00000000"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M142.3,160.5c0,6.6 -5.4,12 -12,12H34.6c-6.6,0 -12,-5.4 -12,-12v-137c0,-6.6 5.4,-12 12,-12h95.7c6.6,0 12,5.4 12,12L142.3,160.5L142.3,160.5z"
+      android:strokeAlpha="0.1"
+      android:fillAlpha="0.1">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="92"
+          android:startX="22.6"
+          android:endY="92"
+          android:endX="142.3"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFFFFF"/>
+        <item android:offset="1" android:color="#00000000"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/AnkiDroid/src/main/res/drawable-v31/ic_anki_unthemed_finish.xml
+++ b/AnkiDroid/src/main/res/drawable-v31/ic_anki_unthemed_finish.xml
@@ -1,0 +1,115 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="192dp"
+    android:height="192dp"
+    android:viewportWidth="192"
+    android:viewportHeight="192">
+  <path
+      android:pathData="M142,161c0,6.6 -5.4,12 -12,12H34.3c-6.6,0 -12,-5.4 -12,-12V24c0,-6.6 5.4,-12 12,-12H130c6.6,0 12,5.4 12,12V161z"
+      android:fillColor="#2F3036"/>
+  <path
+      android:pathData="M127.7,14.6H36.5C22,14.6 22.3,24 22.3,24c0,-6.6 5.4,-12 12,-12H130c6.6,0 12,5.4 12,12C142,24 141.7,14.6 127.7,14.6z"
+      android:fillColor="#E2E2E9"
+      android:fillAlpha="0.1"/>
+  <path
+      android:pathData="M36.5,167h91.2c14.5,0 14.3,-6 14.3,-6c0,6.6 -5.4,12 -12,12H34.2c-6.6,0 -12,-5.4 -12,-12C22.2,161 22.5,167 36.5,167z"
+        android:fillColor="#000000"
+        android:fillAlpha="0.3" />
+
+  <path
+      android:pathData="M35.8,104.2h40v6h-40z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M35.8,126.9h20v6h-20z"
+      android:fillColor="#5D5E64" />
+
+  <path
+      android:pathData="M35.3,148.4h42v6h-42z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M35.8,104.2h40v6h-40z"
+      android:fillColor="#1A1B20" />
+
+  <path
+      android:pathData="M35.8,126.9h20v6h-20z"
+      android:fillColor="#1A1B20" />
+  <path
+      android:pathData="M35.3,148.4h42v6h-42z"
+      android:fillColor="#1A1B20" />
+  <path
+      android:pathData="M35.8,27.9h69.5v6h-69.5z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M35.8,48.7h22.4v6h-22.4z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M36.3,70.2h36.8v6h-36.8z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M65.9,48.7h22.4v6h-22.4z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M35.8,27.9h69.5v6h-69.5z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M35.8,48.7h22.4v6h-22.4z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M36.3,70.2h36.8v6h-36.8z"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M65.9,48.7h22.4v6h-22.4z"
+      android:strokeAlpha="0.2"
+      android:fillColor="#5D5E64" />
+  <path
+      android:pathData="M106.2,59.6c-1,0 -2.1,0.1 -3.1,0.4c-4.2,1.4 -6.3,5.4 -7.3,9.1s-1.2,7.8 -1.3,11.9c-0.1,4.1 -0.2,8.3 -0.5,11.7c-0.3,3.4 -1.2,5.9 -1.7,6.6s-2.7,2.3 -5.8,3.6c-3.1,1.4 -7,2.7 -10.9,4.1s-7.7,2.9 -11,4.9c-3.2,2 -6.4,5.2 -6.4,9.7s3.1,7.6 6.4,9.7s7,3.5 10.9,5c3.9,1.4 7.8,2.7 10.9,4.1c3.1,1.4 5.3,2.9 5.8,3.6c0.5,0.7 1.3,3.3 1.6,6.7c0.3,3.4 0.4,7.5 0.5,11.7c0.1,4.1 0.4,8.2 1.3,11.9s3,7.7 7.2,9.1c4.2,1.4 8.2,-0.6 11.2,-3.1s5.6,-5.6 8.1,-8.8s5,-6.6 7.3,-9.1s4.4,-4.2 5.3,-4.4c0.8,-0.3 3.5,-0.2 6.8,0.5s7.3,2 11.2,3.1c4,1.1 7.9,2.2 11.7,2.4s8.2,-0.5 10.9,-4.1c2.6,-3.6 2,-8 0.6,-11.6s-3.6,-7 -5.9,-10.4c-2.3,-3.4 -4.7,-6.8 -6.4,-9.7c-1.7,-2.9 -2.6,-5.5 -2.6,-6.4c0,-1 1.1,-4 3.3,-7.4c2.1,-3.4 5,-7.3 7.5,-11.1c2,-3 3.7,-6.1 4.8,-9.2c1,-3.2 1.3,-7.1 -1,-10.3c-2.6,-3.6 -7,-4.3 -10.9,-4.1c-3.8,0.2 -7.8,1.3 -11.8,2.4s-7.9,2.4 -11.2,3.1s-6,0.7 -6.8,0.5s-3,-1.9 -5.3,-4.4c-2.3,-2.6 -4.7,-5.9 -7.2,-9.2c-2.5,-3.3 -5.1,-6.4 -8.1,-8.9C112,61.3 109.2,59.7 106.2,59.6L106.2,59.6z"
+      android:fillColor="#D9E2FF"/>
+  <path
+      android:pathData="M105.7,68.2c0.4,-0.1 1.2,-0.1 3.1,1.5s4.3,4.4 6.8,7.5c2.4,3.1 4.9,6.6 7.6,9.5c2.6,3 5.2,5.7 9,6.9c4,1.3 8,0.7 11.4,-0.3c3.9,-0.9 7.9,-2.1 11.7,-3.2s7.4,-2 9.9,-2.1c2.5,-0.2 3.2,0.3 3.4,0.6c0.2,0.3 0.4,0.8 -0.2,2.6s-2,4.5 -3.8,7.2c-2.3,3.5 -5.1,7.4 -7.5,11.2c-2.4,3.8 -4.6,7.5 -4.6,12c0,4 1.8,7.3 3.8,10.7s4.5,6.9 6.7,10.2s4.1,6.4 5.1,8.8c0.9,2.3 0.7,3.1 0.5,3.4c-0.2,0.3 -0.9,0.7 -3.4,0.6c-2.5,-0.2 -6.1,-1 -9.9,-2.1c-3.8,-1.1 -7.9,-2.4 -11.7,-3.3c-3.9,-0.9 -7.6,-1.5 -11.4,-0.3c-3.8,1.2 -6.4,3.9 -9,6.9s-5.2,6.4 -7.6,9.5s-4.9,5.9 -6.8,7.5s-2.7,1.7 -3.1,1.5c-0.4,-0.1 -1,-0.6 -1.6,-3.1s-0.9,-6.1 -1,-10.1s-0.2,-8.2 -0.5,-12.2c-0.4,-4 -0.9,-7.7 -3.2,-10.9c-2.3,-3.2 -5.7,-4.9 -9.3,-6.5s-7.7,-2.9 -11.4,-4.3c-3.7,-1.4 -7.1,-2.8 -9.3,-4.1c-2.1,-1.4 -2.4,-2.1 -2.4,-2.5s0.3,-1.1 2.4,-2.4c2.2,-1.4 5.7,-2.9 9.3,-4.1c3.7,-1.4 7.8,-2.7 11.4,-4.3c3.6,-1.6 7,-3.2 9.3,-6.4c2.3,-3.2 2.9,-7 3.3,-10.9s0.4,-8.2 0.6,-12.2c0.1,-4 0.4,-7.6 1.1,-10.1C104.7,68.8 105.3,68.3 105.7,68.2L105.7,68.2z">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="98.7147"
+          android:startX="79.9001"
+          android:endY="151.12"
+          android:endX="170.6686"
+          android:type="linear">
+          <item android:offset="0" android:color="#7A90C8"/>
+          <item android:offset="1" android:color="#475D92"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M142.3,160.5c0,6.6 -5.4,12 -12,12H34.6c-6.6,0 -12,-5.4 -12,-12v-137c0,-6.6 5.4,-12 12,-12h95.7c6.6,0 12,5.4 12,12L142.3,160.5L142.3,160.5z"
+      android:strokeAlpha="0.1"
+      android:fillAlpha="0.1">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="25.35"
+          android:startX="15.8"
+          android:endY="158.65"
+          android:endX="149.1"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFFFFF"/>
+        <item android:offset="1" android:color="#00000000"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+  <path
+      android:pathData="M142.3,160.5c0,6.6 -5.4,12 -12,12H34.6c-6.6,0 -12,-5.4 -12,-12v-137c0,-6.6 5.4,-12 12,-12h95.7c6.6,0 12,5.4 12,12L142.3,160.5L142.3,160.5z"
+      android:strokeAlpha="0.1"
+      android:fillAlpha="0.1">
+    <aapt:attr name="android:fillColor">
+      <gradient 
+          android:startY="92"
+          android:startX="22.6"
+          android:endY="92"
+          android:endX="142.3"
+          android:type="linear">
+        <item android:offset="0" android:color="#FFFFFFFF"/>
+        <item android:offset="1" android:color="#00000000"/>
+      </gradient>
+    </aapt:attr>
+  </path>
+</vector>

--- a/AnkiDroid/src/main/res/layout-v31/widget_small_unthemed.xml
+++ b/AnkiDroid/src/main/res/layout-v31/widget_small_unthemed.xml
@@ -1,0 +1,84 @@
+<FrameLayout android:id="@+id/ankidroid_widget_small_layout"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#00FFFFFF"
+    android:clickable="true"
+    android:focusable="false"
+    tools:layout_height="100dp"
+    tools:layout_width="100dp">
+
+    <ImageButton
+        android:id="@+id/ankidroid_widget_small_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:background="#00FFFFFF"
+        android:clickable="false"
+        android:contentDescription="@string/app_name"
+        android:focusable="false"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_anki_unthemed" />
+
+    <ImageButton
+        android:id="@+id/ankidroid_widget_small_finish_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:background="#00FFFFFF"
+        android:clickable="false"
+        android:focusable="false"
+        android:scaleType="fitCenter"
+        android:src="@drawable/ic_anki_unthemed_finish"
+        android:visibility="gone" />
+
+    <RelativeLayout
+        android:id="@+id/ankidroid_widget_text_layout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="false"
+        android:focusable="false"
+        android:orientation="horizontal"
+        android:padding="4dip">
+
+        <!-- 7366: Using FixedTextView breaks the widget
+        Error inflating RemoteViews : android.view.InflateException: Binary XML file line #30:
+        Binary XML file line #30: Error inflating class com.ichi2.ui.FixedTextView
+
+        https://stackoverflow.com/a/6150129/-->
+        <TextView
+            android:id="@+id/widget_due"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minWidth="24sp"
+            android:minHeight="24sp"
+            android:padding="3sp"
+            android:background="@drawable/circle_background"
+            android:backgroundTint="#475D92"
+            android:gravity="center"
+            android:singleLine="true"
+            android:textColor="#FFFFFF"
+            android:textSize="18sp"
+            android:visibility="invisible"
+            tools:visibility="visible" />
+
+        <TextView
+            android:id="@+id/widget_eta"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_alignParentEnd="false"
+            android:background="@drawable/circle_background"
+            android:backgroundTint="#475D92"
+            android:gravity="center"
+            android:padding="3sp"
+            android:singleLine="true"
+            android:minWidth="24sp"
+            android:minHeight="24sp"
+            android:textColor="#FFFFFF"
+            android:textSize="14sp"
+            android:visibility="invisible"
+            tools:visibility="visible" />
+    </RelativeLayout>
+</FrameLayout>


### PR DESCRIPTION
MIUI doesn't support Material You well - the color is based on the system background color, with no means to disable it.

https://www.reddit.com/r/Xiaomi/comments/y6zclf/material_you_on_miui_13/

Since we are using a widget, we can't use custom themes as a fix

## Fixes
* Fixes #18869

## Approach
Duplicate the assets/layout as unthemed and fix them there

Use the new layout for `miui` phones

`AdaptionUtil` code copied from 43151b618758c80b2bd4b7134f498a56f5b27170 and converted to Kotlin

## How Has This Been Tested?
Pixel 9 Pro (Android 15):

**after the PR**
<img width="960" height="456" alt="image" src="https://github.com/user-attachments/assets/85d5f0e7-ec50-4d72-b73c-5110e9d2374a" />

**with `isMiui` enabled**
<img width="960" height="463" alt="image" src="https://github.com/user-attachments/assets/743d3b88-15c7-4477-b99b-f3c170c6149a" />

<img width="960" height="499" alt="image" src="https://github.com/user-attachments/assets/94d7a8d1-737e-4cca-bb2b-af3e8002eea5" />

## Learning (optional, can help others)

`circle_background` did not need to be duplicated as the background was tintable, just tinting the star was not possible

* Our emulator tests are running on a fairly old version of Android

**Duplicate unthemed widget icons:**

`@android:color/system_neutral1_100` => #E2E2E9
`@android:color/system_neutral1_600` => #5D5E64
`@android:color/system_neutral1_800` => #2F3036
`@android:color/system_neutral1_900` => #1A1B20
`@android:color/system_neutral1_1000` => #000000

`@android:color/system_accent1_300` => #94AAE4
`@android:color/system_accent1_400` => #7A90C8
`@android:color/system_accent1_500` => #6076AC
`@android:color/system_accent1_600` => #475D92

`ic_anki_unthemed.xml`:        accent1_300 => 500
`ic_anki_unthemed_finish.xml`: accent1_400 => 600

**widget_small_unthemed**

`material_dynamic_primary60` => #7A90C8

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)