### PR TITLE
Fix null deck view in CardBrowser multi select mode collector

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -512,14 +512,14 @@ open class CardBrowser :
                 Timber.d("load multiselect mode")
                 // show title and hide spinner
                 actionBarTitle?.visibility = View.VISIBLE
-                findViewById<TextView>(R.id.deck_name).isVisible = false
-                findViewById<TextView>(R.id.subtitle).isVisible = false
+                findViewById<TextView>(R.id.deck_name)?.isVisible = false
+                findViewById<TextView>(R.id.subtitle)?.isVisible = false
                 multiSelectOnBackPressedCallback.isEnabled = true
             } else {
                 Timber.d("end multiselect mode")
                 refreshSubtitle()
-                findViewById<TextView>(R.id.deck_name).isVisible = true
-                findViewById<TextView>(R.id.subtitle).isVisible = true
+                findViewById<TextView>(R.id.deck_name)?.isVisible = true
+                findViewById<TextView>(R.id.subtitle)?.isVisible = true
                 actionBarTitle?.visibility = View.GONE
                 multiSelectOnBackPressedCallback.isEnabled = false
             }
@@ -943,6 +943,8 @@ open class CardBrowser :
         }
         // set the number of selected rows (only in multiselect)
         actionBarTitle?.text = String.format(LanguageUtil.getLocaleCompat(resources), "%d", viewModel.selectedRowCount())
+        findViewById<TextView>(R.id.deck_name)?.isVisible = !viewModel.hasSelectedAnyRows() && !viewModel.isInMultiSelectMode
+        findViewById<TextView>(R.id.subtitle)?.isVisible = !viewModel.hasSelectedAnyRows() && !viewModel.isInMultiSelectMode
 
         actionBarMenu.findItem(R.id.action_flag).isVisible = viewModel.hasSelectedAnyRows()
         actionBarMenu.findItem(R.id.action_suspend_card).apply {


### PR DESCRIPTION
## Purpose / Description

Bug was happening when opening search in browser and then long clicking a row(and starting the multi select mode). 
Because the SearchView was still opened at that moment the deck related views weren't available.

With the code in this PR the deck related views are updated later after the menu has been invalidated(and SearchView already closed).

## Fixes
* Fixes #19427

## How Has This Been Tested?

Selected many rows in browser, ran tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
