### PR TITLE
chore: convert SingleFragmentActivity to be ViewBinding compatible

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -22,6 +22,7 @@ import android.view.KeyEvent
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.commit
+import com.ichi2.anki.SingleFragmentActivity.Companion.getIntent
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
@@ -42,7 +43,7 @@ import kotlin.reflect.jvm.jvmName
  *
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
-open class SingleFragmentActivity : AnkiActivity() {
+open class SingleFragmentActivity : AnkiActivity(R.layout.single_fragment_activity) {
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -52,7 +53,6 @@ open class SingleFragmentActivity : AnkiActivity() {
         if (!ensureStoragePermissions()) {
             return
         }
-        setContentView(R.layout.single_fragment_activity)
         setTransparentStatusBar()
 
         // avoid recreating the fragment on configuration changes


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/76f7a1f9f6e4faa9e5fc8fd893d55aa4891e1ce7
* Realised ViewBindings weren't necessary, so removed them

## How Has This Been Tested?
Brief test - Open Statistics
* Pixel 34 Tablet emulator - screen opens


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)