### PR TITLE
Fix missing undo action when modifying the description of a deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -132,6 +132,10 @@ class EditDeckDescriptionDialog : DialogFragment() {
                         DismissType.Saved -> {
                             dismiss()
                             showSnackbar(R.string.deck_description_saved)
+                            // notify DeckPicker to invalidate its toolbar menu, otherwise the undo
+                            // action to revert the description change is not going to be visible
+                            // when there are no other undo actions
+                            requireActivity().invalidateOptionsMenu()
                         }
                     }
                 }


### PR DESCRIPTION
## Purpose / Description
The undo action was being created for modifying the description of a deck, however if DeckPicker didn't already had the undo menu item being visible the undo action would not appear(menu item remained hidden, there was no call to update the undo menu item visibility). 

## Fixes
* Fixes #19069

## How Has This Been Tested?

Ran the tests, manually verified the behavior when modifying the description of a deck.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
