### PR TITLE
fix: "Undo" tooltip doesn't show its target

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -52,6 +52,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.ThemeUtils
 import androidx.appcompat.widget.Toolbar
+import androidx.appcompat.widget.TooltipCompat
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.isGone
@@ -864,7 +865,7 @@ open class Reviewer :
                 whiteboard?.reviewerEraserModeIsToggledOn = isEraserMode
 
                 if (getColUnsafe.undoAvailable()) {
-                    //  e.g. Undo Bury, Undo Change Deck, Undo Update Note
+                    // set the undo title to a named action ('Undo Answer Card' etc...)
                     undoIcon.title = getColUnsafe.undoLabel()
                 } else {
                     // In this case, there is no object word for the verb, "Undo",
@@ -874,6 +875,12 @@ open class Reviewer :
                     undoIcon.iconAlpha = Themes.ALPHA_ICON_DISABLED_LIGHT
                 }
             }
+
+            // Set the undo tooltip, only if the icon is shown in the action bar
+            undoIcon.actionView?.let { undoView ->
+                TooltipCompat.setTooltipText(undoView, undoIcon.title)
+            }
+
             menu.findItem(R.id.action_redo)?.apply {
                 if (getColUnsafe.redoAvailable()) {
                     title = getColUnsafe.redoLabel()


### PR DESCRIPTION
## Purpose / Description

Even when Undo is available (i.e., Undo action has its target), the undo action's tooltip just shows `Undo`
in contrast to the label in the overflow menu:

e.g.,
- `Undo Answer Card`
- `Undo Bury`
- `Undo Change Deck`
- `Undo Update Note` 
-  and `Undo Stroke` on whiteboard mode

<img src="https://github.com/user-attachments/assets/60eda415-9b57-4ce7-a202-825636387855" width="300px">
<img src="https://github.com/user-attachments/assets/f510663f-b71e-447f-a0d1-5c5808e82bf5" width="300px">


This PR aims to resolve the inconvenience/inconsistency.

<!--- Please fill the necessary details below -->


## Fixes
* Fixes #18904

## Approach
Set the the undo action's title to the tooltip after the title is determined.

## How Has This Been Tested?

Checked on a physical device (Android 11)

<img src="https://github.com/user-attachments/assets/d94365e0-ddb0-4f96-b664-f073e313d946" width="320px">


https://github.com/user-attachments/assets/dbb29889-8fd5-4be3-996a-d7ca61d70703

- Additionally checked the same operations with placing the undo action in the overflow menu. No unexpected results occurred.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->