### PR TITLE
Update active decks related methods with backend code

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
@@ -482,14 +482,15 @@ class Decks(
 
     fun current(): Deck = this.getLegacy(this.selected()) ?: this.getLegacy(1)!!
 
-    /** The currently active dids. */
+    /** The currently active dids. Returned list is never empty. */
     @RustCleanup("Probably better as a queue")
-    @RustCleanup("should not return an empty list")
     fun active(): LinkedList<DeckId> {
-        val activeDecks = col.config.get<List<DeckId>>(ACTIVE_DECKS) ?: listOf()
-        val result = LinkedList<Long>()
-        result.addAll(activeDecks.asIterable())
-        return result
+        val active = col.sched.activeDecks()
+        return if (active.isNotEmpty()) {
+            LinkedList<DeckId>().apply { addAll(active.asIterable()) }
+        } else {
+            LinkedList<DeckId>().apply { add(1L) }
+        }
     }
 
     /** Select a new branch. */

--- a/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/sched/Scheduler.kt
@@ -497,6 +497,9 @@ open class Scheduler(
     @CheckResult
     fun repositionDefaults(): RepositionDefaultsResponse = col.backend.repositionDefaults()
 
+    @LibAnkiAlias("active_decks")
+    fun activeDecks(): List<DeckId> = col.db.queryLongList("SELECT id FROM active_decks")
+
     /**
      * @return Number of new card in current deck and its descendants. Capped at [REPORT_LIMIT]
      */


### PR DESCRIPTION
## Purpose / Description
This PR adds methods from the backend and updates current methods related to active decks. As a side effect it fixes the linked bug:

_After the initial build of a custom study session, the study options fragment used _Scheduler.totalNewForCurrentDeck()_ to get the problematic number of "Total new cards". This method ended up using the incorrect deck(the deck being the target of the custom study request) through deckLimit() due to incorrect active decks methods code._ 

There are no side effects of the changes as the other usages of the changed methods are in previously used methods, currently unused(which probably should be deleted).

Before this PR(1038 cards in deck):

[Screen1.webm](https://github.com/user-attachments/assets/6845befa-89d5-4787-a0bc-806a544ddf42)

After this PR:

[Screen2.webm](https://github.com/user-attachments/assets/2848f0e5-86fc-4638-8565-92418d2464d3)


## Fixes
* Fixes #18667

## How Has This Been Tested?

Ran the tests, checked the behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
