### PR TITLE
Fix #6669: Enable remote images in deck description

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -394,7 +394,7 @@ open class CardTemplateEditor :
                 template.jsonObject.put("did", deck.deckId)
                 getString(R.string.model_manager_deck_override_added_message, templateName, deck.name)
             }
-
+        displayDiscardChangesCallback.isEnabled = true
         showSnackbar(message, Snackbar.LENGTH_SHORT)
 
         // Deck Override can change from "on" <-> "off"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -32,6 +32,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.constraintlayout.widget.Group
 import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
+import androidx.core.text.parseAsHtml
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
@@ -51,6 +52,7 @@ import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.showDialogFragment
+import com.ichi2.utils.UrlImageGetter
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -459,7 +461,8 @@ class StudyOptionsFragment :
                 }
             }
         if (desc.isNotEmpty()) {
-            textDeckDescription.text = formatDescription(desc)
+            val imageGetter = UrlImageGetter(textDeckDescription, requireContext(), lifecycleScope)
+            textDeckDescription.text = formatDescription(desc, imageGetter)
             textDeckDescription.visibility = View.VISIBLE
         } else {
             textDeckDescription.visibility = View.GONE
@@ -540,14 +543,17 @@ class StudyOptionsFragment :
         @VisibleForTesting
         fun formatDescription(
             @Language("HTML") desc: String,
+            imageGetter: android.text.Html.ImageGetter? = null, // <--- Added parameter
         ): Spanned {
             // #5715: In deck description, ignore what is in style and script tag
-            // Since we don't currently execute the JS/CSS, it's not worth displaying.
             val withStrippedTags = stripHTMLScriptAndStyleTags(desc)
             // #5188 - compat.fromHtml converts newlines into spaces.
             val withoutWindowsLineEndings = withStrippedTags.replace("\r\n", "<br/>")
             val withoutLinuxLineEndings = withoutWindowsLineEndings.replace("\n", "<br/>")
-            return HtmlCompat.fromHtml(withoutLinuxLineEndings, HtmlCompat.FROM_HTML_MODE_LEGACY)
+            return withoutLinuxLineEndings.parseAsHtml(
+                HtmlCompat.FROM_HTML_MODE_LEGACY,
+                imageGetter,
+            )
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UrlImageGetter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UrlImageGetter.kt
@@ -1,0 +1,110 @@
+/*
+ Copyright (c) $today.year Shaan Narendran Here <shaannaren06@gmail.com>
+
+ This program is free software; you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation; either version 3 of the License, or (at your option) any later
+ version.
+
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License along with
+ this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.utils
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.text.Html
+import android.widget.TextView
+import androidx.core.graphics.drawable.toDrawable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.net.URL
+
+// Class implemented for Issue #6669
+class UrlImageGetter(
+    private val textView: TextView,
+    private val context: Context,
+    private val scope: CoroutineScope,
+) : Html.ImageGetter {
+    override fun getDrawable(source: String?): Drawable {
+        // just a holder to later inject our image
+        val holder = BitmapDrawableWrapper(context.resources)
+        // Checking for http/https to sanitise for security
+        if (source != null && (source.startsWith("http://") || source.startsWith("https://"))) {
+            scope.launch(Dispatchers.IO) {
+                try {
+                    val url = URL(source)
+
+                    // Allows us to look at the dimensions of the file without loading it (to avoid memory issues)
+                    val options = BitmapFactory.Options()
+                    options.inJustDecodeBounds = true
+                    url.openStream().use { stream ->
+                        BitmapFactory.decodeStream(stream, null, options)
+                    }
+
+                    // shrinkage calculation in case the image size is very large
+                    options.inSampleSize = calculateInSampleSize(options, 1024, 1024)
+                    options.inJustDecodeBounds = false
+                    val bitmap =
+                        url.openStream().use { stream ->
+                            BitmapFactory.decodeStream(stream, null, options)
+                        }
+
+                    withContext(Dispatchers.Main) {
+                        if (bitmap != null) {
+                            // Injects the image into the holder using the bitmap
+                            val drawable = bitmap.toDrawable(context.resources)
+                            drawable.setBounds(0, 0, bitmap.width, bitmap.height)
+                            holder.drawable = drawable
+                            holder.setBounds(0, 0, bitmap.width, bitmap.height)
+                            textView.text = textView.text
+                            textView.invalidate()
+                        }
+                    }
+                } catch (e: Exception) {
+                    Timber.tag("AnkiImageFix").e("Error: ${e.message}")
+                }
+            }
+        }
+        return holder
+    }
+
+    // Function to calculate the size required (in powers of 2) of the given image to be at least as big as what is required
+    private fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+        reqHeight: Int,
+    ): Int {
+        val (height: Int, width: Int) = options.run { outHeight to outWidth }
+        var inSampleSize = 1
+
+        if (height > reqHeight || width > reqWidth) {
+            val halfHeight: Int = height / 2
+            val halfWidth: Int = width / 2
+            while (halfHeight / inSampleSize >= reqHeight && halfWidth / inSampleSize >= reqWidth) {
+                inSampleSize *= 2
+            }
+        }
+        return inSampleSize
+    }
+
+    class BitmapDrawableWrapper(
+        res: android.content.res.Resources,
+    ) : BitmapDrawable(res, null as Bitmap?) {
+        var drawable: Drawable? = null
+
+        override fun draw(canvas: Canvas) {
+            drawable?.draw(canvas)
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Issue #6669 was related to not being able to see remote images in the deck description, if someone had uploaded an image into a desktop Anki deck and imported it to AnkiDroid, the image would be a green box. This bug seemed like it was a real issue for many users, and so I wanted to try out developing my first real feature.

## Approach
Here, I did not want to overcomplicate things by changing the implementation to webview as discussed in the thread earlier, I think it would be way too much hassle especially since I'm newer to open source. Not only that, textview offers more security since as far as I researched, there can't be script injections in textview form since to evaluate the image we are actually using the Html image getter interface as opposed to a web engine as used in Anki. This does bring in the issue of pixel tracking but this also occurs in Anki, and actually more info is logged there like cookies so I believe it's a small trade off for a useful feature. I couldn't get coil or Picasso to actually work, so instead the class uses the basic android dependencies which is why I had to come with a manual shrinkage for images in case something with say 9999x9999 pixels was uploaded.

## How Has This Been Tested?
I initially uploaded my own png to the latest version of AnkiDroid via my phone (Samsung s22, 5G), when I implemented the changes and used android studio I was able to see the image in the description. I then tried it again with the sample deck uploaded in the issue page, and when you do this without the changes I've made, you get a green box else we can see the image itself.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
<img width="688" height="1546" alt="image" src="https://github.com/user-attachments/assets/97ebe10a-c3ad-4c06-8e85-c30e5e760eec" />
<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->