### PR TITLE
depricate .current() and migrate to col.defaultsForAdding

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -102,12 +102,13 @@ class MediaTest : InstrumentedTest() {
         val file = createNonEmptyFile("fake.png")
         testCol.media.addFile(file)
         // add a note which references it
-        var f = testCol.newNote(testCol.notetypes.current())
+        var defaults = testCol.defaultsForAdding()
+        var f = testCol.newNote(testCol.notetypes.get(defaults.notetypeId)!!)
         f.setField(0, "one")
         f.setField(1, "<img src='fake.png'>")
         testCol.addNote(f)
         // and one which references a non-existent file
-        f = testCol.newNote(testCol.notetypes.current())
+        f = testCol.newNote(testCol.notetypes.get(defaults.notetypeId)!!)
         f.setField(0, "one")
         f.setField(1, "<img src='fake2.png'>")
         testCol.addNote(f)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2365,10 +2365,10 @@ class NoteEditorFragment :
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {
-                return getColUnsafe.notetypes.current().let {
-                    Timber.d("Adding to deck of note type, noteType: %s", it.name)
-                    return@let it.did
-                }
+                val defaults = getColUnsafe.defaultsForAdding()
+                val noteType = getColUnsafe.notetypes.get(defaults.notetypeId)!!
+                Timber.d("Adding to deck of note type, noteType: %s", noteType.name)
+                return noteType.did
             }
 
             val currentDeckId = getColUnsafe.config.get(CURRENT_DECK) ?: 1L
@@ -2404,8 +2404,8 @@ class NoteEditorFragment :
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {
-                    val notetype = notetypes.current()
-                    Note.fromNotetypeId(this@run, notetype.id)
+                    val notetypeId = getColUnsafe.defaultsForAdding().notetypeId
+                    Note.fromNotetypeId(this@run, notetypeId)
                 }
             } else {
                 note
@@ -2771,7 +2771,8 @@ class NoteEditorFragment :
     }
 
     private fun changeNoteType(newId: NoteTypeId) {
-        val oldNoteTypeId = getColUnsafe.notetypes.current().id
+        val defaults = getColUnsafe.defaultsForAdding()
+        val oldNoteTypeId = defaults.notetypeId
         Timber.i("Changing note type to '%d", newId)
 
         if (oldNoteTypeId == newId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -234,8 +234,9 @@ class DevOptionsFragment : SettingsFragment() {
                     }
                     withCol {
                         val deck = decks.addNormalDeckWithName(deckName(i))
+                        val notetypeId = defaultsForAdding().notetypeId
                         addNote(
-                            newNote(notetypes.current()).apply { setField(0, "$i") },
+                            newNote(notetypes.get(notetypeId)!!).apply { setField(0, "$i") },
                             deck.id,
                         )
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1312,7 +1312,7 @@ class CardContentProvider : ContentProvider() {
         col: Collection,
     ): NoteTypeId =
         if (uri.pathSegments[1] == FlashCardsContract.Model.CURRENT_MODEL_ID) {
-            col.notetypes.current().id
+            col.notetypes.get(col.defaultsForAdding().notetypeId)!!.id
         } else {
             try {
                 uri.pathSegments[1].toLong()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -455,7 +455,8 @@ class ReviewerTest : RobolectricTest() {
     @Throws(ConfirmModSchemaException::class)
     @KotlinCleanup("use a assertNotNull which returns rather than !!")
     private fun addNoteWithThreeCards() {
-        var notetype = col.notetypes.copy(col.notetypes.current())
+        val defaults = col.defaultsForAdding()
+        var notetype = col.notetypes.copy(col.notetypes.get(defaults.notetypeId)!!)
         notetype.name = "Three"
         col.notetypes.add(notetype)
         notetype = col.notetypes.byName("Three")!!

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/NoteTypeTest.kt
@@ -39,7 +39,8 @@ class NoteTypeTest : JvmTest() {
     @Test
     fun test_frontSide_field() {
         // #8951 - Anki Special-cases {{FrontSide}} on the front to return empty string
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         noteType.templates[0].qfmt = "{{Front}}{{FrontSide}}"
         col.notetypes.save(noteType)
         val note = col.newNote()
@@ -62,7 +63,8 @@ class NoteTypeTest : JvmTest() {
     @Test
     fun test_field_named_frontSide() {
         // #8951 - A field named "FrontSide" is ignored - this matches Anki 2.1.34 (8af8f565)
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
 
         // Add a field called FrontSide and FrontSide2 (to ensure that fields are added correctly)
         col.notetypes.addFieldModChanged(noteType, col.notetypes.newField("FrontSide"))
@@ -95,13 +97,15 @@ class NoteTypeTest : JvmTest() {
         note.setItem("Back", "2")
         col.addNote(note)
         assertEquals(1, col.cardCount())
-        col.notetypes.remove(col.notetypes.current().id)
+        val defaults = col.defaultsForAdding()
+        col.notetypes.remove(defaults.notetypeId)
         assertEquals(0, col.cardCount())
     }
 
     @Test
     fun test_modelCopy() {
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         val noteType2 = col.notetypes.copy(noteType)
         assertEquals("Basic copy", noteType2.name)
         assertNotEquals(noteType2.id, noteType.id)
@@ -120,7 +124,8 @@ class NoteTypeTest : JvmTest() {
         note.setItem("Front", "1")
         note.setItem("Back", "2")
         col.addNote(note)
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         // make sure renaming a field updates the templates
         col.notetypes.renameFieldLegacy(noteType, noteType.fields[0], "NewFront")
         assertThat(noteType.templates[0].qfmt, containsString("{{NewFront}}"))
@@ -228,7 +233,8 @@ class NoteTypeTest : JvmTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_templates() {
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
@@ -283,7 +289,8 @@ class NoteTypeTest : JvmTest() {
     @Throws(ConfirmModSchemaException::class)
     fun test_cloze_ordinals() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
 
         // We replace the default Cloze template
         val t =
@@ -311,8 +318,9 @@ class NoteTypeTest : JvmTest() {
 
     @Test
     fun test_text() {
+        val defaults = col.defaultsForAdding()
         val noteType =
-            col.notetypes.current().apply {
+            col.notetypes.get(defaults.notetypeId)!!.apply {
                 templates[0].qfmt = "{{text:Front}}"
             }
         col.notetypes.save(noteType)
@@ -393,7 +401,8 @@ class NoteTypeTest : JvmTest() {
     @Suppress("SpellCheckingInspection") // chaine
     fun test_chained_mods() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
 
         // We replace the default Cloze template
         val t =
@@ -427,7 +436,8 @@ class NoteTypeTest : JvmTest() {
     fun test_modelChange() {
         val cloze = col.notetypes.byName("Cloze")
         // enable second template and add a note
-        val basic = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val basic = col.notetypes.get(defaults.notetypeId)!!
         val t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
@@ -555,7 +565,8 @@ class NoteTypeTest : JvmTest() {
 
     @Test
     fun test_updateNotetype_clears_cache() {
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         val originalName = noteType.name
         val noteTypeId = noteType.id
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
@@ -145,6 +145,10 @@ class Notetypes(
      */
 
     /** Get current model.*/
+    @Deprecated(
+        message = "Use defaultsForAdding() instead, which provides both deck and notetype context",
+        replaceWith = ReplaceWith("defaultsForAdding()"),
+    )
     @RustCleanup("Should use defaultsForAdding() instead")
     fun current(forDeck: Boolean = true): NotetypeJson {
         var noteType = get(col.decks.current().getLongOrNull("mid"))

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
@@ -73,7 +73,8 @@ class CardTest : InMemoryAnkiTest() {
         note.setItem("Back", "2")
         col.addNote(note)
         val c = note.cards()[0]
-        col.notetypes.current().id
+        val defaults = col.defaultsForAdding()
+        col.notetypes.get(defaults.notetypeId)
         assertEquals(0, c.template().ord)
     }
 
@@ -84,7 +85,8 @@ class CardTest : InMemoryAnkiTest() {
         note.setItem("Back", "")
         col.addNote(note)
         assertEquals(1, note.numberOfCards())
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         // adding a new template should automatically create cards
         var t =
             Notetypes.newTemplate("rev").apply {

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CollectionTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CollectionTest.kt
@@ -109,7 +109,8 @@ class CollectionTest : InMemoryAnkiTest() {
         var n = col.addNote(note)
         assertEquals(1, n)
         // test multiple cards - add another template
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         val t = Notetypes.newTemplate("Reverse")
         t.qfmt = "{{Back}}"
         t.afmt = "{{Front}}"
@@ -189,7 +190,8 @@ class CollectionTest : InMemoryAnkiTest() {
     @Test
     @Ignore("Pending port of media search from Rust code")
     fun test_furigana() {
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.deckId)!!
         // filter should work
         noteType.templates[0].qfmt = "{{kana:Front}}"
         col.notetypes.save(noteType)

--- a/libanki/src/test/java/com/ichi2/anki/libanki/FinderTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/FinderTest.kt
@@ -126,7 +126,8 @@ class FinderTest : InMemoryAnkiTest() {
         note.setItem("Back", "sheep")
         col.addNote(note)
         val catCard = note.cards()[0]
-        var noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        var noteType = col.notetypes.get(defaults.notetypeId)!!
         noteType = col.notetypes.copy(noteType)
         val t =
             Notetypes.newTemplate("Reverse").apply {
@@ -135,7 +136,7 @@ class FinderTest : InMemoryAnkiTest() {
             }
         col.notetypes.addTemplateModChanged(noteType, t)
         col.notetypes.save(noteType)
-        note = col.newNote()
+        note = col.newNote(noteType)
         note.setItem("Front", "test")
         note.setItem("Back", "foo bar")
         col.addNote(note)

--- a/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
@@ -887,7 +887,8 @@ open class SchedulerTest : InMemoryAnkiTest() {
     @Throws(Exception::class)
     fun test_ordcycleV2() {
         // add two more templates and set second active
-        val noteType = col.notetypes.current()
+        val defaults = col.defaultsForAdding()
+        val noteType = col.notetypes.get(defaults.notetypeId)!!
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/ext/Collection.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/ext/Collection.kt
@@ -68,4 +68,4 @@ fun Collection.createBasicTypingNoteType(name: String): NotetypeJson {
  * the configuration (curModel)
  * @return The new note
  */
-fun Collection.newNote(forDeck: Boolean = true): Note = newNote(notetypes.current(forDeck))
+fun Collection.newNote(forDeck: Boolean = true): Note = newNote(notetypes.get(defaultsForAdding().notetypeId)!!)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Deprecate the NotetypeStorage.current() function and migrate all call sites to use defaultsForAdding()
## Fixes
* Fixes #19650

## Approach
- Added @Deprecated annotation to NotetypeStorage.current()
- Migrated all call sites to use defaultsForAdding()
## How Has This Been Tested?

All existing tests pass without modification

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->