### PR TITLE
fix(deck-picker): hide resizing divider when collection is empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -761,6 +761,11 @@ open class DeckPicker :
             }
         }
 
+        fun onResizingDividerVisibilityChanged(isVisible: Boolean) {
+            val resizingDivider = findViewById<View>(R.id.homescreen_resizing_divider)
+            resizingDivider?.visibility = if (isVisible) View.VISIBLE else View.GONE
+        }
+
         fun onCardsDueChanged(dueCount: Int?) {
             if (dueCount == null) {
                 supportActionBar?.subtitle = null
@@ -815,6 +820,7 @@ open class DeckPicker :
         viewModel.flowOfStudyOptionsVisible.launchCollectionInLifecycleScope(::onStudyOptionsVisibilityChanged)
         viewModel.flowOfDeckList.launchCollectionInLifecycleScope(::onDeckListChanged)
         viewModel.flowOfFocusedDeck.launchCollectionInLifecycleScope(::onFocusedDeckChanged)
+        viewModel.flowOfResizingDividerVisible.launchCollectionInLifecycleScope(::onResizingDividerVisibilityChanged)
     }
 
     private val onReceiveContentListener =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -157,6 +157,12 @@ class DeckPickerViewModel(
 
     val flowOfStudyOptionsVisible = flowOfCollectionHasNoCards.map { noCards -> fragmented && !noCards }
 
+    /** Flow that determines when the resizing divider should be visible */
+    val flowOfResizingDividerVisible =
+        combine(flowOfDeckListInInitialState, flowOfCollectionHasNoCards) { isInInitialState, hasNoCards ->
+            !(isInInitialState == true || hasNoCards)
+        }
+
     /**
      * Deletes the provided deck, child decks. and all cards inside.
      *


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- Hides the resizing divider when there or no decks/ collection is empty.

## Fixes
* Fixes #19053 

## Approach
- adds a check to onCollectionStatusChanged to weather the divider should be visible or not.

## How Has This Been Tested?
No decks:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/5021933e-2667-4906-802c-27e6e022ad0e" />
Empty deck:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/c00f03b6-e1cd-44ed-84ec-5121cf7bcc15" />
Deck with cards:
<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/74d0a4c0-4ef4-4d73-977c-f00669ed8e71" />


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->