### PR TITLE
Enable deck selection only when not using the new browser search view

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -362,9 +362,9 @@ open class CardBrowser :
             // initialize the lateinit variables
             // Load reference to action bar title
             actionBarTitle = findViewById(R.id.toolbar_title)
+            // new deck selection is only available when the new search view is not used
+            findViewById<LinearLayout>(R.id.toolbar_content).setOnClickListener { startDeckSelection(all = true, filtered = true) }
         }
-
-        findViewById<LinearLayout>(R.id.toolbar_content).setOnClickListener { startDeckSelection(all = true, filtered = true) }
 
         startLoadingCollection()
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

When using the new browser search view(must be enabled in the dev options) we show a chip instead of a toolbar deck name view. So we need to setup the deck selection listener only when not using the new search view.

See more lines above the changed code in the diff.

Fixes the issue below for the person using this feature for some reason:

<details>
<summary>Stacktrace</summary>

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.ichi2.anki/com.ichi2.anki.CardBrowser}: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.setOnClickListener(android.view.View$OnClickListener)' on a null object reference
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4397)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4603)
	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:112)
	at android.app.servertransaction.TransactionExecutor.executeNonLifecycleItem(TransactionExecutor.java:186)
	at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:112)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:84)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2876)
	at android.os.Handler.dispatchMessage(Handler.java:107)
	at android.os.Looper.loopOnce(Looper.java:249)
	at android.os.Looper.loop(Looper.java:337)
	at android.app.ActivityThread.main(ActivityThread.java:9410)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:614)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1005)
Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.setOnClickListener(android.view.View$OnClickListener)' on a null object reference
	at com.ichi2.anki.CardBrowser.onCreate$lambda$9(CardBrowser.kt:367)
	at com.ichi2.anki.CardBrowser.onCreate(CardBrowser.kt:367)
	at android.app.Activity.performCreate(Activity.java:9211)
	at android.app.Activity.performCreate(Activity.java:9170)
	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1537)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4379)
	... 13 more
```

</details>

## How Has This Been Tested?

Selected many browser rows, ran tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
