### PR TITLE
chore: convert ReviewerMenuSettingsAdapter to ViewBinding & document class

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsAdapter.kt
@@ -23,6 +23,19 @@ import com.ichi2.anki.R
 import com.ichi2.anki.databinding.ReviewerMenuDisplayTypeBinding
 import com.ichi2.anki.databinding.ReviewerMenuItemBinding
 
+/**
+ * Provides bindings from menu items and display types (headings) to [RecyclerView] views
+ * and support for dragging menu items to change display types or reorder.
+ *
+ * Handles ViewHolders for two classes:
+ * * [ReviewerMenuSettingsRecyclerItem.DisplayType] - Headings: Always show, Menu only, etc...
+ *   * [DisplayTypeViewHolder]
+ * * [ReviewerMenuSettingsRecyclerItem.Action] - Study screen menu items: Undo, Flag, etc...
+ *   * [ActionViewHolder]
+ *
+ * @see ReviewerMenuSettingsFragment
+ * @see ReviewerMenuSettingsRecyclerItem
+ */
 class ReviewerMenuSettingsAdapter(
     private val items: List<ReviewerMenuSettingsRecyclerItem>,
 ) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked 
    * https://github.com/david-allison/Anki-Android/pull/44/commits/62ad1c440704707042f7eadb9e4ef88abf7279e5
* Added docs

## How Has This Been Tested?
Brief test:

* Pixel 9 API 35 Emulator
  * Screen opens via 'Settings': moved items around

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)