### PR TITLE
refactor: clear empty review reminder maps

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -265,7 +265,8 @@ object ReviewRemindersDatabase {
             .associateTo(hashMapOf()) { it.toPair() }
 
     /**
-     * Edit the [ReviewReminder]s for a specific key.
+     * Edit the [ReviewReminder]s for a specific key. Deletes the review reminders map for this key if, after the editing operation,
+     * no review reminders remain.
      * @param key
      * @param reminderEditor A lambda that takes the current map and returns the updated map.
      * @throws SerializationException If the current reminders map has not been stored in SharedPreferences as a valid JSON string.
@@ -278,7 +279,11 @@ object ReviewRemindersDatabase {
         val existingReminders = getRemindersForKey(key)
         val updatedReminders = reminderEditor(existingReminders)
         remindersSharedPrefs.edit {
-            putString(key, encodeJson(updatedReminders))
+            if (updatedReminders.isEmpty()) {
+                remove(key)
+            } else {
+                putString(key, encodeJson(updatedReminders))
+            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -29,6 +29,8 @@ import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.anEmptyMap
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
 import org.hamcrest.TypeSafeMatcher
 import org.junit.After
 import org.junit.Before
@@ -306,6 +308,30 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
             putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, Json.encodeToString(corruptedStoredReviewReminder))
         }
         ReviewRemindersDatabase.getAllDeckSpecificReminders()
+    }
+
+    @Test
+    fun `editRemindersForDeck should delete SharedPreferences key if no reminders are returned`() {
+        ReviewRemindersDatabase.editRemindersForDeck(did1) { dummyDeckSpecificRemindersForDeckOne }
+        ReviewRemindersDatabase.editRemindersForDeck(did1) { emptyMap() }
+        val attemptedRetrieval = ReviewRemindersDatabase.getRemindersForDeck(did1)
+        assertThat(attemptedRetrieval, anEmptyMap())
+        assertThat(
+            ReviewRemindersDatabase.remindersSharedPrefs.all.keys,
+            not(hasItem(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1)),
+        )
+    }
+
+    @Test
+    fun `editAllAppWideReminders should delete SharedPreferences key if no reminders are returned`() {
+        ReviewRemindersDatabase.editAllAppWideReminders { dummyAppWideReminders }
+        ReviewRemindersDatabase.editAllAppWideReminders { emptyMap() }
+        val attemptedRetrieval = ReviewRemindersDatabase.getAllAppWideReminders()
+        assertThat(attemptedRetrieval, anEmptyMap())
+        assertThat(
+            ReviewRemindersDatabase.remindersSharedPrefs.all.keys,
+            not(hasItem(ReviewRemindersDatabase.APP_WIDE_KEY)),
+        )
     }
 
     /**


### PR DESCRIPTION
## Purpose / Description
Currently, if a deck with review reminders has all its review reminders deleted, the code will leave a blank entry in the review reminders SharedPrefs file. However, it's safe to completely delete the SharedPrefs entry. This change implements this, and also adds tests.

## Fixes
GSoC 2025: Review Reminders

## How Has This Been Tested?
- Tests pass.
- Builds and runs on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->