### PR TITLE
 Fix: Disable 'E' edit shortcut in CardBrowser split mode to prevent unwanted save dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -693,6 +693,12 @@ open class CardBrowser :
                 } else if (searchView?.isIconified == true) {
                     Timber.i("E: Edit note")
                     // search box is not available so treat the event as a shortcut
+                    // Disable 'E' edit shortcut in split mode as the integrated NoteEditor
+                    // is already available in the split view, making the shortcut redundant
+                    if (fragmented) {
+                        Timber.i("E: Ignored in split mode")
+                        return true
+                    }
                     openNoteEditorForCurrentlySelectedNote()
                     return true
                 } else {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 Disable 'E' edit shortcut in CardBrowser split mode to prevent unwanted save dialog

## Fixes
* Fixes #18713

## Approach
Modified the 'E' key handler in `CardBrowser.kt` to:
  1. Check if the browser is in split (`fragmented`) mode
  2. If in split mode, ignore the 'E' key press completely

## How Has This Been Tested?

Medium Tablet API 35 (Emulator)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->