### PR TITLE
fix: Deck selection row is visible on initial load for note editor with Image Occlusion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2386,8 +2386,6 @@ class NoteEditorFragment :
         note: Note?,
         changeType: FieldChangeType,
     ) {
-        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
-        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !currentNotetypeIsImageOcclusion()
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {
@@ -2408,6 +2406,11 @@ class NoteEditorFragment :
         updateToolbar()
         populateEditFields(changeType, false)
         updateFieldsFromStickyText()
+
+        // Showing the deck selection parts is not needed for Image Occlusion notetypes
+        // as deck selection is handled by the backend page
+        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
+        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !currentNotetypeIsImageOcclusion()
     }
 
     private fun addClozeButton(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The row for selecting deck in the note editor is unexpectedly visible when the editor is initially loaded with Image Occlusion note type.
<img width="280" height="2412" alt="image" src="https://github.com/user-attachments/assets/0b8d374e-755b-454e-bcc7-34ddf1dc1055" />




-----

## Fixes
* Fixes #19416

## Approach
(Updated)
Move the process of the visibility to the end of `setNote()`

## How Has This Been Tested?

Checked on a physical device (Android 15)
(Confirmed again after the updated approach)
<img width="280" height="2412" alt="image" src="https://github.com/user-attachments/assets/a6d09764-a828-49d1-8650-82ffb2f50c1f" />


## Checklist

- [ ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->