### PR TITLE
Fixing time audio talkback

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
@@ -54,6 +54,13 @@ class EaseButton(
         get() = easeTimeView.text.toString()
         set(value) {
             easeTimeView.text = value
+            val label = easeTextView.text.toString()
+            val spokenTime =
+                nextTime
+                    .replace("m\\b".toRegex(), "minutes")
+                    .replace("d\\b".toRegex(), "days")
+                    .replace("h\\b".toRegex(), "hours")
+            layout.contentDescription = "$spokenTime,$label"
         }
 
     fun hideNextReviewTime() {

--- a/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer_answer_buttons.xml
@@ -103,6 +103,7 @@
                 <com.ichi2.ui.FixedTextView
                     android:id="@+id/ease2"
                     android:text="@string/ease_button_hard"
+
                     style="@style/HardButtonEaseStyle" />
             </LinearLayout>
 
@@ -123,7 +124,6 @@
                     android:id="@+id/nextTime3"
                     style="@style/GoodButtonTimeStyle"
                     tools:text="3 d" />
-
                 <com.ichi2.ui.FixedTextView
                     android:id="@+id/ease3"
                     android:text="@string/ease_button_good"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The problem is when hovering over the ease buttons in talkback, instead of saying "less than 1 minute, hard", the voice would say "less than 1 metre, hard". This was because there was no content description defined there and it was reading 'm' as metre.

## Approach
Added a content description block to the EaseButton.kt file, previously it was just setting the text directly but now the content description is defined while replacing m with minutes, h with hours, d with days.

## How Has This Been Tested?
[Screen_recording_20251209_111440.webm](https://github.com/user-attachments/assets/12705df0-846b-4d00-bdaf-f1287a0ad8dc)



## Learning (optional, can help others)
I had not found any particular buttons which were not working with talkback so I decided to check the reviewer tab and realised its quite unusable in its current state.
I had a lot of difficulty tracing where the text was being set for the button since it's dynamic and not static. I initially made the mistake of thinking AnswerButton.kt is where the time is set and tried to implement the fix there but after a lot of testing, realised it was not. Then I swept for nextTime and managed to find AbstractFlashcardViewer.kt which was using an EaseButton class which was the actual class to be changed.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->