### PR TITLE
logs: trashFiles

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Media.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Media.kt
@@ -152,7 +152,8 @@ open class Media(
 
     /** Move provided files to the trash. */
     @LibAnkiAlias("trash_files")
-    fun trashFiles(fnames: Iterable<String>) {
+    fun trashFiles(fnames: List<String>) {
+        Timber.i("Deleting %d file(s) from %s", fnames.size, dir)
         col.backend.trashMediaFiles(fnames = fnames)
     }
 


### PR DESCRIPTION
Attempting to diagnose

```
net.ankiweb.rsdroid.BackendException$BackendCardTypeException: Cross-device link (os error 18)
	at net.ankiweb.rsdroid.exceptions.BackendIoException.<init>(BackendIoException.java:23)
```

* Issue #19134

## How Has This Been Tested?

Checked logcat:

> Deleting 1 file(s) from /storage/emulated/0/Android/data/com.ichi2.anki.debug/files/AnkiDroid/collection.media

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)