### PR TITLE
Refactor & fix bug: small widget

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -95,9 +95,15 @@ object DayRolloverHandler : BroadcastReceiver() {
         Timber.i("day cutoff changed %d -> %d", lastCutoff, currentCutoff)
         // we do not want to send a "study queues changes" message initially
         if (lastCutoff != null) {
-            Timber.i("updating study queues")
-            ChangeManager.notifySubscribers(opChanges { studyQueues = true }, initiator = null)
+            handleDayRollover()
         }
         this.lastCutoff = currentCutoff
+    }
+
+    private fun handleDayRollover() {
+        Timber.i("day rollover occurred")
+
+        Timber.i("updating study queues")
+        ChangeManager.notifySubscribers(opChanges { studyQueues = true }, initiator = null)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.libanki.EpochSeconds
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
 
@@ -105,5 +106,12 @@ object DayRolloverHandler : BroadcastReceiver() {
 
         Timber.i("updating study queues")
         ChangeManager.notifySubscribers(opChanges { studyQueues = true }, initiator = null)
+
+        Timber.i("day rollover: updating widgets")
+        try {
+            WidgetStatus.updateInBackground(AnkiDroidApp.instance)
+        } catch (e: Exception) {
+            Timber.w(e, "failed to update widgets")
+        }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -620,9 +620,9 @@ object MetaDB {
     /**
      * Return the current status of the widget.
      *
-     * @return [due, eta]
+     * @return [due, eta] ([SmallWidgetStatus])
      */
-    fun getWidgetSmallStatus(context: Context): IntArray {
+    fun getWidgetSmallStatus(context: Context): SmallWidgetStatus {
         openDBIfClosed(context)
         try {
             metaDb!!
@@ -636,13 +636,16 @@ object MetaDB {
                     null,
                 ).use { cursor ->
                     if (cursor.moveToNext()) {
-                        return intArrayOf(cursor.getInt(0), cursor.getInt(1))
+                        return SmallWidgetStatus(
+                            dueCardsCount = cursor.getInt(0),
+                            eta = cursor.getInt(1),
+                        )
                     }
                 }
         } catch (e: SQLiteException) {
             Timber.e(e, "Error while querying widgetStatus")
         }
-        return intArrayOf(0, 0)
+        return SmallWidgetStatus(dueCardsCount = 0, eta = 0)
     }
 
     fun getNotificationStatus(context: Context): Int {
@@ -672,7 +675,7 @@ object MetaDB {
                 metaDb.execSQL("DELETE FROM smallWidgetStatus")
                 metaDb.execSQL(
                     "INSERT INTO smallWidgetStatus(due, eta) VALUES (?, ?)",
-                    arrayOf<Any>(status.due, status.eta),
+                    arrayOf<Any>(status.dueCardsCount, status.eta),
                 )
             }
         } catch (e: IllegalStateException) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MetaDB.kt
@@ -678,6 +678,7 @@ object MetaDB {
                     arrayOf<Any>(status.dueCardsCount, status.eta),
                 )
             }
+            Timber.d("MetaDB:: Cached small widget status")
         } catch (e: IllegalStateException) {
             Timber.e(e, "MetaDB.storeSmallWidgetStatus: failed")
         } catch (e: SQLiteException) {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
@@ -19,6 +19,7 @@ package com.ichi2.widget
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
+import android.content.Intent
 import androidx.annotation.CallSuper
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -61,6 +62,15 @@ abstract class AnalyticsWidgetProvider : AppWidgetProvider() {
         super.onDisabled(context)
         Timber.d("${this.javaClass.name}: Widget disabled")
         UsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "disabled")
+    }
+
+    @CallSuper
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        super.onReceive(context, intent)
+        Timber.v("${this.javaClass.name}: onReceive: %s", intent.action)
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -142,18 +142,8 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                 // Compute the total number of cards due.
                 val (dueCardsCount, eta) = WidgetStatus.fetchSmall(context)
                 val etaIcon: String = "⏱"
-                if (dueCardsCount <= 0) {
-                    if (dueCardsCount == 0) {
-                        updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.VISIBLE)
-                    } else {
-                        updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.INVISIBLE)
-                        updateViews.setViewVisibility(R.id.widget_due, View.VISIBLE)
-                        updateViews.setTextViewText(R.id.widget_due, dueCardsCount.toString())
-                        updateViews.setContentDescription(
-                            R.id.widget_due,
-                            context.resources.getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount),
-                        )
-                    }
+                if (dueCardsCount == 0) {
+                    updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.VISIBLE)
                     updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
                     updateViews.setViewVisibility(R.id.widget_due, View.INVISIBLE)
                 } else {
@@ -165,7 +155,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                         context.resources.getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount),
                     )
                 }
-                if (eta <= 0 || dueCardsCount <= 0) {
+                if (eta <= 0 || dueCardsCount == 0) {
                     updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
                 } else {
                     updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -80,9 +80,15 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
     }
 
     class UpdateService : Service() {
+        /**
+         * Updates the UI of [AnkiDroidWidgetSmall]
+         *
+         * Externals callers should use [WidgetStatus.updateInBackground]
+         */
         fun doUpdate(context: Context) {
             val appWidgetManager = getAppWidgetManager(context) ?: return
-            appWidgetManager.updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), buildUpdate(context))
+            val remoteViews = buildUpdate(context)
+            appWidgetManager.updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), remoteViews)
         }
 
         @Deprecated("Implement onStartCommand(Intent, int, int) instead.") // TODO
@@ -102,7 +108,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
             }
 
         private fun buildUpdate(context: Context): RemoteViews {
-            Timber.d("buildUpdate")
+            Timber.d("updating small widget UI")
             val updateViews = RemoteViews(context.packageName, widgetSmallLayout)
             val mounted = AnkiDroidApp.isSdCardMounted
             if (!mounted) {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -154,16 +154,17 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                         R.id.widget_due,
                         context.resources.getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount),
                     )
-                }
-                if (eta <= 0 || dueCardsCount == 0) {
-                    updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
-                } else {
-                    updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE)
-                    updateViews.setTextViewText(R.id.widget_eta, "$etaIcon$eta")
-                    updateViews.setContentDescription(
-                        R.id.widget_eta,
-                        context.resources.getQuantityString(R.plurals.widget_eta, eta, eta),
-                    )
+
+                    if (eta <= 0) {
+                        updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
+                    } else {
+                        updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE)
+                        updateViews.setTextViewText(R.id.widget_eta, "$etaIcon$eta")
+                        updateViews.setContentDescription(
+                            R.id.widget_eta,
+                            context.resources.getQuantityString(R.plurals.widget_eta, eta, eta),
+                        )
+                    }
                 }
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -120,7 +120,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                                 // context may not have the locale override from AnkiDroidApp
                                 val action = intent.action
                                 if (action != null && action == Intent.ACTION_MEDIA_MOUNTED) {
-                                    Timber.d("mMountReceiver - Action = Media Mounted")
+                                    Timber.d("mountReceiver - Action = Media Mounted")
                                     if (remounted) {
                                         WidgetStatus.updateInBackground(AnkiDroidApp.instance)
                                         remounted = false

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -80,9 +80,6 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
     }
 
     class UpdateService : Service() {
-        /** The cached number of total due cards.  */
-        private var dueCardsCount = 0
-
         fun doUpdate(context: Context) {
             val appWidgetManager = getAppWidgetManager(context) ?: return
             appWidgetManager.updateAppWidget(ComponentName(context, AnkiDroidWidgetSmall::class.java), buildUpdate(context))
@@ -143,10 +140,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                 }
             } else {
                 // Compute the total number of cards due.
-                val counts = WidgetStatus.fetchSmall(context)
-                dueCardsCount = counts[0]
-                // The cached estimated reviewing time.
-                val eta = counts[1]
+                val (dueCardsCount, eta) = WidgetStatus.fetchSmall(context)
                 val etaIcon: String = "⏱"
                 if (dueCardsCount <= 0) {
                     if (dueCardsCount == 0) {
@@ -160,20 +154,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                             context.resources.getQuantityString(R.plurals.widget_cards_due, dueCardsCount, dueCardsCount),
                         )
                     }
-                    if (eta <= 0 || dueCardsCount <= 0) {
-                        updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
-                    } else {
-                        updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE)
-                        if (Build.VERSION.SDK_INT >= 31) {
-                            updateViews.setTextViewText(R.id.widget_eta, "$etaIcon$eta")
-                        } else {
-                            updateViews.setTextViewText(R.id.widget_eta, "$eta")
-                        }
-                        updateViews.setContentDescription(
-                            R.id.widget_eta,
-                            context.resources.getQuantityString(R.plurals.widget_eta, eta, eta),
-                        )
-                    }
+                    updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
                     updateViews.setViewVisibility(R.id.widget_due, View.INVISIBLE)
                 } else {
                     updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.INVISIBLE)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -141,7 +141,6 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
             } else {
                 // Compute the total number of cards due.
                 val (dueCardsCount, eta) = WidgetStatus.fetchSmall(context)
-                val etaIcon: String = "⏱"
                 if (dueCardsCount == 0) {
                     updateViews.setViewVisibility(R.id.ankidroid_widget_small_finish_layout, View.VISIBLE)
                     updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
@@ -159,7 +158,8 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
                         updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)
                     } else {
                         updateViews.setViewVisibility(R.id.widget_eta, View.VISIBLE)
-                        updateViews.setTextViewText(R.id.widget_eta, "$etaIcon$eta")
+                        val etaText = if (Build.VERSION.SDK_INT >= 31) "⏱$eta" else "$eta"
+                        updateViews.setTextViewText(R.id.widget_eta, etaText)
                         updateViews.setContentDescription(
                             R.id.widget_eta,
                             context.resources.getQuantityString(R.plurals.widget_eta, eta, eta),

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -28,9 +28,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+/**
+ * @param dueCardsCount The number of due cards (new + lrn + rev)
+ * @param eta The estimated time to review
+ */
 data class SmallWidgetStatus(
-    var due: Int,
-    var eta: Int,
+    val dueCardsCount: Int,
+    val eta: Int,
 )
 
 /**
@@ -86,7 +90,7 @@ object WidgetStatus {
     }
 
     /** Returns the status of each of the decks.  */
-    fun fetchSmall(context: Context): IntArray = MetaDB.getWidgetSmallStatus(context)
+    fun fetchSmall(context: Context): SmallWidgetStatus = MetaDB.getWidgetSmallStatus(context)
 
     fun fetchDue(context: Context): Int = MetaDB.getNotificationStatus(context)
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -257,13 +257,9 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
     }
 
     override fun onReceive(
-        context: Context?,
-        intent: Intent?,
+        context: Context,
+        intent: Intent,
     ) {
-        if (context == null || intent == null) {
-            Timber.e("Context or intent is null in onReceive")
-            return
-        }
         super.onReceive(context, intent)
 
         val widgetPreferences = CardAnalysisWidgetPreferences(context)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -267,13 +267,9 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
     }
 
     override fun onReceive(
-        context: Context?,
-        intent: Intent?,
+        context: Context,
+        intent: Intent,
     ) {
-        if (context == null || intent == null) {
-            Timber.e("Context or intent is null in onReceive")
-            return
-        }
         super.onReceive(context, intent)
 
         val widgetPreferences = DeckPickerWidgetPreferences(context)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I said I'd look into #14372, I did a few refactorings and fixed some bugs

* #14372

## Bug 1

The icon appeared twice incorrectly on < API 31: 

<img width="302" height="378" alt="image" src="https://github.com/user-attachments/assets/1e18a1dd-b7c5-4aeb-a126-da27fae24ae4" />

## Bug 2

From a user report, we weren't handling the day rollover event, so add a widget update on this event

⚠️ This probably doesn't work if the app is closed. The 'Day Rollover' broadcast was designed for in-app use, rather than use when the app is closed.

## Approach
Various logical refactorings (see commits)

## How Has This Been Tested?
API 31 widget still works (tested with cards, no ETA, and an ETA)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->