### PR TITLE
feat: promote new study screen to public testing

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerTest.kt
@@ -217,7 +217,7 @@ class ReviewerTest : InstrumentedTest() {
     }
 
     private fun disableNewReviewer() {
-        val newReviewerPrefKey = testContext.getString(R.string.new_reviewer_pref_key)
+        val newReviewerPrefKey = testContext.getString(R.string.new_reviewer_options_key)
         val prefs = testContext.sharedPrefs()
         val isUsingNewReviewer = prefs.getBoolean(newReviewerPrefKey, false)
         if (!isUsingNewReviewer) return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -190,13 +190,6 @@ class DevOptionsFragment : SettingsFragment() {
             ActivityCompat.recreate(requireActivity())
             true
         }
-
-        requirePreference<Preference>(R.string.new_reviewer_pref_key).setOnPreferenceChangeListener { pref, newValue ->
-            val boolValue = newValue as? Boolean ?: return@setOnPreferenceChangeListener false
-            pref.sharedPreferences?.edit { putBoolean("newReviewerOptions", boolValue) }
-            ActivityCompat.recreate(requireActivity())
-            true
-        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -32,7 +32,6 @@ import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.toSentenceCase
-import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.compat.CompatHelper
 import com.ichi2.preferences.HeaderPreference
 import com.ichi2.utils.AdaptionUtil
@@ -58,9 +57,6 @@ class HeaderFragment : SettingsFragment() {
 
         requirePreference<Preference>(R.string.pref_dev_options_screen_key)
             .isVisible = Prefs.isDevOptionsEnabled
-
-        requirePreference<HeaderPreference>(R.string.new_reviewer_options_key)
-            .isVisible = sharedPrefs().getBoolean(getString(R.string.new_reviewer_pref_key), false)
 
         requirePreference<HeaderPreference>(R.string.pref_review_reminders_screen_key)
             .setOnPreferenceClickListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -288,8 +288,7 @@ object Prefs {
         get() = getBoolean(R.string.dev_options_enabled_by_user_key, false) || BuildConfig.DEBUG
         set(value) = putBoolean(R.string.dev_options_enabled_by_user_key, value)
 
-    val isNewStudyScreenEnabled: Boolean
-        get() = getBoolean(R.string.new_reviewer_pref_key, false) && getBoolean(R.string.new_reviewer_options_key, false)
+    val isNewStudyScreenEnabled by booleanPref(R.string.new_reviewer_options_key, false)
 
     val devIsCardBrowserFragmented: Boolean
         get() = getBoolean(R.string.dev_card_browser_fragmented, false)

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -262,7 +262,7 @@
     </string-array>
 
     <string-array name="study_screen_summary_entries">
-        <item>@string/pref_cat_appearance</item>
+        <item>@string/screen</item>
         <item>@string/toolbar</item>
         <item>@string/answer_buttons</item>
     </string-array>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -211,7 +211,6 @@
     <string name="pref_lock_database_key">debug_lock_database</string>
     <string name="pref_corrupt_fsrs_params">debug_corrupt_fsrs_params</string>
     <string name="new_congrats_screen_pref_key">new_congrats_screen</string>
-    <string name="new_reviewer_pref_key">newReviewer</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
     <string name="pref_browser_find_replace">browserFindReplace</string>
     <string name="pref_new_review_reminders">newReviewReminders</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -36,6 +36,15 @@
         app:summaryEntries="@array/general_summary_entries">
     </com.ichi2.preferences.HeaderPreference>
 
+
+    <com.ichi2.preferences.HeaderPreference
+        android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"
+        android:title="@string/new_study_screen"
+        android:icon="@drawable/ic_cards_star"
+        android:key="@string/new_reviewer_options_key"
+        app:summaryEntries="@array/study_screen_summary_entries"
+        />
+
     <!-- Reviewing Preferences -->
     <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.ReviewingSettingsFragment"
@@ -114,14 +123,6 @@
         android:icon="@drawable/ic_tune_white"
         app:summaryEntries="@array/advanced_summary_entries">
     </com.ichi2.preferences.HeaderPreference>
-
-    <com.ichi2.preferences.HeaderPreference
-        android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"
-        android:title="@string/new_study_screen"
-        android:icon="@drawable/ic_cards_star"
-        android:key="@string/new_reviewer_options_key"
-        app:summaryEntries="@array/study_screen_summary_entries"
-        />
 
     <com.ichi2.preferences.HeaderPreference
         android:key="@string/pref_dev_options_screen_key"

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -100,10 +100,6 @@
         android:summary="Only for testing. Not suited for use. Don't create reports about them">
 
         <SwitchPreferenceCompat
-            android:title="@string/new_study_screen"
-            android:key="@string/new_reviewer_pref_key"
-            android:defaultValue="false"/>
-        <SwitchPreferenceCompat
             android:title="[Tablet] Side-by-side browser and editor"
             android:key="@string/dev_card_browser_fragmented"
             android:defaultValue="false"/>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -7,11 +7,6 @@
     >
 
     <com.ichi2.preferences.HtmlHelpPreference
-        android:summary="The new study screen is still a WIP developer option with features under development, so please don't create reports about it. The message below requesting feedback only exists at the moment for it to get translated."
-        search:ignore="true"
-        />
-
-    <com.ichi2.preferences.HtmlHelpPreference
         android:summary="@string/new_study_screen_summ"
         app:substitution1="@string/link_anki_forum_ankidroid"
         app:substitution2="@string/link_help"
@@ -21,7 +16,7 @@
     <SwitchPreferenceCompat
         android:key="@string/new_reviewer_options_key"
         android:title="@string/new_study_screen"
-        android:defaultValue="true"
+        android:defaultValue="false"
         search:ignore="true"
         />
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

the last big features of the new study screen already have PRs, so it's time to promote it to public testing

## Fixes

* Closes #14302

## Approach

* Remove the dev option
* Put the new study screen settings section more at the top

## How Has This Been Tested?

Emulator 34

https://github.com/user-attachments/assets/03f43d9b-9fe1-4c57-985f-d6181ac221c3

last commit:

<img width="386" height="71" alt="image" src="https://github.com/user-attachments/assets/3cb50733-f9df-483d-8358-2d51e464c750" />

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->