### PR TITLE
feat: fast scroller bar now jumping to clicked position

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -242,6 +242,27 @@ class RecyclerFastScroller
                 },
             )
 
+            bar.setOnTouchListener { _, event ->
+                val recyclerView = recyclerView ?: return@setOnTouchListener false
+                val adapter = recyclerView.adapter ?: return@setOnTouchListener false
+
+                if (event.actionMasked == MotionEvent.ACTION_DOWN) {
+                    val barHeight = bar.height
+                    val touchY = event.y.coerceIn(0f, barHeight.toFloat())
+
+                    val scrollProportion = touchY / barHeight
+                    val targetPosition =
+                        (scrollProportion * adapter.itemCount)
+                            .toInt()
+                            .coerceIn(0, adapter.itemCount - 1)
+
+                    recyclerView.scrollToPosition(targetPosition)
+                    return@setOnTouchListener true
+                }
+
+                false
+            }
+
             translationX = hiddenTranslationX.toFloat()
         }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Clicking on the fast scroller bar did not scroll the RecyclerView to the expected position. It only responded when dragging the handle, which was unintuitive.

## Fixes
Fixes #18520 (Fast scroller bar not jumping to clicked position)

## Approach
Added a touch listener to the bar view in RecyclerFastScroller.kt so that tapping anywhere along the scrollbar immediately scrolls the RecyclerView to the corresponding adapter position. This aligns with standard fast scroller behavior.

## How Has This Been Tested?

- Built and ran on a physical device (Redmi Note 9 Pro, Android 12).
- Opened deck list and tested scrolling:
          - Dragging the handle works as before.
          - Tapping at random points on the bar correctly jumps to that section of the list. 


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X

https://github.com/user-attachments/assets/9a4630b0-0444-487a-ba4d-da292400c75b

] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)