### PR TITLE
build(deps): adopt new anki 25.09.2 and all backend deps updates

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -97,6 +97,8 @@ val collectionMethods =
         "getIgnoredBeforeCount" to { bytes -> getIgnoredBeforeCountRaw(bytes) },
         "getRetentionWorkload" to { bytes -> getRetentionWorkloadRaw(bytes) },
         "simulateFsrsWorkload" to { bytes -> simulateFsrsWorkloadRaw(bytes) },
+        // https://github.com/ankitects/anki/pull/4326 -> saveCustomColours should be no-op in mobile clients
+        "saveCustomColours" to { bytes -> backendIdentity(bytes) },
     )
 
 suspend fun handleCollectionPostRequest(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ androidxViewpager2 = "1.1.0"
 androidxWebkit = "1.14.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.10.5"
-ankiBackend = '0.1.61-anki25.09'
+ankiBackend = '0.1.62-anki25.09.2'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 colorpicker = "1.2.0"


### PR DESCRIPTION

Mostly deps updates, but does go from anki 25.09 to 25.09.2

https://github.com/ankidroid/Anki-Android-Backend/compare/e267bf24e652ad1f7860abe53b732f566aedcb3d...main