### PR TITLE
refactor(reminders): create allDecksCounts

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Scheduler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Scheduler.kt
@@ -19,6 +19,7 @@ import anki.scheduler.CardAnswer
 import anki.scheduler.CardAnswer.Rating
 import anki.scheduler.SchedulingStates
 import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.sched.Counts
 import com.ichi2.anki.libanki.sched.Scheduler
 
 fun Scheduler.answerCard(
@@ -29,3 +30,18 @@ fun Scheduler.answerCard(
     buildAnswer(card, states, rating).also {
         numberOfAnswersRecorded += 1
     }
+
+/**
+ * @return Number of new, rev and lrn card to review in all decks.
+ */
+fun Scheduler.allDecksCounts(): Counts {
+    val total = Counts()
+    // Only count the top-level decks in the total
+    val nodes = deckDueTree().children
+    for (node in nodes) {
+        total.addNew(node.newCount)
+        total.addLrn(node.lrnCount)
+        total.addRev(node.revCount)
+    }
+    return total
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -16,12 +16,12 @@ package com.ichi2.widget
 
 import android.content.Context
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.R
-import com.ichi2.anki.libanki.sched.Counts
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.ext.allDecksCounts
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -108,18 +108,10 @@ object WidgetStatus {
 
     fun fetchDue(context: Context): Int = MetaDB.getNotificationStatus(context)
 
-    private suspend fun querySmallWidgetStatus(): SmallWidgetStatus {
-        val total = Counts()
-        return CollectionManager.withCol {
-            // Only count the top-level decks in the total
-            val nodes = sched.deckDueTree().children
-            for (node in nodes) {
-                total.addNew(node.newCount)
-                total.addLrn(node.lrnCount)
-                total.addRev(node.revCount)
-            }
+    private suspend fun querySmallWidgetStatus(): SmallWidgetStatus =
+        withCol {
+            val total = sched.allDecksCounts()
             val eta = sched.eta(total, false)
             SmallWidgetStatus(total.count(), eta)
         }
-    }
 }


### PR DESCRIPTION
## Purpose / Description
- Created allDecksCounts scheduler method to abstract out the logic of counting all cards that are due across the entire app, as this logic is used in both WidgetStatus (also updated in this PR) and NotificationService (coming in a later PR).

## Fixes
* For GSoC 2025: Review Reminders

## Approach
- Code consolidation!

## How Has This Been Tested?
- Works on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->