### PR TITLE
Show the number of cards added in NoteEditorFragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1232,13 +1232,15 @@ class NoteEditorFragment :
     // ----------------------------------------------------------------------------
 
     @KotlinCleanup("return early and simplify if possible")
-    private fun onNoteAdded() {
+    private fun onNoteAdded(count: Int) {
         var closeEditorAfterSave = false
         var closeIntent: Intent? = null
         changed = true
         sourceText = null
         refreshNoteData(FieldChangeType.refreshWithStickyFields(shouldReplaceNewlines()))
-        showSnackbar(TR.addingAdded(), Snackbar.LENGTH_SHORT)
+        // backend text ends with dot
+        val successMessage = TR.importingCardsAdded(count).replace(".", "")
+        showSnackbar(successMessage, Snackbar.LENGTH_SHORT)
 
         if (caller == NoteEditorCaller.NOTEEDITOR || aedictIntent) {
             closeEditorAfterSave = true
@@ -1263,14 +1265,15 @@ class NoteEditorFragment :
 
     private suspend fun saveNoteWithProgress() {
         // adding current note to collection
-        requireActivity().withProgress(resources.getString(R.string.saving_facts)) {
-            undoableOp {
-                notetypes.save(editorNote!!.notetype)
-                addNote(editorNote!!, deckId)
+        val changes =
+            requireActivity().withProgress(resources.getString(R.string.saving_facts)) {
+                undoableOp {
+                    notetypes.save(editorNote!!.notetype)
+                    addNote(editorNote!!, deckId)
+                }
             }
-        }
         // update UI based on the result, noOfAddedCards
-        onNoteAdded()
+        onNoteAdded(changes.count)
         updateFieldsFromStickyText()
     }
 


### PR DESCRIPTION
## Purpose / Description

From #19194, Anki 25.09 changed addNote() to also return the number of cards so we can now show this to the user.

Before/After:

<img width="270" height="600" alt="Screenshot_20250913_085025" src="https://github.com/user-attachments/assets/fa191fe5-2e57-4d98-99a5-45e63d1a3132" /><img width="270" height="600" alt="Screenshot_20250912_171152" src="https://github.com/user-attachments/assets/4838f6d9-16e5-47f8-a6d3-338c33cbd6f4" />


## How Has This Been Tested?

Checked adding different number of cards when saving in NoteEditorFragment.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
