### PR TITLE
Revert "Fix #15993: Scroll position wrong after editing"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -102,11 +102,6 @@ class CardBrowserFragment :
         setupFlows()
     }
 
-    override fun onResume() {
-        super.onResume()
-        autoScrollTo(viewModel.lastSelectedPosition, viewModel.oldCardTopOffset)
-    }
-
     override fun onDestroyView() {
         super.onDestroyView()
         if (::cardsListView.isInitialized) {


### PR DESCRIPTION
This partially reverts commit 9261218816eaac2f0cb5352e4c6b949fdb727772.

* #15993
* #18165

----

The position was not saved if closing the Browser, so minimising the window then opening it reset the scroll position to the top of the screen

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->