### PR TITLE
lint: better trim() usage

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
@@ -86,7 +86,7 @@ fun DeckNode.filterAndFlattenDisplay(
         if (filter.isNullOrBlank()) {
             null
         } else {
-            filter.toString().lowercase(Locale.getDefault()).trim { it <= ' ' }
+            filter.toString().lowercase(Locale.getDefault()).trim()
         }
     val list = mutableListOf<DisplayDeckNode>()
     filterAndFlattenDisplayInner(filterPattern, list, parentMatched = false, selectedDeckId)


### PR DESCRIPTION
`TrimLambda` inspection

https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:lint/libs/lint-checks/src/main/java/com/android/tools/lint/checks/TrimDetector.kt

The Kotlin standard library `trim()` call takes an optional lambda \ to specify which characters are considered whitespace.

When converting Java code to Kotlin code, the converter will convert \ calls for Java's `s.trim()` into `s.trim() { it <= ' ' }`. This \ preserves the exact semantics of the Java code, but is likely not \ what you want: the default in Kotlin uses a better definition of what \ constitutes a whitespace character (`Char::isWhitespace`) and also \ results in less bytecode at the call-site.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)