### PR TITLE
fix: pause media in CardViewerFragment on app background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -78,6 +78,22 @@ abstract class CardViewerFragment(
         }
     }
 
+    override fun onPause() {
+        super.onPause()
+        webView.onPause()
+        webView.pauseTimers()
+        webView.evaluateJavascript(
+            "(function(){document.querySelectorAll('audio,video').forEach(function(m){try{m.pause()}catch(e){}})})();",
+            null
+        )
+    }
+
+    override fun onResume() {
+        super.onResume()
+        webView.onResume()
+        webView.resumeTimers()
+    }
+
     protected open fun onLoadInitialHtml(): String =
         stdHtml(
             context = requireContext(),


### PR DESCRIPTION
Closes #19312
Description
This PR adds `onPause()` and `onResume()` overrides to `CardViewerFragment.kt` to properly pause and resume media playback (audio/video in WebView) when the app is sent to the background (e.g., pressing the home button). 

changes
  - In `onPause()`: Calls `webView.onPause()`, `webView.pauseTimers()`, and evaluates JavaScript to pause all `<audio>` and `<video>` elements.
  - In `onResume()`: Calls `webView.onResume()` and `webView.resumeTimers()` to resume playback and timers.

This prevents media from continuing to play indefinitely while the app is minimized, which was the core issue.
Related Issue
Closes #19311 (media does not stop when app is backgrounded in CardViewerFragment).

Testing
- Tested on [your device/OS version, e.g., Android 14 emulator/device].
- Steps: Open a card with audio/video, play it, background the app (home button), confirm media pauses. Foreground the app, confirm it resumes.
- No regressions observed in [briefly mention if you tested other areas, e.g., reviewer or previewer].

Additional Notes
- This applies to all subclasses of `CardViewerFragment` (e.g., `ReviewerFragment`).
- If similar issues exist in the legacy reviewer (`AbstractFlashcardViewer`), a separate fix may be needed.

Please review and merge if appropriate 
