### PR TITLE
chore: log 'Activity & no Application' error

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -20,7 +20,9 @@ import android.app.Activity
 import android.os.Bundle
 import android.os.Process
 import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
+import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.showThemedToast
 import com.ichi2.themes.Themes
 import timber.log.Timber
@@ -58,6 +60,12 @@ object AppLoadedFromBackupWorkaround {
             getString(R.string.ankidroid_cannot_open_after_backup_try_again),
             false,
         )
+        CrashReportService.sendExceptionReport(
+            ManuallyReportedException("19050: Activity started with no application instance"),
+            origin = "showedActivityFailedScreen",
+            additionalInfo = null,
+            onlyIfSilent = true,
+        )
 
         // fixes: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
         // on Importer
@@ -75,6 +83,7 @@ object AppLoadedFromBackupWorkaround {
             } catch (e: InterruptedException) {
                 Timber.w(e)
             }
+            Timber.e("killing process")
             Process.killProcess(Process.myPid())
         }.start()
         return true


### PR DESCRIPTION
> [!IMPORTANT]
> Save this for 2.23.1

It's likely that there's another cause other than the backup manager

* Diagnostics for #19050

## How Has This Been Tested?
⚠️ it's not

I don't know if this will be useful, Timber likely wasn't initialized. Maybe crash reporting won't work (?)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)