### PR TITLE
fix(template-previewer): fragment being created from scratch on recreations

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -45,10 +45,15 @@ class TemplatePreviewerPage : Fragment(R.layout.template_previewer_container) {
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 
-        val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
-        val fragment = TemplatePreviewerFragment.newInstance(arguments)
-        childFragmentManager.commitNow {
-            replace(R.id.fragment_container, fragment)
+        val fragment: TemplatePreviewerFragment
+        if (savedInstanceState == null) {
+            val arguments = BundleCompat.getParcelable(requireArguments(), ARGS_KEY, TemplatePreviewerArguments::class.java)!!
+            fragment = TemplatePreviewerFragment.newInstance(arguments)
+            childFragmentManager.commitNow {
+                replace(R.id.fragment_container, fragment)
+            }
+        } else {
+            fragment = childFragmentManager.findFragmentById(R.id.fragment_container) as TemplatePreviewerFragment
         }
 
         val viewModel = fragment.viewModel


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The `Show answer` wasn't kept after configuration changes in the template previewer

## Approach

Check if the fragment already existed by checking if savedInstanceState is null

## How Has This Been Tested?


https://github.com/user-attachments/assets/7f5fcde6-7c20-449b-a7a2-9b650a5da354


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->