### PR TITLE
Change messages for discardChangesDialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1630,7 +1630,10 @@ class NoteEditorFragment :
     }
 
     private fun showDiscardChangesDialog() {
-        DiscardChangesDialog.showDialog(requireContext()) {
+        DiscardChangesDialog.showDialog(
+            requireContext(),
+            message = if (addNote) TR.addingDiscardCurrentInput() else TR.cardTemplatesDiscardChanges(),
+        ) {
             Timber.i("NoteEditor:: OK button pressed to confirm discard changes")
             closeNoteEditor()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DiscardChangesDialog.kt
@@ -33,7 +33,7 @@ object DiscardChangesDialog {
         positiveButtonText: String = context.getString(R.string.discard),
         negativeButtonText: String = CollectionManager.TR.addingKeepEditing(),
         neutralButtonText: String? = null,
-        message: String = CollectionManager.TR.addingDiscardCurrentInput(),
+        message: String = CollectionManager.TR.cardTemplatesDiscardChanges(),
         negativeMethod: () -> Unit = {},
         neutralMethod: (() -> Unit)? = null,
         positiveMethod: () -> Unit,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -614,7 +614,7 @@ class InstantNoteEditorActivity :
     }
 
     private fun showDiscardChangesDialog() {
-        DiscardChangesDialog.showDialog(this) {
+        DiscardChangesDialog.showDialog(this, message = TR.addingDiscardCurrentInput()) {
             Timber.i("InstantNoteEditorActivity:: OK button pressed to confirm discard changes")
             finish()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -34,6 +34,7 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -104,7 +105,7 @@ abstract class MultimediaFragment(
                 enabled = viewModel.currentMultimediaPath.value != null,
             ) {
                 override fun handleOnBackPressed() {
-                    DiscardChangesDialog.showDialog(requireContext()) {
+                    DiscardChangesDialog.showDialog(requireContext(), message = TR.addingDiscardCurrentInput()) {
                         Timber.i("MultimediaFragment:: OK button pressed to confirm discard changes")
                         isEnabled = false
                         requireActivity().onBackPressedDispatcher.onBackPressed()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -103,14 +103,14 @@ class CardTemplateEditorTest : RobolectricTest() {
         // Make sure we get a confirmation dialog if we hit the back button
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
         advanceRobolectricLooper()
-        assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard current input?")
+        assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard changes?")
         clickAlertDialogButton(DialogInterface.BUTTON_NEGATIVE, false)
         advanceRobolectricLooper()
         assertTrue("note type change not preserved despite canceling back button?", testEditor.noteTypeHasChanged())
 
         // Make sure we things are cleared out after a cancel
         assertTrue("Unable to click?", shadowTestEditor.clickMenuItem(android.R.id.home))
-        assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard current input?")
+        assertEquals("Wrong dialog shown?", getAlertDialogText(true), "Discard changes?")
         clickAlertDialogButton(DialogInterface.BUTTON_POSITIVE, false)
         advanceRobolectricLooper()
         assertFalse("note type change not cleared despite discarding changes?", testEditor.noteTypeHasChanged())


### PR DESCRIPTION
This changes the default dialog message in discardChangesDialog and the dialog messages on specific pages to be more intuitive and closer to the desktop experience.

<!--- Please fill the necessary details below -->
## Purpose / Description
On the desktop application, the dialog "Discard current input?" only appears when adding a new note and exiting before it is added. Other screens (when editing something) use "Discard changes?".

Currently in the Android app, almost all situations use "Discard current input?" which some may find confusing.
From what I can tell, these are all the places discardChangesDialog is used:
```
AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnSelectionFragment.kt
AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
```
Now everything uses a "Discard changes?" message except for the following:
- NoteEditorFragment: conditionally displays "Discard changes?" or "Discard current input?" depending on if a note is being added or edited.
- InstantNoteEditorActivity: from what I can tell it is only possible to add a note from this, so I kept this as "Discard current input?".
- MultimediaFragment: I am not sure which is best here, right now it uses "Discard current input?".
- CardBrowser: Already overrides with its own message.

DeckOptions is a PageFragment and I think it handles displaying the dialog differently. It already displays "Discard changes?".
## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/15788

## Approach
Changed the default message parameter in DiscardChangesDialog, and changed it for some specific activities/fragments as well.

## How Has This Been Tested?
- Automated test suite
- Manually on Emulator
Pixel 6 Pro API 31

Adding a note (nothing new here)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/6014197d-c500-4247-b650-05b6b167d2db" />
Editing a note (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/2f2ce171-9877-4339-8d64-6a2a3bdb89d9" />
Editing a deck description (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/cecd0115-a43f-4136-a9fb-1bb3cb85e466" />
Editing card browser columns (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/38a6dc58-4786-4be1-8acb-a75f80433922" />
Image occlusion (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/c2add4e9-6a0b-4037-b77d-dfdce78e8037" />
Deck picker widget (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/dadecf64-e623-47fa-a091-b394d59dc935" />
Card template editor (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/0ff5e0e4-5527-4a41-b2fd-9c716d6d9451" />
Browser appearance editor (new)
<img width="437" height="937" alt="image" src="https://github.com/user-attachments/assets/16b6257d-8062-4330-b867-5265af64e7dc" />

## Learning (optional, can help others)
It was a good opportunity to explore the repository and learn.
This is my first contribution, if you could point out anything I missed or could improve on, please do! 

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->