### PR TITLE
improvement(codeql): don't run lint checks 

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -101,7 +101,7 @@ jobs:
       if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        ./gradlew assemblePlayRelease
+        ./gradlew assemblePlayRelease -x lintVitalPlayRelease
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
`android.lint.checkReleaseBuilds`  is true, but we don't need it here as we have `lint.yml` to run the checks

* Better performance
* Less noise on a PR with failed lint checks

## Fixes
* Fixes #19633

## Approach
* Determine the check to not run via: `./gradlew assemblePlayRelease --dry-run`
  * https://github.com/ankidroid/Anki-Android/issues/19633#issuecomment-3587110807
* Disable it 

## How Has This Been Tested?

* This PR
----

<img width="874" height="759" alt="Screenshot 2025-11-27 at 19 51 51" src="https://github.com/user-attachments/assets/aa8acfd5-a9c3-4c23-b9e6-645bf6ee385c" />

----

* CodeQL passes, and lint fails


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)