### PR TITLE
fix: black theme browser focus highlight invisible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Paint
 import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
 import android.text.TextUtils
 import android.util.TypedValue
 import android.view.LayoutInflater
@@ -163,6 +164,7 @@ class BrowserMultiColumnAdapter(
             @ColorInt color: Int,
         ) {
             var pressedColor = darkenColor(color, 0.85f)
+            var focusedColor = darkenColor(color, 0.4f)
 
             if (pressedColor == color) {
                 // if the color is black, we can't darken it.
@@ -170,6 +172,7 @@ class BrowserMultiColumnAdapter(
 
                 // 25% was determined by visual inspection
                 pressedColor = lightenColorAbsolute(pressedColor, 0.25f)
+                focusedColor = pressedColor
             }
 
             require(pressedColor != color)
@@ -183,7 +186,15 @@ class BrowserMultiColumnAdapter(
                     null,
                 )
 
-            itemView.background = rippleDrawable
+            // When a row gains keyboard focus, apply a static background color instead of RippleDrawable
+            // to avoid the brief dark flicker caused by Ripple's focus exit animation.
+            // For the other states (pressed/normal), apply the RippleDrawable.
+            val background =
+                StateListDrawable().apply {
+                    addState(intArrayOf(android.R.attr.state_focused), focusedColor.toDrawable())
+                    addState(intArrayOf(), rippleDrawable)
+                }
+            itemView.background = background
         }
 
         fun setIsTruncated(truncated: Boolean) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When the app theme is "Black", keybord focus on a normal (i.e. not colored by mark, suspend, bury, or flags) row of card/note doesn't show any visual feedback.

When the first row is focused by keyboard:
Light theme | Black theme
---|---
highlight is visible<br><img width="720" height="1608" alt="image" src="https://github.com/user-attachments/assets/659e922e-c0b0-487c-a5fd-f8f275a2e5db" />| highlight is invisible<br><img width="720" height="1608" alt="image" src="https://github.com/user-attachments/assets/f3bb869c-b947-47fb-b782-b050458bd5ad" />

**Note**: Further adjustment for the highlight color (especially in day themes) will be desirable, but for now this PR focus on resolving the highlight-invisible issue in the black theme above.


https://github.com/user-attachments/assets/8caf776b-c006-45f6-96bd-9d48e6b76caa


https://github.com/user-attachments/assets/b749b370-a394-4cea-9ecb-3800fff36d08







## Fixes
* Fixes a part of:
 #19320,
 #19343

## Approach
Specify a color for state_focused

## How Has This Been Tested?
Checked on a physical device (Android 15)

When the first row is focused by keyboard:
Light theme | Black theme
---|---
highlight is visible<br>(No unexpected side effects have been observed.)<br><img width="720" height="1608" alt="image" src="https://github.com/user-attachments/assets/4529db85-fe21-4fdc-ae4c-1ef46f671022" />| highlight is visible<br><img width="720" height="1608" alt="image" src="https://github.com/user-attachments/assets/16eabbb8-abc9-4423-b144-6761e4fd2b3c" />

https://github.com/user-attachments/assets/53c4d43b-c955-46eb-99da-0080bb98e7a9


https://github.com/user-attachments/assets/3d89f644-e753-46c6-bd6b-f99a92d1343e


## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->