### PR TITLE
fix(material): use non-transitive R.id/attr references

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/IncludedExcludedTagsAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/IncludedExcludedTagsAdapter.kt
@@ -72,7 +72,7 @@ class IncludedExcludedTagsAdapter(
     init {
         val ta =
             context.obtainStyledAttributes(
-                intArrayOf(android.R.attr.selectableItemBackground, com.google.android.material.R.attr.colorPrimary),
+                intArrayOf(android.R.attr.selectableItemBackground, androidx.appcompat.R.attr.colorPrimary),
             )
         selectableItemBackground = ta.getResourceId(0, 0)
         selectedItemBackground = ta.getColor(1, Color.BLUE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -334,7 +334,7 @@ class TagsDialog : AnalyticsDialogFragment {
         toolbarSearchItem = toolbar.menu.findItem(R.id.tags_dialog_action_filter)
         val toolbarSearchItem: MenuItem? = toolbarSearchItem
         toolbarSearchView = toolbarSearchItem?.actionView as AccessibleSearchView
-        val queryET = toolbarSearchView!!.findViewById<EditText>(com.google.android.material.R.id.search_src_text)
+        val queryET = toolbarSearchView!!.findViewById<EditText>(androidx.appcompat.R.id.search_src_text)
         queryET.filters = arrayOf(addTagFilter)
         toolbarSearchView!!.queryHint = getString(R.string.filter_tags)
         toolbarSearchView!!.setOnQueryTextListener(


### PR DESCRIPTION
Material 1.13.0 uses `android.nonTransitiveRClass=true`

Therefore `com.google.android.material.R.attr.colorPrimary` is no
 longer usable

`colorPrimary` => androidx.appcompat.R.attr.colorPrimary `search_src_text` => androidx.appcompat.R.id.search_src_text

https://github.com/material-components/material-components-android/blob/c2051db2a9be2a1e23f1128bfc76a9ff29ede7c4/docs/getting-started.md#non-transitive-r-classes-referencing-library-resources-programmatically

----

* Added in https://github.com/ankidroid/Anki-Android/pull/19180
* Split from https://github.com/ankidroid/Anki-Android/pull/19341