### PR TITLE
fix(card-template-editor): various tablet mode fixes & refactorings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -166,6 +166,23 @@ open class CardTemplateEditor :
             }
         }
 
+    /**
+     * Triggered when a card template ('Card 1') is selected in the top tab view
+     */
+    private val onCardTemplateSelectedListener: TabLayout.OnTabSelectedListener =
+        object : TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                Timber.i("selected card index: %s", tab.position)
+                loadTemplatePreviewerFragmentIfFragmented()
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab) {
+            }
+
+            override fun onTabReselected(tab: TabLayout.Tab) {
+            }
+        }
+
     // ----------------------------------------------------------------------------
     // Listeners
     // ----------------------------------------------------------------------------
@@ -224,6 +241,8 @@ open class CardTemplateEditor :
         // Open TemplatePreviewerFragment if in fragmented mode
         loadTemplatePreviewerFragmentIfFragmented()
         onBackPressedDispatcher.addCallback(this, displayDiscardChangesCallback)
+
+        topBinding.slidingTabs.addOnTabSelectedListener(onCardTemplateSelectedListener)
     }
 
     /**
@@ -680,21 +699,6 @@ open class CardTemplateEditor :
             binding.editText.post {
                 binding.editText.requestFocus()
             }
-
-            templateEditor.topBinding.slidingTabs.addOnTabSelectedListener(
-                object : TabLayout.OnTabSelectedListener {
-                    override fun onTabSelected(tab: TabLayout.Tab) {
-                        Timber.i("selected card index: %s", tab.position)
-                        templateEditor.loadTemplatePreviewerFragmentIfFragmented()
-                    }
-
-                    override fun onTabUnselected(tab: TabLayout.Tab) {
-                    }
-
-                    override fun onTabReselected(tab: TabLayout.Tab) {
-                    }
-                },
-            )
 
             parentFragmentManager.setFragmentResultListener(insertFieldRequestKey, viewLifecycleOwner) { key, bundle ->
                 // this is guaranteed to be non null, as we put a non null value on the other side

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -127,7 +127,9 @@ open class CardTemplateEditor :
     AnkiActivity(R.layout.card_template_editor),
     DeckSelectionListener {
     private val binding by viewBinding(CardTemplateEditorBinding::bind)
-    private val topBinding: CardTemplateEditorTopBinding
+
+    @VisibleForTesting
+    val topBinding: CardTemplateEditorTopBinding
         get() = binding.templateEditorTop
 
     @VisibleForTesting

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -589,6 +589,7 @@ open class CardTemplateEditor :
             binding.bottomNavigation.setOnItemSelectedListener { item: MenuItem ->
                 val currentSelectedId = item.itemId
                 templateEditor.tabToViewId[cardIndex] = currentSelectedId
+                Timber.i("selected editor view: %s", item.title)
                 when (currentSelectedId) {
                     R.id.styling_edit ->
                         setCurrentEditorView(
@@ -680,14 +681,15 @@ open class CardTemplateEditor :
 
             templateEditor.topBinding.slidingTabs.addOnTabSelectedListener(
                 object : TabLayout.OnTabSelectedListener {
-                    override fun onTabSelected(p0: TabLayout.Tab?) {
+                    override fun onTabSelected(tab: TabLayout.Tab) {
+                        Timber.i("selected card index: %s", tab.position)
                         templateEditor.loadTemplatePreviewerFragmentIfFragmented()
                     }
 
-                    override fun onTabUnselected(p0: TabLayout.Tab?) {
+                    override fun onTabUnselected(tab: TabLayout.Tab) {
                     }
 
-                    override fun onTabReselected(p0: TabLayout.Tab?) {
+                    override fun onTabReselected(tab: TabLayout.Tab) {
                     }
                 },
             )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesState.kt
@@ -62,22 +62,22 @@ data class ManageNoteTypesState(
     )
 
     data class CardEditor(
-        val nid: NoteTypeId,
+        val ntid: NoteTypeId,
     ) : Destination {
         override fun toIntent(context: Context): Intent =
             Intent(context, CardTemplateEditor::class.java).apply {
-                putExtra(CardTemplateEditor.EDITOR_NOTE_TYPE_ID, nid)
+                putExtra(CardTemplateEditor.EDITOR_NOTE_TYPE_ID, ntid)
             }
     }
 
     data class FieldsEditor(
-        val nid: NoteTypeId,
+        val ntid: NoteTypeId,
         val name: String,
     ) : Destination {
         override fun toIntent(context: Context): Intent =
             Intent(context, NoteTypeFieldEditor::class.java).apply {
                 putExtra(NoteTypeFieldEditor.EXTRA_NOTETYPE_NAME, name)
-                putExtra(NoteTypeFieldEditor.EXTRA_NOTETYPE_ID, nid)
+                putExtra(NoteTypeFieldEditor.EXTRA_NOTETYPE_ID, ntid)
             }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -28,7 +28,6 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.utils.BundleUtils.getNullableInt
-import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 
@@ -40,7 +39,7 @@ class TemplatePreviewerFragment :
         TemplatePreviewerViewModel.factory(arguments)
     }
 
-    val binding by viewBinding(TemplatePreviewerBinding::bind)
+    lateinit var binding: TemplatePreviewerBinding
 
     override val webViewLayout: SafeWebViewLayout get() = binding.webViewLayout
 
@@ -51,6 +50,10 @@ class TemplatePreviewerFragment :
         view: View,
         savedInstanceState: Bundle?,
     ) {
+        // binding must be set before super.onViewCreated
+        // as super.onViewCreated depends on webViewLayout, which depends on the binding
+        binding = TemplatePreviewerBinding.bind(view)
+
         super.onViewCreated(view, savedInstanceState)
 
         binding.showAnswer.setOnClickListener { viewModel.toggleShowAnswer() }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -28,12 +28,18 @@ import com.ichi2.anki.dialogs.InsertFieldDialog
 import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.testutils.ext.addNote
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.notetype.ManageNoteTypesState.CardEditor
 import com.ichi2.anki.previewer.CardViewerActivity
+import com.ichi2.anki.scheduling.selectTab
 import com.ichi2.testutils.assertFalse
+import com.ichi2.testutils.withTabletUi
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert
+import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.json.JSONObject
 import org.junit.Assume.assumeThat
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -847,6 +853,18 @@ class CardTemplateEditorTest : RobolectricTest() {
         )
     }
 
+    @Test
+    @Ignore("19589")
+    fun `tab changes succeed with tablet UI - Issue 19589`() =
+        withTabletUi {
+            withCardTemplateEditor(col.notetypes.basicAndReversed) {
+                selectTab(1)
+                selectTab(0)
+
+                assertThat(selectedTabPosition, equalTo(0))
+            }
+        }
+
     private fun addCardType(
         testEditor: CardTemplateEditor,
         shadowTestEditor: ShadowActivity,
@@ -928,3 +946,16 @@ private val CardTemplateEditor.editText: EditText
 
 private val CardTemplateEditor.viewPager
     get() = this.mainBinding.cardTemplateEditorPager
+
+fun RobolectricTest.withCardTemplateEditor(
+    noteType: NotetypeJson = col.notetypes.basic,
+    block: CardTemplateEditor.() -> Unit,
+) {
+    val intent = CardEditor(ntid = noteType.id).toIntent(targetContext)
+    val activity = startActivityNormallyOpenCollectionWithIntent(CardTemplateEditor::class.java, intent)
+    block(activity)
+}
+
+fun CardTemplateEditor.selectTab(index: Int) = topBinding.slidingTabs.selectTab(index)
+
+val CardTemplateEditor.selectedTabPosition: Int get() = topBinding.slidingTabs.selectedTabPosition

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -39,7 +39,6 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.json.JSONObject
 import org.junit.Assume.assumeThat
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
@@ -854,7 +853,6 @@ class CardTemplateEditorTest : RobolectricTest() {
     }
 
     @Test
-    @Ignore("19589")
     fun `tab changes succeed with tablet UI - Issue 19589`() =
         withTabletUi {
             withCardTemplateEditor(col.notetypes.basicAndReversed) {

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ScreenSize.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ScreenSize.kt
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils
+
+import org.robolectric.RuntimeEnvironment
+import timber.log.Timber
+
+/** [block] runs with an `xlarge` Runtime qualifier */
+fun withTabletUi(block: () -> Unit) = withQualifier("xlarge", block)
+
+fun withQualifier(
+    newQualifier: String,
+    block: () -> Unit,
+) {
+    val qualifiers = RuntimeEnvironment.getQualifiers()
+    try {
+        Timber.d("Adding '$newQualifier' to qualifiers $qualifiers")
+        RuntimeEnvironment.setQualifiers("+$newQualifier")
+        block()
+    } finally {
+        Timber.d("Resetting qualifiers to $qualifiers")
+        RuntimeEnvironment.setQualifiers(qualifiers)
+    }
+}

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -335,4 +335,13 @@ interface AnkiTest {
     suspend fun TestScope.runTestInner(testBody: suspend TestScope.() -> Unit) {
         testBody()
     }
+
+    val Notetypes.basic
+        get() = byName("Basic")!!
+
+    val Notetypes.basicAndReversed
+        get() = byName("Basic (and reversed card)")!!
+
+    val Notetypes.cloze
+        get() = byName("Cloze")!!
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

* #19589 led to:
  * finding that it could be triggered ONLY by switching tabs back and forth
    * and tests didn't catch it 
  * finding logs did not include changes of the selected tab
  * we were calling `loadTemplatePreviewerFragmentIfFragmented` twice on a 2-card template
  * #19595
  * `nid` was used instead of `ntid`


## Fixes
* Fixes #19589 
* Fixes #19595

## Approach

Introduced `Deferred<Closeable>.close` which makes use of `invokeOnCompletion` to ensure that the `closeable` is closed, OR the `init` job is cancelled, which **should** invoke the proper `finally` so we don't leak resources.

* Bisect and confirm the issue was ViewBindings
* Have a few tries creating a test
  * tested to be sure `withTabletUi` did something
  * once tested and bisected, easy to fix
* Checking `addOnTabSelectedListener`, ensuring that it was just added incorrectly: on the editor fragment instead of on the host
  * Then an obvious fix 
* More log fixes as I went through


## How Has This Been Tested?
API 34 Tablet: open a note type with 2 templates, and switch between the two panels

* No crashes
* Content on the left and right updates as expected

I added a unit test
I'll trust CI for the rest


## Learning (optional, can help others)
* caused by addition of vbpd: 8d6095a357b2a51994c346b877033d27687efa88
## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->