### PR TITLE
Fix shared text quoting and link cleanup in Instant Card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -186,7 +186,30 @@ class InstantNoteEditorActivity :
     }
 
     /** Gets the shared text received through an Intent. **/
-    private fun getSharedIntentText(receivedIntent: Intent): String? = receivedIntent.getStringExtra(Intent.EXTRA_TEXT)
+    private fun getSharedIntentText(receivedIntent: Intent): String? {
+        val rawText = receivedIntent.getStringExtra(Intent.EXTRA_TEXT) ?: return null
+        val cleaned = cleanSharedText(rawText)
+        return cleaned
+    }
+
+    private fun cleanSharedText(text: String): String {
+        var cleanedText = text
+        // Remove surrounding quotes if present
+        cleanedText = cleanedText.trim()
+        if (cleanedText.startsWith("\"") && cleanedText.contains("\" http")) {
+            // Extract text between quotes, stopping at the quote before the URL
+            val quoteEndIndex = cleanedText.indexOf("\" http")
+            if (quoteEndIndex > 0) {
+                cleanedText = cleanedText.substring(1, quoteEndIndex)
+            }
+        }
+
+        cleanedText = cleanedText.replace(Regex("\\s+https?://[^\\s]*#:~:text=[^\\s]*"), "")
+
+        cleanedText = cleanedText.trim('"')
+
+        return cleanedText.trim()
+    }
 
     private fun openNoteEditor() {
         val sharedText = clozeEditTextField.text.toString()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->

## Purpose / Description
Shared text from certain apps (e.g. Wikipedia) was being inserted into Instant Card with surrounding quotes and appended raw links (e.g. `#:~:text=...` fragments).  
This spoiled answers and created a poor user experience.  

## Fixes
* Fixes #19223

## Approach
- Remove surrounding quotes from shared text  
- Handle `"… " http…` format by extracting only the quoted content  
- Strip `#:~:text=` fragments and reference links  
- Clean up stray quotes and whitespace  

## Recording Attached

https://github.com/user-attachments/assets/d1227e39-0887-4421-beb2-487bec4d87a2



## Testing
- Verified on Android 14 (physical device, SM-M33)  
- Tested sharing text from Wikipedia and other apps  
- Confirmed that quotes and appended links are removed, leaving only clean text  
