### PR TITLE
fix: remove work manager custom initialization

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -691,16 +691,6 @@
             <meta-data android:name="com.ichi2.anki.provider.spec" android:value="2" />
         </provider>
         <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="remove">
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
-        <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.apkgfileprovider"
             android:grantUriPermissions="true"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -33,7 +33,6 @@ import androidx.core.content.edit
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
-import androidx.work.Configuration
 import anki.collection.OpChanges
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -77,7 +76,6 @@ import java.util.Locale
 @KotlinCleanup("IDE Lint")
 open class AnkiDroidApp :
     Application(),
-    Configuration.Provider,
     ChangeManager.Subscriber {
     /** An exception if the WebView subsystem fails to load  */
     private var webViewError: Throwable? = null
@@ -88,9 +86,6 @@ open class AnkiDroidApp :
 
     /** Used to avoid showing extra progress dialogs when one already shown. */
     var progressDialogShown = false
-
-    override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder().build()
 
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     /**


### PR DESCRIPTION
I don't recall exactly why I added it here https://github.com/ankidroid/Anki-Android/pull/16127/commits/94fe4af8eaed60e4e67164c7dc44150e517a3811#diff-5a992450c4da04f5af7ffacb398900013c9d418f35e42d99674df9f3c2a97dfeR604

I think it was to make it work with tests. It apparently doesn't seem necessary anymore (or never was)

* Fixes #18899

## How Has This Been Tested?

Emulator API 36:
- Tried syncing and it worked

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->