### PR TITLE
Disable positive button in Custom Study dialog when value is zero

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -399,7 +399,8 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
 
         editText.doAfterTextChanged {
-            dialog.positiveButton.isEnabled = editText.textAsIntOrNull() != null
+            val num = editText.textAsIntOrNull()
+            dialog.positiveButton.isEnabled = num != null && num != 0
         }
 
         // Show soft keyboard


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
In Custom Study dialog box, inputting "0" virtually makes no sense.

The desktop version disables the downward spin button when input number is 1.
<img width="244" height="412" alt="image" src="https://github.com/user-attachments/assets/2f570eb5-8c30-4e01-a40a-e5bfc96d376e" /><img width="244" height="412" alt="image" src="https://github.com/user-attachments/assets/680dab9b-29dc-4add-b378-7cbac5b5d72e" />

 (Exceptions are the case of "Increase today's new card limit" and "Increase today's new card limit", but even then, "0" merely works as the transit point between "1" and "-1" for the spin buttons. "Increasing limit by zero cards" makes no sense here, too.)

Disabling zero will help reduce users' confusion, such as "In this option, which means today? 0? Or 1?".



## Approach
Disable the positive button in CustomStudyDialog.kt when input number is zero.

## How Has This Been Tested?
Checked on a physical device (Android 15)
<img width="280" height="2325" alt="image" src="https://github.com/user-attachments/assets/0d3fe8c1-baf0-4528-bdbb-28c52ef40180" /><img width="280" height="2316" alt="image" src="https://github.com/user-attachments/assets/90507ca8-8f3d-4293-bb4d-1336605d9748" />
<img width="280" height="2316" alt="image" src="https://github.com/user-attachments/assets/6158a4d5-9456-470a-a46b-220394828200" /><img width="280" height="2322" alt="image" src="https://github.com/user-attachments/assets/fd5b1511-6f4b-4c73-87c6-dbb9f63b09e5" />
<img width="280" height="2319" alt="image" src="https://github.com/user-attachments/assets/a89975e5-92ee-444a-8c95-6b519a68900a" /><img width="280" height="2319" alt="image" src="https://github.com/user-attachments/assets/06ee0573-0fab-4842-b8fd-d44300eed292" />



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->