### PR TITLE
Use the backend string for the title of the card info page

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/PagesTest.kt
@@ -88,13 +88,13 @@ fun PagesTest.getStatistics(context: Context): Intent = Statistics.getIntent(con
 fun PagesTest.getCardInfo(context: Context): Intent =
     addNoteUsingBasicNoteType().firstCard(col).let { card ->
         this.card = card
-        CardInfoDestination(card.id).toIntent(context)
+        CardInfoDestination(card.id, "Unused").toIntent(context)
     }
 
 fun PagesTest.getCongratsPage(context: Context): Intent =
     addNoteUsingBasicNoteType().firstCard(col).let { card ->
         this.card = card
-        CardInfoDestination(card.id).toIntent(context)
+        CardInfoDestination(card.id, "Unused").toIntent(context)
     }
 
 fun PagesTest.getDeckOptions(context: Context): Intent =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -796,7 +796,7 @@ open class Reviewer :
             return
         }
         Timber.i("opening card info")
-        val intent = CardInfoDestination(currentCard!!.id).toIntent(this)
+        val intent = CardInfoDestination(currentCard!!.id, TR.cardStatsCurrentCard(TR.decksStudy())).toIntent(this)
         val animation = getAnimationTransitionFromGesture(fromGesture)
         intent.putExtra(FINISH_ANIMATION_EXTRA, getInverseTransition(animation) as Parcelable)
         startActivityWithAnimation(intent, animation)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -322,7 +322,7 @@ class CardBrowserViewModel(
 
     suspend fun queryCardInfoDestination(): CardInfoDestination? {
         val firstSelectedCard = selectedRows.firstOrNull()?.toCardId(cardsOrNotes) ?: return null
-        return CardInfoDestination(firstSelectedCard)
+        return CardInfoDestination(firstSelectedCard, TR.cardStatsCurrentCard(TR.qtMiscBrowse()))
     }
 
     suspend fun queryDataForCardEdit(id: CardOrNoteId): CardId = id.toCardId(cardsOrNotes)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -17,15 +17,12 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
-import com.ichi2.anki.R
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.utils.Destination
 
 data class CardInfoDestination(
     val cardId: CardId,
+    val title: String,
 ) : Destination {
-    override fun toIntent(context: Context): Intent {
-        val title = context.getString(R.string.card_info_title)
-        return PageFragment.getIntent(context, "card-info/$cardId", title)
-    }
+    override fun toIntent(context: Context): Intent = PageFragment.getIntent(context, "card-info/$cardId", title)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CardInfoDestination.kt
@@ -17,12 +17,28 @@ package com.ichi2.anki.pages
 
 import android.content.Context
 import android.content.Intent
+import com.ichi2.anki.R
 import com.ichi2.anki.libanki.CardId
+import com.ichi2.anki.libanki.withoutUnicodeIsolation
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.Destination
 
 data class CardInfoDestination(
     val cardId: CardId,
     val title: String,
 ) : Destination {
-    override fun toIntent(context: Context): Intent = PageFragment.getIntent(context, "card-info/$cardId", title)
+    override fun toIntent(context: Context): Intent {
+        // title contains FSI and PDI character types
+        val simplifiedTitle = withoutUnicodeIsolation(title)
+        val sentenceStrings =
+            listOf(
+                simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_study),
+                simplifiedTitle.toSentenceCase(context, R.string.sentence_card_stats_current_card_browse),
+            )
+        return PageFragment.getIntent(
+            context,
+            "card-info/$cardId",
+            sentenceStrings.firstOrNull { it != simplifiedTitle } ?: title,
+        )
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -245,7 +245,7 @@ class ReviewerViewModel :
 
     private suspend fun emitCardInfoDestination() {
         val cardId = currentCard.await().id
-        val destination = CardInfoDestination(cardId)
+        val destination = CardInfoDestination(cardId, TR.cardStatsCurrentCard(TR.decksStudy()))
         Timber.i("Launching 'card info' for card %d", cardId)
         destinationFlow.emit(destination)
     }

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -52,4 +52,6 @@ undoActionUndone()
     <string name="sentence_empty_trash">Empty trash</string>
     <string name="sentence_restore_deleted">Restore deleted</string>
     <string name="sentence_grade_now">Grade now</string>
+    <string name="sentence_card_stats_current_card_study">Current card (study)</string>
+    <string name="sentence_card_stats_current_card_browse">Current card (browse)</string>
 </resources>


### PR DESCRIPTION
## Purpose / Description

Switch to use the backend string for the card info page which offers the user some context about the caller(currently study/browse). The second commit adds sentence case support for the string.

This will also be useful for the previous card info functionality.

## How Has This Been Tested?

Checked the title in the card info page in english and other languages. Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
