### PR TITLE
fix: `<audio>` leaking after leaving the study screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -78,6 +78,11 @@ abstract class CardViewerFragment(
         }
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        webView.destroy() // stops <audio> playbacks
+    }
+
     protected open fun onLoadInitialHtml(): String =
         stdHtml(
             context = requireContext(),


### PR DESCRIPTION
the webview need to be manually destroyed for some reason ¯\_(ツ)_/¯

## Fixes
* Fixes #19300 (also affects the previewers)

## How Has This Been Tested?

Emulator 34

[Screen_recording_20251009_094843.webm](https://github.com/user-attachments/assets/b69efe67-b01f-4396-927f-92811968c9b6)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->