### PR TITLE
Use legacy tags dialog when selecting tags for custom studying

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -45,6 +45,7 @@ import anki.scheduler.CustomStudyDefaultsResponse
 import anki.scheduler.CustomStudyRequest.Cram.CramKind
 import anki.scheduler.copy
 import anki.scheduler.customStudyRequest
+import anki.search.SearchNode
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
@@ -59,9 +60,9 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.ST
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_PREVIEW
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_TAGS
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.Companion.toDomainModel
-import com.ichi2.anki.dialogs.customstudy.TagLimitFragment.Companion.KEY_EXCLUDED_TAGS
-import com.ichi2.anki.dialogs.customstudy.TagLimitFragment.Companion.KEY_INCLUDED_TAGS
-import com.ichi2.anki.dialogs.customstudy.TagLimitFragment.Companion.REQUEST_CUSTOM_STUDY_TAGS
+import com.ichi2.anki.dialogs.tags.TagsDialog
+import com.ichi2.anki.dialogs.tags.TagsDialogListener.Companion.ON_SELECTED_TAGS_KEY
+import com.ichi2.anki.dialogs.tags.TagsDialogListener.Companion.ON_SELECTED_TAGS__SELECTED_TAGS
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.Deck
 import com.ichi2.anki.libanki.DeckId
@@ -147,14 +148,13 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        parentFragmentManager.setFragmentResultListener(REQUEST_CUSTOM_STUDY_TAGS, this) { _, bundle ->
-            val tagsToInclude = bundle.getStringArrayList(KEY_INCLUDED_TAGS) ?: emptyList<String>()
-            val tagsToExclude = bundle.getStringArrayList(KEY_EXCLUDED_TAGS) ?: emptyList<String>()
+        parentFragmentManager.setFragmentResultListener(ON_SELECTED_TAGS_KEY, this) { _, bundle ->
+            val tagsToInclude = bundle.getStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS) ?: emptyList<String>()
             val option = selectedSubDialog ?: return@setFragmentResultListener
             if (selectedStatePosition == AdapterView.INVALID_POSITION) return@setFragmentResultListener
             val kind = CustomStudyCardState.entries[selectedStatePosition].kind
             val cardsAmount = userInputValue ?: 100 // the default value
-            launchCustomStudy(option, cardsAmount, kind, tagsToInclude, tagsToExclude)
+            launchCustomStudy(option, cardsAmount, kind, tagsToInclude, emptyList())
         }
     }
 
@@ -369,8 +369,24 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                     // mark allowSubmit as true because, if the user cancels TagLimitFragment, when
                     // we come back we wouldn't be able to trigger again TagLimitFragment
                     allowSubmit = true
-                    val tagsSelectionDialog = TagLimitFragment.newInstance(dialogDeckId)
-                    tagsSelectionDialog.show(parentFragmentManager, TagLimitFragment.TAG)
+                    launchCatchingTask {
+                        val nids =
+                            withCol {
+                                val currentDeckname = decks.name(dialogDeckId)
+                                val search = SearchNode.newBuilder().setDeck(currentDeckname).build()
+                                val query = buildSearchString(search)
+                                findNotes(query)
+                            }
+                        if (isAdded) {
+                            val tagsDialog =
+                                TagsDialog().withArguments(
+                                    requireContext(),
+                                    TagsDialog.DialogType.CUSTOM_STUDY,
+                                    nids,
+                                )
+                            tagsDialog.show(parentFragmentManager, "TagsDialog")
+                        }
+                    }
                     return@setOnClickListener
                 }
                 launchCustomStudy(contextMenuOption, n)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsArrayAdapter.kt
@@ -44,6 +44,7 @@ import java.util.TreeSet
  */
 class TagsArrayAdapter(
     private val tags: TagsList,
+    private val onSelectionUpdate: () -> Unit,
 ) : RecyclerView.Adapter<TagsArrayAdapter.ViewHolder>(),
     Filterable {
     class ViewHolder(
@@ -256,6 +257,7 @@ class TagsArrayAdapter(
                 INDETERMINATE -> tags.setIndeterminate(vh.node.tag)
             }
             vh.node.onCheckStateChanged(tags)
+            onSelectionUpdate()
         }
         // clicking other parts toggles the expansion state, or the checkbox (for leaf)
         vh.itemView.setOnClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.OnContextAndLongClickListener
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
@@ -37,6 +38,7 @@ import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.NoteId
+import com.ichi2.anki.libanki.withCollapsedWhitespace
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.ui.AccessibleSearchView
@@ -237,7 +239,7 @@ class TagsDialog : AnalyticsDialogFragment {
 
             val tags = viewModel.tags.await()
 
-            tagsArrayAdapter = TagsArrayAdapter(tags)
+            tagsArrayAdapter = TagsArrayAdapter(tags) { view.showMaxTagSelectedNotice(tags) }
             tagsListRecyclerView.adapter = tagsArrayAdapter
             noTagsTextView = view.findViewById(R.id.tags_dialog_no_tags_textview)
             if (tags.isEmpty) {
@@ -262,6 +264,24 @@ class TagsDialog : AnalyticsDialogFragment {
         }
 
         return dialog
+    }
+
+    private fun View.showMaxTagSelectedNotice(tags: TagsList) {
+        if (type == DialogType.CUSTOM_STUDY && tags.copyOfCheckedTagList().size > 100) {
+            // the backend text is long and is more like an explanation and doesn't fit into
+            // a snackbar so cut just for the first sentence:
+            //  "A maximum of 100 tags can be selected."
+            val backendText = withCollapsedWhitespace(TR.errors100TagsMax())
+            val firstPointIndex = backendText.indexOf(".")
+            val userFacingText =
+                if (firstPointIndex < 0) {
+                    // backend text was changed so just return the full text
+                    backendText
+                } else {
+                    backendText.substring(0..firstPointIndex)
+                }
+            this.showSnackbar(userFacingText)
+        }
     }
 
     private fun onPositiveButton() {
@@ -337,6 +357,7 @@ class TagsDialog : AnalyticsDialogFragment {
                 val didChange = tags.toggleAllCheckedStatuses()
                 if (didChange) {
                     tagsArrayAdapter?.notifyDataSetChanged()
+                    view?.showMaxTagSelectedNotice(tags)
                 }
             }
             true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -73,6 +73,8 @@ class TagsDialog : AnalyticsDialogFragment {
          * Filter notes by tags
          */
         FILTER_BY_TAG,
+
+        CUSTOM_STUDY,
     }
 
     private var type: DialogType? = null
@@ -97,7 +99,17 @@ class TagsDialog : AnalyticsDialogFragment {
             requireNotNull(requireArguments().getStringArrayList(ARG_CHECKED_TAGS)) {
                 "$ARG_CHECKED_TAGS is required"
             }
-        viewModelFactory { initializer { TagsDialogViewModel(noteIds = noteIds, checkedTags = checkedTags) } }
+        val type = BundleCompat.getParcelable(requireArguments(), ARG_DIALOG_TYPE, DialogType::class.java)
+        val isCustomStudying = type != null && type == DialogType.CUSTOM_STUDY
+        viewModelFactory {
+            initializer {
+                TagsDialogViewModel(
+                    noteIds = noteIds,
+                    checkedTags = checkedTags,
+                    isCustomStudying = isCustomStudying,
+                )
+            }
+        }
     }
 
     /**
@@ -177,7 +189,7 @@ class TagsDialog : AnalyticsDialogFragment {
             }
         val optionsGroup =
             view.findViewById<RadioGroup>(R.id.tags_dialog_options_radiogroup).apply {
-                isVisible = type != DialogType.EDIT_TAGS
+                isVisible = type != DialogType.EDIT_TAGS && type != DialogType.CUSTOM_STUDY
                 for (i in 0 until childCount) {
                     getChildAt(i).id = i
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
@@ -26,11 +26,14 @@ import kotlinx.coroutines.flow.asStateFlow
 /**
  * @param noteIds IDs of notes whose tags should bfe retrieved and marked as "checked"
  * @param checkedTags additional list of checked tags.
+ * @param isCustomStudying true if all inputs are to be handled as unchecked tags, false otherwise(
+ * this is a temporary parameter until custom study by tags is modified)
  *  They are joined with the tags retrieved from noteIds
  */
 class TagsDialogViewModel(
     noteIds: Collection<NoteId> = emptyList(),
     checkedTags: Collection<String> = emptyList(),
+    isCustomStudying: Boolean = false,
 ) : ViewModel() {
     val tags: Deferred<TagsList>
 
@@ -51,11 +54,19 @@ class TagsDialogViewModel(
                         }
                 _initProgress.emit(InitProgress.Processing)
                 val uncheckedTags = allTags - allCheckedTags
-                TagsList(
-                    allTags = allTags,
-                    checkedTags = allCheckedTags,
-                    uncheckedTags = uncheckedTags,
-                ).also {
+                if (isCustomStudying) {
+                    TagsList(
+                        allTags = allCheckedTags,
+                        checkedTags = emptyList(),
+                        uncheckedTags = allCheckedTags,
+                    )
+                } else {
+                    TagsList(
+                        allTags = allTags,
+                        checkedTags = allCheckedTags,
+                        uncheckedTags = uncheckedTags,
+                    )
+                }.also {
                     _initProgress.emit(InitProgress.Finished)
                 }
             }

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Lang.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Lang.kt
@@ -23,3 +23,6 @@ import com.ichi2.anki.libanki.utils.LibAnkiAlias
  */
 @LibAnkiAlias("without_unicode_isolation")
 fun withoutUnicodeIsolation(s: String): String = s.replace("\u2068", "").replace("\u2069", "")
+
+@LibAnkiAlias("with_collapsed_whitespace")
+fun withCollapsedWhitespace(s: String): String = s.replace("\\s+", " ")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Switch to use the old tags dialog when selecting tags for custom studying to offer a better UX when selecting from a large amount of tags. The dialog was modified a bit to show only the tags for the study target deck.

Note I thought about adding a neutral button in the current _Study by tags_ option called _Legacy_ to have both the current and old tags options, but this felt confusing to the user as they are not identical in behavior and functionality.

## Fixes

Related to #18885 as a temporary ux improvement. The proper fix would be a new UI which I'm going to do later.

## How Has This Been Tested?

Checked the old tags dialog used when custom studying.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

