### PR TITLE
chore: convert TemplatePreviewerFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -55,7 +55,6 @@ import androidx.viewpager2.adapter.FragmentStateAdapter
 import anki.notetypes.StockNotetype
 import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_UNKNOWN_VALUE
 import anki.notetypes.notetypeId
-import com.google.android.material.button.MaterialButton
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
@@ -255,15 +254,13 @@ open class CardTemplateEditor :
             // Modify the "Show Answer" button height to 80dp to maintain visual consistency with the BottomNavigationView,
             // which has a default height of 80dp.
             fragment.view?.post {
-                val showAnswerButton = fragment.view?.findViewById<MaterialButton>(R.id.show_answer)
-                showAnswerButton?.let { button ->
+                fragment.binding.showAnswer.let { button ->
                     button.layoutParams.height = 80.dp.toPx(button.context)
                     button.requestLayout()
                 }
 
                 // Adjust the top margin of the webview container to match template editor top margin
-                val webView = fragment.view?.findViewById<MaterialCardView>(R.id.webview_container)
-                webView?.let { container ->
+                fragment.binding.webViewContainer.let { container ->
                     val params = container.layoutParams as ViewGroup.MarginLayoutParams
                     val topMargin = resources.getDimensionPixelSize(R.dimen.reviewer_side_margin)
                     params.topMargin = topMargin

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -21,14 +21,14 @@ import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
-import com.google.android.material.button.MaterialButton
-import com.google.android.material.card.MaterialCardView
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.TemplatePreviewerBinding
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.utils.BundleUtils.getNullableInt
+import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -39,10 +39,13 @@ class TemplatePreviewerFragment :
         val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
         TemplatePreviewerViewModel.factory(arguments)
     }
-    override val webViewLayout: SafeWebViewLayout get() = requireView().findViewById(R.id.webview_layout)
+
+    val binding by viewBinding(TemplatePreviewerBinding::bind)
+
+    override val webViewLayout: SafeWebViewLayout get() = binding.webViewLayout
 
     override val baseSnackbarBuilder: SnackbarBuilder
-        get() = { anchorView = this@TemplatePreviewerFragment.view?.findViewById(R.id.show_answer) }
+        get() = { anchorView = binding.showAnswer }
 
     override fun onViewCreated(
         view: View,
@@ -50,13 +53,10 @@ class TemplatePreviewerFragment :
     ) {
         super.onViewCreated(view, savedInstanceState)
 
-        val showAnswerButton =
-            view.findViewById<MaterialButton>(R.id.show_answer).apply {
-                setOnClickListener { viewModel.toggleShowAnswer() }
-            }
+        binding.showAnswer.setOnClickListener { viewModel.toggleShowAnswer() }
         viewModel.showingAnswer
             .onEach { showingAnswer ->
-                showAnswerButton.text =
+                binding.showAnswer.text =
                     if (showingAnswer) {
                         getString(R.string.hide_answer)
                     } else {
@@ -65,7 +65,7 @@ class TemplatePreviewerFragment :
             }.launchIn(lifecycleScope)
 
         if (sharedPrefs().getBoolean("safeDisplay", false)) {
-            view.findViewById<MaterialCardView>(R.id.webview_container).elevation = 0F
+            binding.webViewContainer.elevation = 0F
         }
 
         arguments?.getNullableInt(ARG_BACKGROUND_OVERRIDE_COLOR)?.let { color ->

--- a/AnkiDroid/src/main/res/layout/template_previewer.xml
+++ b/AnkiDroid/src/main/res/layout/template_previewer.xml
@@ -7,7 +7,7 @@
     android:orientation="vertical">
 
     <com.google.android.material.card.MaterialCardView
-        android:id="@+id/webview_container"
+        android:id="@+id/web_view_container"
         android:layout_width="match_parent"
         android:layout_marginHorizontal="@dimen/reviewer_side_margin"
         android:layout_height="0dp"
@@ -16,7 +16,7 @@
         >
 
         <com.ichi2.anki.workarounds.SafeWebViewLayout
-            android:id="@+id/webview_layout"
+            android:id="@+id/web_view_layout"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             />


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/2ac1ecdb7f2f10476dbb2cf2dffafeaf961992fc
* converted to vbpd

## How Has This Been Tested?
Brief test - Open Card Template Editor Preview
* Pixel 36 Tablet emulator - screen opens
* Pixel 36 Pixel 9 Pro emulator - screen opens

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)