### PR TITLE
style: decrease ScheduleReminders font size

### DIFF
--- a/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
@@ -25,7 +25,7 @@
             android:id="@+id/reminders_list_time_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="32sp"
+            android:textSize="28sp"
             android:textStyle="bold"
             tools:text="12:00 a.m." />
 


### PR DESCRIPTION
## Purpose / Description
Minor change. Per a poll on Discord, we've decided to lower the font size of the ScheduleReminders time TextView from 32sp to 28sp. Perhaps we'll revise it again before review reminders go public.

<img width="395" height="839" alt="image" src="https://github.com/user-attachments/assets/6265490b-87fa-4544-9143-e238674e961f" />

## Fixes
GSoC 2025: Review Reminders

## How Has This Been Tested?
- Builds and runs on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->