### PR TITLE
fix: preferences panels overlaying each other on large screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/Preferences.kt
@@ -102,6 +102,12 @@ class PreferencesFragment :
     ): Boolean {
         val className = pref.fragment ?: return false
         val fragmentClass = FragmentFactory.loadFragmentClass(requireActivity().classLoader, className)
+
+        // #18963: Remove any subscreens after opening a new primary screen
+        if (settingsIsSplit && caller is HeaderFragment) {
+            childFragmentManager.popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE)
+        }
+
         childFragmentManager.commit {
             setReorderingAllowed(true)
             replace(R.id.settings_container, fragmentClass, null)


### PR DESCRIPTION
## Fixes
* Fixes #18963

## Approach

Remove backstack subscreens after opening a new primary section in big screens

## How Has This Been Tested?

https://github.com/user-attachments/assets/f99984e1-a7b4-48aa-a024-13cee1119f23


## Learning (optional, can help others)

this was tough to figure out because of the backstack listener, search bar and the navigation itself

https://developer.android.com/reference/android/app/FragmentManager#POP_BACK_STACK_INCLUSIVE

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->