### PR TITLE
Editing notes triggers the timebox popup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -1208,11 +1208,16 @@ open class Reviewer :
                     topCard.renderOutput(this@withCol, reload = true)
                 }
             }
-        state?.timeboxReached?.let { dealWithTimeBox(it) }
+
         currentCard = state?.topCard
         queueState = state
     }
 
+    /**
+     * Answer the current card, update the scheduler and checks if the timebox limit has been reached
+     * and, if so, displays a dialog to the user
+     * @param rating The user's rating for the card
+     */
     override suspend fun answerCardInner(rating: Rating) {
         val state = queueState!!
         val cardId = currentCard!!.id
@@ -1234,6 +1239,12 @@ open class Reviewer :
                     }
                 showSnackbar(leechMessage, Snackbar.LENGTH_SHORT)
             }
+        }
+
+        // showing the timebox reached dialog if the timebox is reached
+        val timebox = withCol { timeboxReached() }
+        if (timebox != null) {
+            dealWithTimeBox(timebox)
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Previously, the timebox limit was checked whenever the updateCurrentCard function was called, which lead to unnecessary timebox reached popup, this logic has been moved to the answerCardInner function. This makes it so that the popup is only shown when a card has been answered.

## Fixes
* Fixes #18374 

## How Has This Been Tested?
Tested on an android 15 phone

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->