### PR TITLE
feat(reminders): ensure valid deck selected during edits

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -51,6 +51,12 @@ class AddEditReminderDialogViewModel(
         )
     val time: LiveData<ReviewReminderTime> = _time
 
+    /**
+     * Here, we set an immediate default value for the deck selected based on the dialog mode.
+     * However, it is possible that the deck with this deck ID does not currently exist in the collection
+     * (ex. due to a deleted deck, changed collection folder, etc.). Since checking for this case requires
+     * accessing the collection, we handle it in [AddEditReminderDialog.ensureValidDeckSelected].
+     */
     private val _deckSelected =
         MutableLiveData(
             when (dialogMode) {


### PR DESCRIPTION
## Purpose / Description
Currently, if the user tries to edit a review reminder corresponding to a non-existent deck, the deck spinner will become bugged (it will display that a certain deck is selected, but after hitting save, the review reminder's deck does not change). This edit ensures the AddEditReminderDialog always has a valid deck selected. For example, this change means that if the user deletes a deck and goes to check their reminders, quickly clicking and saving the review reminder which is now no longer associated with a deck will cause the review reminder to be immediately reassigned to a valid deck.

## Fixes
GSoC 2025: Review Reminders

## Approach
If the default deck is present (has non-zero cards), we fall back to it (as the review reminder is deck-specific). If the default deck is not present, we fall back to the "All Decks" option, converting the review reminder to a global reminder.

## How Has This Been Tested?
- Runs and works on a physical Samsung S23, API 34.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->