### PR TITLE
fix(whiteboard): crash after dismissing popup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -67,7 +67,7 @@ class WhiteboardFragment :
     val binding by viewBinding(FragmentWhiteboardBinding::bind)
 
     private var eraserPopup: PopupWindow? = null
-    private var strokeWidthPopup: PopupWindow? = null
+    private var brushConfigPopup: PopupWindow? = null
 
     /**
      * Sets up the view, observers, and event listeners.
@@ -235,7 +235,7 @@ class WhiteboardFragment :
         button.setOnClickListener {
             if (viewModel.activeBrushIndex.value == index && !viewModel.isEraserActive.value) {
                 button.isChecked = true
-                showStrokeWidthPopup(it, index)
+                showBrushConfigurationPopup(it, index)
             } else {
                 viewModel.setActiveBrush(index)
             }
@@ -305,9 +305,9 @@ class WhiteboardFragment :
     }
 
     /**
-     * Shows a popup for adjusting the stroke width of a specific brush.
+     * Shows a popup for adjusting the stroke width or color of a specific brush.
      */
-    private fun showStrokeWidthPopup(
+    private fun showBrushConfigurationPopup(
         anchorView: View,
         brushIndex: Int,
     ) {
@@ -349,17 +349,17 @@ class WhiteboardFragment :
             value.roundToInt().toString()
         }
 
-        strokeWidthPopup =
+        brushConfigPopup =
             PopupWindow(popupBrushBinding.root, ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT, true)
-        strokeWidthPopup?.elevation = resources.getDimension(R.dimen.study_screen_elevation)
-        strokeWidthPopup?.setOnDismissListener {
-            strokeWidthPopup = null
+        brushConfigPopup?.elevation = resources.getDimension(R.dimen.study_screen_elevation)
+        brushConfigPopup?.setOnDismissListener {
+            brushConfigPopup = null
         }
 
         popupBrushBinding.root.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED)
         val yOffset = -(anchorView.height + popupBrushBinding.root.measuredHeight)
         val xOffset = (anchorView.width - popupBrushBinding.root.measuredWidth) / 2
-        strokeWidthPopup?.showAsDropDown(anchorView, xOffset, yOffset)
+        brushConfigPopup?.showAsDropDown(anchorView, xOffset, yOffset)
     }
 
     /**
@@ -373,7 +373,7 @@ class WhiteboardFragment :
                 object : ColorPickerPopUp.OnPickColorListener {
                     override fun onColorPicked(color: Int) {
                         viewModel.updateBrushColor(color)
-                        strokeWidthPopup?.dismiss()
+                        brushConfigPopup?.dismiss()
                     }
 
                     override fun onCancel() {}


### PR DESCRIPTION
## Fixes

the following issue:

1. Open the new whiteboard (in the new study screen or in the drawing attachment option in the note editor)
2. Open a brush popup
3. Resize the screen
4. Dismiss the popup

https://github.com/user-attachments/assets/abf5a612-7525-4a8d-88c8-c4932678b475

## Approach

1. Removed an unnecessary call of `updateToolbarSelection()`
2. Some refactors

## How Has This Been Tested?

Same reproduction steps and device -> No crash

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->