### PR TITLE
fix: tab alignment in tablets

### DIFF
--- a/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
+++ b/AnkiDroid/src/main/res/layout/controls_tab_layout.xml
@@ -5,7 +5,9 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="@style/Widget.Material3.TabLayout"
-    app:tabMode="fixed">
+    app:tabMode="fixed"
+    app:tabMaxWidth="0dp"
+    app:tabGravity="fill">
 
     <com.google.android.material.tabs.TabItem
         android:id="@+id/reviews_tab"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Tab alignment issue in Controls -> Reviews/Previews on tablets/Chromebooks

## Fixes
* Fixes #19709

## Approach
```
app:tabMaxWidth="0dp"
app:tabGravity="fill"
```

## How Has This Been Tested?
Preview UI mode
<img width="867" height="546" alt="image" src="https://github.com/user-attachments/assets/5b8fe758-71df-4e9f-84eb-65a2dd690871" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->