### PR TITLE
fix: custom sync

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -75,7 +75,7 @@ fun syncAuth(): SyncAuth? {
 }
 
 fun getEndpoint(): String? {
-    val currentEndpoint = Prefs.customSyncUri?.ifEmpty { null }
+    val currentEndpoint = Prefs.currentSyncUri?.ifEmpty { null }
     val customEndpoint =
         if (Prefs.isCustomSyncEnabled) {
             Prefs.customSyncUri

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -215,7 +215,7 @@ object Prefs {
     //region Custom sync server
 
     val customSyncCertificate by stringPref(R.string.custom_sync_certificate_key)
-    val customSyncUri by stringPref(R.string.current_sync_uri_key)
+    val customSyncUri by stringPref(R.string.custom_sync_server_collection_url_key)
     val isCustomSyncEnabled by booleanPref(R.string.custom_sync_server_enabled_key, defaultValue = false)
 
     //endregion


### PR DESCRIPTION
I swapped currentSyncUri with customSyncUri in https://github.com/ankidroid/Anki-Android/pull/19010/commits/5cf509b2e49aa73879a380b054222b4a51fe5dcb

then again, on a different way, in https://github.com/ankidroid/Anki-Android/pull/19102

## Fixes
* Fixes #19164

## How Has This Been Tested?

AnkiWeb sync still works

AnkiDroid tries to use the Custom sync server if set

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->