### PR TITLE
chore: hide 'Enable gestures' if new study screen is enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -131,7 +131,11 @@ class ControlsSettingsFragment :
     ): String = this.toSentenceCase(this@ControlsSettingsFragment, resId)
 
     private fun setupNewStudyScreenSettings() {
-        if (!Prefs.isNewStudyScreenEnabled) return
+        if (!Prefs.isNewStudyScreenEnabled) {
+            findPreference<Preference>(R.string.gestures_corner_touch_preference)?.dependency = getString(R.string.gestures_preference)
+            findPreference<Preference>(R.string.pref_swipe_sensitivity_key)?.dependency = getString(R.string.gestures_preference)
+            return
+        }
         for (keyRes in legacyStudyScreenSettings) {
             val key = getString(keyRes)
             findPreference<Preference>(key)?.isVisible = false
@@ -159,6 +163,7 @@ class ControlsSettingsFragment :
                 R.string.toggle_eraser_command_key,
                 R.string.clear_whiteboard_command_key,
                 R.string.change_whiteboard_pen_color_command_key,
+                R.string.gestures_preference,
             )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/PreferenceUtils.kt
@@ -78,6 +78,13 @@ inline fun <reified T : Preference> PreferenceFragmentCompat.requirePreference(
     return requirePreference(key)
 }
 
+inline fun <reified T : Preference> PreferenceFragmentCompat.findPreference(
+    @StringRes resId: Int,
+): T? {
+    val key = getString(resId)
+    return findPreference(key)
+}
+
 /** shorthand method to get the default [SharedPreferences] instance */
 fun Context.sharedPrefs(): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(this)
 

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.reviewer.Binding
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.anki.reviewer.ReviewerBinding
+import com.ichi2.anki.settings.Prefs
 
 class ReviewerControlPreference : ControlPreference {
     @Suppress("unused")
@@ -47,7 +48,7 @@ class ReviewerControlPreference : ControlPreference {
     private val viewerAction get() = ViewerAction.fromPreferenceKey(key)
 
     override val areGesturesEnabled: Boolean
-        get() = sharedPreferences?.getBoolean(GestureProcessor.PREF_KEY, false) ?: false
+        get() = Prefs.isNewStudyScreenEnabled || sharedPreferences?.getBoolean(GestureProcessor.PREF_KEY, false) ?: false
 
     override fun getMappableBindings(): List<ReviewerBinding> = ReviewerBinding.fromPreferenceString(value).toList()
 

--- a/AnkiDroid/src/main/res/xml/preferences_controls.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_controls.xml
@@ -29,13 +29,11 @@
         android:title="@string/gestures" />
     <SwitchPreferenceCompat
         android:defaultValue="false"
-        android:dependency="@string/gestures_preference"
         android:key="@string/gestures_corner_touch_preference"
         android:summary="@string/gestures_corner_touch_summary"
         android:title="@string/gestures_corner_touch" />
     <com.ichi2.preferences.SliderPreference
         android:key="@string/pref_swipe_sensitivity_key"
-        android:dependency="@string/gestures_preference"
         android:title="@string/swipe_sensitivity"
         android:defaultValue="100"
         android:valueFrom="20"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

In the old study screen, the setting is useful if a note type has interactable elements that collide with gestures.

Since the new study screen solves that issue, its usefulness is almost non existent.

## Fixes
* Fixes #19250

## How Has This Been Tested?

Emulator 34

[Screen_recording_20250920_161403.webm](https://github.com/user-attachments/assets/302b3c04-3886-42d0-807a-f27de7901c4a)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->