### PR TITLE
Remove fragmented parameter from DeckPickerViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -71,8 +71,6 @@ import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.draganddrop.DropHelper
 import androidx.fragment.app.commit
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -251,23 +249,12 @@ open class DeckPicker :
     ApkgImportResultLauncherProvider,
     CsvImportResultLauncherProvider,
     CollectionPermissionScreenLauncher {
-    val viewModel: DeckPickerViewModel by viewModels {
-        object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                val fragmented =
-                    (
-                        resources.configuration.screenLayout and
-                            Configuration.SCREENLAYOUT_SIZE_MASK
-                    ) ==
-                        Configuration.SCREENLAYOUT_SIZE_XLARGE
-                @Suppress("UNCHECKED_CAST")
-                return DeckPickerViewModel(fragmented) as T
-            }
-        }
-    }
+    val viewModel: DeckPickerViewModel by viewModels()
 
     override var fragmented: Boolean
-        get() = viewModel.fragmented
+        get() =
+            resources.configuration.screenLayout and Configuration.SCREENLAYOUT_SIZE_MASK ==
+                Configuration.SCREENLAYOUT_SIZE_XLARGE
         set(_) = throw UnsupportedOperationException()
 
     // Short animation duration from system
@@ -800,9 +787,9 @@ open class DeckPicker :
             }
         }
 
-        fun onStudyOptionsVisibilityChanged(isVisible: Boolean) {
+        fun onStudyOptionsVisibilityChanged(collectionHasNoCards: Boolean) {
             invalidateOptionsMenu()
-            studyoptionsFrame?.isVisible = isVisible
+            studyoptionsFrame?.isVisible = fragmented && !collectionHasNoCards
         }
 
         fun onDeckListChanged(deckList: FlattenedDeckList) {
@@ -876,7 +863,7 @@ open class DeckPicker :
         viewModel.flowOfStudiedTodayStats.launchCollectionInLifecycleScope(::onStudiedTodayChanged)
         viewModel.flowOfDeckListInInitialState.filterNotNull().launchCollectionInLifecycleScope(::onCollectionStatusChanged)
         viewModel.flowOfCardsDue.launchCollectionInLifecycleScope(::onCardsDueChanged)
-        viewModel.flowOfStudyOptionsVisible.launchCollectionInLifecycleScope(::onStudyOptionsVisibilityChanged)
+        viewModel.flowOfCollectionHasNoCards.launchCollectionInLifecycleScope(::onStudyOptionsVisibilityChanged)
         viewModel.flowOfDeckList.launchCollectionInLifecycleScope(::onDeckListChanged)
         viewModel.flowOfFocusedDeck.launchCollectionInLifecycleScope(::onFocusedDeckChanged)
         viewModel.flowOfResizingDividerVisible.launchCollectionInLifecycleScope(::onResizingDividerVisibilityChanged)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -51,7 +51,6 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -60,12 +59,9 @@ import timber.log.Timber
 
 /**
  * ViewModel for the [DeckPicker]
- *
- * @param fragmented whether the study options is shown alongside the deck picker
  */
-class DeckPickerViewModel(
-    val fragmented: Boolean,
-) : ViewModel(),
+class DeckPickerViewModel :
+    ViewModel(),
     OnErrorListener {
     val flowOfStartupResponse = MutableStateFlow<StartupResponse?>(null)
 
@@ -163,8 +159,6 @@ class DeckPickerViewModel(
 
     /** "Studied N cards in 0 seconds today */
     val flowOfStudiedTodayStats = MutableStateFlow("")
-
-    val flowOfStudyOptionsVisible = flowOfCollectionHasNoCards.map { noCards -> fragmented && !noCards }
 
     /** Flow that determines when the resizing divider should be visible */
     val flowOfResizingDividerVisible =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckPickerViewModelTest.kt
@@ -39,7 +39,7 @@ import timber.log.Timber
 /** Test of [DeckPickerViewModel] */
 @RunWith(AndroidJUnit4::class)
 class DeckPickerViewModelTest : RobolectricTest() {
-    private val viewModel = DeckPickerViewModel(fragmented = false)
+    private val viewModel = DeckPickerViewModel()
 
     @Test
     fun `empty cards - flow`() =


### PR DESCRIPTION
## Purpose / Description

DeckPickerViewModel was initialized with the "fragmented" status of DeckPicker but as it was never updated during the viewmodel's lifetime there could be situations when it would be inconsistent with the actual fragmented state of DeckPicker. One of this situations is when in split mode because the activity is recreated bu the viewmodel is preserved.

The fix removes the fragmented property and the only flow it was used in. DeckPicker was changed to use the backing flow for the removed flow and the collect lambda was updated with the previous logic from the ViewModel that used fragmented.

## Fixes
* Fixes #19131

## How Has This Been Tested?

Ran the tests, verified the scenario on a resizable emulator.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
