### PR TITLE
Fix: DeckPicker - opExecuted failed

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -14,6 +14,7 @@ import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
 import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
+import anki.collection.opChanges
 import anki.scheduler.CardAnswer.Rating
 import app.cash.turbine.test
 import com.ichi2.anki.common.time.TimeManager
@@ -25,6 +26,7 @@ import com.ichi2.anki.dialogs.DeckPickerContextMenu
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
 import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.Destination
@@ -51,6 +53,7 @@ import org.junit.Assume.assumeTrue
 import org.junit.Before
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -86,6 +89,15 @@ class DeckPickerTest : RobolectricTest() {
     fun before() {
         RuntimeEnvironment.setQualifiers(qualifiers)
         setIntroductionSlidesShown(true)
+    }
+
+    @Test
+    fun `receiving opExecuted call doesn't crash if ViewModel is not yet initialized`() {
+        // Instantiate DeckPicker directly to simulate a state where the object exists,
+        // but Android lifecycle callback (onCreate) have not yet executed.
+        DeckPicker()
+
+        assertDoesNotThrow { ChangeManager.notifySubscribers(opChanges { studyQueues = true }, null) }
     }
 
     @Test


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes a startup crash caused by a race condition where DeckPicker received ChangeManager events before the Activity was attached to the Application.

This occurred because the subscription happened in the init block (or immediately upon instantiation), and background events triggered opExecuted on a background thread. This caused an attempt to access the ViewModel before onCreate completed, resulting in (posted by David and is on ACRA)
`java.lang.IllegalStateException: Your activity is not yet attached to the Application instance.`

## Fixes
* Fixes #19689

## Approach
Lifecycle-Aware Subscriptions: Introduced subscribeToChangeManager extension functions for LifecycleOwner

## How Has This Been Tested?
I added a new Robolectric regression test to verify the fix and prevent regression.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->