### PR TITLE
fix: crash on startup if WebView uninstalled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -28,12 +28,12 @@ import android.os.Bundle
 import android.os.Environment
 import android.system.Os
 import android.webkit.CookieManager
-import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
 import anki.collection.OpChanges
+import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.CrashReportService.sendExceptionReport
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
@@ -60,6 +60,7 @@ import com.ichi2.utils.AdaptionUtil
 import com.ichi2.utils.ExceptionUtil
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.Permissions
+import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import kotlinx.coroutines.CoroutineScope
@@ -162,7 +163,7 @@ open class AnkiDroidApp :
             showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
         }
 
-        WebView.setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
+        setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
 
         CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
             this,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -15,7 +15,6 @@
  */
 package com.ichi2.anki.preferences
 
-import android.webkit.WebView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
@@ -34,6 +33,7 @@ import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.withProgress
 import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.utils.show
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -199,7 +199,7 @@ class DevOptionsFragment : SettingsFragment() {
         requirePreference<SwitchPreferenceCompat>(R.string.html_javascript_debugging_key).apply {
             isVisible = !BuildConfig.DEBUG
             setOnPreferenceChangeListener { isEnabled ->
-                WebView.setWebContentsDebuggingEnabled(isEnabled)
+                setWebContentsDebuggingEnabled(isEnabled)
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
@@ -153,3 +153,32 @@ private fun getAndroidSystemWebViewPackageInfo(packageManager: PackageManager): 
     return getPackage("com.google.android.webview")
         ?: getPackage("com.android.webview") // com.android.webview is used on API 24
 }
+
+/**
+ * Enables debugging of web contents (HTML / CSS / JavaScript)
+ * loaded into any WebViews of this application. This flag can be enabled
+ * in order to facilitate debugging of web layouts and JavaScript
+ * code running inside WebViews. Please refer to WebView documentation
+ * for the debugging guide.
+ *
+ * In WebView 113.0.5656.0 and later, this is enabled automatically if the
+ * app is declared as
+ * [`android:debuggable="true"`](https://developer.android.com/guide/topics/manifest/application-element#debug)
+ * in its manifest; otherwise, the
+ * default is {@code false}.
+ *
+ * Enabling web contents debugging allows the state of any WebView in the
+ * app to be inspected and modified by the user via adb. This is a security
+ * liability and should not be enabled in production builds of apps unless
+ * this is an explicitly intended use of the app. More info on
+ * [secure debug settings](https://developer.android.com/topic/security/risks/android-debuggable)
+ *
+ * @param enabled whether to enable web contents debugging
+ */
+fun setWebContentsDebuggingEnabled(enabled: Boolean) =
+    try {
+        WebView.setWebContentsDebuggingEnabled(enabled)
+    } catch (e: Exception) {
+        // android.util.AndroidRuntimeException: android.webkit.WebViewFactory$MissingWebViewPackageException: Failed to load WebView provider: No WebView installed
+        Timber.w(e, "setWebContentsDebuggingEnabled")
+    }


### PR DESCRIPTION
Caused by 32a1b44ee14c7e8915ecd427a9fa70f07f93a2ad

## How Has This Been Tested?
Tested on API 29 emulator with:

`adb shell pm uninstall --user 0 com.google.android.webview`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->