### PR TITLE
Abstract TimeManager to create reusable resettable variable

### DIFF
--- a/common/src/main/java/com/ichi2/anki/common/time/TimeManager.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/TimeManager.kt
@@ -17,8 +17,7 @@
 package com.ichi2.anki.common.time
 
 import android.annotation.SuppressLint
-import androidx.annotation.VisibleForTesting
-import java.util.Stack
+import com.ichi2.anki.common.utils.ObjectForTest
 
 /** Singleton providing an instance of [Time].
  * Used for tests to mock the time provider
@@ -26,22 +25,10 @@ import java.util.Stack
  *
  * For later: move this into a DI container
  */
+// Only used to add the property [time]
 @SuppressLint("DirectSystemTimeInstantiation")
-object TimeManager {
-    @VisibleForTesting
-    fun reset() {
-        mockInstances.clear()
-    }
-
-    @VisibleForTesting
-    fun resetWith(mockTime: Time) {
-        reset()
-        mockInstances.push(mockTime)
-    }
-
-    private var mockInstances: Stack<Time> = Stack()
-
-    var time: Time = SystemTime()
-        get() = if (mockInstances.any()) mockInstances.peek() else field
-        private set
+class TimeManagerClass : ObjectForTest<Time>(SystemTime()) {
+    val time = value
 }
+
+val TimeManager = TimeManagerClass()

--- a/common/src/main/java/com/ichi2/anki/common/utils/TestUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/TestUtils.kt
@@ -13,6 +13,7 @@
  */
 package com.ichi2.anki.common.utils
 
+import androidx.annotation.VisibleForTesting
 import timber.log.Timber
 
 /** make default HTML / JS debugging true for debug build and disable for unit/android tests
@@ -31,3 +32,24 @@ val isRunningAsUnitTest: Boolean
         Timber.d("isRunningAsUnitTest: %b", true)
         return true
     }
+
+/**
+ * A class that provide a default value that can be changed in test.
+ */
+open class ObjectForTest<T>(
+    val defaultValue: T,
+) {
+    @VisibleForTesting
+    fun reset() {
+        mockInstance = null
+    }
+
+    @VisibleForTesting
+    fun resetWith(mock: T) {
+        mockInstance = mock
+    }
+
+    private var mockInstance: T? = null
+
+    val value: T = mockInstance ?: defaultValue
+}


### PR DESCRIPTION
Other values than TimeManager may need to be set in test and reset otherwise. In particular it could be useful for #18856.

I tried to abtsract this class. As the stack always had a single value, I removed it.

I don't expect that defining a child class will be useful all the time. But in this case, introducing `time` avoid changing many many files and keep the code more readble.
