### PR TITLE
feat(new study screen): show ripple in answers' button click

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
@@ -63,4 +63,22 @@ class AnswerButton : MaterialButton {
                 easeName
             }
     }
+
+    companion object {
+        private const val CLICK_DELAY_MS = 100L
+
+        /**
+         * Register a callback to be called with a delay after this button is clicked.
+         */
+        fun MaterialButton.setOnClickDelayedListener(listener: OnClickListener) {
+            val delayedListener =
+                OnClickListener {
+                    postDelayed(
+                        { listener.onClick(this) },
+                        CLICK_DELAY_MS,
+                    )
+                }
+            setOnClickListener(delayedListener)
+        }
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
@@ -51,16 +51,12 @@ class AnswerButton : MaterialButton {
 
     fun setNextTime(nextTime: String?) {
         text =
-            if (nextTime != null) {
-                buildSpannedString {
-                    inSpans(RelativeSizeSpan(0.8F)) {
-                        append(nextTime)
-                    }
+            buildSpannedString {
+                if (nextTime != null) {
+                    inSpans(RelativeSizeSpan(0.8f)) { append(nextTime) }
                     append("\n")
-                    append(easeName)
                 }
-            } else {
-                easeName
+                append(easeName)
             }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerButton.kt
@@ -24,41 +24,43 @@ import com.google.android.material.button.MaterialButton
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.ext.usingStyledAttributes
 
-class AnswerButton
-    @JvmOverloads
+class AnswerButton : MaterialButton {
+    private val easeName: String
+    constructor(context: Context) : this(context, null)
     constructor(
         context: Context,
-        attrs: AttributeSet? = null,
-        defStyleAttr: Int = com.google.android.material.R.attr.materialButtonStyle,
-    ) : MaterialButton(context, attrs, defStyleAttr) {
-        private val easeName: String =
+        attrs: AttributeSet?,
+    ) : this(context, attrs, com.google.android.material.R.attr.materialButtonStyle)
+    constructor(
+        context: Context,
+        attrs: AttributeSet?,
+        defStyleAttr: Int,
+    ) : super(context, attrs, defStyleAttr) {
+        easeName =
             context.usingStyledAttributes(attrs, R.styleable.AnswerButton) {
                 requireNotNull(getString(R.styleable.AnswerButton_easeName)) {
                     "app:easeName value not set"
                 }
             }
-
-        init {
-            val nextTime =
-                context.usingStyledAttributes(attrs, R.styleable.AnswerButton) {
-                    getString(R.styleable.AnswerButton_nextTime)
-                }
-
-            setNextTime(nextTime)
-        }
-
-        fun setNextTime(nextTime: String?) {
-            text =
-                if (nextTime != null) {
-                    buildSpannedString {
-                        inSpans(RelativeSizeSpan(0.8F)) {
-                            append(nextTime)
-                        }
-                        append("\n")
-                        append(easeName)
-                    }
-                } else {
-                    easeName
-                }
-        }
+        val nextTime =
+            context.usingStyledAttributes(attrs, R.styleable.AnswerButton) {
+                getString(R.styleable.AnswerButton_nextTime)
+            }
+        setNextTime(nextTime)
     }
+
+    fun setNextTime(nextTime: String?) {
+        text =
+            if (nextTime != null) {
+                buildSpannedString {
+                    inSpans(RelativeSizeSpan(0.8F)) {
+                        append(nextTime)
+                    }
+                    append("\n")
+                    append(easeName)
+                }
+            } else {
+                easeName
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -83,6 +83,7 @@ import com.ichi2.anki.settings.enums.ToolbarPosition
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.windows.reviewer.AnswerButton.Companion.setOnClickDelayedListener
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.anki.utils.ext.collectIn
 import com.ichi2.anki.utils.ext.collectLatestIn
@@ -376,19 +377,19 @@ class ReviewerFragment :
 
         val againButton =
             view.findViewById<AnswerButton>(R.id.again_button).apply {
-                setOnClickListener { viewModel.answerCard(Rating.AGAIN) }
+                setOnClickDelayedListener { viewModel.answerCard(Rating.AGAIN) }
             }
         val hardButton =
             view.findViewById<AnswerButton>(R.id.hard_button).apply {
-                setOnClickListener { viewModel.answerCard(Rating.HARD) }
+                setOnClickDelayedListener { viewModel.answerCard(Rating.HARD) }
             }
         val goodButton =
             view.findViewById<AnswerButton>(R.id.good_button).apply {
-                setOnClickListener { viewModel.answerCard(Rating.GOOD) }
+                setOnClickDelayedListener { viewModel.answerCard(Rating.GOOD) }
             }
         val easyButton =
             view.findViewById<AnswerButton>(R.id.easy_button).apply {
-                setOnClickListener { viewModel.answerCard(Rating.EASY) }
+                setOnClickDelayedListener { viewModel.answerCard(Rating.EASY) }
             }
 
         viewModel.answerButtonsNextTimeFlow
@@ -402,7 +403,7 @@ class ReviewerFragment :
 
         val showAnswerButton =
             view.findViewById<MaterialButton>(R.id.show_answer).apply {
-                setOnClickListener { viewModel.onShowAnswer() }
+                setOnClickDelayedListener { viewModel.onShowAnswer() }
             }
         val answerButtonsLayout = view.findViewById<LinearLayout>(R.id.answer_buttons)
 

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -115,6 +115,7 @@
     <attr name="hardButtonRef" format="reference"/>
     <attr name="goodButtonRef" format="reference"/>
     <attr name="easyButtonRef" format="reference"/>
+    <attr name="answerButtonRipple" format="color"/>
     <!-- Same thing but with ripples -->
     <attr name="againButtonRippleRef" format="reference"/>
     <attr name="hardButtonRippleRef" format="reference"/>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -34,6 +34,7 @@
         <item name="cornerRadius">@dimen/answer_button_corner_radius</item>
         <item name="android:textSize">@dimen/reviewer_answer_button_textSize</item>
         <item name="elevation">@dimen/study_screen_elevation</item>
+        <item name="rippleColor">?attr/answerButtonRipple</item>
     </style>
 
     <!--  Material Design-style persistent footer button -->

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -70,6 +70,7 @@
         <item name="hardButtonRippleRef">@drawable/footer_button_all_black_ripple</item>
         <item name="goodButtonRippleRef">@drawable/footer_button_all_black_ripple</item>
         <item name="easyButtonRippleRef">@drawable/footer_button_all_black_ripple</item>
+        <item name="answerButtonRipple">#11777777</item>
         <!-- Card Browser Colors -->
         <item name="cardBrowserDivider">@color/white</item>
         <!-- Browser colors -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -97,6 +97,7 @@
         <item name="hardButtonRippleRef">@drawable/footer_button_ripple</item>
         <item name="goodButtonRippleRef">@drawable/footer_button_ripple</item>
         <item name="easyButtonRippleRef">@drawable/footer_button_ripple</item>
+        <item name="answerButtonRipple">#33777777</item>
         <!-- Card Browser Colors -->
         <item name="cardBrowserDivider">@color/white</item>
         <!-- Browser colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -89,6 +89,7 @@
         <item name="hardButtonRippleRef">@drawable/footer_button_ripple</item>
         <item name="goodButtonRippleRef">@drawable/footer_button_ripple</item>
         <item name="easyButtonRippleRef">@drawable/footer_button_ripple</item>
+        <item name="answerButtonRipple">#33ffffff</item>
         <!-- Card Browser Colors -->
         <item name="cardBrowserDivider">#CCCCCC</item>
         <!-- Browser colors -->


### PR DESCRIPTION
it improves the feedback of answering a button

## Approach

In the commits

## How Has This Been Tested?

Galaxy Tab S9, Android 15

https://github.com/user-attachments/assets/7994464f-4fd4-4c1c-bbbd-657dec72babc

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->