### PR TITLE
fix(deck-picker): prefer to use binding over checking 'fragmented' status

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -330,10 +330,10 @@ open class CardBrowser :
 
         if (fragmented) {
             ResizablePaneManager(
-                parentLayout = requireNotNull(binding.cardBrowserXlView),
-                divider = requireNotNull(binding.cardBrowserResizingDivider),
-                leftPane = requireNotNull(binding.cardBrowserFrame),
-                rightPane = requireNotNull(binding.noteEditorFrame),
+                parentLayout = requireNotNull(binding.cardBrowserXlView) { "cardBrowserXlView" },
+                divider = requireNotNull(binding.cardBrowserResizingDivider) { "cardBrowserResizingDivider" },
+                leftPane = requireNotNull(binding.cardBrowserFrame) { "cardBrowserFrame" },
+                rightPane = requireNotNull(binding.noteEditorFrame) { "noteEditorFrame" },
                 sharedPrefs = Prefs.getUiConfig(this),
                 leftPaneWeightKey = PREF_CARD_BROWSER_PANE_WEIGHT,
                 rightPaneWeightKey = PREF_NOTE_EDITOR_PANE_WEIGHT,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -209,10 +209,10 @@ open class CardTemplateEditor :
 
         if (fragmented) {
             ResizablePaneManager(
-                parentLayout = requireNotNull(binding.cardTemplateEditorXlView),
-                divider = requireNotNull(binding.cardTemplateEditorResizingDivider),
-                leftPane = requireNotNull(binding.templateEditor.root),
-                rightPane = requireNotNull(binding.fragmentContainer),
+                parentLayout = requireNotNull(binding.cardTemplateEditorXlView) { "cardTemplateEditorXlView" },
+                divider = requireNotNull(binding.cardTemplateEditorResizingDivider) { "cardTemplateEditorResizingDivider" },
+                leftPane = requireNotNull(binding.templateEditor.root) { "templateEditor.root" },
+                rightPane = requireNotNull(binding.fragmentContainer) { "fragmentContainer" },
                 sharedPrefs = Prefs.getUiConfig(this),
                 leftPaneWeightKey = PREF_TEMPLATE_EDITOR_PANE_WEIGHT,
                 rightPaneWeightKey = PREF_TEMPLATE_PREVIEWER_PANE_WEIGHT,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -808,10 +808,10 @@ open class DeckPicker :
 
                     if (tryShowStudyOptionsPanel()) {
                         ResizablePaneManager(
-                            parentLayout = requireNotNull(binding.deckpickerXlView),
-                            divider = requireNotNull(binding.resizingDivider),
+                            parentLayout = requireNotNull(binding.deckpickerXlView) { "deckpickerXlView" },
+                            divider = requireNotNull(binding.resizingDivider) { "resizingDivider" },
                             leftPane = deckPickerBinding.root,
-                            rightPane = requireNotNull(binding.studyoptionsFragment),
+                            rightPane = requireNotNull(binding.studyoptionsFragment) { "studyoptionsFragment" },
                             sharedPrefs = Prefs.getUiConfig(this),
                             leftPaneWeightKey = PREF_DECK_PICKER_PANE_WEIGHT,
                             rightPaneWeightKey = PREF_STUDY_OPTIONS_PANE_WEIGHT,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -116,7 +116,7 @@ class InstantEditorViewModel :
             }
 
             @Suppress("RedundantRequireNotNullCall") // postValue lint requires this
-            val clozeNoteType = requireNotNull(noteType)
+            val clozeNoteType = requireNotNull(noteType) { "noteType" }
             Timber.d("Changing to cloze type note")
             _currentlySelectedNotetype.postValue(clozeNoteType)
             Timber.i("Using note type '%d", clozeNoteType.id)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -191,7 +191,7 @@ class RecyclerFastScroller
                         v: View,
                         event: MotionEvent,
                     ): Boolean {
-                        val recyclerView = requireNotNull(recyclerView)
+                        val recyclerView = requireNotNull(recyclerView) { "recyclerView" }
                         val recyclerViewAdapter = recyclerView.adapter
                         if (recyclerViewAdapter == null || recyclerViewAdapter.itemCount == 0) return false
 


### PR DESCRIPTION
Now we have moved to bindings, we can more easily detect whether the screen is fragmented

* https://github.com/ankidroid/Anki-Android/pull/19420

## Fixes
* ⚠️ I suspect this fixes #19555

## Approach
* use `tryShowStudyOptionsPanel` to detect if the view is fragmented
* and a few logical improvements based on a view being nullable

## How Has This Been Tested?
⚠️ API 34 tablet emulator - screen still works, unit tests still run 


## Learning (optional, can help others)

I strongly suspect this is another `android:configChanges` bug:
* #12832

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)