### PR TITLE
fix(libanki): create `collection.media` on collection init

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Media.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Media.kt
@@ -35,18 +35,25 @@ import java.io.File
 open class Media(
     private val col: Collection,
 ) {
-    // Test may not have a media folder. This `lazy` enables initialization of the class under
-    // this circumstance
+    /**
+     * The on-disk `collection.media` folder
+     *
+     * @throws UnsupportedOperationException The collection is in-memory
+     */
     val dir: File by lazy {
-        col.requireMediaFolder().also { mediaDir ->
-            if (!mediaDir.exists()) {
-                mediaDir.mkdirs()
-            }
-        }
+        // Tests are in-memory with no disk access by default
+        // `lazy` enables initialization of the class, failing when the media folder is required
+        col.requireMediaFolder()
     }
 
     init {
         Timber.v("dir %s", col.mediaFolder)
+        col.mediaFolder?.let {
+            if (!it.exists()) {
+                Timber.i("Creating collection.media")
+                it.mkdirs()
+            }
+        }
     }
 
     /*

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CollectionOnDiskTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CollectionOnDiskTest.kt
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.libanki
+
+import com.ichi2.anki.libanki.testutils.InMemoryAnkiTest
+import com.ichi2.anki.libanki.testutils.InMemoryCollectionManager
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class CollectionOnDiskTest : InMemoryAnkiTest() {
+    @get:Rule
+    var directory = TemporaryFolder()
+
+    override val collectionManager =
+        object : InMemoryCollectionManager() {
+            override val collectionFiles: CollectionFiles
+                get() =
+                    CollectionFiles.InMemoryWithMedia(
+                        directory.newFolder().apply {
+                            delete()
+                        },
+                    )
+        }
+
+    @Test
+    fun `media folder exists after collection created`() {
+        assertThat("media ffolder exists", col.mediaFolder?.exists(), equalTo(true))
+    }
+}


### PR DESCRIPTION
'Create Collection', then 'Export' did not access `Media.dir`, which caused the export to fail

## Fixes

* Fixes #18990

## Learning

* Broken in #18924 (3bbf49832b0a60758ef8d0b5264eee04eca9cc88)

This moved `collection.media` creation to `Media.dir:get`



past code was

```kotlin
   val dir = col.collectionFiles.mediaFolder

    init {
        Timber.v("dir %s", dir)
        val file = dir
        if (!file.exists()) {
            file.mkdirs()
        }
    }
```

## How Has This Been Tested?
Only unit tested

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)