### PR TITLE
refactor: prepare BootService for review reminders

### DIFF
--- a/common/src/main/java/com/ichi2/anki/common/annotations/LegacyNotifications.kt
+++ b/common/src/main/java/com/ichi2/anki/common/annotations/LegacyNotifications.kt
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.common.annotations
+
+/**
+ * Indicates that a section of code is part of the legacy notifications system in place before
+ * August 2025. Code flagged with this annotation is slated to be eventually deleted once the
+ * review reminders system becomes stable.
+ *
+ * Also see all conditional points gated by Prefs.newReviewRemindersEnabled.
+ *
+ * Once all occurrences of both this annotation and Prefs.newReviewRemindersEnabled are no longer
+ * present in the code base, the migration from the legacy notifications system to the new review
+ * reminders system will be complete.
+ */
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.VALUE_PARAMETER,
+    AnnotationTarget.EXPRESSION,
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+)
+@Repeatable
+@Retention(AnnotationRetention.SOURCE)
+@MustBeDocumented
+annotation class LegacyNotifications(
+    val optionalReason: String = "",
+)


### PR DESCRIPTION
## Purpose / Description
This is the class that runs when the phone initially starts up. It listens to the system boot-completed intent and was previously used for the old studying notification system. However, it is messy and needs to be refactored. Most of its functionality will be replaced by my code. Here, I'm cleaning up the code I plan to keep and marking the code I plan to eventually delete.

- Add missing docstring and proper attribution for file creation to BootService -- I checked who created the file using `git blame`
- Use conditionals to gate where new review reminder code will be run
- Made it so that old notification code will only run if review reminders are disabled
- Renamed `sWasRun` Hungarian notation variable to be `wasRun`
- Used Intent constant instead of hard-coding `BOOT_COMPLETED_INTENT`
- Annotated methods that will not be used for the review reminders system (i.e., they can be deleted after August) with `@LegacyNotifications`, a new annotation

## Fixes
* For GSoC 2025: Review Reminders

## Approach
I plan on doing this for every file that the original notification system used. I've learned my lesson after trying to merge the large RecyclerView and AddEditReminderDialog PR, haha, so I'm trying to make smaller commit and open up smaller PRs more often. This is some of my current progress in deprecating the old code.

## How Has This Been Tested?
- Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->