### PR TITLE
Add utility functions for extracting cloze numbers from Anki notes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ClozeUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ClozeUtils.kt
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2025 Hari Srinivasan <harisrini21@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import timber.log.Timber
+
+/**
+ * Utility functions for working with cloze deletions in Anki notes
+ */
+object ClozeUtils {
+    /**
+     * Regular expression pattern to find cloze deletions in text.
+     * Matches patterns like {{c1::text}} or {{c2::text::hint}}
+     */
+    private val CLOZE_PATTERN = Regex("\\{\\{c(\\d+)::(.+?)(?:::(.+?))?\\}\\}")
+
+    /**
+     * Extracts all cloze numbers from a list of field values.
+     *
+     * @param fields The list of field values to search for cloze deletions
+     * @return A sorted set of cloze numbers found in the fields
+     */
+    fun extractClozeNumbers(fields: List<String>): Set<Int> {
+        val clozeNumbers = mutableSetOf<Int>()
+
+        fields.forEach { fieldContent ->
+            val matches = CLOZE_PATTERN.findAll(fieldContent)
+            matches.forEach { match ->
+                try {
+                    val clozeNumber = match.groupValues[1].toInt()
+                    clozeNumbers.add(clozeNumber)
+                } catch (e: NumberFormatException) {
+                    Timber.w(e, "Failed to parse cloze number from: ${match.groupValues[1]}")
+                }
+            }
+        }
+
+        return clozeNumbers.toSortedSet()
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ClozeUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ClozeUtilsTest.kt
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2025 Hari Srinivasan <harisrini21@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ClozeUtilsTest {
+    @Test
+    fun `extractClozeNumbers returns empty set when no cloze deletions exist`() {
+        val fields = listOf("Plain text", "More plain text")
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(emptySet<Int>(), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers finds single cloze deletion`() {
+        val fields = listOf("Text with {{c1::cloze}}")
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(setOf(1), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers finds multiple cloze deletions of same number`() {
+        val fields = listOf("{{c1::One}} and {{c1::another one}}")
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(setOf(1), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers finds multiple different cloze numbers`() {
+        val fields = listOf("{{c1::First}} and {{c2::second}} and {{c3::third}}")
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(setOf(1, 2, 3), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers works with cloze hints`() {
+        val fields = listOf("{{c1::deletion::hint}}")
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(setOf(1), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers finds cloze numbers across multiple fields`() {
+        val fields =
+            listOf(
+                "Field one with {{c1::cloze}}",
+                "Field two with {{c2::another}} cloze",
+                "Field three with no cloze",
+            )
+        val result = ClozeUtils.extractClozeNumbers(fields)
+        assertEquals(setOf(1, 2), result)
+    }
+
+    @Test
+    fun `extractClozeNumbers returns numbers in sorted order`() {
+        val fields = listOf("{{c3::Third}} {{c1::first}} {{c2::second}}")
+        val result = ClozeUtils.extractClozeNumbers(fields).toList()
+        assertEquals(listOf(1, 2, 3), result)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Util functions for extracting cloze numbers from Anki notes. Needed for #18724 
- Was proposed as a idea by @Arthur-Milchior here: https://github.com/ankidroid/Anki-Android/pull/18724#discussion_r2196266835

## Fixes
* For GSoC 2025: Tablet & Chromebook UI

## How Has This Been Tested?
- Added unit testing for the function

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->