### PR TITLE
feat(reminders): review reminders RecyclerView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -20,19 +20,29 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.setFragmentResult
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
+import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.libanki.DeckId
 import timber.log.Timber
 
 /**
  * Fragment for creating, viewing, editing, and deleting review reminders.
  */
-class ScheduleReminders : Fragment(R.layout.fragment_schedule_reminders) {
+class ScheduleReminders :
+    Fragment(R.layout.fragment_schedule_reminders),
+    DeckSelectionDialog.DeckSelectionListener {
     /**
      * Whether this fragment has been opened to edit all review reminders or just a specific deck's reminders.
      * @see ReviewReminderScope
@@ -45,7 +55,17 @@ class ScheduleReminders : Fragment(R.layout.fragment_schedule_reminders) {
         ) ?: ReviewReminderScope.Global
     }
 
+    private lateinit var database: ReviewRemindersDatabase
     private lateinit var toolbar: MaterialToolbar
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: ScheduleRemindersAdapter
+
+    /**
+     * Retrieving deck names for a given deck ID in [setDeckNameFromScopeForView] requires a call to the collection.
+     * However, most reminders in the RecyclerView will often be from the same deck (and are guaranteed to be if
+     * this fragment is opened in [ReviewReminderScope.DeckSpecific] mode). Hence, we cache deck names.
+     */
+    private val cachedDeckNames: HashMap<DeckId, String> = hashMapOf()
 
     override fun onViewCreated(
         view: View,
@@ -57,6 +77,33 @@ class ScheduleReminders : Fragment(R.layout.fragment_schedule_reminders) {
         toolbar = view.findViewById(R.id.toolbar)
         reloadToolbarText()
         (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
+
+        // Set up add button
+        val addButton = view.findViewById<ExtendedFloatingActionButton>(R.id.schedule_reminders_add_reminder_fab)
+        addButton.setOnClickListener { addReminder() }
+
+        // Set up recycler view
+        recyclerView = view.findViewById(R.id.schedule_reminders_recycler_view)
+        val layoutManager = LinearLayoutManager(requireContext())
+        recyclerView.layoutManager = layoutManager
+        recyclerView.addItemDecoration(DividerItemDecoration(requireContext(), layoutManager.orientation))
+
+        // Set up database
+        database = ReviewRemindersDatabase()
+
+        // Set up adapter
+        adapter =
+            ScheduleRemindersAdapter(
+                mutableListOf(),
+                // Pass functionality to the adapter
+                ::setDeckNameFromScopeForView,
+                ::toggleReminderEnabled,
+                ::editReminder,
+            )
+        recyclerView.adapter = adapter
+
+        // Retrieve reminders based on the editing scope
+        launchCatchingTask { loadDatabaseRemindersIntoUI() }
     }
 
     private fun reloadToolbarText() {
@@ -71,11 +118,129 @@ class ScheduleReminders : Fragment(R.layout.fragment_schedule_reminders) {
         }
     }
 
+    /**
+     * Fetch all reminders from the database and put them into the RecyclerView.
+     */
+    private suspend fun loadDatabaseRemindersIntoUI() {
+        Timber.d("Loading review reminders from database")
+        val remindersAsMap =
+            when (val scope = scheduleRemindersScope) {
+                is ReviewReminderScope.Global -> {
+                    (database.getAllAppWideReminders() + database.getAllDeckSpecificReminders())
+                }
+                is ReviewReminderScope.DeckSpecific -> database.getRemindersForDeck(scope.did)
+            }
+        val remindersAsList = remindersAsMap.values.sortedBy { it.time.toSecondsFromMidnight() }
+        adapter.reminders.addAll(remindersAsList)
+        adapter.notifyDataSetChanged()
+        Timber.d("Database review reminders successfully loaded")
+    }
+
+    /**
+     * Sets a TextView's text based on a [ReviewReminderScope].
+     * The text is either the scope's associated deck's name, or "All Decks" if the scope is global.
+     * For example, this is used to display the [ScheduleRemindersAdapter]'s deck name column.
+     */
+    private fun setDeckNameFromScopeForView(
+        scope: ReviewReminderScope,
+        view: TextView,
+    ) {
+        when (scope) {
+            is ReviewReminderScope.Global -> view.text = "All Decks"
+            is ReviewReminderScope.DeckSpecific -> {
+                launchCatchingTask {
+                    val deckName = cachedDeckNames.getOrPut(scope.did) { scope.getDeckName() }
+                    view.text = deckName
+                }
+            }
+        }
+    }
+
+    /**
+     * Toggles whether a review reminder is enabled, i.e. whether its notifications will fire.
+     * Saves this information immediately to the database and then updates the UI.
+     */
+    private fun toggleReminderEnabled(
+        id: ReviewReminderId,
+        scope: ReviewReminderScope,
+        position: Int,
+    ) {
+        Timber.d("Toggling reminder enabled state: %s", id)
+        val newState = !adapter.reminders[position].enabled
+
+        val performToggle:
+            (HashMap<ReviewReminderId, ReviewReminder>) -> Map<ReviewReminderId, ReviewReminder> =
+            { reminders ->
+                reminders[id]?.enabled = newState
+                reminders
+            }
+
+        when (scope) {
+            is ReviewReminderScope.Global -> database.editAllAppWideReminders(performToggle)
+            is ReviewReminderScope.DeckSpecific -> database.editRemindersForDeck(scope.did, performToggle)
+        }
+
+        adapter.reminders[position].enabled = newState
+        adapter.notifyItemChanged(position)
+    }
+
+    /**
+     * The method that runs when the "+" icon is pressed, allowing the user to create a new review reminder.
+     * Opens [AddEditReminderDialog] in [AddEditReminderDialog.DialogMode.Add] mode.
+     */
+    private fun addReminder() {
+        Timber.d("Adding new review reminder")
+    }
+
+    /**
+     * The method that runs when an existing reminder is tapped, allowing the user to change its fields.
+     * Opens [AddEditReminderDialog] in [AddEditReminderDialog.DialogMode.Edit] mode.
+     */
+    private fun editReminder(reminder: ReviewReminder) {
+        Timber.d("Editing review reminder: %s", reminder.id)
+    }
+
+    /**
+     * [AddEditReminderDialog] requires a [DeckSelectionDialog.DeckSelectionListener] to catch changes to
+     * the [com.ichi2.anki.DeckSpinnerSelection]. However, [AddEditReminderDialog] is removed from the
+     * fragment stack when the [DeckSelectionDialog] appears, so we set [ScheduleReminders] as the listener
+     * and forward data to [AddEditReminderDialog] when a deck is selected.
+     */
+    override fun onDeckSelected(deck: DeckSelectionDialog.SelectableDeck?) {
+        Timber.d("Deck selected in deck spinner: %s", deck)
+        setFragmentResult(
+            DECK_SELECTION_RESULT_REQUEST_KEY,
+            Bundle().apply {
+                putParcelable(DECK_SELECTION_RESULT_REQUEST_KEY, deck)
+            },
+        )
+    }
+
     companion object {
         /**
          * Arguments key for passing the [ReviewReminderScope] to open this fragment with.
          */
         private const val EXTRAS_SCOPE_KEY = "scope"
+
+        /**
+         * Arguments key for storing the current or latest [AddEditReminderDialog] instance.
+         * We save this so we can pass [onDeckSelected] onward to the dialog
+         * and so we can determine what reminder has been recently edited.
+         */
+        private const val ACTIVE_DIALOG_MODE_ARGUMENTS_KEY = "active_dialog_mode"
+
+        /**
+         * Fragment result key for receiving the result of [AddEditReminderDialog].
+         * Public so [AddEditReminderDialog] can access it, too.
+         */
+        const val ADD_EDIT_DIALOG_RESULT_REQUEST_KEY = "add_edit_reminder_dialog_result_request_key"
+
+        /**
+         * Fragment result key for sending [AddEditReminderDialog] the result of the deck spinner selection event.
+         * Public so [AddEditReminderDialog] can access it, too.
+         * @see onDeckSelected
+         */
+        const val DECK_SELECTION_RESULT_REQUEST_KEY = "reminder_deck_selection_result_request_key"
 
         /**
          * Creates an intent to start the ScheduleReminders fragment.
@@ -95,7 +260,7 @@ class ScheduleReminders : Fragment(R.layout.fragment_schedule_reminders) {
                         putParcelable(EXTRAS_SCOPE_KEY, scope)
                     },
                 ).apply {
-                    Timber.i("launching ScheduleReminders for $scope scope")
+                    Timber.i("launching ScheduleReminders for %s scope", scope)
                 }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.annotation.SuppressLint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.materialswitch.MaterialSwitch
+import com.ichi2.anki.R
+
+class ScheduleRemindersAdapter(
+    val reminders: MutableList<ReviewReminder>,
+    private val setDeckNameFromScopeForView: (ReviewReminderScope, TextView) -> Unit,
+    private val toggleReminderEnabled: (ReviewReminderId, ReviewReminderScope, Int) -> Unit,
+    private val editReminder: (ReviewReminder) -> Unit,
+) : RecyclerView.Adapter<ScheduleRemindersAdapter.ViewHolder>() {
+    inner class ViewHolder(
+        holder: View,
+    ) : RecyclerView.ViewHolder(holder) {
+        var reminder: ReviewReminder? = null
+        val deckTextView: TextView = holder.findViewById(R.id.reminders_list_deck_text)
+        val timeTextView: TextView = holder.findViewById(R.id.reminders_list_time_text)
+        val switchView: MaterialSwitch = holder.findViewById(R.id.reminders_list_switch)
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): ViewHolder {
+        val view =
+            LayoutInflater
+                .from(parent.context)
+                .inflate(R.layout.schedule_reminders_list_item, parent, false)
+        return ViewHolder(view)
+    }
+
+    @SuppressLint("DefaultLocale")
+    override fun onBindViewHolder(
+        holder: ViewHolder,
+        position: Int,
+    ) {
+        val reminder = reminders[position]
+        holder.reminder = reminder
+
+        setDeckNameFromScopeForView(reminder.scope, holder.deckTextView)
+        holder.timeTextView.text = reminder.time.toString()
+
+        holder.itemView.setOnClickListener { editReminder(reminder) }
+
+        holder.switchView.isChecked = reminder.enabled
+        holder.switchView.setOnClickListener { toggleReminderEnabled(reminder.id, reminder.scope, position) }
+    }
+
+    override fun getItemCount(): Int = reminders.size
+}


### PR DESCRIPTION
## Purpose / Description
- Added RecyclerView to ScheduleReminders fragment.
- Created ScheduleRemindersAdapter, which holds the state of each individual row in the RecyclerView. The adapter has functionality in the form of functions passed to it via its constructor to keep most of the key functionality centralized within ScheduleReminders and to avoid injecting a Context into the adapter, which should optimally be context-free. I tried to keep the adapter as short as possible; it only governs the UI of each individual reminder in the RecyclerView.
- Added `setDeckNameFromScopeView` method, which retrieves deck names from the collection for displaying in the UI. Deck names are cached to prevent repeated calls to the collection.
- Added empty placeholder methods for adding reminders and editing reminders that will be filled in by a future PR.
- Added logic for toggling whether reminders are enabled and saving that state.
- Added `onDeckSelected`, a method that will allow the code to detect if the AddEditReminderDialog (coming soon) has had the deck selected in the deck selection dialog changed. We must catch this in ScheduleReminders because this onChange event has to be caught by a Fragment, whereas the AddEditReminderDialog is just a dialog that gets briefly removed when the deck selection dialog appears. The data is forwarded to the AddEditReminderDialog via a FragmentResult, a very simple way of passing information between fragments.
- Added constants that will be used for pushing information to and from the AddEditReminderDialog to the ScheduleReminders companion object.
- Fixed a small Timber call to use format arguments rather than interpolation.

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- I've tried to explain the motivation for implementation details in Purpose / Description. Let me know if anything is unclear.

## How Has This Been Tested?
- Launches using a physical Samsung S23, API 34.
- The full review reminders CRUD works when this PR is integrated with my AddEditReminderDialog and TimePicker code. Full testing should be possible once those are also merged.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->