### PR TITLE
fix(study screen): IME shown even with a hidden `<input>`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -249,7 +249,6 @@ class ReviewerFragment :
         }
 
         val isHtmlTypeAnswerEnabled = Prefs.isHtmlTypeAnswerEnabled
-        val insetsController = WindowInsetsControllerCompat(window, binding.root)
         lifecycleScope.launch {
             val autoFocusTypeAnswer = Prefs.autoFocusTypeAnswer
             lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -262,8 +261,9 @@ class ReviewerFragment :
                     if (isHtmlTypeAnswerEnabled) {
                         if (!autoFocusTypeAnswer) return@collect
                         webViewLayout.focusOnWebView()
-                        webViewLayout.evaluateJavascript("document.getElementById('typeans').focus();", null)
-                        insetsController.show(WindowInsetsCompat.Type.ime())
+                        // `evaluateJavascript()` doesn't trigger the IME unless the WebView
+                        // has been touched before, so ´loadUrl()` is used instead.
+                        webViewLayout.loadUrl("javascript:document.getElementById('typeans')?.focus();")
                         return@collect
                     }
 


### PR DESCRIPTION
## Fixes
* Fixes #19490

## Approach

This took me way longer than I wanted to.

Calling `.focus()` in the type-in-answer `<input>`, only worked if the WebView had been touched before. To fix that, I made the reviewer show the keyboard if `auto focus` was enabled. But it created a new issue with people that hide their `<input>` fields dynamically with JavaScript (#19490), so I had to use another fix. 

The goal was to make the IME show after calling `.focus()` on JavaScript.  But this was the kind of issue where neither logic, nor the docs, nor upstream code help. You need to test stuff a lot and do some rain dance until something magically works.

I tried hacking a touch in the WebView with dispatchTouchEvent (works, but too hacky), tried using `requestFocusFromTouch` and many combinations of focus between the webview and other views, and tried many using some delays here and there. I've reviewed the old reviewer code and tried to figure out what made it work, but I was unsucessful.

Then suddenly I copied and pasted some stuff, got it working, then pinned down to the use of `loadUrl()` instead of `evaluateJavascript()`

## How Has This Been Tested?

Emulator 34

[Screen_recording_20251120_141859.webm](https://github.com/user-attachments/assets/55e9d22e-fa9b-4313-ac38-314108c14392)

## Learning (optional, can help others)

Dealing with WebViews is painful

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->