### PR TITLE
fix(resizable-pane): prevent parent from intercepting touch events during resizing drag

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
@@ -77,6 +77,12 @@ class ResizablePaneManager(
 
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
+                    /*
+                        Request parent to not intercept touch events so that the divider does not get intercepted by
+                        the parent layout, when Full screen navigation drawer setting is enabled
+                     */
+                    v.parent.requestDisallowInterceptTouchEvent(true)
+
                     v.setBackgroundColor(dragColor)
                     initialTouchX = event.rawX
                     initialLeftWeight = leftParams.weight
@@ -84,6 +90,8 @@ class ResizablePaneManager(
                     true
                 }
                 MotionEvent.ACTION_MOVE -> {
+                    v.parent.requestDisallowInterceptTouchEvent(true)
+
                     val deltaX = event.rawX - initialTouchX
                     val totalParentWidth = parentLayout.width.toFloat()
 


### PR DESCRIPTION
## Purpose / Description
- Fixes the bug caused when resizing panes when Full screen navigation drawer setting is enabled

## Fixes
* Fixes #19105 

## Approach
- Uses `requestDisallowInterceptTouchEvent` to stop the drag event being intercepted.

## How Has This Been Tested?
- Physical Acer Chromebook API 34
- Tablet Emulator API 35
[nav.webm](https://github.com/user-attachments/assets/2459bf25-125b-40fb-8fbb-2b594d41398c)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->