### PR TITLE
Fix: Refresh Undo menu label after saving deck description

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU General Public License along with         *
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
-
+//hhh
 package com.ichi2.anki
 
 import android.annotation.SuppressLint

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/DeckPickerTest.kt
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU General Public License along with         *
  * this program.  If not, see <http://www.gnu.org/licenses/>.                           *
  ****************************************************************************************/
-//hhh
 package com.ichi2.anki
 
 import android.annotation.SuppressLint

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -172,29 +172,10 @@ class EditDeckDescriptionDialog : DialogFragment() {
         }
     }
 
-<<<<<<< HEAD
     fun showDiscardChangesDialog() {
         Timber.i("asking if user should discard changes")
         DiscardChangesDialog.showDialog(requireContext()) {
             viewModel.closeWithoutSaving()
-=======
-    override fun onStart() {
-        super.onStart()
-
-        dialog!!.window!!.setLayout(
-            ViewGroup.LayoutParams.MATCH_PARENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-        )
-    }
-
-    private fun saveAndExit() =
-        launchCatchingTask {
-            setDescription(currentDescription)
-            Timber.i("closing deck description dialog")
-            // Refresh the host activity's menu to update the Undo label
-            requireActivity().invalidateOptionsMenu()
-            dismiss()
->>>>>>> 189a74ce94 (git commit -am "Fix: Refresh Undo menu label after saving deck description (#19073)")
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -172,10 +172,29 @@ class EditDeckDescriptionDialog : DialogFragment() {
         }
     }
 
+<<<<<<< HEAD
     fun showDiscardChangesDialog() {
         Timber.i("asking if user should discard changes")
         DiscardChangesDialog.showDialog(requireContext()) {
             viewModel.closeWithoutSaving()
+=======
+    override fun onStart() {
+        super.onStart()
+
+        dialog!!.window!!.setLayout(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT,
+        )
+    }
+
+    private fun saveAndExit() =
+        launchCatchingTask {
+            setDescription(currentDescription)
+            Timber.i("closing deck description dialog")
+            // Refresh the host activity's menu to update the Undo label
+            requireActivity().invalidateOptionsMenu()
+            dismiss()
+>>>>>>> 189a74ce94 (git commit -am "Fix: Refresh Undo menu label after saving deck description (#19073)")
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
This Pull Request addresses an issue where the Undo menu label does not update correctly after saving a deck description. The label remains outdated until another action is performed or the menu is reopened.

## Fixes
Fixes #19073

## Approach
The solution includes adding a call to `invalidateOptionsMenu()` in the `saveAndExit()` method of the `EditDeckDescriptionDialog.kt` class. This ensures the host activity refreshes its menu immediately after saving the deck description, updating the Undo label to reflect the latest undoable action.

## How Has This Been Tested?
1. Switch to a different deck so the Undo menu reads "Undo select deck."
2. Open the deck description dialog, make a change, and save.
3. Verify that the Undo menu label updates immediately to "Undo update deck."

Tested on:
- Android SDK version: 35
- Emulator/Device: Resizable (Experimental) API 35

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings).
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor).