### PR TITLE
feat(reminders): canUserAccessDeck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckUtils.kt
@@ -47,6 +47,17 @@ private fun Collection.isDeckEmpty(
 suspend fun isDefaultDeckEmpty(): Boolean = withCol { isDeckEmpty(Consts.DEFAULT_DECK_ID) }
 
 /**
+ * Checks if the deck with the specified ID is accessible to the user. For most decks, a deck is viewable
+ * and editable by the user simply if it exists. However, the default deck (ID=1) is always present in the collection
+ * but is hidden from the user when it is empty. Therefore, for the default deck, we check if it is empty.
+ */
+suspend fun canUserAccessDeck(did: DeckId): Boolean =
+    when (did) {
+        Consts.DEFAULT_DECK_ID -> !isDefaultDeckEmpty()
+        else -> withCol { decks.have(did) }
+    }
+
+/**
  * Returns whether the deck picker displays any deck.
  * Technically, it means that there is a non-default deck, or that the default deck is non-empty.
  *

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Decks.kt
@@ -172,7 +172,6 @@ class Decks(
             null
         }
 
-    @Suppress("unused")
     fun have(id: DeckId): Boolean = getLegacy(id) != null
 
     @RustCleanup("implement and make public")


### PR DESCRIPTION
## Purpose / Description
Adds a helper method in DeckUtils to check if the user can access a deck. This block of code is used by a lot of my code which handles deck deletion, so I've decided to pull it out into a separate utility function.

## Fixes
GSoC 2025: Review Reminders

## How Has This Been Tested?
- Builds and runs on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->