### PR TITLE
chore: convert PermissionsItem to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsItem.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsItem.kt
@@ -20,13 +20,11 @@ import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
-import android.widget.ImageView
-import androidx.appcompat.widget.SwitchCompat
 import androidx.core.content.withStyledAttributes
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.PermissionsItemBinding
 import com.ichi2.anki.utils.ext.usingStyledAttributes
-import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.Permissions
 import timber.log.Timber
 
@@ -56,7 +54,7 @@ class PermissionsItem(
     context: Context,
     attrs: AttributeSet,
 ) : FrameLayout(context, attrs) {
-    private val switch: SwitchCompat
+    val binding = PermissionsItemBinding.inflate(LayoutInflater.from(context), this, true)
 
     /**
      * The value of either app:permissions or app:permission.
@@ -65,15 +63,12 @@ class PermissionsItem(
     val areGranted get() = Permissions.hasAllPermissions(context, permissions)
 
     init {
-        LayoutInflater.from(context).inflate(R.layout.permissions_item, this, true)
-
-        switch =
-            findViewById<SwitchCompat>(R.id.switch_widget).apply {
-                isEnabled = true
-                setOnCheckedChangeListener { button, _ ->
-                    button.isChecked = areGranted
-                }
+        binding.switchWidget.apply {
+            isEnabled = true
+            setOnCheckedChangeListener { button, _ ->
+                button.isChecked = areGranted
             }
+        }
 
         permissions =
             context.usingStyledAttributes(attrs, R.styleable.PermissionItem) {
@@ -83,13 +78,13 @@ class PermissionsItem(
             }
 
         context.withStyledAttributes(attrs, R.styleable.PermissionItem) {
-            findViewById<FixedTextView>(R.id.title).text = getText(R.styleable.PermissionItem_permissionTitle)
-            findViewById<FixedTextView>(R.id.summary).text = getText(R.styleable.PermissionItem_permissionSummary)
+            binding.title.text = getText(R.styleable.PermissionItem_permissionTitle)
+            binding.summary.text = getText(R.styleable.PermissionItem_permissionSummary)
 
             val icon = getDrawable(R.styleable.PermissionItem_permissionIcon)
             icon?.let {
                 val color = MaterialColors.getColor(this@PermissionsItem, android.R.attr.colorControlNormal)
-                findViewById<ImageView>(R.id.icon).apply {
+                binding.icon.apply {
                     setImageDrawable(it)
                     imageTintList = ColorStateList.valueOf(color)
                 }
@@ -100,7 +95,7 @@ class PermissionsItem(
             permissionsRequested?.invoke(areGranted)
         }
 
-        switch.setOnClickListener {
+        binding.switchWidget.setOnClickListener {
             Timber.i("Permission switch clicked, requesting permissions: $areGranted")
             permissionsRequested?.invoke(areGranted)
         }
@@ -118,7 +113,7 @@ class PermissionsItem(
      * or uncheck if not
      */
     fun updateSwitchCheckedStatus() {
-        switch.isChecked = areGranted
+        binding.switchWidget.isChecked = areGranted
     }
 
     /**


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/89deacd11999c47e5b86385ee4eca6d75a29dc03
* Moved to a local `binding` variable

## How Has This Been Tested?
Brief test:

* Pixel 9 Pro API 36 Emulator - screen opens

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)