### PR TITLE
refactor(deck-picker): extract `loadDeckCounts` 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -787,6 +787,19 @@ open class DeckPicker :
             }
         }
 
+        fun onCardsDueChanged(dueCount: Int?) {
+            if (dueCount == null) {
+                supportActionBar?.subtitle = null
+                return
+            }
+
+            supportActionBar?.apply {
+                subtitle = if (dueCount == 0) null else resources.getQuantityString(R.plurals.widget_cards_due, dueCount, dueCount)
+                val toolbar = findViewById<Toolbar>(R.id.toolbar)
+                TooltipCompat.setTooltipText(toolbar, toolbar.subtitle)
+            }
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -805,6 +818,7 @@ open class DeckPicker :
         viewModel.flowOfOnDecksLoaded.launchCollectionInLifecycleScope(::onDecksLoadedChanged)
         viewModel.flowOfStudiedTodayStats.launchCollectionInLifecycleScope(::onStudiedTodayChanged)
         viewModel.flowOfDeckListInInitialState.filterNotNull().launchCollectionInLifecycleScope(::onCollectionStatusChanged)
+        viewModel.flowOfCardsDue.launchCollectionInLifecycleScope(::onCardsDueChanged)
     }
 
     private val onReceiveContentListener =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -326,7 +326,8 @@ open class DeckPicker :
     var optionsMenuState: OptionsMenuState? = null
 
     @VisibleForTesting
-    var dueTree: DeckNode? = null
+    val dueTree: DeckNode?
+        get() = viewModel.dueTree
 
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     var searchDecksIcon: MenuItem? = null
@@ -2252,7 +2253,6 @@ open class DeckPicker :
             invalidateOptionsMenu()
             studyoptionsFrame!!.visibility = if (collectionHasNoCards) View.GONE else View.VISIBLE
         }
-        dueTree = result
         launchCatchingTask { renderPage(collectionHasNoCards) }
         Timber.d("Startup - Deck List UI Completed")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -800,6 +800,11 @@ open class DeckPicker :
             }
         }
 
+        fun onStudyOptionsVisibilityChanged(isVisible: Boolean) {
+            invalidateOptionsMenu()
+            studyoptionsFrame?.isVisible = isVisible
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -819,6 +824,7 @@ open class DeckPicker :
         viewModel.flowOfStudiedTodayStats.launchCollectionInLifecycleScope(::onStudiedTodayChanged)
         viewModel.flowOfDeckListInInitialState.filterNotNull().launchCollectionInLifecycleScope(::onCollectionStatusChanged)
         viewModel.flowOfCardsDue.launchCollectionInLifecycleScope(::onCardsDueChanged)
+        viewModel.flowOfStudyOptionsVisible.launchCollectionInLifecycleScope(::onStudyOptionsVisibilityChanged)
     }
 
     private val onReceiveContentListener =
@@ -2309,11 +2315,6 @@ open class DeckPicker :
     ) {
         Timber.i("Updating deck list UI")
         hideProgressBar()
-        // Make sure the fragment is visible
-        if (fragmented) {
-            invalidateOptionsMenu()
-            studyoptionsFrame!!.visibility = if (collectionHasNoCards) View.GONE else View.VISIBLE
-        }
         launchCatchingTask { renderPage(collectionHasNoCards) }
         Timber.d("Startup - Deck List UI Completed")
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -813,6 +813,10 @@ open class DeckPicker :
             )
         }
 
+        fun onFocusedDeckChanged(deckId: DeckId?) {
+            scrollDecklistToDeck(deckId)
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -834,6 +838,7 @@ open class DeckPicker :
         viewModel.flowOfCardsDue.launchCollectionInLifecycleScope(::onCardsDueChanged)
         viewModel.flowOfStudyOptionsVisible.launchCollectionInLifecycleScope(::onStudyOptionsVisibilityChanged)
         viewModel.flowOfDeckList.launchCollectionInLifecycleScope(::onDeckListChanged)
+        viewModel.flowOfFocusedDeck.launchCollectionInLifecycleScope(::onFocusedDeckChanged)
     }
 
     private val onReceiveContentListener =
@@ -1627,7 +1632,7 @@ open class DeckPicker :
                     if (event.isShiftPressed) {
                         // Shortcut: Shift + DEL - Delete deck without confirmation dialog
                         Timber.i("Shift+DEL: Deck deck without confirmation")
-                        deleteDeck(viewModel.focusedDeck)
+                        viewModel.focusedDeck?.let { did -> deleteDeck(did) }
                     } else {
                         // Shortcut: DEL
                         Timber.i("Delete Deck from keypress")
@@ -1642,7 +1647,7 @@ open class DeckPicker :
                 // that is, when it appears in the trailing study option fragment
                 if (fragmented) {
                     Timber.i("Rename Deck from keypress")
-                    renameDeckDialog(viewModel.focusedDeck)
+                    viewModel.focusedDeck?.let { did -> renameDeckDialog(did) }
                     return true
                 }
             }
@@ -1690,18 +1695,24 @@ open class DeckPicker :
      */
     private fun showDeleteDeckConfirmationDialog() =
         launchCatchingTask {
+            val focusedDeck =
+                viewModel.focusedDeck ?: run {
+                    Timber.w("no focused deck")
+                    return@launchCatchingTask
+                }
+
             val (deckName, totalCards, isFilteredDeck) =
                 withCol {
                     Triple(
-                        decks.name(viewModel.focusedDeck),
-                        decks.cardCount(viewModel.focusedDeck, includeSubdecks = true),
-                        decks.isFiltered(viewModel.focusedDeck),
+                        decks.name(focusedDeck),
+                        decks.cardCount(focusedDeck, includeSubdecks = true),
+                        decks.isFiltered(focusedDeck),
                     )
                 }
             val confirmDeleteDeckDialog =
                 DeckPickerConfirmDeleteDeckDialog.newInstance(
                     deckName = deckName,
-                    deckId = viewModel.focusedDeck,
+                    deckId = focusedDeck,
                     totalCards = totalCards,
                     isFilteredDeck = isFilteredDeck,
                 )
@@ -2262,8 +2273,8 @@ open class DeckPicker :
      *
      * @param did The deck ID of the deck to select.
      */
-    private fun scrollDecklistToDeck(did: DeckId) {
-        val position = findDeckPosition(did)
+    private fun scrollDecklistToDeck(did: DeckId?) {
+        val position = did?.let { findDeckPosition(it) } ?: 0
         recyclerViewLayoutManager.scrollToPositionWithOffset(position, recyclerView.height / 2)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1175,6 +1175,7 @@ open class DeckPicker :
                     }
 
                     override fun onQueryTextChange(newText: String): Boolean {
+                        viewModel.updateDeckFilter(newText)
                         val adapter = recyclerView.adapter as DeckAdapter
                         launchCatchingTask {
                             val selectedDeckId = withCol { decks.current().id }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -729,6 +729,17 @@ open class DeckPicker :
             onDecksLoaded(result.deckDueTree, result.collectionHasNoCards)
         }
 
+        fun onStudiedTodayChanged(studiedToday: String) {
+            reviewSummaryTextView.text = studiedToday
+            val fabLinearLayout = findViewById<LinearLayout>(R.id.fabLinearLayout)
+            // Adjust bottom margin of fabLinearLayout based on reviewSummaryTextView height
+            reviewSummaryTextView.doOnLayout {
+                val layoutParams = fabLinearLayout.layoutParams as ViewGroup.MarginLayoutParams
+                layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
+                fabLinearLayout.layoutParams = layoutParams
+            }
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -745,6 +756,7 @@ open class DeckPicker :
         viewModel.flowOfPromptUserToUpdateScheduler.launchCollectionInLifecycleScope(::onPromptUserToUpdateScheduler)
         viewModel.flowOfUndoUpdated.launchCollectionInLifecycleScope(::onUndoUpdated)
         viewModel.flowOfOnDecksLoaded.launchCollectionInLifecycleScope(::onDecksLoadedChanged)
+        viewModel.flowOfStudiedTodayStats.launchCollectionInLifecycleScope(::onStudiedTodayChanged)
     }
 
     private val onReceiveContentListener =
@@ -2242,21 +2254,6 @@ open class DeckPicker :
         }
         dueTree = result
         launchCatchingTask { renderPage(collectionHasNoCards) }
-        // Update the mini statistics bar as well
-        launchCatchingTask {
-            reviewSummaryTextView.text =
-                withCol {
-                    // Backend returns studiedToday() with newlines for HTML formatting,so we replace them with spaces.
-                    sched.studiedToday().replace("\n", " ")
-                }
-            val fabLinearLayout = findViewById<LinearLayout>(R.id.fabLinearLayout)
-            // Adjust bottom margin of fabLinearLayout based on reviewSummaryTextView height
-            reviewSummaryTextView.doOnLayout {
-                val layoutParams = fabLinearLayout.layoutParams as ViewGroup.MarginLayoutParams
-                layoutParams.setMargins(0, 0, 0, reviewSummaryTextView.height / 2)
-                fabLinearLayout.layoutParams = layoutParams
-            }
-        }
         Timber.d("Startup - Deck List UI Completed")
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -112,6 +112,7 @@ import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
+import com.ichi2.anki.deckpicker.DeckPickerViewModel.OnDecksLoadedResult
 import com.ichi2.anki.deckpicker.EmptyCardsResult
 import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
 import com.ichi2.anki.dialogs.AsyncDialogFragment
@@ -443,7 +444,6 @@ open class DeckPicker :
     // stored for testing purposes
     @VisibleForTesting
     var createMenuJob: Job? = null
-    private var loadDeckCounts: Job? = null
 
     init {
         ChangeManager.subscribe(this)
@@ -479,7 +479,7 @@ open class DeckPicker :
                         sched.haveBuried(),
                     )
                 }
-            updateDeckList() // focus has changed
+            updateDeckList()?.join() // focus has changed
             showDialogFragment(
                 DeckPickerContextMenu.newInstance(
                     id = deckId,
@@ -495,12 +495,6 @@ open class DeckPicker :
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {
             Timber.i("notification permission: %b", it)
         }
-
-    /**
-     * Tracks the scheduler version for which the upgrade dialog was last shown,
-     * to avoid repeatedly prompting the user for the same collection version.
-     */
-    private var schedulerUpgradeDialogShownForVersion: Long? = null
 
     // ----------------------------------------------------------------------------
     // ANDROID ACTIVITY METHODS
@@ -703,6 +697,38 @@ open class DeckPicker :
             startActivity(destination.toIntent(this))
         }
 
+        fun onPromptUserToUpdateScheduler(op: Unit) {
+            SchedulerUpgradeDialog(
+                activity = this,
+                onUpgrade = {
+                    launchCatchingRequiringOneWaySync {
+                        this@DeckPicker.withProgress { withCol { sched.upgradeToV2() } }
+                        showThemedToast(this@DeckPicker, TR.schedulingUpdateDone(), false)
+                    }
+                },
+                onCancel = {
+                    onBackPressedDispatcher.onBackPressed()
+                },
+            ).showDialog()
+        }
+
+        fun onUndoUpdated(a: Unit) {
+            launchCatchingTask {
+                withOpenColOrNull {
+                    optionsMenuState =
+                        optionsMenuState?.copy(
+                            undoLabel = undoLabel(),
+                            undoAvailable = undoAvailable(),
+                        )
+                }
+                invalidateOptionsMenu()
+            }
+        }
+
+        fun onDecksLoadedChanged(result: OnDecksLoadedResult) {
+            onDecksLoaded(result.deckDueTree, result.collectionHasNoCards)
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -716,6 +742,9 @@ open class DeckPicker :
         viewModel.flowOfDeckCountsChanged.launchCollectionInLifecycleScope(::onDeckCountsChanged)
         viewModel.flowOfDestination.launchCollectionInLifecycleScope(::onDestinationChanged)
         viewModel.onError.launchCollectionInLifecycleScope(::onError)
+        viewModel.flowOfPromptUserToUpdateScheduler.launchCollectionInLifecycleScope(::onPromptUserToUpdateScheduler)
+        viewModel.flowOfUndoUpdated.launchCollectionInLifecycleScope(::onUndoUpdated)
+        viewModel.flowOfOnDecksLoaded.launchCollectionInLifecycleScope(::onDecksLoadedChanged)
     }
 
     private val onReceiveContentListener =
@@ -1092,16 +1121,6 @@ open class DeckPicker :
         updateDeckRelatedMenuItems(menu)
     }
 
-    private suspend fun updateUndoMenuState() {
-        withOpenColOrNull {
-            optionsMenuState =
-                optionsMenuState?.copy(
-                    undoLabel = undoLabel(),
-                    undoAvailable = undoAvailable(),
-                )
-        }
-    }
-
     /**
      * Shows/hides deck related menu items based on the collection being empty or not.
      */
@@ -1369,7 +1388,7 @@ open class DeckPicker :
     override fun onPause() {
         activityPaused = true
         // The deck count will be computed on resume. No need to compute it now
-        loadDeckCounts?.cancel()
+        viewModel.loadDeckCounts?.cancel()
         super.onPause()
     }
 
@@ -2109,21 +2128,6 @@ open class DeckPicker :
         }
     }
 
-    private fun promptUserToUpdateScheduler() {
-        SchedulerUpgradeDialog(
-            activity = this,
-            onUpgrade = {
-                launchCatchingRequiringOneWaySync {
-                    this@DeckPicker.withProgress { withCol { sched.upgradeToV2() } }
-                    showThemedToast(this@DeckPicker, TR.schedulingUpdateDone(), false)
-                }
-            },
-            onCancel = {
-                onBackPressedDispatcher.onBackPressed()
-            },
-        ).showDialog()
-    }
-
     @NeedsTest("14608: Ensure that the deck options refer to the selected deck")
     @NeedsTest("18586: handle clicking on an empty filtered deck")
     private suspend fun handleDeckSelection(
@@ -2212,9 +2216,9 @@ open class DeckPicker :
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     @RustCleanup("backup with 5 minute timer, instead of deck list refresh")
-    fun updateDeckList() {
+    fun updateDeckList(): Job? {
         if (!CollectionManager.isOpenUnsafe()) {
-            return
+            return null
         }
         if (Build.FINGERPRINT != "robolectric") {
             // uses user's desktop settings to determine whether a backup
@@ -2222,33 +2226,7 @@ open class DeckPicker :
             performBackupInBackground()
         }
         Timber.d("updateDeckList")
-        loadDeckCounts?.cancel()
-        loadDeckCounts =
-            launchCatchingTask {
-                withProgress {
-                    Timber.d("Refreshing deck list")
-                    val (deckDueTree, collectionHasNoCards) =
-                        withCol {
-                            Pair(sched.deckDueTree(), isEmpty)
-                        }
-                    onDecksLoaded(deckDueTree, collectionHasNoCards)
-
-                    /**
-                     * Checks the current scheduler version and prompts the upgrade dialog if using the legacy version.
-                     * Ensures the dialog is only shown once per collection load, even if [updateDeckList()] is called multiple times.
-                     */
-                    val currentSchedulerVersion = withCol { config.get("schedVer") as? Long ?: 1L }
-
-                    if (currentSchedulerVersion == 1L && schedulerUpgradeDialogShownForVersion != 1L) {
-                        schedulerUpgradeDialogShownForVersion = 1L
-                        promptUserToUpdateScheduler()
-                    } else {
-                        schedulerUpgradeDialogShownForVersion = currentSchedulerVersion
-                    }
-
-                    updateUndoMenuState()
-                }
-            }
+        return launchCatchingTask { withProgress { viewModel.reloadDeckCounts()?.join() } }
     }
 
     private fun onDecksLoaded(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -71,6 +71,18 @@ class DeckPickerViewModel(
     /** User filter of the deck list. Shown as a search in the UI */
     private val flowOfCurrentDeckFilter = MutableStateFlow("")
 
+    val flowOfDeckList =
+        combine(flowOfDeckDueTree, flowOfCurrentDeckFilter) { tree, filter ->
+            if (tree == null) return@combine FlattenedDeckList.empty
+
+            val currentDeckId = withCol { decks.current().getLong("id") }
+
+            FlattenedDeckList(
+                data = tree.filterAndFlattenDisplay(filter, currentDeckId),
+                hasSubDecks = tree.children.any { it.children.any() },
+            )
+        }
+
     /**
      * @see deleteDeck
      * @see DeckDeletionResult
@@ -294,6 +306,16 @@ class DeckPickerViewModel(
         val deckDueTree: DeckNode,
         val collectionHasNoCards: Boolean,
     )
+
+    /** Represents [dueTree] as a list */
+    data class FlattenedDeckList(
+        val data: List<DisplayDeckNode>,
+        val hasSubDecks: Boolean,
+    ) {
+        companion object {
+            val empty = FlattenedDeckList(emptyList(), hasSubDecks = false)
+        }
+    }
 }
 
 /** Result of [DeckPickerViewModel.deleteDeck] */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.browser.BrowserDestination
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.Consts.DEFAULT_DECK_ID
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.libanki.utils.extend
@@ -111,7 +112,7 @@ class DeckPickerViewModel(
         combine(flowOfDeckDueTree, flowOfCollectionHasNoCards) { tree, noCards ->
             if (tree == null) return@combine null
             // Check if default deck is the only available and there are no cards
-            tree.children.size == 1 && tree.children[0].did == 1L && noCards
+            tree.onlyHasDefaultDeck() && noCards
         }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = null)
 
     val flowOfCardsDue =
@@ -313,3 +314,5 @@ data class EmptyCardsResult(
     @CheckResult
     fun toHumanReadableString() = TR.emptyCardsDeletedCount(cardsDeleted)
 }
+
+fun DeckNode.onlyHasDefaultDeck() = children.singleOrNull()?.did == DEFAULT_DECK_ID

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -56,6 +56,10 @@ class DeckPickerViewModel(
     val fragmented: Boolean,
 ) : ViewModel(),
     OnErrorListener {
+    /** The root of the tree displaying all decks */
+    var dueTree: DeckNode? = null
+        private set
+
     /**
      * @see deleteDeck
      * @see DeckDeletionResult
@@ -227,6 +231,7 @@ class DeckPickerViewModel(
                     withCol {
                         Pair(sched.deckDueTree(), isEmpty)
                     }
+                dueTree = deckDueTree
                 flowOfOnDecksLoaded.emit(OnDecksLoadedResult(deckDueTree, collectionHasNoCards))
 
                 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -126,8 +126,6 @@ class DeckPickerViewModel(
 
     val flowOfUndoUpdated = MutableSharedFlow<Unit>()
 
-    val flowOfOnDecksLoaded = MutableSharedFlow<OnDecksLoadedResult>()
-
     val flowOfCollectionHasNoCards = MutableStateFlow(true)
 
     val flowOfDeckListInInitialState =
@@ -144,14 +142,7 @@ class DeckPickerViewModel(
         }
 
     /** "Studied N cards in 0 seconds today */
-    val flowOfStudiedTodayStats =
-        flowOfOnDecksLoaded
-            .map {
-                withCol {
-                    // Backend returns studiedToday() with newlines for HTML formatting,so we replace them with spaces.
-                    sched.studiedToday().replace("\n", " ")
-                }
-            }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = "")
+    val flowOfStudiedTodayStats = MutableStateFlow("")
 
     val flowOfStudyOptionsVisible = flowOfCollectionHasNoCards.map { noCards -> fragmented && !noCards }
 
@@ -282,7 +273,9 @@ class DeckPickerViewModel(
 
                 flowOfCollectionHasNoCards.value = collectionHasNoCards
 
-                flowOfOnDecksLoaded.emit(OnDecksLoadedResult(deckDueTree, collectionHasNoCards))
+                // TODO: This is in the wrong place
+                // Backend returns studiedToday() with newlines for HTML formatting,so we replace them with spaces.
+                flowOfStudiedTodayStats.value = withCol { sched.studiedToday().replace("\n", " ") }
 
                 /**
                  * Checks the current scheduler version and prompts the upgrade dialog if using the legacy version.
@@ -310,12 +303,6 @@ class DeckPickerViewModel(
         Timber.d("filter: %s", filterText)
         flowOfCurrentDeckFilter.value = filterText
     }
-
-    // Temp class for refactoring
-    data class OnDecksLoadedResult(
-        val deckDueTree: DeckNode,
-        val collectionHasNoCards: Boolean,
-    )
 
     /** Represents [dueTree] as a list */
     data class FlattenedDeckList(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -68,6 +68,9 @@ class DeckPickerViewModel(
             flowOfDeckDueTree.value = value
         }
 
+    /** User filter of the deck list. Shown as a search in the UI */
+    private val flowOfCurrentDeckFilter = MutableStateFlow("")
+
     /**
      * @see deleteDeck
      * @see DeckDeletionResult
@@ -279,6 +282,11 @@ class DeckPickerViewModel(
             }
         this.loadDeckCounts = loadDeckCounts
         return loadDeckCounts
+    }
+
+    fun updateDeckFilter(filterText: String) {
+        Timber.d("filter: %s", filterText)
+        flowOfCurrentDeckFilter.value = filterText
     }
 
     // Temp class for refactoring

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -43,9 +43,14 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
-/** @see [DeckPicker] */
-class DeckPickerViewModel :
-    ViewModel(),
+/**
+ * ViewModel for the [DeckPicker]
+ *
+ * @param fragmented whether the study options is shown alongside the deck picker
+ */
+class DeckPickerViewModel(
+    val fragmented: Boolean,
+) : ViewModel(),
     OnErrorListener {
     /**
      * @see deleteDeck

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -41,6 +41,7 @@ import com.ichi2.anki.reviewreminders.ScheduleRemindersDestination
 import com.ichi2.anki.utils.Destination
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
@@ -97,6 +98,8 @@ class DeckPickerViewModel(
     val flowOfUndoUpdated = MutableSharedFlow<Unit>()
 
     val flowOfOnDecksLoaded = MutableSharedFlow<OnDecksLoadedResult>()
+
+    val flowOfDeckListInInitialState = MutableStateFlow<Boolean?>(null)
 
     /** "Studied N cards in 0 seconds today */
     val flowOfStudiedTodayStats =
@@ -232,6 +235,11 @@ class DeckPickerViewModel(
                         Pair(sched.deckDueTree(), isEmpty)
                     }
                 dueTree = deckDueTree
+
+                // Check if default deck is the only available and there are no cards
+                val isEmpty = deckDueTree.children.size == 1 && deckDueTree.children[0].did == 1L && collectionHasNoCards
+                flowOfDeckListInInitialState.emit(isEmpty)
+
                 flowOfOnDecksLoaded.emit(OnDecksLoadedResult(deckDueTree, collectionHasNoCards))
 
                 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -41,6 +41,9 @@ import com.ichi2.anki.reviewreminders.ScheduleRemindersDestination
 import com.ichi2.anki.utils.Destination
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -90,6 +93,16 @@ class DeckPickerViewModel(
     val flowOfUndoUpdated = MutableSharedFlow<Unit>()
 
     val flowOfOnDecksLoaded = MutableSharedFlow<OnDecksLoadedResult>()
+
+    /** "Studied N cards in 0 seconds today */
+    val flowOfStudiedTodayStats =
+        flowOfOnDecksLoaded
+            .map {
+                withCol {
+                    // Backend returns studiedToday() with newlines for HTML formatting,so we replace them with spaces.
+                    sched.studiedToday().replace("\n", " ")
+                }
+            }.stateIn(viewModelScope, SharingStarted.Eagerly, initialValue = "")
 
     /**
      * Deletes the provided deck, child decks. and all cards inside.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -40,7 +40,7 @@ import timber.log.Timber
 /** Test of [DeckPickerViewModel] */
 @RunWith(AndroidJUnit4::class)
 class DeckPickerViewModelTest : RobolectricTest() {
-    private val viewModel = DeckPickerViewModel()
+    private val viewModel = DeckPickerViewModel(fragmented = false)
 
     @Test
     fun `empty cards - flow`() =


### PR DESCRIPTION
I wanted to look into #18886, but I felt that I would be adding complexity with the fix, or testing the view logic.

The underlying cause was a blocking check to see if the collection was openable. 

A fix would involve moving this check inside two `launch` functions in the activity, and there was significant complexity in this.

Moving to a ViewModel moves a large part of this complexity out of the Activity, and makes it easier to reason about what will occur when the collection would not open or about timing constraints between taking a backup, and loading the deck list.

This shaves about 100 LOC out the DeckPicker, not huge, but I feel the code is much more readable now `renderPage` is split into the constituent flows.

This moves `dueTree` into the DeckPicker, so there's an opportunity for more refactorings, but this PR is already hairy with little possible to reduce the slog, and I wanted to be as thankful to reviewers as possible

## Fixes
* Prep for #18886

## How Has This Been Tested?
Unit tested and tested on an API 34 tablet emulator and Pixel 9 Pro (API 35)

Tested when opening a corrupt collection, dialog occurred as expected

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->