### PR TITLE
fix: startup with `getExternalFilesDir` corrupt on upgraded device

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -45,7 +45,6 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
-import kotlin.test.Ignore
 
 @RunWith(AndroidJUnit4::class)
 @Config(shadows = [ShadowNullExternalFilesDir::class])
@@ -65,7 +64,6 @@ class DeckPickerNoExternalFilesDirTest : RobolectricTest() {
     }
 
     @Test
-    @Ignore("19652")
     @Config(application = AnkiDroidAppWithCollectionButUnwritableStorage::class)
     fun `Fatal error is shown when getExternalFilesDir is null and collection is set but unwritable`() {
         // IntroductionActivity should be skipped by our code so we can show the error


### PR DESCRIPTION
> [!IMPORTANT]
> Please check logic carefully here
> To my understanding, this would not block any previously apps from starting up

<!--- Please fill the necessary details below -->
## Purpose / Description

If the collection path is set, then our error handling threw an exception

**Situation:**
* `getExternalFilesDir` is null
* Collection path is set
* `CollectionHelper.initializeAnkiDroidDirectory` throws `StorageAccessException`

and the AnkiDroid Directory is in `getExternalFilesDir`

## Fixes
* Fixes #19652

## Approach
Fix by catching the exception and failing - the selected directory is not writable and storage permissions are likely corrupted

## How Has This Been Tested?
Unit tested

## Learning (optional, can help others)
I asked a few AIs about how to run code before `Application.onCreate` and they came up with a number of solutions which didn't work

`Files.createTempDirectory` isn't deleted when the tests end

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)