### PR TITLE
feat(new study screen): 'Browse' and 'Statistics' commands / menu actions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/StatisticsDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/StatisticsDestination.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.pages
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.utils.Destination
+
+class StatisticsDestination : Destination {
+    override fun toIntent(context: Context): Intent = PageFragment.getIntent(context, "graphs", null, Statistics::class)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.preferences.reviewer.ViewerAction
 import com.ichi2.anki.previewer.PreviewerAction
 import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
@@ -134,6 +135,13 @@ class ControlsSettingsFragment :
         for (keyRes in legacyStudyScreenSettings) {
             val key = getString(keyRes)
             findPreference<Preference>(key)?.isVisible = false
+        }
+        requirePreference<ControlPreference>(R.string.statistics_command_key).apply {
+            title = TR.statisticsTitle()
+            isVisible = true
+            if (value == null) {
+                value = ViewerAction.STATISTICS.getBindings(sharedPrefs()).toPreferenceString()
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -136,6 +136,13 @@ class ControlsSettingsFragment :
             val key = getString(keyRes)
             findPreference<Preference>(key)?.isVisible = false
         }
+        requirePreference<ControlPreference>(R.string.browse_command_key).apply {
+            title = TR.qtMiscBrowse()
+            isVisible = true
+            if (value == null) {
+                value = ViewerAction.BROWSE.getBindings(sharedPrefs()).toPreferenceString()
+            }
+        }
         requirePreference<ControlPreference>(R.string.statistics_command_key).apply {
             title = TR.statisticsTitle()
             isVisible = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -64,6 +64,7 @@ enum class ViewerAction(
     DELETE(R.id.action_delete, R.drawable.ic_delete_white, R.string.menu_delete_note, MENU_ONLY),
 
     // Disabled
+    STATISTICS(R.id.action_statistics, R.drawable.ic_bar_chart_black, R.string.empty_string, DISABLED),
     DECK_OPTIONS(R.id.action_deck_options, R.drawable.ic_tune_white, R.string.menu__deck_options, DISABLED),
     CARD_INFO(R.id.action_card_info, R.drawable.ic_dialog_info, R.string.card_info_title, DISABLED),
     ADD_NOTE(R.id.action_add_note, R.drawable.ic_add, R.string.menu_add_note, DISABLED),
@@ -137,6 +138,7 @@ enum class ViewerAction(
             SHOW_ALL_HINTS -> listOf(keycode(KeyEvent.KEYCODE_G))
             RECORD_VOICE -> listOf(keycode(KeyEvent.KEYCODE_V, shift()))
             REPLAY_VOICE -> listOf(keycode(KeyEvent.KEYCODE_V))
+            STATISTICS -> listOf(keycode(KeyEvent.KEYCODE_T))
             TOGGLE_FLAG_RED ->
                 listOf(
                     keycode(KeyEvent.KEYCODE_1, ctrl()),
@@ -237,6 +239,7 @@ enum class ViewerAction(
 
     fun title(context: Context): String =
         when (this) {
+            STATISTICS -> TR.statisticsTitle()
             RESCHEDULE_NOTE -> TR.actionsSetDueDate().toSentenceCase(context, R.string.sentence_set_due_date)
             else -> context.getString(titleRes)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -64,6 +64,7 @@ enum class ViewerAction(
     DELETE(R.id.action_delete, R.drawable.ic_delete_white, R.string.menu_delete_note, MENU_ONLY),
 
     // Disabled
+    BROWSE(R.id.action_browse, R.drawable.ic_flashcard_black, R.string.empty_string, DISABLED),
     STATISTICS(R.id.action_statistics, R.drawable.ic_bar_chart_black, R.string.empty_string, DISABLED),
     DECK_OPTIONS(R.id.action_deck_options, R.drawable.ic_tune_white, R.string.menu__deck_options, DISABLED),
     CARD_INFO(R.id.action_card_info, R.drawable.ic_dialog_info, R.string.card_info_title, DISABLED),
@@ -138,6 +139,7 @@ enum class ViewerAction(
             SHOW_ALL_HINTS -> listOf(keycode(KeyEvent.KEYCODE_G))
             RECORD_VOICE -> listOf(keycode(KeyEvent.KEYCODE_V, shift()))
             REPLAY_VOICE -> listOf(keycode(KeyEvent.KEYCODE_V))
+            BROWSE -> listOf(keycode(KeyEvent.KEYCODE_B))
             STATISTICS -> listOf(keycode(KeyEvent.KEYCODE_T))
             TOGGLE_FLAG_RED ->
                 listOf(
@@ -239,6 +241,7 @@ enum class ViewerAction(
 
     fun title(context: Context): String =
         when (this) {
+            BROWSE -> TR.qtMiscBrowse()
             STATISTICS -> TR.statisticsTitle()
             RESCHEDULE_NOTE -> TR.actionsSetDueDate().toSentenceCase(context, R.string.sentence_set_due_date)
             else -> context.getString(titleRes)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.AnkiServer
 import com.ichi2.anki.pages.CardInfoDestination
 import com.ichi2.anki.pages.DeckOptionsDestination
+import com.ichi2.anki.pages.StatisticsDestination
 import com.ichi2.anki.preferences.reviewer.ViewerAction
 import com.ichi2.anki.previewer.CardViewerViewModel
 import com.ichi2.anki.previewer.TypeAnswer
@@ -672,6 +673,7 @@ class ReviewerViewModel :
                 ViewerAction.USER_ACTION_9 -> userAction(9)
                 ViewerAction.SUSPEND_MENU -> suspendCard()
                 ViewerAction.BURY_MENU -> buryCard()
+                ViewerAction.STATISTICS -> destinationFlow.emit(StatisticsDestination())
                 ViewerAction.FLAG_MENU -> {}
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -26,6 +26,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.asyncIO
+import com.ichi2.anki.browser.BrowserDestination
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
@@ -252,6 +253,13 @@ class ReviewerViewModel :
         val isFiltered = withCol { decks.isFiltered(deckId) }
         val destination = DeckOptionsDestination(deckId, isFiltered)
         Timber.i("Launching 'deck options' for deck %d", deckId)
+        destinationFlow.emit(destination)
+    }
+
+    private suspend fun emitBrowseDestination() {
+        val deckId = withCol { decks.getCurrentId() }
+        val destination = BrowserDestination(deckId)
+        Timber.i("Launching 'browse options' for deck %d", deckId)
         destinationFlow.emit(destination)
     }
 
@@ -674,6 +682,7 @@ class ReviewerViewModel :
                 ViewerAction.SUSPEND_MENU -> suspendCard()
                 ViewerAction.BURY_MENU -> buryCard()
                 ViewerAction.STATISTICS -> destinationFlow.emit(StatisticsDestination())
+                ViewerAction.BROWSE -> emitBrowseDestination()
                 ViewerAction.FLAG_MENU -> {}
             }
         }

--- a/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_bar_chart_black.xml
@@ -23,8 +23,10 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
+    android:viewportHeight="24"
+    android:tint="?colorControlNormal"
+    >
   <path
-      android:fillColor="#FF000000"
+      android:fillColor="#FFFFFF"
       android:pathData="M5,13.2h3L8,19L5,19zM10.6,5h2.8v14h-2.8zM16.2,9L19,9v10h-2.8z"/>
 </vector>

--- a/AnkiDroid/src/main/res/values/ids.xml
+++ b/AnkiDroid/src/main/res/values/ids.xml
@@ -41,6 +41,7 @@
     <item type="id" name="action_toggle_auto_advance"/>
     <item type="id" name="action_record_voice"/>
     <item type="id" name="action_set_due_date"/>
+    <item type="id" name="action_browse"/>
     <item type="id" name="action_statistics"/>
 
     <item type="id" name="user_action_1"/>

--- a/AnkiDroid/src/main/res/values/ids.xml
+++ b/AnkiDroid/src/main/res/values/ids.xml
@@ -41,6 +41,7 @@
     <item type="id" name="action_toggle_auto_advance"/>
     <item type="id" name="action_record_voice"/>
     <item type="id" name="action_set_due_date"/>
+    <item type="id" name="action_statistics"/>
 
     <item type="id" name="user_action_1"/>
     <item type="id" name="user_action_2"/>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -122,6 +122,7 @@
     <string name="remove_flag_command_key">binding_UNSET_FLAG</string>
     <string name="page_up_command_key">binding_PAGE_UP</string>
     <string name="page_down_command_key">binding_PAGE_DOWN</string>
+    <string name="statistics_command_key">binding_STATISTICS</string>
     <string name="tag_command_key">binding_TAG</string>
     <string name="card_info_command_key">binding_CARD_INFO</string>
     <string name="record_voice_command_key">binding_RECORD_VOICE</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -122,6 +122,7 @@
     <string name="remove_flag_command_key">binding_UNSET_FLAG</string>
     <string name="page_up_command_key">binding_PAGE_UP</string>
     <string name="page_down_command_key">binding_PAGE_DOWN</string>
+    <string name="browse_command_key">binding_BROWSE</string>
     <string name="statistics_command_key">binding_STATISTICS</string>
     <string name="tag_command_key">binding_TAG</string>
     <string name="card_info_command_key">binding_CARD_INFO</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -149,6 +149,12 @@
             android:icon="@drawable/ic_double_arrow_down"
             />
         <com.ichi2.preferences.ReviewerControlPreference
+            android:key="@string/statistics_command_key"
+            android:icon="@drawable/ic_bar_chart_black"
+            app:isPreferenceVisible="false"
+            tools:title="Statistics"
+            />
+        <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/abort_command_key"
             android:title="@string/gesture_abort_learning"
             android:icon="@drawable/close_icon"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer_controls.xml
@@ -149,6 +149,12 @@
             android:icon="@drawable/ic_double_arrow_down"
             />
         <com.ichi2.preferences.ReviewerControlPreference
+            android:key="@string/browse_command_key"
+            android:icon="@drawable/ic_flashcard_black"
+            app:isPreferenceVisible="false"
+            tools:title="Browse"
+            />
+        <com.ichi2.preferences.ReviewerControlPreference
             android:key="@string/statistics_command_key"
             android:icon="@drawable/ic_bar_chart_black"
             app:isPreferenceVisible="false"


### PR DESCRIPTION
It improves the ecosystem compatibility, since they are actions that can be triggered in the study screen top bar or with a keybind.

It also reduces any kind of complaints related to the new study screen not using a navigation drawer like the old one did

## How Has This Been Tested?

Emulator 34

https://github.com/user-attachments/assets/1bf600ad-ecd0-4029-88a4-3d23d84c4ccf

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->