### PR TITLE
feat: add hover effects to divider in ResizablePaneManager

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.ui
 
 import android.content.SharedPreferences
 import android.view.MotionEvent
+import android.view.PointerIcon
 import android.view.View
 import android.widget.LinearLayout
 import androidx.core.content.edit
@@ -51,6 +52,24 @@ class ResizablePaneManager(
         var initialTouchX = 0f
         var initialLeftWeight = 0f
         var initialRightWeight = 0f
+
+        divider.setOnHoverListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_HOVER_ENTER -> {
+                    divider.pointerIcon =
+                        PointerIcon.getSystemIcon(
+                            divider.context,
+                            PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW,
+                        )
+                    true
+                }
+                MotionEvent.ACTION_HOVER_EXIT -> {
+                    divider.pointerIcon = null
+                    true
+                }
+                else -> false
+            }
+        }
 
         divider.setOnTouchListener { v, event ->
             val leftParams = leftPane.layoutParams as LinearLayout.LayoutParams

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizingDivider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizingDivider.kt
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2025 Hari Srinivasan <harisrini21@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.FrameLayout
+import com.ichi2.anki.R
+
+/**
+ * Custom component that represents a resizable divider used in multi-pane layouts.
+ * Encapsulates the resizing divider layout for better reusability.
+ */
+class ResizingDivider
+    @JvmOverloads
+    constructor(
+        context: Context,
+        attrs: AttributeSet? = null,
+        defStyleAttr: Int = 0,
+    ) : FrameLayout(context, attrs, defStyleAttr) {
+        private val dividerHandle: View
+
+        init {
+            // Inflate the original layout into this custom view
+            LayoutInflater.from(context).inflate(R.layout.resizing_divider_internal, this, true)
+
+            // Get reference to the divider handle
+            dividerHandle = findViewById(R.id.divider_handle)
+
+            // Set the default background color
+            setBackgroundColor(context.getColor(R.color.idle_divider_color))
+        }
+    }

--- a/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_browser.xml
@@ -19,18 +19,12 @@
                 android:layout_width="1dip"
                 android:layout_weight="3"
                 android:layout_height="match_parent"/>
-            <FrameLayout
+
+            <com.ichi2.anki.ui.ResizingDivider
                 android:id="@+id/card_browser_resizing_divider"
                 android:layout_width="8dp"
-                android:layout_height="match_parent"
-                android:background="@color/idle_divider_color">
-                <View
-                    android:id="@+id/card_browser_divider_handle"
-                    android:layout_width="3dp"
-                    android:layout_height="30dp"
-                    android:layout_gravity="center"
-                    android:background="@drawable/divider_handle_background" />
-            </FrameLayout>
+                android:layout_height="match_parent" />
+
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/note_editor_frame"
                 android:layout_weight="2"

--- a/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/card_template_editor.xml
@@ -28,18 +28,10 @@
                 android:layout_weight="3"
                 android:layout_height="match_parent" />
 
-            <FrameLayout
+            <com.ichi2.anki.ui.ResizingDivider
                 android:id="@+id/card_template_editor_resizing_divider"
                 android:layout_width="8dp"
-                android:layout_height="match_parent"
-                android:background="@color/idle_divider_color">
-                <View
-                    android:id="@+id/card_template_editor_divider_handle"
-                    android:layout_width="3dp"
-                    android:layout_height="30dp"
-                    android:layout_gravity="center"
-                    android:background="@drawable/divider_handle_background" />
-            </FrameLayout>
+                android:layout_height="match_parent" />
 
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/fragment_container"

--- a/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
+++ b/AnkiDroid/src/main/res/layout-xlarge/homescreen.xml
@@ -22,18 +22,10 @@
                 android:layout_weight="3"
                 android:layout_height="match_parent"/>
 
-            <FrameLayout
+            <com.ichi2.anki.ui.ResizingDivider
                 android:id="@+id/homescreen_resizing_divider"
                 android:layout_width="8dp"
-                android:layout_height="match_parent"
-                android:background="@color/idle_divider_color">
-                <View
-                    android:id="@+id/homescreen_divider_handle"
-                    android:layout_width="3dp"
-                    android:layout_height="30dp"
-                    android:layout_gravity="center"
-                    android:background="@drawable/divider_handle_background" />
-            </FrameLayout>
+                android:layout_height="match_parent" />
 
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/studyoptions_fragment"
@@ -43,4 +35,3 @@
         </LinearLayout>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>
-

--- a/AnkiDroid/src/main/res/layout/resizing_divider_internal.xml
+++ b/AnkiDroid/src/main/res/layout/resizing_divider_internal.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- res/layout/resizing_divider_internal.xml -->
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+    <View
+        android:id="@+id/divider_handle"
+        android:layout_width="3dp"
+        android:layout_height="30dp"
+        android:layout_gravity="center"
+        android:background="@drawable/divider_handle_background" />
+</merge>
+


### PR DESCRIPTION
## Purpose / Description
- Resizable divider onHover changes PointerIcon to a resizing indicator and sets divider to dragColor

## Fixes
* For GSoC 2025: Tablet & Chromebook UI

## Approach
- As suggested by @SanjaySargam this will add a onHoverListner to the `ResizablePaneManager` to show users that it is resizable

## How Has This Been Tested?
Tested on Chromebook emulator - API 34
[hover.webm](https://github.com/user-attachments/assets/07cb0549-ab77-460a-be58-03a3b18dee88)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->