### PR TITLE
refactor: prepare AnkiActivity for review reminders

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -62,6 +62,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.dialogs.AsyncDialogFragment
@@ -74,9 +75,9 @@ import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SAVE
 import com.ichi2.anki.dialogs.ExportReadyDialog.Companion.REQUEST_EXPORT_SHARE
 import com.ichi2.anki.dialogs.SimpleMessageDialog
 import com.ichi2.anki.libanki.Collection
-import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.workarounds.AppLoadedFromBackupWorkaround.showedActivityFailedScreen
@@ -586,54 +587,56 @@ open class AnkiActivity :
         message: String?,
         channel: Channel,
     ) {
-        val prefs = this.sharedPrefs()
-        // Show a notification unless all notifications have been totally disabled
-        if (prefs
-                .getString(getString(R.string.pref_notifications_minimum_cards_due_key), "0")!!
-                .toInt() <= PENDING_NOTIFICATIONS_ONLY
-        ) {
-            // Use the title as the ticker unless the title is simply "AnkiDroid"
-            val ticker: String? =
-                if (title == resources.getString(R.string.app_name)) {
-                    message
-                } else {
-                    title
-                }
-            // Build basic notification
-            val builder =
-                NotificationCompat
-                    .Builder(
-                        this,
-                        channel.id,
-                    ).setSmallIcon(R.drawable.ic_star_notify)
-                    .setContentTitle(title)
-                    .setContentText(message)
-                    .setColor(this.getColor(R.color.material_light_blue_500))
-                    .setStyle(NotificationCompat.BigTextStyle().bigText(message))
-                    .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
-                    .setTicker(ticker)
+        // Use the title as the ticker unless the title is simply "AnkiDroid"
+        val ticker: String? =
+            if (title == resources.getString(R.string.app_name)) {
+                message
+            } else {
+                title
+            }
+        // Build basic notification
+        val builder =
+            NotificationCompat
+                .Builder(
+                    this,
+                    channel.id,
+                ).setSmallIcon(R.drawable.ic_star_notify)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setColor(getColor(R.color.material_light_blue_500))
+                .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setTicker(ticker)
+        configureLegacyNotificationSettings(builder)
+        // Creates an explicit intent for an Activity in your app
+        val resultIntent = Intent(this, DeckPicker::class.java)
+        resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        val resultPendingIntent =
+            PendingIntentCompat.getActivity(
+                this,
+                0,
+                resultIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                false,
+            )
+        builder.setContentIntent(resultPendingIntent)
+        val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+        // mId allows you to update the notification later on.
+        notificationManager.notify(SIMPLE_NOTIFICATION_ID, builder.build())
+    }
+
+    @LegacyNotifications("Delete once review reminders are stable, these are configurable from OS settings")
+    private fun configureLegacyNotificationSettings(builder: NotificationCompat.Builder) {
+        if (!Prefs.newReviewRemindersEnabled) {
             // Enable vibrate and blink if set in preferences
+            // In the new review reminders system, the user sets these by going to the OS settings themselves
+            val prefs = this.sharedPrefs()
             if (prefs.getBoolean("widgetVibrate", false)) {
                 builder.setVibrate(longArrayOf(1000, 1000, 1000))
             }
             if (prefs.getBoolean("widgetBlink", false)) {
                 builder.setLights(Color.BLUE, 1000, 1000)
             }
-            // Creates an explicit intent for an Activity in your app
-            val resultIntent = Intent(this, DeckPicker::class.java)
-            resultIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-            val resultPendingIntent =
-                PendingIntentCompat.getActivity(
-                    this,
-                    0,
-                    resultIntent,
-                    PendingIntent.FLAG_UPDATE_CURRENT,
-                    false,
-                )
-            builder.setContentIntent(resultPendingIntent)
-            val notificationManager = getSystemService(NOTIFICATION_SERVICE) as NotificationManager
-            // mId allows you to update the notification later on.
-            notificationManager.notify(SIMPLE_NOTIFICATION_ID, builder.build())
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

Continuing to mark old legacy review reminder code for deletion, preparing the existing codebase for the new review reminder code.

- `showSimpleNotification` is used to send general notifications and sync notifications. However, for some reason, the old code didn't send general and sync notifications if legacy review alerts weren't set, which was a weird coupling. This change removes that `if` condition and just runs the code immediately. After all, whether the user has enabled legacy review alerts should not affect whether they receive sync notifications. If the user wants to disable sync notifications, they can turn off notifications in the OS settings menu.
- Gated the vibration and blink settings behind a legacy review reminders conditional. We no longer support these settings in the new review reminders system, as vibration can be configured manually by the user within the OS settings and light blinking is now an accessibility feature that cannot be set by users for specific individual apps.

## Fixes
* GSoC 2025: Review Reminders

## Approach
- Got rid of an `if`, added an `if`.

## How Has This Been Tested?
- Launches using a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->