### PR TITLE
fix(database-error): handle `SystemStorageException`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -457,6 +457,11 @@ open class AnkiDroidApp :
             return Intent(Intent.ACTION_VIEW, parsed)
         } // TODO actually this can be done by translating "link_help" string for each language when the App is
 
+        @VisibleForTesting
+        fun clearFatalError() {
+            this.instance.fatalInitializationError = null
+        }
+
         /**
          * Get the url for the properly translated feedback page
          * @return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -25,7 +25,6 @@ import androidx.core.content.edit
 import com.ichi2.anki.AnkiDroidFolder.AppPrivateFolder
 import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.CollectionHelper.getCurrentAnkiDroidDirectory
-import com.ichi2.anki.CollectionHelper.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.backend.createDatabaseUsingAndroidFramework
 import com.ichi2.anki.exception.StorageAccessException
 import com.ichi2.anki.exception.SystemStorageException
@@ -313,15 +312,18 @@ object CollectionHelper {
         }
 
     /**
-     * Resets the AnkiDroid directory to the [getDefaultAnkiDroidDirectory]
+     * Resets the AnkiDroid directory to [directory]
      * Note: if [android.R.attr.preserveLegacyExternalStorage] is in use
      * this will represent a change from `/AnkiDroid` to `/Android/data/...`
+     *
+     * @throws SystemStorageException if `getExternalFilesDir` returns null
      */
-    fun resetAnkiDroidDirectory(context: Context) {
-        val preferences = context.sharedPrefs()
-        val directory = getDefaultAnkiDroidDirectory(context)
+    fun resetAnkiDroidDirectory(
+        context: Context,
+        directory: File = getDefaultAnkiDroidDirectory(context),
+    ) {
         Timber.d("resetting AnkiDroid directory to %s", directory)
-        preferences.edit { putString(PREF_COLLECTION_PATH, directory.absolutePath) }
+        context.sharedPrefs().edit { putString(PREF_COLLECTION_PATH, directory.absolutePath) }
     }
 
     @Throws(UnknownDatabaseVersionException::class)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -129,6 +129,7 @@ import com.ichi2.anki.dialogs.DeckPickerNoSpaceLeftDialog
 import com.ichi2.anki.dialogs.DialogHandlerMessage
 import com.ichi2.anki.dialogs.EditDeckDescriptionDialog
 import com.ichi2.anki.dialogs.EmptyCardsDialogFragment
+import com.ichi2.anki.dialogs.FatalErrorDialog
 import com.ichi2.anki.dialogs.ImportDialog.ImportDialogListener
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.ApkgImportResultLauncherProvider
 import com.ichi2.anki.dialogs.ImportFileSelectionFragment.CsvImportResultLauncherProvider
@@ -194,7 +195,6 @@ import com.ichi2.utils.customView
 import com.ichi2.utils.dp
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
-import com.ichi2.utils.neutralButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
@@ -1000,20 +1000,7 @@ open class DeckPicker :
                 Timber.i("Displaying database locked error")
                 showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_LOCKED)
             }
-            is StartupFailure.InitializationError ->
-                AlertDialog.Builder(this).show {
-                    title(R.string.ankidroid_init_failed_webview_title)
-                    message(text = failure.toHumanReadableString(this@DeckPicker))
-                    positiveButton(R.string.close) {
-                        closeCollectionAndFinish()
-                    }
-                    failure.infoLink?.let { url ->
-                        neutralButton(R.string.help) {
-                            openUrl(url)
-                        }
-                    }
-                    cancelable(false)
-                }
+            is StartupFailure.InitializationError -> FatalErrorDialog.build(this, failure).show()
             is DiskFull -> displayNoStorageError()
             is DBError -> displayDatabaseFailure(CustomExceptionData.fromException(failure.exception))
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FatalErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/FatalErrorDialog.kt
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import android.content.Context
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.InitialActivity.StartupFailure.InitializationError
+import com.ichi2.anki.R
+import com.ichi2.utils.cancelable
+import com.ichi2.utils.create
+import com.ichi2.utils.message
+import com.ichi2.utils.neutralButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.title
+import timber.log.Timber
+
+object FatalErrorDialog {
+    fun build(
+        activity: AnkiActivity,
+        failure: InitializationError,
+    ): AlertDialog {
+        val context: Context = activity
+        Timber.i("Displaying 'Fatal error'")
+        return AlertDialog.Builder(context).create {
+            title(R.string.ankidroid_init_failed_webview_title)
+            message(text = failure.toHumanReadableString(context))
+            positiveButton(R.string.close) {
+                activity.closeCollectionAndFinish()
+            }
+            failure.infoLink?.let { url ->
+                neutralButton(R.string.help) {
+                    activity.openUrl(url)
+                }
+            }
+            cancelable(false)
+        }
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -17,15 +17,22 @@
 package com.ichi2.anki
 
 import android.content.Context
-import android.content.Intent
 import androidx.appcompat.app.AlertDialog
-import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.dialogs.utils.ankiListView
 import com.ichi2.anki.dialogs.utils.message
+import com.ichi2.anki.dialogs.utils.title
+import com.ichi2.testutils.TestException
+import com.ichi2.testutils.withNoWritePermission
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
 import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import org.robolectric.annotation.Implementation
 import org.robolectric.annotation.Implements
@@ -43,13 +50,40 @@ class DeckPickerNoExternalFilesDirTest : RobolectricTest() {
 
         // IntroductionActivity should be skipped by our code so we can show the error
         // without user interaction
-        getPreferences().edit { putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, false) }
-
-        startActivityNormallyOpenCollectionWithIntent(DeckPicker::class.java, Intent()).run {
+        deckPicker(skipIntroduction = false) {
             val message = (ShadowDialog.getLatestDialog() as AlertDialog).message
             assertThat(message, containsString("getExternalFilesDir unexpectedly returned null"))
         }
     }
+
+    @Test
+    fun `fatal error is shown after 'Create a new collection' and getExternalFilesDir is null`() =
+        try {
+            AnkiDroidApp.clearFatalError()
+            withNoWritePermission {
+                CollectionHelper.ankiDroidDirectoryOverride = tempFolder.newFolder()
+
+                mockkObject(CollectionHelper, CollectionManager, AnkiDroidApp)
+                every { CollectionHelper.isCurrentAnkiDroidDirAccessible(any()) } returns false
+                every { CollectionManager.getColUnsafe() } throws TestException("")
+                every { AnkiDroidApp.isSdCardMounted } returns true
+
+                setIntroductionSlidesShown(true)
+
+                deckPicker {
+                    (ShadowDialog.getLatestDialog() as AlertDialog).also { dialog ->
+                        assertThat(dialog.title, equalTo("Inaccessible collection"))
+                        shadowOf(dialog.ankiListView).clickFirstItemContainingText("Create a new collection")
+                    }
+
+                    val dialog = (ShadowDialog.getLatestDialog() as AlertDialog)
+                    assertThat(dialog.message, containsString("getExternalFilesDir unexpectedly returned null"))
+                }
+            }
+        } finally {
+            CollectionHelper.ankiDroidDirectoryOverride = null
+            unmockkAll()
+        }
 }
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -706,7 +706,7 @@ class DeckPickerTest : RobolectricTest() {
     }
 }
 
-private fun RobolectricTest.setIntroductionSlidesShown(shown: Boolean) {
+fun RobolectricTest.setIntroductionSlidesShown(shown: Boolean) {
     getPreferences().edit {
         putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, shown)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
@@ -21,6 +21,7 @@ import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.test.platform.app.InstrumentationRegistry
+import com.ichi2.anki.R
 import com.ichi2.utils.HandlerUtils.executeFunctionUsingHandler
 import com.ichi2.utils.getInputField
 import org.hamcrest.MatcherAssert.assertThat
@@ -43,6 +44,10 @@ val AlertDialog.message
         requireNotNull(this.findViewById<TextView>(android.R.id.message)) {
             "android.R.id.message not found"
         }.text.toString()
+
+val AlertDialog.ankiListView
+    get() =
+        requireNotNull(this.listView ?: findViewById(R.id.dialog_list_view)) { "ankiListView not found" }
 
 fun AlertDialog.performPositiveClick() {
     // This exists as callOnClick did not call the listener


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`getExternalFilesDir` is corrupt, but the user needs to reset the storage location

We can't reset, so show a fatal error

## Fixes
* Fixes #19554

## Approach
* determine the directory to reset to, and check we can obtain the directory
  * If we can't: show a fatal error 

## How Has This Been Tested?

Unit tests


```patch
Subject: [PATCH] fix(database-error): handle 'new collection' under `SystemStorageException`
---
Index: AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt	(revision ccb532d7c9a5c64703152555c68429b0783fa328)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt	(date 1763751619468)
@@ -226,14 +226,14 @@
         // This value *may* be null but we strictly require it. This has caused NullPointerException
         // in previous releases as we dereference. We can't recover but for purposes of triage,
         // we will now check for null and if so try to log more information about why.
-        if (externalFilesDir == null) {
+        // if (externalFilesDir == null) {
             Timber.e("Attempting to determine collection path, but no valid external storage?")
             throw SystemStorageException.build(
                 errorDetail = "getExternalFilesDir unexpectedly returned null",
                 infoUri = "https://github.com/ankidroid/Anki-Android/issues/13207",
             )
-        }
-        return externalFilesDir.absolutePath
+        // }
+        // return externalFilesDir.absolutePath
     }
 
     /**
Index: AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt	(revision ccb532d7c9a5c64703152555c68429b0783fa328)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt	(date 1763751619472)
@@ -72,6 +72,7 @@
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import timber.log.Timber.DebugTree
+import java.io.File
 import java.util.Locale
 
 /**
@@ -198,6 +199,7 @@
         CardBrowser.clearLastDeckId()
         LanguageUtil.setDefaultBackendLanguages()
 
+        CollectionHelper.ankiDroidDirectoryOverride = File("/storage/emulated/0/AnkiDroid")
         // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
         // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
         //  is not considered to be a fatal error
```
<img width="372" height="799" alt="Screenshot 2025-11-21 at 19 02 18" src="https://github.com/user-attachments/assets/ed201d12-ef47-4080-8487-f3ec1451ad5c" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->