### PR TITLE
feat(filtered-decks): Sort by ascending/descending retrievability

### DIFF
--- a/AnkiDroid/src/main/res/values/11-arrays.xml
+++ b/AnkiDroid/src/main/res/values/11-arrays.xml
@@ -23,23 +23,6 @@
     <string name="error_reporting_choice_never_report">Never report</string>
     <string name="error_reporting_choice_ask_user">Ask me</string>
 
-    <!-- leech_action_labels -->
-    <!-- 01-core:menu_suspend_card -->
-
-
-    <!-- new_order_labels -->
-
-    <!-- cram_deck_conf_order_labels -->
-    <string name="cram_deck_conf_order_oldest_seen_first">Oldest seen first</string>
-    <string name="cram_deck_conf_order_random">Random</string>
-    <string name="cram_deck_conf_order_increasing_intervals">Increasing intervals</string>
-    <string name="cram_deck_conf_order_decreasing_intervals">Decreasing intervals</string>
-    <string name="cram_deck_conf_order_most_lapsed">Most lapsed</string>
-    <string name="cram_deck_conf_order_order_added">Order added</string>
-    <string name="cram_deck_conf_order_order_due">Order due</string>
-    <string name="cram_deck_conf_order_latest_added_first">Latest added first</string>
-    <string name="cram_deck_conf_order_relative_overdueness">Relative overdueness</string>
-
     <!-- add_to_cur_labels -->
     <string name="add_to_deck_use_current_deck">Use current deck</string>
     <string name="add_to_deck_decide_by_note_type">Decide by note type</string>

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -70,17 +70,6 @@
         <item>@string/error_reporting_choice_never_report</item>
         <item>@string/error_reporting_choice_ask_user</item>
     </string-array>
-    <string-array name="cram_deck_conf_order_labels">
-        <item>@string/cram_deck_conf_order_oldest_seen_first</item>
-        <item>@string/cram_deck_conf_order_random</item>
-        <item>@string/cram_deck_conf_order_increasing_intervals</item>
-        <item>@string/cram_deck_conf_order_decreasing_intervals</item>
-        <item>@string/cram_deck_conf_order_most_lapsed</item>
-        <item>@string/cram_deck_conf_order_order_added</item>
-        <item>@string/cram_deck_conf_order_order_due</item>
-        <item>@string/cram_deck_conf_order_latest_added_first</item>
-        <item>@string/cram_deck_conf_order_relative_overdueness</item>
-    </string-array>
     <string-array name="add_to_cur_labels">
         <item>@string/add_to_deck_use_current_deck</item>
         <item>@string/add_to_deck_decide_by_note_type</item>
@@ -161,17 +150,6 @@
     <string name="link_help_forget_cards">https://docs.ankiweb.net/studying.html#editing-and-more</string>
     <string name="link_scheduler_upgrade_faq">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html#updating-to-v2-from-v1</string>
 
-    <string-array name="cram_deck_conf_order_values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
-        <item>3</item>
-        <item>4</item>
-        <item>5</item>
-        <item>6</item>
-        <item>7</item>
-        <item>8</item>
-    </string-array>
     <string-array name="add_to_cur_values">
         <item>0</item>
         <item>1</item>

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
@@ -16,7 +16,9 @@
 
 package com.ichi2.anki.libanki
 
+import anki.decks.Deck.Filtered.SearchTerm.Order
 import com.ichi2.anki.common.utils.ext.deepClonedInto
+import net.ankiweb.rsdroid.Translations
 import org.json.JSONObject
 
 class Deck : JSONObject {
@@ -101,3 +103,25 @@ class Deck : JSONObject {
             put("md", value)
         }
 }
+
+/**
+ * Converts a Sort Order for a filtered deck to a display string
+ *
+ * `Order.OLDEST_REVIEWED_FIRST` -> "Oldest seen first"
+ *
+ * @throws IllegalArgumentException if [Order.UNRECOGNIZED] is provided
+ */
+fun Order.toDisplayString(translations: Translations) =
+    when (this) {
+        Order.OLDEST_REVIEWED_FIRST -> translations.decksOldestSeenFirst()
+        Order.RANDOM -> translations.decksRandom()
+        Order.INTERVALS_ASCENDING -> translations.decksIncreasingIntervals()
+        Order.INTERVALS_DESCENDING -> translations.decksDecreasingIntervals()
+        Order.LAPSES -> translations.decksMostLapses()
+        Order.ADDED -> translations.decksOrderAdded()
+        Order.DUE -> translations.decksOrderDue()
+        Order.REVERSE_ADDED -> translations.decksLatestAddedFirst()
+        Order.RETRIEVABILITY_ASCENDING -> translations.deckConfigSortOrderRetrievabilityAscending()
+        Order.RETRIEVABILITY_DESCENDING -> translations.deckConfigSortOrderRetrievabilityDescending()
+        Order.UNRECOGNIZED -> throw IllegalArgumentException("Can't display an unknown enum value.")
+    }


### PR DESCRIPTION
⚠️ Perceived removal: Relative Overdueness is now 'Ascending retrievability'

## Fixes
* Fixes #19019

## Approach
Fixed via using the Anki Backend enum values and translations

Manually checked strings against the provided screenshot

## How Has This Been Tested?
<img width="960" height="2142" alt="image" src="https://github.com/user-attachments/assets/f9cc245e-7ce7-4eb8-8536-5fe64fc78f98" />


## Learning (optional, can help others)

I used `CardSelectionOrder.ADDED.number.toString()` over `CardSelectionOrder.ADDED_VALUE.toString()` due to personal preference

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->