### PR TITLE
docs(libanki): DeckId

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Deck.kt
@@ -57,6 +57,11 @@ class Deck : JSONObject {
             put("collapsed", value)
         }
 
+    /**
+     * Unique identifier of the deck
+     *
+     * @see DeckId
+     */
     var id: DeckId
         get() = getLong("id")
         set(value) {

--- a/libanki/src/main/java/com/ichi2/anki/libanki/PythonTypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/PythonTypes.kt
@@ -16,8 +16,21 @@
 
 package com.ichi2.anki.libanki
 
-/** Identifier of a [Deck] */
-typealias DeckId = Long
+/**
+ * Identifier of a [Deck].
+ *
+ * The default deck has an ID of [1][Consts.DEFAULT_DECK_ID] (`Consts.DEFAULT_DECK_ID`)
+ *
+ * User-created decks use the deck creation time [(ms since the Unix epoch)][EpochMilliseconds]
+ *
+ * **Examples**
+ * * `1428219222352` -> Deck created at 5 April 2015 07:33:42.352
+ * * `1` -> Default Deck
+ *
+ * @see EpochMilliseconds
+ * @see Deck.id
+ */
+typealias DeckId = EpochMilliseconds
 
 /** Identifier of a [Card] */
 typealias CardId = Long
@@ -40,3 +53,13 @@ typealias NoteTypeId = Long
  * example: 6 February 2024 19:15:49 -> `1707246949`
  */
 typealias EpochSeconds = Long
+
+/**
+ * The number of non-leap milliseconds which have elapsed since the
+ * [Unix Epoch](https://en.wikipedia.org/wiki/Unix_time) (00:00:00 UTC on 1 January 1970)
+ *
+ * See: [https://www.epochconverter.com/](https://www.epochconverter.com/)
+ *
+ * example: 5 April 2015 07:33:42.352 -> `1428219222352`
+ */
+typealias EpochMilliseconds = Long


### PR DESCRIPTION
A question was raised about deck IDs being duplicated

This isn't feasible, aside from imports/the default deck, so I felt it warranted a minor docs update