### PR TITLE
fix: bump oldest working webview version

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
@@ -31,8 +31,8 @@ import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
 import timber.log.Timber
 
-internal const val OLDEST_WORKING_WEBVIEW_VERSION_CODE = 386507305L
-internal const val OLDEST_WORKING_WEBVIEW_VERSION = 77
+internal const val OLDEST_WORKING_WEBVIEW_VERSION_CODE = 418306960L
+internal const val OLDEST_WORKING_WEBVIEW_VERSION = 85
 
 /**
  * Shows a dialog if the current WebView version is older than the last supported version.


### PR DESCRIPTION
opening Statistics or IO results in:

```text
"Uncaught (in promise) TypeError: t.replaceAll is not a function", source: http://127.0.0.1:36299/_app/immutable/chunks/D0Kcqh4a.mjs (1)
```

https://caniuse.com/wf-string-replaceall

## How Has This Been Tested?

Emulator 31 (WebView 85.0):

open Statistics and Image Occlusion

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->