### PR TITLE
refactor: Middle blue line now moves left to mid

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioWaveform.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/audio/AudioWaveform.kt
@@ -24,8 +24,7 @@ import android.util.AttributeSet
 import android.view.View
 import androidx.core.content.withStyledAttributes
 import com.ichi2.anki.R
-
-// TODO : Middle blue line should move left->mid https://github.com/ankidroid/Anki-Android/pull/14591#issuecomment-1791037102
+import kotlin.math.ceil
 
 /**This class represents a custom View used for creating audio waveforms when recording audio.
  * It loops over each spike and add it on the screen and the height of the spike is determined by the
@@ -77,7 +76,7 @@ class AudioWaveform(
 
     private val spikeCount
         get() =
-            (sw / (w + d) * percentageOfWidthToFill)
+            ceil(sw / (w + d) * percentageOfWidthToFill)
                 .toInt()
 
     init {
@@ -120,8 +119,18 @@ class AudioWaveform(
         }
 
         if (displayVerticalLine) {
-            // mid blue vertical line
-            val centerX = width / 2f
+            val maxCenterX = width / 2f
+            val isFilled = audioSpikes.size == spikeCount
+
+            val centerX =
+                if (isFilled) {
+                    maxCenterX
+                } else {
+                    val currentLineX = audioSpikes.size * (w + d)
+
+                    currentLineX.coerceAtMost(maxCenterX)
+                }
+
             val startY = 0f
             val endY = height.toFloat()
             canvas.drawLine(centerX, startY, centerX, endY, verticalLinePaint)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Resolves a TODO from waveform long pending(took me quite some time to figure out)

## Fixes
NA

## Approach
- In the onDraw method, The blue line's X-coordinate (centerX) is now calculated dynamically. It moves along with the end of the waveform as spikes are added, and then "locks" to the exact center (width / 2f) as soon as the waveform fills the left half.
- This is achieved by checking if the number of spikes being-drawn (audioSpikes.size) has reached the maximum allowed (spikeCount).
- use ceil (ceiling) instead of truncating. This rounds up to the nearest whole number and avoids jerk when the Blue line settles I tested without ceil (original code) but there is a jerk and on inspection I found this issue so using ceil method

## How Has This Been Tested?
Pixel 9 API 31
[Screen_recording_20251107_043338.webm](https://github.com/user-attachments/assets/3d6423d0-8796-45e9-9b7f-9f5fd17ee586)


## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->