### PR TITLE
chore(lint): Check casing of Anki apps

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/TranslationTypo.kt
@@ -27,6 +27,7 @@ import com.android.tools.lint.detector.api.XmlContext
 import com.android.tools.lint.detector.api.XmlScanner
 import com.android.utils.forEach
 import com.google.common.annotations.VisibleForTesting
+import com.ichi2.anki.lint.rules.TranslationTypo.CheckStringCase.Companion.create
 import com.ichi2.anki.lint.utils.Constants
 import com.ichi2.anki.lint.utils.CrowdinContext.Companion.toCrowdinContext
 import com.ichi2.anki.lint.utils.ext.isRightToLeftLanguage
@@ -83,6 +84,12 @@ class TranslationTypo :
 
         // CrowdIn strings+ additional string XML which are not translated
         val STRING_XML_FILES = I18N_FILES + listOf("constants.xml", "sentence-case.xml")
+
+        val javascriptCasingCheck = CheckStringCase.create("JavaScript")
+        val ankiWebCasingCheck = CheckStringCase.create("AnkiWeb")
+        val ankiDroidCasingCheck = CheckStringCase.create("AnkiDroid")
+        val ankiCasingCheck = CheckStringCase.create("Anki")
+        val ankiMobileCasingCheck = CheckStringCase.create("AnkiMobile")
     }
 
     override fun getApplicableElements(): Collection<String>? = ALL
@@ -120,16 +127,25 @@ class TranslationTypo :
             )
         }
 
+        fun CheckStringCase.reportIfIssue() {
+            if (!this.shouldReport(element)) return
+            element.reportIssue("should be '${this.expectedCasing}'")
+        }
+
         // use the unicode character instead of three dots for ellipsis
         // ignore RTL to reduce maintenance: GitHub incorrectly displays ellipsis, so hard to review
         if (element.textContent.contains("...") && !context.isRightToLeftLanguage()) {
             element.reportIssue("should use unicode '&#8230;' for ellipsis not three dots; RTL languages best viewed on crowdin")
         }
 
-        // casing of 'JavaScript'
-        if (element.textContent.lowercase().contains("javascript") && !element.textContent.contains("JavaScript")) {
-            element.reportIssue("should be 'JavaScript'")
+        javascriptCasingCheck.reportIfIssue()
+        ankiWebCasingCheck.reportIfIssue()
+        ankiDroidCasingCheck.reportIfIssue()
+        // anki = current in Turkish
+        if (context.file.parentFile.name != "values-tr") {
+            ankiCasingCheck.reportIfIssue()
         }
+        ankiMobileCasingCheck.reportIfIssue()
 
         // remove empty strings
         if (element.textContent.isEmpty() && element.getAttribute("name") != "empty_string") {
@@ -147,6 +163,40 @@ class TranslationTypo :
             if (isValid) {
                 element.reportIssue("should not contain trailing whitespace")
             }
+        }
+    }
+
+    /**
+     * Performs case-sensitive validation of a string: `"ankidroid"` should be `"AnkiDroid"`
+     *
+     * @param regex Used to check for the presence of a badly cased string. See [create]
+     * @param expectedCasing String in the expected casing. e.g. `"JavaScript"`
+     */
+    data class CheckStringCase(
+        val regex: Regex,
+        val expectedCasing: String,
+    ) {
+        /** Flags 'javascript' when 'JavaScript' should be used */
+        fun shouldReport(element: Element): Boolean {
+            // if it's a link, don't check it - www.ankiweb.net matches the below
+            if (element.textContent.contains("://")) return false
+
+            // if it contains 'javascript', but casing is not the correct 'JavaScript'
+            return regex.containsMatchIn(element.textContent) && !element.textContent.contains(expectedCasing)
+        }
+
+        companion object {
+            /**
+             * Creates a [CheckStringCase] for case-sensitive validation of a string in `values`
+             * @param expectedCasing The string in the expected casing. e.g. `"JavaScript"`
+             */
+            fun create(expectedCasing: String): CheckStringCase =
+                CheckStringCase(
+                    // (?:^|[\p{P}\s]) = (start of string | punctuation | space)
+                    // (?:$|[\p{P}\s]) = (end of string | punctuation | space)
+                    regex = Regex("""(?:^|[\p{P}\s])$expectedCasing(?:$|[\p{P}\s])""", RegexOption.IGNORE_CASE),
+                    expectedCasing = expectedCasing,
+                )
         }
     }
 }

--- a/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
+++ b/lint-rules/src/test/java/com/ichi2/anki/lint/rules/TranslationTypoTest.kt
@@ -56,7 +56,7 @@ class TranslationTypoTest {
     fun `plurals - javascript fails`() {
         val invalidLowerCase = """<resources>
            <plurals name="pl">
-               <item quantity="other">>javascript</item>
+               <item quantity="other">javascript</item>
            </plurals>
         </resources>"""
 
@@ -72,6 +72,33 @@ class TranslationTypoTest {
         </resources>"""
 
         TranslationTypo.ISSUE.assertXmlStringsHasError(invalidLowerCase, "should be 'JavaScript'")
+    }
+
+    @Test
+    fun `quoted text gives error`() {
+        val withQuotes = """<resources>
+           <string name="ankiweb">'ankiweb'</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(withQuotes, "should be 'AnkiWeb'")
+    }
+
+    @Test
+    fun `rtl text produces error`() {
+        val rtl = """<resources>
+            <string name="sample">فایل ankidroid فایل</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsHasError(rtl, "should be 'AnkiDroid'")
+    }
+
+    @Test
+    fun `ankiweb url is not detected`() {
+        val url = """<resources>
+           <string name="url">https://faqs.ankiweb.net/example_for_testing</string>
+        </resources>"""
+
+        TranslationTypo.ISSUE.assertXmlStringsNoIssues(url)
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Noticed 'Ankiweb' in Slovak

## Approach
Add the cases in our lint rule

## How Has This Been Tested?
Added a couple unit tests, but it's lint - let the linter pick up on issues

## Learning (optional, can help others)
I knew `anki` was a Turkish word, Google Translate lists it as 'current'


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->