### PR TITLE
Add `dir="auto"` to cards for stable card direction

### DIFF
--- a/AnkiDroid/src/main/assets/card_template.html
+++ b/AnkiDroid/src/main/assets/card_template.html
@@ -16,7 +16,7 @@
         <script src="file:///android_asset/backend/js/reviewer_extras_bundle.js"> </script>
     </head>
     <body class="::class::">
-        <div id="content">
+        <div id="content" dir="auto">
         ::content::
         </div>
     </body>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
@@ -74,7 +74,7 @@ fun stdHtml(
             </style>
         </head>
         <body class="${bodyClass()}">
-            <div id="qa"></div>
+            <div id="qa" dir="auto"></div>
             $jsTxt
             <script>bridgeCommand = function(){};</script>
         </body>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Currently, the direction in which a card is rendered is not stable by default. If the UI of Ankidroid is English, text direction is left-to-right by default. If the UI of Ankidroidis Arabic, text direction is right-to-left by default. Although this can be changed from the settings (changing css for example), the card direction should be stable by default, being viewed in the same way regardless of the direction of the UI. 

## Fixes
This commit makes the direction of cards stable, regardless of the UI language.

## Approach
This commit attempts to solve the issue by adding `dir="auto"` by default for all cards. It will not break existing cards that override the direction via css or html, but it will make cards that don't specify a direction stable.

## How Has This Been Tested?

I haven't built Ankidroid, but I tested adding this attribute to card template front and back and it worked correctly, making the card direction stable regardless of the UI language.