### PR TITLE
fix(deckpicker): Added contentDescription to sync and add card buttons

### DIFF
--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -183,6 +183,7 @@
                     app:srcCompat="@drawable/ic_add_white"
                     app:backgroundTint="?attr/fab_normal"
                     app:fabSize="normal"
+                    android:contentDescription="@string/menu_add"
                     android:focusable="true"
                     android:clickable="true"
                     />

--- a/AnkiDroid/src/main/res/layout/sync_progress_layout.xml
+++ b/AnkiDroid/src/main/res/layout/sync_progress_layout.xml
@@ -15,6 +15,8 @@
         android:tooltipText="@string/button_sync"
         android:tint="@color/white"
         tools:tint="?attr/colorControlNormal"
+        android:contentDescription="@string/button_sync"
+        android:focusable="true"
         />
 
     <com.google.android.material.progressindicator.LinearProgressIndicator


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In talkback mode, there are buttons that do not read out their description and instead read out "button" due to missing content description or focusable tags, I added this to the sync and add buttons. I just wanted to check if I am right with what I have done and if so I hope I can get the issue assigned to help out with more buttons at once.

## Approach
Added the following lines to sync_progress_layout.xml:
android:contentDescription="@string/button_sync"
 android:focusable="true"
 
 Added the following lines to floating_add_button.xml:
 android:contentDescription="@string/menu_add"
 
 I stuck to using the existing string resources so I used what I thought was closest to the buttons.


## How Has This Been Tested?
[Screen_recording_20251208_234311.webm](https://github.com/user-attachments/assets/03039f5d-6632-4695-a320-95f67d87184d)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->