### PR TITLE
fix: padding in instant card dialog

### DIFF
--- a/AnkiDroid/src/main/res/layout/instant_editor_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/instant_editor_dialog.xml
@@ -118,8 +118,9 @@
 
                 <com.google.android.material.chip.ChipGroup
                     app:chipSpacingVertical="0dp"
-                    app:chipSpacingHorizontal="4dp"
+                    app:chipSpacingHorizontal="6dp"
                     android:id="@+id/cloze_text_chip_group"
+                    android:padding="4dp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"/>
             </LinearLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR fixes the behaviour where the badges were cut of in small screen i.e. 
<img width="356" height="634" alt="Screenshot 2025-10-09 at 9 29 46 PM" src="https://github.com/user-attachments/assets/e1d6de20-0804-48a6-a44d-dde5f1c2bb0d" />
 so adding padding and increasing the horizontal spacing resolves the issue

## Fixes
* Fixes #18812

## Approach
_How does this change address the problem?_

## How Has This Been Tested?
Small screen emulator API 24
<img width="341" height="564" alt="Screenshot 2025-10-09 at 9 41 28 PM" src="https://github.com/user-attachments/assets/839d2cc8-ed2d-4ba7-8bcb-4016cb335be5" />
<img width="343" height="571" alt="Screenshot 2025-10-09 at 9 42 14 PM" src="https://github.com/user-attachments/assets/f97da812-fea4-4c6f-ba42-6e61f25d4f0c" />


## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->