### PR TITLE
fix(sync): empty endpoint

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -238,7 +238,7 @@ private suspend fun handleNormalSync(
             }
         }
 
-    if (output.hasNewEndpoint()) {
+    if (output.hasNewEndpoint() && output.newEndpoint.isNotEmpty()) {
         Timber.i("sync endpoint updated")
         deckPicker.sharedPrefs().edit {
             putString(SyncPreferences.CURRENT_SYNC_URI, output.newEndpoint)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -73,8 +73,8 @@ class SyncMediaWorker(
 
             // The collection must be open, but we should not block collection operations while
             // `syncMedia` is executing, the app should be usable during a background media sync
-            CollectionManager.getColUnsafe().backend.syncMedia(auth)
-            val backend = CollectionManager.getBackend()
+            val backend = CollectionManager.getColUnsafe().backend
+            backend.syncMedia(input = auth)
 
             delay(1000) // avoid notifications if sync occurs too quickly
             if (backend.mediaSyncStatus().active) {

--- a/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/SyncStatus.kt
@@ -54,7 +54,7 @@ enum class SyncStatus {
                 // Use CollectionManager to ensure that this doesn't block 'deck count' tasks
                 // throws if a .colpkg import or similar occurs just before this call
                 val output = withContext(Dispatchers.IO) { CollectionManager.getBackend().syncStatus(auth) }
-                if (output.hasNewEndpoint()) {
+                if (output.hasNewEndpoint() && output.newEndpoint.isNotEmpty()) {
                     context.sharedPrefs().edit {
                         putString(SyncPreferences.CURRENT_SYNC_URI, output.newEndpoint)
                     }


### PR DESCRIPTION
## Fixes
* Fixes #18937 (I hope)

## Approach

Similar to #18893 and https://github.com/ankidroid/Anki-Android/commit/02deb0a0a5905f1cca91aa20cedf67c80cc1bc83 -> Check if the endpoint is empty before setting it (I didn't see these call sites before)

## How Has This Been Tested?

Emulator 34:

I can still sync the collection and media

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->