### PR TITLE
fix(card-browser): maintain scroll position [non-multi-select] (PR 2)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -54,6 +54,9 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
+// Minor BUG: 'don't keep activities' and huge selection
+// At some point, starting between 35k and 60k selections, the scroll position is lost on recreation
+// This occurred on a Pixel 9 Pro, Android 15
 class CardBrowserFragment :
     Fragment(R.layout.cardbrowser),
     ChangeManager.Subscriber {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -49,6 +49,7 @@ import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserColumn.TAGS
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.DeepLink
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.SystemContextMenu
+import com.ichi2.anki.browser.CardBrowserViewModel.Companion.STATE_MULTISELECT_VALUES
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_ALL
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_NONE
 import com.ichi2.anki.browser.RepositionCardsRequest.ContainsNonNewCardsError
@@ -85,7 +86,6 @@ import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.lessThan
 import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.nullValue
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.runner.RunWith
@@ -1126,17 +1126,17 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     @Test
-    @Ignore("not implemented")
     fun `multiselect checked state is restored`() {
         val handle = SavedStateHandle()
-
         var idOfSelectedRow: CardOrNoteId? = null
-        runViewModelTest(savedStateHandle = handle, notes = 2) {
+        runViewModelTest(savedStateHandle = handle, notes = 2, manualInit = false) {
             selectRowAtPosition(1)
             idOfSelectedRow = selectedRows.single()
+            // HACK: easiest way to add it to the bundle. This is called on destruction
+            handle[STATE_MULTISELECT_VALUES] = generateExpensiveSavedState()
         }
 
-        runViewModelTest(savedStateHandle = handle) {
+        runViewModelTest(savedStateHandle = handle, manualInit = false) {
             assertThat("row is still selected", selectedRows, hasSize(1))
             assertThat("same row is selected", selectedRows.single(), equalTo(idOfSelectedRow))
         }
@@ -1208,6 +1208,7 @@ class CardBrowserViewModelTest : JvmTest() {
             viewModel.manualInit()
         }
         testBody(viewModel)
+        Timber.d("end runViewModelTest")
     }
 
     companion object {


### PR DESCRIPTION
This is not cherry-pickable as it depends on my multiselect work in https://github.com/ankidroid/Anki-Android/pull/18576

Should be valid for 2.22, but not 2.21

@lukstbit THANK YOU SO MUCH FOR THE REVIEW ON THE BELOW!!!

* https://github.com/ankidroid/Anki-Android/pull/18576

## Fixes

* Fixes #14220

## Approach
* Introduce a `SavedStateHandle` for the Card Browser:
  * `MULTISELECT`
  * `MULTISELECT_VALUES` 
* stored separately as `VALUES` is an `IdsFile` which reads from disk


## How Has This Been Tested?
Pixel 9 Pro with 'Don't Keep Activities'

* Scroll position maintained
* Scroll position maintained after search
* Scroll position maintained after selection
* ❌ Scroll position not maintained after between 35k and 60k selected
* Notes mode also tested

and unit tests

## Learning

`setSavedStateProvider` allos lazy collection of `SavedStateHandle` data: https://developer.android.com/reference/androidx/lifecycle/SavedStateHandle#setSavedStateProvider(kotlin.String,androidx.savedstate.SavedStateRegistry.SavedStateProvider)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->