### PR TITLE
test: use api36 emulator for tests

### DIFF
--- a/.github/workflows/tests_emulator.yml
+++ b/.github/workflows/tests_emulator.yml
@@ -60,10 +60,8 @@ jobs:
               }
             }
 
-            // TODO Refactor to make these dynamic with a low/high bracket only on schedule, not push
-            // For now this is the latest supported API. Previously API 29 was fastest.
-            // #13695: This was reverted to API 30, 31 was unstable. This should be fixed
-            let apiLevel = [30];
+            // TODO Refactor to make these dynamic with a minSdk/max bracket only on schedule, not push
+            let apiLevel = [36];
 
             // These are used for performance tuning what emulator to use.
             // try different architectures, targets, delays etc


### PR DESCRIPTION
@david-allison noted in #18871 that our emulator tests were running on a pretty old emulator

This is true, and one of the reasons was a fear-inducing comment that the emulator one API over the one in use was flaky

Hard to test that except wait! We just merged the emulator test "flake hammer" so we can run a big batch on this API to make sure it's not flaky

I'll do that on my fork --> https://github.com/mikehardy/Anki-Android/actions/runs/16280413858