### PR TITLE
improve count color contrast to pass accessibility scanner

### DIFF
--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -36,7 +36,7 @@
         <item name="expandRef">@drawable/ic_chevron_right_white</item>
         <item name="collapseRef">@drawable/ic_expand_more_white</item>
         <!-- Count colors -->
-        <item name="newCountColor">@color/material_blue_700</item>
+        <item name="newCountColor">@color/material_blue_600</item>
         <item name="learnCountColor">@color/material_red_400</item>
         <item name="reviewCountColor">@color/material_green_400</item>
         <item name="buryCountColor">@color/disabled_gray_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -53,7 +53,7 @@
         <!-- Count colors -->
         <item name="newCountColor">@color/material_indigo_700</item>
         <item name="learnCountColor">@color/material_red_700</item>
-        <item name="reviewCountColor">@color/material_green_700</item>
+        <item name="reviewCountColor">@color/material_green_800</item>
         <item name="buryCountColor">@color/disabled_gray_light</item>
         <item name="zeroCountColor">#1f000000</item>
         <!-- Study Screen colors -->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

There was some accessibility warnings in the counts so I fixed them

## Approach

Changed the colors to material colors that pass the accessibility scan

## How Has This Been Tested?

<img width="1080" height="2400" alt="Screenshot_20250727_170433" src="https://github.com/user-attachments/assets/1ead3ef4-8f3e-49ef-bee2-34563673c00f" />


<img width="1080" height="2400" alt="Screenshot_20250727_170348" src="https://github.com/user-attachments/assets/559b1df6-708f-48df-99cf-d05184b2827b" />

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->