### PR TITLE
Revert "Hide fields in NoteEditorFragment for image occlusion notetypes"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2403,6 +2403,8 @@ class NoteEditorFragment :
         note: Note?,
         changeType: FieldChangeType,
     ) {
+        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
+        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !currentNotetypeIsImageOcclusion()
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {
@@ -2423,12 +2425,6 @@ class NoteEditorFragment :
         updateToolbar()
         populateEditFields(changeType, false)
         updateFieldsFromStickyText()
-
-        // When adding a note, ImageOcclusion handles the deck selection
-        // as a user can reach this screen directly from an intent
-        val disableDeckEditing = addNote && currentNotetypeIsImageOcclusion()
-        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !disableDeckEditing
-        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !disableDeckEditing
     }
 
     private fun addClozeButton(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2650,9 +2650,6 @@ class NoteEditorFragment :
                     .trim()
                     .replace(" ", ", "),
             )
-        // showing the tags is not needed for image occlusion notetypes as they are handled by the
-        // backend page
-        tagsButton?.isVisible = !currentNotetypeIsImageOcclusion()
     }
 
     /** Update the list of card templates for current note type  */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2393,8 +2393,6 @@ class NoteEditorFragment :
         note: Note?,
         changeType: FieldChangeType,
     ) {
-        requireView().findViewById<TextView>(R.id.CardEditorDeckText).isVisible = !currentNotetypeIsImageOcclusion()
-        requireView().findViewById<View>(R.id.note_deck_name).isVisible = !currentNotetypeIsImageOcclusion()
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1798,12 +1798,22 @@ class NoteEditorFragment :
         editNoteTypeMode: Boolean,
     ) {
         val editLines = fieldState.loadFieldEditLines(type)
-        // showing the fields is not needed for image occlusion notetypes as they are handled by the
-        // backend page
-        fieldsLayoutContainer?.isVisible = !currentNotetypeIsImageOcclusion()
         fieldsLayoutContainer!!.removeAllViews()
         customViewIds.clear()
         imageOcclusionButtonsContainer?.isVisible = currentNotetypeIsImageOcclusion()
+
+        val indicesToHide = mutableListOf<Int>()
+        if (currentNotetypeIsImageOcclusion()) {
+            val occlusionTag = "0"
+            val imageTag = "1"
+            val fields = currentlySelectedNotetype!!.fields
+            for ((i, field) in fields.withIndex()) {
+                val tag = field.imageOcclusionTag
+                if (tag == occlusionTag || tag == imageTag) {
+                    indicesToHide.add(i)
+                }
+            }
+        }
 
         editFields = LinkedList()
 
@@ -1892,6 +1902,7 @@ class NoteEditorFragment :
             toggleStickyButton.contentDescription =
                 getString(R.string.note_editor_toggle_sticky, editLineView.name)
 
+            editLineView.isVisible = i !in indicesToHide
             fieldsLayoutContainer!!.addView(editLineView)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1805,10 +1805,6 @@ class NoteEditorFragment :
         customViewIds.clear()
         imageOcclusionButtonsContainer?.isVisible = currentNotetypeIsImageOcclusion()
 
-        // Showing the bottom toolbar (for HTML format) is not needed for image occlusion notetypes
-        // as there are no fields for inputting text.
-        toolbar.isVisible = !currentNotetypeIsImageOcclusion()
-
         editFields = LinkedList()
 
         var previous: FieldEditLine? = null

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -917,8 +917,8 @@ class NoteEditorFragment :
             )
         }
 
-        // Don't open keyboard if not adding note or the note type is Image Occlusion
-        if (!addNote || currentNotetypeIsImageOcclusion()) {
+        // don't open keyboard if not adding note
+        if (!addNote) {
             requireActivity().window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1452,22 +1452,12 @@ class NoteEditorFragment :
                 }
             }
         }
-        if (currentNotetypeIsImageOcclusion()) {
-            // Showing options related to editing text in fields is not needed
-            // for image occlusion notetypes as there are no fields for inputting
-            // text in the editor screen. (Text is handled by the backend page.)
-            menu.findItem(R.id.action_font_size).isVisible = false
-            menu.findItem(R.id.action_show_toolbar).isVisible = false
-            menu.findItem(R.id.action_scroll_toolbar).isVisible = false
-            menu.findItem(R.id.action_capitalize).isVisible = false
-        } else {
-            menu.findItem(R.id.action_show_toolbar).isChecked =
-                !shouldHideToolbar()
-            menu.findItem(R.id.action_capitalize).isChecked =
-                sharedPrefs().getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
-            menu.findItem(R.id.action_scroll_toolbar).isChecked =
-                sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
-        }
+        menu.findItem(R.id.action_show_toolbar).isChecked =
+            !shouldHideToolbar()
+        menu.findItem(R.id.action_capitalize).isChecked =
+            sharedPrefs().getBoolean(PREF_NOTE_EDITOR_CAPITALIZE, true)
+        menu.findItem(R.id.action_scroll_toolbar).isChecked =
+            sharedPrefs().getBoolean(PREF_NOTE_EDITOR_SCROLL_TOOLBAR, true)
     }
 
     /**
@@ -1818,6 +1808,7 @@ class NoteEditorFragment :
         // Showing the bottom toolbar (for HTML format) is not needed for image occlusion notetypes
         // as there are no fields for inputting text.
         toolbar.isVisible = !currentNotetypeIsImageOcclusion()
+
         editFields = LinkedList()
 
         var previous: FieldEditLine? = null
@@ -1907,7 +1898,6 @@ class NoteEditorFragment :
 
             fieldsLayoutContainer!!.addView(editLineView)
         }
-        requireActivity().invalidateOptionsMenu()
     }
 
     private fun getActionModeCallback(


### PR DESCRIPTION
## Purpose / Description
The Image Occlusion page does not support pasting images into the fields in a viable manner. Images are inserted as base64, which bloats the collection

I reverted a number of changes to the Note Editor Image Occlusion functionality (sorry: @lukstbit @criticalAY  @snowtimeglass @david-allison)

Specifically:

* Fields are now visible
* I reverted hiding tags and deck selection because it felt misplaced to have some editable parts of the page being moved to `ImageOcclusion`

## Fixes
* Workaround for #19679

## Approach
I reverted commits, fixed up conflicts when they occurred, and edited the commit message to refer to the cause of the revert

## How Has This Been Tested?
I added a note, using a newly created deck, then added an occlusion

<img width="433" height="388" alt="Screenshot 2025-12-04 at 06 43 58" src="https://github.com/user-attachments/assets/f7557e2e-b2cf-43ce-bdd0-3e12bcb6b0fb" />
<img width="435" height="324" alt="Screenshot 2025-12-04 at 06 44 39" src="https://github.com/user-attachments/assets/99fd7dd9-4427-431e-8ed9-e8f09a437ab1" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)