### PR TITLE
Add filtered decks related backend methods

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2397,7 +2397,7 @@ open class DeckPicker :
                 withCol {
                     Timber.d("rebuildFiltered: doInBackground - RebuildCram")
                     decks.select(did)
-                    sched.rebuildDyn(decks.selected())
+                    sched.rebuildFilteredDeck(decks.selected())
                 }
             }
             updateDeckList()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -292,7 +292,7 @@ class FilteredDeckOptions :
         if (prefChanged) {
             // Rebuild the filtered deck if a setting has changed
             try {
-                col.sched.rebuildDyn(deck.getLong("id"))
+                col.sched.rebuildFilteredDeck(deck.getLong("id"))
             } catch (e: JSONException) {
                 Timber.e(e)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -319,7 +319,7 @@ class StudyOptionsFragment :
             requireActivity().withProgress(resources.getString(R.string.rebuild_filtered_deck)) {
                 withCol {
                     Timber.d("doInBackground - RebuildCram")
-                    sched.rebuildDyn(decks.selected())
+                    sched.rebuildFilteredDeck(decks.selected())
                     fetchStudyOptionsData()
                 }
             }
@@ -332,7 +332,7 @@ class StudyOptionsFragment :
             requireActivity().withProgress(resources.getString(R.string.empty_filtered_deck)) {
                 withCol {
                     Timber.d("doInBackgroundEmptyCram")
-                    sched.emptyDyn(decks.selected())
+                    sched.emptyFilteredDeck(decks.selected())
                     fetchStudyOptionsData()
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -234,7 +234,7 @@ class DeckPickerViewModel :
         viewModelScope.launch {
             Timber.i("empty filtered deck %s", deckId)
             withCol { decks.select(deckId) }
-            undoableOp { sched.emptyDyn(decks.selected()) }
+            undoableOp { sched.emptyFilteredDeck(decks.selected()) }
             flowOfDeckCountsChanged.emit(Unit)
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -539,7 +539,7 @@ class DeckPickerTest : RobolectricTest() {
                         .map { addBasicNote("$it", "").firstCard().id }
                 assertTrue(allCardsInSameDeck(cardIds, 1))
                 val deckId = addDynamicDeck("Deck 1")
-                getColUnsafe.sched.rebuildDyn(deckId)
+                getColUnsafe.sched.rebuildFilteredDeck(deckId)
                 assertTrue(allCardsInSameDeck(cardIds, deckId))
                 updateDeckList()
                 assertEquals(1, visibleDeckCount)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -485,7 +485,7 @@ class NoteEditorTest : RobolectricTest() {
     private fun moveToDynamicDeck(note: Note): DeckId {
         val dyn = addDynamicDeck("All")
         col.decks.select(dyn)
-        col.sched.rebuildDyn()
+        col.sched.rebuildFilteredDeck(dyn)
         assertThat("card is in dynamic deck", note.firstCard().did, equalTo(dyn))
         return dyn
     }

--- a/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
@@ -439,11 +439,30 @@ open class Scheduler(
     }
 
     /**
-     * Gets the filtered deck with given [did]
-     * or creates a new one if [did] = 0
+     * Rebuilds a filtered deck.
+     * @param did id of deck to rebuild. 0 means current deck.
+     */
+    @LibAnkiAlias("rebuild_filtered_deck")
+    fun rebuildFilteredDeck(did: DeckId) = col.backend.rebuildFilteredDeck(did)
+
+    /**
+     * Removes all cards from a filtered deck.
+     * @param did id of deck to empty. 0 means current deck.
+     */
+    @LibAnkiAlias("empty_filtered_deck")
+    fun emptyFilteredDeck(did: DeckId) = col.backend.emptyFilteredDeck(did)
+
+    /**
+     * Gets the filtered deck with given [did] or creates a new one if [did] = 0.
      */
     @LibAnkiAlias("get_or_create_filtered_deck")
     fun getOrCreateFilteredDeck(did: DeckId): FilteredDeckForUpdate = col.backend.getOrCreateFilteredDeck(did = did)
+
+    @LibAnkiAlias("add_or_update_filtered_deck")
+    fun addOrUpdateFilteredDeck(input: FilteredDeckForUpdate) = col.backend.addOrUpdateFilteredDeck(input)
+
+    @LibAnkiAlias("filtered_deck_order_labels")
+    fun filteredDeckOrderLabels() = col.backend.filteredDeckOrderLabels()
 
     /** Rebuild a dynamic deck.
      * @param did The deck to rebuild. 0 means current deck.

--- a/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
@@ -464,22 +464,6 @@ open class Scheduler(
     @LibAnkiAlias("filtered_deck_order_labels")
     fun filteredDeckOrderLabels() = col.backend.filteredDeckOrderLabels()
 
-    /** Rebuild a dynamic deck.
-     * @param did The deck to rebuild. 0 means current deck.
-     */
-    open fun rebuildDyn(did: DeckId) {
-        col.backend.rebuildFilteredDeck(did)
-    }
-
-    fun rebuildDyn() {
-        rebuildDyn(col.decks.selected())
-    }
-
-    /** Remove all cards from a dynamic deck
-     * @param did The deck to empty. 0 means current deck.
-     */
-    open fun emptyDyn(did: DeckId) = col.backend.emptyFilteredDeck(did)
-
     fun deckDueTree(): DeckNode = deckTree(true)
 
     /**

--- a/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
@@ -706,7 +706,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         // should cope with cards in cram decks
         c.update { this.due = 1 }
         addDynamicDeck("tmp")
-        col.sched.rebuildDyn()
+        col.sched.rebuildFilteredDeck(col.decks.selected())
         c.load()
         Assert.assertNotEquals(1, c.due)
         Assert.assertNotEquals(1, c.did)
@@ -740,7 +740,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         Assert.assertEquals(Counts(0, 0, 0), col.sched.counts())
         // create a dynamic deck and refresh it
         val did = addDynamicDeck("Cram")
-        col.sched.rebuildDyn(did)
+        col.sched.rebuildFilteredDeck(did)
         // should appear as normal in the deck list
 
         // TODO: sort
@@ -783,7 +783,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
             ivl = 100
             due = (col.sched.today + 75)
         }
-        col.sched.rebuildDyn(did)
+        col.sched.rebuildFilteredDeck(did)
         c = col.sched.card!!
         Assert.assertEquals(60 * SECONDS_PER_DAY, col.sched.nextIvl(c, Rating.HARD))
         Assert.assertEquals(100 * SECONDS_PER_DAY, col.sched.nextIvl(c, Rating.GOOD))
@@ -812,7 +812,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
 
         // create a dynamic deck and refresh it
         val did = addDynamicDeck("Cram")
-        col.sched.rebuildDyn(did)
+        col.sched.rebuildFilteredDeck(did)
 
         // card should still be in learning state
         c.load()
@@ -829,7 +829,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         )
 
         // emptying the deck preserves learning state
-        col.sched.emptyDyn(did)
+        col.sched.emptyFilteredDeck(did)
         c.load()
         Assert.assertEquals(QueueType.Lrn, c.queue)
         Assert.assertEquals(CardType.Lrn, c.type)
@@ -855,7 +855,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         val cram = col.decks.getLegacy(did)!!
         cram.put("resched", false)
         col.decks.save(cram)
-        col.sched.rebuildDyn(did)
+        col.sched.rebuildFilteredDeck(did)
         // grab the first card
         val c: Card = col.sched.card!!
         Assert.assertEquals(60, col.sched.nextIvl(c, Rating.AGAIN))
@@ -876,7 +876,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         Assert.assertEquals(CardType.New, c2.type)
 
         // emptying the filtered deck should restore card
-        col.sched.emptyDyn(did)
+        col.sched.emptyFilteredDeck(did)
         c.load()
         Assert.assertEquals(QueueType.New, c.queue)
         Assert.assertEquals(0, c.reps)
@@ -1292,8 +1292,8 @@ open class SchedulerTest : InMemoryAnkiTest() {
             }
         // into and out of filtered deck
         val did = addDynamicDeck("Cram")
-        col.sched.rebuildDyn(did)
-        col.sched.emptyDyn(did)
+        col.sched.rebuildFilteredDeck(did)
+        col.sched.emptyFilteredDeck(did)
         c.load()
         Assert.assertEquals(-5, c.due)
     }
@@ -1334,7 +1334,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
         val did = addDynamicDeck("test")
         val deck = decks.getLegacy(did)!!
         deck.put("resched", false)
-        sched.rebuildDyn(did)
+        sched.rebuildFilteredDeck(did)
         var card: Card?
         for (i in 0..2) {
             card = sched.card

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -181,7 +181,7 @@ interface AnkiTest {
                 val deck = col.decks.getLegacy(did)!!
                 deck.getJSONArray("terms").getJSONArray(0).put(0, search)
                 col.decks.save(deck)
-                col.sched.rebuildDyn(did)
+                col.sched.rebuildFilteredDeck(did)
             }
         } catch (filteredAncestor: BackendDeckIsFilteredException) {
             throw RuntimeException(filteredAncestor)


### PR DESCRIPTION
## Purpose / Description

Add all backend methods related to filtered decks in Scheduler.kt. I'm planing to use some of these for some changes in StudyOptionsFragment.

## How Has This Been Tested?

Ran the tests. The functionality wasn't changed, just the names.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

