### PR TITLE
NF: Rename inFragmentedActivity to inCardBrowserActivity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1949,8 +1949,8 @@ open class CardBrowser :
         @VisibleForTesting
         fun createAddNoteLauncher(
             viewModel: CardBrowserViewModel,
-            inFragmentedActivity: Boolean = false,
-        ): NoteEditorLauncher = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel, inFragmentedActivity)
+            inCardBrowserActivity: Boolean = false,
+        ): NoteEditorLauncher = NoteEditorLauncher.AddNoteFromCardBrowser(viewModel, inCardBrowserActivity)
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -288,8 +288,8 @@ class NoteEditorFragment :
      * Whether this is displayed in a fragment view.
      * If true, this fragment is on the trailing side of the card browser.
      */
-    private val inFragmentedActivity
-        get() = requireArguments().getBoolean(IN_FRAGMENTED_ACTIVITY)
+    private val inCardBrowserActivity
+        get() = requireArguments().getBoolean(IN_CARD_BROWSER_ACTIVITY)
 
     private val requestAddLauncher =
         registerForActivityResult(
@@ -1431,7 +1431,7 @@ class NoteEditorFragment :
         } else {
             // Hide add note item if fragment is in fragmented activity
             // because this item is already present in CardBrowser
-            menu.findItem(R.id.action_add_note_from_note_editor).isVisible = !inFragmentedActivity
+            menu.findItem(R.id.action_add_note_from_note_editor).isVisible = !inCardBrowserActivity
         }
         if (editFields != null) {
             for (i in editFields!!.indices) {
@@ -1663,7 +1663,7 @@ class NoteEditorFragment :
             CardTemplateNotetype.clearTempNoteTypeFiles()
 
             // Don't close this fragment if it is in fragmented activity
-            if (inFragmentedActivity) {
+            if (inCardBrowserActivity) {
                 Timber.i("not closing activity: fragmented")
                 return
             }
@@ -2971,7 +2971,7 @@ class NoteEditorFragment :
         const val NOTE_CHANGED_EXTRA_KEY = "noteChanged"
         const val RELOAD_REQUIRED_EXTRA_KEY = "reloadRequired"
         const val EXTRA_IMG_OCCLUSION = "image_uri"
-        const val IN_FRAGMENTED_ACTIVITY = "inFragmentedActivity"
+        const val IN_CARD_BROWSER_ACTIVITY = "inCardBrowserActivity"
 
         // calling activity
         enum class NoteEditorCaller(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -105,14 +105,14 @@ sealed interface NoteEditorLauncher : Destination {
      */
     data class AddNoteFromCardBrowser(
         val viewModel: CardBrowserViewModel,
-        val inFragmentedActivity: Boolean = false,
+        val inCardBrowserActivity: Boolean = false,
     ) : NoteEditorLauncher {
         override fun toBundle(): Bundle {
             val fragmentArgs =
                 bundleOf(
                     NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.CARDBROWSER_ADD.value,
                     NoteEditorFragment.EXTRA_TEXT_FROM_SEARCH_VIEW to viewModel.searchTerms,
-                    NoteEditorFragment.IN_FRAGMENTED_ACTIVITY to inFragmentedActivity,
+                    NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY to inCardBrowserActivity,
                 )
             if (viewModel.lastDeckId?.let { id -> id > 0 } == true) {
                 fragmentArgs.putLong(NoteEditorFragment.EXTRA_DID, viewModel.lastDeckId!!)
@@ -172,14 +172,14 @@ sealed interface NoteEditorLauncher : Destination {
     data class EditCard(
         val cardId: CardId,
         val animation: ActivityTransitionAnimation.Direction,
-        val inFragmentedActivity: Boolean = false,
+        val inCardBrowserActivity: Boolean = false,
     ) : NoteEditorLauncher {
         override fun toBundle(): Bundle =
             bundleOf(
                 NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.EDIT.value,
                 NoteEditorFragment.EXTRA_CARD_ID to cardId,
                 AnkiActivity.FINISH_ANIMATION_EXTRA to animation as Parcelable,
-                NoteEditorFragment.IN_FRAGMENTED_ACTIVITY to inFragmentedActivity,
+                NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY to inCardBrowserActivity,
             )
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Renames the inFragmentedActivity to more accurately represent that it is a check for weather `NoteEditorFragment` is launched by the `cardBrowser`
- Will help to more clearly differentiate it from `fragmented` var to be introduced by #18724 

## Fixes
* Minor fixup for #18724 which will help address [this](https://github.com/ankidroid/Anki-Android/pull/18724#discussion_r2234082041)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->