### PR TITLE
Remove search from deck download menu

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/preferences/PreferencesNavigationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/preferences/PreferencesNavigationTest.kt
@@ -66,8 +66,8 @@ class PreferencesNavigationTest {
         closeGetStartedScreenIfExists()
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
         onView(withId(R.id.nav_settings)).perform(click())
-        onView(withId(R.id.search)).perform(click())
-        onView(allOf(withId(R.id.search), hasFocus())).perform(typeText("Controls"))
+        onView(withId(com.bytehamster.lib.preferencesearch.R.id.search)).perform(click())
+        onView(allOf(withId(com.bytehamster.lib.preferencesearch.R.id.search), hasFocus())).perform(typeText("Controls"))
         pressBack()
         // Checking the list of Settings Categories are displayed on the basis of our search "Controls"
         onView(allOf(withResourceName("list"), isAssignableFrom(RecyclerView::class.java))).check(
@@ -94,8 +94,8 @@ class PreferencesNavigationTest {
         closeGetStartedScreenIfExists()
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
         onView(withId(R.id.nav_settings)).perform(click())
-        onView(withId(R.id.search)).perform(click())
-        onView(allOf(withId(R.id.search), hasFocus())).perform(typeText("Card"))
+        onView(withId(com.bytehamster.lib.preferencesearch.R.id.search)).perform(click())
+        onView(allOf(withId(com.bytehamster.lib.preferencesearch.R.id.search), hasFocus())).perform(typeText("Card"))
         onView(withText(R.string.card_zoom)).perform(click())
         onView(withId(R.id.settings_container)).check(matches(isDisplayed()))
         onView(withText(R.string.notification_pref)).perform(click())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -30,14 +30,12 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
-import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.ui.AccessibleSearchView
 import com.ichi2.utils.FileNameAndExtension
 import timber.log.Timber
 import java.io.Serializable
@@ -258,23 +256,6 @@ class SharedDecksActivity : AnkiActivity() {
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
         menuInflater.inflate(R.menu.download_shared_decks_menu, menu)
-
-        val searchView = menu.findItem(R.id.search)?.actionView as AccessibleSearchView
-        searchView.queryHint = getString(R.string.search_using_deck_name)
-        searchView.setMaxWidth(Integer.MAX_VALUE)
-        searchView.setOnQueryTextListener(
-            object : SearchView.OnQueryTextListener {
-                override fun onQueryTextSubmit(query: String?): Boolean {
-                    webView.loadUrl(resources.getString(R.string.shared_decks_url) + query)
-                    return true
-                }
-
-                override fun onQueryTextChange(newText: String?): Boolean {
-                    // Nothing to do here
-                    return false
-                }
-            },
-        )
         return true
     }
 

--- a/AnkiDroid/src/main/res/menu/download_shared_decks_menu.xml
+++ b/AnkiDroid/src/main/res/menu/download_shared_decks_menu.xml
@@ -7,11 +7,4 @@
         android:title="@string/home"
         android:icon="@drawable/home_icon"
         app:showAsAction="ifRoom" />
-        
-    <item
-        android:id="@+id/search"
-        android:title="@string/search_for_download_deck"
-        android:icon="@drawable/ic_search_white"
-        app:showAsAction="ifRoom|collapseActionView"
-        app:actionViewClass="com.ichi2.ui.AccessibleSearchView" />
 </menu>

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -114,7 +114,6 @@
     <string name="empty_filtered_deck">Emptying filtered deck…</string>
     <string name="search_deck" comment="Deck search for selecting it">Deck Search</string>
     <string name="empty_deck">This deck is empty</string>
-    <string name="search_for_download_deck" comment="Deck search value for downloading deck" maxLength="28">Deck Search</string>
     <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for today.</string>
     <string name="studyoptions_congrats_next_due_in" comment="The param will be replaced with 'The next card will be ready in X time'">Deck finished for now! %s</string>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -298,7 +298,6 @@
     <string name="download_failed">Download failed</string>
     <string name="deck_download_progress_message">You can use other apps while the download is running</string>
     <string name="check_network">Please check your network connection</string>
-    <string name="search_using_deck_name">Search using deck name</string>
     <string name="external_storage_unavailable">Download aborted, the external storage is not available</string>
     <string name="home" maxLength="28">Home</string>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- There was a search option in menu which is not required IMO as there is already an option to search decks in webview and the search option in menu is redundant so this PR removes that

## Fixes
NA but related to #19381

## Approach
Remove search option from menu so that user now use the search option from web page itself

## How Has This Been Tested?
Locally on API 35 Google emulator 

## Learning (optional, can help others)
NA
## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->