### PR TITLE
Feature 1617

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -309,7 +309,7 @@ class ReviewerFragment :
                 addTextChangedListener { editable ->
                     viewModel.typedAnswer = editable?.toString() ?: ""
 
-                    // Check if input is numeric and contains a decimal separator
+                    // Check if ',' needs to be replaced with '.' or vice versa
                     val inputTypeNumber =
                         InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or InputType.TYPE_NUMBER_FLAG_SIGNED
                     val expectedAnswer = viewModel.typeAnswerFlow.value?.expectedAnswer

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Bundle
+import android.text.InputType
 import android.text.SpannableString
 import android.text.style.UnderlineSpan
 import android.view.KeyEvent
@@ -41,6 +42,7 @@ import androidx.constraintlayout.widget.ConstraintSet
 import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import androidx.core.text.HtmlCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -306,6 +308,18 @@ class ReviewerFragment :
                 }
                 addTextChangedListener { editable ->
                     viewModel.typedAnswer = editable?.toString() ?: ""
+
+                    // Check if input is numeric and contains a decimal separator
+                    val inputTypeNumber =
+                        InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or InputType.TYPE_NUMBER_FLAG_SIGNED
+                    val expectedAnswer = viewModel.typeAnswerFlow.value?.expectedAnswer
+
+                    if (inputType == inputTypeNumber) {
+                        when {
+                            expectedAnswer?.contains(',') == true -> viewModel.typedAnswer = viewModel.typedAnswer.replace('.', ',')
+                            expectedAnswer?.contains('.') == true -> viewModel.typedAnswer = viewModel.typedAnswer.replace(',', '.')
+                        }
+                    }
                 }
             }
 
@@ -326,6 +340,14 @@ class ReviewerFragment :
 
                     typeAnswerContainer.isVisible = true
                     typeAnswerEditText.apply {
+                        // bring up numeric keyboard, if answer is a number
+                        inputType =
+                            if (stripHtml(typeInAnswer.expectedAnswer).matches(Regex("^-?\\d+([.,]\\d*)?$"))) {
+                                InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or InputType.TYPE_NUMBER_FLAG_SIGNED
+                            } else {
+                                InputType.TYPE_CLASS_TEXT
+                            }
+
                         if (imeHintLocales != typeInAnswer.imeHintLocales) {
                             imeHintLocales = typeInAnswer.imeHintLocales
                             context?.getSystemService<InputMethodManager>()?.restartInput(this)
@@ -341,6 +363,9 @@ class ReviewerFragment :
             typeAnswerEditText.text = null
         }
     }
+
+    /** Removes HTML tags from a string */
+    fun stripHtml(html: String): String = HtmlCompat.fromHtml(html, HtmlCompat.FROM_HTML_MODE_LEGACY).toString()
 
     private fun resetZoom() {
         webView.settings.loadWithOverviewMode = false


### PR DESCRIPTION
## Purpose / Description
bring up numeric keyboard if "type answer" is enabled and the expected answer is a number

## Fixes
* Fixes #1617

## Approach
Check if the expected answer is a number; if it is, show the numeric keyboard; otherwise, show the regular text keyboard.

## How Has This Been Tested?
Tested on physical devices:
Samsung S21
Samsung A54

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
 
Before:
![Before](https://github.com/user-attachments/assets/52290dbc-abfc-4f6d-929c-a0bf2851b1ff)

After:
![After](https://github.com/user-attachments/assets/a8a02a6e-f5fe-43f4-8fd0-6cc37f55b8ec)

