### PR TITLE
fix: key not found

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -38,7 +38,8 @@ class AccessibilitySettingsFragment : SettingsFragment() {
         requirePreference<Preference>(R.string.answer_button_size_pref_key).isVisible = true
 
         for (key in legacyStudyScreenSettings) {
-            requirePreference<Preference>(key).isVisible = false
+            val keyString = getString(key)
+            findPreference<Preference>(keyString)?.isVisible = false
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AdvancedSettingsFragment.kt
@@ -150,7 +150,8 @@ class AdvancedSettingsFragment : SettingsFragment() {
     private fun setupNewStudyScreenSettings() {
         if (!Prefs.isNewStudyScreenEnabled) return
         for (key in legacyStudyScreenSettings) {
-            requirePreference<Preference>(key).isVisible = false
+            val keyString = getString(key)
+            findPreference<Preference>(keyString)?.isVisible = false
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -213,7 +213,8 @@ class AppearanceSettingsFragment : SettingsFragment() {
     private fun setupNewStudyScreenSettings() {
         if (!Prefs.isNewStudyScreenEnabled) return
         for (key in legacyStudyScreenSettings) {
-            requirePreference<Preference>(key).isVisible = false
+            val keyString = getString(key)
+            findPreference<Preference>(keyString)?.isVisible = false
         }
     }
 


### PR DESCRIPTION
double_scrolling wasn't found in AdvancedSettingsFragment, and that led to a crash if the new study screen was enabled

I used findPreference instead of requirePreference in other screens as well to avoid that

## Fixes
* Fixes #19172

## How Has This Been Tested?

Advanced settings now open with the new reviewer enabled

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->