### PR TITLE
Remove unused MaterialTapTargetPrompt dependency

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -423,7 +423,6 @@ dependencies {
     implementation libs.jsoup
     implementation libs.java.semver // For AnkiDroid JS API Versioning
     implementation libs.drakeet.drawer
-    implementation libs.tapTargetPrompt
     implementation libs.colorpicker
     implementation libs.kotlin.reflect
     implementation libs.kotlin.test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -92,7 +92,6 @@ ktlintGradlePlugin = "13.1.0"
 leakcanaryAndroid = "2.14"
 lint = '31.13.0'
 material = "1.13.0"
-materialTapTargetPrompt = "3.3.2"
 
 mockitoInline = "5.2.0"
 mockitoKotlin = "6.1.0"
@@ -159,7 +158,6 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
 google-material = { module = "com.google.android.material:material", version.ref = "material" }
-tapTargetPrompt = { module = "uk.co.samuelwall:material-tap-target-prompt", version.ref = "materialTapTargetPrompt" }
 nanohttpd = { module = "org.nanohttpd:nanohttpd", version.ref = "nanohttpd" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 android-lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It's unused, it's a leftover from #16946. I'll remove the license as well from wiki.

## Fixes

* Fixes #19371

## How Has This Been Tested?

App build/works.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Licenses

**Maintainers:**

* [x] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [x] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
