### PR TITLE
refactor(new study screen): extract menu setup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.con>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer
+
+import android.view.Menu
+import androidx.appcompat.view.menu.SubMenuBuilder
+import androidx.core.view.isVisible
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import androidx.lifecycle.flowWithLifecycle
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.R
+import com.ichi2.anki.preferences.reviewer.ReviewerMenuView
+import com.ichi2.anki.preferences.reviewer.ViewerAction
+import com.ichi2.anki.utils.ext.collectLatestIn
+import com.ichi2.anki.utils.ext.menu
+import com.ichi2.anki.utils.ext.removeSubMenu
+import com.ichi2.utils.setPaddedIcon
+
+fun ReviewerMenuView.setup(
+    lifecycle: Lifecycle,
+    viewModel: ReviewerViewModel,
+) {
+    if (isEmpty()) {
+        isVisible = false
+        return
+    }
+
+    viewModel.flagFlow
+        .flowWithLifecycle(lifecycle)
+        .collectLatestIn(lifecycle.coroutineScope) { flagCode ->
+            findItem(ViewerAction.FLAG_MENU.menuId)?.setPaddedIcon(context, flagCode.drawableRes)
+        }
+
+    val markItem = findItem(ViewerAction.MARK.menuId)
+    viewModel.isMarkedFlow
+        .flowWithLifecycle(lifecycle)
+        .collectLatestIn(lifecycle.coroutineScope) { isMarked ->
+            if (isMarked) {
+                markItem?.setPaddedIcon(context, R.drawable.ic_star)
+                markItem?.setTitle(R.string.menu_unmark_note)
+            } else {
+                markItem?.setPaddedIcon(context, R.drawable.ic_star_border_white)
+                markItem?.setTitle(R.string.menu_mark_note)
+            }
+        }
+
+    val undoItem = findItem(ViewerAction.UNDO.menuId)
+    viewModel.undoLabelFlow
+        .flowWithLifecycle(lifecycle)
+        .collectLatestIn(lifecycle.coroutineScope) { label ->
+            undoItem?.title = label ?: CollectionManager.TR.undoUndo()
+            undoItem?.isEnabled = label != null
+        }
+
+    val redoItem = findItem(ViewerAction.REDO.menuId)
+    viewModel.redoLabelFlow
+        .flowWithLifecycle(lifecycle)
+        .collectLatestIn(lifecycle.coroutineScope) { label ->
+            redoItem?.title = label ?: CollectionManager.TR.undoRedo()
+            redoItem?.isEnabled = label != null
+        }
+
+    val suspendItem = findItem(ViewerAction.SUSPEND_MENU.menuId) ?: return
+    val suspendFlow = viewModel.canSuspendNoteFlow.flowWithLifecycle(lifecycle)
+    suspendFlow.collectLatestIn(lifecycle.coroutineScope) { canSuspendNote ->
+        if (canSuspendNote) {
+            if (suspendItem.hasSubMenu()) return@collectLatestIn
+            suspendItem.setTitle(ViewerAction.SUSPEND_MENU.titleRes)
+            val submenu =
+                SubMenuBuilder(context, suspendItem.menu, suspendItem).apply {
+                    add(Menu.NONE, ViewerAction.SUSPEND_NOTE.menuId, Menu.NONE, ViewerAction.SUSPEND_NOTE.titleRes)
+                    add(Menu.NONE, ViewerAction.SUSPEND_CARD.menuId, Menu.NONE, ViewerAction.SUSPEND_CARD.titleRes)
+                }
+            suspendItem.setSubMenu(submenu)
+        } else {
+            suspendItem.removeSubMenu()
+            suspendItem.setTitle(ViewerAction.SUSPEND_CARD.titleRes)
+        }
+    }
+
+    val buryItem = findItem(ViewerAction.BURY_MENU.menuId) ?: return
+    val flow = viewModel.canBuryNoteFlow.flowWithLifecycle(lifecycle)
+    flow.collectLatestIn(lifecycle.coroutineScope) { canBuryNote ->
+        if (canBuryNote) {
+            if (buryItem.hasSubMenu()) return@collectLatestIn
+            buryItem.setTitle(ViewerAction.BURY_MENU.titleRes)
+            val submenu =
+                SubMenuBuilder(context, buryItem.menu, buryItem).apply {
+                    add(Menu.NONE, ViewerAction.BURY_NOTE.menuId, Menu.NONE, ViewerAction.BURY_NOTE.titleRes)
+                    add(Menu.NONE, ViewerAction.BURY_CARD.menuId, Menu.NONE, ViewerAction.BURY_CARD.titleRes)
+                }
+            buryItem.setSubMenu(submenu)
+        } else {
+            buryItem.removeSubMenu()
+            buryItem.setTitle(ViewerAction.BURY_CARD.titleRes)
+        }
+    }
+}


### PR DESCRIPTION
The ReviewerFragment.kt file has become too big, so I'm trying to encapsulate what I can

This also makes easier to test just the menu

## How Has This Been Tested?

Emulator 34: the new study screen menu works the same way, e.g.:

- flag icon padding doesn't change when changing flags
- Bury/Suspend text is updated if it is only possible to bury/suspend a card
- etc

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->