### PR TITLE
chore(dev-options): fix sentence casing

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -31,7 +31,7 @@
         android:defaultValue="false"
         android:key="@string/html_javascript_debugging_key"
         android:summary="Enable remote WebView connections, and save card HTML to AnkiDroid directory"
-        android:title="HTML / JavaScript Debugging"/>
+        android:title="HTML / JavaScript debugging"/>
     <Preference
         android:title="Trigger test crash"
         android:summary="Touch here for an immediate test crash"
@@ -41,11 +41,11 @@
         android:summary="Touch here to use Analytics dev tag and 100% sample rate"
         android:key="@string/pref_analytics_debug_key"/>
     <Preference
-        android:title="Lock Database"
+        android:title="Lock database"
         android:summary="Touch here to lock the database (all threads block in-process, exception if using second process)"
         android:key="@string/pref_lock_database_key"/>
     <Preference
-        android:title="Set Database to pre-Scoped Storage default"
+        android:title="Set database to pre-scoped storage default"
         android:summary="Touch here to set the database path to /storage/emulated/0/AnkiDroid"
         android:key="@string/pref_set_database_path_debug_key"/>
     <SwitchPreferenceCompat
@@ -100,7 +100,7 @@
             android:key="@string/new_reviewer_pref_key"
             android:defaultValue="false"/>
         <SwitchPreferenceCompat
-            android:title="[Tablet] Side-by-side Browser and Editor"
+            android:title="[Tablet] Side-by-side browser and editor"
             android:key="@string/dev_card_browser_fragmented"
             android:defaultValue="false"/>
         <SwitchPreferenceCompat


### PR DESCRIPTION
* Part of Issue #15760

Trivial fix as I was in the area, and was requested by reporter

<img width="392" height="617" alt="Screenshot 2025-07-30 at 10 52 16" src="https://github.com/user-attachments/assets/bd31e57e-50b0-44f4-9c34-8410e38c800a" />
<img width="442" height="461" alt="Screenshot 2025-07-30 at 10 52 12" src="https://github.com/user-attachments/assets/1e875a6d-bf34-4b2b-812e-140c6382c17d" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->