### PR TITLE
feat+fix(new study screen): HTML type in answer improvements

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid.js
@@ -23,14 +23,6 @@ globalThis.ankidroid.showAllHints = function () {
 };
 
 /**
- * @param {InputEvent} event - the oninput event of the type answer <input>
- */
-globalThis.ankidroid.onTypeAnswerInput = function (event) {
-    const encodedValue = encodeURIComponent(event.target.value);
-    window.location.href = `ankidroid://typeinput/${encodedValue}`;
-};
-
-/**
  * @param {KeyboardEvent} event - the onkeydown event of the type answer <input>
  */
 globalThis.ankidroid.onTypeAnswerKeyDown = function (event) {


### PR DESCRIPTION
## Fixes
* Fixes #16213

## Approach

1. For listening to `Enter` presses in the `<input>` box, I used `onkeydown`, similar to what Anki Desktop does (although they use the deprecated `onkeypress` listener there).
    - And I know that the screen darkens after that, but I'll fix that in the future (I think the same happens in other scenarios, but I don't recall any right now)
2. The best way I thought for the ViewModel to listen to the View (specifically the WebView in this case) was to use a CompletableDeferred Flow. I haven't tested, but it shouldn't result in any leakages, it is testable, and it doesn't couple the ViewModel with the View. It feels a bit hacky, and I suspect that this needs to be hacky, but I'm open to more elegant solutions. Maybe there are some flow or coroutines tricks that can be done.

## How Has This Been Tested?

Emulator 34

[Screen_recording_20251102_120321.webm](https://github.com/user-attachments/assets/db711efe-ca4b-433b-bbed-d96b872d0a09)

[Screen_recording_20251102_120231.webm](https://github.com/user-attachments/assets/bc7fa402-6a3f-45da-9601-87224e41ca35)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->