### PR TITLE
Fix  ui issues for DeckPicker adapter when sub decks status changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/widgets/DeckAdapter.kt
@@ -103,25 +103,12 @@ class DeckAdapter(
         data: List<DisplayDeckNode>,
         hasSubDecks: Boolean,
     ) {
-        // submitList is smart to not trigger a refresh if the new list is the same, but we do need
-        // an adapter refresh if the other two properties have changed even if the new data is the
-        // same as they modify some of the adapter's content appearance
-        val forceRefresh =
-            areDataSetsEqual(currentList, data) &&
-                (this.hasSubdecks != hasSubDecks)
+        // force refresh when sub decks status changes as this info isn't encapsulated in the
+        // adapter's items so there wouldn't be an ui refresh just from using submitList()
+        val forceRefresh = this.hasSubdecks != hasSubDecks
         this.hasSubdecks = hasSubDecks
         submitList(data)
         if (forceRefresh) notifyDataSetChanged()
-    }
-
-    private fun areDataSetsEqual(
-        currentSet: List<DisplayDeckNode>,
-        newSet: List<DisplayDeckNode>,
-    ): Boolean {
-        if (currentSet.size != newSet.size) return false
-        return currentSet.zip(newSet).all { (fst, snd) ->
-            fst.fullDeckName == snd.fullDeckName
-        }
     }
 
     /**
@@ -154,6 +141,7 @@ class DeckAdapter(
             runBlocking { setDeckExpander(holder.deckExpander, holder.indentView, node) }
         } else {
             holder.deckExpander.visibility = View.GONE
+            holder.indentView.minimumWidth = 0
             deckLayout.setPaddingRelative(startPadding, 0, endPadding, 0)
         }
         if (node.canCollapse) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Currently there are some ui bugs in DeckPicker when various actions(creating, deleting or importing decks) lead to the adapter sub decks status to change(we need to show/hide a dropdown indicator). See the video below. 

The fix consists in resetting the indent width when there are no sub decks and updating the logic to force refresh on every sub decks changes(checking for data sets equality was incorrect: I could be deleting the only deck that had sub decks, in this situation the sub decks status changed but the lists would be different so no refresh).

[Screen_recording_20251018_184921.webm](https://github.com/user-attachments/assets/cc4fc0a0-3276-4721-9bb9-56c9c9c3fae7)

## How Has This Been Tested?

Checked various scenarios where sub decks status would change. Ran the tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

