### PR TITLE
fix: stop FAB from covering review reminders

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
@@ -29,6 +29,7 @@
             android:overScrollFooter="@color/transparent"
             android:clipToPadding="false"
             android:drawSelectorOnTop="true"
+            android:paddingBottom="84dp"
             android:scrollbars="vertical"
             android:contentDescription="List of scheduled review reminders"
             tools:listitem="@layout/schedule_reminders_list_item"


### PR DESCRIPTION
## Purpose / Description
Adds padding to the bottom of the ScheduleReminders RecyclerView to stop the "Add reminder" FAB from covering a review reminder. Otherwise, the user will sometimes be unable to toggle whether their latest review reminder is enabled or not.

<img width="635" height="1170" alt="image" src="https://github.com/user-attachments/assets/8e29ad02-7f1e-4cd3-bf02-b50734947928" />

## Fixes
GSoC 2025: Review Reminders

## How Has This Been Tested?
Builds and runs on a physical Samsung S23, API 34. Switching languages, changing the 12h/24h setting works, etc.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->