### PR TITLE
Hide unrelated note editor content for image occlusion notetypes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2647,6 +2647,9 @@ class NoteEditorFragment :
                     .trim()
                     .replace(" ", ", "),
             )
+        // showing the tags is not needed for image occlusion notetypes as they are handled by the
+        // backend page
+        tagsButton?.isVisible = !currentNotetypeIsImageOcclusion()
     }
 
     /** Update the list of card templates for current note type  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1789,6 +1789,9 @@ class NoteEditorFragment :
         editNoteTypeMode: Boolean,
     ) {
         val editLines = fieldState.loadFieldEditLines(type)
+        // showing the fields is not needed for image occlusion notetypes as they are handled by the
+        // backend page
+        fieldsLayoutContainer?.isVisible = !currentNotetypeIsImageOcclusion()
         fieldsLayoutContainer!!.removeAllViews()
         customViewIds.clear()
         imageOcclusionButtonsContainer?.isVisible = currentNotetypeIsImageOcclusion()


### PR DESCRIPTION
## Purpose / Description

Hides the fields and tags button in NoteEditorFragment when the notetype is set to image occlusion. The desktop app doesn't show the fields for this type of notetype and the backend page handles the tags.

## Fixes
* Fixes #16083 (this PR fixes the main issue but #19259 also fixes a part(I'll leave a note there or make the PR myself))

## How Has This Been Tested?

Ran the tests, checked the behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
