### PR TITLE
build(deps): anki25.07.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.2"
-ankiBackend = '0.1.59-anki25.07.3'
+ankiBackend = '0.1.59-anki25.07.4'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

Integrate latest upstream release - pretty small bugfix release upstream, only has two items that will flow through to Anki-Android at all, but might as well get it in

This will need a close / reopen once this PR has been merged and published:

- https://github.com/ankidroid/Anki-Android-Backend/pull/556