### PR TITLE
fix: insert field adds fields to the wrong card type

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -521,6 +521,13 @@ open class CardTemplateEditor :
         private val refreshFragmentHandler = Handler(Looper.getMainLooper())
         private lateinit var editorEditText: FixedEditText
 
+        // Index of this card template fragment in ViewPager
+        private val cardIndex
+            get() = requireArguments().getInt(CARD_INDEX)
+
+        val insertFieldRequestKey
+            get() = "request_field_insert_$cardIndex"
+
         var currentEditorViewId = 0
 
         private lateinit var templateEditor: CardTemplateEditor
@@ -535,7 +542,6 @@ open class CardTemplateEditor :
             // Storing a reference to the templateEditor allows us to use member variables
             templateEditor = activity as CardTemplateEditor
             val mainView = inflater.inflate(R.layout.card_template_editor_item, container, false)
-            val cardIndex = requireArguments().getInt(CARD_INDEX)
             tempModel = templateEditor.tempNoteType!!
             // Load template
             val template: BackendCardTemplate =
@@ -728,8 +734,7 @@ open class CardTemplateEditor :
         )
         fun showInsertFieldDialog() {
             templateEditor.fieldNames?.let { fieldNames ->
-                val cardIndex = requireArguments().getInt(CARD_INDEX)
-                val dialog = InsertFieldDialog.newInstance(fieldNames, cardIndex)
+                val dialog = InsertFieldDialog.newInstance(fieldNames, insertFieldRequestKey)
                 templateEditor.showDialogFragment(dialog)
             }
         }
@@ -812,9 +817,7 @@ open class CardTemplateEditor :
                 },
             )
 
-            val cardIndex = requireArguments().getInt(CARD_INDEX)
-            val requestKey = InsertFieldDialog.requestKey(cardIndex)
-            parentFragmentManager.setFragmentResultListener(requestKey, viewLifecycleOwner) { key, bundle ->
+            parentFragmentManager.setFragmentResultListener(insertFieldRequestKey, viewLifecycleOwner) { key, bundle ->
                 // this is guaranteed to be non null, as we put a non null value on the other side
                 insertField(bundle.getString(InsertFieldDialog.KEY_INSERTED_FIELD)!!)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -38,7 +38,7 @@ import com.ichi2.utils.title
  */
 class InsertFieldDialog : DialogFragment() {
     private lateinit var fieldList: List<String>
-    private var cardIndex: Int = 0
+    private lateinit var requestKey: String
 
     /**
      * A dialog for inserting field in card template editor
@@ -46,7 +46,7 @@ class InsertFieldDialog : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
         super.onCreate(savedInstanceState)
         fieldList = requireArguments().getStringArrayList(KEY_FIELD_ITEMS)!!
-        cardIndex = requireArguments().getInt(KEY_CARD_INDEX, 0)
+        requestKey = requireArguments().getString(KEY_REQUEST_KEY)!!
         val adapter: RecyclerView.Adapter<*> =
             object : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                 override fun onCreateViewHolder(
@@ -77,7 +77,7 @@ class InsertFieldDialog : DialogFragment() {
 
     private fun selectFieldAndClose(textView: TextView) {
         parentFragmentManager.setFragmentResult(
-            requestKey(cardIndex),
+            requestKey,
             bundleOf(KEY_INSERTED_FIELD to textView.text.toString()),
         )
         dismiss()
@@ -85,35 +85,28 @@ class InsertFieldDialog : DialogFragment() {
 
     companion object {
         /**
-         * Other fragments sharing the activity can use this with
-         * [androidx.fragment.app.FragmentManager.setFragmentResultListener] to get a result back.
-         */
-        private const val REQUEST_FIELD_INSERT = "request_field_insert"
-
-        /**
-         * Other fragments sharing the activity can use this with
-         * [androidx.fragment.app.FragmentManager.setFragmentResultListener] to get a result back.
-         *
-         * Adding [cardIndex] ensures unique request key for each card.
-         */
-        fun requestKey(cardIndex: Int): String = "${REQUEST_FIELD_INSERT}_$cardIndex"
-
-        /**
          * This fragment requires that a list of fields names to be passed in.
          */
         const val KEY_INSERTED_FIELD = "key_inserted_field"
         private const val KEY_FIELD_ITEMS = "key_field_items"
-        private const val KEY_CARD_INDEX = "key_card_index"
+        private const val KEY_REQUEST_KEY = "key_request_key"
 
+        /**
+         * Creates a new instance of [InsertFieldDialog]
+         *
+         * @param fieldItems The list of field names to be displayed in the dialog.
+         * @param requestKey The key used to identify the result when returning the selected field
+         *                   to the calling fragment.
+         */
         fun newInstance(
             fieldItems: List<String>,
-            cardIndex: Int,
+            requestKey: String,
         ): InsertFieldDialog =
             InsertFieldDialog().apply {
                 arguments =
                     bundleOf(
                         KEY_FIELD_ITEMS to ArrayList(fieldItems),
-                        KEY_CARD_INDEX to cardIndex,
+                        KEY_REQUEST_KEY to requestKey,
                     )
             }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -807,11 +807,9 @@ class CardTemplateEditorTest : RobolectricTest() {
         firstFragmentAgain!!.showInsertFieldDialog()
         advanceRobolectricLooper()
 
-        val cardIndex = 0
-        val requestKey = InsertFieldDialog.requestKey(cardIndex)
         val resultBundle = Bundle()
         resultBundle.putString(InsertFieldDialog.KEY_INSERTED_FIELD, fieldToInsert)
-        testEditor.supportFragmentManager.setFragmentResult(requestKey, resultBundle)
+        testEditor.supportFragmentManager.setFragmentResult(firstFragmentAgain.insertFieldRequestKey, resultBundle)
         advanceRobolectricLooper()
 
         // Verify the field was inserted into the first fragment


### PR DESCRIPTION
## Purpose / Description
fix: insert field adds fields to the wrong card type

## Fixes
* Fixes #19304 

## Approach

### Issue
When setting up the fragment result listener in CardTemplateFragment, all fragments use the same request key (REQUEST_FIELD_INSERT). This causes a conflict because:
- ViewPager2 keeps multiple fragments alive in memory simultaneously
- Each fragment registers a listener with the identical request key
- When a new fragment registers its listener, it overwrites the previous fragment's listener due to same key
- Consequently, when InsertFieldDialog sets a fragment result, only the most recently registered listener (typically the last fragment) receives the callback, not the currently visible fragment

### Solution
Make each fragment's result listener unique by incorporating the card index into the request key:
- Pass card index to the dialog: Modify InsertFieldDialog.newInstance() to accept and store a cardIndex parameter
- Generate unique request keys: Append the card index to create unique keys
- Use matching keys for listener and result

## How Has This Been Tested?
Manually Tested
Added unit test to simulate this behaviour
Passes existing tests

https://github.com/user-attachments/assets/a88986c5-5c6d-449b-a2c5-13b044ced2d9


https://github.com/user-attachments/assets/d0bed901-2d7c-4416-b710-29ef47ece786




## Learning (optional, can help others)
Listeners are stored as Map<Key, Listener>
https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/fragment/fragment/src/main/java/androidx/fragment/app/FragmentManager.java#1214

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->