### PR TITLE
Fix deck menu remaining open after editing description

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.StudyOptionsFragment
 import com.ichi2.anki.dialogs.EditDeckDescriptionDialogViewModel.DismissType
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard
 import com.ichi2.utils.AndroidUiUtils.setFocusAndOpenKeyboard
 import com.ichi2.utils.create
@@ -150,9 +151,9 @@ class EditDeckDescriptionDialog : DialogFragment() {
                 .filterNotNull()
                 .collect { dismissType ->
                     when (dismissType) {
-                        DismissType.ClosedWithoutSaving -> dismiss()
+                        DismissType.ClosedWithoutSaving -> requireActivity().dismissAllDialogFragments()
                         DismissType.Saved -> {
-                            dismiss()
+                            requireActivity().dismissAllDialogFragments()
                             showSnackbar(R.string.deck_description_saved)
                             // notify DeckPicker to invalidate its toolbar menu, otherwise the undo
                             // action to revert the description change is not going to be visible


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The edit deck description dialog does not dismiss the underlying context menu, which is unlike other deck context menu dialogs.

## Fixes
* Fixes #19068

## Approach
In situations where the `EditDeckDescriptionDialog` fragment is dismissed, all fragments are dismissed so that the `DeckPickerContextMenu` fragment does not appear on top of the keyboard and action snackbar.

## How Has This Been Tested?
- Automated test suite
- Manually on Emulator
  Pixel 6 Pro API 31

Existing behavior:

https://github.com/user-attachments/assets/170f2d34-3ea3-4c8e-be91-a03ce61863a1

New behavior:

https://github.com/user-attachments/assets/db52c66a-1e9b-45be-a8bf-7e0856145ab1



## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->