### PR TITLE
refactor(deck-picker): move some of startup to ViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -21,13 +21,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-fun DeckPicker.performBackupInBackground() {
-    launchCatchingTask {
-        // Wait a second to allow the deck list to finish loading first, or it
-        // will hang until the first stage of the backup completes.
-        delay(1000)
-        createBackup(force = false)
-    }
+suspend fun performBackupInBackground() {
+    // Wait a second to allow the deck list to finish loading first, or it
+    // will hang until the first stage of the backup completes.
+    delay(1000)
+    createBackup(force = false)
 }
 
 fun <Activity> Activity.importColpkg(colpkgPath: String) where Activity : AnkiActivity, Activity : ImportColpkgListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -202,7 +202,6 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import net.ankiweb.rsdroid.RustCleanup
 import net.ankiweb.rsdroid.Translations
 import net.ankiweb.rsdroid.exceptions.BackendNetworkException
 import org.json.JSONException
@@ -2271,26 +2270,12 @@ open class DeckPicker :
     }
 
     /**
-     * Launch an asynchronous task to rebuild the deck list and recalculate the deck counts. Use this
-     * after any change to a deck (e.g., rename, importing, add/delete) that needs to be reflected
-     * in the deck list.
-     *
-     * This method also triggers an update for the widget to reflect the newly calculated counts.
+     * @see DeckPickerViewModel.updateDeckList
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
-    @RustCleanup("backup with 5 minute timer, instead of deck list refresh")
     fun updateDeckList() {
-        if (!CollectionManager.isOpenUnsafe()) {
-            return
-        }
-        if (Build.FINGERPRINT != "robolectric") {
-            // uses user's desktop settings to determine whether a backup
-            // actually happens
-            performBackupInBackground()
-        }
-        Timber.d("updateDeckList")
         launchCatchingTask {
-            withProgress { viewModel.reloadDeckCounts()?.join() }
+            withProgress { viewModel.updateDeckList()?.join() }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -480,7 +480,7 @@ open class DeckPicker :
                         sched.haveBuried(),
                     )
                 }
-            updateDeckList()?.join() // focus has changed
+            updateDeckList()
             showDialogFragment(
                 DeckPickerContextMenu.newInstance(
                     id = deckId,
@@ -2274,9 +2274,9 @@ open class DeckPicker :
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     @RustCleanup("backup with 5 minute timer, instead of deck list refresh")
-    fun updateDeckList(): Job? {
+    fun updateDeckList() {
         if (!CollectionManager.isOpenUnsafe()) {
-            return null
+            return
         }
         if (Build.FINGERPRINT != "robolectric") {
             // uses user's desktop settings to determine whether a backup
@@ -2284,7 +2284,7 @@ open class DeckPicker :
             performBackupInBackground()
         }
         Timber.d("updateDeckList")
-        return launchCatchingTask {
+        launchCatchingTask {
             withProgress { viewModel.reloadDeckCounts()?.join() }
             hideProgressBar()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -112,7 +112,9 @@ import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
+import com.ichi2.anki.deckpicker.DeckPickerViewModel.AnkiDroidEnvironment
 import com.ichi2.anki.deckpicker.DeckPickerViewModel.FlattenedDeckList
+import com.ichi2.anki.deckpicker.DeckPickerViewModel.StartupResponse
 import com.ichi2.anki.deckpicker.EmptyCardsResult
 import com.ichi2.anki.dialogs.AsyncDialogFragment
 import com.ichi2.anki.dialogs.BackupPromptDialog
@@ -165,6 +167,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.animations.fadeIn
 import com.ichi2.anki.ui.animations.fadeOut
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -316,9 +319,6 @@ open class DeckPicker :
     // flag keeping track of when the app has been paused
     var activityPaused = false
         private set
-
-    // Flag to keep track of startup error
-    private var startupError = false
 
     /** See [OptionsMenuState]. */
     @VisibleForTesting
@@ -527,29 +527,14 @@ open class DeckPicker :
 
         setContentView(R.layout.homescreen)
         enableToolbar()
+        // TODO This method is run on every activity recreation, which can happen often.
+        //  It seems that the original idea was for for this to only run once, on app start.
+        //  This method triggers backups, sync, and may re-show dialogs
+        //  that may have been dismissed. Make this run only once?
         handleStartup()
         val mainView = findViewById<View>(android.R.id.content)
 
         studyoptionsFrame = findViewById(R.id.studyoptions_fragment)
-
-        // Open StudyOptionsFragment if in fragmented mode
-        if (fragmented && !startupError) {
-            loadStudyOptionsFragment(false)
-
-            val resizingDivider = findViewById<View>(R.id.homescreen_resizing_divider)
-            val parentLayout = findViewById<LinearLayout>(R.id.deckpicker_xl_view)
-            val deckPickerPane = findViewById<View>(R.id.deck_picker_pane)
-            val studyOptionsPane = findViewById<View>(R.id.studyoptions_fragment)
-            ResizablePaneManager(
-                parentLayout = parentLayout,
-                divider = resizingDivider,
-                leftPane = deckPickerPane,
-                rightPane = studyOptionsPane,
-                sharedPrefs = Prefs.getUiConfig(this),
-                leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
-                rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,
-            )
-        }
         registerReceiver()
 
         // create inherited navigation drawer layout here so that it can be used by parent class
@@ -804,6 +789,40 @@ open class DeckPicker :
             hideProgressBar()
         }
 
+        fun onStartupResponse(response: StartupResponse) {
+            Timber.d("onStartupResponse: %s", response)
+            when (response) {
+                is StartupResponse.RequestPermissions ->
+                    permissionScreenLauncher.launch(
+                        PermissionsActivity.getIntent(this, response.requiredPermissions),
+                    )
+
+                is StartupResponse.Success -> {
+                    showStartupScreensAndDialogs(sharedPrefs(), 0)
+
+                    // Open StudyOptionsFragment if in fragmented mode
+                    if (fragmented) {
+                        loadStudyOptionsFragment(false)
+
+                        val resizingDivider = findViewById<View>(R.id.homescreen_resizing_divider)
+                        val parentLayout = findViewById<LinearLayout>(R.id.deckpicker_xl_view)
+                        val deckPickerPane = findViewById<View>(R.id.deck_picker_pane)
+                        val studyOptionsPane = findViewById<View>(R.id.studyoptions_fragment)
+                        ResizablePaneManager(
+                            parentLayout = parentLayout,
+                            divider = resizingDivider,
+                            leftPane = deckPickerPane,
+                            rightPane = studyOptionsPane,
+                            sharedPrefs = Prefs.getUiConfig(this),
+                            leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
+                            rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,
+                        )
+                    }
+                }
+                is StartupResponse.FatalError -> handleStartupFailure(response.failure)
+            }
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -827,6 +846,7 @@ open class DeckPicker :
         viewModel.flowOfFocusedDeck.launchCollectionInLifecycleScope(::onFocusedDeckChanged)
         viewModel.flowOfResizingDividerVisible.launchCollectionInLifecycleScope(::onResizingDividerVisibilityChanged)
         viewModel.flowOfDecksReloaded.launchCollectionInLifecycleScope(::onDecksReloaded)
+        viewModel.flowOfStartupResponse.filterNotNull().launchCollectionInLifecycleScope(::onStartupResponse)
     }
 
     private val onReceiveContentListener =
@@ -934,32 +954,24 @@ open class DeckPicker :
     }
 
     /**
-     * The first call in showing dialogs for startup - error or success.
-     * Attempts startup if storage permission has been acquired, else, it requests the permission
-     *
-     * TODO This method is run on every activity recreation, which can happen often.
-     *   It seems that the original idea was for for this to only run once, on app start.
-     *   This method triggers backups, sync, and may re-show dialogs
-     *   that may have been dismissed. Make this run only once?
+     * @see DeckPickerViewModel.handleStartup
      */
     private fun handleStartup() {
-        if (collectionPermissionScreenWasOpened()) {
-            return
-        }
+        val context = AnkiDroidApp.instance
 
-        Timber.d("handleStartup: Continuing after permission granted")
-        val failure = InitialActivity.getStartupFailureType(this)
-        startupError =
-            if (failure == null) {
-                // Show any necessary dialogs (e.g. changelog, special messages, etc)
-                val sharedPrefs = this.sharedPrefs()
-                showStartupScreensAndDialogs(sharedPrefs, 0)
-                false
-            } else {
-                // Show error dialogs
-                handleStartupFailure(failure)
-                true
+        val environment: AnkiDroidEnvironment =
+            object : AnkiDroidEnvironment {
+                private val folder = selectAnkiDroidFolder(context)
+
+                override fun hasRequiredPermissions(): Boolean = folder.hasRequiredPermissions(context)
+
+                override val requiredPermissions: PermissionSet
+                    get() = folder.permissionSet
+
+                override fun initializeAnkiDroidFolder(): Boolean = CollectionHelper.isCurrentAnkiDroidDirAccessible(context)
             }
+
+        viewModel.handleStartup(environment = environment)
     }
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -33,7 +33,6 @@ import android.content.res.Configuration
 import android.database.SQLException
 import android.graphics.PixelFormat
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.os.Bundle
 import android.os.Message
 import android.text.util.Linkify
@@ -177,7 +176,6 @@ import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.anki.worker.SyncWorker
 import com.ichi2.anki.worker.UniqueWorkNames
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
-import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.ui.BadgeDrawableBuilder
 import com.ichi2.utils.AdaptionUtil
@@ -1781,17 +1779,6 @@ open class DeckPicker :
         preferences: SharedPreferences,
         skip: Int,
     ) {
-        // For Android 8/8.1 we want to use software rendering by default or the Reviewer UI is broken #7369
-        if (sdkVersion == Build.VERSION_CODES.O ||
-            sdkVersion == Build.VERSION_CODES.O_MR1
-        ) {
-            if (!preferences.contains("softwareRender")) {
-                Timber.i("Android 8/8.1 detected with no render preference. Turning on software render.")
-                preferences.edit { putBoolean("softwareRender", true) }
-            } else {
-                Timber.i("Android 8/8.1 detected, software render preference already exists.")
-            }
-        }
         if (!BackupManager.enoughDiscSpace(CollectionHelper.getCurrentAnkiDroidDirectory(this))) {
             Timber.i("Not enough space to do backup")
             showDialogFragment(DeckPickerNoSpaceLeftDialog.newInstance())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -801,6 +801,10 @@ open class DeckPicker :
             }, 10)
         }
 
+        fun onDecksReloaded(param: Unit) {
+            hideProgressBar()
+        }
+
         fun onError(errorMessage: String) {
             AlertDialog
                 .Builder(this)
@@ -823,6 +827,7 @@ open class DeckPicker :
         viewModel.flowOfDeckList.launchCollectionInLifecycleScope(::onDeckListChanged)
         viewModel.flowOfFocusedDeck.launchCollectionInLifecycleScope(::onFocusedDeckChanged)
         viewModel.flowOfResizingDividerVisible.launchCollectionInLifecycleScope(::onResizingDividerVisibilityChanged)
+        viewModel.flowOfDecksReloaded.launchCollectionInLifecycleScope(::onDecksReloaded)
     }
 
     private val onReceiveContentListener =
@@ -2286,7 +2291,6 @@ open class DeckPicker :
         Timber.d("updateDeckList")
         launchCatchingTask {
             withProgress { viewModel.reloadDeckCounts()?.join() }
-            hideProgressBar()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -33,6 +33,7 @@ import com.ichi2.anki.ui.windows.permissions.Full30and31PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment
 import com.ichi2.anki.ui.windows.permissions.PermissionsUntil29Fragment
 import com.ichi2.anki.ui.windows.permissions.TiramisuPermissionsFragment
+import com.ichi2.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import kotlinx.parcelize.Parcelize
@@ -238,4 +239,19 @@ fun selectAnkiDroidFolder(context: Context): AnkiDroidFolder {
         canManageExternalStorage = Permissions.canManageExternalStorage(context),
         currentFolderIsAccessibleAndLegacy = currentFolderIsAccessibleAndLegacy,
     )
+}
+
+/**
+ * Configures either hardware or software rendering
+ */
+fun configureRenderingMode() {
+    val preferences = AnkiDroidApp.sharedPrefs()
+    // For Android 8/8.1 we want to use software rendering by default or the Reviewer UI is broken #7369
+    if (sdkVersion != Build.VERSION_CODES.O && sdkVersion != Build.VERSION_CODES.O_MR1) return
+    if (!preferences.contains("softwareRender")) {
+        Timber.i("Android 8/8.1 detected with no render preference. Turning on software render.")
+        preferences.edit { putBoolean("softwareRender", true) }
+    } else {
+        Timber.i("Android 8/8.1 detected, software render preference already exists.")
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -38,13 +38,16 @@ import com.ichi2.utils.VersionUtils.pkgVersionName
 import kotlinx.parcelize.Parcelize
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
-import java.lang.Exception
 
 /** Utilities for launching the first activity (currently the DeckPicker)  */
 object InitialActivity {
+    @CheckResult
+    fun getStartupFailureType(context: Context): StartupFailure? =
+        getStartupFailureType { CollectionHelper.isCurrentAnkiDroidDirAccessible(context) }
+
     /** Returns null on success  */
     @CheckResult
-    fun getStartupFailureType(context: Context): StartupFailure? {
+    fun getStartupFailureType(initializeAnkiDroidDirectory: () -> Boolean): StartupFailure? {
         // A WebView failure means that we skip `AnkiDroidApp`, and therefore haven't loaded the collection
         if (AnkiDroidApp.webViewFailedToLoad()) {
             return StartupFailure.WebviewFailed
@@ -76,7 +79,7 @@ object InitialActivity {
 
         if (!AnkiDroidApp.isSdCardMounted) {
             return StartupFailure.SDCardNotMounted
-        } else if (!CollectionHelper.isCurrentAnkiDroidDirAccessible(context)) {
+        } else if (!initializeAnkiDroidDirectory()) {
             return StartupFailure.DirectoryNotAccessible
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -163,6 +163,10 @@ class DeckPickerViewModel(
             !(isInInitialState == true || hasNoCards)
         }
 
+    // HACK: dismiss a legacy progress bar
+    // TODO: Replace with better progress handling for first load/corrupt collections
+    val flowOfDecksReloaded = MutableSharedFlow<Unit>()
+
     /**
      * Deletes the provided deck, child decks. and all cards inside.
      *
@@ -311,6 +315,8 @@ class DeckPickerViewModel(
                 // current deck may have changed
                 focusedDeck = withCol { decks.current().id }
                 flowOfUndoUpdated.emit(Unit)
+
+                flowOfDecksReloaded.emit(Unit)
             }
         this.loadDeckCounts = loadDeckCounts
         return loadDeckCounts

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.InitialActivity
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.browser.BrowserDestination
+import com.ichi2.anki.configureRenderingMode
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.Consts
@@ -399,8 +400,16 @@ class DeckPickerViewModel(
 
         Timber.d("handleStartup: Continuing after permission granted")
         val failure = InitialActivity.getStartupFailureType(environment::initializeAnkiDroidFolder)
-        flowOfStartupResponse.value =
-            if (failure == null) StartupResponse.Success else StartupResponse.FatalError(failure)
+        if (failure != null) {
+            flowOfStartupResponse.value = StartupResponse.FatalError(failure)
+            return
+        }
+
+        // successful startup
+
+        configureRenderingMode()
+
+        flowOfStartupResponse.value = StartupResponse.Success
     }
 
     interface AnkiDroidEnvironment {


### PR DESCRIPTION
## Purpose / Description
* slow progress on #18886
  * The goal is to move startup into the ViewModel
  * From there, we can move launching 'updateDeckList' from `onResume` to startup
  * This avoids either a race condition, or blocking the main thread/collection on knowing whether the collection is usable
    * We can /probably/ do this now,  but I want to move all of `showStartupScreensAndDialogs` before I tackle it

## How Has This Been Tested?
CI still passes, and briefly tested the Deck Picker

⚠️ Please suggest unit tests, I'm happy to block this for a round of feedback

## Learning (optional, can help others)
I thought I had more time, this isn't a huge change, but is forward progress

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)