### PR TITLE
fix(previewer): persist "backside only" 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -49,7 +49,11 @@ class PreviewerViewModel(
     savedStateHandle: SavedStateHandle,
 ) : CardViewerViewModel(),
     ChangeManager.Subscriber {
-    val currentIndex = MutableStateFlow<Int>(savedStateHandle.require(PreviewerFragment.CURRENT_INDEX_ARG))
+    val currentIndex =
+        savedStateHandle.getMutableStateFlow(
+            KEY_CURRENT_INDEX,
+            initialValue = savedStateHandle.require<Int>(PreviewerFragment.CURRENT_INDEX_ARG),
+        )
     val backSideOnly = savedStateHandle.getMutableStateFlow(KEY_BACKSIDE_ONLY, false)
     val isMarked = MutableStateFlow(false)
     val flag: MutableStateFlow<Flag> = MutableStateFlow(Flag.NONE)
@@ -79,9 +83,6 @@ class PreviewerViewModel(
         ChangeManager.subscribe(this)
         showingAnswer.collectIn(viewModelScope) {
             savedStateHandle[SHOWING_ANSWER_KEY] = it
-        }
-        currentIndex.collectIn(viewModelScope) {
-            savedStateHandle[PreviewerFragment.CURRENT_INDEX_ARG] = it
         }
     }
 
@@ -276,6 +277,7 @@ class PreviewerViewModel(
 
     companion object {
         private const val KEY_BACKSIDE_ONLY = "backsideOnly"
+        private const val KEY_CURRENT_INDEX = "currentIndex"
         private const val SHOWING_ANSWER_KEY = "showingAnswer"
     }
 }


### PR DESCRIPTION
with `Don't keep activities`

## How Has This Been Tested?

Emulator 31:
1. Enable `Don't keep activities` in the device's dev options
2. Go to the previewer
3. Enable backside only
4. Press the device home button
5. Go back to AnkiDroid
6. Check if `Backside only` is still enabled

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->