### PR TITLE
chore: convert ForgetCardsDialog to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/ForgetCardsDialog.kt
@@ -21,13 +21,13 @@ import android.os.Bundle
 import androidx.core.content.edit
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
-import com.google.android.material.checkbox.MaterialCheckBox
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.databinding.DialogForgetCardsBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.sched.Scheduler
@@ -94,23 +94,23 @@ class ForgetCardsDialog : DialogFragment() {
                 resetRepetitionAndLapseCounts = getBoolean(ARG_RESET_REPETITION, false)
             }
         }
-        val contentView =
-            layoutInflater.inflate(R.layout.dialog_forget_cards, null).apply {
-                findViewById<MaterialCheckBox>(R.id.restore_original_position)!!.apply {
-                    isChecked = restoreOriginalPositionIfPossible
-                    setOnCheckedChangeListener { _, isChecked ->
-                        restoreOriginalPositionIfPossible = isChecked
-                    }
-                    text = TR.schedulingRestorePosition()
-                }
-                findViewById<MaterialCheckBox>(R.id.reset_lapse_counts)!!.apply {
-                    isChecked = resetRepetitionAndLapseCounts
-                    setOnCheckedChangeListener { _, isChecked ->
-                        resetRepetitionAndLapseCounts = isChecked
-                    }
-                    text = TR.schedulingResetCounts()
-                }
+        val binding = DialogForgetCardsBinding.inflate(layoutInflater)
+
+        binding.restoreOriginalPosition.apply {
+            isChecked = restoreOriginalPositionIfPossible
+            setOnCheckedChangeListener { _, isChecked ->
+                restoreOriginalPositionIfPossible = isChecked
             }
+            text = TR.schedulingRestorePosition()
+        }
+        binding.resetLapseCounts.apply {
+            isChecked = resetRepetitionAndLapseCounts
+            setOnCheckedChangeListener { _, isChecked ->
+                resetRepetitionAndLapseCounts = isChecked
+            }
+            text = TR.schedulingResetCounts()
+        }
+
         return MaterialAlertDialogBuilder(requireContext()).create {
             // BUG: this is 'Reset Card'/'Forget Card' in Anki Desktop (24.04)
             // title(text = TR.actionsForgetCard().toSentenceCase(R.string.sentence_forget_cards))
@@ -132,7 +132,7 @@ class ForgetCardsDialog : DialogFragment() {
                 )
             }
             negativeButton(R.string.dialog_cancel)
-            setView(contentView)
+            setView(binding.root)
         }
     }
 


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked 
    * https://github.com/david-allison/Anki-Android/pull/44/commits/ada70e0c50b3a41149e1bd5b27cca76f665c729f
* Nothing more

## How Has This Been Tested?
Brief test:

* Medium Tablet API 34 - fragment opens

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)