### PR TITLE
refactor(card-browser): extract 'save search' to ViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -257,6 +257,13 @@ class CardBrowserViewModel(
      */
     val flowOfCardStateChanged = MutableSharedFlow<Unit>()
 
+    /**
+     * Opens a prompt for the user to input a saved search name
+     *
+     * The parameter is the 'searchTerms' to be used in the saved search
+     */
+    val flowOfSaveSearchNamePrompt = MutableSharedFlow<String>()
+
     var focusedRow: CardOrNoteId? = null
         set(value) {
             if (!isFragmented) return
@@ -1359,6 +1366,17 @@ class CardBrowserViewModel(
      * Returns the decks which are suitable for [moveSelectedCardsToDeck]
      */
     suspend fun getAvailableDecks(): List<DeckNameId> = withCol { decks.allNamesAndIds(includeFiltered = false) }
+
+    /** Opens the UI to save the current [tempSearchQuery] as a saved search */
+    fun saveCurrentSearch() =
+        viewModelScope.launch {
+            val query = tempSearchQuery
+            if (query.isNullOrEmpty()) {
+                Timber.d("not prompting to saving search: no query")
+                return@launch
+            }
+            flowOfSaveSearchNamePrompt.emit(query)
+        }
 }
 
 enum class SaveSearchResult {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1144,6 +1144,31 @@ class CardBrowserViewModelTest : JvmTest() {
         }
     }
 
+    @Test
+    fun `saving a blank query does nothing`() =
+        runViewModelTest {
+            flowOfSaveSearchNamePrompt.test {
+                updateQueryText("AAA")
+                updateQueryText("")
+
+                saveCurrentSearch()
+
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `saving a search opens the 'name' dialog`() =
+        runViewModelTest {
+            flowOfSaveSearchNamePrompt.test {
+                updateQueryText("AAA")
+
+                saveCurrentSearch()
+
+                assertThat("save search is opened", expectMostRecentItem(), equalTo("AAA"))
+            }
+        }
+
     private fun assertDate(str: String?) {
         // 2025-01-09 @ 18:06
         assertNotNull(str)


### PR DESCRIPTION
I want to move saved searches to the SearchView in issue #18709

* #18709

## How Has This Been Tested?
Added unit tests

* API 36 Google Pixel 9 Pro
  * Saved a search, dialog still appeared and search still worked
  * Closed the SearchActionView and did the same

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->