### PR TITLE
chore: convert WidgetConfigScreenAdapter to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetConfigScreenAdapter.kt
@@ -17,16 +17,12 @@
 package com.ichi2.widget
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import android.widget.ImageButton
-import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CollectionManager.withCol
-import com.ichi2.anki.R
+import com.ichi2.anki.databinding.WidgetItemDeckConfigBinding
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.utils.ext.findViewById
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -48,11 +44,8 @@ class WidgetConfigScreenAdapter(
     val deckIds: List<Long> get() = decks.map { it.deckId }
 
     class DeckViewHolder(
-        itemView: View,
-    ) : RecyclerView.ViewHolder(itemView) {
-        val deckNameTextView: TextView = findViewById(R.id.deck_name)
-        val removeButton: ImageButton = findViewById(R.id.action_button_remove_deck)
-    }
+        val binding: WidgetItemDeckConfigBinding,
+    ) : RecyclerView.ViewHolder(binding.root)
 
     /** Creates and inflates the view for each item in the RecyclerView
      * @param parent the parent ViewGroup
@@ -62,11 +55,8 @@ class WidgetConfigScreenAdapter(
         parent: ViewGroup,
         viewType: Int,
     ): DeckViewHolder {
-        val view =
-            LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.widget_item_deck_config, parent, false)
-        return DeckViewHolder(view)
+        val layoutInflater = LayoutInflater.from(parent.context)
+        return DeckViewHolder(WidgetItemDeckConfigBinding.inflate(layoutInflater, parent, false))
     }
 
     override fun onBindViewHolder(
@@ -80,10 +70,10 @@ class WidgetConfigScreenAdapter(
                 withContext(Dispatchers.IO) {
                     withCol { decks.getLegacy(deck.deckId)!!.name }
                 }
-            holder.deckNameTextView.text = deckName
+            holder.binding.deckNameTextView.text = deckName
         }
 
-        holder.removeButton.setOnClickListener {
+        holder.binding.removeDeckButton.setOnClickListener {
             onDeleteDeck(deck, position)
         }
     }

--- a/AnkiDroid/src/main/res/layout/widget_item_deck_config.xml
+++ b/AnkiDroid/src/main/res/layout/widget_item_deck_config.xml
@@ -8,7 +8,7 @@
     android:theme="@style/Theme.Material3.DynamicColors.DayNight">
 
     <TextView
-        android:id="@+id/deck_name"
+        android:id="@+id/deck_name_text_view"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_weight="1"
@@ -18,7 +18,7 @@
         android:textSize="18sp" />
 
     <ImageButton
-        android:id="@+id/action_button_remove_deck"
+        android:id="@+id/remove_deck_button"
         android:layout_width="48dp"
         android:layout_height="wrap_content"
         android:layout_gravity="end"


### PR DESCRIPTION
* Part of #11116

## Approach

* Using the commit: https://github.com/david-allison/Anki-Android/pull/44/commits/ab8a64d8066d74917fc06dee13de65cfa51a47b5 

## How Has This Been Tested?
Brief test:

* API 36 Tablet emulator: Deck Picker Widget config opens and appears suable

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)