### PR TITLE
Fix crash in ControlSettingsFragment due to required browse/statistics preferences

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -136,14 +136,14 @@ class ControlsSettingsFragment :
             val key = getString(keyRes)
             findPreference<Preference>(key)?.isVisible = false
         }
-        requirePreference<ControlPreference>(R.string.browse_command_key).apply {
+        findPreference<ControlPreference>(getString(R.string.browse_command_key))?.apply {
             title = TR.qtMiscBrowse()
             isVisible = true
             if (value == null) {
                 value = ViewerAction.BROWSE.getBindings(sharedPrefs()).toPreferenceString()
             }
         }
-        requirePreference<ControlPreference>(R.string.statistics_command_key).apply {
+        findPreference<ControlPreference>(getString(R.string.statistics_command_key))?.apply {
             title = TR.statisticsTitle()
             isVisible = true
             if (value == null) {


### PR DESCRIPTION
## Purpose / Description

The previews tab in ControlSettinsFragment "required" the two browse/statistics controls introduced in  #19181 although it didn't show/use these controls. Use findPreference() instead to gracefully handle the preferences not being available.

## Fixes
```

ACRA caught a IllegalStateException for com.ichi2.anki.debug
   java.lang.IllegalStateException: missing preference: 'binding_BROWSE'
    at com.ichi2.anki.preferences.ControlsSettingsFragment.setupNewStudyScreenSettings(ControlsSettingsFragment.kt:229)
    at com.ichi2.anki.preferences.ControlsSettingsFragment.onTabSelected(ControlsSettingsFragment.kt:80)
```

## How Has This Been Tested?

Opened both tabs in controls settings.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
