### PR TITLE
feat(new study screen): replay media command/menu action

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -73,6 +73,7 @@ enum class ViewerAction(
     RESCHEDULE_NOTE(R.id.action_set_due_date, R.drawable.ic_reschedule, titleRes = R.string.empty_string, DISABLED),
     TOGGLE_AUTO_ADVANCE(R.id.action_toggle_auto_advance, R.drawable.ic_fast_forward, R.string.toggle_auto_advance, DISABLED),
     RECORD_VOICE(R.id.action_record_voice, R.drawable.ic_action_mic, R.string.record_voice, DISABLED),
+    PLAY_MEDIA(R.id.action_replay_media, R.drawable.ic_play_circle_white, R.string.replay_media, DISABLED),
     USER_ACTION_1(R.id.user_action_1, R.drawable.user_action_1, R.string.user_action_1, DISABLED),
     USER_ACTION_2(R.id.user_action_2, R.drawable.user_action_2, R.string.user_action_2, DISABLED),
     USER_ACTION_3(R.id.user_action_3, R.drawable.user_action_3, R.string.user_action_3, DISABLED),
@@ -141,6 +142,7 @@ enum class ViewerAction(
             REPLAY_VOICE -> listOf(keycode(KeyEvent.KEYCODE_V))
             BROWSE -> listOf(keycode(KeyEvent.KEYCODE_B))
             STATISTICS -> listOf(keycode(KeyEvent.KEYCODE_T))
+            PLAY_MEDIA -> listOf(keycode(KeyEvent.KEYCODE_R))
             TOGGLE_FLAG_RED ->
                 listOf(
                     keycode(KeyEvent.KEYCODE_1, ctrl()),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -27,6 +27,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.Reviewer
 import com.ichi2.anki.asyncIO
 import com.ichi2.anki.browser.BrowserDestination
+import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.launchCatchingIO
 import com.ichi2.anki.libanki.Card
@@ -626,6 +627,11 @@ class ReviewerViewModel :
         answerTimerStatusFlow.emit(AnswerTimerStatus.Running(limitInMillis))
     }
 
+    private suspend fun replayMedia() {
+        val side = if (showingAnswer.value) SingleCardSide.BACK else SingleCardSide.FRONT
+        cardMediaPlayer.replayAll(side)
+    }
+
     fun executeAction(action: ViewerAction) {
         Timber.v("ReviewerViewModel::executeAction %s", action.name)
         launchCatchingIO {
@@ -683,6 +689,7 @@ class ReviewerViewModel :
                 ViewerAction.BURY_MENU -> buryCard()
                 ViewerAction.STATISTICS -> destinationFlow.emit(StatisticsDestination())
                 ViewerAction.BROWSE -> emitBrowseDestination()
+                ViewerAction.PLAY_MEDIA -> replayMedia()
                 ViewerAction.FLAG_MENU -> {}
             }
         }

--- a/AnkiDroid/src/main/res/values/ids.xml
+++ b/AnkiDroid/src/main/res/values/ids.xml
@@ -40,6 +40,7 @@
     <item type="id" name="action_suspend_note"/>
     <item type="id" name="action_toggle_auto_advance"/>
     <item type="id" name="action_record_voice"/>
+    <item type="id" name="action_replay_media"/>
     <item type="id" name="action_set_due_date"/>
     <item type="id" name="action_browse"/>
     <item type="id" name="action_statistics"/>


### PR DESCRIPTION
## Purpose / Description
_Describe the problem or feature and motivation_

Implements the "Replay media" command and menu action in the new study screen

## How Has This Been Tested?

Emulator 34

[Screen_recording_20250908_164250.webm](https://github.com/user-attachments/assets/05d2df03-7ebf-4ae0-9036-18bf0630ea0f)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->