### PR TITLE
fix(sync): reduce notification update rate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -26,6 +26,13 @@ import androidx.core.app.NotificationManagerCompat
 import timber.log.Timber
 
 /**
+ * Minimum delay between notifications to avoid reaching the
+ * maximum update rate, which currently is 5 updates per second.
+ * https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/app/NotificationManager.java;l=675;drc=e13ace5dabea6d65c05dbfd9d19dc697a687d7be
+ */
+const val NOTIFICATION_MIN_DELAY_MS = 200L
+
+/**
  * Create or update all the notification channels for the app
  *
  * In Oreo and higher, you must create a channel for all notifications.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -120,7 +120,7 @@ class SyncMediaWorker(
                 val notificationText = syncProgress.run { "$added $removed $checked" }
                 notify(getProgressNotification(notificationText))
             }
-            delay(100)
+            delay(NOTIFICATION_UPDATE_RATE_MS)
         }
     }
 
@@ -174,6 +174,7 @@ class SyncMediaWorker(
     companion object {
         private const val HKEY_KEY = "hkey"
         private const val ENDPOINT_KEY = "endpoint"
+        const val NOTIFICATION_UPDATE_RATE_MS = 500L
 
         fun getWorkRequest(auth: SyncAuth): OneTimeWorkRequest {
             val constraints =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
@@ -136,7 +136,7 @@ class SyncWorker(
                         val text = syncProgress.run { "$added\n$removed" }
                         notify(getProgressNotification(text))
                     }
-                    delay(100)
+                    delay(SyncMediaWorker.NOTIFICATION_UPDATE_RATE_MS)
                 }
             }
         val response =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncMediaWorkerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/worker/SyncMediaWorkerTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.worker
+
+import com.ichi2.anki.NOTIFICATION_MIN_DELAY_MS
+import org.junit.Test
+
+class SyncMediaWorkerTest {
+    @Test
+    @Suppress("SimplifyBooleanWithConstants")
+    fun `notification update delay is not lower than min delay`() {
+        assert(SyncMediaWorker.NOTIFICATION_UPDATE_RATE_MS >= NOTIFICATION_MIN_DELAY_MS)
+    }
+}


### PR DESCRIPTION
make it slower, but still fast enough to be responsive

## Fixes
* Fixes #19546

## How Has This Been Tested?

I haven't. The logic is straightforward

## Learning (optional, can help others)

Android has some kind of notification rate limit. I haven't found any official documentation about the exact limit.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->