### PR TITLE
feat: add global widget dynamic theming control

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -19,8 +19,10 @@ package com.ichi2.anki
 
 import android.app.Activity
 import android.app.Application
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Build
@@ -115,6 +117,10 @@ open class AnkiDroidApp :
             }
         }
         instance = this
+
+        // Register for configuration changes to update widgets when theme changes
+        val filter = IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED)
+        registerReceiver(configurationChangeReceiver, filter)
 
         // Get preferences
         val preferences = this.sharedPrefs()
@@ -259,6 +265,26 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    private val configurationChangeReceiver =
+        object : BroadcastReceiver() {
+            override fun onReceive(
+                context: Context?,
+                intent: Intent?,
+            ) {
+                if (intent?.action == Intent.ACTION_CONFIGURATION_CHANGED) {
+                    Timber.d("Configuration changed, updating widgets for theme change")
+                    updateWidgetsForThemeChange()
+                }
+            }
+        }
+
+    /**
+     * Updates all CardAnalysisWidget instances when theme changes
+     */
+    fun updateWidgetsForThemeChange() {
+        CardAnalysisWidget.updateCardAnalysisWidgets(this)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -567,6 +567,8 @@ object UsageAnalytics {
             R.string.user_action_7_key,
             R.string.user_action_8_key,
             R.string.user_action_9_key,
+            // ******************************** Widget *********************************************
+            R.string.widget_dynamic_theming_key, // Widget dynamic theming
             // ******************************** Accessibility ******************************************
             R.string.card_zoom_preference,
             R.string.image_zoom_preference,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -242,6 +242,7 @@ class HeaderFragment : SettingsFragment() {
                 is ReviewerOptionsFragment, is ReviewerMenuSettingsFragment -> R.string.new_reviewer_options_key
                 is DevOptionsFragment -> R.string.pref_dev_options_screen_key
                 is AboutFragment -> R.string.about_screen_key
+                is WidgetSettingsFragment -> R.string.pref_widget_screen_key
                 else -> null
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/WidgetSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/WidgetSettingsFragment.kt
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.preferences
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Intent
+import androidx.preference.SwitchPreferenceCompat
+import com.ichi2.anki.R
+import com.ichi2.widget.cardanalysis.CardAnalysisWidget
+
+class WidgetSettingsFragment : SettingsFragment() {
+    override val preferenceResource: Int
+        get() = R.xml.preferences_widget
+    override val analyticsScreenNameConstant: String
+        get() = "prefs.widget"
+
+    override fun initSubscreen() {
+        val dynamicThemingPref = requirePreference<SwitchPreferenceCompat>(R.string.widget_dynamic_theming_key)
+        dynamicThemingPref.setOnPreferenceChangeListener { _ ->
+            // Trigger widget updates when the global setting changes
+            updateAllWidgets()
+        }
+    }
+
+    private fun updateAllWidgets() {
+        val context = requireContext()
+        val appWidgetManager = AppWidgetManager.getInstance(context)
+
+        // Update CardAnalysisWidget instances
+        val cardAnalysisProvider = ComponentName(context, CardAnalysisWidget::class.java)
+        val cardAnalysisWidgetIds = appWidgetManager.getAppWidgetIds(cardAnalysisProvider)
+        if (cardAnalysisWidgetIds.isNotEmpty()) {
+            val updateIntent =
+                Intent(context, CardAnalysisWidget::class.java).apply {
+                    action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+                    putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, cardAnalysisWidgetIds)
+                }
+            context.sendBroadcast(updateIntent)
+        }
+    }
+
+    companion object {
+        fun isGlobalDynamicThemingEnabled(context: android.content.Context): Boolean {
+            val prefs = androidx.preference.PreferenceManager.getDefaultSharedPreferences(context)
+            return prefs.getBoolean(context.getString(R.string.widget_dynamic_theming_key), true)
+        }
+    }
+} 

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -2,6 +2,7 @@
  Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>
  Copyright (c) 2015 Timothy Rae <perceptualchaos2@gmail.com>
  Copyright (c) 2021 Akshay Jadhav <jadhavakshay0701@gmail.com>
+ Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
 
  This program is free software; you can redistribute it and/or modify it under
  the terms of the GNU General Public License as published by the Free Software
@@ -33,6 +34,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.ui.AppCompatPreferenceActivity
+import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import timber.log.Timber
 
 /**
@@ -76,6 +78,7 @@ object Themes {
                 context.sharedPrefs()
             }
 
+        val previousTheme = currentTheme
         currentTheme =
             if (themeFollowsSystem(prefs)) {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM)
@@ -90,6 +93,11 @@ object Themes {
                     AppCompatDelegate.setDefaultNightMode(mode)
                 }
             }
+
+        // Update widgets if theme changed
+        if (previousTheme != currentTheme) {
+            CardAnalysisWidget.updateCardAnalysisWidgets(context)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -24,6 +24,7 @@ import android.content.Context
 import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
+import androidx.core.content.ContextCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShorcuts
@@ -33,6 +34,7 @@ import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks.Companion.NOT_FOUND_DECK_ID
 import com.ichi2.anki.pages.DeckOptionsDestination
+import com.ichi2.anki.preferences.WidgetSettingsFragment
 import com.ichi2.widget.ACTION_UPDATE_WIDGET
 import com.ichi2.widget.AnalyticsWidgetProvider
 import com.ichi2.widget.cancelRecurringAlarm
@@ -72,6 +74,29 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
         ) {
             val deckId = getDeckIdForWidget(context, appWidgetId)
             val remoteViews = RemoteViews(context.packageName, R.layout.widget_card_analysis)
+
+            // Apply dynamic theming or default background colors
+            val dynamicTheming = WidgetSettingsFragment.isGlobalDynamicThemingEnabled(context)
+            if (!dynamicTheming) {
+                val isNight =
+                    (context.resources.configuration.uiMode and android.content.res.Configuration.UI_MODE_NIGHT_MASK) ==
+                        android.content.res.Configuration.UI_MODE_NIGHT_YES
+                val bgColor =
+                    if (isNight) {
+                        ContextCompat.getColor(context, R.color.widget_bg_dark)
+                    } else {
+                        ContextCompat.getColor(context, R.color.widget_bg_light)
+                    }
+                remoteViews.setInt(R.id.widget_deck_picker, "setBackgroundColor", bgColor)
+                remoteViews.setInt(R.id.cardAnalysisDataHolder, "setBackgroundColor", bgColor)
+            } else {
+                remoteViews.setInt(R.id.widget_deck_picker, "setBackgroundResource", R.drawable.widget_card_analysis_rounded_background)
+                remoteViews.setInt(
+                    R.id.cardAnalysisDataHolder,
+                    "setBackgroundResource",
+                    R.drawable.widget_card_analysis_rounded_inner_background,
+                )
+            }
 
             if (deckId == NOT_FOUND_DECK_ID) {
                 // If deckId is null, it means no deck was selected or the selected deck was deleted.

--- a/AnkiDroid/src/main/res/values/arrays.xml
+++ b/AnkiDroid/src/main/res/values/arrays.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string-array name="widget_summary_entries">
+        <item>Configure widget appearance and theming</item>
+    </string-array>
+</resources> 

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -148,5 +148,9 @@
     <color name="idle_divider_color">#C7C7C7</color>
     <color name="drag_divider_color">#1A90FF</color>
     <color name="divider_handle_color">#4D4D4D</color>
+
+    <!-- Widget background colors -->
+    <color name="widget_bg_light">#FFFFFF</color>
+    <color name="widget_bg_dark">#232323</color>
 </resources>
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -244,4 +244,10 @@
     <string name="reviewer_toolbar_position_key">reviewerToolbarPosition</string>
     <string name="addons_category_key">addonsCat</string>
 
+    <!-- Widget -->
+    <string name="pref_widget_screen_key">widgetScreen</string>
+    <string name="widget_dynamic_theming_key">widgetDynamicTheming</string>
+    <string name="widget_dynamic_theming_title">Enable dynamic theming for widgets</string>
+    <string name="widget_dynamic_theming_summary">If enabled, widgets will use wallpaper-based colors. If disabled, widgets will use default colors for light/dark mode.</string>
+
 </resources>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -106,6 +106,14 @@
         app:summaryEntries="@array/backup_limits_summary_entries"
         tools:title="Backups"/>
 
+    <!-- Widget Preferences -->
+    <com.ichi2.preferences.HeaderPreference
+        android:fragment="com.ichi2.anki.preferences.WidgetSettingsFragment"
+        android:key="@string/pref_widget_screen_key"
+        android:title="Widget"
+        android:icon="@drawable/ic_widgets"
+        app:summaryEntries="@array/widget_summary_entries"/>
+
     <!-- Advanced Preferences -->
     <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.AdvancedSettingsFragment"

--- a/AnkiDroid/src/main/res/xml/preferences_widget.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_widget.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:title="Widget"
+    android:key="@string/pref_widget_screen_key">
+
+    <SwitchPreferenceCompat
+        android:key="@string/widget_dynamic_theming_key"
+        android:title="@string/widget_dynamic_theming_title"
+        android:summary="@string/widget_dynamic_theming_summary"
+        android:defaultValue="true" />
+
+</PreferenceScreen> 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -61,6 +61,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.pref_review_reminders_screen_key, // reviewRemindersScreen
             R.string.pref_backup_limits_screen_key, // backupLimitsScreen
             R.string.about_screen_key, // aboutScreen
+            R.string.pref_widget_screen_key, // widgetScreen
             // Categories: don't have a value
             R.string.pref_appearance_screen_key, // appearance_preference_group
             R.string.pref_cat_plugins_key, // category_plugins


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Add a new "Widget" section in settings with a toggle to control dynamic
theming for all widgets globally. When disabled, widgets use default
light/dark theme colors instead of wallpaper-based colors.

## Fixes
* #18873 

## How Has This Been Tested?
### Card Analysis Widget
https://github.com/user-attachments/assets/f8600695-6fca-461c-8558-69154c19710c


## Checklist
_Please, go through these checks before submitting the PR._

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->