### PR TITLE
fix: grade now

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1082,6 +1082,11 @@ open class CardBrowser :
                 displayCardInfo()
                 return true
             }
+            R.id.action_grade_now -> {
+                Timber.i("CardBrowser:: Grade now button pressed")
+                openGradeNow()
+                return true
+            }
         }
 
         // TODO: make better use of MenuProvider


### PR DESCRIPTION
the menu action was removed in cff45c77121edd307e1a4251bcf5888243682836

## Fixes
* Fixes Grade now not working

## Approach

Revert the removal

## How Has This Been Tested?

1. Open card browser
2. Select a note
3. Open the menu
4. Select grade now

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->