### PR TITLE
fix: reset sharedPrefs override

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsDelegatesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsDelegatesTest.kt
@@ -66,6 +66,7 @@ class PrefsDelegatesTest {
         @JvmStatic
         fun after() {
             unmockkObject(Prefs)
+            AnkiDroidApp.sharedPreferencesTestingOverride = null
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
@@ -78,6 +78,7 @@ class PrefsRobolectricTest : RobolectricTest() {
             property.getter.call(Prefs)
         }
         unmockkObject(Prefs)
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
         return keysAndDefaultValues
     }
 
@@ -127,6 +128,7 @@ class PrefsRobolectricTest : RobolectricTest() {
             propertyNamesAndKeys[property.name] = keys.last()
         }
         unmockkObject(Prefs)
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
         return propertyNamesAndKeys
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsTest.kt
@@ -59,5 +59,6 @@ class PrefsTest {
             assertThat("The getter and setter of '${property.name}' use the same key", getterKey, equalTo(setterKey))
         }
         unmockkObject(Prefs)
+        AnkiDroidApp.sharedPreferencesTestingOverride = null
     }
 }


### PR DESCRIPTION
## Purpose / Description
A testing injection of SharedPreferences in AnkiDroidApp was not getting reset, causing the global state change to leak into other tests. This change resets the sharedPreferencesTestingOverride after each test where it is used. This change only affects tests.

## Fixes
Fixes failing tests.

## How Has This Been Tested?
- Tests pass.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->