### PR TITLE
Make ESC key work for any FAB menus in Deck picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -356,17 +356,31 @@ class DeckPickerFloatingActionMenu(
         return animDuration != 0f && animTransition != 0f && animWindow != 0f
     }
 
-    private fun createActivationKeyListener(
+    private fun onFabMenuItemsKeyListener(
         logMessage: String,
-        action: () -> Unit,
+        onEnter: () -> Unit,
     ): View.OnKeyListener =
         View.OnKeyListener { _, keyCode, event ->
-            if (event.action == KeyEvent.ACTION_DOWN &&
-                (keyCode == KeyEvent.KEYCODE_ENTER || keyCode == KeyEvent.KEYCODE_DPAD_CENTER)
-            ) {
-                Timber.d(logMessage)
-                action()
-                return@OnKeyListener true
+            if (event.action != KeyEvent.ACTION_DOWN) {
+                return@OnKeyListener false
+            }
+
+            when (keyCode) {
+                KeyEvent.KEYCODE_ENTER,
+                KeyEvent.KEYCODE_DPAD_CENTER,
+                -> {
+                    Timber.d(logMessage)
+                    onEnter()
+                    return@OnKeyListener true
+                }
+
+                KeyEvent.KEYCODE_ESCAPE -> {
+                    if (isFABOpen) {
+                        Timber.d("ESC key pressed - closing FAB menu")
+                        closeFloatingActionMenu(applyRiseAndShrinkAnimation = true)
+                        return@OnKeyListener true
+                    }
+                }
             }
             false
         }
@@ -397,30 +411,18 @@ class DeckPickerFloatingActionMenu(
             },
         )
 
-        // Enable keyboard activation for Enter/DPAD_CENTER/ESC keys
-        fabMain.setOnKeyListener { _, keyCode, event ->
-            if (event.action == KeyEvent.ACTION_DOWN) {
-                when (keyCode) {
-                    KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER -> {
-                        Timber.d("FAB main button: ENTER key pressed")
-                        if (!isFABOpen) {
-                            showFloatingActionMenu()
-                        } else {
-                            addNote()
-                        }
-                        return@setOnKeyListener true
-                    }
-                    KeyEvent.KEYCODE_ESCAPE -> {
-                        if (isFABOpen) {
-                            Timber.d("FAB main button: ESC key pressed - closing menu")
-                            closeFloatingActionMenu(applyRiseAndShrinkAnimation = true)
-                            return@setOnKeyListener true
-                        }
-                    }
+        // Enable keyboard activation for Enter/DPAD_CENTER keys
+        val mainFabKeyListener =
+            onFabMenuItemsKeyListener(
+                logMessage = "FAB main: ENTER pressed",
+            ) {
+                if (!isFABOpen) {
+                    showFloatingActionMenu()
+                } else {
+                    addNote()
                 }
             }
-            false
-        }
+        fabMain.setOnKeyListener(mainFabKeyListener)
 
         fabBGLayout.setOnClickListener { closeFloatingActionMenu(applyRiseAndShrinkAnimation = true) }
         val addDeckListener =
@@ -435,7 +437,7 @@ class DeckPickerFloatingActionMenu(
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addDeckKeyListener =
-            createActivationKeyListener("Add Deck button: ENTER key pressed") {
+            onFabMenuItemsKeyListener("Add Deck button: ENTER key pressed") {
                 if (isFABOpen) {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
                     deckPicker.showCreateDeckDialog()
@@ -443,6 +445,7 @@ class DeckPickerFloatingActionMenu(
             }
         addDeckButton.setOnKeyListener(addDeckKeyListener)
         addDeckLabel.setOnKeyListener(addDeckKeyListener)
+
         val addFilteredDeckListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -455,7 +458,7 @@ class DeckPickerFloatingActionMenu(
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addFilteredDeckKeyListener =
-            createActivationKeyListener("Add Filtered Deck button: ENTER key pressed") {
+            onFabMenuItemsKeyListener("Add Filtered Deck button: ENTER key pressed") {
                 if (isFABOpen) {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
                     deckPicker.showCreateFilteredDeckDialog()
@@ -463,6 +466,7 @@ class DeckPickerFloatingActionMenu(
             }
         addFilteredDeckButton.setOnKeyListener(addFilteredDeckKeyListener)
         addFilteredDeckLabel.setOnKeyListener(addFilteredDeckKeyListener)
+
         val addSharedListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -476,7 +480,7 @@ class DeckPickerFloatingActionMenu(
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addSharedKeyListener =
-            createActivationKeyListener("Add Shared Deck button: ENTER key pressed") {
+            onFabMenuItemsKeyListener("Add Shared Deck button: ENTER key pressed") {
                 if (isFABOpen) {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
                     deckPicker.openAnkiWebSharedDecks()
@@ -484,6 +488,7 @@ class DeckPickerFloatingActionMenu(
             }
         addSharedButton.setOnKeyListener(addSharedKeyListener)
         addSharedLabel.setOnKeyListener(addSharedKeyListener)
+
         val addNoteLabelListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -496,7 +501,7 @@ class DeckPickerFloatingActionMenu(
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         addNote.setOnKeyListener(
-            createActivationKeyListener("Add Note label: ENTER key pressed") {
+            onFabMenuItemsKeyListener("Add Note label: ENTER key pressed") {
                 if (isFABOpen) {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)
                     addNote()


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description

Make the FAB menu on the Deck Picker collapse with the ESC key regardless of which FAB button has focus.


## Approach
Add handling for KeyEvent.KEYCODE_ESCAPE to the common listener.

## How Has This Been Tested?
Checked on a physical device (Android 15 / SDK 15)


https://github.com/user-attachments/assets/af86022d-d6af-47d3-8ef1-fd11788ec550

Also, confirmed that:
- ESC key works for each labels as well
- Enter key works for each FAB button as before



## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->