### PR TITLE
chore: convert BrowserOptionsDialog to ViewBinding

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/BrowserOptionsDialogTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/BrowserOptionsDialogTest.kt
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.tests.InstrumentedTest
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/** Tests [BrowserOptionsDialog] */
+@RunWith(AndroidJUnit4::class)
+class BrowserOptionsDialogTest : InstrumentedTest() {
+    @get:Rule
+    val activityRule = ActivityScenarioRule(CardBrowser::class.java)
+
+    @Test
+    fun dialogLoads() {
+        activityRule.scenario.onActivity { activity ->
+            BrowserOptionsDialog
+                .newInstance(
+                    CardsOrNotes.CARDS,
+                    isTruncated = true,
+                ).show(activity.supportFragmentManager, "BrowserOptionsDialog")
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -17,7 +17,6 @@
 package com.ichi2.anki.dialogs
 
 import android.app.Dialog
-import android.content.DialogInterface
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.os.bundleOf
@@ -29,6 +28,9 @@ import com.ichi2.anki.browser.BrowserColumnSelectionFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.databinding.BrowserOptionsDialogBinding
 import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.utils.create
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
 import timber.log.Timber
 
 class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.browser_options_dialog) {
@@ -45,7 +47,8 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.browser_options_di
             }
         }
 
-    private val positiveButtonClick = { _: DialogInterface, _: Int ->
+    /** Persists updated options to the ViewModel */
+    fun saveChanges() {
         if (cardsOrNotes != dialogCardsOrNotes) {
             viewModel.setCardsOrNotes(dialogCardsOrNotes)
         }
@@ -109,14 +112,11 @@ class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.browser_options_di
 
         binding.browsingTextView.text = TR.preferencesBrowsing()
 
-        return MaterialAlertDialogBuilder(requireContext()).run {
-            this.setView(binding.root)
-            this.setTitle(getString(R.string.browser_options_dialog_heading))
-            this.setNegativeButton(getString(R.string.dialog_cancel)) { _: DialogInterface, _: Int ->
-                dismiss()
-            }
-            this.setPositiveButton(getString(R.string.dialog_ok), DialogInterface.OnClickListener(function = positiveButtonClick))
-            this.create()
+        return MaterialAlertDialogBuilder(requireContext()).create {
+            setView(binding.root)
+            setTitle(getString(R.string.browser_options_dialog_heading))
+            positiveButton(R.string.dialog_ok) { saveChanges() }
+            negativeButton(R.string.dialog_cancel)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/BrowserOptionsDialog.kt
@@ -19,14 +19,6 @@ package com.ichi2.anki.dialogs
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
-import android.view.View
-import android.widget.Button
-import android.widget.CheckBox
-import android.widget.LinearLayout
-import android.widget.RadioButton
-import android.widget.RadioGroup
-import android.widget.TextView
-import androidx.annotation.IdRes
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
@@ -35,20 +27,19 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.BrowserColumnSelectionFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
+import com.ichi2.anki.databinding.BrowserOptionsDialogBinding
 import com.ichi2.anki.model.CardsOrNotes
 import timber.log.Timber
 
-class BrowserOptionsDialog : AppCompatDialogFragment() {
-    private lateinit var dialogView: View
-
+class BrowserOptionsDialog : AppCompatDialogFragment(R.layout.browser_options_dialog) {
     private val viewModel: CardBrowserViewModel by activityViewModels()
+
+    private lateinit var binding: BrowserOptionsDialogBinding
 
     /** The unsaved value of [CardsOrNotes] */
     private val dialogCardsOrNotes: CardsOrNotes
         get() {
-            @IdRes val selectedButtonId =
-                dialogView.findViewById<RadioGroup>(R.id.select_browser_mode).checkedRadioButtonId
-            return when (selectedButtonId) {
+            return when (binding.selectBrowserMode.checkedRadioButtonId) {
                 R.id.select_cards_mode -> CardsOrNotes.CARDS
                 else -> CardsOrNotes.NOTES
             }
@@ -58,13 +49,13 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
         if (cardsOrNotes != dialogCardsOrNotes) {
             viewModel.setCardsOrNotes(dialogCardsOrNotes)
         }
-        val newTruncate = dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked
+        val newTruncate = binding.truncateCheckBox.isChecked
 
         if (newTruncate != isTruncated) {
             viewModel.setTruncated(newTruncate)
         }
 
-        val newIgnoreAccent = dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).isChecked
+        val newIgnoreAccent = binding.ignoreAccentsCheckBox.isChecked
         if (newIgnoreAccent != viewModel.shouldIgnoreAccents) {
             viewModel.setIgnoreAccents(newIgnoreAccent)
         }
@@ -90,37 +81,36 @@ class BrowserOptionsDialog : AppCompatDialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val layoutInflater = requireActivity().layoutInflater
-        dialogView = layoutInflater.inflate(R.layout.browser_options_dialog, null)
+        binding = BrowserOptionsDialogBinding.inflate(layoutInflater)
 
         if (cardsOrNotes == CardsOrNotes.CARDS) {
-            dialogView.findViewById<RadioButton>(R.id.select_cards_mode).isChecked = true
+            binding.selectCardsMode.isChecked = true
         } else {
-            dialogView.findViewById<RadioButton>(R.id.select_notes_mode).isChecked = true
+            binding.selectNotesMode.isChecked = true
         }
 
-        dialogView.findViewById<CheckBox>(R.id.truncate_checkbox).isChecked = isTruncated
+        binding.truncateCheckBox.isChecked = isTruncated
 
-        dialogView.findViewById<LinearLayout>(R.id.action_rename_flag).setOnClickListener {
+        binding.renameFlag.setOnClickListener {
             Timber.d("Rename flag clicked")
             val flagRenameDialog = FlagRenameDialog()
             flagRenameDialog.show(parentFragmentManager, "FlagRenameDialog")
             dismiss()
         }
 
-        dialogView.findViewById<Button>(R.id.manage_columns_button).setOnClickListener {
+        binding.manageColumnsButton.setOnClickListener {
             openColumnManager()
         }
 
-        dialogView.findViewById<CheckBox>(R.id.ignore_accents_checkbox).apply {
+        binding.ignoreAccentsCheckBox.apply {
             text = TR.preferencesIgnoreAccentsInSearch()
             isChecked = viewModel.shouldIgnoreAccents
         }
 
-        dialogView.findViewById<TextView>(R.id.browsing_text_view).text = TR.preferencesBrowsing()
+        binding.browsingTextView.text = TR.preferencesBrowsing()
 
         return MaterialAlertDialogBuilder(requireContext()).run {
-            this.setView(dialogView)
+            this.setView(binding.root)
             this.setTitle(getString(R.string.browser_options_dialog_heading))
             this.setNegativeButton(getString(R.string.dialog_cancel)) { _: DialogInterface, _: Int ->
                 dismiss()

--- a/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/browser_options_dialog.xml
@@ -57,7 +57,7 @@
             android:layout_marginHorizontal="16dp" />
 
             <CheckBox
-            android:id="@+id/truncate_checkbox"
+            android:id="@+id/truncate_check_box"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="@string/card_browser_truncate"
@@ -87,7 +87,7 @@
                 android:layout_marginHorizontal="16dp" />
 
             <CheckBox
-                android:id="@+id/ignore_accents_checkbox"
+                android:id="@+id/ignore_accents_check_box"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="16dp"
@@ -137,7 +137,7 @@
             <LinearLayout
             android:gravity="center"
             android:minHeight="?attr/listPreferredItemHeightSmall"
-            android:id="@+id/action_rename_flag"
+            android:id="@+id/rename_flag"
             android:background="?attr/selectableItemBackground"
             android:layout_marginHorizontal="16dp"
             android:layout_width="match_parent"


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/89571697b4221e79d577d659edfeaecaf38a2bb9
* Tried vbpd, failed
* No unit test breakage... write one

## How Has This Been Tested?
Brief test:

* API 34 tablet - screen opens
* Added an instrumented test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)