### PR TITLE
refactor: prepare AnkiDroidApp, widget, and day-rollover for review reminders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NavigationDrawerActivity.kt
@@ -275,6 +275,10 @@ abstract class NavigationDrawerActivity :
                 REQUEST_PREFERENCES_UPDATE,
                 result.resultCode,
             )
+
+            // We trigger a notifications channel set-up since the user may have changed the locale set
+            // from within the app, which should cause the notification channel names to be reloaded to
+            // match the new locale
             setupNotificationChannels(applicationContext)
             // Restart the activity on preference change
             // collection path hasn't been changed so just restart the current activity

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.services.BootService.Companion.scheduleNotification
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.preferences.SliderPreference
@@ -85,6 +86,6 @@ suspend fun setDayOffset(
     undoableOp {
         setPreferences(newPrefs)
     }
-    scheduleNotification(TimeManager.time, context)
+    if (!Prefs.newReviewRemindersEnabled) scheduleNotification(TimeManager.time, context)
     Timber.i("set day offset: '%d'", hours)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -40,6 +40,9 @@ import java.util.Calendar
 /**
  * BroadcastReceiver which listens to the Android system-level intent that fires when the device starts up.
  * Schedules notifications for review reminders.
+ *
+ * Note that Android battery optimizations may potentially block us from receiving the [Intent.ACTION_BOOT_COMPLETED]
+ * intent, which could cause review reminders to not be scheduled.
  */
 @NeedsTest("Check on various Android versions that this can execute")
 class BootService : BroadcastReceiver() {


### PR DESCRIPTION
## Purpose / Description
More cleanup to prepare for AlarmManagerService and an updated NotificationService.

- Annotated parts of AnkiDroidApp that can be removed after review reminders are implemented
- Deleted a `BootService.onReceive` call in AnkiDroidApp that does nothing since BootService filters out all intents without the proper system-level intent
- Wrapped the `observeForever` pathway that allows the widget to trigger notifications via AnkiDroidApp with a `Prefs.newReviewRemindersEnabled` to mark that it can be deleted once review reminders are stable; this includes moving old legacy notifications code within WidgetStatus into proper conditional gates
- Added a docstring to BootService describing possible battery optimization problems as requested by David
- Added some comments to NavigationDrawerActivity to explain what I found to be a confusing call to `setupNotificationChannels`: I almost deleted this line, thinking it was useless
- Gated a `scheduleNotification` call that fires when the start-of-day value is changed to only run when the new review reminders system is disabled, as the new system does not need to worry about rollover time

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Using the annotation created in my last PR and Prefs.newReviewRemindersEnabled

## How Has This Been Tested?
Tested on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->