### PR TITLE
chore: convert CardTemplateBrowserAppearanceEditor to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -25,12 +25,14 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged
+import com.ichi2.anki.databinding.CardBrowserAppearanceBinding
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.CardTemplate
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
+import dev.androidbroadcast.vbpd.viewBinding
 import org.jetbrains.annotations.Contract
 import timber.log.Timber
 
@@ -39,9 +41,8 @@ import timber.log.Timber
  * We do not allow the user to change fonts as Android only has a handful
  * We do not allow the user to change the font size as this can be done in the Appearance settings.
  */
-class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
-    private lateinit var questionEditText: EditText
-    private lateinit var answerEditText: EditText
+class CardTemplateBrowserAppearanceEditor : AnkiActivity(R.layout.card_browser_appearance) {
+    private val binding by viewBinding(CardBrowserAppearanceBinding::bind)
 
     // start with the callback disabled as there aren't any changes yet
     private val discardChangesCallback =
@@ -66,10 +67,10 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
         // default result, only changed to RESULT_OK if actually saving changes
         setResult(RESULT_CANCELED)
         onBackPressedDispatcher.addCallback(discardChangesCallback)
-        questionEditText.doAfterTextChanged { _ ->
+        binding.questionFormat.doAfterTextChanged { _ ->
             discardChangesCallback.isEnabled = hasChanges()
         }
-        answerEditText.doAfterTextChanged { _ ->
+        binding.answerFormat.doAfterTextChanged { _ ->
             discardChangesCallback.isEnabled = hasChanges()
         }
     }
@@ -129,13 +130,8 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
     }
 
     private fun initializeUiFromBundle(bundle: Bundle) {
-        setContentView(R.layout.card_browser_appearance)
-
-        questionEditText = findViewById(R.id.question_format)
-        questionEditText.setText(bundle.getString(INTENT_QUESTION_FORMAT))
-
-        answerEditText = findViewById(R.id.answer_format)
-        answerEditText.setText(bundle.getString(INTENT_ANSWER_FORMAT))
+        binding.questionFormat.setText(bundle.getString(INTENT_QUESTION_FORMAT))
+        binding.answerFormat.setText(bundle.getString(INTENT_ANSWER_FORMAT))
 
         discardChangesCallback.isEnabled = hasChanges()
 
@@ -148,16 +144,16 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity() {
     private fun questionHasChanged(intent: Intent): Boolean = intent.getStringExtra(INTENT_QUESTION_FORMAT) != questionFormat
 
     private val questionFormat: String
-        get() = getTextValue(questionEditText)
+        get() = getTextValue(binding.questionFormat)
     private val answerFormat: String
-        get() = getTextValue(answerEditText)
+        get() = getTextValue(binding.answerFormat)
 
     private fun getTextValue(editText: EditText): String = editText.text.toString()
 
     private fun restoreDefaultAndClose() {
         Timber.i("Restoring Default and Closing")
-        questionEditText.setText(VALUE_USE_DEFAULT)
-        answerEditText.setText(VALUE_USE_DEFAULT)
+        binding.questionFormat.setText(VALUE_USE_DEFAULT)
+        binding.answerFormat.setText(VALUE_USE_DEFAULT)
         saveAndExit()
     }
 


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/484a08f8b9ed874a737f8820f1b33eaf5e4d9b06
* converted to vbpd

## How Has This Been Tested?
Brief test - Open Card Template Editor
* Pixel 36 Tablet emulator - screen opens

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)