### PR TITLE
fix(tests): flaky test

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -286,6 +286,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
     }
 
     @Test
+    @Flaky(OS.ALL) // Flaky on MACOS and WINDOWS, not seen a breakage on LINUX
     fun noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632() =
         runTest {
             val controller = getViewerController(addCard = true, startedWithShortcut = false)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -509,7 +509,7 @@ class DeckPickerTest : RobolectricTest() {
         }
 
     @Test
-    @Flaky(OS.WINDOWS)
+    @Flaky(OS.ALL)
     fun `ContextMenu unburied cards when selecting UNBURY`() =
         runTest {
             startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {


### PR DESCRIPTION
* Part of #19136

```
AbstractFlashcardViewerTest > noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632 FAILED
    java.lang.AssertionError: messages after flipping card
    Expected: <true>
         but: was <false>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at com.ichi2.anki.AbstractFlashcardViewerTest$noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632$1.invokeSuspend(AbstractFlashcardViewerTest.kt:297)
        at com.ichi2.anki.AbstractFlashcardViewerTest$noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632$1.invoke(AbstractFlashcardViewerTest.kt)
        at com.ichi2.anki.AbstractFlashcardViewerTest$noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632$1.invoke(AbstractFlashcardViewerTest.kt)
        at com.ichi2.anki.RobolectricTest.runTestInner$suspendImpl(RobolectricTest.kt:446)
        at com.ichi2.anki.RobolectricTest.runTestInner(RobolectricTest.kt)
        at com.ichi2.anki.libanki.testutils.AnkiTest$runTest$1$1.invokeSuspend(AnkiTest.kt:329)
        at com.ichi2.anki.libanki.testutils.AnkiTest$runTest$1$1.invoke(AnkiTest.kt)
        at com.ichi2.anki.libanki.testutils.AnkiTest$runTest$1$1.invoke(AnkiTest.kt)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$1.invokeSuspend(TestBuilders.kt:317)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.test.TestDispatcher.processEvent$kotlinx_coroutines_test(TestDispatcher.kt:24)
        at kotlinx.coroutines.test.TestCoroutineScheduler.tryRunNextTaskUnless$kotlinx_coroutines_test(TestCoroutineScheduler.kt:99)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$workRunner$1.invokeSuspend(TestBuilders.kt:326)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:94)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:70)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersJvmKt.createTestResult(TestBuildersJvm.kt:10)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:309)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:167)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at com.ichi2.anki.libanki.testutils.AnkiTest.runTest(AnkiTest.kt:328)
        at com.ichi2.anki.libanki.testutils.AnkiTest.runTest$default(AnkiTest.kt:317)
        at com.ichi2.anki.AbstractFlashcardViewerTest.noAutomaticAnswerAfterRenderProcessGoneAndPaused_issue9632(AbstractFlashcardViewerTest.kt:290)
```

https://github.com/ankidroid/Anki-Android/actions/runs/16764886728/job/47467988383

----

```
DeckPickerTest > [0] > ContextMenu unburied cards when selecting UNBURY[0] FAILED
    java.lang.AssertionError: expected:<1> but was:<0>
        at org.junit.Assert.fail(Assert.java:89)
        at org.junit.Assert.failNotEquals(Assert.java:835)
        at org.junit.Assert.assertEquals(Assert.java:120)
        at org.junit.Assert.assertEquals(Assert.java:146)
        at com.ichi2.anki.DeckPickerTest$ContextMenu unburied cards when selecting UNBURY$1.invokeSuspend(DeckPickerTest.kt:533)
        at com.ichi2.anki.DeckPickerTest$ContextMenu unburied cards when selecting UNBURY$1.invoke(DeckPickerTest.kt)
        at com.ichi2.anki.DeckPickerTest$ContextMenu unburied cards when selecting UNBURY$1.invoke(DeckPickerTest.kt)
        at com.ichi2.testutils.TestClass$runTest$1$1.invokeSuspend(TestClass.kt:342)
        at com.ichi2.testutils.TestClass$runTest$1$1.invoke(TestClass.kt)
        at com.ichi2.testutils.TestClass$runTest$1$1.invoke(TestClass.kt)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$1.invokeSuspend(TestBuilders.kt:317)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.test.TestDispatcher.processEvent$kotlinx_coroutines_test(TestDispatcher.kt:24)
        at kotlinx.coroutines.test.TestCoroutineScheduler.tryRunNextTaskUnless$kotlinx_coroutines_test(TestCoroutineScheduler.kt:99)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt$runTest$2$1$workRunner$1.invokeSuspend(TestBuilders.kt:326)
        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:100)
        at kotlinx.coroutines.EventLoopImplBase.processNextEvent(EventLoop.common.kt:263)
        at kotlinx.coroutines.BlockingCoroutine.joinBlocking(Builders.kt:94)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking(Builders.kt:70)
        at kotlinx.coroutines.BuildersKt.runBlocking(Unknown Source)
        at kotlinx.coroutines.BuildersKt__BuildersKt.runBlocking$default(Builders.kt:48)
        at kotlinx.coroutines.BuildersKt.runBlocking$default(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersJvmKt.createTestResult(TestBuildersJvm.kt:10)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:309)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at kotlinx.coroutines.test.TestBuildersKt__TestBuildersKt.runTest-8Mi8wO0(TestBuilders.kt:167)
        at kotlinx.coroutines.test.TestBuildersKt.runTest-8Mi8wO0(Unknown Source)
        at com.ichi2.testutils.TestClass.runTest(TestClass.kt:340)
        at com.ichi2.testutils.TestClass.runTest$default(TestClass.kt:329)
        at com.ichi2.anki.DeckPickerTest.ContextMenu unburied cards when selecting UNBURY(DeckPickerTest.kt:521)
```

https://github.com/ankidroid/Anki-Android/actions/runs/16039122124/job/45257136402