### PR TITLE
feat(new study screen): timebox

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -445,7 +445,7 @@ class ReviewerViewModel :
                     )
                 }
 
-            undoableOp { sched.answerCard(answer) }
+            undoableOp(handler = this) { sched.answerCard(answer) }
             answerFeedbackFlow.emit(rating)
 
             val wasLeech = withCol { sched.stateIsLeech(answer.newState) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.windows.reviewer.autoadvance.AutoAdvance
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.anki.utils.Destination
+import com.ichi2.anki.utils.ext.answerCard
 import com.ichi2.anki.utils.ext.flag
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.CompletableDeferred
@@ -437,7 +438,7 @@ class ReviewerViewModel :
             val card = currentCard.await()
             val answer =
                 withCol {
-                    sched.buildAnswer(
+                    sched.answerCard(
                         card = card,
                         states = state.states,
                         rating,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -21,7 +21,7 @@ import anki.frontend.SetSchedulingStatesRequest
 import anki.scheduler.CardAnswer.Rating
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_NO_MORE_CARDS
-import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
@@ -258,7 +258,7 @@ class ReviewerViewModel :
             undoableOp {
                 removeNotes(cardIds = listOf(cardId))
             }.count
-        actionFeedbackFlow.emit(CollectionManager.TR.browsingCardsDeleted(noteCount))
+        actionFeedbackFlow.emit(TR.browsingCardsDeleted(noteCount))
         updateCurrentCard()
     }
 
@@ -268,7 +268,7 @@ class ReviewerViewModel :
             undoableOp {
                 sched.buryCards(cids = listOf(cardId))
             }.count
-        actionFeedbackFlow.emit(CollectionManager.TR.studyingCardsBuried(noteCount))
+        actionFeedbackFlow.emit(TR.studyingCardsBuried(noteCount))
         updateCurrentCard()
     }
 
@@ -278,7 +278,7 @@ class ReviewerViewModel :
             undoableOp {
                 sched.buryNotes(nids = listOf(noteId))
             }.count
-        actionFeedbackFlow.emit(CollectionManager.TR.studyingCardsBuried(noteCount))
+        actionFeedbackFlow.emit(TR.studyingCardsBuried(noteCount))
         updateCurrentCard()
     }
 
@@ -287,7 +287,7 @@ class ReviewerViewModel :
         undoableOp {
             sched.suspendCards(ids = listOf(cardId))
         }.count
-        actionFeedbackFlow.emit(CollectionManager.TR.studyingCardSuspended())
+        actionFeedbackFlow.emit(TR.studyingCardSuspended())
         updateCurrentCard()
     }
 
@@ -296,7 +296,7 @@ class ReviewerViewModel :
         undoableOp {
             sched.suspendNotes(ids = listOf(noteId))
         }
-        actionFeedbackFlow.emit(CollectionManager.TR.studyingNoteSuspended())
+        actionFeedbackFlow.emit(TR.studyingNoteSuspended())
         updateCurrentCard()
     }
 
@@ -312,9 +312,9 @@ class ReviewerViewModel :
             }
         val message =
             if (changes.operation.isEmpty()) {
-                CollectionManager.TR.actionsNothingToUndo()
+                TR.actionsNothingToUndo()
             } else {
-                CollectionManager.TR.undoActionUndone(changes.operation)
+                TR.undoActionUndone(changes.operation)
             }
         actionFeedbackFlow.emit(message)
     }
@@ -331,9 +331,9 @@ class ReviewerViewModel :
             }
         val message =
             if (changes.operation.isEmpty()) {
-                CollectionManager.TR.actionsNothingToRedo()
+                TR.actionsNothingToRedo()
             } else {
-                CollectionManager.TR.undoRedoAction(changes.operation)
+                TR.undoRedoAction(changes.operation)
             }
         actionFeedbackFlow.emit(message)
     }
@@ -354,9 +354,9 @@ class ReviewerViewModel :
         autoAdvance.isEnabled = !autoAdvance.isEnabled
         val message =
             if (autoAdvance.isEnabled) {
-                CollectionManager.TR.actionsAutoAdvanceActivated()
+                TR.actionsAutoAdvanceActivated()
             } else {
-                CollectionManager.TR.actionsAutoAdvanceDeactivated()
+                TR.actionsAutoAdvanceDeactivated()
             }
         actionFeedbackFlow.emit(message)
 
@@ -464,10 +464,10 @@ class ReviewerViewModel :
     // https://github.com/ankitects/anki/blob/da907053460e2b78c31199f97bbea3cf3600f0c2/qt/aqt/reviewer.py#L954
     private suspend fun onLeech(isSuspended: Boolean) {
         Timber.i("ReviewerViewModel::onLeech (isSuspended = %b)", isSuspended)
-        val message = StringBuilder(CollectionManager.TR.studyingCardWasALeech())
+        val message = StringBuilder(TR.studyingCardWasALeech())
         if (isSuspended) {
             message.append(" ")
-            message.append(CollectionManager.TR.studyingItHasBeenSuspended())
+            message.append(TR.studyingItHasBeenSuspended())
         }
         actionFeedbackFlow.emit(message.toString())
     }
@@ -542,6 +542,7 @@ class ReviewerViewModel :
         text: String,
         typeAnswer: TypeAnswer,
     ): String {
+        @Suppress("XmlDeprecatedElement") // upstream uses `<center>`
         @Language("HTML")
         val repl =
             """

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Scheduler.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils.ext
+
+import anki.scheduler.CardAnswer
+import anki.scheduler.CardAnswer.Rating
+import anki.scheduler.SchedulingStates
+import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.sched.Scheduler
+
+fun Scheduler.answerCard(
+    card: Card,
+    states: SchedulingStates,
+    rating: Rating,
+): CardAnswer =
+    buildAnswer(card, states, rating).also {
+        numberOfAnswersRecorded += 1
+    }


### PR DESCRIPTION
## Approach

In the commits

## How Has This Been Tested?

Galaxy Tab S9, Android 15
- Set timebox limit to 1 minute
- Open the new study screen
- Answer some cards
- Wait 1 minute
- Answer another card
- See the timebox dialog

![Screenshot_20250813_194931_AnkiDroid](https://github.com/user-attachments/assets/534c2dc3-383e-4365-9bf9-56566690a1a0)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->