### PR TITLE
feat(new reviewer): add auto focus support to HTML type in

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -306,7 +306,6 @@ class ReviewerFragment :
             }
 
         lifecycleScope.launch {
-            if (Prefs.isHtmlTypeAnswerEnabled) return@launch
             val autoFocusTypeAnswer = Prefs.autoFocusTypeAnswer
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.typeAnswerFlow.collect { typeInAnswer ->
@@ -314,6 +313,13 @@ class ReviewerFragment :
                         typeAnswerContainer.isVisible = false
                         return@collect
                     }
+
+                    if (Prefs.isHtmlTypeAnswerEnabled) {
+                        webView.requestFocus()
+                        webView.evaluateJavascript("document.getElementById('typeans').focus();", null)
+                        return@collect
+                    }
+
                     typeAnswerContainer.isVisible = true
                     typeAnswerEditText.apply {
                         if (imeHintLocales != typeInAnswer.imeHintLocales) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

Auto focus didn't work with HTML type in answer in the new study screen

## How Has This Been Tested?

[Screen_recording_20250909_185158.webm](https://github.com/user-attachments/assets/aef26d3d-fc15-4c06-8f83-847dc0d51c28)

## Learning (optional, can help others)

didn't thought before to focus on the webview

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->