### PR TITLE
fix: Note Editor: "No image found on clipboard" Snackbar is not shown if the initial note type is 'Image Occlusion'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -479,8 +479,9 @@ class NoteEditorFragment :
             }
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        if (sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, true)) {
-            anchorView = requireView().findViewById<Toolbar>(R.id.editor_toolbar)
+        val view = this@NoteEditorFragment.view?.findViewById<Toolbar?>(R.id.editor_toolbar)
+        if (view?.isVisible == true) {
+            anchorView = view
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/snackbar/Snackbars.kt
@@ -21,12 +21,15 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.snackbar.onAttachedToWindow2
 import com.ichi2.anki.BuildConfig
+import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
+import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.showThemedToast
 import timber.log.Timber
 
@@ -206,6 +209,21 @@ fun View.showSnackbar(
 
     if (snackbarBuilder != null) {
         snackbar.snackbarBuilder()
+    }
+
+    if (snackbar.anchorView?.isVisible == false) {
+        val errorMessage = "While trying to show a snackbar, anchorView was not visible"
+        if (BuildConfig.DEBUG) {
+            throw IllegalArgumentException(errorMessage)
+        }
+        Timber.w(errorMessage)
+        CrashReportService.sendExceptionReport(
+            ManuallyReportedException(errorMessage),
+            "View.showSnackbar",
+            onlyIfSilent = true,
+        )
+
+        snackbar.anchorView = null
     }
 
     snackbar.show()


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
The "No image found on clipboard" Snackbar is invisible when the note editor is initially loaded with Image Occlusion note type.

## Fixes
* Fixes #19643

## Approach
Show the Snackbar via the Activity root view

## How Has This Been Tested?


Tested on a physical device (Android 15 / SDK 35)

https://github.com/user-attachments/assets/7ca89e21-c8da-4871-8164-634b72079cad




## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->