### PR TITLE
chore(field-editor): add layout preview

### DIFF
--- a/AnkiDroid/src/main/res/layout/note_type_field_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_type_field_editor.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/root_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,9 +13,10 @@
         <include layout="@layout/toolbar" />
 
         <ListView
+            android:id="@+id/note_type_editor_fields"
             android:layout_width="match_parent"
             android:gravity="center"
             android:layout_height="wrap_content"
-            android:id="@+id/note_type_editor_fields"/>
+            tools:listitem="@layout/note_type_field_editor_list_item"/>
     </LinearLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
I noticed this when reviewing the following, but didn't want to expand the scope

* https://github.com/ankidroid/Anki-Android/pull/19046

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)