### PR TITLE
fix: hide save button in fragmented activity to prevent duplication

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1020,9 +1020,10 @@ open class CardBrowser :
             showBackIcon()
             increaseHorizontalPaddingOfOverflowMenuIcons(menu)
         }
-        // Append note editor menu to card browser menu if fragmented and deck is not empty
-        if (fragmented && viewModel.rowCount != 0) {
-            fragment?.onCreateMenu(menu, menuInflater)
+        // Remove save note and preview note options if there are no notes
+        if (fragmented && viewModel.rowCount == 0) {
+            menu.removeItem(R.id.action_save)
+            menu.removeItem(R.id.action_preview)
         }
         actionBarMenu?.findItem(R.id.action_undo)?.run {
             isVisible = getColUnsafe.undoAvailable()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Hides the save button from `NoteEditorFragment` in cardBrowser to prevent duplication

## Fixes
* Fixes #18921 

## Approach
- The cardBrowser already has a 'save_note' being added, and noteEditorFragment adds another one. 
- Here we introduce a check to prevent additional 'save_note' buttons from being added.
- This occurred after the NoteEditor was separated into the NoteEditorActivity.
- Since NoteEditorFragment is a MenuProvider we do not need onCreateMenu anymore.

## How Has This Been Tested?

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/b1f9da36-7d47-4233-8462-b2b2108636be" />

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->