### PR TITLE
feat: select an arbitrary deck when sharing an image to Image Occlusion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2383,6 +2383,8 @@ class NoteEditorFragment :
         note: Note?,
         changeType: FieldChangeType,
     ) {
+        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
+        requireView().findViewById<View>(R.id.note_deck_spinner).isVisible = !currentNotetypeIsImageOcclusion()
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages.viewmodel
+
+import android.os.Parcelable
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.pages.ImageOcclusion
+import kotlinx.coroutines.launch
+import kotlinx.parcelize.Parcelize
+import org.json.JSONObject
+
+@Parcelize
+data class ImageOcclusionArgs(
+    val kind: String,
+    val id: Long,
+    val imagePath: String?,
+    val editorDeckId: Long,
+) : Parcelable
+
+/**
+ * ViewModel for the Image Occlusion fragment.
+ */
+class ImageOcclusionViewModel(
+    savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    var selectedDeckId: Long
+
+    /**
+     * The ID of the deck that was originally selected when the editor was opened.
+     * This is used to restore the deck after saving a note to prevent unexpected deck changes.
+     */
+    val oldDeckId: Long
+
+    /**
+     * A [JSONObject] containing options for initializing the WebView. This includes
+     * the type of operation ("add" or "edit"), and relevant IDs and paths.
+     */
+    val webViewOptions: JSONObject
+
+    init {
+        val args: ImageOcclusionArgs = checkNotNull(savedStateHandle[ImageOcclusion.IO_ARGS_KEY])
+
+        selectedDeckId = args.editorDeckId
+        oldDeckId = args.editorDeckId
+
+        webViewOptions =
+            JSONObject().apply {
+                put("kind", args.kind)
+                if (args.kind == "add") {
+                    put("imagePath", args.imagePath)
+                    put("notetypeId", args.id)
+                } else {
+                    put("noteId", args.id)
+                }
+            }
+    }
+
+    /**
+     * Handles the selection of a new deck.
+     *
+     * @param deckId The [DeckId] object representing the selected deck. Can be null if no deck is selected.
+     */
+    fun handleDeckSelection(deckId: DeckId): Boolean {
+        if (deckId == selectedDeckId) return false
+        selectedDeckId = deckId
+        return true
+    }
+
+    fun onSaveOperationCompleted() {
+        if (oldDeckId == selectedDeckId) return
+        viewModelScope.launch {
+            CollectionManager.withCol { backend.setCurrentDeck(oldDeckId) }
+        }
+    }
+}

--- a/AnkiDroid/src/main/res/layout/image_occlusion.xml
+++ b/AnkiDroid/src/main/res/layout/image_occlusion.xml
@@ -35,8 +35,15 @@
             android:layout_height="wrap_content"
             app:navigationContentDescription="@string/abc_action_bar_up_description"
             app:navigationIcon="?attr/homeAsUpIndicator"
-            app:menu="@menu/image_occlusion"/>
+            app:menu="@menu/image_occlusion">
 
+                <Spinner
+                    android:id="@+id/deck_selector"
+                    android:layout_gravity="center_vertical"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:dropDownWidth="wrap_content"/>
+        </com.google.android.material.appbar.MaterialToolbar>
     </com.google.android.material.appbar.AppBarLayout>
 
     <WebView


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Allow the user to change deck while in IO screen anki also allows the user to change the decks i.e. where the note is being saved but in collection it stays unchanged

## Fixes
* Fixes  #15612
* Fixes #18891

## Approach
Used a viewmodel to save old deck id and allow the user to change deck from the spinner at the top and then later revert back to original deck once the note is saved

## How Has This Been Tested?
Google Pixel 9 API 31

[Screen_recording_20250922_015908.webm](https://github.com/user-attachments/assets/1dde9f50-3ed6-4d61-9a70-22a885a7c79c)



## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->