### PR TITLE
fix: reload media tags when note is edited in new study screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -723,6 +723,7 @@ class ReviewerViewModel :
                 changes.noteText -> {
                     val card = currentCard.await()
                     withCol { card.load(this) }
+                    cardMediaPlayer.loadCardAvTags(card)
                     updateMarkIcon()
                     if (showingAnswer.value) {
                         showAnswer()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes replay media functionality in the new study screen to correctly update after editing a note.
When using the new study screen, after editing a note (adding/removing audio files), the "Replay media" action would play outdated audio instead of the current note content. The displayed card updated correctly showing new audio buttons, but the replay media functionality used stale cached data.
The `CardMediaPlayer` caches audio/video tags (`AvTag`) when a card is loaded. When a note is edited, the visual content gets refreshed via `showQuestion()`/`showAnswer()`, but the media player's cached tags were not reloaded, causing replay media to use outdated content.

## Fixes
* Fixes #19262

## Approach
Added `cardMediaPlayer.loadCardAvTags(card)` to the `opExecuted()` method when `changes.noteText` is detected. This ensures both the visual display and media player are synchronized with updated note content.

## How Has This Been Tested?

Physical Device (Realme 9 Pro 5G)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->