### PR TITLE
build(deps): forward port to android gradle plugin 9

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -28,6 +28,7 @@
       <w>gtxt</w>
       <w>instanceof</w>
       <w>keypress</w>
+      <w>kotlinc</w>
       <w>librsdroid</w>
       <w>longclick</w>
       <w>mediaplayer</w>

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -4,7 +4,6 @@ plugins {
     // Gradle plugin portal
     alias(libs.plugins.tripletPlay)
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.keeper)
@@ -50,6 +49,7 @@ android {
         buildConfig = true
         aidl = true
         viewBinding = true
+        resValues = true
     }
 
     if (rootProject.testReleaseBuild) {
@@ -277,12 +277,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
         coreLibraryDesugaringEnabled = true
     }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
-    }
-
 
     packagingOptions {
         resources {
@@ -332,7 +326,6 @@ tasks.register('installGitHook', Copy) {
 }
 // to run manually: `./gradlew installGitHook`
 tasks.named('preBuild').configure { dependsOn('installGitHook') }
-
 
 // Issue 11078 - some emulators run, but run zero tests, and still report success
 tasks.register('assertNonzeroAndroidTests') {

--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -92,15 +92,13 @@ def fileFilter = [
         '**/*$Result$*.*'
 ]
 
-def flavorClassDir = 'tmp/kotlin-classes/play'
-def moduleClassDir = 'tmp/kotlin-classes/'
-if (rootProject.testReleaseBuild) {
-    flavorClassDir += "Release"
-    moduleClassDir += "release"
-} else {
-    flavorClassDir += "Debug"
-    moduleClassDir += "debug"
+static def builtInKotlincClassDir(String variant) {
+    // AGP9 built-in Kotlin compiler writes classes to
+    // build/intermediates/built_in_kotlinc/<variant>/compile<Variant>Kotlin/classes
+    "intermediates/built_in_kotlinc/${variant}/compile${variant.capitalize()}Kotlin/classes"
 }
+def flavorClassDir = builtInKotlincClassDir("play${rootProject.androidTestVariantName}")
+def moduleClassDir = builtInKotlincClassDir(rootProject.androidTestVariantName.toLowerCase())
 
 // Our merge report task
 tasks.register('jacocoTestReport', JacocoReport) {
@@ -155,9 +153,11 @@ tasks.register('jacocoUnitTestReport', JacocoReport) {report ->
 
 gradle.projectsEvaluated {
     // ensure test results aren't cached
-    tasks.named('testPlayDebugUnitTest') {task ->
-        task.outputs.upToDateWhen { false }
-        task.outputs.cacheIf { false }
+    tasks.configureEach { task ->
+        if (task.name == 'testPlayDebugUnitTest') {
+            task.outputs.upToDateWhen { false }
+            task.outputs.cacheIf { false }
+        }
     }
     for (module in modulesToUnitTest) {
         project(module).tasks.named('testDebugUnitTest')?.configure {task ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -87,9 +87,9 @@ abstract class MultimediaFragment(
             Timber.d("Getting MultimediaActivityExtra values from arguments")
             @Suppress("USELESS_CAST")
             val multimediaActivityExtra =
-                arguments?.getSerializableCompat(
+                arguments?.getSerializableCompat<MultimediaActivityExtra>(
                     MultimediaActivity.MULTIMEDIA_ARGS_EXTRA,
-                ) as? MultimediaActivityExtra
+                )
 
             if (multimediaActivityExtra != null) {
                 indexValue = multimediaActivityExtra.index

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,9 +1,9 @@
+import com.android.build.api.dsl.LibraryExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     id("maven-publish")
 }
 
@@ -12,9 +12,14 @@ version = "2.0.0"
 
 kotlin {
     explicitApi()
+    compilerOptions {
+        // enable explicit api mode for additional checks related to the public api
+        // see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
+        freeCompilerArgs.add("-Xexplicit-api=strict")
+    }
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "com.ichi2.anki.api"
     compileSdk =
         libs.versions.compileSdk
@@ -48,21 +53,13 @@ android {
         }
         release {
             isMinifyEnabled = false
-            proguardFiles(getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro")
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
     compileOptions {
         // API remains on VERSION_11 for compatibility
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-    kotlin {
-        compilerOptions {
-            // enable explicit api mode for additional checks related to the public api
-            // see https://kotlinlang.org/docs/whatsnew14.html#explicit-api-mode-for-library-authors
-            freeCompilerArgs.add("-Xexplicit-api=strict")
-            jvmTarget = JvmTarget.JVM_11
-        }
     }
 
     publishing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ if (project.rootProject.file("local.properties").exists()) {
 val fatalWarnings = localProperties["fatal_warnings"] != "false"
 
 // can't be obtained inside 'subprojects'
-val ktlintVersion: String? = libs.versions.ktlint.get()
+val ktlintVersion: String = libs.versions.ktlint.get()
 
 // Here we extract per-module "best practices" settings to a single top-level evaluation
 subprojects {
@@ -45,7 +45,7 @@ subprojects {
 
     afterEvaluate {
         plugins.withType<com.android.build.gradle.BasePlugin> {
-            val androidExtension = extensions.getByName("android") as CommonExtension<*, *, *, *, *, *>
+            val androidExtension = extensions.getByName("android") as CommonExtension
             androidExtension.testOptions.unitTests {
                 isIncludeAndroidResources = true
             }
@@ -127,7 +127,7 @@ subprojects {
 }
 
 val jvmVersion = Jvm.current().javaVersion?.majorVersion.parseIntOrDefault(defaultValue = 0)
-val minSdk: String? = libs.versions.minSdk.get()
+val minSdk: String = libs.versions.minSdk.get()
 val jvmVersionLowerBound = 21
 val jvmVersionUpperBound = 25
 if (jvmVersion !in jvmVersionLowerBound..jvmVersionUpperBound) {

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -1,11 +1,11 @@
+import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
-android {
+configure<LibraryExtension> {
     // this cannot conflict with com.ichi2.anki
     // but we can define files in 'com.ichi2.anki' inside 'common'
     // even with this namespace
@@ -38,11 +38,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
 }
 

--- a/compat/build.gradle.kts
+++ b/compat/build.gradle.kts
@@ -1,11 +1,11 @@
+import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "com.ichi2.anki.compat"
     testFixtures.enable = true
     compileSdk =
@@ -25,11 +25,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,3 +30,10 @@ org.gradle.vfs.watch=true
 
 # Enable Kotlin support for Android test fixtures
 android.experimental.enableTestFixturesKotlinSupport=true
+
+# Keeper does not tolerate newDsl in AGP9 yet
+# it is fixed on a fork https://github.com/slackhq/keeper/pull/154#issuecomment-3921848493
+# ...but keeper looking for long-term home, AGP9 compatibility is currently unpublished
+# attempting to use the github maven repo package publish from that comment did not work initially
+# perhaps can vendor a compiled lib / local maven repository for that plugin
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,9 @@ ktlint = '1.8.0'
 #
 # Old changelogs - See 'Table of Contents' in sidebar
 # https://developer.android.com/build/releases/past-releases
-androidGradlePlugin = "8.13.2"
+# Pinned to 9.0.1 until building androidTest in release mode circular dependency issue resolved
+# Upstream reference https://issuetracker.google.com/issues/491718901
+androidGradlePlugin = "9.0.1"
 # https://developer.android.com/jetpack/androidx/releases/activity
 androidxActivity = "1.12.4"
 # https://developer.android.com/jetpack/androidx/releases/annotation
@@ -117,7 +119,7 @@ slf4jTimber = "3.1"
 timber = "5.0.1"
 # https://github.com/Triple-T/gradle-play-publisher/releases
 # In the past, releases have been published before the changelog
-triplet = "3.13.0"
+triplet = "4.0.0"
 turbine = "1.2.1"
 
 [libraries]
@@ -163,7 +165,7 @@ java-semver = { module = "com.github.zafarkhaja:java-semver", version.ref = "jav
 jsoup = { module = "org.jsoup:jsoup", version.ref = "jsoup" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 leakcanary-android = { module = "com.squareup.leakcanary:leakcanary-android", version.ref = "leakcanaryAndroid" }
 google-material = { module = "com.google.android.material:material", version.ref = "material" }
 nanohttpd = { module = "org.nanohttpd:nanohttpd", version.ref = "nanohttpd" }

--- a/libanki/build.gradle.kts
+++ b/libanki/build.gradle.kts
@@ -1,13 +1,13 @@
+import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "com.ichi2.anki.libanki"
     testFixtures.enable = true
     compileSdk =
@@ -20,18 +20,11 @@ android {
             libs.versions.minSdk
                 .get()
                 .toInt()
-
-        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
 }
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/DB.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/DB.kt
@@ -145,7 +145,9 @@ class DB(
     fun executeScript(sql: String) {
         val queries = sql.split(";")
         for (query in queries) {
-            database.execSQL(query)
+            if (query.isNotEmpty()) {
+                database.execSQL(query)
+            }
         }
     }
 

--- a/vbpd/build.gradle.kts
+++ b/vbpd/build.gradle.kts
@@ -1,11 +1,11 @@
+import com.android.build.api.dsl.LibraryExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.kotlin.android)
 }
 
-android {
+configure<LibraryExtension> {
     namespace = "dev.androidbroadcast.vbpd"
     compileSdk =
         libs.versions.compileSdk
@@ -37,11 +37,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-    kotlin {
-        compilerOptions {
-            jvmTarget = JvmTarget.JVM_17
-        }
     }
 }
 


### PR DESCRIPTION

AGP9 changes all sorts of stuff, but it's mostly easy

The only thing truly difficult (IMNSHO) is that someone (could be us...) needs to provide a stable forever home for the "Keeper" plugin which allows us to test minified builds - it has an AGP9 forward-port PR but that will likely never be published in current repo - until we solve or workaround that (with a local maven repo and vendored build?) we cannot enable `newDsl`, currently we have to disable it for compatibility reasons with that plugin


- Obsoletes #20740
- Obsoletes #20220