### PR TITLE
test(ci): only run the passive deflake scan weekly

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -20,7 +20,7 @@ on:
           - '["macos-14"]'
           - '["ubuntu-latest"]'
   schedule:
-    - cron: "42 0 * * *"
+    - cron: "42 0 * * 2"
   pull_request:
   push:
     # Ignore merge queue branches on push; avoids merge_group+push concurrency race since ref is same


### PR DESCRIPTION
Prompted by thoughts of how we are pulling forward the inevitable heat death of the universe (and our local part of it) with the CPU burn here, and thinking we can likely reduce it greatly without losing a periodic nudge to de-flake as needed

while we were doing the initial de-flake that prompted this, it was useful signal to have it daily

now that we are no longer flaky in general, we can reduce the frequency to weekly

