### PR TITLE
Feat: Right click to select in CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -177,6 +177,9 @@ class CardBrowserFragment :
                 onLongPress = { rowId ->
                     activityViewModel.handleRowLongPress(rowId.toRowSelection())
                 },
+                onRightClick = { rowId ->
+                    activityViewModel.handleRightClick(rowId.toRowSelection())
+                },
             )
         cardsListView.adapter = cardsAdapter
         cardsAdapter.stateRestorationPolicy = RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -500,6 +500,22 @@ class CardBrowserViewModel(
             focusedRow = id
         }
 
+    /**
+     * Handles right-click on a row, by default delegating to onLongPress
+     */
+    fun handleRightClick(rowSelection: RowSelection) {
+        viewModelScope.launch {
+            val id = rowSelection.rowId
+            currentCardId = id.toCardId(cardsOrNotes)
+            if (isInMultiSelectMode && lastSelectedId != null) {
+                selectRowsBetween(lastSelectedId!!, id)
+            } else {
+                toggleRowSelection(rowSelection)
+            }
+            focusedRow = id
+        }
+    }
+
     // on a row tap
     fun openNoteEditorForCard(cardId: CardId) {
         currentCardId = cardId


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Adds the ability to right click to select a card in card browser instead of just long press.

## Fixes
* For GSoC 2025: Tablet & Chromebook UI

## Approach
- Uses MotionEvent to check if the right mouse button is pressed, and selects the card.

## How Has This Been Tested?
- Chromebook emulator API 34:

[mouse.webm](https://github.com/user-attachments/assets/0eab5ba9-4bd2-42be-ad96-43d975d96e47)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->