### PR TITLE
feat: Allow card options in notes mode 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -1000,17 +1000,6 @@ open class CardBrowser :
         }
     }
 
-    /**
-     * @return `false` if the user may proceed; `true` if a warning is shown due to being in [NOTES]
-     */
-    fun warnUserIfInNotesOnlyMode(): Boolean {
-        if (viewModel.cardsOrNotes != NOTES) return false
-        showSnackbar(R.string.card_browser_unavailable_when_notes_mode) {
-            setAction(R.string.error_handling_options) { cardBrowserFragment.showOptionsDialog() }
-        }
-        return true
-    }
-
     @NeedsTest("filter-marked query needs testing")
     @NeedsTest("filter-suspended query needs testing")
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -701,10 +701,15 @@ class CardBrowserFragment :
             Timber.i("Attempted reschedule - no cards selected")
             return
         }
-        if (ankiActivity.warnUserIfInNotesOnlyMode()) return
 
         launchCatchingTask {
             val allCardIds = activityViewModel.queryAllSelectedCardIds()
+            Timber.i(
+                "Reschedule: mode=%s, selected rows=%d, cards=%d",
+                activityViewModel.cardsOrNotes,
+                activityViewModel.selectedRows.size,
+                allCardIds.size,
+            )
             showDialogFragment(SetDueDateDialog.newInstance(allCardIds))
         }
     }
@@ -712,7 +717,6 @@ class CardBrowserFragment :
     /** @see repositionCardsNoValidation */
     fun repositionSelectedCards(): Boolean {
         Timber.i("CardBrowser:: Reposition button pressed")
-        if (ankiActivity.warnUserIfInNotesOnlyMode()) return false
         launchCatchingTask {
             when (val repositionCardsResult = activityViewModel.prepareToRepositionCards()) {
                 is ContainsNonNewCardsError -> {
@@ -758,7 +762,15 @@ class CardBrowserFragment :
         }
 
     fun onResetProgress() {
-        if (ankiActivity.warnUserIfInNotesOnlyMode()) return
+        launchCatchingTask {
+            val allCardIds = activityViewModel.queryAllSelectedCardIds()
+            Timber.i(
+                "Reset Progress: mode=%s, selected rows=%d, cards=%d",
+                activityViewModel.cardsOrNotes,
+                activityViewModel.selectedRows.size,
+                allCardIds.size,
+            )
+        }
         showDialogFragment(ForgetCardsDialog())
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -405,8 +405,6 @@ opening the system text to speech settings fails">Failed to open text to speech 
 
     <string name="failed_to_copy">Failed to copy</string>
 
-    <string name="card_browser_unavailable_when_notes_mode">Unavailable in ‘Notes’ mode</string>
-
     <plurals name="unbury_cards_feedback">
         <item quantity="one">%d card unburied</item>
         <item quantity="other">%d cards unburied</item>


### PR DESCRIPTION
## Purpose / Description

Card Browser previously blocked reposition, set due date, and reset progress operations in notes mode with an error message. Desktop Anki allows these operations via the Cards submenu. 
## Fixes
* Fixes #18307

## Approach

Removed `warnUserIfInNotesOnlyMode()` blocking method from `CardBrowser.kt` and its checks from three operations in `CardBrowserFragment.kt`:
- `rescheduleSelectedCards()` 
- `repositionSelectedCards()`
- `onResetProgress()`

Added verification logging for data integrity. The existing `queryAllSelectedCardIds()` already handles both modes correctly ; querying all card IDs for selected notes when in notes mode.

## How Has This Been Tested?

By unit tests and manual testing ;

Added 2 tests in `CardBrowserViewModelTest.kt`:
- `reposition in notes mode affects all cards 18307` - Verifies repositioning affects all cards of selected notes
- `reset progress in notes mode affects all cards 18307` - Verifies reset affects all cards of selected notes

Run: `./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "*18307"`

Both tests will pass.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->