### PR TITLE
Issue get external files dir

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -126,6 +126,7 @@ class AnkiDroidAppWithCollectionButUnwritableStorage : AnkiDroidApp() {
                 this.sharedPrefs().edit {
                     putString(CollectionHelper.PREF_COLLECTION_PATH, path.absolutePathString())
                 }
+                path.toFile().setWritable(false)
                 super.onCreate()
             } finally {
                 unmockkObject(CollectionHelper)


### PR DESCRIPTION
**<!--- Please fill the necessary details below -->
## Purpose / Description
The app incorrectly showed a fatal error when initializeAnkiDroidDirectory() fails to create a new directory, even if a previously valid collection directory already exists. Add logic to check if an existing AnkiDroid directory is valid before showing the fatal error.
## Fixes
* Fixes #19551

## Approach
A fatal error is shown only if both:
- No existing valid directory is available, and
- Creating or accessing a new directory fails.
## How Has This Been Tested?
- Ran unit tests in AnkiDroidAppTest.kt

## Learning (optional, can help others)
_Describe the research stage_
- Executed libanki module tests

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->