### PR TITLE
fix(study screen): HTML type-in-answer autofocus IME issues

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -263,6 +263,7 @@ class ReviewerFragment :
             }
 
         val isHtmlTypeAnswerEnabled = Prefs.isHtmlTypeAnswerEnabled
+        val insetsController = WindowInsetsControllerCompat(window, view)
         lifecycleScope.launch {
             val autoFocusTypeAnswer = Prefs.autoFocusTypeAnswer
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -273,8 +274,10 @@ class ReviewerFragment :
                     }
 
                     if (isHtmlTypeAnswerEnabled) {
+                        if (!autoFocusTypeAnswer) return@collect
                         webViewLayout.focusOnWebView()
                         webViewLayout.evaluateJavascript("document.getElementById('typeans').focus();", null)
+                        insetsController.show(WindowInsetsCompat.Type.ime())
                         return@collect
                     }
 


### PR DESCRIPTION
## Fixes
* Fixes #19453

## Approach

In the commits

## How Has This Been Tested?

Emulator 34:
1. enable both HTML type in answer and auto focus on `Settings > Advanced`
2. Open a type-in-answer card
    - it should automatically show the keyboard
    - showing the answer should hide the keyboard

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->