### PR TITLE
feat: move "double tap timeout" to "Accessibility"

### DIFF
--- a/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_accessibility.xml
@@ -73,4 +73,14 @@
         android:valueFrom="0"
         android:valueTo="2000"
         app:displayFormat="@string/pref_milliseconds"/>
+    <com.ichi2.preferences.SliderPreference
+        android:key="@string/double_tap_timeout_pref_key"
+        android:title="@string/pref_double_tap_time_interval"
+        android:summary="@string/pref_double_tap_time_interval_summary"
+        android:valueFrom="0"
+        android:valueTo="1000"
+        android:defaultValue="200"
+        android:stepSize="10"
+        app:displayFormat="@string/pref_milliseconds"
+        />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -55,15 +55,5 @@
             android:key="@string/keep_screen_on_preference"
             android:summary="@string/pref_keep_screen_on_summ"
             android:title="@string/pref_keep_screen_on" />
-        <com.ichi2.preferences.SliderPreference
-            android:key="@string/double_tap_timeout_pref_key"
-            android:title="@string/pref_double_tap_time_interval"
-            android:summary="@string/pref_double_tap_time_interval_summary"
-            android:valueFrom="0"
-            android:valueTo="1000"
-            android:defaultValue="200"
-            android:stepSize="10"
-            app1:displayFormat="@string/pref_milliseconds"
-            />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
It's an accessibility setting after all

## How Has This Been Tested?

<img width="345" height="597" alt="image" src="https://github.com/user-attachments/assets/c4fb6167-db75-48d2-a14f-39c91ed306fd" />

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->