### PR TITLE
[Kotlin cleanup] Remove redundant qualifier name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -2814,7 +2814,7 @@ abstract class AbstractFlashcardViewer :
                     error: TtsPlayer.TtsError,
                     isAutomaticPlayback: Boolean,
                 ) {
-                    AbstractFlashcardViewer.mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
+                    mediaErrorHandler.processTtsFailure(error, isAutomaticPlayback) {
                         when (error) {
                             is AndroidTtsError.MissingVoiceError ->
                                 TtsPlaybackErrorDialog.ttsPlaybackErrorDialog(activity, supportFragmentManager, error.tag)
@@ -2836,7 +2836,7 @@ abstract class AbstractFlashcardViewer :
                         // Retrying fixes most of these
                         if (file.exists()) return RETRY_MEDIA
                         // just doesn't exist - process the error
-                        AbstractFlashcardViewer.mediaErrorHandler.processMissingMedia(
+                        mediaErrorHandler.processMissingMedia(
                             file,
                         ) { filename: String? -> displayCouldNotFindMediaSnackbar(filename) }
                         return CONTINUE_MEDIA

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -3,7 +3,6 @@
 
 package com.ichi2.anki
 
-import android.app.Activity
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.ActivityNotFoundException
@@ -126,7 +125,7 @@ open class AnkiActivity(
     private lateinit var fileExportPath: String
     private val saveFileLauncher: ActivityResultLauncher<Intent> =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
-            if (result.resultCode == Activity.RESULT_OK) {
+            if (result.resultCode == RESULT_OK) {
                 saveFileCallback(result)
             } else {
                 Timber.i("The file selection for the exported collection was cancelled")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FieldEditLine.kt
@@ -57,10 +57,10 @@ class FieldEditLine : FrameLayout {
         binding.toggleSticky.setTooltipTextCompat(CollectionManager.TR.editingToggleSticky())
         // 7433 -
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
-            binding.editText.id = View.generateViewId()
-            binding.toggleSticky.id = View.generateViewId()
-            binding.mediaButton.id = View.generateViewId()
-            binding.expandButton.id = View.generateViewId()
+            binding.editText.id = generateViewId()
+            binding.toggleSticky.id = generateViewId()
+            binding.mediaButton.id = generateViewId()
+            binding.expandButton.id = generateViewId()
             binding.editText.nextFocusForwardId = binding.toggleSticky.id
             binding.toggleSticky.nextFocusForwardId = binding.mediaButton.id
             binding.mediaButton.nextFocusForwardId = binding.expandButton.id


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Remove redundant qualifier name in:
- AnkiActivity
- AbstractFlashcardViewer
- FieldEditLine

## Fixes
* Fixes a part of #13282 

## Approach
Remove redundant qualifier name.

## How Has This Been Tested?
Build successfully.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->