### PR TITLE
fix & improvement: Specify editor text highlight color for each theme

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditText.kt
@@ -28,6 +28,7 @@ import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.widget.EditText
 import androidx.annotation.VisibleForTesting
+import androidx.core.graphics.toColorInt
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.preferences.sharedPrefs
@@ -87,6 +88,14 @@ class FieldEditText :
         // Fixes bug where new instances of this object have wrong colors, probably
         // from some reuse mechanic in Android.
         setDefaultStyle()
+
+        val highlightColor =
+            MaterialColors.getColor(
+                context,
+                R.attr.editTextHighlightColor,
+                "#99CCFF".toColorInt(), // light blue color for fallback just-in-case
+            )
+        setHighlightColor(highlightColor)
     }
 
     fun setPasteListener(pasteListener: PasteListener) {

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -149,6 +149,7 @@
     <!-- Note editor colors -->
     <attr name="duplicateColor" format="color"/>
     <attr name="editTextBackgroundColor" format="color"/>
+    <attr name="editTextHighlightColor" format="color"/><!-- TODO replace this with colorOnPrimaryContainer, see #19361 -->
     <attr name="toolbarBackgroundColor" format="color"/>
     <attr name="toolbarIconColor" format="color"/>
     <attr name="buttonShadowColor" format="color"/>

--- a/AnkiDroid/src/main/res/values/theme_black.xml
+++ b/AnkiDroid/src/main/res/values/theme_black.xml
@@ -80,6 +80,7 @@
         <item name="duplicateColor">#855</item>
         <!-- Note editor colors -->
         <item name="editTextBackgroundColor">#EE5C5C5C</item>
+        <item name="editTextHighlightColor">@color/material_light_blue_900</item>
         <item name="toolbarBackgroundColor">#616161</item>
         <item name="toolbarIconColor">@color/white</item>
         <item name="buttonShadowColor">#726B6B</item>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -106,6 +106,7 @@
         <!-- Note editor colors -->
         <item name="duplicateColor">#855</item>
         <item name="editTextBackgroundColor">#EE5C5C5C</item>
+        <item name="editTextHighlightColor">@color/material_light_blue_900</item>
         <item name="toolbarBackgroundColor">#616161</item>
         <item name="toolbarIconColor">@color/white</item>
         <item name="buttonShadowColor">#bdbdbd</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -99,6 +99,7 @@
         <!-- Note editor colors -->
         <item name="duplicateColor">#fcc</item>
         <item name="editTextBackgroundColor">#EBCCCCCC</item>
+        <item name="editTextHighlightColor">@color/material_light_blue_200</item>
         <item name="toolbarBackgroundColor">#D6D7D7</item>
         <item name="toolbarIconColor">@color/black</item>
         <item name="buttonShadowColor">#FFAAAAAA</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -48,6 +48,7 @@
         <item name="cardBrowserDivider">#CCCCCC</item>
         <!-- Note editor colors -->
         <item name="editTextBackgroundColor">#EBCCCCCC</item>
+        <item name="editTextHighlightColor">@color/material_grey_300</item>
         <item name="toolbarBackgroundColor">#D6D7D7</item>
         <item name="toolbarIconColor">@color/black</item>
         <item name="buttonShadowColor">#FFAAAAAA</item>


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
- Fix "invisible highlight" issue on 2.23.0alpha5
- Improve text highlight colors to match each theme

## Fixes
* Fixes #19361

## Approach
Specify the highlight color in FieldEditText.kt

## How Has This Been Tested?

Checked in a physical device (Android 15) about each theme: Light, Plain, Black, Dark

 |2.23.0α4 | 2.23.0α5 | this PR
---|---|---|
purple<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/4346482e-4fc9-484a-8047-efc28c72fd9f" />|invisible<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/12858631-aaa8-45e0-bb4b-6949a8fb40d5" />|light blue<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/65c14fb4-2e37-4855-a601-9cbbb11fbda3" />
purple<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/5b4c2cc1-e7c5-4466-b08c-25086d7e1bf8" />|invisible<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/2835d0f7-417f-44e5-b281-35dd574819a9" />|light grey<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/44b97fc0-81f5-4029-a79e-ac46ab9b12ff" />
purple<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/414d936b-8bda-4120-b3cf-5261e3f79d69" />|purple (same as α4)<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/f41d12b1-7e0c-428d-b11b-6825ee095ee3" />| blue<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/7b10ccc6-f773-45d8-ad71-c7daebf5efde" />
purple<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/889db333-8c41-4042-a015-cb44c45cf100" />|purple (same as α4)<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/5e2aaa49-7544-4df8-bf02-83c4bf594d96" />|blue<br><img width="200" height="2412" alt="image" src="https://github.com/user-attachments/assets/49ea6d51-ed35-4075-bb35-58c3ef7738dd" />|





## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->