### PR TITLE
docs: fix renamed method in AddEditReminderDialogViewModel

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/AddEditReminderDialogViewModel.kt
@@ -55,7 +55,7 @@ class AddEditReminderDialogViewModel(
      * Here, we set an immediate default value for the deck selected based on the dialog mode.
      * However, it is possible that the deck with this deck ID does not currently exist in the collection
      * (ex. due to a deleted deck, changed collection folder, etc.). Since checking for this case requires
-     * accessing the collection, we handle it in [AddEditReminderDialog.ensureValidDeckSelected].
+     * accessing the collection, we handle it in [AddEditReminderDialog.setInitialDeckSelection].
      */
     private val _deckSelected =
         MutableLiveData(


### PR DESCRIPTION
`ensureValidDeckSelected` has now been replaced by `setInitialDeckSelection`.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->