### PR TITLE
fix: enforce alwaysShowDefault choice in deck spinner

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SelectableDeck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SelectableDeck.kt
@@ -72,12 +72,17 @@ sealed class SelectableDeck : Parcelable {
 
     companion object {
         /**
+         * @param skipEmptyDefault If true, will not include the default deck if it is empty;
+         * if false, will always include the default deck
          * @param includeFiltered Whether to include filtered decks in the output
          * @return all [SelectableDecks][SelectableDeck] in the collection satisfying the filter
          */
-        suspend fun fromCollection(includeFiltered: Boolean): List<Deck> =
+        suspend fun fromCollection(
+            skipEmptyDefault: Boolean = false,
+            includeFiltered: Boolean = true,
+        ): List<Deck> =
             CollectionManager
-                .withCol { decks.allNamesAndIds(includeFiltered = includeFiltered) }
+                .withCol { decks.allNamesAndIds(skipEmptyDefault = skipEmptyDefault, includeFiltered = includeFiltered) }
                 .map { nameAndId -> Deck(nameAndId) }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -188,7 +188,7 @@ class AddEditReminderDialog : DialogFragment() {
                 context = (activity as AppCompatActivity),
                 spinner = deckSpinner,
                 showAllDecks = true,
-                alwaysShowDefault = true,
+                alwaysShowDefault = false,
                 showFilteredDecks = true,
             )
         launchCatchingTask {


### PR DESCRIPTION
## Purpose and Approach
**Related to:**
- https://github.com/ankidroid/Anki-Android/issues/18875

`DeckSpinnerSelection` is very broken, as per issue #18875. While I don't have time to take on a full refactor and rewrite of the file right now, I've noticed some broken behaviour when the collection is empty. Basically, if the user has no decks and no cards and then opens a DeckSpinnerSelection selection menu to select a deck, then the Default deck will always be shown as an option, even though it is not visible in the DeckPicker.

For the NoteEditorFragment and InstantNoteEditorActivity, it makes sense to auto-select the Default deck, as it allows the user to instantly create cards once they install the app. However, it makes less sense for the CardBrowser (clicking into the CardBrowser without any decks or cards automatically selects the Default deck when it should really select "All Decks") and even less sense for the Statistics screen (Clicking into the Statistics screen without any decks or cards causes the deck dropdown at the top of the screen to have zero text visible, and clicking on the header shows the deck selection menu, with the Default deck visible - however, selecting that option doesn't fix the broken text at the top of the screen). The thing that pushed me over the edge to quickly write this fix is that this bug messes up AddEditReminderDialog, too. If the user has an empty collection and tries to create or edit a review reminder, the Default deck will be listed as a possible option, even though it's empty and invisible to the user.

The reason why this bug occurs is that the DeckSelectionDialog is launched via the `displayDeckSelectionDialog` in DeckSpinnerSelection, which retrieves decks via `fromCollection`. `fromCollection` is defined in `SelectableDeck` and is implemented via `decks.allNamesAndIds`. It *always* returns the Default deck due to its implementation defaulting to the default value of `skipEmptyDefault` when calling `decks.allNamesAndIds`, which is `false`.

Luckily, the solution to this problem is basically already sitting in DeckSpinnerSelection and just needs to be used. There's an unused `alwaysShowDefault` argument which classes like CardBrowser and Statistics set, but it doesn't actually do anything. **This change fixes `fromCollection` so that it can configure the `skipEmptyDefault` argument of `decks.allNamesAndIds` and then passes the negation of `alwaysShowDefault` wherever DeckSpinnerSelection needs to fetch a list of decks from the collection.**

I really don't like the names of these parameters: passing `!alwaysShowDefault` to `skipEmptyDefault` is difficult to read and understand. **Reviewers, if you'd like, I'm willing to rename `alwaysShowDefault` to `skipEmptyDefault` and flip the boolean argument at every location in the codebase where `alwaysShowDefault` is currently specified. I haven't done it yet for two reasons.** First, it will make this changeset a lot larger and harder to understand, and second, DeckSpinnerSelection is set for a rewrite soon anyways, so rationalizing the arguments of DeckSpinnerSelection is probably a job for whoever takes on that job instead (perhaps me in a few months if I have some free time, but no promises). In the meantime, though, I think this change I have here is a fair and quick interim solution for an aesthetic bug that may have high visibility for first-time users.

While I'm at it, general thoughts on the DeckSelectionDialog, which I might paste into #18875 later, too. Both `fromCollection` and `decks.allNamesAndIds` are used to retrieve the deck names from the collection, which is confusing. We should figure out a single unified method for checking if a deck should be displayed in the DeckSelectionDialog. If we want to use `SelectableDeck.fromCollection` for doing so, then this should be properly documented and all direct uses of `decks.allNamesAndIds` should be removed. Further, why is DeckSelectionDialog providing logic for filtering the list of decks it's provided even further (see [this line](https://github.com/ankidroid/Anki-Android/blob/main/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt#L408) in `DeckSelectionDialog`)? Either we should move all the logic for figuring out what decks to display to DeckSelectionDialog, or DeckSelectionDialog should be simplified so it immediately shows the decks it's provided without applying any further filtering logic. In short: the code for deciding which decks to display should be centralized. Once the classes are cleaned up, testing will need to be done to ensure this issue is solved in all possible use cases for DeckSpinnerSelection (Statistics, CardBrowser, etc.).

## How Has This Been Tested?
- With a full collection, all correct prior behaviour is still observed in CardBrowser, NoteEditorFragment, InstantNoteEditorActivity, Statistics, and AddEditReminderDialog. These are all the classes that instantiate a DeckSpinnerSelection.
- With an empty collection:
  - CardBrowser automatically selects All Decks instead of Default and does not show Default as an option anymore.
  - NoteEditorFragment still shows Default as the default option.
  - InstantNoteEditorActivity still shows Default as the default option.
  - Statistics still initially selects no option at all but now no longer allows the user to select Default (which existed before but was a no-op).
  - AddEditReminderDialog no longer provides the option to set a review reminder for a non-existent Default deck.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->