### PR TITLE
docs: map past FSRS library versions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/Fsrs.kt
@@ -42,6 +42,7 @@ value class FsrsVersion(
     val displayString: String? get() =
         when (libraryVersion) {
             "0.6.4" -> "FSRS 4.5"
+            "1.4.3", "2.0.3" -> "FSRS 5"
             "4.1.1", "5.1.0" -> "FSRS 6"
             else -> null
         }


### PR DESCRIPTION
A user was asking about this, so I mapped AnkiDroid 2.20 and 2.21's version for posterity.

AnkiDroid 2.18 did not list the version on the 'About' page

```
FSRS 0.6.4 = AnkiDroid 2.19 = Anki 24.06.3 = FSRS 4.5
FSRS 1.4.3 = AnkiDroid 2.20 = Anki 24.11   = FSRS 5
FSRS 2.0.3 = AnkiDroid 2.21 = Anki 25.02   = FSRS 5
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->