### PR TITLE
fix: remove extra undo entry when adding note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1279,7 +1279,6 @@ class NoteEditorFragment :
         val changes =
             requireActivity().withProgress(resources.getString(R.string.saving_facts)) {
                 undoableOp {
-                    notetypes.save(editorNote!!.notetype)
                     addNote(editorNote!!, deckId)
                 }
             }
@@ -1304,9 +1303,6 @@ class NoteEditorFragment :
             for (f in editFields!!) {
                 updateField(f)
             }
-            // Save deck to noteType
-            Timber.d("setting 'last deck' of note type %s to %d", editorNote!!.notetype.name, deckId)
-            editorNote!!.notetype.did = deckId
             // Save tags to model
             editorNote!!.setTagsFromStr(getColUnsafe, tagsAsString(selectedTags!!))
             val tags = JSONArray()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -154,8 +154,6 @@ class InstantEditorViewModel :
      */
     private suspend fun saveNote(): SaveNoteResult {
         return try {
-            editorNote.notetype.did = deckId!!
-
             val note = editorNote
             val deckId = deckId ?: return SaveNoteResult.Failure()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -487,7 +487,8 @@ class NoteEditorTest : RobolectricTest() {
             addDeck("Basic")
             val reversedDeckId = addDeck("Reversed", setAsSelected = true)
 
-            assertThat("setup: deckId", col.notetypes.byName("Basic")!!.did, equalTo(1))
+            val basicNotetypeId = col.notetypes.byName("Basic")!!.id
+            assertThat("setup: no default deck set yet", col.defaultDeckForNoteType(basicNotetypeId), equalTo(null))
 
             getNoteEditorAdding(NoteType.BASIC).build().also { editor ->
                 editor.onDeckSelected(SelectableDeck.Deck(reversedDeckId, "Reversed"))
@@ -498,7 +499,7 @@ class NoteEditorTest : RobolectricTest() {
             col.notetypes.clearCache()
 
             assertThat("a note was added", col.noteCount(), equalTo(1))
-            assertThat("note type deck is updated", col.notetypes.byName("Basic")!!.did, equalTo(reversedDeckId))
+            assertThat("default deck for notetype is updated", col.defaultDeckForNoteType(basicNotetypeId), equalTo(reversedDeckId))
 
             getNoteEditorAdding(NoteType.BASIC).build().also { editor ->
                 assertThat("Deck ID is remembered", editor.deckId, equalTo(reversedDeckId))


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 When undoing the note, the unlabeled entry from `notetypes.save()` would be exposed, causing `undoAvailable()` to return false and hiding previous deck operations from the undo stack.

## Fixes
* Fixes  #19508 

## Approach
Remove `notetypes.save()` from `undoableOp` block as it's redundant - the note already contains notetype information.

## How Has This Been Tested?

https://github.com/user-attachments/assets/dab67e8b-c03e-459a-8d9e-527a9f5a2c62




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->