### PR TITLE
Don't open keyboard for Image Occlusion note edit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -903,8 +903,8 @@ class NoteEditorFragment :
             )
         }
 
-        // don't open keyboard if not adding note
-        if (!addNote) {
+        // Don't open keyboard if not adding note or the note type is Image Occlusion
+        if (!addNote || currentNotetypeIsImageOcclusion()) {
             requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         }
 


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Opening keyboard automatically on the note editor screen is not needed when the note type is Image Occlusion, as there are no fields for inputting text in that case.

<img width="280" height="2412" alt="image" src="https://github.com/user-attachments/assets/ff66ed1a-c168-4b74-a7a5-b8db177632ca" />


## Approach
Add the condition of Image Occlusion to the existing process that stop opening the keyboard.

## How Has This Been Tested?
Checked on a physical device (Android 15)

<img width="280" height="1616" alt="image" src="https://github.com/user-attachments/assets/8795e003-35af-442b-b06d-9fcc3215d987" />

https://github.com/user-attachments/assets/1485e1dc-4590-4414-8a4e-e3222f7027d7





## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->