### PR TITLE
feat(reminders): created TimePickerDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/TimePickerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/TimePickerDialog.kt
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.app.Dialog
+import android.os.Bundle
+import android.widget.TimePicker
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.BundleCompat
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import com.ichi2.anki.R
+import com.ichi2.utils.customView
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+
+class TimePickerDialog : DialogFragment() {
+    private lateinit var timePicker: TimePicker
+
+    /**
+     * The initial time to display on this TimePicker, retrieved from arguments and set by [getInstance].
+     */
+    private val reviewReminderTime: ReviewReminderTime by lazy {
+        requireNotNull(
+            BundleCompat.getParcelable(requireArguments(), REVIEW_REMINDER_TIME_ARGUMENTS_KEY, ReviewReminderTime::class.java),
+        ) {
+            "Review reminder time cannot be null"
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        super.onCreateDialog(savedInstanceState)
+        val contentView = layoutInflater.inflate(R.layout.time_picker_dialog, null)
+
+        val dialog =
+            AlertDialog
+                .Builder(requireActivity())
+                .positiveButton(R.string.dialog_ok) { onSubmit() }
+                .negativeButton(R.string.dialog_cancel)
+                .customView(contentView)
+                .create()
+
+        timePicker = contentView.findViewById(R.id.time_picker)
+        timePicker.hour = reviewReminderTime.hour
+        timePicker.minute = reviewReminderTime.minute
+
+        return dialog
+    }
+
+    private fun onSubmit() {
+        val newTime = ReviewReminderTime(timePicker.hour, timePicker.minute)
+        setFragmentResult(
+            "TIME_FRAGMENT_RESULT_REQUEST_KEY_HARDCODED_PLACEHOLDER",
+            Bundle().apply {
+                putParcelable("TIME_FRAGMENT_RESULT_REQUEST_KEY_HARDCODED_PLACEHOLDER", newTime)
+            },
+        )
+    }
+
+    companion object {
+        /**
+         * Arguments key for the initial time to display on this TimePicker.
+         */
+        private const val REVIEW_REMINDER_TIME_ARGUMENTS_KEY = "review_reminder_time"
+
+        /**
+         * Creates a new instance of this dialog with the given initial time.
+         */
+        fun getInstance(reviewReminderTime: ReviewReminderTime): TimePickerDialog =
+            TimePickerDialog().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(REVIEW_REMINDER_TIME_ARGUMENTS_KEY, reviewReminderTime)
+                    }
+            }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/time_picker_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/time_picker_dialog.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/root_linear_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/add_edit_reminder_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="@style/ActionBarStyle"
+            android:background="?attr/appBarColor"
+            app:title="Select reminder time" />
+
+        <TimePicker
+            android:id="@+id/time_picker"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="24dp"
+            style="@style/TimePickerStyle"
+            android:timePickerMode="clock" />
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -254,4 +254,9 @@
     <style name="ThemeOverlay.App.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
         <item name="android:navigationBarColor" tools:ignore="NewApi">@android:color/transparent</item>
     </style>
+
+    <style name="TimePickerStyle" parent="ThemeOverlay.Material3.MaterialTimePicker">
+        <item name="android:headerBackground">?attr/colorPrimary</item>
+        <item name="android:numbersSelectorColor">?attr/colorPrimary</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Purpose / Description
- Created TimePickerDialog for picking the time of a review reminder. This is a separate dialog from the AddEditReminderDialog that opens when you click on the time button to minimize visual clutter on the already-crammed AddEditReminderDialog. Pulling this out into a separate dialog allows the user to only focus on inputting the time on the native Material UI TimePicker.
- Made it so the TimePickerDialog sends its results back to the AddEditReminderDialog via a FragmentResult, a simple method of passing information between fragments. Currently, the request key used for the result-passing is a hardcoded placeholder: the actual constant is defined within AddEditReminderDialog, which I will push as a separate PR to make these easier to review. Once that is merged, I will change this requestKey to no longer be this hardcoded placeholder value.
- Created the time_picker_dialog XML file, which is minimalistic, featuring only a Toolbar and the built-in TimePicker.
- Added a TimePickerStyle to styles.xml to make sure the TimePicker is the right color.

## UI
<img width="763" height="802" alt="image" src="https://github.com/user-attachments/assets/b43456ee-388e-4860-bdcf-2d9d9acfecdd" />
<img width="770" height="806" alt="image" src="https://github.com/user-attachments/assets/9ccf1e71-160f-4552-bce6-8af8594176fe" />

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Creates an isolated new dialog. See above for motivation.

## How Has This Been Tested?
- Launches using a physical Samsung S23, API 34.
- The full review reminders CRUD works when this PR is integrated with my AddEditReminderDialog and TimePicker code. Full testing should be possible once those are also merged.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->