### PR TITLE
fix(deck-picker): ANR during syncing

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -648,6 +648,7 @@ class DeckPickerTest : RobolectricTest() {
             deckToClick.performLongClick()
 
             // ASSERT
+            advanceRobolectricLooper() // ensure that 'focusedDeck' is current
             assertThat("unbury is visible: one card is buried", col.sched.haveBuried())
             assertThat("deck focus has changed", viewModel.focusedDeck, equalTo(deckWithCards))
         }


### PR DESCRIPTION
## Purpose / Description

* Sync
* Background app
* Resume app
* ANR

This is caused by `updateDeckList` being called on the main thread and `isOpenUnsafe` blocking until the sync completed, blocking the main thread.

## Fixes
* Fixes #18886

## Approach
* Launch `updateDeckList` on the background thread so it does not ANR
* Add TODOs to avoid calling the method entirely

## How Has This Been Tested?
I performed the above steps in `release` and the UI no longer hangs
After a brief test, the screen appears to work as expected (API 33 emulator)

```patch
Index: libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt	(revision 7d4ad95987898d7738d9cbec1945a2e30aaafe35)
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt	(date 1762802142909)
@@ -80,6 +80,7 @@
 import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
 import timber.log.Timber
 import java.io.File
+import kotlin.time.Duration.Companion.seconds
 
 typealias ImportLogWithChanges = anki.import_export.ImportResponse
 
@@ -1211,7 +1212,11 @@
     fun syncCollection(
         auth: SyncAuth,
         syncMedia: Boolean,
-    ): SyncCollectionResponse = backend.syncCollection(auth, syncMedia)
+    ): SyncCollectionResponse {
+        return backend.syncCollection(auth, syncMedia).also {
+            Thread.sleep(20.seconds.inWholeMilliseconds)
+        }
+    }
 
     @LibAnkiAlias("sync_media")
     fun syncMedia(auth: SyncAuth) = backend.syncMedia(auth)
```

## Learning
Robolectric WILL get better once we're fully using ViewModels, but the combination of Activity & ViewModel-based threading is painful

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->