### PR TITLE
Fixed Android Studio warnings in files ExifUtil & UniqueArrayList

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ExifUtil.kt
@@ -30,30 +30,22 @@ object ExifUtil {
     fun rotateFromCamera(
         theFile: File,
         bitmap: Bitmap,
-    ): Bitmap {
-        var bmp = bitmap
-        return try {
+    ): Bitmap =
+        try {
             val exif = ExifInterface(theFile.path)
             val orientation = exif.getAttributeInt(ExifInterface.TAG_ORIENTATION, ExifInterface.ORIENTATION_NORMAL)
-            var angle = 0
-            when (orientation) {
-                ExifInterface.ORIENTATION_ROTATE_90 -> {
-                    angle = 90
+            val angle =
+                when (orientation) {
+                    ExifInterface.ORIENTATION_ROTATE_90 -> 90
+                    ExifInterface.ORIENTATION_ROTATE_180 -> 180
+                    ExifInterface.ORIENTATION_ROTATE_270 -> 270
+                    else -> 0
                 }
-                ExifInterface.ORIENTATION_ROTATE_180 -> {
-                    angle = 180
-                }
-                ExifInterface.ORIENTATION_ROTATE_270 -> {
-                    angle = 270
-                }
-            }
             val mat = Matrix()
             mat.postRotate(angle.toFloat())
-            bmp = Bitmap.createBitmap(bmp, 0, 0, bmp.width, bmp.height, mat, true)
-            bmp
+            Bitmap.createBitmap(bitmap, 0, 0, bitmap.width, bitmap.height, mat, true)
         } catch (e: Exception) {
             Timber.w(e)
-            bmp
+            bitmap
         }
-    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/UniqueArrayList.kt
@@ -61,7 +61,7 @@ class UniqueArrayList<E> /**
          *
          * This is the same list as the one used internally in [SetUniqueList]. We keep a reference to it here in
          * order to be able to sort it. [SetUniqueList] implementation needs to make sure the internal [Set]
-         * and [List] don't get out of sync, and [<] cannot be sorted via [Collections.sort]
+         * and [List] don't get out of sync, and [SetUniqueList] cannot be sorted via [java.util.Collections.sort]
          * or [SetUniqueList.sort] both will throw an exception, due to a limitation on this class [java.util.ListIterator]
          *
          * Sorting can be only done via [UniqueArrayList.sort] or [UniqueArrayList.sort].
@@ -107,15 +107,15 @@ class UniqueArrayList<E> /**
          * The specified list must be modifiable, but need not be resizable.
          *
          * @implNote
-         * DO NOT call [Collections.sort] using this list directly
-         * this can throw due to a limitation on setting items on the [ListIterator]
-         * returned by [listIterator]
+         * DO NOT call [java.util.Collections.sort] using this list directly
+         * this can throw due to a limitation on setting items on the [java.util.ListIterator]
+         * returned by [java.util.ListIterator]
          *
          * @param c the comparator to determine the order of the list.  A
          * `null` value indicates that the elements' *natural
          * ordering* should be used.
          *
-         * @see Collections.sort
+         * @see java.util.Collections.sort
          */
         @KotlinCleanup("sortWith")
         override fun sort(c: Comparator<in E>?) {


### PR DESCRIPTION
## Purpose / Description
Fixes Android Studio warnings in files ExifUtil.kt and UniqueArrayList.kt as part of addressing the issue #13282. This addresses code inspection warnings by converting mutable variables to immutable and fixing unresolved KDoc references.

## Fixes
* #13282

## Approach
1. Open android studio
2. did select complete folder to analyze
3. found many warnings, did choose kt(cuz easier)
4. did refactor accordingly until no error found, while selecting 2 files individually and analyzing.

## How Has This Been Tested?
Ran Android Studio Code Inspection to verify all warnings are resolved
Confirmed no compilation errors with `./gradlew build`
Pre-commit hooks (ktlint) passed successfully

## Learning (optional, can help others)
https://youtu.be/h1ycqzKq8L4
https://www.jetbrains.com/help/idea/2025.2/file-and-project-analysis.html?refactoring.safeDelete&keymap=Windows
i did use these 2 for referring 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] No UI changes in this PR