### PR TITLE
Fix missing minus symbol when updating tags in card browser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsList.kt
@@ -45,7 +45,8 @@ class TagsList(
     private val checkedTags: MutableSet<String> = TreeSet(java.lang.String.CASE_INSENSITIVE_ORDER)
 
     /**
-     * A Set containing the tags with indeterminate state
+     * A Set containing the tags with indeterminate state.
+     * For a tag to be in indeterminate state it should be present in checkedTags and also in uncheckedTags.
      */
     private val indeterminateTags: MutableSet<String>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModelTest.kt
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2025 Divyansh Kushwaha <thedroiddiv@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs.tags
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.libanki.NoteId
+import com.ichi2.anki.libanki.testutils.ext.newNote
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.properties.Delegates
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(AndroidJUnit4::class)
+class TagsDialogViewModelTest : RobolectricTest() {
+    private var note1 by Delegates.notNull<NoteId>()
+    private var note2 by Delegates.notNull<NoteId>()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    /**
+     * Initialize the collections with three notes with each having some tags
+     * ```
+     * note1    a,b,c
+     * note2    b,d
+     * note3    e,f
+     * ```
+     */
+    @Before
+    fun setupNotes() {
+        setupTestDispatcher(testDispatcher)
+
+        val n1 = col.newNote()
+        col.addNote(n1, 0)
+        col.tags.bulkAdd(listOf(n1.id), "a b c")
+        note1 = n1.id
+
+        val n2 = col.newNote()
+        col.addNote(n2, 0)
+        col.tags.bulkAdd(listOf(n2.id), "b d")
+        note2 = n2.id
+
+        val n3 = col.newNote()
+        col.addNote(n3, 0)
+        col.tags.bulkAdd(listOf(n3.id), "e f")
+    }
+
+    @Test
+    fun `single note produces correct checked, indeterminate and all sets`() =
+        runTest(testDispatcher) {
+            val vm =
+                TagsDialogViewModel(
+                    noteIds = listOf(note1),
+                    checkedTags = listOf("a"),
+                    isCustomStudying = false,
+                )
+            val tags = vm.tags.await()
+            // only one note, tags can either be checked or unchecked only
+            // all : {a,b,c,d,e,f}
+            // indeterminate: { }
+            // checked: {a,b,c}
+            assertEquals(listOf("a", "b", "c"), tags.copyOfCheckedTagList().sorted())
+            assertTrue(tags.copyOfIndeterminateTagList().isEmpty())
+            assertEquals(listOf("a", "b", "c", "d", "e", "f"), tags.copyOfAllTagList().sorted())
+        }
+
+    @Test
+    fun `multiple notes create indeterminate tags correctly`() =
+        runTest(testDispatcher) {
+            // note 1           a, b, c
+            // note 2              b, d
+            val vm =
+                TagsDialogViewModel(
+                    noteIds = listOf(note1, note2),
+                    checkedTags = emptyList(),
+                    isCustomStudying = false,
+                )
+
+            val tags = vm.tags.await()
+            val checked = tags.copyOfCheckedTagList()
+            val ind = tags.copyOfIndeterminateTagList()
+
+            // All tags in the collection: {a,b,c,d,e,f}
+            // Assuming indeterminate logic in [TagsList] is correct
+            // a    [-] - indeterminate
+            // b    [x] - checked
+            // c    [-] - indeterminate
+            // d    [-] - indeterminate
+            // e    [ ] - unchecked
+            // f    [ ] - unchecked
+            assertEquals(listOf("b"), checked.sorted())
+            assertEquals(listOf("a", "c", "d"), ind.sorted())
+            assertFalse(tags.isChecked("e"))
+            assertFalse(tags.isChecked("f"))
+        }
+
+    @Test
+    fun `extra checkedTags is absolute checked and not indeterminate`() =
+        runTest(testDispatcher) {
+            val vm =
+                TagsDialogViewModel(
+                    noteIds = listOf(note1),
+                    checkedTags = listOf("d", "x"),
+                    isCustomStudying = false,
+                )
+
+            // note1.tags       {a,b}
+            // extraCheckedTags {d, x}
+            // allTags          {a,b,c,d,e}
+            // implies inside dialog
+            // checkedTags      {a, b, d, x}
+            // uncheckedTags    { c, e }
+            // indeterminate    { }
+            val tags = vm.tags.await()
+            assertTrue(tags.isChecked("d"))
+            assertFalse(tags.isIndeterminate("d"))
+            assertTrue(tags.isChecked("x"))
+            assertFalse(tags.isIndeterminate("d"))
+            assertTrue(tags.copyOfAllTagList().contains("x"))
+        }
+
+    @Test
+    fun `custom study mode makes all tags unchecked`() =
+        runTest(testDispatcher) {
+            val vm =
+                TagsDialogViewModel(
+                    noteIds = listOf(note1, note2),
+                    checkedTags = listOf("a"),
+                    isCustomStudying = true,
+                )
+            val tags = vm.tags.await()
+            // tags from both notes = {a,b,c,d}
+            val all = tags.copyOfAllTagList().sorted()
+            assertEquals(listOf("a", "b", "c", "d"), all)
+            // custom study: checked = empty
+            assertTrue(tags.copyOfCheckedTagList().isEmpty())
+            // custom study: indeterminate = empty
+            assertTrue(tags.copyOfIndeterminateTagList().isEmpty())
+            // custom study:
+            // checked - empty, unchecked - empty, all - not empty
+            // implies unchecked = allTags
+            assertTrue(tags.copyOfAllTagList().isNotEmpty())
+        }
+}


### PR DESCRIPTION
## Purpose / Description
Fix missing minus symbol when selecting several cards at once in the card browser to update tags.

## Fixes
* Fixes #19083

## Approach

### Problem
This happened because the previous implementation
- treated all notes present in any note as "checked"
- remaining all were marked as "unchecked

### Expected
- tags present in all notes : "checked"
- tags present in some, but not all notes: "indeterminate"
- tags present in none of the notes: unchecked

### Fix
- check all notes, check if each tag is present or absent
- add to checked list if present else add to unchecked list
- this operations might result in few tags being present in both lists
- intersecting tags are the "indeterminate" ones which are correctly captured by [TagsList] 
- tags coming from intent's `extras` are treated as absolute `checked` and cannot be indeterminate 


## How Has This Been Tested?
Added unit test for "indeterminate"
Existing tests pass
Manually Tested

<img width="300" alt="image" src="https://github.com/user-attachments/assets/f31b9544-96bc-4bb0-84db-f205e792cfac" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b1d43250-91b3-4080-aff1-0daa40e240bd" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/b6528f24-88df-4c72-a759-ee9c45b38303" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/d2b555c8-83fd-4262-8b75-611c06a06563" />




## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->