### PR TITLE
NF: Resizable Screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -398,19 +398,18 @@ open class CardBrowser :
         if (fragmented) {
             val parentLayout = findViewById<LinearLayout>(R.id.card_browser_xl_view)
             val divider = findViewById<View>(R.id.card_browser_resizing_divider)
-            val leftPane = findViewById<View>(R.id.card_browser_frame)
-            val rightPane = findViewById<View>(R.id.note_editor_frame)
-            if (parentLayout != null && divider != null && leftPane != null && rightPane != null) {
-                ResizablePaneManager(
-                    parentLayout = parentLayout,
-                    divider = divider,
-                    leftPane = leftPane,
-                    rightPane = rightPane,
-                    sharedPrefs = Prefs.getUiConfig(this),
-                    leftPaneWeightKey = PREF_CARD_BROWSER_PANE_WEIGHT,
-                    rightPaneWeightKey = PREF_NOTE_EDITOR_PANE_WEIGHT,
-                )
-            }
+            val cardBrowserPane = findViewById<View>(R.id.card_browser_frame)
+            val noteEditorPane = findViewById<View>(R.id.note_editor_frame)
+
+            ResizablePaneManager(
+                parentLayout = parentLayout,
+                divider = divider,
+                leftPane = cardBrowserPane,
+                rightPane = noteEditorPane,
+                sharedPrefs = Prefs.getUiConfig(this),
+                leftPaneWeightKey = PREF_CARD_BROWSER_PANE_WEIGHT,
+                rightPaneWeightKey = PREF_NOTE_EDITOR_PANE_WEIGHT,
+            )
         }
 
         // must be called once we have an accessible collection

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -222,19 +222,17 @@ open class CardTemplateEditor :
         if (fragmented) {
             val parentLayout = findViewById<LinearLayout>(R.id.card_template_editor_xl_view)
             val divider = findViewById<View>(R.id.card_template_editor_resizing_divider)
-            val leftPane = findViewById<View>(R.id.template_editor)
-            val rightPane = findViewById<View>(R.id.fragment_container)
-            if (parentLayout != null && divider != null && leftPane != null && rightPane != null) {
-                ResizablePaneManager(
-                    parentLayout = parentLayout,
-                    divider = divider,
-                    leftPane = leftPane,
-                    rightPane = rightPane,
-                    sharedPrefs = Prefs.getUiConfig(this),
-                    leftPaneWeightKey = PREF_TEMPLATE_EDITOR_PANE_WEIGHT,
-                    rightPaneWeightKey = PREF_TEMPLATE_PREVIEWER_PANE_WEIGHT,
-                )
-            }
+            val cardTemplateEditorPane = findViewById<View>(R.id.template_editor)
+            val templatePreviewerPane = findViewById<View>(R.id.fragment_container)
+            ResizablePaneManager(
+                parentLayout = parentLayout,
+                divider = divider,
+                leftPane = cardTemplateEditorPane,
+                rightPane = templatePreviewerPane,
+                sharedPrefs = Prefs.getUiConfig(this),
+                leftPaneWeightKey = PREF_TEMPLATE_EDITOR_PANE_WEIGHT,
+                rightPaneWeightKey = PREF_TEMPLATE_PREVIEWER_PANE_WEIGHT,
+            )
         }
 
         // Open TemplatePreviewerFragment if in fragmented mode

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -527,25 +527,17 @@ open class DeckPicker :
 
             val resizingDivider = findViewById<View>(R.id.homescreen_resizing_divider)
             val parentLayout = findViewById<LinearLayout>(R.id.deckpicker_xl_view)
-
-            // Get references to the panes
             val deckPickerPane = findViewById<View>(R.id.deck_picker_pane)
             val studyOptionsPane = findViewById<View>(R.id.studyoptions_fragment)
-
-            if (deckPickerPane == null || studyOptionsPane == null) {
-                Timber.w("DeckPicker or StudyOptions pane not found. Resizing divider will not function.")
-            } else {
-                // Initialize the ResizablePaneManager
-                ResizablePaneManager(
-                    parentLayout = parentLayout,
-                    divider = resizingDivider,
-                    leftPane = deckPickerPane,
-                    rightPane = studyOptionsPane,
-                    sharedPrefs = Prefs.getUiConfig(this),
-                    leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
-                    rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,
-                )
-            }
+            ResizablePaneManager(
+                parentLayout = parentLayout,
+                divider = resizingDivider,
+                leftPane = deckPickerPane,
+                rightPane = studyOptionsPane,
+                sharedPrefs = Prefs.getUiConfig(this),
+                leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
+                rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,
+            )
         }
         registerReceiver()
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Minor refactors on Resizable screens involving:
- Clean up unnecessary null checks for ResizablePaneManager, since fragmented check is only true when panes are non-null
- Clearer naming for leftPane and rightPane variables in ResizablePaneManager Calls

## Fixes
* For GSoC 2025: Tablet & Chromebook UI

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->