### PR TITLE
feat(reminders): AddEditReminderDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -159,7 +159,8 @@ class DeckSpinnerSelection(
             decks.allNamesAndIds(includeFiltered = showFilteredDecks, skipEmptyDefault = true)
         }.toMutableList().let { decks ->
             dropDownDecks = decks
-            val deckNames = decks.map { it.name }
+            val deckNames = decks.map { it.name }.toMutableList()
+            if (showAllDecks) deckNames.add(0, context.getString(R.string.card_browser_all_decks))
             val noteDeckAdapter: ArrayAdapter<String?> =
                 object :
                     ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -1,0 +1,349 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.app.Dialog
+import android.content.res.Configuration
+import android.os.Bundle
+import android.os.Parcelable
+import android.text.format.DateFormat
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.Spinner
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.core.os.BundleCompat
+import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
+import androidx.fragment.app.viewModels
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.textfield.TextInputLayout
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import com.ichi2.anki.DeckSpinnerSelection
+import com.ichi2.anki.R
+import com.ichi2.anki.dialogs.ConfirmationDialog
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
+import com.ichi2.utils.customView
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.neutralButton
+import com.ichi2.utils.positiveButton
+import kotlinx.parcelize.Parcelize
+import timber.log.Timber
+
+class AddEditReminderDialog : DialogFragment() {
+    /**
+     * Possible states of this dialog.
+     * In particular, whether this dialog will be used to add a new review reminder or edit an existing one.
+     */
+    @Parcelize
+    sealed class DialogMode : Parcelable {
+        /**
+         * Adding a new review reminder. Requires the editing scope of [ScheduleReminders] as an argument so that the dialog can
+         * pick a default deck to add to (or, if the scope is global, so that the dialog can
+         * show that the review reminder will default to being a global reminder).
+         */
+        data class Add(
+            val schedulerScope: ReviewReminderScope,
+        ) : DialogMode()
+
+        /**
+         * Editing an existing review reminder. Requires the reminder being edited so that the
+         * dialog's fields can be populated with its information.
+         */
+        data class Edit(
+            val reminderToBeEdited: ReviewReminder,
+        ) : DialogMode()
+    }
+
+    private val viewModel: AddEditReminderDialogViewModel by viewModels()
+
+    private lateinit var contentView: View
+
+    /**
+     * The mode of this dialog, retrieved from arguments and set by [getInstance].
+     * @see DialogMode
+     */
+    private val dialogMode: DialogMode by lazy {
+        requireNotNull(
+            BundleCompat.getParcelable(requireArguments(), DIALOG_MODE_ARGUMENTS_KEY, DialogMode::class.java),
+        ) {
+            "Dialog mode cannot be null"
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        super.onCreateDialog(savedInstanceState)
+        contentView = layoutInflater.inflate(R.layout.add_edit_reminder_dialog, null)
+        Timber.d("dialog mode: %s", dialogMode.toString())
+
+        val dialogBuilder =
+            AlertDialog.Builder(requireActivity()).apply {
+                customView(contentView)
+                positiveButton(R.string.dialog_ok)
+                neutralButton(R.string.dialog_cancel)
+
+                if (dialogMode is DialogMode.Edit) {
+                    negativeButton(R.string.dialog_positive_delete)
+                }
+            }
+        val dialog = dialogBuilder.create()
+
+        // We cannot create onClickListeners by directly using the lambda argument of positiveButton / negativeButton
+        // because setting the onClickListener that way makes the dialog auto-dismiss upon the lambda completing.
+        // We may need to abort submission or deletion. Hence we manually set the click listener here and only
+        // dismiss conditionally from within the click listener methods (see onSubmit and onDelete).
+        dialog.setOnShowListener {
+            val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            val negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+            positiveButton.setOnClickListener { onSubmit() }
+            negativeButton?.setOnClickListener { onDelete() } // delete button does not exist in Add mode, hence null check
+        }
+
+        Timber.d("Setting up fields")
+        setUpToolbar()
+        setUpTimeButton()
+        setUpDeckSpinner()
+        setUpAdvancedDropdown()
+        setUpCardThresholdInput()
+
+        // For getting the result of the deck selection sub-dialog from ScheduleReminders
+        // See ScheduleReminders.onDeckSelected for more information
+        setFragmentResultListener(ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY) { _, bundle ->
+            val selectedDeck =
+                BundleCompat.getParcelable(
+                    bundle,
+                    ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY,
+                    SelectableDeck::class.java,
+                )
+            Timber.d("Received result from deck selection sub-dialog: %s", selectedDeck)
+            val selectedDeckId: DeckId =
+                when (selectedDeck) {
+                    is SelectableDeck.Deck -> selectedDeck.deckId
+                    is SelectableDeck.AllDecks -> DeckSpinnerSelection.ALL_DECKS_ID
+                    else -> Consts.DEFAULT_DECK_ID
+                }
+            viewModel.setDeckSelected(selectedDeckId)
+        }
+
+        dialog.window?.let { resizeWhenSoftInputShown(it) }
+        return dialog
+    }
+
+    private fun setUpToolbar() {
+        val toolbar = contentView.findViewById<Toolbar>(R.id.add_edit_reminder_toolbar)
+        toolbar.title =
+            getString(
+                when (dialogMode) {
+                    is DialogMode.Add -> R.string.add_review_reminder
+                    is DialogMode.Edit -> R.string.edit_review_reminder
+                },
+            )
+    }
+
+    private fun setUpTimeButton() {
+        val timeButton = contentView.findViewById<MaterialButton>(R.id.add_edit_reminder_time_button)
+        timeButton.setOnClickListener {
+            Timber.i("Time button clicked")
+            val time = viewModel.time.value ?: ReviewReminderTime.getCurrentTime()
+            showTimePickerDialog(time.hour, time.minute)
+        }
+        viewModel.time.observe(this) { time ->
+            timeButton.text = time.toFormattedString(requireContext())
+        }
+    }
+
+    private fun setUpDeckSpinner() {
+        val deckSpinner = contentView.findViewById<Spinner>(R.id.add_edit_reminder_deck_spinner)
+        val deckSpinnerSelection =
+            DeckSpinnerSelection(
+                context = (activity as AppCompatActivity),
+                spinner = deckSpinner,
+                showAllDecks = true,
+                alwaysShowDefault = true,
+                showFilteredDecks = true,
+            )
+        launchCatchingTask {
+            Timber.d("Setting up deck spinner")
+            deckSpinnerSelection.initializeScheduleRemindersDeckSpinner()
+            deckSpinnerSelection.selectDeckById(viewModel.deckSelected.value ?: Consts.DEFAULT_DECK_ID, setAsCurrentDeck = false)
+        }
+    }
+
+    private fun setUpAdvancedDropdown() {
+        val advancedDropdown = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_dropdown)
+        val advancedDropdownIcon = contentView.findViewById<ImageView>(R.id.add_edit_reminder_advanced_dropdown_icon)
+        val advancedContent = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_content)
+
+        advancedDropdown.setOnClickListener {
+            viewModel.toggleAdvancedSettingsOpen()
+        }
+        viewModel.advancedSettingsOpen.observe(this) { advancedSettingsOpen ->
+            when (advancedSettingsOpen) {
+                true -> {
+                    advancedContent.isVisible = true
+                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_EXPANDED_CHEVRON)
+                }
+                false -> {
+                    advancedContent.isVisible = false
+                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_COLLAPSED_CHEVRON)
+                }
+            }
+        }
+    }
+
+    private fun setUpCardThresholdInput() {
+        val cardThresholdInputWrapper = contentView.findViewById<TextInputLayout>(R.id.add_edit_reminder_card_threshold_input_wrapper)
+        val cardThresholdInput = contentView.findViewById<EditText>(R.id.add_edit_reminder_card_threshold_input)
+        cardThresholdInput.setText(viewModel.cardTriggerThreshold.value.toString())
+        cardThresholdInput.doOnTextChanged { text, _, _, _ ->
+            val value: Int? = text.toString().toIntOrNull()
+            cardThresholdInputWrapper.error =
+                when {
+                    (value == null) -> "Please enter a whole number of cards"
+                    (value < 0) -> "The threshold must be at least 0"
+                    else -> null
+                }
+            viewModel.setCardTriggerThreshold(value ?: 0)
+        }
+    }
+
+    /**
+     * Show the time picker dialog for selecting a time with a given hour and minute.
+     * Does not automatically dismiss the old dialog.
+     */
+    private fun showTimePickerDialog(
+        hour: Int,
+        minute: Int,
+    ) {
+        val dialog =
+            MaterialTimePicker
+                .Builder()
+                .setTheme(R.style.TimePickerStyle)
+                .setTimeFormat(if (DateFormat.is24HourFormat(activity)) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H)
+                .setHour(hour)
+                .setMinute(minute)
+                .build()
+        dialog.addOnPositiveButtonClickListener {
+            viewModel.setTime(ReviewReminderTime(dialog.hour, dialog.minute))
+        }
+        dialog.show(parentFragmentManager, TIME_PICKER_TAG)
+    }
+
+    /**
+     * For some reason, the TimePicker dialog does not automatically redraw itself properly when the device rotates.
+     * Thus, if the TimePicker dialog is active, we manually show a new copy and then dismiss the old one.
+     * We need to show the new one before dismissing the old one to ensure there is no annoying flicker.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        val previousDialog = parentFragmentManager.findFragmentByTag(TIME_PICKER_TAG) as? MaterialTimePicker
+        previousDialog?.let {
+            showTimePickerDialog(it.hour, it.minute)
+            it.dismiss()
+        }
+    }
+
+    private fun onSubmit() {
+        Timber.i("Submitted dialog")
+        // Do nothing if numerical fields are invalid
+        val cardThresholdInputWrapper = contentView.findViewById<TextInputLayout>(R.id.add_edit_reminder_card_threshold_input_wrapper)
+        cardThresholdInputWrapper.error?.let {
+            contentView.showSnackbar(R.string.something_wrong)
+            return
+        }
+
+        val reminderToBeReturned = viewModel.outputStateAsReminder()
+        Timber.d("Reminder to be returned: %s", reminderToBeReturned)
+        setFragmentResult(
+            ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+            Bundle().apply {
+                putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, reminderToBeReturned)
+            },
+        )
+        dismiss()
+    }
+
+    private fun onDelete() {
+        Timber.i("Selected delete reminder button")
+
+        val confirmationDialog = ConfirmationDialog()
+        confirmationDialog.setArgs(
+            "Delete this reminder?",
+            "This action cannot be undone.",
+        )
+        confirmationDialog.setConfirm {
+            setFragmentResult(
+                ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+                Bundle().apply {
+                    putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, null)
+                },
+            )
+            dismiss()
+        }
+
+        showDialogFragment(confirmationDialog)
+    }
+
+    companion object {
+        /**
+         * Icon that shows next to the advanced settings section when the dropdown is open.
+         */
+        private val DROPDOWN_EXPANDED_CHEVRON = R.drawable.ic_expand_more_black_24dp_xml
+
+        /**
+         * Icon that shows next to the advanced settings section when the dropdown is closed.
+         */
+        private val DROPDOWN_COLLAPSED_CHEVRON = R.drawable.ic_baseline_chevron_right_24
+
+        /**
+         * Arguments key for the dialog mode to open this dialog in.
+         * Public so that [AddEditReminderDialogViewModel] can also access it to populate its initial state.
+         *
+         * @see DialogMode
+         */
+        const val DIALOG_MODE_ARGUMENTS_KEY = "dialog_mode"
+
+        /**
+         * Unique fragment tag for the Material TimePicker shown for setting the time of a review reminder.
+         */
+        private const val TIME_PICKER_TAG = "REMINDER_TIME_PICKER_DIALOG"
+
+        /**
+         * Creates a new instance of this dialog with the given dialog mode.
+         */
+        fun getInstance(dialogMode: DialogMode): AddEditReminderDialog =
+            AddEditReminderDialog().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
+                    }
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -1,0 +1,152 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.DeckSpinnerSelection
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.DeckId
+import timber.log.Timber
+
+/**
+ * Represents the state of an [AddEditReminderDialog]'s UI. Does not represent the [ReviewReminder] object itself.
+ * For example, instead of storing the card trigger threshold as a [ReviewReminderCardTriggerThreshold], we store an Int, since that's
+ * the input type the user is using to enter the threshold into the app. In other words, this class reflects the concrete
+ * EditText fields in the dialog, not abstract backend data representations.
+ */
+class AddEditReminderDialogViewModel(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    /**
+     * The dialog mode of the [AddEditReminderDialog] which is using this ViewModel. Retrieved via arguments.
+     */
+    private val dialogMode =
+        requireNotNull(
+            savedStateHandle.get<AddEditReminderDialog.DialogMode>(AddEditReminderDialog.DIALOG_MODE_ARGUMENTS_KEY),
+        ) { "dialogMode is required" }
+
+    private val _time =
+        MutableLiveData(
+            when (dialogMode) {
+                is AddEditReminderDialog.DialogMode.Add -> ReviewReminderTime.getCurrentTime()
+                is AddEditReminderDialog.DialogMode.Edit -> dialogMode.reminderToBeEdited.time
+            },
+        )
+    val time: LiveData<ReviewReminderTime> = _time
+
+    private val _deckSelected =
+        MutableLiveData(
+            when (dialogMode) {
+                is AddEditReminderDialog.DialogMode.Add -> {
+                    when (dialogMode.schedulerScope) {
+                        is ReviewReminderScope.Global -> DeckSpinnerSelection.ALL_DECKS_ID
+                        is ReviewReminderScope.DeckSpecific -> dialogMode.schedulerScope.did
+                    }
+                }
+                is AddEditReminderDialog.DialogMode.Edit -> {
+                    when (dialogMode.reminderToBeEdited.scope) {
+                        is ReviewReminderScope.Global -> DeckSpinnerSelection.ALL_DECKS_ID
+                        is ReviewReminderScope.DeckSpecific -> dialogMode.reminderToBeEdited.scope.did
+                    }
+                }
+            },
+        )
+
+    /**
+     * [com.ichi2.anki.DeckSpinnerSelection.ALL_DECKS_ID] is used to represent All Decks
+     * (i.e. [ReviewReminderScope.Global]) being selected.
+     */
+    val deckSelected: LiveData<DeckId> = _deckSelected
+
+    private val _cardTriggerThreshold =
+        MutableLiveData(
+            when (dialogMode) {
+                is AddEditReminderDialog.DialogMode.Add -> INITIAL_CARD_THRESHOLD
+                is AddEditReminderDialog.DialogMode.Edit -> dialogMode.reminderToBeEdited.cardTriggerThreshold.threshold
+            },
+        )
+    val cardTriggerThreshold: LiveData<Int> = _cardTriggerThreshold
+
+    private val _advancedSettingsOpen = MutableLiveData(INITIAL_ADVANCED_SETTINGS_OPEN)
+    val advancedSettingsOpen: LiveData<Boolean> = _advancedSettingsOpen
+
+    fun setTime(time: ReviewReminderTime) {
+        Timber.d("Updated time to %s", time)
+        _time.value = time
+    }
+
+    fun setDeckSelected(deckId: DeckId) {
+        Timber.d("Updated deck selected to %s", deckId)
+        _deckSelected.value = deckId
+    }
+
+    fun setCardTriggerThreshold(threshold: Int) {
+        Timber.d("Updated card trigger threshold to %s", threshold)
+        _cardTriggerThreshold.value = threshold
+    }
+
+    fun toggleAdvancedSettingsOpen() {
+        Timber.d("Toggled advanced settings open from %s", _advancedSettingsOpen.value)
+        _advancedSettingsOpen.value = !(_advancedSettingsOpen.value ?: false)
+    }
+
+    /**
+     * Packages up the state of this ViewModel as a newly-created [ReviewReminder].
+     * Used when the user clicks on the "OK" button in the dialog.
+     */
+    fun outputStateAsReminder(): ReviewReminder =
+        ReviewReminder.createReviewReminder(
+            time = time.value ?: ReviewReminderTime.getCurrentTime(),
+            cardTriggerThreshold =
+                ReviewReminderCardTriggerThreshold(
+                    threshold = cardTriggerThreshold.value ?: INITIAL_CARD_THRESHOLD,
+                ),
+            scope =
+                when (deckSelected.value) {
+                    DeckSpinnerSelection.ALL_DECKS_ID -> ReviewReminderScope.Global
+                    else ->
+                        ReviewReminderScope.DeckSpecific(
+                            did = deckSelected.value ?: Consts.DEFAULT_DECK_ID,
+                        )
+                },
+            enabled =
+                when (dialogMode) {
+                    is AddEditReminderDialog.DialogMode.Add -> true
+                    is AddEditReminderDialog.DialogMode.Edit -> dialogMode.reminderToBeEdited.enabled
+                },
+        )
+
+    companion object {
+        /**
+         * The default minimum card trigger threshold that is filled into the dialog when a new review
+         * reminder is being created. Since this is set to one, the default behaviour is that users
+         * will not get notified about a deck if there are no cards to review for that deck.
+         * Users may choose to instead set it to zero, or any other non-negative integer value.
+         * This is an Int because that is what the EditText's inputType is.
+         */
+        private const val INITIAL_CARD_THRESHOLD: Int = 1
+
+        /**
+         * Whether the advanced settings dropdown is initially open.
+         * We start with it closed to avoid overwhelming the user.
+         */
+        private const val INITIAL_ADVANCED_SETTINGS_OPEN = false
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -79,6 +79,19 @@ data class ReviewReminderTime(
     }
 
     fun toSecondsFromMidnight(): Long = (hour.hours + minute.minutes).inWholeSeconds
+
+    companion object {
+        /**
+         * Returns the current time as a [ReviewReminderTime].
+         * Used as the default displayed time when creating a review reminder.
+         */
+        fun getCurrentTime(): ReviewReminderTime {
+            val calendarInstance = TimeManager.time.calendar()
+            val currentHour = calendarInstance.get(Calendar.HOUR_OF_DAY)
+            val currentMinute = calendarInstance.get(Calendar.MINUTE)
+            return ReviewReminderTime(currentHour, currentMinute)
+        }
+    }
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.reviewreminders
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
@@ -54,7 +53,6 @@ class ScheduleRemindersAdapter(
         return ViewHolder(view)
     }
 
-    @SuppressLint("DefaultLocale")
     override fun onBindViewHolder(
         holder: ViewHolder,
         position: Int,

--- a/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/root_linear_layout"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/add_edit_reminder_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="@style/ActionBarStyle"
+            android:background="?attr/appBarColor"
+            app:title="Add / edit review reminder" />
+
+        <ScrollView
+            android:id="@+id/add_edit_reminder_scrollview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:id="@+id/add_edit_reminder_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingTop="24dp"
+                android:paddingHorizontal="24dp">
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_time_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="8dp">
+
+                    <TextView
+                        android:id="@+id/add_edit_reminder_time_label"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical"
+                        android:text="Time:"
+                        android:textSize="18sp"
+                        tools:ignore="HardcodedText" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/add_edit_reminder_time_button"
+                        android:layout_width="0dp"
+                        android:layout_weight="3"
+                        android:layout_height="match_parent"
+                        app:cornerRadius="8dp"
+                        android:layout_marginStart="12dp"
+                        android:textSize="24sp"
+                        android:text="12:00"
+                        tools:ignore="HardcodedText" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_deck_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/add_edit_reminder_deck_label"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical"
+                        android:text="Deck:"
+                        android:textSize="18sp"
+                        tools:ignore="HardcodedText" />
+
+                    <Spinner
+                        android:id="@+id/add_edit_reminder_deck_spinner"
+                        android:layout_width="0dp"
+                        android:layout_weight="3"
+                        android:layout_height="match_parent"
+                        app:popupTheme="@style/ActionBar.Popup"
+                        android:minHeight="?minTouchTargetSize"
+                        android:layout_marginStart="12dp" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_advanced_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:id="@+id/add_edit_reminder_advanced_dropdown"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="?attr/minTouchTargetSize"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:id="@+id/add_edit_reminder_advanced_dropdown_icon"
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginEnd="8dp" />
+
+                        <TextView
+                            android:id="@+id/add_edit_reminder_advanced_label"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:textSize="18sp"
+                            android:text="Advanced settings"
+                            tools:ignore="HardcodedText" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/add_edit_reminder_advanced_content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="32dp"
+                        android:orientation="vertical">
+
+                        <LinearLayout
+                            android:id="@+id/add_edit_reminder_card_threshold_section"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            tools:ignore="UselessParent">
+
+                            <LinearLayout
+                                android:id="@+id/add_edit_reminder_card_threshold_label_container"
+                                android:layout_width="0dp"
+                                android:layout_weight="1"
+                                android:layout_height="wrap_content"
+                                android:paddingVertical="4dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:id="@+id/add_edit_reminder_card_threshold_label"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:textSize="16sp"
+                                    android:text="Card threshold:"
+                                    tools:ignore="HardcodedText" />
+
+                                <TextView
+                                    android:id="@+id/add_edit_reminder_card_threshold_description"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:text="Do not send me notifications if there are less than this many cards due"
+                                    tools:ignore="HardcodedText" />
+
+                            </LinearLayout>
+
+                            <com.google.android.material.textfield.TextInputLayout
+                                android:id="@+id/add_edit_reminder_card_threshold_input_wrapper"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:layout_gravity="center"
+                                android:layout_marginStart="24dp">
+
+                                <com.google.android.material.textfield.TextInputEditText
+                                    android:id="@+id/add_edit_reminder_card_threshold_input"
+                                    android:layout_width="match_parent"
+                                    android:layout_height="wrap_content"
+                                    android:inputType="number" />
+
+                            </com.google.android.material.textfield.TextInputLayout>
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </ScrollView>
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -221,6 +221,8 @@
 
     <!-- Review reminders -->
     <string name="add_reminder" comment="Label for the add reminder button in the screen for adding and editing review reminders">Add reminder</string>
+    <string name="add_review_reminder" comment="Title of the screen for creating a new review reminder">Add review reminder</string>
+    <string name="edit_review_reminder" comment="Title of the screen for editing an existing review reminder">Edit review reminder</string>
 
     <!-- studyoptions -->
     <string name="studyoptions_limit_select_tags">Select tags</string>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -266,4 +266,11 @@
         <item name="cardUseCompatPadding">false</item>
         <item name="cardBackgroundColor">?popupBackgroundColor</item>
     </style>
+
+    <style name="TimePickerStyle" parent="ThemeOverlay.Material3.MaterialTimePicker">
+        <item name="elevationOverlayEnabled">false</item>
+        <item name="colorTertiaryContainer">?colorPrimary</item>
+        <item name="colorOnTertiaryContainer">?colorOnPrimary</item>
+        <item name="colorPrimaryContainer">?colorPrimary</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Purpose / Description
Allows users to add and edit review reminders.

**All commit messages, together:**
- `initializeScheduleRemindersDeckSpinner` doesn't properly handle what happens if showAllDecks is true. This makes pressing on a deck select the wrong deck. This commit fixes this.
- Added TimePicker styling, used when users edit the time of a review reminder.
- The AddEditReminderDialog displays the current time in the TimePicker when a review reminder is being created. Adds a utility function to ReviewReminderTime's companion object to calculate this time. I decided to put this function within ReviewReminderTime so it can be accessed by both AddEditReminderDialog and AddEditReminderDialogViewModel.
- XML file for AddEditReminderDialog. Allows time and deck modification. Also has a dropdown for advanced settings, including minimum card trigger threshold (with more advanced settings hopefully coming soon). The advanced settings will be grouped under a dropdown to prevent them from overwhelming users when the dialog initially opens.
- Created a ViewModel for the AddEditReminderDialog. A specific view model is created because this allows the dialog's state to persist across redraws, ex. if the theme changes, if the device rotates, etc. It also centralizes the data of the review reminder being edited in a single source of truth.
- Creates AddEditReminderDialog.
- Adds DialogMode, which represents whether the dialog is in adding or editing mode.
- Sets submit, cancel, and delete actions for the dialog; this is the main way users can delete review reminders. Deletion is locked behind a confirmation box just in case the user accidentally clicks the button.
- Results for the deck picker dropdown in the dialog are received in ScheduleReminders and sent to the AddEditReminderDialog via a FragmentResult. See the docstring of `onDeckSelected` in ScheduleReminders to see why this is done.
- Filling in the values in the dialog fields and setting listeners for when the values change is pulled out into separate methods for readability.
- Adds `showTimePickerDialog`. Shows a TimePicker dialog for picking review reminder time via modern Material3 guidelines. Overrides `onConfigurationChanged` to properly handle device rotation, which for some reason is not handled by default by MaterialTimePicker.
- An edited review reminder is passed back to ReviewRemindersDatabase as a FragmentResult, which is a simple way of passing information between fragments.
- Adds a fragment result listener to ScheduleReminders to detect when an AddEditReminderDialog has completed, and if so, edits the database and UI accordingly.
- Filled out the `addReminder` and `editReminder` methods to show the AddEditReminderDialog.

**UI Screenshots:**
Dialog:
<img width="835" height="880" alt="image" src="https://github.com/user-attachments/assets/e11896ff-276b-4e9b-864e-fd218beb60d6" />
<img width="831" height="879" alt="image" src="https://github.com/user-attachments/assets/8b30cd70-f490-4243-a4c0-0086002ab5be" />

Error handling:
<img width="1092" height="780" alt="image" src="https://github.com/user-attachments/assets/a3d4ee5d-37a2-4245-b48b-b92024d9e602" />

Sub-dialogs:
<img width="830" height="873" alt="image" src="https://github.com/user-attachments/assets/eca30c9a-6a6a-4eaa-b298-d6b4113af6c7" />

TimePickers:
<img width="817" height="873" alt="image" src="https://github.com/user-attachments/assets/05d1f743-e214-4e72-91f1-ee71ba0000c6" />
<img width="825" height="881" alt="image" src="https://github.com/user-attachments/assets/118ab9e5-57be-47a5-86aa-01e4e230b93e" />

Tablet:
<img width="1497" height="903" alt="image" src="https://github.com/user-attachments/assets/5b236e90-5a11-41ed-9119-979d073431ae" />
<img width="1492" height="899" alt="image" src="https://github.com/user-attachments/assets/0e12ddb5-0764-4ecb-b91a-c60bdfc6943e" />

## Fixes
For GSoC 2025: Review Reminders

## Approach
Creates a ViewModel to store the state of the dialog. Information is passed between the dialog and ScheduleReminders via fragment results, which is a simple and straightforward API.

## How Has This Been Tested?
- Works on a physical Samsung S23, API 34; can create, read, update, and delete review reminders. I've been casually testing this code for the last month as I've developed other features, and I think it should be fairly stable.
- Works on a Medium Tablet, API 36.
- I plan on writing instrumented tests in the last week of August.

## Learning (optional, can help others)
- This code has been waiting to be merged for a while! Really happy to see it finally up as a PR.
- Had a lot of trouble in the final stretch with TimePicker. Turns out there are three different ways to make it: using XML, using the provided TimePickerDialog, and using MaterialTimePicker. The latter is the only way to get the nice styling. Also, the background was always tinted a bit blue no matter what I did. Turns out I had to add `<item name="elevationOverlayEnabled">false</item>`.
- Also had trouble making sure the TimePicker dialog redrew whenever you rotated your screen. I ended up redrawing it manually since there didn't seem to be built-in handling for it.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->