### PR TITLE
fix(login): don't hang on network errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginViewModel.kt
@@ -133,7 +133,7 @@ enum class LoginError(
     EMPTY_PASSWORD(R.string.password_empty),
     ;
 
-    fun toHumanReadableString(context: Context): String? = context.getString(this.messageResId)
+    fun toHumanReadableString(context: Context): String = context.getString(this.messageResId)
 }
 
 /** Handles the Login State */


### PR DESCRIPTION
## Purpose / Description
I had a bad emulator, I tried to log in and the operation hung

## Fixes
* Fixes #19627

## Approach
Catch the exception and display it

## How Has This Been Tested?
Pixel 9 API 35 Emulator: couldn't connect to AnkiWeb as the internet was borked

<img width="365" height="250" alt="Screenshot 2025-11-27 at 16 49 36" src="https://github.com/user-attachments/assets/2ff6503e-93df-4593-8939-65bf12e40674" />

## Learning

Cause: 

* Unhandled exception thrown 
  * 48a5557c9f3519b2f61196827171e1c87bc1435f
  * https://github.com/ankidroid/Anki-Android/pull/17908 
* Some unhandled exceptions no longer crash
  * 333ef64eab2990f0542648772d9d3893103a6054
  * https://github.com/ankidroid/Anki-Android/pull/17402
  * https://github.com/ankidroid/Anki-Android/issues/17392

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->