### PR TITLE
Feat/internet permissions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -160,6 +160,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.animations.fadeIn
 import com.ichi2.anki.ui.animations.fadeOut
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -178,6 +179,7 @@ import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.ImportUtils.ImportResult
 import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
+import com.ichi2.utils.Permissions
 import com.ichi2.utils.SyncStatus
 import com.ichi2.utils.VersionUtils
 import com.ichi2.utils.cancelable
@@ -1299,6 +1301,12 @@ open class DeckPicker :
         super.onResume()
         if (navDrawerIsReady() && hasCollectionStoragePermissions()) {
             refreshState()
+        }
+
+        if (!Permissions.canAccessInternet(this) && !SessionPermissionTracker.hasShownInternetInfo) {
+            SessionPermissionTracker.hasShownInternetInfo = true
+            this.startActivity(PermissionsActivity.getIntent(this, PermissionSet.INTERNET_BLOCKED_INFO))
+            Timber.d("Internet not accessible")
         }
         message?.let { dialogHandler.sendStoredMessage(it) }
     }
@@ -2691,3 +2699,8 @@ private fun AnkiActivity.launchCatchingRequiringOneWaySync(block: suspend () -> 
             showDialogFragment(confirmModSchemaDialog)
         }
     }
+
+/** Tracks if the Internet info screen has been shown during the current app session. */
+object SessionPermissionTracker {
+    var hasShownInternetInfo = false
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.setPreferencesUpToDate
 import com.ichi2.anki.servicelayer.ScopedStorageService.isLegacyStorage
 import com.ichi2.anki.ui.windows.permissions.Full30and31PermissionsFragment
+import com.ichi2.anki.ui.windows.permissions.InternetInfoFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsUntil29Fragment
 import com.ichi2.anki.ui.windows.permissions.TiramisuPermissionsFragment
@@ -195,6 +196,11 @@ enum class PermissionSet(
     ),
 
     APP_PRIVATE(emptyList(), null),
+
+    INTERNET_BLOCKED_INFO(
+        permissions = emptyList(),
+        permissionsFragment = InternetInfoFragment::class.java,
+    ),
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/InternetInfoFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/InternetInfoFragment.kt
@@ -1,0 +1,47 @@
+package com.ichi2.anki.ui.windows.permissions
+
+import android.content.Intent
+import android.os.Bundle
+import android.provider.Settings
+import android.view.View
+import androidx.core.net.toUri
+import com.ichi2.anki.R
+
+/**
+ * A PermissionsFragment that informs the user about the requirement for Internet access,
+ * specifically for localhost communication (e.g., in environments like GrapheneOS or Xiaomi).
+ *
+ * This screen is shown via PermissionsActivity and explains that although no runtime
+ * INTERNET permission is needed, disabling Internet manually can break app functionality.
+ *
+ * The user is provided with a switch-style PermissionItem that:
+ * - Opens the app settings screen to re-enable Internet access
+ * - Enables the continue button in PermissionsActivity after acknowledgment
+ */
+class InternetInfoFragment : PermissionsFragment(R.layout.permission_internet_xiomi) {
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val internetPermissionItem =
+            view.findViewById<PermissionItem>(R.id.internet_permission)
+
+        internetPermissionItem.setOnSwitchClickListener {
+            // Optionally open settings
+            openAppSettings()
+
+            // Enable the continue button in PermissionsActivity
+            (activity as? PermissionsActivity)?.setContinueButtonEnabled(true)
+        }
+    }
+
+    private fun openAppSettings() {
+        val intent =
+            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                data = ("package:" + requireContext().packageName).toUri()
+            }
+        startActivity(intent)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -184,6 +184,10 @@ object Permissions {
     fun canPostNotifications(context: Context): Boolean =
         Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU ||
             ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+
+    /** Returns true if the app has INTERNET permission granted. */
+    fun canAccessInternet(context: Context): Boolean =
+        ContextCompat.checkSelfPermission(context, Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED
 }
 
 fun Fragment.hasAnyOfPermissionsBeenDenied(permissions: Collection<String>): Boolean {

--- a/AnkiDroid/src/main/res/layout/permission_internet_xiomi.xml
+++ b/AnkiDroid/src/main/res/layout/permission_internet_xiomi.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    tools:context=".ui.windows.permissions.InternetInfoFragment">
+
+    <com.ichi2.anki.ui.windows.permissions.PermissionItem
+        android:id="@+id/internet_permission"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:permissionTitle="@string/internet_access_title"
+        app:permissionSummary="@string/internet_access_summary"
+        app:permission="@string/manage_internet_permission"
+        />
+</LinearLayout>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -206,4 +206,8 @@
 
     <!-- Instant Note Editor -->
     <string name="instant_card" comment="Used in the Android system context menu/share dialog to quickly create a note. This does not need to be translated literally, translate the concept of quickly adding a Cloze note with a popup. ">Instant card</string>
+    
+    <!-- Internet Permissions -->
+    <string name="internet_access_title">Internet Access Required</string>
+    <string name="internet_access_summary">AnkiDroid uses a local server on your device (called localhost) to function correctly.</string>
 </resources>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -359,6 +359,7 @@
     </string-array>
 
     <string name="manage_external_storage_permission">android.permission.MANAGE_EXTERNAL_STORAGE</string>
+    <string name="manage_internet_permission">android.permission.INTERNET</string>
     <string-array name="legacy_storage_permissions">
         <item>android.permission.READ_EXTERNAL_STORAGE</item>
         <item>android.permission.WRITE_EXTERNAL_STORAGE</item>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Some devices like Xiaomi and GrapheneOS allow users to manually disable Internet access, which breaks AnkiDroid’s localhost-based functionality. This PR adds a non-blocking permission info screen that appears once per app launch (if localhost access is not available), explaining why Internet access is critical and guiding the user to app settings.

## Fixes
* Fixes #18982.

## Approach

1. Added a new PermissionSet.INTERNET_BLOCKED_INFO
2. Created InternetInfoFragment using the existing PermissionsFragment system
3. Shown once per app launch using an in-memory session flag
4. Includes a switch that opens app settings and enables the continue button

## How Has This Been Tested?
Tested on a Xiaomi device by manually disabling Internet access and simulating a localhost failure by pinging a URL. This successfully triggered the Internet permission info screen.
📸 Screenshot of the permission screen:

<img width="300" height="1000" alt="Internet Permission Screen" src="https://github.com/user-attachments/assets/1dcef0d2-15d6-4e63-b00a-b85ac23e4f5f" />

**My device does not support full Internet permission blocking, so original testing on GrapheneOS or similar devices is still required for final validation.**

## Learning (optional, can help others)
Reused the existing PermissionsActivity and PermissionsFragment infrastructure to maintain consistency with other permission flows.
As someone more familiar with Jetpack Compose, this task helped me gain hands-on experience with XML-based UI and understand AnkiDroid’s legacy layout system.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->