### PR TITLE
fix: `Study by card state or tag` dropdown menu is prone to overflow

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -308,7 +308,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                     android.R.layout.simple_spinner_item,
                     CustomStudyCardState.entries.map { it.labelProducer() },
                 ).apply {
-                    setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+                    setDropDownViewResource(R.layout.multiline_spinner_item)
                 }
         }
         val editText =

--- a/AnkiDroid/src/main/res/layout/multiline_spinner_item.xml
+++ b/AnkiDroid/src/main/res/layout/multiline_spinner_item.xml
@@ -19,6 +19,7 @@
     style="?android:attr/spinnerDropDownItemStyle"
     android:singleLine="false"
     android:maxLines="5"
+    android:paddingVertical="14dp"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:minHeight="?attr/dropdownListPreferredItemHeight"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Some labels in `Study by card state or tag` dropdown menu labels are relatively long, so they are prone to overflow on a single line.
<img width="380" height="2310" alt="image" src="https://github.com/user-attachments/assets/88863776-0222-4020-9031-7b21d1d34fce" />

This PR aims to resolve the issue.

## Fixes
* Fixes #18953

## Approach
Use the existing `multiline_spinner_item.xml` instead of `simple_spinner_item` for layout


## How Has This Been Tested?
Checked on a physical device (Android 11)

Before | After
---|---
<img width="1080" height="1793" alt="image" src="https://github.com/user-attachments/assets/0ae884c6-823c-4f32-a4bc-7009ca2632bd" />|<img width="1080" height="1802" alt="image" src="https://github.com/user-attachments/assets/7f7360a9-1944-45a7-a4ee-8a01295126e2" />
<img width="1080" height="627" alt="image" src="https://github.com/user-attachments/assets/51e4add4-24f1-409c-80d1-1146b714e5af" />(In German)|<img width="1080" height="630" alt="image" src="https://github.com/user-attachments/assets/343f4ccd-8bac-4634-808e-0e6b23a20172" />
<img width="1080" height="624" alt="image" src="https://github.com/user-attachments/assets/0185f064-7538-4f46-b085-e8a69929a492" />(In Spanish)|<img width="1080" height="627" alt="image" src="https://github.com/user-attachments/assets/a4735feb-4416-4373-bd0c-33925cf71cee" />



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->