### PR TITLE
fix: Sync From AnkiWeb should open Deck Picker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -74,7 +74,7 @@ class IntroductionActivity : AnkiActivity(R.layout.introduction_activity) {
 
     private fun openLoginDialog() {
         Timber.i("Opening login screen")
-        val intent = AccountActivity.getIntent(this)
+        val intent = AccountActivity.getIntent(context = this, forResult = true)
         onLoginResult.launch(intent)
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The result should take the user to DeckPicker but since the flag was not passed in the parameter the user was not redirected to DeckPicker screen this PR resolves that

## Fixes
* Fixes #19600

## Approach
NA

## How Has This Been Tested?
Pixel 9 Pro Google Emulator API 36
[Screen_recording_20251203_044059.webm](https://github.com/user-attachments/assets/bd7dcd9f-8371-47f6-876c-9e8078ba958a)



## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->