### PR TITLE
Hide note editor options for editing text if the note type is Image Occlusion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1446,12 +1446,22 @@ class NoteEditorFragment :
                 }
             }
         }
-        menu.findItem(R.id.action_show_toolbar).isChecked =
-            !shouldHideToolbar()
-        menu.findItem(R.id.action_capitalize).isChecked =
-            sharedPrefs().getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
-        menu.findItem(R.id.action_scroll_toolbar).isChecked =
-            sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
+        if (currentNotetypeIsImageOcclusion()) {
+            // Showing options related to editing text in fields is not needed
+            // for image occlusion notetypes as there are no fields for inputting
+            // text in the editor screen. (Text is handled by the backend page.)
+            menu.findItem(R.id.action_font_size).isVisible = false
+            menu.findItem(R.id.action_show_toolbar).isVisible = false
+            menu.findItem(R.id.action_scroll_toolbar).isVisible = false
+            menu.findItem(R.id.action_capitalize).isVisible = false
+        } else {
+            menu.findItem(R.id.action_show_toolbar).isChecked =
+                !shouldHideToolbar()
+            menu.findItem(R.id.action_capitalize).isChecked =
+                sharedPrefs().getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
+            menu.findItem(R.id.action_scroll_toolbar).isChecked =
+                sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
+        }
     }
 
     /**
@@ -1802,7 +1812,6 @@ class NoteEditorFragment :
         // Showing the bottom toolbar (for HTML format) is not needed for image occlusion notetypes
         // as there are no fields for inputting text.
         toolbar.isVisible = !currentNotetypeIsImageOcclusion()
-
         editFields = LinkedList()
 
         var previous: FieldEditLine? = null
@@ -1892,6 +1901,7 @@ class NoteEditorFragment :
 
             fieldsLayoutContainer!!.addView(editLineView)
         }
+        requireActivity().invalidateOptionsMenu()
     }
 
     private fun getActionModeCallback(


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Showing options related to editing text in fields is not needed for image occlusion notetypes as there are no fields for inputting text in the editor screen. (Text is handled by the backend page.)
<img width="280" height="2412" alt="image" src="https://github.com/user-attachments/assets/cb8563c8-f213-4980-b12c-c544951df0e9" /> <img width="280" height="2412" alt="image" src="https://github.com/user-attachments/assets/e013d4b7-c971-42d5-ab83-4d6275a58fac" />





## Approach
Make the options invisible when the note type is Image Occlusion, in `onPrepareMenu()` of `NoteEditorFragment.kt`

## How Has This Been Tested?

Checked on a physical device (Android 15)

Before|After
---|:---:
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/6559e517-f4de-482e-98cd-ab5e1132aa3e" />|<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/5b4bbc1c-f2c8-40f4-8cbd-9842f2398f97" />
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/bf5018af-829d-4367-bfa3-02f29c42cd39" />|No overflow menu
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/7d95ecd1-f1c0-4532-88e4-5ed445879ae3" />|Same as before change<br><img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/65d516c0-80b8-47e3-b3e5-a1a52616ed6f" />
<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/5863534f-d31d-47ec-920d-6062b3f55583" />|<img width="1080" height="2412" alt="image" src="https://github.com/user-attachments/assets/9f42290c-2007-48b0-8269-ecc22a5586ca" />



https://github.com/user-attachments/assets/8e761694-543e-4de5-8b9f-4898990733a2



https://github.com/user-attachments/assets/0e77a8ef-57b4-4f06-bf37-6db405c45953




## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->