### PR TITLE
fix(new study screen): timer being reset

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -151,9 +151,6 @@ class ReviewerFragment :
     override fun onStart() {
         super.onStart()
         if (!requireActivity().isChangingConfigurations) {
-            if (viewModel.answerTimerStatusFlow.value is AnswerTimerStatus.Running) {
-                timer?.resume()
-            }
             shakeDetector?.start(sensorManager, SensorManager.SENSOR_DELAY_UI)
         }
     }
@@ -162,7 +159,6 @@ class ReviewerFragment :
         super.onStop()
         if (!requireActivity().isChangingConfigurations) {
             viewModel.stopAutoAdvance()
-            timer?.stop()
             shakeDetector?.stop()
         }
     }


### PR DESCRIPTION
there was no need to manually reset the timer on the lifecycle events

* Fixes #19307 

<!--- Please fill the necessary details below -->
## How Has This Been Tested?

Emulator 34

[Screen_recording_20251009_092054.webm](https://github.com/user-attachments/assets/cbf6ee39-2aae-4b1e-8bce-aad172ed8868)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->