### PR TITLE
Fix DeckPicker freezing after theme changes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -105,7 +105,7 @@ class DeckPickerViewModel :
     /**
      * Used if the Deck Due Tree is mutated
      */
-    private val flowOfRefreshDeckList = MutableSharedFlow<Unit>()
+    private val flowOfRefreshDeckList = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     val flowOfDeckList =
         combine(
@@ -130,16 +130,16 @@ class DeckPickerViewModel :
      * @see deleteDeck
      * @see DeckDeletionResult
      */
-    val deckDeletedNotification = MutableSharedFlow<DeckDeletionResult>()
-    val emptyCardsNotification = MutableSharedFlow<EmptyCardsResult>()
-    val flowOfDestination = MutableSharedFlow<Destination>()
-    override val onError = MutableSharedFlow<String>()
+    val deckDeletedNotification = MutableSharedFlow<DeckDeletionResult>(extraBufferCapacity = 1)
+    val emptyCardsNotification = MutableSharedFlow<EmptyCardsResult>(extraBufferCapacity = 1)
+    val flowOfDestination = MutableSharedFlow<Destination>(extraBufferCapacity = 1)
+    override val onError = MutableSharedFlow<String>(extraBufferCapacity = 1)
 
     /**
      * A notification that the study counts have changed
      */
     // TODO: most of the recalculation should be moved inside the ViewModel
-    val flowOfDeckCountsChanged = MutableSharedFlow<Unit>()
+    val flowOfDeckCountsChanged = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     var loadDeckCounts: Job? = null
         private set
@@ -150,9 +150,9 @@ class DeckPickerViewModel :
      */
     private var schedulerUpgradeDialogShownForVersion: Long? = null
 
-    val flowOfPromptUserToUpdateScheduler = MutableSharedFlow<Unit>()
+    val flowOfPromptUserToUpdateScheduler = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
-    val flowOfUndoUpdated = MutableSharedFlow<Unit>()
+    val flowOfUndoUpdated = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     val flowOfCollectionHasNoCards = MutableStateFlow(true)
 
@@ -180,7 +180,7 @@ class DeckPickerViewModel :
 
     // HACK: dismiss a legacy progress bar
     // TODO: Replace with better progress handling for first load/corrupt collections
-    val flowOfDecksReloaded = MutableSharedFlow<Unit>()
+    val flowOfDecksReloaded = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
 
     /**
      * Deletes the provided deck, child decks. and all cards inside.


### PR DESCRIPTION
https://github.com/user-attachments/assets/5843d5bf-3df8-4a2e-9822-36b1080f3771

## Purpose / Description
Fixes a critical issue where DeckPicker would freeze/hang after changing themes. The app becomes unresponsive and requires force-close when users switch between light/dark themes.

## Fixes
* Fixes #19512

## Approach
The issue occurred due to two main problems:

1. **MutableSharedFlow deadlock**: DeckPickerViewModel uses `MutableSharedFlow` instances without buffers. When the activity is recreated during theme changes, collectors are temporarily inactive, causing `emit()` calls to suspend indefinitely.

2. **Progress dialog state inconsistency**: The `progressDialogShown` flag and `FLAG_NOT_TOUCHABLE` window flags were not being reset when the activity was recreated, leaving the UI in a frozen state.

The fix addresses both issues:
- Added `extraBufferCapacity = 1` to all `MutableSharedFlow` instances in DeckPickerViewModel
- Reset `progressDialogShown` flag and clear window flags in [onResume()](cci:1://file:///c:/Users/abdul/OneDrive/Desktop/REPOS/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt:1446:4-1465:5)

## How Has This Been Tested?
- Added unit test `testProgressDialogShownFlagIsResetInOnResume` to verify the flag reset behavior
- Tested theme changes manually on Android emulator (API 30) - verified app no longer freezes after switching between light/dark/black themes
- Verified all existing functionality remains intact (deck loading, navigation, sync operations)

## Learning (optional, can help others)
- `MutableSharedFlow` without buffers requires active collectors; otherwise `emit()` suspends
- `lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED)` only collects when activity is RESUMED
- Activity recreation during theme changes can leave global state inconsistent if not properly reset

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)