### PR TITLE
feat(reminders): create notification channel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -47,11 +47,15 @@ fun setupNotificationChannels(context: Context) {
         val importance = NotificationManagerCompat.IMPORTANCE_DEFAULT
         Timber.i("Creating notification channel with id/name: %s/%s", id, name)
 
+        // Vibration is enabled by default, but the user can turn it off from the system settings
+        // Vibration will also not occur if the phone has been set to silent
         val notificationChannel =
             NotificationChannelCompat
                 .Builder(id, importance)
                 .setName(name)
                 .setShowBadge(true)
+                .setVibrationPattern(longArrayOf(0, 500))
+                .setVibrationEnabled(true)
                 .build()
 
         manager.createNotificationChannel(notificationChannel)
@@ -70,11 +74,7 @@ enum class Channel(
 ) {
     GENERAL("General Notifications", R.string.app_name),
     SYNC("Synchronization", R.string.sync_title),
-    GLOBAL_REMINDERS(
-        "Global Reminders",
-        R.string.widget_minimum_cards_due_notification_ticker_title,
-    ),
-    DECK_REMINDERS("Deck Reminders", R.string.deck_conf_reminders),
+    REVIEW_REMINDERS("Review Reminders", R.string.review_reminders_do_not_translate),
     ;
 
     fun getName(res: Resources) = res.getString(nameId)

--- a/AnkiDroid/src/main/res/values/08-widget.xml
+++ b/AnkiDroid/src/main/res/values/08-widget.xml
@@ -20,7 +20,6 @@
 <resources>
 
     <!-- Widget -->
-    <string name="widget_minimum_cards_due_notification_ticker_title">Cards due</string>
     <plurals name="widget_minimum_cards_due_notification_ticker_text">
         <item quantity="one">%d AnkiDroid card due</item>
         <item quantity="other">%d AnkiDroid cards due</item>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -226,7 +226,6 @@
     <string name="studyoptions_limit_select_tags">Select tags</string>
     <!-- Deck configurations -->
     <string name="deck_conf_general" maxLength="41" comment="Label of the submenu for the general options of new deck">General</string>
-    <string name="deck_conf_reminders" maxLength="41">Reminders</string>
     <string name="deck_conf_cram_filter" maxLength="41">Filter</string>
     <string name="deck_conf_cram_search" maxLength="41" comment = "Label of a text field that contains a search query.">Search</string>
     <string name="deck_conf_cram_limit" maxLength="41">Limit to</string>

--- a/AnkiDroid/src/main/res/values/12-dont-translate.xml
+++ b/AnkiDroid/src/main/res/values/12-dont-translate.xml
@@ -42,5 +42,6 @@ If you want to use a string in your code that can't be translated, please use:
     <!-- Review Reminders: In progress for GSoC 2025 -->
     <!-- TODO: Move this to a proper string resource file and collect all other strings associated with this feature once it is stable. -->
     <string name="schedule_reminders_do_not_translate" maxLength="28" comment="Do not translate this string, this feature is still in development. Name of the screen that appears when review reminders are being scheduled.">Schedule reminders</string>
+    <string name="review_reminders_do_not_translate" comment="Do not translate this string, this feature is still in development. Name of the notification channel for review reminders.">Review Reminders</string>
 </resources>
 


### PR DESCRIPTION
## Purpose / Description
- Created notification channel for review reminders. Deleted old and unused channels for deck-specific and app-wide reminders.
- I needed to set the name of the notification channel in a string resource file because NotificationChannels requires a string resource as an argument when creating a channel.
- Also added vibration to the channel. As discussed in Discord, users can disable vibration from the OS settings, so there is no need to create our own AnkiDroid-specific toggle setting.

## Fixes
* GSoC 2025: Review Reminders

## How Has This Been Tested?
- Works on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->