### PR TITLE
fix: sound play deadlock in previewer and new study screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -619,6 +619,7 @@ abstract class AbstractFlashcardViewer :
         gestureDetectorImpl.stopShakeDetector()
         if (this::cardMediaPlayer.isInitialized) {
             cardMediaPlayer.isEnabled = false
+            ReadText.stopTts()
         }
         // Prevent loss of data in Cookies
         CookieManager.getInstance().flush()
@@ -821,7 +822,7 @@ abstract class AbstractFlashcardViewer :
                     "AbstractFlashcardViewer:: OK button pressed to delete note %d",
                     currentCard!!.nid,
                 )
-                launchCatchingTask { cardMediaPlayer.stop() }
+                launchCatchingTask { stopCardMediaPlayer() }
                 deleteNoteWithoutConfirmation()
             }
             negativeButton(R.string.dialog_cancel)
@@ -863,7 +864,7 @@ abstract class AbstractFlashcardViewer :
                 }
                 // Temporarily sets the answer indicator dots appearing below the toolbar
                 previousAnswerIndicator?.displayAnswerIndicator(rating)
-                cardMediaPlayer.stop()
+                stopCardMediaPlayer()
                 currentEase = rating
 
                 answerCardInner(rating)
@@ -1589,7 +1590,7 @@ abstract class AbstractFlashcardViewer :
                     sched.buryCards(listOf(currentCard!!.id))
                 }
             }
-            cardMediaPlayer.stop()
+            stopCardMediaPlayer()
             showSnackbar(R.string.card_buried, Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1603,7 +1604,7 @@ abstract class AbstractFlashcardViewer :
                     sched.suspendCards(listOf(currentCard!!.id))
                 }
             }
-            cardMediaPlayer.stop()
+            stopCardMediaPlayer()
             showSnackbar(TR.studyingCardSuspended(), Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1620,7 +1621,7 @@ abstract class AbstractFlashcardViewer :
                 }
             val count = changed.count
             val noteSuspended = resources.getQuantityString(R.plurals.note_suspended, count, count)
-            cardMediaPlayer.stop()
+            stopCardMediaPlayer()
             showSnackbar(noteSuspended, Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
@@ -1635,10 +1636,15 @@ abstract class AbstractFlashcardViewer :
                         sched.buryNotes(listOf(currentCard!!.nid))
                     }
                 }
-            cardMediaPlayer.stop()
+            stopCardMediaPlayer()
             showSnackbar(TR.studyingCardsBuried(changed.count), Reviewer.ACTION_SNACKBAR_TIME)
         }
         return true
+    }
+
+    private suspend fun stopCardMediaPlayer() {
+        cardMediaPlayer.stop()
+        ReadText.stopTts()
     }
 
     override fun executeCommand(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -618,7 +618,9 @@ abstract class AbstractFlashcardViewer :
         super.onPause()
         gestureDetectorImpl.stopShakeDetector()
         if (this::cardMediaPlayer.isInitialized) {
-            cardMediaPlayer.isEnabled = false
+            launchCatchingTask {
+                cardMediaPlayer.setEnabled(false)
+            }
             ReadText.stopTts()
         }
         // Prevent loss of data in Cookies
@@ -629,7 +631,9 @@ abstract class AbstractFlashcardViewer :
         super.onResume()
         gestureDetectorImpl.startShakeDetector()
         if (this::cardMediaPlayer.isInitialized) {
-            cardMediaPlayer.isEnabled = true
+            launchCatchingTask {
+                cardMediaPlayer.setEnabled(true)
+            }
         }
         // Reset the activity title
         updateActionBar()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1481,7 +1481,7 @@ abstract class AbstractFlashcardViewer :
                 val side = if (displayAnswer) SingleCardSide.BACK else SingleCardSide.FRONT
                 when (doMediaReplay) {
                     true -> cardMediaPlayer.replayAll(side)
-                    false -> cardMediaPlayer.playAll(side)
+                    false -> cardMediaPlayer.playAllForSide(side.toCardSide())
                 }
             }
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -30,6 +30,7 @@ import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
 import android.hardware.SensorManager
+import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
@@ -71,12 +72,14 @@ import androidx.annotation.IdRes
 import androidx.annotation.RequiresApi
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
+import androidx.core.net.toFile
 import androidx.core.net.toUri
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.children
 import androidx.core.view.isVisible
 import androidx.lifecycle.Lifecycle.State.RESUMED
+import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
 import anki.scheduler.CardAnswer.Rating
 import com.drakeet.drawer.FullDraggableContainer
@@ -93,18 +96,25 @@ import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.GestureProcessor
 import com.ichi2.anki.cardviewer.JavascriptEvaluator
+import com.ichi2.anki.cardviewer.MediaErrorBehavior
+import com.ichi2.anki.cardviewer.MediaErrorBehavior.CONTINUE_MEDIA
+import com.ichi2.anki.cardviewer.MediaErrorBehavior.RETRY_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorHandler
+import com.ichi2.anki.cardviewer.MediaErrorListener
 import com.ichi2.anki.cardviewer.OnRenderProcessGoneDelegate
 import com.ichi2.anki.cardviewer.RenderedCard
 import com.ichi2.anki.cardviewer.SingleCardSide
+import com.ichi2.anki.cardviewer.SoundTagPlayer
 import com.ichi2.anki.cardviewer.TTS
 import com.ichi2.anki.cardviewer.TypeAnswer
 import com.ichi2.anki.cardviewer.TypeAnswer.Companion.createInstance
+import com.ichi2.anki.cardviewer.VideoPlayer
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.cardviewer.ViewerRefresh
 import com.ichi2.anki.cardviewer.handledGamepadKeyDown
 import com.ichi2.anki.cardviewer.handledGamepadKeyUp
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.dialogs.TtsPlaybackErrorDialog
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
@@ -116,6 +126,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.libanki.SoundOrVideoTag
 import com.ichi2.anki.libanki.TTSTag
+import com.ichi2.anki.libanki.TtsPlayer
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.multimedia.getAvTag
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
@@ -162,7 +173,9 @@ import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
 import com.squareup.seismic.ShakeDetector
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 import java.io.File
@@ -588,7 +601,7 @@ abstract class AbstractFlashcardViewer :
     public override fun onCollectionLoaded(col: Collection) {
         super.onCollectionLoaded(col)
         val mediaDir = col.media.dir
-        cardMediaPlayer = CardMediaPlayer.newInstance(this, getMediaBaseUrl(mediaDir))
+        cardMediaPlayer = getCardMediaPlayerInstance(this, getMediaBaseUrl(mediaDir))
         registerReceiver()
         restoreCollectionPreferences(col)
         initLayout()
@@ -2771,6 +2784,77 @@ abstract class AbstractFlashcardViewer :
                 return "$mediaDirUri/"
             }
             return ""
+        }
+
+        fun getCardMediaPlayerInstance(
+            viewer: AbstractFlashcardViewer,
+            mediaUriBase: String,
+        ): CardMediaPlayer {
+            val scope = viewer.lifecycleScope
+            val soundErrorListener = viewer.createMediaErrorListener()
+            // tts can take a long time to init, this defers the operation until it's needed
+            val tts = scope.async(Dispatchers.IO) { AndroidTtsPlayer.createInstance(viewer.lifecycleScope) }
+
+            val soundPlayer = SoundTagPlayer(mediaUriBase, VideoPlayer { viewer.webViewClient!! })
+
+            return CardMediaPlayer(
+                soundTagPlayer = soundPlayer,
+                ttsPlayer = tts,
+                mediaErrorListener = soundErrorListener,
+            ).apply {
+                setOnMediaGroupCompletedListener(viewer::onMediaGroupCompleted)
+            }
+        }
+
+        fun AbstractFlashcardViewer.createMediaErrorListener(): MediaErrorListener {
+            val activity = this
+            return object : MediaErrorListener {
+                override fun onMediaPlayerError(
+                    mp: MediaPlayer?,
+                    which: Int,
+                    extra: Int,
+                    uri: Uri,
+                ): MediaErrorBehavior {
+                    Timber.w("Media Error: (%d, %d)", which, extra)
+                    return onError(uri)
+                }
+
+                override fun onTtsError(
+                    error: TtsPlayer.TtsError,
+                    isAutomaticPlayback: Boolean,
+                ) {
+                    AbstractFlashcardViewer.mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
+                        when (error) {
+                            is AndroidTtsError.MissingVoiceError ->
+                                TtsPlaybackErrorDialog.ttsPlaybackErrorDialog(activity, supportFragmentManager, error.tag)
+                            is AndroidTtsError.InvalidVoiceError ->
+                                activity.showSnackbar(getString(R.string.voice_not_supported))
+                            else -> activity.showSnackbar(error.localizedErrorMessage(activity))
+                        }
+                    }
+                }
+
+                override fun onError(uri: Uri): MediaErrorBehavior {
+                    if (uri.scheme != "file") {
+                        return CONTINUE_MEDIA
+                    }
+
+                    try {
+                        val file = uri.toFile()
+                        // There is a multitude of transient issues with the MediaPlayer. (1, -1001) for example
+                        // Retrying fixes most of these
+                        if (file.exists()) return RETRY_MEDIA
+                        // just doesn't exist - process the error
+                        AbstractFlashcardViewer.mediaErrorHandler.processMissingMedia(
+                            file,
+                        ) { filename: String? -> displayCouldNotFindMediaSnackbar(filename) }
+                        return CONTINUE_MEDIA
+                    } catch (e: Exception) {
+                        Timber.w(e)
+                        return CONTINUE_MEDIA
+                    }
+                }
+            }
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -108,13 +108,14 @@ class CardMediaPlayer : Closeable {
     private lateinit var answerAvTags: List<AvTag>
 
     lateinit var config: CardSoundConfig
-    var isEnabled = true
-        set(value) {
-            if (!value) {
-                scope.launch { stop() }
-            }
-            field = value
-        }
+
+    var isEnabled: Boolean = true
+        private set
+
+    suspend fun setEnabled(enabled: Boolean) {
+        if (!enabled) stop()
+        this.isEnabled = enabled
+    }
 
     @VisibleForTesting
     var playAvTagsJob: Job? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -25,7 +25,6 @@ import com.ichi2.anki.AndroidTtsPlayer
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionHelper.getMediaDirectory
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.ReadText
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.CONTINUE_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.RETRY_MEDIA
 import com.ichi2.anki.cardviewer.MediaErrorBehavior.STOP_MEDIA
@@ -76,11 +75,6 @@ import java.io.Closeable
  *
  * [setOnMediaGroupCompletedListener] can be used to call
  * something when [playAllForSide] or [replayAll] completes
- *
- * **Out of scope**
- * [com.ichi2.anki.ReadText]: AnkiDroid has a legacy "tts" setting, before Anki Desktop TTS.
- * This uses [com.ichi2.anki.MetaDB], and may either read `<tts>` or all text on a card
- *
  */
 @NeedsTest("Integration test: A video is autoplayed if it's the first media on a card")
 @NeedsTest("A sound is played after a video finishes")
@@ -221,7 +215,6 @@ class CardMediaPlayer : Closeable {
     suspend fun stop() {
         if (isPlaying) Timber.i("stopping playing all AV tags")
         cancelPlayAvTagsJob(playAvTagsJob)
-        ReadText.stopTts() // TODO: Reconsider design
     }
 
     override fun close() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.cardviewer
 import android.media.MediaPlayer
 import android.net.Uri
 import androidx.annotation.CheckResult
+import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.getMediaBaseUrl
 import com.ichi2.anki.AndroidTtsError
 import com.ichi2.anki.AndroidTtsPlayer
@@ -115,7 +116,8 @@ class CardMediaPlayer : Closeable {
             field = value
         }
 
-    private var playAvTagsJob: Job? = null
+    @VisibleForTesting
+    var playAvTagsJob: Job? = null
     val isPlaying get() = playAvTagsJob != null
 
     private var onMediaGroupCompleted: (() -> Unit)? = null
@@ -159,24 +161,22 @@ class CardMediaPlayer : Closeable {
         }
     }
 
-    fun autoplayAllForSide(cardSide: CardSide): Job? {
+    fun autoplayAllForSide(cardSide: CardSide) {
         if (config.autoplay) {
-            return playAllForSide(cardSide)
+            playAllForSide(cardSide)
         }
-        return null
     }
 
-    fun playAllForSide(cardSide: CardSide): Job? {
-        if (!isEnabled) return null
+    fun playAllForSide(cardSide: CardSide) {
+        if (!isEnabled) return
         playAvTagsJob {
             Timber.i("playing sounds for %s", cardSide)
             playAllAvTagsInternal(cardSide, isAutomaticPlayback = true)
         }
-        return this.playAvTagsJob
     }
 
-    suspend fun playOne(tag: AvTag): Job? {
-        if (!isEnabled) return null
+    suspend fun playOne(tag: AvTag) {
+        if (!isEnabled) return
         cancelPlayAvTagsJob()
         Timber.i("playing one AV Tag")
 
@@ -209,7 +209,6 @@ class CardMediaPlayer : Closeable {
                 Timber.v("completed playing one AV Tag")
                 playAvTagsJob = null
             }
-        return playAvTagsJob
     }
 
     suspend fun stop() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -364,7 +364,7 @@ class CardMediaPlayer : Closeable {
     }
 
     companion object {
-        const val TTS_PLAYER_TIMEOUT_MS = 2_500L
+        private const val TTS_PLAYER_TIMEOUT_MS = 2_500L
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -66,7 +66,7 @@ import java.io.Closeable
  * This class combines the above concerns behind an "adapter" interface in order to simplify complexity.
  *
  * **Public interface**
- * * [playAll]
+ * * [playAllForSide]
  * * [replayAll]
  * * [playOne]
  * * [stop]
@@ -75,7 +75,7 @@ import java.io.Closeable
  * @see AvTag
  *
  * [setOnMediaGroupCompletedListener] can be used to call
- * something when [playAll] or [replayAll] completes
+ * something when [playAllForSide] or [replayAll] completes
  *
  * **Out of scope**
  * [com.ichi2.anki.ReadText]: AnkiDroid has a legacy "tts" setting, before Anki Desktop TTS.
@@ -325,15 +325,6 @@ class CardMediaPlayer : Closeable {
 
     /** Whether the provided side has available media */
     fun hasMedia(displayAnswer: Boolean): Boolean = if (displayAnswer) answerAvTags.any() else questionAvTags.any()
-
-    /**
-     * Plays all sounds for the current side, calling [onMediaGroupCompleted] when completed
-     */
-    fun playAll(side: SingleCardSide) =
-        when (side) {
-            SingleCardSide.FRONT -> playAllForSide(CardSide.QUESTION)
-            SingleCardSide.BACK -> playAllForSide(CardSide.ANSWER)
-        }
 
     /**
      * Replays all sounds for [side], calling [onMediaGroupCompleted] when completed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/SoundTagPlayer.kt
@@ -75,7 +75,7 @@ class SoundTagPlayer(
         mediaErrorListener: MediaErrorListener?,
     ) {
         val tagType = tag.getType()
-        return suspendCancellableCoroutine { continuation ->
+        suspendCancellableCoroutine { continuation ->
             Timber.d("Playing SoundOrVideoTag")
             when (tagType) {
                 SoundOrVideoTag.Type.AUDIO -> playSound(continuation, tag, mediaErrorListener)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
@@ -36,7 +36,7 @@ import kotlin.coroutines.resumeWithException
  * @see com.ichi2.anki.libanki.Sound.expandSounds
  */
 class VideoPlayer(
-    private val jsEval: () -> JavascriptEvaluator?,
+    private val jsEval: JavascriptEvaluator,
 ) {
     private var continuation: CancellableContinuation<Unit>? = null
 
@@ -51,7 +51,7 @@ class VideoPlayer(
 
         // BUG: We don't have the index of the tag in the list
         // so the wrong video would be played if contained twice in the card content
-        jsEval()?.evaluateAfterDOMContentLoaded(
+        jsEval.evaluateAfterDOMContentLoaded(
             """
                     var videos = document.getElementsByTagName("video")
             

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -42,9 +42,8 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
 import timber.log.Timber
 
-abstract class CardViewerViewModel(
-    cardMediaPlayer: CardMediaPlayer,
-) : ViewModel(),
+abstract class CardViewerViewModel :
+    ViewModel(),
     OnErrorListener,
     PostRequestHandler {
     override val onError = MutableSharedFlow<String>()
@@ -57,7 +56,7 @@ abstract class CardViewerViewModel(
     open val showingAnswer = MutableStateFlow(false)
 
     protected val cardMediaPlayer =
-        cardMediaPlayer.apply {
+        CardMediaPlayer().apply {
             setMediaErrorListener(createSoundErrorListener())
             javascriptEvaluator = { JavascriptEvaluator { launchCatchingIO { eval.emit(it) } } }
             addCloseable(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -86,7 +86,9 @@ abstract class CardViewerViewModel(
     fun baseUrl(): String = server.baseUrl()
 
     fun setSoundPlayerEnabled(isEnabled: Boolean) {
-        cardMediaPlayer.isEnabled = isEnabled
+        viewModelScope.launch {
+            cardMediaPlayer.setEnabled(isEnabled)
+        }
     }
 
     fun playSoundFromUrl(url: String) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -24,7 +24,6 @@ import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.cardviewer.CardMediaPlayer
-import com.ichi2.anki.cardviewer.JavascriptEvaluator
 import com.ichi2.anki.cardviewer.MediaErrorBehavior
 import com.ichi2.anki.cardviewer.MediaErrorHandler
 import com.ichi2.anki.cardviewer.MediaErrorListener
@@ -56,10 +55,11 @@ abstract class CardViewerViewModel :
     open val showingAnswer = MutableStateFlow(false)
 
     protected val cardMediaPlayer =
-        CardMediaPlayer().apply {
-            setMediaErrorListener(createSoundErrorListener())
-            javascriptEvaluator = { JavascriptEvaluator { launchCatchingIO { eval.emit(it) } } }
-            addCloseable(this)
+        CardMediaPlayer(
+            javascriptEvaluator = { launchCatchingIO { eval.emit(it) } },
+            mediaErrorListener = createSoundErrorListener(),
+        ).also {
+            addCloseable(it)
         }
     abstract var currentCard: Deferred<Card>
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -60,6 +60,7 @@ abstract class CardViewerViewModel(
         cardMediaPlayer.apply {
             setMediaErrorListener(createSoundErrorListener())
             javascriptEvaluator = { JavascriptEvaluator { launchCatchingIO { eval.emit(it) } } }
+            addCloseable(this)
         }
     abstract var currentCard: Deferred<Card>
 
@@ -67,7 +68,6 @@ abstract class CardViewerViewModel(
 
     @CallSuper
     override fun onCleared() {
-        cardMediaPlayer.close()
         server.stop()
         super.onCleared()
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -22,7 +22,6 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.asyncIO
 import com.ichi2.anki.browser.IdsFile
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.launchCatchingIO
@@ -47,7 +46,7 @@ import timber.log.Timber
 
 class PreviewerViewModel(
     stateHandle: SavedStateHandle,
-) : CardViewerViewModel(CardMediaPlayer()),
+) : CardViewerViewModel(),
     ChangeManager.Subscriber {
     val currentIndex = MutableStateFlow<Int>(stateHandle.require(PreviewerFragment.CURRENT_INDEX_ARG))
     val backSideOnly = MutableStateFlow(false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -25,7 +25,6 @@ import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.ichi2.anki.R
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.utils.ext.sharedPrefs
@@ -38,7 +37,7 @@ class TemplatePreviewerFragment :
     BaseSnackbarBuilderProvider {
     override val viewModel: TemplatePreviewerViewModel by viewModels {
         val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
-        TemplatePreviewerViewModel.factory(arguments, CardMediaPlayer())
+        TemplatePreviewerViewModel.factory(arguments)
     }
     override val webView: WebView
         get() = requireView().findViewById(R.id.webview)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -24,7 +24,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NotetypeFile
 import com.ichi2.anki.asyncIO
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Consts.DEFAULT_DECK_ID
@@ -44,8 +43,7 @@ import org.jetbrains.annotations.VisibleForTesting
 
 class TemplatePreviewerViewModel(
     arguments: TemplatePreviewerArguments,
-    cardMediaPlayer: CardMediaPlayer,
-) : CardViewerViewModel(cardMediaPlayer) {
+) : CardViewerViewModel() {
     private val notetype = arguments.notetype
     private val fillEmpty = arguments.fillEmpty
     private val isCloze = notetype.isCloze
@@ -230,13 +228,10 @@ class TemplatePreviewerViewModel(
         @Language("HTML")
         private const val EMPTY_FRONT_LINK = """<a href='https://docs.ankiweb.net/templates/errors.html#front-of-card-is-blank'>"""
 
-        fun factory(
-            arguments: TemplatePreviewerArguments,
-            cardMediaPlayer: CardMediaPlayer,
-        ): ViewModelProvider.Factory =
+        fun factory(arguments: TemplatePreviewerArguments): ViewModelProvider.Factory =
             viewModelFactory {
                 initializer {
-                    TemplatePreviewerViewModel(arguments, cardMediaPlayer)
+                    TemplatePreviewerViewModel(arguments)
                 }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -64,7 +64,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.TapGestureMode
 import com.ichi2.anki.common.utils.android.isRobolectric
@@ -124,9 +123,7 @@ class ReviewerFragment :
     DispatchKeyEventListener,
     TagsDialogListener,
     ShakeDetector.Listener {
-    override val viewModel: ReviewerViewModel by viewModels {
-        ReviewerViewModel.factory(CardMediaPlayer())
-    }
+    override val viewModel: ReviewerViewModel by viewModels()
 
     override val webView: WebView get() = requireView().findViewById(R.id.webview)
     private val timer: AnswerTimer? get() = view?.findViewById(R.id.timer)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -474,7 +474,7 @@ class ReviewerViewModel(
     private suspend fun loadAndPlayMedia(side: CardSide) {
         Timber.v("ReviewerViewModel::loadAndPlaySounds")
         cardMediaPlayer.loadCardAvTags(currentCard.await())
-        cardMediaPlayer.playAllForSide(side)
+        cardMediaPlayer.autoplayAllForSide(side)
     }
 
     private suspend fun updateMarkIcon() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -15,9 +15,6 @@
  */
 package com.ichi2.anki.ui.windows.reviewer
 
-import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.viewmodel.initializer
-import androidx.lifecycle.viewmodel.viewModelFactory
 import anki.collection.OpChanges
 import anki.collection.OpChangesAfterUndo
 import anki.frontend.SetSchedulingStatesRequest
@@ -29,7 +26,6 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.asyncIO
-import com.ichi2.anki.cardviewer.CardMediaPlayer
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
@@ -70,9 +66,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import org.intellij.lang.annotations.Language
 import timber.log.Timber
 
-class ReviewerViewModel(
-    cardMediaPlayer: CardMediaPlayer,
-) : CardViewerViewModel(cardMediaPlayer),
+class ReviewerViewModel :
+    CardViewerViewModel(),
     ChangeManager.Subscriber,
     BindingProcessor<ReviewerBinding, ViewerAction> {
     private var queueState: Deferred<CurrentQueueState?> =
@@ -707,14 +702,5 @@ class ReviewerViewModel(
                 }
             }
         }
-    }
-
-    companion object {
-        fun factory(soundPlayer: CardMediaPlayer): ViewModelProvider.Factory =
-            viewModelFactory {
-                initializer {
-                    ReviewerViewModel(soundPlayer)
-                }
-            }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
@@ -211,15 +211,18 @@ class CardMediaPlayerTest : JvmTest() {
     }
 
     private suspend fun CardMediaPlayer.playAllAndWait(side: SingleCardSide = SingleCardSide.FRONT) {
-        this.playAllForSide(side.toCardSide())?.join()
+        this.playAllForSide(side.toCardSide())
+        playAvTagsJob?.join()
     }
 
     private suspend fun CardMediaPlayer.replayAllAndWait(side: SingleCardSide) {
-        this.replayAll(side)?.join()
+        this.replayAll(side)
+        playAvTagsJob?.join()
     }
 
     private suspend fun CardMediaPlayer.playOneAndWait(tag: AvTag) {
-        playOne(tag)?.join()
+        playOne(tag)
+        playAvTagsJob?.join()
     }
 
     suspend fun CardMediaPlayer.setup(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/CardMediaPlayerTest.kt
@@ -211,7 +211,7 @@ class CardMediaPlayerTest : JvmTest() {
     }
 
     private suspend fun CardMediaPlayer.playAllAndWait(side: SingleCardSide = SingleCardSide.FRONT) {
-        this.playAll(side)?.join()
+        this.playAllForSide(side.toCardSide())?.join()
     }
 
     private suspend fun CardMediaPlayer.replayAllAndWait(side: SingleCardSide) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TemplatePreviewerViewModelTest.kt
@@ -25,7 +25,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 
 @RunWith(AndroidJUnit4::class)
 class TemplatePreviewerViewModelTest : JvmTest() {
@@ -80,7 +79,7 @@ class TemplatePreviewerViewModelTest : JvmTest() {
                 tags = mutableListOf(),
                 ord = ord,
             )
-        val viewModel = TemplatePreviewerViewModel(arguments, mock())
+        val viewModel = TemplatePreviewerViewModel(arguments)
         block(viewModel)
     }
 }
@@ -99,6 +98,6 @@ fun AnkiTest.runClozeTest(
             tags = mutableListOf(),
             ord = ord,
         )
-    val viewModel = TemplatePreviewerViewModel(arguments, mock())
+    val viewModel = TemplatePreviewerViewModel(arguments)
     block(viewModel)
 }


### PR DESCRIPTION
My guess is that the Dispatchers.IO thread pool gets full if too many sound tasks are opened quickly

if the thread pool is full, it isn't possible to launch another job to cancel the previous ones. That way, the scope gets deadlock

The issue is fixed by using a mutex, so the audio tasks are serialized, and only one audio can play at a time

It is also reproducible in the browser previewer.

it probably is harder to reproduce it on the old reviewer because the answer buttons have delays, and because the card rendering is slower, which means that it takes longer to parse the card data and start running the new audio files

Using Dispatchers.IO.limitedParallelism(1) would also work, but that would block the ttsPlayer initialization, so I went with a mutex.

## Approach

In the commits. I did a bunch of refactors while trying to understand/simplify the code and get the issue's root

## How Has This Been Tested?

Emulator 34, with an auto clicker:

(before the fix, the audios would stop playing completely with no way to make them play again)

[sound.webm](https://github.com/user-attachments/assets/05227153-9351-4b03-a03e-6b4e53bf9a63)

## Learning (optional, can help others)

Dispatchers.IO thread pool is shared with Dispatchers.Default. 

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->