### PR TITLE
chore: convert TagsArrayAdapter to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/tags_item_list_dialog.xml
@@ -17,14 +17,14 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageButton
-        android:id="@+id/id_expand_button"
+        android:id="@+id/expand_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:background="@drawable/ic_chevron_right_black"
         android:clickable="false" />
 
     <TextView
-        android:id="@+id/tags_dialog_tag_item_text"
+        android:id="@+id/text_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
@@ -33,7 +33,7 @@
         tools:text="Example Tag" />
 
     <com.ichi2.ui.CheckBoxTriStates
-        android:id="@+id/tags_dialog_tag_item_checkbox"
+        android:id="@+id/check_box_view"
         android:layout_width="48dp"
         android:layout_height="48dp"
         android:clickable="false"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogTest.kt
@@ -605,3 +605,6 @@ class TagsDialogTest : RobolectricTest() {
         }
     }
 }
+
+val TagsArrayAdapter.ViewHolder.checkBoxView: CheckBoxTriStates
+    get() = this.binding.checkBoxView


### PR DESCRIPTION
* Part of #11116

## Approach

* Using the commit as a base: https://github.com/david-allison/Anki-Android/pull/44/commits/17d8da39918c4018948c9ad19315ef901ef60198 
* Fixed conflict

## How Has This Been Tested?
Brief test:

* API 36 Tablet emulator: I can add a tag and add a subtag within the screen

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)