### PR TITLE
fix: respect 24h time display preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -16,18 +16,18 @@
 
 package com.ichi2.anki.reviewreminders
 
+import android.content.Context
 import android.os.Parcelable
+import android.text.format.DateFormat
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.settings.Prefs
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
 import timber.log.Timber
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
-import java.time.format.FormatStyle
-import java.util.Locale
+import java.util.Calendar
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
@@ -66,14 +66,17 @@ data class ReviewReminderTime(
         require(minute in 0..59) { "Minute must be between 0 and 59" }
     }
 
-    override fun toString(): String =
-        LocalTime
-            .of(hour, minute)
-            .format(
-                DateTimeFormatter
-                    .ofLocalizedTime(FormatStyle.SHORT)
-                    .withLocale(Locale.getDefault()),
-            )
+    /**
+     * Formats the time as a string in the user's locale and 12/24-hour preference.
+     */
+    fun toFormattedString(context: Context): String {
+        val calendarInstance =
+            TimeManager.time.calendar().apply {
+                set(Calendar.HOUR_OF_DAY, hour)
+                set(Calendar.MINUTE, minute)
+            }
+        return DateFormat.getTimeFormat(context).format(calendarInstance.time)
+    }
 
     fun toSecondsFromMidnight(): Long = (hour.hours + minute.minutes).inWholeSeconds
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleRemindersAdapter.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.reviewreminders
 
 import android.annotation.SuppressLint
+import android.content.Context
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -36,6 +37,7 @@ class ScheduleRemindersAdapter(
         holder: View,
     ) : RecyclerView.ViewHolder(holder) {
         var reminder: ReviewReminder? = null
+        val context: Context = holder.context
         val deckTextView: TextView = holder.findViewById(R.id.reminders_list_deck_text)
         val timeTextView: TextView = holder.findViewById(R.id.reminders_list_time_text)
         val switchView: MaterialSwitch = holder.findViewById(R.id.reminders_list_switch)
@@ -61,7 +63,7 @@ class ScheduleRemindersAdapter(
         holder.reminder = reminder
 
         setDeckNameFromScopeForView(reminder.scope, holder.deckTextView)
-        holder.timeTextView.text = reminder.time.toString()
+        holder.timeTextView.text = reminder.time.toFormattedString(holder.context)
 
         holder.itemView.setOnClickListener { editReminder(reminder) }
 


### PR DESCRIPTION
## Purpose / Description
Fixed an issue where the time displayed for ReviewReminders did not respect the OS setting for whether to use 12h or 24h time.

## Fixes
GSoC 2025: Review Reminders

## Approach
Accomplished by simply utilizing a Context.

## How Has This Been Tested?
Builds and runs on a physical Samsung S23, API 34. Switching languages, changing the 12h/24h setting works, etc.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->