### PR TITLE
feat(reminders): only notify if no reviews

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -625,6 +625,11 @@
             android:exported="false"
             />
         <receiver
+            android:name=".services.AlarmManagerService"
+            android:enabled="true"
+            android:exported="false"
+            />
+        <receiver
             android:name=".services.BootService"
             android:enabled="true"
             android:exported="false"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -53,6 +53,7 @@ import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.servicelayer.DebugInfoService
 import com.ichi2.anki.servicelayer.ThrowableFilterService
+import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.services.NotificationService
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.dialogs.ActivityAgnosticDialogs
@@ -208,7 +209,9 @@ open class AnkiDroidApp :
 
         if (Prefs.newReviewRemindersEnabled) {
             Timber.i("Setting review reminder notifications if they have not already been set")
-            // TODO: GSoC 2025
+            applicationScope.launch {
+                AlarmManagerService.scheduleAllEnabledReviewReminderNotifications(applicationContext)
+            }
         } else {
             // Register for notifications
             Timber.i("AnkiDroidApp: Starting Services")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -159,7 +159,8 @@ class DeckSpinnerSelection(
             decks.allNamesAndIds(includeFiltered = showFilteredDecks, skipEmptyDefault = true)
         }.toMutableList().let { decks ->
             dropDownDecks = decks
-            val deckNames = decks.map { it.name }
+            val deckNames = decks.map { it.name }.toMutableList()
+            if (showAllDecks) deckNames.add(0, context.getString(R.string.card_browser_all_decks))
             val noteDeckAdapter: ArrayAdapter<String?> =
                 object :
                     ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -1,0 +1,411 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import android.app.Dialog
+import android.content.res.Configuration
+import android.os.Bundle
+import android.os.Parcelable
+import android.text.format.DateFormat
+import android.view.View
+import android.widget.EditText
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.Spinner
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.core.os.BundleCompat
+import androidx.core.view.isVisible
+import androidx.core.widget.doOnTextChanged
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.viewmodel.initializer
+import androidx.lifecycle.viewmodel.viewModelFactory
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.timepicker.MaterialTimePicker
+import com.google.android.material.timepicker.TimeFormat
+import com.ichi2.anki.DeckSpinnerSelection
+import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.dialogs.ConfirmationDialog
+import com.ichi2.anki.dialogs.DeckSelectionDialog
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
+import com.ichi2.utils.customView
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.neutralButton
+import com.ichi2.utils.positiveButton
+import kotlinx.parcelize.Parcelize
+import timber.log.Timber
+import java.util.Calendar
+
+class AddEditReminderDialog : DialogFragment() {
+    /**
+     * Possible states of this dialog.
+     * In particular, whether this dialog will be used to add a new review reminder or edit an existing one.
+     */
+    @Parcelize
+    sealed class DialogMode : Parcelable {
+        /**
+         * Adding a new review reminder. Requires the editing scope of [ScheduleReminders] as an argument so that the dialog can
+         * pick a default deck to add to (or, if the scope is global, so that the dialog can
+         * show that the review reminder will default to being a global reminder).
+         */
+        data class Add(
+            val schedulerScope: ReviewReminderScope,
+        ) : DialogMode()
+
+        /**
+         * Editing an existing review reminder. Requires the reminder being edited so that the
+         * dialog's fields can be populated with its information.
+         */
+        data class Edit(
+            val reminderToBeEdited: ReviewReminder,
+        ) : DialogMode()
+    }
+
+    private val viewModel: AddEditReminderDialogViewModel by viewModels {
+        viewModelFactory {
+            initializer {
+                Timber.d("Initializing AddEditReminderDialogViewModel")
+                when (val mode = dialogMode) {
+                    is DialogMode.Add ->
+                        AddEditReminderDialogViewModel(
+                            initialTime = getCurrentTime(),
+                            initialDeckSelected =
+                                when (mode.schedulerScope) {
+                                    is ReviewReminderScope.Global -> DeckSpinnerSelection.ALL_DECKS_ID
+                                    is ReviewReminderScope.DeckSpecific -> mode.schedulerScope.did
+                                },
+                            initialCardTriggerThreshold = INITIAL_CARD_THRESHOLD,
+                            initialAdvancedSettingsOpen = INITIAL_ADVANCED_SETTINGS_OPEN,
+                        )
+                    is DialogMode.Edit ->
+                        AddEditReminderDialogViewModel(
+                            initialTime = mode.reminderToBeEdited.time,
+                            initialDeckSelected =
+                                when (mode.reminderToBeEdited.scope) {
+                                    is ReviewReminderScope.Global -> DeckSpinnerSelection.ALL_DECKS_ID
+                                    is ReviewReminderScope.DeckSpecific -> mode.reminderToBeEdited.scope.did
+                                },
+                            initialCardTriggerThreshold = mode.reminderToBeEdited.cardTriggerThreshold.threshold,
+                            initialAdvancedSettingsOpen = INITIAL_ADVANCED_SETTINGS_OPEN,
+                        )
+                }
+            }
+        }
+    }
+
+    private lateinit var contentView: View
+
+    /**
+     * The mode of this dialog, retrieved from arguments and set by [getInstance].
+     * @see DialogMode
+     */
+    private val dialogMode: DialogMode by lazy {
+        requireNotNull(
+            BundleCompat.getParcelable(requireArguments(), DIALOG_MODE_ARGUMENTS_KEY, DialogMode::class.java),
+        ) {
+            "Dialog mode cannot be null"
+        }
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        super.onCreateDialog(savedInstanceState)
+        contentView = layoutInflater.inflate(R.layout.add_edit_reminder_dialog, null)
+        Timber.d("dialog mode: %s", dialogMode.toString())
+
+        val dialogBuilder =
+            AlertDialog.Builder(requireActivity()).apply {
+                customView(contentView)
+                positiveButton(R.string.dialog_ok)
+                neutralButton(R.string.dialog_cancel)
+
+                if (dialogMode is DialogMode.Edit) {
+                    negativeButton(R.string.dialog_positive_delete)
+                }
+            }
+        val dialog = dialogBuilder.create()
+
+        // We cannot create onClickListeners by directly using the lambda argument of positiveButton / negativeButton
+        // because setting the onClickListener that way makes the dialog auto-dismiss upon the lambda completing.
+        // We may need to abort submission or deletion. Hence we manually set the click listener here and only
+        // dismiss conditionally from within the click listener methods (see onSubmit and onDelete).
+        dialog.setOnShowListener {
+            val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            val negativeButton = dialog.getButton(AlertDialog.BUTTON_NEGATIVE)
+            positiveButton.setOnClickListener { onSubmit() }
+            negativeButton.setOnClickListener { onDelete() }
+        }
+
+        Timber.d("Setting up fields")
+        setUpToolbar()
+        setUpTimeButton()
+        setUpDeckSpinner()
+        setUpAdvancedDropdown()
+        setUpCardThresholdInput()
+
+        // For getting the result of the deck selection sub-dialog from ScheduleReminders
+        // See ScheduleReminders.onDeckSelected for more information
+        setFragmentResultListener(ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY) { _, bundle ->
+            val selectedDeck =
+                BundleCompat.getParcelable(
+                    bundle,
+                    ScheduleReminders.DECK_SELECTION_RESULT_REQUEST_KEY,
+                    DeckSelectionDialog.SelectableDeck::class.java,
+                )
+            Timber.d("Received result from deck selection sub-dialog: %s", selectedDeck)
+            viewModel.setDeckSelected(selectedDeck?.deckId ?: Consts.DEFAULT_DECK_ID)
+        }
+
+        dialog.window?.let { resizeWhenSoftInputShown(it) }
+        return dialog
+    }
+
+    private fun setUpToolbar() {
+        val toolbar = contentView.findViewById<Toolbar>(R.id.add_edit_reminder_toolbar)
+        toolbar.title =
+            when (dialogMode) {
+                is DialogMode.Add -> "Add review reminder"
+                is DialogMode.Edit -> "Edit review reminder"
+            }
+    }
+
+    private fun setUpTimeButton() {
+        val timeButton = contentView.findViewById<MaterialButton>(R.id.add_edit_reminder_time_button)
+        timeButton.setOnClickListener {
+            Timber.d("Time button clicked")
+            val time = viewModel.time.value ?: getCurrentTime()
+            showTimePickerDialog(time.hour, time.minute)
+        }
+        viewModel.time.observe(this) { time ->
+            timeButton.text = time.toString()
+        }
+    }
+
+    private fun setUpDeckSpinner() {
+        val deckSpinner = contentView.findViewById<Spinner>(R.id.add_edit_reminder_deck_spinner)
+        val deckSpinnerSelection =
+            DeckSpinnerSelection(
+                context = (activity as AppCompatActivity),
+                spinner = deckSpinner,
+                showAllDecks = true,
+                alwaysShowDefault = true,
+                showFilteredDecks = true,
+            )
+        launchCatchingTask {
+            Timber.d("Setting up deck spinner")
+            deckSpinnerSelection.initializeScheduleRemindersDeckSpinner()
+            deckSpinnerSelection.selectDeckById(viewModel.deckSelected.value ?: Consts.DEFAULT_DECK_ID, setAsCurrentDeck = false)
+        }
+    }
+
+    private fun setUpAdvancedDropdown() {
+        val advancedDropdown = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_dropdown)
+        val advancedDropdownIcon = contentView.findViewById<ImageView>(R.id.add_edit_reminder_advanced_dropdown_icon)
+        val advancedContent = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_advanced_content)
+
+        advancedDropdown.setOnClickListener {
+            viewModel.toggleAdvancedSettingsOpen()
+        }
+        viewModel.advancedSettingsOpen.observe(this) { advancedSettingsOpen ->
+            when (advancedSettingsOpen) {
+                true -> {
+                    advancedContent.isVisible = true
+                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_EXPANDED_CHEVRON)
+                }
+                false -> {
+                    advancedContent.isVisible = false
+                    advancedDropdownIcon.setBackgroundResource(DROPDOWN_COLLAPSED_CHEVRON)
+                }
+            }
+        }
+    }
+
+    private fun setUpCardThresholdInput() {
+        val cardThresholdInput = contentView.findViewById<EditText>(R.id.add_edit_reminder_card_threshold_input)
+        cardThresholdInput.setText(viewModel.cardTriggerThreshold.value.toString())
+        cardThresholdInput.doOnTextChanged { text, _, _, _ ->
+            viewModel.setCardTriggerThreshold(text.toString().toIntOrNull() ?: 0)
+        }
+    }
+
+    /**
+     * Show the time picker dialog for selecting a time with a given hour and minute.
+     * Does not automatically dismiss the old dialog.
+     */
+    private fun showTimePickerDialog(
+        hour: Int,
+        minute: Int,
+    ) {
+        val dialog =
+            MaterialTimePicker
+                .Builder()
+                .setTheme(R.style.TimePickerStyle)
+                .setTimeFormat(if (DateFormat.is24HourFormat(activity)) TimeFormat.CLOCK_24H else TimeFormat.CLOCK_12H)
+                .setHour(hour)
+                .setMinute(minute)
+                .build()
+        dialog.addOnPositiveButtonClickListener {
+            viewModel.setTime(ReviewReminderTime(dialog.hour, dialog.minute))
+        }
+        dialog.show(parentFragmentManager, TIME_PICKER_TAG)
+    }
+
+    /**
+     * For some reason, the TimePicker dialog does not automatically redraw itself properly when the device rotates.
+     * Thus, if the TimePicker dialog is active, we manually show a new copy and then dismiss the old one.
+     * We need to show the new one before dismissing the old one to ensure there is no annoying flicker.
+     */
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        val previousDialog = parentFragmentManager.findFragmentByTag(TIME_PICKER_TAG) as? MaterialTimePicker
+        previousDialog?.let {
+            showTimePickerDialog(it.hour, it.minute)
+            it.dismiss()
+        }
+    }
+
+    /**
+     * We display the current time as the initial review reminder time when a review reminder is created from scratch.
+     */
+    private fun getCurrentTime(): ReviewReminderTime {
+        val calendarInstance = TimeManager.time.calendar()
+        val currentHour = calendarInstance.get(Calendar.HOUR_OF_DAY)
+        val currentMinute = calendarInstance.get(Calendar.MINUTE)
+        return ReviewReminderTime(currentHour, currentMinute)
+    }
+
+    private fun onSubmit() {
+        Timber.d("Submitted dialog")
+
+        // Validate numerical fields
+        if ((viewModel.cardTriggerThreshold.value ?: -1) < 0) {
+            contentView.showSnackbar(
+                "The card trigger threshold must be a whole number of cards and at least 0",
+            )
+            return
+        }
+
+        val reminderToBeReturned =
+            ReviewReminder.createReviewReminder(
+                time = viewModel.time.value ?: getCurrentTime(),
+                cardTriggerThreshold =
+                    ReviewReminderCardTriggerThreshold(
+                        threshold = viewModel.cardTriggerThreshold.value ?: INITIAL_CARD_THRESHOLD,
+                    ),
+                scope =
+                    when (viewModel.deckSelected.value) {
+                        DeckSpinnerSelection.ALL_DECKS_ID -> ReviewReminderScope.Global
+                        else ->
+                            ReviewReminderScope.DeckSpecific(
+                                did = viewModel.deckSelected.value ?: Consts.DEFAULT_DECK_ID,
+                            )
+                    },
+                enabled =
+                    when (val mode = dialogMode) {
+                        is DialogMode.Add -> true
+                        is DialogMode.Edit -> mode.reminderToBeEdited.enabled
+                    },
+            )
+
+        Timber.d("Reminder to be returned: %s", reminderToBeReturned)
+        setFragmentResult(
+            ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+            Bundle().apply {
+                putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, reminderToBeReturned)
+            },
+        )
+        dismiss()
+    }
+
+    private fun onDelete() {
+        Timber.d("Selected delete reminder button")
+
+        val confirmationDialog = ConfirmationDialog()
+        confirmationDialog.setArgs(
+            "Delete this reminder?",
+            "This action cannot be undone.",
+        )
+        confirmationDialog.setConfirm {
+            setFragmentResult(
+                ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+                Bundle().apply {
+                    putParcelable(ScheduleReminders.ADD_EDIT_DIALOG_RESULT_REQUEST_KEY, null)
+                },
+            )
+            dismiss()
+        }
+
+        showDialogFragment(confirmationDialog)
+    }
+
+    companion object {
+        /**
+         * Icon that shows next to the advanced settings section when the dropdown is open.
+         */
+        private val DROPDOWN_EXPANDED_CHEVRON = R.drawable.ic_expand_more_black_24dp_xml
+
+        /**
+         * Icon that shows next to the advanced settings section when the dropdown is closed.
+         */
+        private val DROPDOWN_COLLAPSED_CHEVRON = R.drawable.ic_baseline_chevron_right_24
+
+        /**
+         * Arguments key for the dialog mode to open this dialog in.
+         * @see DialogMode
+         */
+        private const val DIALOG_MODE_ARGUMENTS_KEY = "dialog_mode"
+
+        /**
+         * Unique fragment tag for the Material TimePicker shown for setting the time of a review reminder.
+         */
+        private const val TIME_PICKER_TAG = "REMINDER_TIME_PICKER_DIALOG"
+
+        /**
+         * The default minimum card trigger threshold that is filled into the dialog when a new review
+         * reminder is being created. Since this is set to one, the default behaviour is that users
+         * will not get notified about a deck if there are no cards to review for that deck.
+         * Users may choose to instead set it to zero, or any other non-negative integer value.
+         * This is an Int because that is what the EditText's inputType is.
+         */
+        private const val INITIAL_CARD_THRESHOLD: Int = 1
+
+        /**
+         * Whether the advanced settings dropdown is initially open.
+         * We start with it closed to avoid overwhelming the user.
+         */
+        private const val INITIAL_ADVANCED_SETTINGS_OPEN = false
+
+        /**
+         * Creates a new instance of this dialog with the given dialog mode.
+         */
+        fun getInstance(dialogMode: DialogMode): AddEditReminderDialog =
+            AddEditReminderDialog().apply {
+                arguments =
+                    Bundle().apply {
+                        putParcelable(DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
+                    }
+            }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -39,6 +39,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.timepicker.MaterialTimePicker
 import com.google.android.material.timepicker.TimeFormat
 import com.ichi2.anki.DeckSpinnerSelection
@@ -98,6 +99,7 @@ class AddEditReminderDialog : DialogFragment() {
                                     is ReviewReminderScope.DeckSpecific -> mode.schedulerScope.did
                                 },
                             initialCardTriggerThreshold = INITIAL_CARD_THRESHOLD,
+                            initialOnlyNotifyIfNoReviews = INITIAL_ONLY_NOTIFY_IF_NO_REVIEWS,
                             initialAdvancedSettingsOpen = INITIAL_ADVANCED_SETTINGS_OPEN,
                         )
                     is DialogMode.Edit ->
@@ -109,6 +111,7 @@ class AddEditReminderDialog : DialogFragment() {
                                     is ReviewReminderScope.DeckSpecific -> mode.reminderToBeEdited.scope.did
                                 },
                             initialCardTriggerThreshold = mode.reminderToBeEdited.cardTriggerThreshold.threshold,
+                            initialOnlyNotifyIfNoReviews = mode.reminderToBeEdited.onlyNotifyIfNoReviews,
                             initialAdvancedSettingsOpen = INITIAL_ADVANCED_SETTINGS_OPEN,
                         )
                 }
@@ -164,6 +167,7 @@ class AddEditReminderDialog : DialogFragment() {
         setUpDeckSpinner()
         setUpAdvancedDropdown()
         setUpCardThresholdInput()
+        setUpOnlyNotifyIfNoReviewsCheckbox()
 
         // For getting the result of the deck selection sub-dialog from ScheduleReminders
         // See ScheduleReminders.onDeckSelected for more information
@@ -250,6 +254,20 @@ class AddEditReminderDialog : DialogFragment() {
         }
     }
 
+    private fun setUpOnlyNotifyIfNoReviewsCheckbox() {
+        val contentSection = contentView.findViewById<LinearLayout>(R.id.add_edit_reminder_only_notify_if_no_reviews_section)
+        val checkbox = contentView.findViewById<MaterialCheckBox>(R.id.add_edit_reminder_only_notify_if_no_reviews_checkbox)
+        contentSection.setOnClickListener {
+            viewModel.toggleOnlyNotifyIfNoReviews()
+        }
+        checkbox.setOnClickListener {
+            viewModel.toggleOnlyNotifyIfNoReviews()
+        }
+        viewModel.onlyNotifyIfNoReviews.observe(this) { onlyNotifyIfNoReviews ->
+            checkbox.isChecked = onlyNotifyIfNoReviews
+        }
+    }
+
     /**
      * Show the time picker dialog for selecting a time with a given hour and minute.
      * Does not automatically dismiss the old dialog.
@@ -327,6 +345,7 @@ class AddEditReminderDialog : DialogFragment() {
                         is DialogMode.Add -> true
                         is DialogMode.Edit -> mode.reminderToBeEdited.enabled
                     },
+                onlyNotifyIfNoReviews = viewModel.onlyNotifyIfNoReviews.value ?: INITIAL_ONLY_NOTIFY_IF_NO_REVIEWS,
             )
 
         Timber.d("Reminder to be returned: %s", reminderToBeReturned)
@@ -390,6 +409,13 @@ class AddEditReminderDialog : DialogFragment() {
          * This is an Int because that is what the EditText's inputType is.
          */
         private const val INITIAL_CARD_THRESHOLD: Int = 1
+
+        /**
+         * The default value for whether a notification should only be fired if no reviews have been done today
+         * for the corresponding deck / all decks. Since this is set to false, the default behaviour is that
+         * notifications will always be sent, regardless of whether reviews have been done today.
+         */
+        private const val INITIAL_ONLY_NOTIFY_IF_NO_REVIEWS = false
 
         /**
          * Whether the advanced settings dropdown is initially open.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.libanki.DeckId
+import timber.log.Timber
+
+/**
+ * Represents the state of an [AddEditReminderDialog]'s UI. Does not represent the [ReviewReminder] object itself.
+ * For example, instead of storing the card trigger threshold as a [ReviewReminderCardTriggerThreshold], we store an Int, since that's
+ * the input type the user is using to enter the threshold into the app. In other words, this class reflects the concrete
+ * EditText fields in the dialog, not abstract backend data representations.
+ */
+class AddEditReminderDialogViewModel(
+    initialTime: ReviewReminderTime,
+    initialDeckSelected: DeckId,
+    initialCardTriggerThreshold: Int,
+    initialAdvancedSettingsOpen: Boolean,
+) : ViewModel() {
+    private val _time = MutableLiveData(initialTime)
+    val time: LiveData<ReviewReminderTime> = _time
+
+    private val _deckSelected = MutableLiveData(initialDeckSelected)
+
+    /**
+     * [com.ichi2.anki.DeckSpinnerSelection.ALL_DECKS_ID] is used to represent All Decks
+     * (i.e. [ReviewReminderScope.Global]) being selected.
+     */
+    val deckSelected: LiveData<DeckId> = _deckSelected
+
+    private val _cardTriggerThreshold = MutableLiveData(initialCardTriggerThreshold)
+    val cardTriggerThreshold: LiveData<Int> = _cardTriggerThreshold
+
+    private val _advancedSettingsOpen = MutableLiveData(initialAdvancedSettingsOpen)
+    val advancedSettingsOpen: LiveData<Boolean> = _advancedSettingsOpen
+
+    fun setTime(time: ReviewReminderTime) {
+        Timber.d("Updated time to %s", time)
+        _time.value = time
+    }
+
+    fun setDeckSelected(deckId: DeckId) {
+        Timber.d("Updated deck selected to %s", deckId)
+        _deckSelected.value = deckId
+    }
+
+    fun setCardTriggerThreshold(threshold: Int) {
+        Timber.d("Updated card trigger threshold to %s", threshold)
+        _cardTriggerThreshold.value = threshold
+    }
+
+    fun toggleAdvancedSettingsOpen() {
+        Timber.d("Toggled advanced settings open from %s", _advancedSettingsOpen.value)
+        _advancedSettingsOpen.value = !(_advancedSettingsOpen.value ?: false)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -32,6 +32,7 @@ class AddEditReminderDialogViewModel(
     initialTime: ReviewReminderTime,
     initialDeckSelected: DeckId,
     initialCardTriggerThreshold: Int,
+    initialOnlyNotifyIfNoReviews: Boolean,
     initialAdvancedSettingsOpen: Boolean,
 ) : ViewModel() {
     private val _time = MutableLiveData(initialTime)
@@ -47,6 +48,9 @@ class AddEditReminderDialogViewModel(
 
     private val _cardTriggerThreshold = MutableLiveData(initialCardTriggerThreshold)
     val cardTriggerThreshold: LiveData<Int> = _cardTriggerThreshold
+
+    private val _onlyNotifyIfNoReviews = MutableLiveData(initialOnlyNotifyIfNoReviews)
+    val onlyNotifyIfNoReviews: LiveData<Boolean> = _onlyNotifyIfNoReviews
 
     private val _advancedSettingsOpen = MutableLiveData(initialAdvancedSettingsOpen)
     val advancedSettingsOpen: LiveData<Boolean> = _advancedSettingsOpen
@@ -64,6 +68,11 @@ class AddEditReminderDialogViewModel(
     fun setCardTriggerThreshold(threshold: Int) {
         Timber.d("Updated card trigger threshold to %s", threshold)
         _cardTriggerThreshold.value = threshold
+    }
+
+    fun toggleOnlyNotifyIfNoReviews() {
+        Timber.d("Toggled onlyNotifyIfNoReviews from %s", _onlyNotifyIfNoReviews.value)
+        _onlyNotifyIfNoReviews.value = !(_onlyNotifyIfNoReviews.value ?: false)
     }
 
     fun toggleAdvancedSettingsOpen() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -35,7 +35,7 @@ import kotlin.time.Duration.Companion.minutes
 @Serializable
 @Parcelize
 value class ReviewReminderId(
-    val id: Int,
+    val value: Int,
 ) : Parcelable {
     companion object {
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -162,13 +162,13 @@ sealed class ReviewReminderScope : Parcelable {
  * Preferably, also add some unit tests to ensure your migration works properly on all user devices once your update is rolled out.
  * See ReviewRemindersDatabaseTest for examples on how to do this.
  *
- * TODO: add remaining fields planned for GSoC 2025.
- *
  * @param id Unique, auto-incremented ID of the review reminder.
  * @param time See [ReviewReminderTime].
  * @param cardTriggerThreshold See [ReviewReminderCardTriggerThreshold].
  * @param scope See [ReviewReminderScope].
  * @param enabled Whether the review reminder's notifications are active or disabled.
+ * @param onlyNotifyIfNoReviews If true, the reminder will not trigger a notification if the deck the review reminder is for has
+ * already been reviewed at least once today.
  */
 @Serializable
 @Parcelize
@@ -179,6 +179,7 @@ data class ReviewReminder private constructor(
     val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
     val scope: ReviewReminderScope,
     var enabled: Boolean,
+    val onlyNotifyIfNoReviews: Boolean,
 ) : Parcelable,
     ReviewReminderSchema {
     companion object {
@@ -192,12 +193,14 @@ data class ReviewReminder private constructor(
             cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
             scope: ReviewReminderScope = ReviewReminderScope.Global,
             enabled: Boolean = true,
+            onlyNotifyIfNoReviews: Boolean = false,
         ) = ReviewReminder(
             id = ReviewReminderId.getAndIncrementNextFreeReminderId(),
             time,
             cardTriggerThreshold,
             scope,
             enabled,
+            onlyNotifyIfNoReviews,
         )
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -37,6 +37,7 @@ import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.services.AlarmManagerService
 import com.ichi2.anki.showError
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
@@ -181,6 +182,7 @@ class ScheduleReminders :
         Timber.d("Handling add/edit dialog result: mode=%s reminder=%s", modeOfFinishedDialog, newOrModifiedReminder)
         updateDatabaseForAddEditDialog(newOrModifiedReminder, modeOfFinishedDialog)
         updateUIForAddEditDialog(newOrModifiedReminder, modeOfFinishedDialog)
+        updateAlarmsForAddEditDialog(newOrModifiedReminder, modeOfFinishedDialog)
         // Feedback
         showSnackbar(
             when (modeOfFinishedDialog) {
@@ -278,6 +280,28 @@ class ScheduleReminders :
     }
 
     /**
+     * Update the AlarmManager notifications for the new or modified reminder.
+     * @see handleAddEditDialogResult
+     */
+    private fun updateAlarmsForAddEditDialog(
+        newOrModifiedReminder: ReviewReminder?,
+        modeOfFinishedDialog: AddEditReminderDialog.DialogMode,
+    ) {
+        if (modeOfFinishedDialog is AddEditReminderDialog.DialogMode.Edit) {
+            AlarmManagerService.unscheduleReviewReminderNotifications(
+                requireContext(),
+                modeOfFinishedDialog.reminderToBeEdited,
+            )
+        }
+        newOrModifiedReminder?.let {
+            AlarmManagerService.scheduleReviewReminderNotification(
+                requireContext(),
+                it,
+            )
+        }
+    }
+
+    /**
      * Sets a TextView's text based on a [ReviewReminderScope].
      * The text is either the scope's associated deck's name, or "All Decks" if the scope is global.
      * For example, this is used to display the [ScheduleRemindersAdapter]'s deck name column.
@@ -329,6 +353,12 @@ class ScheduleReminders :
         // Update UI
         reminder.enabled = newState
         triggerUIUpdate()
+
+        // Update scheduled AlarmManager notifications
+        when (newState) {
+            true -> AlarmManagerService.scheduleReviewReminderNotification(requireContext(), reminder)
+            false -> AlarmManagerService.unscheduleReviewReminderNotifications(requireContext(), reminder)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -25,6 +25,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResult
+import androidx.fragment.app.setFragmentResultListener
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -37,6 +38,10 @@ import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.showError
+import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
+import com.ichi2.anki.snackbar.SnackbarBuilder
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.withProgress
 import kotlinx.serialization.SerializationException
 import timber.log.Timber
@@ -46,7 +51,8 @@ import timber.log.Timber
  */
 class ScheduleReminders :
     Fragment(R.layout.fragment_schedule_reminders),
-    DeckSelectionDialog.DeckSelectionListener {
+    DeckSelectionDialog.DeckSelectionListener,
+    BaseSnackbarBuilderProvider {
     /**
      * Whether this fragment has been opened to edit all review reminders or just a specific deck's reminders.
      * @see ReviewReminderScope
@@ -62,6 +68,10 @@ class ScheduleReminders :
     private lateinit var toolbar: MaterialToolbar
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: ScheduleRemindersAdapter
+
+    override val baseSnackbarBuilder: SnackbarBuilder = {
+        anchorView = requireView().findViewById<ExtendedFloatingActionButton>(R.id.schedule_reminders_add_reminder_fab)
+    }
 
     /**
      * The reminders currently being displayed in the UI. To make changes to this list show up on screen,
@@ -109,6 +119,26 @@ class ScheduleReminders :
 
         // Retrieve reminders based on the editing scope
         launchCatchingTask { loadDatabaseRemindersIntoUI() }
+
+        // If the user creates or edits a review reminder, the dialog for doing so opens
+        // Once their changes are complete, the dialog closes and this fragment is reloaded
+        // Hence, we check for any fragment results here and update the database accordingly
+        setFragmentResultListener(ADD_EDIT_DIALOG_RESULT_REQUEST_KEY) { _, bundle ->
+            val modeOfFinishedDialog =
+                BundleCompat.getParcelable(
+                    requireArguments(),
+                    ACTIVE_DIALOG_MODE_ARGUMENTS_KEY,
+                    AddEditReminderDialog.DialogMode::class.java,
+                ) ?: return@setFragmentResultListener
+            val newOrModifiedReminder =
+                BundleCompat.getParcelable(
+                    bundle,
+                    ADD_EDIT_DIALOG_RESULT_REQUEST_KEY,
+                    ReviewReminder::class.java,
+                )
+            Timber.d("Dialog result received with recent dialog mode: %s", modeOfFinishedDialog)
+            handleAddEditDialogResult(newOrModifiedReminder, modeOfFinishedDialog)
+        }
     }
 
     private fun reloadToolbarText() {
@@ -142,6 +172,112 @@ class ScheduleReminders :
     }
 
     /**
+     * When a [AddEditReminderDialog] instance finishes, we handle the result of the dialog fragment via this method.
+     */
+    private fun handleAddEditDialogResult(
+        newOrModifiedReminder: ReviewReminder?,
+        modeOfFinishedDialog: AddEditReminderDialog.DialogMode,
+    ) {
+        Timber.d("Handling add/edit dialog result: mode=%s reminder=%s", modeOfFinishedDialog, newOrModifiedReminder)
+        updateDatabaseForAddEditDialog(newOrModifiedReminder, modeOfFinishedDialog)
+        updateUIForAddEditDialog(newOrModifiedReminder, modeOfFinishedDialog)
+        // Feedback
+        showSnackbar(
+            when (modeOfFinishedDialog) {
+                is AddEditReminderDialog.DialogMode.Add -> "Successfully added new review reminder"
+                is AddEditReminderDialog.DialogMode.Edit -> {
+                    when (newOrModifiedReminder) {
+                        null -> "Successfully deleted review reminder"
+                        else -> "Successfully edited review reminder"
+                    }
+                }
+            },
+        )
+    }
+
+    /**
+     * Write the new or modified reminder to the database.
+     * @see handleAddEditDialogResult
+     */
+    private fun updateDatabaseForAddEditDialog(
+        newOrModifiedReminder: ReviewReminder?,
+        modeOfFinishedDialog: AddEditReminderDialog.DialogMode,
+    ) {
+        launchCatchingTask {
+            catchDatabaseExceptions {
+                if (modeOfFinishedDialog is AddEditReminderDialog.DialogMode.Edit) {
+                    // Delete the existing reminder if we're in edit mode
+                    // This action must be separated from writing the modified reminder because the user may have updated the reminder's deck,
+                    // meaning we need to delete the old reminder in the old deck, then add a new reminder to the new deck
+                    val reminderToDelete = modeOfFinishedDialog.reminderToBeEdited
+                    Timber.d("Deleting old reminder from database")
+                    when (reminderToDelete.scope) {
+                        is ReviewReminderScope.Global -> ReviewRemindersDatabase.editAllAppWideReminders(deleteReminder(reminderToDelete))
+                        is ReviewReminderScope.DeckSpecific ->
+                            ReviewRemindersDatabase.editRemindersForDeck(
+                                reminderToDelete.scope.did,
+                                deleteReminder(reminderToDelete),
+                            )
+                    }
+                }
+                newOrModifiedReminder?.let { reminder ->
+                    Timber.d("Writing new or modified reminder to database")
+                    when (reminder.scope) {
+                        is ReviewReminderScope.Global -> ReviewRemindersDatabase.editAllAppWideReminders(upsertReminder(reminder))
+                        is ReviewReminderScope.DeckSpecific ->
+                            ReviewRemindersDatabase.editRemindersForDeck(
+                                reminder.scope.did,
+                                upsertReminder(reminder),
+                            )
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
+     * [ReviewRemindersDatabase.editAllAppWideReminders] which deletes the given review reminder.
+     */
+    private fun deleteReminder(reminder: ReviewReminder) =
+        { reminders: HashMap<ReviewReminderId, ReviewReminder> ->
+            reminders.remove(reminder.id)
+            reminders
+        }
+
+    /**
+     * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
+     * [ReviewRemindersDatabase.editAllAppWideReminders] which updates the given review reminder if it
+     * exists or inserts it if it doesn't (an "upsert" operation)
+     */
+    private fun upsertReminder(reminder: ReviewReminder) =
+        { reminders: HashMap<ReviewReminderId, ReviewReminder> ->
+            reminders[reminder.id] = reminder
+            reminders
+        }
+
+    /**
+     * Update the RecyclerView with the new or modified reminder.
+     * @see handleAddEditDialogResult
+     */
+    private fun updateUIForAddEditDialog(
+        newOrModifiedReminder: ReviewReminder?,
+        modeOfFinishedDialog: AddEditReminderDialog.DialogMode,
+    ) {
+        if (modeOfFinishedDialog is AddEditReminderDialog.DialogMode.Edit) {
+            Timber.d("Deleting old reminder from UI")
+            reminders.remove(modeOfFinishedDialog.reminderToBeEdited.id)
+        }
+        newOrModifiedReminder?.let {
+            if (scheduleRemindersScope == ReviewReminderScope.Global || scheduleRemindersScope == it.scope) {
+                Timber.d("Adding new reminder to UI")
+                reminders[it.id] = it
+            }
+        }
+        triggerUIUpdate()
+    }
+
+    /**
      * Sets a TextView's text based on a [ReviewReminderScope].
      * The text is either the scope's associated deck's name, or "All Decks" if the scope is global.
      * For example, this is used to display the [ScheduleRemindersAdapter]'s deck name column.
@@ -151,7 +287,7 @@ class ScheduleReminders :
         view: TextView,
     ) {
         when (scope) {
-            is ReviewReminderScope.Global -> view.text = "All Decks"
+            is ReviewReminderScope.Global -> view.text = getString(R.string.card_browser_all_decks)
             is ReviewReminderScope.DeckSpecific -> {
                 launchCatchingTask {
                     val deckName = cachedDeckNames.getOrPut(scope.did) { scope.getDeckName() }
@@ -201,6 +337,11 @@ class ScheduleReminders :
      */
     private fun addReminder() {
         Timber.d("Adding new review reminder")
+        val dialogMode = AddEditReminderDialog.DialogMode.Add(scheduleRemindersScope)
+        val dialog = AddEditReminderDialog.getInstance(dialogMode)
+        // Save the dialog mode so that we refer back to it once the dialog closes
+        requireArguments().putParcelable(ACTIVE_DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
+        showDialogFragment(dialog)
     }
 
     /**
@@ -209,6 +350,11 @@ class ScheduleReminders :
      */
     private fun editReminder(reminder: ReviewReminder) {
         Timber.d("Editing review reminder: %s", reminder.id)
+        val dialogMode = AddEditReminderDialog.DialogMode.Edit(reminder)
+        val dialog = AddEditReminderDialog.getInstance(dialogMode)
+        // Save the dialog mode so that we refer back to it once the dialog closes
+        requireArguments().putParcelable(ACTIVE_DIALOG_MODE_ARGUMENTS_KEY, dialogMode)
+        showDialogFragment(dialog)
     }
 
     /**
@@ -265,8 +411,15 @@ class ScheduleReminders :
          */
         const val DECK_SELECTION_RESULT_REQUEST_KEY = "reminder_deck_selection_result_request_key"
 
+        /**
+         * TODO: Move to string resources for translation once review reminders are stable.
+         */
         private const val SERIALIZATION_ERROR_MESSAGE =
             "Something went wrong. A serialization error was encountered while working with review reminders."
+
+        /**
+         * TODO: Move to string resources for translation once review reminders are stable.
+         */
         private const val DATA_TYPE_ERROR_MESSAGE =
             "Something went wrong. An unexpected data type was found while working with review reminders."
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -275,7 +275,7 @@ class ScheduleReminders :
          * Shows an error dialog if [SerializationException]s or [IllegalArgumentException]s are thrown.
          * Shows a progress dialog if database access takes a long time.
          */
-        private suspend fun <T> Fragment.catchDatabaseExceptions(block: () -> T): T? =
+        private suspend fun <T> Fragment.catchDatabaseExceptions(block: suspend () -> T): T? =
             try {
                 Timber.d("Attempting ReviewRemindersDatabase operation")
                 withProgress { block() }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -1,0 +1,298 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.PendingIntentCompat
+import androidx.core.os.BundleCompat
+import com.ichi2.anki.R
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.showThemedToast
+import timber.log.Timber
+import java.util.Calendar
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Schedules review reminder notifications, including scheduling snoozed instances of review reminders.
+ * See [ReviewReminder] for the distinction between a "review reminder" and a "notification".
+ * Actual notification firing is handled by [NotificationService].
+ */
+class AlarmManagerService : BroadcastReceiver() {
+    companion object {
+        /**
+         * Extra key for sending a review reminder as an extra to this BroadcastReceiver.
+         */
+        private const val EXTRA_REVIEW_REMINDER = "alarm_manager_service_review_reminder"
+
+        /**
+         * Extra key for sending a snooze delay interval as an extra to this BroadcastReceiver.
+         * The stored value is an integer number of minutes.
+         */
+        private const val EXTRA_SNOOZE_INTERVAL = "alarm_manager_service_snooze_interval"
+
+        /**
+         * Interval passed to [AlarmManager.setWindow], in milliseconds. The OS is allowed to delay AnkiDroid's notifications
+         * by at much this amount of time. We set it to 10 minutes, which is the minimum allowable duration
+         * according to [the docs](https://developer.android.com/reference/android/app/AlarmManager).
+         */
+        private val WINDOW_LENGTH_MS: Long = 10.minutes.inWholeMilliseconds
+
+        /**
+         * Shows error messages if an error occurs when scheduling review reminders via AlarmManager.
+         * This function wraps all calls to AlarmManager in this class.
+         */
+        private fun catchAlarmManagerExceptions(
+            context: Context,
+            block: () -> Unit,
+        ) {
+            var error: Int? = null
+            try {
+                block()
+            } catch (ex: SecurityException) {
+                // #6332 - Too Many Alarms on Samsung Devices - this stops a fatal startup crash.
+                // We warn the user if they breach this limit
+                Timber.w(ex)
+                error = R.string.boot_service_too_many_notifications
+            } catch (e: Exception) {
+                Timber.w(e)
+                error = R.string.boot_service_failed_to_schedule_notifications
+            }
+            if (error != null) {
+                showThemedToast(context, context.getString(error), false)
+            }
+        }
+
+        /**
+         * Gets the pending intent of a review reminder's scheduled notifications, either the normal recurring ones
+         * (if the action is set to [NotificationService.NotificationServiceAction.ScheduleRecurringNotifications])
+         * or the one-time snoozed ones (if the action is set to [NotificationService.NotificationServiceAction.SnoozeNotification]).
+         * This pending intent can then be used to either schedule those notifications or cancel them.
+         *
+         * If a review reminder with an identical ID has already had notifications scheduled via the pending intent
+         * returned by this method, new notifications scheduled using this pending intent will update the existing
+         * notifications rather than create duplicate new ones.
+         */
+        private fun getReviewReminderNotificationPendingIntent(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            intentAction: NotificationService.NotificationServiceAction,
+        ): PendingIntent? {
+            val intent = NotificationService.getIntent(context, reviewReminder, intentAction)
+            return PendingIntentCompat.getBroadcast(
+                context,
+                reviewReminder.id.value,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                false,
+            )
+        }
+
+        /**
+         * Queues a review reminder to have its notification fired at its specified time. Does not check
+         * if the review reminder is enabled or not, the caller must handle this.
+         *
+         * Note that this only schedules the next upcoming notification, using [AlarmManager.setWindow]
+         * rather than [AlarmManager.setRepeating]. This is because [AlarmManager.setRepeating] sometimes
+         * postpones alarm firings for long periods of time, with intervals as long as one hour observed
+         * in testing. In contrast, [AlarmManager.setWindow] permits us to specify a maximum allowable
+         * length of time the OS can delay the alarm for, leading to a better UX. Each time an alarm is fired,
+         * triggering [NotificationService.sendReviewReminderNotification], this method is called again to
+         * schedule the next upcoming notification. If for some reason the next day's alarm fails to be set by
+         * the current day's notification, we fall back to setting alarms whenever the app is opened: see
+         * [com.ichi2.anki.AnkiDroidApp]'s call to [scheduleAllEnabledReviewReminderNotifications].
+         *
+         * If an old version of this review reminder with the same review reminder ID has already had
+         * its notifications scheduled, this will merely update the existing notifications. If, however,
+         * an old version of this review reminder with a different review reminder ID has already had its
+         * notifications scheduled, this will NOT delete the old scheduled notifications. They must be
+         * manually deleted via [unscheduleReviewReminderNotifications].
+         */
+        fun scheduleReviewReminderNotification(
+            context: Context,
+            reviewReminder: ReviewReminder,
+        ) {
+            Timber.d("Beginning scheduleReviewReminderNotifications for ${reviewReminder.id}")
+            Timber.v("Review reminder: $reviewReminder")
+            val pendingIntent =
+                getReviewReminderNotificationPendingIntent(
+                    context,
+                    reviewReminder,
+                    NotificationService.NotificationServiceAction.ScheduleRecurringNotifications,
+                ) ?: return
+            Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
+
+            val currentTimestamp = TimeManager.time.calendar()
+            val alarmTimestamp = currentTimestamp.clone() as Calendar
+            alarmTimestamp.apply {
+                set(Calendar.HOUR_OF_DAY, reviewReminder.time.hour)
+                set(Calendar.MINUTE, reviewReminder.time.minute)
+                set(Calendar.SECOND, 0)
+                if (before(currentTimestamp)) {
+                    add(Calendar.DAY_OF_YEAR, 1)
+                }
+            }
+
+            catchAlarmManagerExceptions(context) {
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.setWindow(
+                    AlarmManager.RTC_WAKEUP,
+                    alarmTimestamp.timeInMillis,
+                    WINDOW_LENGTH_MS,
+                    pendingIntent,
+                )
+                Timber.d("Successfully scheduled review reminder notifications for ${reviewReminder.id}")
+            }
+        }
+
+        /**
+         * Deletes any scheduled notifications for this review reminder. Does not actually delete the
+         * review reminder itself from anywhere, only deletes any queued alarms for the review reminder.
+         */
+        fun unscheduleReviewReminderNotifications(
+            context: Context,
+            reviewReminder: ReviewReminder,
+        ) {
+            Timber.d("Beginning unscheduleReviewReminderNotifications for ${reviewReminder.id}")
+            Timber.v("Review reminder: $reviewReminder")
+            val pendingIntent =
+                getReviewReminderNotificationPendingIntent(
+                    context,
+                    reviewReminder,
+                    NotificationService.NotificationServiceAction.ScheduleRecurringNotifications,
+                ) ?: return
+            Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
+            catchAlarmManagerExceptions(context) {
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.cancel(pendingIntent)
+                Timber.d("Successfully unscheduled review reminder notifications for ${reviewReminder.id}")
+            }
+        }
+
+        /**
+         * Schedules notifications for all currently-enabled review reminders. Reads from the [ReviewRemindersDatabase].
+         *
+         * If, for a review reminder in the database, an old version of a review reminder with the same review
+         * reminder ID has already had its notifications scheduled, this will merely update the existing notifications.
+         * If, however, an old version of a review reminder with a different review reminder ID has already had its
+         * notifications scheduled, this will NOT delete the old scheduled notifications. They must be
+         * manually deleted via [unscheduleReviewReminderNotifications].
+         */
+        suspend fun scheduleAllEnabledReviewReminderNotifications(context: Context) {
+            Timber.d("scheduleAllEnabledReviewReminderNotifications")
+            val allReviewRemindersAsMap =
+                ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()
+            val enabledReviewReminders = allReviewRemindersAsMap.values.filter { it.enabled }
+            for (reviewReminder in enabledReviewReminders) {
+                scheduleReviewReminderNotification(context, reviewReminder)
+            }
+        }
+
+        /**
+         * Schedules a one-time notification for a review reminder after a set amount of minutes.
+         * Used for snoozing functionality.
+         *
+         * We could instead use WorkManager and enqueue a OneTimeWorkRequest with an initial delay of [snoozeIntervalInMinutes],
+         * but WorkManager work is sometimes deferred for long periods of time by the OS.
+         * Setting an explicit alarm via AlarmManager, either via [AlarmManager.set] or [AlarmManager.setWindow],
+         * tends to result in more timely snooze notification recurrences. Here, we use [AlarmManager.setWindow]
+         * to ensure the OS does not delay the notification for longer than at most ten minutes.
+         */
+        private fun scheduleSnoozedNotification(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            snoozeIntervalInMinutes: Int,
+        ) {
+            Timber.d("Beginning scheduleSnoozedNotification for ${reviewReminder.id}")
+            Timber.v("Review reminder: $reviewReminder")
+            val pendingIntent =
+                getReviewReminderNotificationPendingIntent(
+                    context,
+                    reviewReminder,
+                    NotificationService.NotificationServiceAction.SnoozeNotification,
+                ) ?: return
+            Timber.v("Pending intent for ${reviewReminder.id} is $pendingIntent")
+
+            val alarmTimestamp = TimeManager.time.calendar()
+            alarmTimestamp.add(Calendar.MINUTE, snoozeIntervalInMinutes)
+            catchAlarmManagerExceptions(context) {
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+                alarmManager.setWindow(
+                    AlarmManager.RTC_WAKEUP,
+                    alarmTimestamp.timeInMillis,
+                    WINDOW_LENGTH_MS,
+                    pendingIntent,
+                )
+                Timber.d("Successfully scheduled snoozed review reminder notifications for ${reviewReminder.id}")
+            }
+        }
+
+        /**
+         * Method for getting an intent to snooze a review reminder for this service.
+         */
+        fun getIntent(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            snoozeInterval: Duration,
+        ) = Intent(context, AlarmManagerService::class.java).apply {
+            val snoozeIntervalInMinutes = snoozeInterval.inWholeMinutes.toInt()
+            // Includes the snooze interval in the action string so that the pending intents for different snooze interval
+            // buttons on review reminder notifications are different.
+            action = "com.ichi2.anki.ACTION_START_REMINDER_SNOOZING_$snoozeIntervalInMinutes"
+            putExtra(EXTRA_REVIEW_REMINDER, reviewReminder)
+            putExtra(EXTRA_SNOOZE_INTERVAL, snoozeIntervalInMinutes)
+        }
+    }
+
+    /**
+     * Begins snoozing a review reminder.
+     * @see getIntent
+     */
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        Timber.d("onReceive")
+        // Get the request type
+        val extras = intent.extras ?: return
+        val reviewReminder =
+            BundleCompat.getParcelable(
+                extras,
+                EXTRA_REVIEW_REMINDER,
+                ReviewReminder::class.java,
+            ) ?: return
+        // The following returns 0 if the key is not found, meaning the snooze interval is 0 minutes,
+        // which is an acceptable error fallback case.
+        val snoozeIntervalInMinutes = extras.getInt(EXTRA_SNOOZE_INTERVAL)
+
+        scheduleSnoozedNotification(
+            context,
+            reviewReminder,
+            snoozeIntervalInMinutes,
+        )
+        // Dismiss the snoozed notification when the snooze button is clicked
+        val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        manager.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.libanki.Decks
+import com.ichi2.anki.libanki.EpochSeconds
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewreminders.ReviewReminder
@@ -43,6 +44,7 @@ import com.ichi2.anki.utils.remainingTime
 import com.ichi2.widget.WidgetStatus
 import timber.log.Timber
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
@@ -96,6 +98,12 @@ class NotificationService : BroadcastReceiver() {
                     ReviewRemindersDatabase.deleteAllRemindersForDeck(reviewReminder.scope.did)
                     return
                 }
+            }
+
+            // Cancel if the user wants notifications to only fire if no reviews have been done today AND there has been a review today
+            if (reviewReminder.onlyNotifyIfNoReviews && wasScopeReviewedToday(reviewReminder.scope)) {
+                Timber.d("Aborting notification due to onlyNotifyIfNoReviews")
+                return
             }
 
             val dueCardsCount =
@@ -215,6 +223,34 @@ class NotificationService : BroadcastReceiver() {
                 PendingIntent.FLAG_UPDATE_CURRENT,
                 false,
             )
+        }
+
+        /**
+         * Checks if a deck, or any decks, have been reviewed since the latest day cutoff, accomplished by joining the
+         * cards and revlog tables of the collection database. Used for the "only notify me if no reviews have
+         * been done today" review reminder feature. Checks for existence rather than counting to increase efficiency.
+         */
+        private suspend fun wasScopeReviewedToday(scope: ReviewReminderScope): Boolean {
+            val extraWhereClause =
+                when (scope) {
+                    is ReviewReminderScope.Global -> ""
+                    is ReviewReminderScope.DeckSpecific -> "AND cards.did = ${scope.did}"
+                }
+            val queryResult =
+                withCol {
+                    val startOfToday: EpochSeconds = sched.dayCutoff - 1.days.inWholeSeconds
+                    val query = """
+                        SELECT EXISTS (
+                            SELECT 1
+                            FROM cards
+                            JOIN revlog ON revlog.cid = cards.id
+                            WHERE revlog.id > $startOfToday
+                            $extraWhereClause
+                        )
+                    """
+                    db.queryScalar(query)
+                }
+            return (queryResult == 1)
         }
 
         /** The id of the notification for due cards.  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -20,21 +20,208 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
+import androidx.core.os.BundleCompat
 import com.ichi2.anki.Channel
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
+import com.ichi2.anki.common.annotations.LegacyNotifications
+import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.runGloballyWithTimeout
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.utils.ext.allDecksCounts
+import com.ichi2.anki.utils.remainingTime
 import com.ichi2.widget.WidgetStatus
 import timber.log.Timber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Performs the actual firing of review reminder notifications.
+ * See [ReviewReminder] for the distinction between a "review reminder" and a "notification".
+ * The scheduling of these notifications is handled by [AlarmManagerService].
+ */
 class NotificationService : BroadcastReceiver() {
     companion object {
+        /**
+         * NotificationManager tag for review reminder notifications, passed to the [NotificationManager.notify] method.
+         * We specify this explicitly so that even if other parts of AnkiDroid create a notification with the
+         * same integer ID as a review reminder notification (see [com.ichi2.anki.notifications.NotificationId]),
+         * the two can coexist simultaneously without one interfering with the other.
+         */
+        const val REVIEW_REMINDER_NOTIFICATION_TAG = "com.ichi2.anki.review_reminder_notification_tag"
+
+        /**
+         * Extra key for sending a review reminder as an extra to this broadcast receiver.
+         */
+        private const val EXTRA_REVIEW_REMINDER = "notification_service_review_reminder"
+
+        /**
+         * Timeout for the process of sending a review reminder notification.
+         */
+        private val SEND_REVIEW_REMINDER_TIMEOUT = 10.seconds
+
+        /**
+         * Sends a notification for a review reminder.
+         *
+         * Marked as visible for testing so that tests can call this directly rather than calling [onReceive].
+         * We cannot run [onReceive] in tests because [onReceive] launches this method on the global scope,
+         * which wreaks havoc with tests.
+         */
+        @VisibleForTesting
+        suspend fun sendReviewReminderNotification(
+            context: Context,
+            reviewReminder: ReviewReminder,
+        ) {
+            Timber.i("sendReviewReminderNotification for ${reviewReminder.id}")
+            Timber.v("Review reminder: $reviewReminder")
+
+            // Cancel and delete if the review reminder is deck specific and if the associated deck does not exist
+            if (reviewReminder.scope is ReviewReminderScope.DeckSpecific) {
+                val doesDeckExist =
+                    withCol {
+                        decks.have(reviewReminder.scope.did)
+                    }
+                if (!doesDeckExist) {
+                    ReviewRemindersDatabase.deleteAllRemindersForDeck(reviewReminder.scope.did)
+                    return
+                }
+            }
+
+            val dueCardsCount =
+                when (reviewReminder.scope) {
+                    is ReviewReminderScope.Global -> withCol { sched.allDecksCounts() }
+                    is ReviewReminderScope.DeckSpecific ->
+                        withCol {
+                            decks.select(reviewReminder.scope.did)
+                            sched.counts()
+                        }
+                }
+            val dueCardsTotal = dueCardsCount.count()
+            if (dueCardsTotal < reviewReminder.cardTriggerThreshold.threshold) {
+                Timber.d("Aborting notification due to threshold: $dueCardsTotal < ${reviewReminder.cardTriggerThreshold.threshold}")
+                return
+            }
+
+            val onClickIntent =
+                when (reviewReminder.scope) {
+                    is ReviewReminderScope.Global -> Intent(context, DeckPicker::class.java)
+                    is ReviewReminderScope.DeckSpecific -> {
+                        val deckId = reviewReminder.scope.did
+                        IntentHandler.getReviewDeckIntent(context, deckId)
+                    }
+                }
+            onClickIntent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+
+            val title =
+                when (reviewReminder.scope) {
+                    is ReviewReminderScope.Global -> "It's time to study your cards"
+                    is ReviewReminderScope.DeckSpecific -> {
+                        val fullDeckName = reviewReminder.scope.getDeckName()
+                        val deckName =
+                            Decks.basename(fullDeckName) // don't show the full path with "::" included
+                        "It's time to study $deckName"
+                    }
+                }
+
+            val eta = withCol { sched.eta(dueCardsCount, false) }
+            val remainingTimeString = remainingTime(context, (eta * 60).toLong())
+            val description = "$dueCardsTotal cards due, $remainingTimeString"
+
+            fireReviewReminderNotification(context, reviewReminder, title, description, onClickIntent)
+        }
+
+        /**
+         * Fires a notification with the given title, description, and intent for click actions.
+         * Requires the review reminder the notification is for in order to get a unique ID and create
+         * the hardcoded snooze buttons.
+         */
+        private fun fireReviewReminderNotification(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            title: String,
+            description: String,
+            onClickIntent: Intent,
+        ) {
+            val pendingIntent =
+                PendingIntentCompat
+                    .getActivity(
+                        context,
+                        reviewReminder.id.value,
+                        onClickIntent,
+                        PendingIntent.FLAG_CANCEL_CURRENT,
+                        false,
+                    )
+
+            // Create intents for snooze buttons
+            val fiveMinuteSnooze = createSnoozePendingIntent(context, reviewReminder, 5.minutes)
+            val oneHourSnooze = createSnoozePendingIntent(context, reviewReminder, 60.minutes)
+
+            val builder =
+                NotificationCompat
+                    .Builder(context, Channel.REVIEW_REMINDERS.id)
+                    .setCategory(NotificationCompat.CATEGORY_REMINDER)
+                    .setSmallIcon(R.drawable.ic_star_notify)
+                    .setColor(context.getColor(R.color.material_light_blue_700))
+                    .setContentTitle(title)
+                    .setContentText(description)
+                    .setContentIntent(pendingIntent)
+                    // Vibration and priority are set here for backwards compatibility; they are set via channel for API 33+
+                    .setVibrate(longArrayOf(0, 500))
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    .setAutoCancel(true) // Dismiss on click
+                    .setTicker(title) // Accessibility
+                    // Note that we set an icon for the buttons, but it's only for backwards compatibility and
+                    // only shows up below API 24, which is less than AnkiDroid's minimum supported API level.
+                    .addAction(R.drawable.ic_fast_forward, "Snooze 5m", fiveMinuteSnooze)
+                    .addAction(R.drawable.ic_fast_forward, "Snooze 1h", oneHourSnooze)
+
+            val manager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            Timber.d("Sending notification with ID ${reviewReminder.id.value}")
+            manager.notify(REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value, builder.build())
+        }
+
+        /**
+         * Creates review reminder snoozing pending intent for a given review reminder and snooze interval.
+         * If this method is run twice for the same review reminder ID and snooze interval, it will return the same
+         * pending intent.
+         */
+        private fun createSnoozePendingIntent(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            snoozeInterval: Duration,
+        ): PendingIntent? {
+            val intent =
+                AlarmManagerService.getIntent(
+                    context,
+                    reviewReminder,
+                    snoozeInterval,
+                )
+            Timber.v("Created snooze intent with action ${intent.action}")
+            return PendingIntentCompat.getBroadcast(
+                context,
+                reviewReminder.id.value,
+                intent,
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                false,
+            )
+        }
+
         /** The id of the notification for due cards.  */
+        @LegacyNotifications("Each notification will have a unique ID")
         private const val WIDGET_NOTIFY_ID = 1
 
+        @LegacyNotifications("Replaced by new review reminder notification firing logic")
         fun triggerNotificationFor(context: Context) {
             Timber.i("NotificationService: OnStartCommand")
             val manager =
@@ -96,12 +283,77 @@ class NotificationService : BroadcastReceiver() {
                 manager.cancel(WIDGET_NOTIFY_ID)
             }
         }
+
+        /**
+         * Method for getting an intent for this service.
+         * When broadcasted, fires a notification for the provided review reminder.
+         */
+        fun getIntent(
+            context: Context,
+            reviewReminder: ReviewReminder,
+            intentAction: NotificationServiceAction,
+        ) = Intent(context, NotificationService::class.java).apply {
+            action = intentAction.actionString
+            putExtra(EXTRA_REVIEW_REMINDER, reviewReminder)
+        }
     }
 
+    /**
+     * Alarms for triggering this service's functionality are set by both the normal review reminder
+     * daily repeating notifications and the one-time snoozed notifications that can be created by clicking
+     * snooze on a review reminder's notification. We need to explicitly distinguish between the two on the intents
+     * for launching this service, otherwise the act of snoozing a notification will cancel the normal
+     * daily repeating notifications.
+     */
+    sealed class NotificationServiceAction(
+        val actionString: String,
+    ) {
+        /**
+         * Action sent to [NotificationService] when firing recurring notifications for a review reminder.
+         */
+        object ScheduleRecurringNotifications :
+            NotificationServiceAction(actionString = "com.ichi2.anki.ACTION_SCHEDULE_REMINDER_NOTIFICATIONS")
+
+        /**
+         * Action sent to [NotificationService] when firing a one-time notification for a snoozed review reminder.
+         */
+        object SnoozeNotification :
+            NotificationServiceAction(actionString = "com.ichi2.anki.ACTION_SNOOZE_REMINDER_NOTIFICATION")
+    }
+
+    /**
+     * @see getIntent
+     */
     override fun onReceive(
         context: Context,
         intent: Intent,
     ) {
-        triggerNotificationFor(context)
+        if (Prefs.newReviewRemindersEnabled) {
+            Timber.d("onReceive")
+            val action = intent.action ?: return
+            val extras = intent.extras ?: return
+            val reviewReminder =
+                BundleCompat.getParcelable(
+                    extras,
+                    EXTRA_REVIEW_REMINDER,
+                    ReviewReminder::class.java,
+                ) ?: return
+            Timber.d("onReceive: ${reviewReminder.id}")
+            // Schedule the next instance of this review reminder notification if this is a recurring notification
+            if (action == NotificationServiceAction.ScheduleRecurringNotifications.actionString) {
+                Timber.d("Scheduling next review reminder notification")
+                AlarmManagerService.scheduleReviewReminderNotification(context, reviewReminder)
+            }
+            // Then send the actual notification itself
+            runGloballyWithTimeout(SEND_REVIEW_REMINDER_TIMEOUT) {
+                // We run this on the global scope for simplicity's sake, as BroadcastReceivers do not have CoroutineScopes.
+                // Theoretically we could also use an expedited Worker, but AnkiDroid is only allotted a fixed number
+                // of expedited Worker calls per day, and these expedited calls are also used by the sync service,
+                // so it's best to conserve them.
+                sendReviewReminderNotification(context, reviewReminder)
+            }
+        } else {
+            triggerNotificationFor(context)
+        }
     }
 }

--- a/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/root_linear_layout"
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/add_edit_reminder_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:theme="@style/ActionBarStyle"
+            android:background="?attr/appBarColor"
+            app:title="Add / edit review reminder" />
+
+        <ScrollView
+            android:id="@+id/add_edit_reminder_scrollview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <LinearLayout
+                android:id="@+id/add_edit_reminder_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:paddingTop="24dp"
+                android:paddingHorizontal="24dp">
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_time_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="8dp">
+
+                    <TextView
+                        android:id="@+id/add_edit_reminder_time_label"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical"
+                        android:text="Time:"
+                        android:textSize="18sp"
+                        tools:ignore="HardcodedText" />
+
+                    <com.google.android.material.button.MaterialButton
+                        android:id="@+id/add_edit_reminder_time_button"
+                        android:layout_width="0dp"
+                        android:layout_weight="3"
+                        android:layout_height="match_parent"
+                        app:cornerRadius="8dp"
+                        android:layout_marginStart="12dp"
+                        android:textSize="24sp"
+                        android:text="12:00"
+                        tools:ignore="HardcodedText" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_deck_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:id="@+id/add_edit_reminder_deck_label"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:gravity="center_vertical"
+                        android:text="Deck:"
+                        android:textSize="18sp"
+                        tools:ignore="HardcodedText" />
+
+                    <Spinner
+                        android:id="@+id/add_edit_reminder_deck_spinner"
+                        android:layout_width="0dp"
+                        android:layout_weight="3"
+                        android:layout_height="match_parent"
+                        app:popupTheme="@style/ActionBar.Popup"
+                        android:minHeight="?minTouchTargetSize"
+                        android:layout_marginStart="12dp" />
+
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/add_edit_reminder_advanced_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:id="@+id/add_edit_reminder_advanced_dropdown"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="?attr/minTouchTargetSize"
+                        android:orientation="horizontal">
+
+                        <ImageView
+                            android:id="@+id/add_edit_reminder_advanced_dropdown_icon"
+                            android:layout_width="32dp"
+                            android:layout_height="32dp"
+                            android:layout_gravity="center_vertical"
+                            android:layout_marginEnd="8dp" />
+
+                        <TextView
+                            android:id="@+id/add_edit_reminder_advanced_label"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:textSize="18sp"
+                            android:text="Advanced settings"
+                            tools:ignore="HardcodedText" />
+
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:id="@+id/add_edit_reminder_advanced_content"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="32dp"
+                        android:orientation="vertical">
+
+                        <LinearLayout
+                            android:id="@+id/add_edit_reminder_card_threshold_section"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal"
+                            tools:ignore="UselessParent">
+
+                            <LinearLayout
+                                android:id="@+id/add_edit_reminder_card_threshold_label_container"
+                                android:layout_width="0dp"
+                                android:layout_weight="1"
+                                android:layout_height="wrap_content"
+                                android:paddingVertical="4dp"
+                                android:orientation="vertical">
+
+                                <TextView
+                                    android:id="@+id/add_edit_reminder_card_threshold_label"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:textSize="16sp"
+                                    android:text="Card threshold:"
+                                    tools:ignore="HardcodedText" />
+
+                                <TextView
+                                    android:id="@+id/add_edit_reminder_card_threshold_description"
+                                    android:layout_width="wrap_content"
+                                    android:layout_height="wrap_content"
+                                    android:layout_gravity="center_vertical"
+                                    android:text="Do not send me notifications if there are less than this many cards due"
+                                    tools:ignore="HardcodedText" />
+
+                            </LinearLayout>
+
+                            <EditText
+                                android:id="@+id/add_edit_reminder_card_threshold_input"
+                                android:layout_width="0dp"
+                                android:layout_weight="1"
+                                android:layout_height="?minTouchTargetSize"
+                                android:layout_gravity="bottom"
+                                android:layout_marginStart="24dp"
+                                android:inputType="number" />
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+        </ScrollView>
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
@@ -134,8 +134,7 @@
                             android:id="@+id/add_edit_reminder_card_threshold_section"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:orientation="horizontal"
-                            tools:ignore="UselessParent">
+                            android:orientation="horizontal">
 
                             <LinearLayout
                                 android:id="@+id/add_edit_reminder_card_threshold_label_container"
@@ -172,6 +171,27 @@
                                 android:layout_gravity="bottom"
                                 android:layout_marginStart="24dp"
                                 android:inputType="number" />
+
+                        </LinearLayout>
+
+                        <LinearLayout
+                            android:id="@+id/add_edit_reminder_only_notify_if_no_reviews_section"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <com.google.android.material.checkbox.MaterialCheckBox
+                                android:id="@+id/add_edit_reminder_only_notify_if_no_reviews_checkbox"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content" />
+
+                            <TextView
+                                android:id="@+id/add_edit_reminder_only_notify_if_no_reviews_label"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:text="Only notify me if no reviews have been done today"
+                                tools:ignore="HardcodedText" />
 
                         </LinearLayout>
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -266,4 +266,11 @@
         <item name="cardUseCompatPadding">false</item>
         <item name="cardBackgroundColor">?popupBackgroundColor</item>
     </style>
+
+    <style name="TimePickerStyle" parent="ThemeOverlay.Material3.MaterialTimePicker">
+        <item name="elevationOverlayEnabled">false</item>
+        <item name="colorTertiaryContainer">?colorPrimary</item>
+        <item name="colorOnTertiaryContainer">?colorOnPrimary</item>
+        <item name="colorPrimaryContainer">?colorPrimary</item>
+    </style>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -1,0 +1,253 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.app.PendingIntentCompat
+import androidx.core.content.edit
+import androidx.core.os.BundleCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.time.MockTime
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderCardTriggerThreshold
+import com.ichi2.anki.reviewreminders.ReviewReminderId
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
+import com.ichi2.anki.reviewreminders.ReviewReminderTime
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.anEmptyMap
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Calendar
+import kotlin.time.Duration.Companion.minutes
+
+@RunWith(AndroidJUnit4::class)
+class AlarmManagerServiceTest : RobolectricTest() {
+    companion object {
+        private val mockTime = MockTime(2024, 0, 1, 12, 0, 0, 0, 0)
+    }
+
+    private lateinit var context: Context
+    private lateinit var alarmManager: AlarmManager
+    private lateinit var notificationManager: NotificationManager
+    private lateinit var reviewReminder: ReviewReminder
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        context = mockk(relaxed = true)
+        alarmManager = mockk(relaxed = true)
+        notificationManager = mockk(relaxed = true)
+        every { context.getSystemService(Context.ALARM_SERVICE) } returns alarmManager
+        every { context.getSystemService(Context.NOTIFICATION_SERVICE) } returns notificationManager
+        reviewReminder =
+            ReviewReminder.createReviewReminder(
+                time = ReviewReminderTime(20, 0),
+                cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                scope = ReviewReminderScope.Global,
+                enabled = true,
+            )
+        TimeManager.resetWith(mockTime)
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        unmockkAll()
+        TimeManager.reset()
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
+    @Test
+    fun `scheduleReviewReminderNotifications calls AlarmManager setWindow`() {
+        val expectedSchedulingTime = mockTime.calendar().clone() as Calendar
+        expectedSchedulingTime.apply {
+            set(Calendar.HOUR_OF_DAY, 20)
+        }
+        AlarmManagerService.scheduleReviewReminderNotification(context, reviewReminder)
+        verify {
+            alarmManager.setWindow(
+                AlarmManager.RTC_WAKEUP,
+                expectedSchedulingTime.timeInMillis,
+                10.minutes.inWholeMilliseconds,
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `scheduleReviewReminderNotifications for past time calls AlarmManager setWindow with future time`() {
+        val pastTimeReviewReminder =
+            ReviewReminder.createReviewReminder(
+                time = ReviewReminderTime(3, 0),
+                cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                scope = ReviewReminderScope.Global,
+                enabled = true,
+            )
+        val expectedSchedulingTime = mockTime.calendar().clone() as Calendar
+        expectedSchedulingTime.apply {
+            set(Calendar.HOUR_OF_DAY, 3)
+            add(Calendar.DAY_OF_YEAR, 1)
+        }
+        AlarmManagerService.scheduleReviewReminderNotification(context, pastTimeReviewReminder)
+        verify {
+            alarmManager.setWindow(
+                AlarmManager.RTC_WAKEUP,
+                expectedSchedulingTime.timeInMillis,
+                10.minutes.inWholeMilliseconds,
+                any(),
+            )
+        }
+    }
+
+    @Test
+    fun `unscheduleReviewReminderNotifications calls AlarmManager cancel`() {
+        mockkStatic(PendingIntentCompat::class)
+        val pendingIntent = mockk<PendingIntent>()
+        every {
+            PendingIntentCompat.getBroadcast(
+                any(),
+                any(),
+                any(),
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                any(),
+            )
+        } returns pendingIntent
+
+        AlarmManagerService.unscheduleReviewReminderNotifications(context, reviewReminder)
+        verify { alarmManager.cancel(pendingIntent) }
+    }
+
+    @Test
+    fun `scheduleAllEnabledReviewReminderNotifications schedules reminders for all enabled reminders in database`() =
+        runTest {
+            val did1 = addDeck("Deck1")
+            val did2 = addDeck("Deck2")
+            val reminder1 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(9, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.DeckSpecific(did1),
+                    enabled = true,
+                )
+            val reminder2 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(10, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.DeckSpecific(did2),
+                    enabled = true,
+                )
+            val reminder3 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(11, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.Global,
+                    enabled = true,
+                )
+            val disabledReminder =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(11, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.Global,
+                    enabled = false,
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reminder1) }
+            ReviewRemindersDatabase.editRemindersForDeck(did2) { mapOf(ReviewReminderId(1) to reminder2) }
+            ReviewRemindersDatabase.editAllAppWideReminders {
+                mapOf(
+                    ReviewReminderId(2) to reminder3,
+                    ReviewReminderId(3) to disabledReminder,
+                )
+            }
+
+            AlarmManagerService.scheduleAllEnabledReviewReminderNotifications(context)
+            verify(exactly = 3) { alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), 10.minutes.inWholeMilliseconds, any()) }
+        }
+
+    @Test
+    fun `scheduleAllEnabledReviewReminderNotifications deletes review reminders for nonexistent decks`() =
+        runTest {
+            val did1 = addDeck("Deck1")
+            val did2 = addDeck("Deck2")
+            val reminder1 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(9, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.DeckSpecific(did1),
+                    enabled = true,
+                )
+            val reminder2 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(10, 0),
+                    cardTriggerThreshold = ReviewReminderCardTriggerThreshold(0),
+                    scope = ReviewReminderScope.DeckSpecific(did2),
+                    enabled = true,
+                )
+
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reminder1) }
+            ReviewRemindersDatabase.editRemindersForDeck(did2) { mapOf(ReviewReminderId(1) to reminder2) }
+            withCol { decks.remove(listOf(did1)) }
+
+            AlarmManagerService.scheduleAllEnabledReviewReminderNotifications(context)
+            verify(exactly = 1) { alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), 10.minutes.inWholeMilliseconds, any()) }
+            val attemptedRetrieval = ReviewRemindersDatabase.getRemindersForDeck(did1)
+            assertThat(attemptedRetrieval, anEmptyMap())
+            assertThat(
+                ReviewRemindersDatabase.remindersSharedPrefs.all.keys,
+                not(hasItem(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1)),
+            )
+        }
+
+    @Test
+    fun `onReceive schedules snoozed notification and cancels clicked notification`() {
+        val extras = mockk<Bundle>()
+        every { extras.getInt(any()) } returns 5
+        val intent = mockk<Intent>()
+        every { intent.extras } returns extras
+        mockkStatic(BundleCompat::class)
+        every { BundleCompat.getParcelable(extras, any(), ReviewReminder::class.java) } returns reviewReminder
+
+        AlarmManagerService().onReceive(context, intent)
+        verify {
+            alarmManager.setWindow(
+                AlarmManager.RTC_WAKEUP,
+                mockTime.intTimeMS() + 5.minutes.inWholeMilliseconds,
+                10.minutes.inWholeMilliseconds,
+                any(),
+            )
+        }
+        verify { notificationManager.cancel(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value) }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.scheduler.CardAnswer
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.reviewreminders.ReviewReminder
@@ -109,6 +110,106 @@ class NotificationServiceTest : RobolectricTest() {
 
             NotificationService.sendReviewReminderNotification(context, reviewReminder)
             verify(exactly = 0) { notificationManager.notify(any(), any(), any()) }
+        }
+
+    @Test
+    fun `onReceive with reviews today and onlyNotifyIfNoReviews is true should not fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            addNotes(1).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            withCol {
+                decks.select(did1)
+                sched.answerCard(sched.card!!, CardAnswer.Rating.GOOD)
+            }
+            val reviewReminderDeckSpecific =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did1),
+                    onlyNotifyIfNoReviews = true,
+                )
+            val reviewReminderAppWide =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.Global,
+                    onlyNotifyIfNoReviews = true,
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminderDeckSpecific)
+            NotificationService.sendReviewReminderNotification(context, reviewReminderAppWide)
+            verify(exactly = 0) { notificationManager.notify(any(), any(), any()) }
+        }
+
+    @Test
+    fun `onReceive with no reviews today and onlyNotifyIfNoReviews is true should fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            addNotes(1).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            val reviewReminderDeckSpecific =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did1),
+                    onlyNotifyIfNoReviews = true,
+                )
+            val reviewReminderAppWide =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.Global,
+                    onlyNotifyIfNoReviews = true,
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminderDeckSpecific)
+            NotificationService.sendReviewReminderNotification(context, reviewReminderAppWide)
+            verify(
+                exactly = 1,
+            ) {
+                notificationManager.notify(
+                    NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG,
+                    reviewReminderDeckSpecific.id.value,
+                    any(),
+                )
+            }
+            verify(
+                exactly = 1,
+            ) { notificationManager.notify(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminderAppWide.id.value, any()) }
+        }
+
+    @Test
+    fun `onReceive with onlyNotifyIfNoReviews is false should always fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            addNotes(1).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            val reviewReminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did1),
+                    onlyNotifyIfNoReviews = false,
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminder) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            withCol {
+                decks.select(did1)
+                sched.answerCard(sched.card!!, CardAnswer.Rating.GOOD)
+            }
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            verify(
+                exactly = 2,
+            ) { notificationManager.notify(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value, any()) }
         }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2025 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.services
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.content.edit
+import androidx.test.core.app.ApplicationProvider.getApplicationContext
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderCardTriggerThreshold
+import com.ichi2.anki.reviewreminders.ReviewReminderId
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
+import com.ichi2.anki.reviewreminders.ReviewReminderTime
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.settings.Prefs
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.anEmptyMap
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NotificationServiceTest : RobolectricTest() {
+    private lateinit var context: Context
+    private lateinit var notificationManager: NotificationManager
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        context = spyk(getApplicationContext())
+        notificationManager = mockk(relaxed = true)
+        every { context.getSystemService(Context.NOTIFICATION_SERVICE) } returns notificationManager
+        Prefs.newReviewRemindersEnabled = true
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        unmockkAll()
+        ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
+    }
+
+    @Test
+    fun `onReceive with non-existent deck should delete reminders for deck and not fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            val reviewReminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(0),
+                    ReviewReminderScope.DeckSpecific(did1),
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminder) }
+            withCol { decks.remove(listOf(did1)) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            val attemptedRetrieval = ReviewRemindersDatabase.getRemindersForDeck(did1)
+            assertThat(attemptedRetrieval, anEmptyMap())
+            assertThat(
+                ReviewRemindersDatabase.remindersSharedPrefs.all.keys,
+                not(hasItem(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1)),
+            )
+            verify(exactly = 0) { notificationManager.notify(any(), any(), any()) }
+        }
+
+    @Test
+    fun `onReceive with less cards than card threshold should not fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            addNotes(2).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            val reviewReminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(3),
+                    ReviewReminderScope.DeckSpecific(did1),
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminder) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            verify(exactly = 0) { notificationManager.notify(any(), any(), any()) }
+        }
+
+    @Test
+    fun `onReceive with happy path for single deck should fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck")
+            addNotes(2).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            val reviewReminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did1),
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminder) }
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            verify(
+                exactly = 1,
+            ) { notificationManager.notify(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value, any()) }
+        }
+
+    @Test
+    fun `onReceive with happy path for global reminder should fire notification`() =
+        runTest {
+            val did1 = addDeck("Deck1")
+            val did2 = addDeck("Deck2")
+            addNotes(2).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            addNotes(2).forEach {
+                it.firstCard().update { did = did2 }
+            }
+            val reviewReminder =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(4),
+                    ReviewReminderScope.Global,
+                )
+
+            NotificationService.sendReviewReminderNotification(context, reviewReminder)
+            verify(
+                exactly = 1,
+            ) { notificationManager.notify(NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG, reviewReminder.id.value, any()) }
+        }
+
+    @Test
+    fun `snooze actions of different notifications and different intervals should be different`() =
+        runTest {
+            val did1 = addDeck("Deck1")
+            val did2 = addDeck("Deck2")
+            addNotes(2).forEach {
+                it.firstCard().update { did = did1 }
+            }
+            addNotes(2).forEach {
+                it.firstCard().update { did = did2 }
+            }
+            val reviewReminderOne =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did1),
+                )
+            val reviewReminderTwo =
+                ReviewReminder.createReviewReminder(
+                    ReviewReminderTime(9, 0),
+                    ReviewReminderCardTriggerThreshold(1),
+                    ReviewReminderScope.DeckSpecific(did2),
+                )
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderOne) }
+            ReviewRemindersDatabase.editRemindersForDeck(did2) { mapOf(ReviewReminderId(1) to reviewReminderTwo) }
+
+            val slotOne = slot<Notification>()
+            val slotTwo = slot<Notification>()
+            NotificationService.sendReviewReminderNotification(context, reviewReminderOne)
+            NotificationService.sendReviewReminderNotification(context, reviewReminderTwo)
+            verify(
+                exactly = 1,
+            ) {
+                notificationManager.notify(
+                    NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG,
+                    reviewReminderOne.id.value,
+                    capture(slotOne),
+                )
+            }
+            verify(
+                exactly = 1,
+            ) {
+                notificationManager.notify(
+                    NotificationService.REVIEW_REMINDER_NOTIFICATION_TAG,
+                    reviewReminderTwo.id.value,
+                    capture(slotTwo),
+                )
+            }
+
+            val snoozeIntents =
+                setOf(
+                    slotOne.captured.actions[0].actionIntent,
+                    slotOne.captured.actions[1].actionIntent,
+                    slotTwo.captured.actions[0].actionIntent,
+                    slotTwo.captured.actions[1].actionIntent,
+                )
+            assertThat(snoozeIntents.size, equalTo(4))
+        }
+}

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
@@ -172,7 +172,6 @@ class Decks(
             null
         }
 
-    @Suppress("unused")
     fun have(id: DeckId): Boolean = getLegacy(id) != null
 
     @RustCleanup("implement and make public")


### PR DESCRIPTION
**Based on top of, and blocked by:**
- https://github.com/ankidroid/Anki-Android/pull/19065
- https://github.com/ankidroid/Anki-Android/pull/19109
- https://github.com/ankidroid/Anki-Android/pull/19118
- https://github.com/ankidroid/Anki-Android/pull/19119

## Purpose / Description
Adds an advanced review reminder option. When this setting is enabled, the review reminder only triggers notifications if the deck the review reminder is for has not been reviewed yet today.

Adds a checkbox to the AddEditReminderDialog to toggle this setting on or off. Adds a method to NotificationService to check if a deck (or all decks) have been reviewed yet today. The check is accomplished via a database query of the `revlog` and `cards` tables. In my experience there is no noticeable latency, the query I've written should be fairly efficient.

## UI
![Screenshot_20250828_232854_AnkiDroid](https://github.com/user-attachments/assets/50ba8f1a-033b-4321-9047-a8e995162eb4)

## Fixes
* GSoC 2025: Review Reminders

## Approach
The SQL query is:
```
SELECT EXISTS (
    SELECT 1
    FROM cards
    JOIN revlog ON revlog.cid = cards.id
    WHERE revlog.id > $startOfToday
    AND cards.did = ${scope.did} -- this line is removed if the scope is Global
)
```
Where `startOfToday` is calculated via `sched.dayCutoff - 1.days.inWholeSeconds`

## How Has This Been Tested?
- Unit tests pass.
- Builds and runs on a physical Samsung S23, API 34.
- Based on my own personal testing, it seems the feature works! I created a few review reminders, reviewed a few cards, etc.

## Learning (optional, can help others)
I found the database schema wiki page useful: https://github.com/ankidroid/Anki-Android/wiki/Database-Structure

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->