### PR TITLE
fix: stop duplicate permissions request screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -814,10 +814,12 @@ open class DeckPicker :
         fun onStartupResponse(response: StartupResponse) {
             Timber.d("onStartupResponse: %s", response)
             when (response) {
-                is StartupResponse.RequestPermissions ->
+                is StartupResponse.RequestPermissions -> {
+                    viewModel.flowOfStartupResponse.value = null // Prevent duplicate permission screen launches
                     permissionScreenLauncher.launch(
                         PermissionsActivity.getIntent(this, response.requiredPermissions),
                     )
+                }
 
                 is StartupResponse.Success -> {
                     showStartupScreensAndDialogs(sharedPrefs(), 0)


### PR DESCRIPTION
## Purpose / Description
- When AnkiDroid requests mandatory permissions on first-time-launch -- particularly below API 29 when it requests the storage permission -- providing the permission and then hitting continue causes the window to appear a second time. The user then needs to hit "Continue" for a second time.
- Looking through the logs, this seems to be because the `onStartupResponse` listener attached to the StartupResponse StateFlow is being triggered twice with the RequestPermissions state, despite RequestPermissions only being posted to the StateFlow exactly once. This change sets the StateFlow's value to null when the RequestPermissions state is received, ensuring duplicate listener calls do not occur and ensuring the permission screen is only launched once.

## Fixes
* I found this bug while testing my changes to the permissions screen for https://github.com/ankidroid/Anki-Android/pull/18978

## Approach
- Simply sets the StateFlow to null after a StateFlow value of RequestPermissions is received.

## How Has This Been Tested?
- Solves the bug at and below API 29 on an emulated Pixel 3a, API 28.
- On API 30+, (tested with a Medium Tablet, API 36), the previous flow was that the user would see the permissions screen for granting the external storage permission, click to enable it, be directed to the OS settings, and then click "back" to return to the app, where the switch would now be highlighted as "granted" and the continue button available for pressing. However, with this change, upon clicking "back" to return to the app, the DeckPicker activity will immediately launch. I personally think this is a fine change, and an ok price to pay for the lack of duplicate screens showing up below API 29.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->