### PR TITLE
Move mainToolbar to NoteEditorActivity and NoteEditorFragment NF cleanup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -211,6 +211,15 @@ open class AnkiActivity :
         supportActionBar?.title = title
     }
 
+    /**
+     * Sets the title of the toolbar (support action bar) for the activity.
+     *
+     * @param title The new title to be set for the toolbar.
+     */
+    open fun setToolbarTitle(
+        @StringRes titleRes: Int,
+    ) = setToolbarTitle(getString(titleRes))
+
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         if (item.itemId == android.R.id.home) {
             Timber.i("Home button pressed")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorActivity.kt
@@ -47,6 +47,9 @@ class NoteEditorActivity :
 
     lateinit var noteEditorFragment: NoteEditorFragment
 
+    private val mainToolbar: androidx.appcompat.widget.Toolbar
+        get() = findViewById(R.id.toolbar)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -116,6 +119,15 @@ class NoteEditorActivity :
             }
         } else {
             noteEditorFragment = existingFragment as NoteEditorFragment
+        }
+
+        enableToolbar()
+
+        // R.id.home is handled in setNavigationOnClickListener
+        // Set a listener for back button clicks in the toolbar
+        mainToolbar.setNavigationOnClickListener {
+            Timber.i("NoteEditor:: Back button on the menu was pressed")
+            onBackPressedDispatcher.onBackPressed()
         }
 
         startLoadingCollection()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -295,7 +295,7 @@ class NoteEditorFragment :
         registerForActivityResult(
             ActivityResultContracts.StartActivityForResult(),
             NoteEditorActivityResultCallback {
-                if (it.resultCode != Activity.RESULT_CANCELED) {
+                if (it.resultCode != RESULT_CANCELED) {
                     changed = true
                 }
             },
@@ -370,7 +370,7 @@ class NoteEditorFragment :
         registerForActivityResult(
             ActivityResultContracts.StartActivityForResult(),
             NoteEditorActivityResultCallback { result ->
-                if (result.resultCode != Activity.RESULT_CANCELED) {
+                if (result.resultCode != RESULT_CANCELED) {
                     changed = true
                     if (!addNote) {
                         reloadRequired = true
@@ -641,7 +641,7 @@ class NoteEditorFragment :
         return try {
             val inputStream = requireContext().contentResolver.openInputStream(uri) ?: return null
 
-            val fileName = ContentResolverUtil.getFileName(requireContext().contentResolver, uri) ?: return null
+            val fileName = ContentResolverUtil.getFileName(requireContext().contentResolver, uri)
             val cacheDir = requireContext().cacheDir
             val destFile = File(cacheDir, fileName)
 
@@ -773,7 +773,7 @@ class NoteEditorFragment :
                             Timber.i("onGalleryClicked")
                             try {
                                 ioEditorLauncher.launch("image/*")
-                            } catch (ex: ActivityNotFoundException) {
+                            } catch (_: ActivityNotFoundException) {
                                 Timber.w("No app found to handle onGalleryClicked request")
                                 activity?.showSnackbar(R.string.activity_start_failed)
                             }
@@ -2278,7 +2278,7 @@ class NoteEditorFragment :
         val pair: Pair<Int, Field>? =
             try {
                 Notetypes.fieldMap(currentlySelectedNotetype!!)[name]
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 Timber.w("Failed to obtain field '%s'", name)
                 return null
             }
@@ -2618,13 +2618,13 @@ class NoteEditorFragment :
         get() =
             ShortcutGroup(
                 listOf(
-                    shortcut("Ctrl+ENTER", { getString(R.string.save) }),
-                    shortcut("Ctrl+D", { getString(R.string.select_deck) }),
-                    shortcut("Ctrl+L", { getString(R.string.card_template_editor_group) }),
-                    shortcut("Ctrl+N", { getString(R.string.select_note_type) }),
-                    shortcut("Ctrl+Shift+T", { getString(R.string.tag_editor) }),
-                    shortcut("Ctrl+Shift+C", { getString(R.string.multimedia_editor_popup_cloze) }),
-                    shortcut("Ctrl+P", { getString(R.string.card_editor_preview_card) }),
+                    shortcut("Ctrl+ENTER") { getString(R.string.save) },
+                    shortcut("Ctrl+D") { getString(R.string.select_deck) },
+                    shortcut("Ctrl+L") { getString(R.string.card_template_editor_group) },
+                    shortcut("Ctrl+N") { getString(R.string.select_note_type) },
+                    shortcut("Ctrl+Shift+T") { getString(R.string.tag_editor) },
+                    shortcut("Ctrl+Shift+C") { getString(R.string.multimedia_editor_popup_cloze) },
+                    shortcut("Ctrl+P") { getString(R.string.card_editor_preview_card) },
                 ),
                 R.string.note_editor_group,
             )
@@ -2814,7 +2814,7 @@ class NoteEditorFragment :
                 val tmpls =
                     try {
                         newNoteType.templates
-                    } catch (e: Exception) {
+                    } catch (_: Exception) {
                         Timber.w("error in obtaining templates from note type %s", allNoteTypeIds!![pos])
                         return
                     }
@@ -2871,8 +2871,6 @@ class NoteEditorFragment :
         modifyCurrentSelection(TextWrapper(prefix, suffix), textBox)
     }
 
-    private fun hasClozeDeletions(): Boolean = nextClozeIndex > 1
-
     // BUG: This assumes all fields are inserted as: {{cloze:Text}}
     private val nextClozeIndex: Int
         get() {
@@ -2912,7 +2910,7 @@ class NoteEditorFragment :
     }
 
     /**
-     * Whether sticky fields are currently being loaded. In this card, don't consider the text chagned.
+     * Whether sticky fields are currently being loaded. In this card, don't consider the text changed.
      */
     private var loadingStickyFields = false
 


### PR DESCRIPTION
## Purpose / Description
- Moving the toolbar implementation to the activity
- Cleanup warnings in NoteEditorFragment

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->