### PR TITLE
fix(DeckPickerWidget): handle ACTION_UPDATE_WIDGET

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -302,9 +302,27 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
             // It is triggered by the setRecurringAlarm method to refresh the widget's data periodically.
             ACTION_UPDATE_WIDGET -> {
                 val appWidgetId = intent.getAppWidgetId()
-                if (appWidgetId != INVALID_APPWIDGET_ID) {
-                    Timber.d("Received ACTION_UPDATE_WIDGET for widget ID: $appWidgetId")
+                if (appWidgetId == INVALID_APPWIDGET_ID) {
+                    return
                 }
+
+                val selectedDeckIds = widgetPreferences.getSelectedDeckIdsFromPreferences(appWidgetId)
+                if (selectedDeckIds.isEmpty()) {
+                    /**
+                     * Rationale: see [performUpdate]
+                     */
+                    Timber.d(
+                        "Ignoring ACTION_UPDATE_WIDGET for widget ID: $appWidgetId because selectedDeckIds is empty",
+                    )
+                    return
+                }
+
+                Timber.d(
+                    "Updating widget with ID: $appWidgetId on ACTION_UPDATE_WIDGET. selectedDeckIds: ${
+                        selectedDeckIds.joinToString(", ")
+                    }",
+                )
+                updateWidget(context, AppWidgetManager.getInstance(context), appWidgetId, selectedDeckIds)
             }
             AppWidgetManager.ACTION_APPWIDGET_DELETED -> {
                 Timber.d("ACTION_APPWIDGET_DELETED received")

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -437,7 +437,7 @@ class DeckPickerWidgetConfig :
                 action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
                 putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, intArrayOf(appWidgetId.id))
 
-                putExtra("deck_picker_widget_selected_deck_ids", selectedDecks.toList().toLongArray())
+                putExtra(DeckPickerWidget.EXTRA_SELECTED_DECK_IDS, selectedDecks.toList().toLongArray())
             }
 
         sendBroadcast(updateIntent)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Prior to this change, DeckPickerWidget would only acknowledge the `ACTION_UPDATE_WIDGET` intent by logging a message, but it wouldn't act on it. With this change, the widget will try to update itself when receiving this intent, matching the behavior of CardAnalysisWidget.

## Fixes
* Fixes #18323

## Approach
If `widgetPreferences.getSelectedDeckIdsFromPreferences(appWidgetId)` can retrieve a non-empty list of deck IDs, the widget will be updated. Otherwise, the widget will maintain its last state.

## How Has This Been Tested?

Tested on a physical device (Galaxy Tab S9+, Android 15) by adding new cards via Ankiconnect Android while AnkiDroid wasn't in the foreground and waiting for the `ACTION_UPDATE_WIDGET` intent.
```bash
$ curl localhost:8765 -X POST -d '{ "action": "addNote", "version": 6, "params": { "note": { "deckName": "Dummy deck", "modelName": "Basic", "fields": { "Front": "Test" } } } }'
{"result":1755962966504,"error":null}
```
There's some nuance to reproducing this issue because the widget is wired to update in a couple of other cases. Keeping AnkiDroid in the background lets you avoid these other triggers.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->