### PR TITLE
[CleanUp]:remove runBlocking warning in CardBrowserTest.kt by converting …

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -872,9 +872,10 @@ class CardBrowserTest : RobolectricTest() {
 
     /** PR #14859  */
     @Test
-    fun checkDisplayOrderAfterTogglingCardsToNotes() {
-        browserWithNoNewCards.apply {
+    fun checkDisplayOrderAfterTogglingCardsToNotes() =
+        withBrowser {
             viewModel.changeCardOrder(SortType.EASE) // order no. 7 corresponds to "cardEase"
+
             viewModel.changeCardOrder(SortType.EASE) // reverse the list
 
             viewModel.setCardsOrNotes(NOTES)
@@ -891,7 +892,6 @@ class CardBrowserTest : RobolectricTest() {
                 equalTo(true),
             )
         }
-    }
 
     data class CheckedCardResult(
         val row: BrowserRow,
@@ -1681,13 +1681,13 @@ val CardBrowser.columnHeadings
     get() =
         columnHeadingViews.map { it.text.toString() }
 
-fun CardBrowser.searchCards(search: String? = null) {
+suspend fun CardBrowser.searchCards(search: String? = null) {
     if (search != null) {
         viewModel.launchSearchForCards(search)
     } else {
         viewModel.launchSearchForCards()
     }
-    runBlocking { viewModel.searchJob?.join() }
+    viewModel.searchJob?.join()
 }
 
 fun CardBrowser.showFindAndReplaceDialog() = cardBrowserFragment.showFindAndReplaceDialog()


### PR DESCRIPTION
Purpose / Description
Fix Android Studio coroutine-related inspection warnings in CardBrowserTest.kt.
Fixes part of #13282, specifically warning inside:

CardBrowserTest.kt

Approach
Remove  Android Studio warning of runBlocking in coroutine by making the searchCards function a suspend function
and using runTest block in function calls of searchCards

How Has This Been Tested?
Verified that the warning no longer appears under Code → Inspect Code.


### Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings).
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner.


