### PR TITLE
Fix study finish snackbar not appearing in tablet mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -655,6 +655,11 @@ open class DeckPicker :
             )
         }
 
+        setFragmentResultListener(StudyOptionsFragment.REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->
+            Timber.d("Opening study screen from DeckPicker's study options panel")
+            openReviewer()
+        }
+
         pullToSyncWrapper.configureView(
             this,
             IMPORT_MIME_TYPES,
@@ -1453,6 +1458,9 @@ open class DeckPicker :
     private fun processReviewResults(resultCode: Int) {
         if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
             CongratsPage.onReviewsCompleted(this, getColUnsafe.sched.totalCount() == 0)
+            if (fragmented) {
+                fragment?.refreshInterface()
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.ui.RtlCompliantActionProvider
 import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class StudyOptionsActivity :
     AnkiActivity(),
@@ -60,6 +61,14 @@ class StudyOptionsActivity :
                 ->
                     currentFragment!!.refreshInterface()
             }
+        }
+        setFragmentResultListener(StudyOptionsFragment.REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->
+            Timber.d("Opening study screen from study options screen")
+            val reviewer = Reviewer.getIntent(this)
+            // go back to DeckPicker after studying when not in tablet mode
+            reviewer.flags = Intent.FLAG_ACTIVITY_FORWARD_RESULT
+            startActivity(reviewer)
+            finish()
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

Fixes the linked issue by making StudyOptionsFragment to delegate(through a fragment result) the interaction with the reviewer to its parent activity. This way  DeckPicker can use its own code to handle the study finish when in fragmented mode.

Note: I plan to make more changes to StudyOptionsFragment, it's too complicated for what it's doing.

## Fixes
* Fixes #19126

## How Has This Been Tested?

Ran the tests, checked the behavior in portrait and tablet mode.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
