### PR TITLE
Refactor deck selection code in add review reminders fragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckSpinnerSelection.kt
@@ -154,40 +154,6 @@ class DeckSpinnerSelection(
         }
     }
 
-    @MainThread // spinner.adapter
-    suspend fun initializeScheduleRemindersDeckSpinner() {
-        withCol {
-            decks.allNamesAndIds(includeFiltered = showFilteredDecks, skipEmptyDefault = true)
-        }.toMutableList().let { decks ->
-            dropDownDecks = decks
-            val deckNames = decks.map { it.name }.toMutableList()
-            if (showAllDecks) deckNames.add(0, context.getString(R.string.card_browser_all_decks))
-            val noteDeckAdapter: ArrayAdapter<String?> =
-                object :
-                    ArrayAdapter<String?>(context, R.layout.multiline_spinner_item, deckNames as List<String?>) {
-                    override fun getDropDownView(
-                        position: Int,
-                        convertView: View?,
-                        parent: ViewGroup,
-                    ): View {
-                        // Cast the drop down items (popup items) as text view
-                        val tv = super.getDropDownView(position, convertView, parent) as TextView
-
-                        // If this item is selected
-                        if (position == spinner.selectedItemPosition) {
-                            tv.setBackgroundColor(context.getColor(R.color.note_editor_selected_item_background))
-                            tv.setTextColor(context.getColor(R.color.note_editor_selected_item_text))
-                        }
-
-                        // Return the modified view
-                        return tv
-                    }
-                }
-            spinner.adapter = noteDeckAdapter
-            setSpinnerListener()
-        }
-    }
-
     /** @return All decks. */
     private fun computeDropDownDecks(
         col: Collection,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialog.kt
@@ -25,9 +25,8 @@ import android.view.View
 import android.widget.EditText
 import android.widget.ImageView
 import android.widget.LinearLayout
-import android.widget.Spinner
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
@@ -50,6 +49,7 @@ import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.startDeckSelection
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.utils.DisplayUtils.resizeWhenSoftInputShown
 import com.ichi2.utils.customView
@@ -131,7 +131,7 @@ class AddEditReminderDialog : DialogFragment() {
         Timber.d("Setting up fields")
         setUpToolbar()
         setUpTimeButton()
-        setUpDeckSpinner()
+        setInitialDeckSelection()
         setUpAdvancedDropdown()
         setUpCardThresholdInput()
 
@@ -152,6 +152,8 @@ class AddEditReminderDialog : DialogFragment() {
                     else -> Consts.DEFAULT_DECK_ID
                 }
             viewModel.setDeckSelected(selectedDeckId)
+            this.dialog?.findViewById<TextView>(R.id.add_edit_reminder_deck_name)?.text =
+                selectedDeck?.getDisplayName(requireContext())
         }
 
         dialog.window?.let { resizeWhenSoftInputShown(it) }
@@ -181,46 +183,47 @@ class AddEditReminderDialog : DialogFragment() {
         }
     }
 
-    private fun setUpDeckSpinner() {
-        val deckSpinner = contentView.findViewById<Spinner>(R.id.add_edit_reminder_deck_spinner)
-        val deckSpinnerSelection =
-            DeckSpinnerSelection(
-                context = (activity as AppCompatActivity),
-                spinner = deckSpinner,
-                showAllDecks = true,
-                alwaysShowDefault = true,
-                showFilteredDecks = true,
-            )
+    private fun setInitialDeckSelection() {
+        val deckName = contentView.findViewById<TextView>(R.id.add_edit_reminder_deck_name)
+        deckName.setOnClickListener { startDeckSelection(all = true, filtered = true) }
         launchCatchingTask {
-            Timber.d("Setting up deck spinner")
-            deckSpinnerSelection.initializeScheduleRemindersDeckSpinner()
-            val deckToSelect = ensureValidDeckSelected()
-            deckSpinnerSelection.selectDeckById(deckToSelect, setAsCurrentDeck = false)
+            Timber.d("Setting up deck name view")
+            val (selectedDeckId, selectedDeckName) = getValidDeckSelection()
+            Timber.d("Initial selection of deck %s(id=%d)", selectedDeckName, selectedDeckId)
+            deckName.text = selectedDeckName
+            viewModel.setDeckSelected(selectedDeckId)
         }
     }
 
     /**
-     * Checks to see if the ViewModel's selected deck is valid and exists. If it does not, we set the selected deck to a
-     * valid deck (either the default deck or "all decks", depending on whether the default deck is present or not).
+     * Checks to see if the ViewModel's selected deck is valid and exists. If it does not, we select
+     * a valid deck (either the default deck or "all decks", depending on whether the default deck
+     * is present or not).
      *
-     * @return The valid deck ID that is now selected.
+     * @return a [Pair] with the [DeckId] and name of the selected valid deck
      */
-    private suspend fun ensureValidDeckSelected(): DeckId {
-        val fallbackSelection = if (isDefaultDeckEmpty()) DeckSpinnerSelection.ALL_DECKS_ID else Consts.DEFAULT_DECK_ID
+    private suspend fun getValidDeckSelection(): Pair<DeckId, String> {
+        suspend fun getFallbackSelection(): Pair<DeckId, String> =
+            if (isDefaultDeckEmpty()) {
+                Pair(DeckSpinnerSelection.ALL_DECKS_ID, getString(R.string.card_browser_all_decks))
+            } else {
+                Pair(Consts.DEFAULT_DECK_ID, withCol { decks.name(Consts.DEFAULT_DECK_ID) })
+            }
+
         val currentlySelectedDeckID = viewModel.deckSelected.value
-        val deckToSelect =
-            when (currentlySelectedDeckID) {
-                DeckSpinnerSelection.ALL_DECKS_ID -> DeckSpinnerSelection.ALL_DECKS_ID
-                Consts.DEFAULT_DECK_ID -> fallbackSelection
-                null -> fallbackSelection
-                else -> {
-                    val doesDeckExist = withCol { decks.have(currentlySelectedDeckID) }
-                    if (doesDeckExist) currentlySelectedDeckID else fallbackSelection
+        return when (currentlySelectedDeckID) {
+            DeckSpinnerSelection.ALL_DECKS_ID -> Pair(DeckSpinnerSelection.ALL_DECKS_ID, getString(R.string.card_browser_all_decks))
+            Consts.DEFAULT_DECK_ID -> getFallbackSelection()
+            null -> getFallbackSelection()
+            else -> {
+                val doesDeckExist = withCol { decks.have(currentlySelectedDeckID) }
+                if (doesDeckExist) {
+                    Pair(currentlySelectedDeckID, withCol { decks.name(currentlySelectedDeckID) })
+                } else {
+                    getFallbackSelection()
                 }
             }
-        viewModel.setDeckSelected(deckToSelect)
-        Timber.d("Initial selected deck ID: %s, newly selected deck ID: %s", currentlySelectedDeckID, deckToSelect)
-        return deckToSelect
+        }
     }
 
     private fun setUpAdvancedDropdown() {

--- a/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
@@ -81,14 +81,21 @@
                         android:textSize="18sp"
                         tools:ignore="HardcodedText" />
 
-                    <Spinner
-                        android:id="@+id/add_edit_reminder_deck_spinner"
+                    <TextView
+                        android:id="@+id/add_edit_reminder_deck_name"
                         android:layout_width="0dp"
                         android:layout_weight="3"
                         android:layout_height="match_parent"
-                        app:popupTheme="@style/ActionBar.Popup"
+                        android:textAppearance="?attr/textAppearanceListItem"
                         android:minHeight="?minTouchTargetSize"
-                        android:layout_marginStart="12dp" />
+                        android:maxLines="1"
+                        android:gravity="center_vertical"
+                        android:drawableEnd="@drawable/id_arrow_drop_down"
+                        android:background="?attr/selectableItemBackground"
+                        android:ellipsize="end"
+                        android:layout_marginStart="12dp"
+                        tools:text="Deck name here"
+                        />
 
                 </LinearLayout>
 


### PR DESCRIPTION
## Purpose / Description

Built on top of  #19327 to use the helper function defined there(the last commit is new).
Simplifies the deck selection code in add review remind fragment to not use the verbose Spinner.

With Spinner/ With TextView:

<img width="270" height="600" alt="Screenshot_20251016_082404" src="https://github.com/user-attachments/assets/250f6346-1b65-47a1-8df0-40be4e1c989f" /><img width="270" height="600" alt="Screenshot_20251016_082254" src="https://github.com/user-attachments/assets/48037c8e-8c92-4bdf-a44e-c2ea5c275236" />


## Fixes
* Related to #18875

## How Has This Been Tested?

Checked deck selection in the fragment, rand tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
