### PR TITLE
feat(reminders): add multiprofile ID to ReviewReminder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -169,6 +169,8 @@ sealed class ReviewReminderScope : Parcelable {
  * @param cardTriggerThreshold See [ReviewReminderCardTriggerThreshold].
  * @param scope See [ReviewReminderScope].
  * @param enabled Whether the review reminder's notifications are active or disabled.
+ * @param profileID ID representing the profile which created this review reminder, as review reminders for
+ * multiple profiles might be active simultaneously.
  */
 @Serializable
 @Parcelize
@@ -179,6 +181,7 @@ data class ReviewReminder private constructor(
     val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
     val scope: ReviewReminderScope,
     var enabled: Boolean,
+    val profileID: String,
 ) : Parcelable,
     ReviewReminderSchema {
     companion object {
@@ -192,12 +195,14 @@ data class ReviewReminder private constructor(
             cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
             scope: ReviewReminderScope = ReviewReminderScope.Global,
             enabled: Boolean = true,
+            profileID: String = "",
         ) = ReviewReminder(
             id = ReviewReminderId.getAndIncrementNextFreeReminderId(),
             time,
             cardTriggerThreshold,
             scope,
             enabled,
+            profileID,
         )
     }
 


### PR DESCRIPTION
## Purpose / Description
As discussed on Discord, once the upcoming multiprofile system is implemented, we will need to fire review reminder notifications for all profiles, not just the active one. Currently however, once a notification is scheduled by AlarmManagerService and passed to the OS, there is no indication of which profile it is attached to as ReviewReminder does not include profile information. This is a problem because once the notification fires, it will need to open the corresponding collection to check if there are cards due. Without storing some sort of profile ID in ReviewReminder, the notification code will need to open each profile's collection one after the other to find the deck it is looking for.

This small change rectifies this issue by adding a profileID string field to ReviewReminder. The field is a string because most discussion around the profile ID in Discord and in candidate GSoC proposals revolves around using either a UUID or a string name. In the case of a UUID, we cannot use the built-in Java UUID type because it is not Serializable. Hence, it will need to be converted to a string before it is stored in ReviewReminder. In both cases, a string is sufficient.

See https://github.com/ankidroid/Anki-Android/pull/19065 and Discord (_#multiprofile_) for more context.

## Fixes
* GSoC 2025: Review Reminders

## How Has This Been Tested?
- Runs with the AddEdit code fine on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->