### PR TITLE
build(deps): bump test dependencies in a group

### DIFF
--- a/AnkiDroid/proguard-test-rules.pro
+++ b/AnkiDroid/proguard-test-rules.pro
@@ -7,5 +7,8 @@
 -keep class kotlin.test.** { *; }
 -keep class **.R$layout { <init> (...); <fields>; }
 
+# Used by some test classes, not important for us
+-dontwarn androidx.concurrent.futures.SuspendToFutureAdapter
+
 # Ignore unused packages
 -dontwarn com.google.protobuf.GeneratedMessageLite$*

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ androidxSqlite = "2.5.2"
 # https://developer.android.com/jetpack/androidx/releases/swiperefreshlayout
 androidxSwipeRefreshLayout = "1.1.0"
 # https://developer.android.com/jetpack/androidx/releases/test
-androidxTest = "1.6.1"
+androidxTest = "1.7.0"
 # https://developer.android.com/jetpack/androidx/releases/test-uiautomator
 androidxTestUiAutomator = "2.3.0"
 # https://developer.android.com/jetpack/androidx/releases/viewpager2
@@ -72,7 +72,7 @@ commonsIo = "2.20.0"
 coroutines = '1.10.2'
 desugar-jdk-libs-nio = "2.1.5"
 drawer = "1.0.3"
-espresso = '3.6.1'
+espresso = '3.7.0'
 mikehardyGoogleAnalyticsJava7 = "2.0.13"
 hamcrest = "3.0"
 imageCropper = "4.6.0"
@@ -81,7 +81,7 @@ javaSemver = "0.10.2"
 jetbrainsAnnotations = "26.0.2"
 json = "20250517"
 jsoup = "1.21.1"
-androidTestJunit = "1.2.1"
+androidTestJunit = "1.3.0"
 # https://github.com/junit-team/junit5/releases/
 junitJupiter = "5.13.4"
 # https://github.com/junit-team/junit5/releases/ - version numbers differ; changelogs in bundle


### PR DESCRIPTION
required one proguard fixup since test dependencies don't test release mode often or well upstream and they forget things sometimes

This will obsolete these, but dependabot will pick that up once it is merged and auto-close them. If we close them dependabot will track that as meaning something about what to update or ignore, and best not to mess with that

- #18998 
- #18999 
- #19001 


Tested locally with:

> TEST_RELEASE_BUILD=true ./gradlew uninstallAll jacocoAndroidTestReport
