### PR TITLE
Hide HTML toolbar when notetype is Image Occlusion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1799,6 +1799,10 @@ class NoteEditorFragment :
         customViewIds.clear()
         imageOcclusionButtonsContainer?.isVisible = currentNotetypeIsImageOcclusion()
 
+        // Showing the bottom toolbar (for HTML format) is not needed for image occlusion notetypes
+        // as there are no fields for inputting text.
+        toolbar.isVisible = !currentNotetypeIsImageOcclusion()
+
         editFields = LinkedList()
 
         var previous: FieldEditLine? = null


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
In the note editor ("Add" or "Edit note") screen, showing the bottom toolbar (for HTML format) is not needed for Image Occlusion note types as there are no fields for inputting text there.
<img src="https://github.com/user-attachments/assets/871002a2-49bb-44b3-9cfb-a5dfb59a0498" width="220px">




## Approach
In `NoteEditorFragment.kt`, make `toolbar.isVisible` false when the current note type is Image Occlusion.

## How Has This Been Tested?
Checked on a physical device (Android 15)

**"Add" screen**
<img width="285" height="1681" alt="image" src="https://github.com/user-attachments/assets/4be4b54b-4066-4988-94a7-14d5befdc8d9" />

**"Edit note" screen**
<img width="285" height="2474" alt="image" src="https://github.com/user-attachments/assets/23f1d6a4-c5c2-4a88-bf2e-89ff0027c323" />

https://github.com/user-attachments/assets/0f65dfdd-f982-4f62-be11-6d6899e1293b


## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->