### PR TITLE
fix(image-occlusion): support updating a note's deck

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -141,6 +141,7 @@ import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.ImageOcclusion
+import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.previewer.TemplatePreviewerArguments
 import com.ichi2.anki.previewer.TemplatePreviewerPage
@@ -2751,22 +2752,28 @@ class NoteEditorFragment :
     private fun currentNotetypeIsImageOcclusion() = currentlySelectedNotetype?.isImageOcclusion == true
 
     private fun setupImageOcclusionEditor(imagePath: String = "") {
-        val kind: String
-        val id: Long
-        if (addNote) {
-            kind = "add"
-            // if opened from an intent, the selected note type may not be suitable for IO
-            id =
-                if (currentNotetypeIsImageOcclusion()) {
-                    currentlySelectedNotetype!!.id
-                } else {
-                    0
-                }
-        } else {
-            kind = "edit"
-            id = editorNote?.id!!
-        }
-        val intent = ImageOcclusion.getIntent(requireContext(), kind, id, imagePath, deckId)
+        val args =
+            if (addNote) {
+                // if opened from an intent, the selected note type may not be suitable for IO
+                val noteTypeId =
+                    if (currentNotetypeIsImageOcclusion()) {
+                        currentlySelectedNotetype!!.id
+                    } else {
+                        0
+                    }
+                ImageOcclusionArgs.Add(
+                    noteTypeId = noteTypeId,
+                    imagePath = imagePath,
+                    deckId = deckId,
+                )
+            } else {
+                ImageOcclusionArgs.Edit(
+                    noteId = editorNote!!.id,
+                    deckId = deckId,
+                )
+            }
+
+        val intent = ImageOcclusion.getIntent(requireContext(), args)
         requestIOEditorCloser.launch(intent)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2423,10 +2423,11 @@ class NoteEditorFragment :
         populateEditFields(changeType, false)
         updateFieldsFromStickyText()
 
-        // Showing the deck selection parts is not needed for Image Occlusion notetypes
-        // as deck selection is handled by the backend page
-        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
-        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !currentNotetypeIsImageOcclusion()
+        // When adding a note, ImageOcclusion handles the deck selection
+        // as a user can reach this screen directly from an intent
+        val disableDeckEditing = addNote && currentNotetypeIsImageOcclusion()
+        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !disableDeckEditing
+        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !disableDeckEditing
     }
 
     private fun addClozeButton(
@@ -2764,12 +2765,11 @@ class NoteEditorFragment :
                 ImageOcclusionArgs.Add(
                     noteTypeId = noteTypeId,
                     imagePath = imagePath,
-                    deckId = deckId,
+                    originalDeckId = deckId,
                 )
             } else {
                 ImageOcclusionArgs.Edit(
                     noteId = editorNote!!.id,
-                    deckId = deckId,
                 )
             }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel
+import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.IO_ARGS_KEY
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.selectedDeckIfNotFiltered
 import com.ichi2.anki.startDeckSelection
@@ -135,8 +136,6 @@ class ImageOcclusion :
         }
 
     companion object {
-        const val IO_ARGS_KEY = "IMAGE_OCCLUSION_ARGS"
-
         /**
          * @param editorWorkingDeckId the current deck id that [com.ichi2.anki.NoteEditorFragment] is using
          */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -34,7 +34,6 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.launchCatchingTask
-import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel
@@ -103,7 +102,7 @@ class ImageOcclusion :
                 url: String?,
             ) {
                 super.onPageFinished(view, url)
-                viewModel.webViewOptions.let { options ->
+                viewModel.args.toImageOcclusionMode().let { options ->
                     view?.evaluateJavascript("globalThis.anki.imageOcclusion.mode = $options") {
                         super.onPageFinished(view, url)
                     }
@@ -137,24 +136,17 @@ class ImageOcclusion :
 
     companion object {
         /**
-         * @param editorWorkingDeckId the current deck id that [com.ichi2.anki.NoteEditorFragment] is using
+         * @param args arguments for either adding or editing a note
          */
         fun getIntent(
             context: Context,
-            kind: String,
-            noteOrNotetypeId: Long,
-            imagePath: String?,
-            editorWorkingDeckId: DeckId,
+            args: ImageOcclusionArgs,
         ): Intent {
-            val suffix = if (kind == "edit") noteOrNotetypeId else Uri.encode(imagePath)
-
-            val args =
-                ImageOcclusionArgs(
-                    kind = kind,
-                    id = noteOrNotetypeId,
-                    imagePath = imagePath,
-                    editorDeckId = editorWorkingDeckId,
-                )
+            val suffix =
+                when (args) {
+                    is ImageOcclusionArgs.Add -> Uri.encode(args.imagePath)
+                    is ImageOcclusionArgs.Edit -> args.noteId
+                }
 
             val arguments =
                 bundleOf(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -24,6 +24,7 @@ import android.webkit.WebView
 import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.core.os.bundleOf
+import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
@@ -52,6 +53,8 @@ import timber.log.Timber
  * IO: Like an image-based cloze: hide parts of an image, revealed on the back
  * ([docs](https://docs.ankiweb.net/editing.html#image-occlusion) and
  * [source](https://github.com/ankitects/anki/blob/main/proto/anki/image_occlusion.proto)).
+ *
+ * When adding, a user may select the deck of the note
  *
  * **Paths**
  * `/image-occlusion/$PATH`
@@ -132,7 +135,9 @@ class ImageOcclusion :
             deckNameView.text = name
         }
 
-        viewModel.deckNameFlow.launchCollectionInLifecycleScope(::onDeckNameChanged)
+        viewModel.deckNameFlow?.launchCollectionInLifecycleScope(::onDeckNameChanged) ?: run {
+            deckNameView.isVisible = false
+        }
     }
 
     // TODO: Move this to an extension method once we have context parameters

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -44,6 +44,20 @@ import com.ichi2.anki.startDeckSelection
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
+/**
+ * Page provided by the backend, for a user to add or edit an image occlusion (IO) note
+ *
+ * IO: Like an image-based cloze: hide parts of an image, revealed on the back
+ * ([docs](https://docs.ankiweb.net/editing.html#image-occlusion) and
+ * [source](https://github.com/ankitects/anki/blob/main/proto/anki/image_occlusion.proto)).
+ *
+ * **Paths**
+ * `/image-occlusion/$PATH`
+ * `/image-occlusion/$NOTE_ID`
+ *
+ * @see ImageOcclusionViewModel
+ * @see ImageOcclusion.getIntent
+ */
 class ImageOcclusion :
     PageFragment(R.layout.image_occlusion),
     DeckSelectionDialog.DeckSelectionListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/ImageOcclusion.kt
@@ -25,23 +25,25 @@ import android.widget.TextView
 import androidx.activity.addCallback
 import androidx.core.os.bundleOf
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.android.material.appbar.MaterialToolbar
-import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.dialogs.DiscardChangesDialog
-import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.IO_ARGS_KEY
-import com.ichi2.anki.requireAnkiActivity
-import com.ichi2.anki.selectedDeckIfNotFiltered
 import com.ichi2.anki.startDeckSelection
+import com.ichi2.utils.HandlerUtils
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 /**
@@ -80,11 +82,6 @@ class ImageOcclusion :
         deckNameView = view.findViewById(R.id.deck_name)
         deckNameView.setOnClickListener { startDeckSelection(all = false, filtered = false, skipEmptyDefault = false) }
 
-        requireAnkiActivity().launchCatchingTask {
-            val selectedDeck = withCol { selectedDeckIfNotFiltered() }
-            deckNameView.text = selectedDeck.name
-        }
-
         @NeedsTest("#17393 verify that the added image occlusion cards are put in the correct deck")
         view.findViewById<MaterialToolbar>(R.id.toolbar).setOnMenuItemClickListener {
             if (it.itemId == R.id.action_save) {
@@ -93,6 +90,8 @@ class ImageOcclusion :
             }
             return@setOnMenuItemClickListener true
         }
+
+        setupFlows()
     }
 
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient =
@@ -113,13 +112,7 @@ class ImageOcclusion :
     override fun onDeckSelected(deck: SelectableDeck?) {
         if (deck == null) return
         require(deck is SelectableDeck.Deck)
-        deckNameView.text = deck.name
-        val deckDidChange = viewModel.handleDeckSelection(deck.deckId)
-        if (deckDidChange) {
-            viewLifecycleOwner.lifecycleScope.launch {
-                withCol { decks.select(viewModel.selectedDeckId) }
-            }
-        }
+        viewModel.handleDeckSelection(deck.deckId)
     }
 
     // HACK: detect a successful save; #19443 will provide a better method
@@ -133,6 +126,29 @@ class ImageOcclusion :
                 "addImageOcclusionNote", "updateImageOcclusionNote" -> viewModel.onSaveOperationCompleted()
             }
         }
+
+    private fun setupFlows() {
+        fun onDeckNameChanged(name: String) {
+            deckNameView.text = name
+        }
+
+        viewModel.deckNameFlow.launchCollectionInLifecycleScope(::onDeckNameChanged)
+    }
+
+    // TODO: Move this to an extension method once we have context parameters
+    private fun <T> Flow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit) {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                this@launchCollectionInLifecycleScope.collect {
+                    if (isRobolectric) {
+                        HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
+                    } else {
+                        block(it)
+                    }
+                }
+            }
+        }
+    }
 
     companion object {
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModel.kt
@@ -52,8 +52,10 @@ class ImageOcclusionViewModel(
     val oldDeckId: Long
 
     /**
-     * A [JSONObject] containing options for initializing the WebView. This includes
-     * the type of operation ("add" or "edit"), and relevant IDs and paths.
+     * A [JSONObject] containing options for loading the [image occlusion page][ImageOcclusion].
+     * This includes the type of operation ("add" or "edit"), and relevant IDs and paths.
+     *
+     * Defined in https://github.com/ankitects/anki/blob/main/ts/routes/image-occlusion/lib.ts
      */
     val webViewOptions: JSONObject
 
@@ -86,6 +88,9 @@ class ImageOcclusionViewModel(
         return true
     }
 
+    /**
+     * Executed when the 'save' operation is completed, before the UI receives the response
+     */
     fun onSaveOperationCompleted() {
         Timber.i("save operation completed")
         if (oldDeckId == selectedDeckId) return

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -48,7 +48,6 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.not
 import org.hamcrest.MatcherAssert.assertThat
 import org.intellij.lang.annotations.Language
-import org.json.JSONObject
 import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -104,7 +103,7 @@ class CustomStudyDialogTest : RobolectricTest() {
                     "usn": -1
                 }
                 """.trimIndent()
-            assertThat(customStudy, isJsonEqual(JSONObject(expected)))
+            assertThat(customStudy, isJsonEqual(expected))
         }
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
@@ -1,0 +1,230 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
+import com.ichi2.anki.libanki.Consts
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.libanki.NoteId
+import com.ichi2.anki.libanki.NoteTypeId
+import com.ichi2.anki.libanki.testutils.AnkiTest
+import com.ichi2.anki.pages.viewmodel.ImageOcclusionViewModel.Companion.IO_ARGS_KEY
+import com.ichi2.anki.pages.viewmodel.NoteIdBuilder.Id
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.JvmTest
+import com.ichi2.testutils.isJsonEqual
+import kotlinx.coroutines.flow.first
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.jupiter.api.assertNull
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.properties.Delegates.notNull
+import kotlin.test.assertNotNull
+
+/**
+ * Tests [ImageOcclusionViewModel]
+ */
+// TODO: make this run with no Android dependencies
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class ImageOcclusionViewModelTest : JvmTest() {
+    private var deckIdToSwitchTo by notNull<DeckId>()
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        deckIdToSwitchTo = addDeck(OTHER_DECK_NAME)
+    }
+
+    @Test
+    fun `ADD - deck name is set`() =
+        withAddViewModel {
+            assertThat("deckId", selectedDeckIdFlow?.value, equalTo(1))
+            assertNotNull(deckNameFlow)
+            assertThat("deck name", deckNameFlow.first(), equalTo("Default"))
+        }
+
+    @Test
+    fun `ADD - deck selection changes id`() =
+        withAddViewModel {
+            val deckIdFlow = assertNotNull(selectedDeckIdFlow, "selectedDeckIdFlow")
+            deckIdFlow.test {
+                assertThat("initial deck id", awaitItem(), equalTo(1))
+                handleDeckSelection(deckIdToSwitchTo)
+                assertThat("changed deck id", awaitItem(), equalTo(deckIdToSwitchTo))
+            }
+        }
+
+    @Test
+    fun `ADD - deck selection changes name`() =
+        withAddViewModel {
+            val deckNameFlow = assertNotNull(deckNameFlow, "deckNameFlow")
+            deckNameFlow.test {
+                assertThat("initial deck name", awaitItem(), equalTo("Default"))
+                handleDeckSelection(deckIdToSwitchTo)
+                assertThat("changed deck name", awaitItem(), equalTo(OTHER_DECK_NAME))
+            }
+        }
+
+    // This test is subject to change
+    //  *  decks.current could only be set during the 'add' operation
+    //  *  the proto could be extended to accept a deckId
+    @Test
+    fun `ADD - selected deck is changed and reverted`() =
+        withAddViewModel {
+            // change the deck
+            assertNotNull(deckNameFlow)
+            deckNameFlow.test {
+                assertThat("initial deck", this.awaitItem(), equalTo("Default"))
+                assertThat("initial current deck", col.decks.getCurrentId(), equalTo(1))
+
+                handleDeckSelection(deckIdToSwitchTo)
+
+                assertThat("changed deck", this.awaitItem(), equalTo(OTHER_DECK_NAME))
+                assertThat("changed current deck", col.decks.getCurrentId(), equalTo(deckIdToSwitchTo))
+            }
+
+            onSaveOperationCompleted()
+            assertThat("current deck is reverted", col.decks.getCurrentId(), equalTo(1))
+        }
+
+    @Test
+    fun `EDIT - flows are null`() =
+        withEditViewModel {
+            assertNull(selectedDeckIdFlow)
+            assertNull(deckNameFlow)
+        }
+
+    @Test
+    fun `EDIT - full test`() =
+        withEditViewModel {
+            // effectively a no-op: call doesn't do anything for 'EDIT' yet
+            assertDoesNotThrow { onSaveOperationCompleted() }
+        }
+
+    @Test
+    fun `ADD - args are copied correctly`() =
+        withAddViewModel(imagePath = "/", noteTypeId = 12, deckId = 2) {
+            val args = assertInstanceOf<ImageOcclusionArgs.Add>(args)
+
+            val expected =
+                ImageOcclusionArgs.Add(
+                    imagePath = "/",
+                    noteTypeId = 12,
+                    originalDeckId = 2,
+                )
+            assertThat(args, equalTo(expected))
+        }
+
+    @Test
+    fun `EDIT - args are copied correctly`() =
+        withEditViewModel(noteIdBuilder = Id(12)) {
+            val args = assertInstanceOf<ImageOcclusionArgs.Edit>(args)
+            val expected = ImageOcclusionArgs.Edit(noteId = 12)
+            assertThat(args, equalTo(expected))
+        }
+
+    @Test
+    fun `ADD - JSON Serialization`() {
+        val expected = """
+            {
+                "kind": "add",
+                "imagePath":  "/",
+                "notetypeId": 12 
+            }
+        """
+
+        withAddViewModel(imagePath = "/", noteTypeId = 12, deckId = 2) {
+            assertThat(args.toImageOcclusionMode(), isJsonEqual(expected))
+        }
+    }
+
+    @Test
+    fun `EDIT - JSON Serialization`() {
+        val expected = """
+            {
+                "kind": "edit",
+                "noteId": 12 
+            }
+        """
+
+        withEditViewModel(noteIdBuilder = Id(12)) {
+            assertThat(args.toImageOcclusionMode(), isJsonEqual(expected))
+        }
+    }
+
+    companion object {
+        const val OTHER_DECK_NAME = "Temp"
+    }
+}
+
+fun AnkiTest.withViewModel(
+    args: ImageOcclusionArgs,
+    block: suspend ImageOcclusionViewModel.() -> Unit,
+) = runTest {
+    val savedStateHandle =
+        SavedStateHandle().apply {
+            this[IO_ARGS_KEY] = args
+        }
+
+    block(ImageOcclusionViewModel(savedStateHandle))
+}
+
+fun AnkiTest.withAddViewModel(
+    imagePath: String = "",
+    noteTypeId: NoteTypeId = 0,
+    deckId: DeckId = Consts.DEFAULT_DECK_ID,
+    block: suspend ImageOcclusionViewModel.() -> Unit,
+) = withViewModel(
+    ImageOcclusionArgs.Add(
+        imagePath = imagePath,
+        noteTypeId = noteTypeId,
+        originalDeckId = deckId,
+    ),
+    block,
+)
+
+fun AnkiTest.withEditViewModel(
+    noteIdBuilder: NoteIdBuilder = NoteIdBuilder.CreateNew,
+    block: suspend ImageOcclusionViewModel.() -> Unit,
+) = withViewModel(
+    ImageOcclusionArgs.Edit(
+        noteId = noteIdBuilder.build(this),
+    ),
+    block,
+)
+
+sealed class NoteIdBuilder {
+    companion object CreateNew : NoteIdBuilder()
+
+    data class Id(
+        val id: NoteId,
+    ) : NoteIdBuilder()
+
+    fun build(testContext: AnkiTest): NoteId =
+        when (this) {
+            is Id -> id
+            is CreateNew -> testContext.addBasicNote().id
+        }
+}


### PR DESCRIPTION
## Purpose / Description
From the Reviewer, I could not edit the deck of an image occlusion note

This functionality was not implemented on `ImageOcclusion`. Only editing the deck of 'add' was supported, and the 'edit deck' functionality of `NoteEditorFragment` was hidden

In future, we can handle this inImageOcclusion, BUT:

There are 3 cases:
* A user wants to edit a card when studying
* A user wants to edit a selection of cards from the same note [Card Browser - CARDS]
* A user wants to edit a note [Card Browser - NOTES]
  * What does it mean to edit the deck of a note, is a user aware of this?

And a user can remove the cards they are editing (by removing masks).

Since we don't yet have full control over the process of adding an occlusion note, I decided it was a risk to take the time to implement this, and went for a simple fix

## Fixes
* Fixes #19605
* Fixes #19426

## Approach

Beforehand, I refactored the Image Occlusion screen: 
* Moving to a discriminated union, to make invalid states non-representable
* Moving to flows, to reduce 

Then:
* Enable editing the deck in NoteEditorFragment if in edit mode
* Disable editing the deck in ImageOcclusion if in edit mode

## How Has This Been Tested?

Pixel 9 API 35 emulator:

* Add Image Occlusion note by 'share' & change deck from default
  * ✅ Deck is set on note
  * ✅ Current deck is not changed
* Add Image Occlusion note by 'add'
  * ✅ Deck is set on note
  * ✅ Current deck is not changed
* Edit Image Occlusion note in 'Review'
  * ✅ Deck is settable in Note Editor
  * ✅ Deck is not settable in Image Occlusion Editor
* Edit Image Occlusion note in 'Review' - removing current mask
  * ✅ 'No cloze 1 found on card ...'
* Edit Image Occlusion card in 'Card Browser'
  * ✅ Deck is changeable in Note Editor
* Edit Image Occlusion note in 'Card Browser'
  * ⚠️ Known buggy: https://github.com/ankidroid/Anki-Android/issues/17415

<img width="358" height="284" alt="Screenshot 2025-11-24 at 20 52 55" src="https://github.com/user-attachments/assets/fa0c3565-b094-4890-977e-f773eb2d148e" />

<img width="360" height="634" alt="Screenshot 2025-11-24 at 20 53 03" src="https://github.com/user-attachments/assets/f8c42878-5b9d-4e82-968c-0be3afd4b412" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)