### PR TITLE
refactor(libanki): bring Collection.kt up to date with upstream

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -116,6 +116,7 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.anki.libanki.Notetypes.Companion.NOT_FOUND_NOTE_TYPE
 import com.ichi2.anki.libanki.Utils
+import com.ichi2.anki.libanki.clozeNumbersInNote
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.multimedia.AudioRecordingFragment
 import com.ichi2.anki.multimedia.AudioVideoFragment

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserRowCollection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserRowCollection.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.browser
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.NoteId
+import com.ichi2.anki.libanki.notesOfCards
 import com.ichi2.anki.model.CardsOrNotes
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -60,6 +60,7 @@ import com.ichi2.anki.libanki.DeckNameId
 import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.QueueType.ManuallyBuried
 import com.ichi2.anki.libanki.QueueType.SiblingBuried
+import com.ichi2.anki.libanki.notesOfCards
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.NotetypeJson
+import com.ichi2.anki.libanki.clozeNumbersInNote
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.reviewer.CardSide
 import kotlinx.coroutines.CompletableDeferred

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2011 Norbert Nagold <norbert.nagold@gmail.com>
  * Copyright (c) 2012 Kostas Spyropoulos <inigo.aldana@gmail.com>
- * Copyright (c) 2024 David Allison <davidallisongithub@gmail.com>
+ * Copyright (c) 2022 Ankitects Pty Ltd <http://apps.ankiweb.net>
+ * Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
  *
  * This program is free software; you can redistribute it and/or modify it under
  * the terms of the GNU General private License as published by the Free Software

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -96,6 +96,7 @@ data class ComputedMemoryState(
     val desiredRetention: Float,
     val stability: Float? = null,
     val difficulty: Float? = null,
+    val decay: Float? = null,
 )
 
 // Anki maintains a cache of used tags so it can quickly present a list of tags
@@ -1275,9 +1276,13 @@ class Collection(
                 desiredRetention = resp.desiredRetention,
                 stability = resp.state.stability,
                 difficulty = resp.state.difficulty,
+                decay = resp.decay,
             )
         }
-        return ComputedMemoryState(desiredRetention = resp.desiredRetention)
+        return ComputedMemoryState(
+            desiredRetention = resp.desiredRetention,
+            decay = resp.decay,
+        )
     }
 
     /** The delta days of fuzz applied if reviewing the card in v3. */

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -1288,29 +1288,6 @@ class Collection(
         interval: Int,
     ): Int = backend.fuzzDelta(cardId = cardId, interval = interval)
 
-    // Python code has a cardsOfNote, but not vice-versa yet
-    @CheckResult
-    @NotInLibAnki
-    fun notesOfCards(cids: Iterable<CardId>): List<NoteId> = db.queryLongList("select distinct nid from cards where id in ${ids2str(cids)}")
-
-    /**
-     * returns the list of cloze ordinals in a note
-     *
-     * `"{{c1::A}} {{c3::B}}" => [1, 3]`
-     */
-    @CheckResult
-    @NotInLibAnki
-    fun clozeNumbersInNote(n: Note): List<Int> {
-        // the call appears to be non-deterministic. Sort ascending
-        return backend
-            .clozeNumbersInNote(n.toBackendNote())
-            .sorted()
-    }
-
-    @NotInLibAnki
-    @CheckResult
-    fun filterToValidCards(cards: LongArray?): List<Long> = db.queryLongList("select id from cards where id in " + ids2str(cards))
-
     @NotInLibAnki
     fun getImageForOcclusionRaw(input: ByteArray): ByteArray = backend.getImageForOcclusionRaw(input = input)
 
@@ -1407,11 +1384,40 @@ class Collection(
 @NotInLibAnki
 fun EmptyCardsReport.emptyCids(): List<CardId> = notesList.flatMap { it.cardIdsList }
 
+// Python code has a cardsOfNote, but not vice-versa yet
+@CheckResult
+@NotInLibAnki
+fun Collection.notesOfCards(cids: Iterable<CardId>): List<NoteId> =
+    db.queryLongList("select distinct nid from cards where id in ${ids2str(cids)}")
+
+/**
+ * returns the list of cloze ordinals in a note
+ *
+ * `"{{c1::A}} {{c3::B}}" => [1, 3]`
+ */
+@CheckResult
+@NotInLibAnki
+fun Collection.clozeNumbersInNote(n: Note): List<Int> {
+    // the call appears to be non-deterministic. Sort ascending
+    return backend
+        .clozeNumbersInNote(n.toBackendNote())
+        .sorted()
+}
+
+/**
+ * Given a list of potential Card Ids, return the subset which are Ids of cards in the collection
+ */
+@NotInLibAnki
+@CheckResult
+fun Collection.filterToValidCards(cards: LongArray?): List<CardId> = db.queryLongList("select id from cards where id in " + ids2str(cards))
+
 /**
  * @return [File] referencing the media folder (`collection.media`)
  *
  * @throws UnsupportedOperationException if the collection is in-memory
  */
+@NotInLibAnki
+@CheckResult
 fun Collection.requireMediaFolder() = collectionFiles.requireMediaFolder()
 
 /**
@@ -1419,4 +1425,6 @@ fun Collection.requireMediaFolder() = collectionFiles.requireMediaFolder()
  *
  * (testing) `null` if the collection is in-memory
  */
+@NotInLibAnki
+@get:CheckResult
 val Collection.mediaFolder: File? get() = collectionFiles.mediaFolder

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -1288,54 +1288,6 @@ class Collection(
         interval: Int,
     ): Int = backend.fuzzDelta(cardId = cardId, interval = interval)
 
-    @NotInLibAnki
-    fun getImageForOcclusionRaw(input: ByteArray): ByteArray = backend.getImageForOcclusionRaw(input = input)
-
-    @NotInLibAnki
-    fun getImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.getImageOcclusionNoteRaw(input = input)
-
-    @NotInLibAnki
-    fun getImageOcclusionFieldsRaw(input: ByteArray): ByteArray = backend.getImageOcclusionFieldsRaw(input = input)
-
-    @NotInLibAnki
-    fun addImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.addImageOcclusionNoteRaw(input = input)
-
-    @NotInLibAnki
-    fun updateImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.updateImageOcclusionNoteRaw(input = input)
-
-    @NotInLibAnki
-    fun congratsInfoRaw(input: ByteArray): ByteArray = backend.congratsInfoRaw(input = input)
-
-    @NotInLibAnki
-    fun latestProgressRaw(input: ByteArray): ByteArray = backend.latestProgressRaw(input = input)
-
-    @NotInLibAnki
-    fun getSchedulingStatesWithContextRaw(input: ByteArray): ByteArray = backend.getSchedulingStatesWithContextRaw(input = input)
-
-    @NotInLibAnki
-    fun setSchedulingStatesRaw(input: ByteArray): ByteArray = backend.setSchedulingStatesRaw(input = input)
-
-    @NotInLibAnki
-    fun getChangeNotetypeInfoRaw(input: ByteArray): ByteArray = backend.getChangeNotetypeInfoRaw(input = input)
-
-    @NotInLibAnki
-    fun changeNotetypeRaw(input: ByteArray): ByteArray = backend.changeNotetypeRaw(input = input)
-
-    @NotInLibAnki
-    fun importJsonStringRaw(input: ByteArray): ByteArray = backend.importJsonStringRaw(input = input)
-
-    @NotInLibAnki
-    fun importJsonFileRaw(input: ByteArray): ByteArray = backend.importJsonFileRaw(input = input)
-
-    @NotInLibAnki
-    fun getIgnoredBeforeCountRaw(input: ByteArray): ByteArray = backend.getIgnoredBeforeCountRaw(input = input)
-
-    @NotInLibAnki
-    fun getRetentionWorkloadRaw(input: ByteArray): ByteArray = backend.getRetentionWorkloadRaw(input = input)
-
-    @NotInLibAnki
-    fun evaluateParamsLegacyRaw(input: ByteArray): ByteArray = backend.evaluateParamsLegacyRaw(input = input)
-
     /*
      * Timeboxing
      * ***********************************************************
@@ -1379,6 +1331,58 @@ class Collection(
             null
         }
     }
+
+    /*
+     * Raw methods used by Anki Pages
+     * ***********************************************************
+     * Not upstream: methods for communication between the Svelte UI and backend
+     * These methods should be blocking (e.g. `latestProgress` should directly use the backend)
+     */
+
+    @NotInLibAnki
+    fun getImageForOcclusionRaw(input: ByteArray): ByteArray = backend.getImageForOcclusionRaw(input = input)
+
+    @NotInLibAnki
+    fun getImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.getImageOcclusionNoteRaw(input = input)
+
+    @NotInLibAnki
+    fun getImageOcclusionFieldsRaw(input: ByteArray): ByteArray = backend.getImageOcclusionFieldsRaw(input = input)
+
+    @NotInLibAnki
+    fun addImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.addImageOcclusionNoteRaw(input = input)
+
+    @NotInLibAnki
+    fun updateImageOcclusionNoteRaw(input: ByteArray): ByteArray = backend.updateImageOcclusionNoteRaw(input = input)
+
+    @NotInLibAnki
+    fun congratsInfoRaw(input: ByteArray): ByteArray = backend.congratsInfoRaw(input = input)
+
+    @NotInLibAnki
+    fun getSchedulingStatesWithContextRaw(input: ByteArray): ByteArray = backend.getSchedulingStatesWithContextRaw(input = input)
+
+    @NotInLibAnki
+    fun setSchedulingStatesRaw(input: ByteArray): ByteArray = backend.setSchedulingStatesRaw(input = input)
+
+    @NotInLibAnki
+    fun getChangeNotetypeInfoRaw(input: ByteArray): ByteArray = backend.getChangeNotetypeInfoRaw(input = input)
+
+    @NotInLibAnki
+    fun changeNotetypeRaw(input: ByteArray): ByteArray = backend.changeNotetypeRaw(input = input)
+
+    @NotInLibAnki
+    fun importJsonStringRaw(input: ByteArray): ByteArray = backend.importJsonStringRaw(input = input)
+
+    @NotInLibAnki
+    fun importJsonFileRaw(input: ByteArray): ByteArray = backend.importJsonFileRaw(input = input)
+
+    @NotInLibAnki
+    fun getIgnoredBeforeCountRaw(input: ByteArray): ByteArray = backend.getIgnoredBeforeCountRaw(input = input)
+
+    @NotInLibAnki
+    fun getRetentionWorkloadRaw(input: ByteArray): ByteArray = backend.getRetentionWorkloadRaw(input = input)
+
+    @NotInLibAnki
+    fun evaluateParamsLegacyRaw(input: ByteArray): ByteArray = backend.evaluateParamsLegacyRaw(input = input)
 }
 
 @NotInLibAnki


### PR DESCRIPTION
## Purpose / Description
Implements `collection.py` - there are some `@RustCleanup` annotations, but the structure of the file now matches upstream

* as-of commit: https://github.com/ankitects/anki/blob/f94d05bcbe17c8d1eacad3178c77f58c9fb3c3bd/pylib/anki/collection.py
* last commit implemented: https://github.com/ankitects/anki/blob/5cb191d624ce8ea1f8bc8578cd2414df8a54904d/pylib/anki/collection.py
  

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/pull/18552 🥳

## Approach
See commits for lines matched

https://github.com/ankitects/anki/blob/5cb191d624ce8ea1f8bc8578cd2414df8a54904d/pylib/anki/collection.py

## How Has This Been Tested?
⚠️ I intended to not make functional changes, so did not test this

## Learning

Hardest part is splitting the PRs to the level where I didn't need 20 of them, but they weren't too much of a slog to review.

Thank you all! `collection.py` is... done enough for us to move on

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)