### PR TITLE
Auto-sync on login from settings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2413,6 +2413,27 @@ open class DeckPicker :
 
         private const val PREF_DECK_PICKER_PANE_WEIGHT = "deckPickerPaneWeight"
         private const val PREF_STUDY_OPTIONS_PANE_WEIGHT = "studyOptionsPaneWeight"
+
+        /**
+         * Builds an intent for [DeckPicker]
+         */
+        fun getIntent(
+            context: Context,
+            autoSync: Boolean = false,
+        ) = Intent(context, DeckPicker::class.java).apply {
+            if (autoSync) {
+                putExtra(INTENT_SYNC_FROM_LOGIN, true)
+            }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        this.intent = intent
+        if (intent.hasExtra(INTENT_SYNC_FROM_LOGIN)) {
+            Timber.i("Sync requested from Login")
+            this.syncOnResume = true
+        }
     }
 
     override fun opExecuted(

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -275,4 +275,8 @@ also changes the interval of the card"
     <string name="import_error_resolution_check_internet">Ensure you are connected to the internet</string>
     <string name="import_error_resolution_copy_to_device">Copy the file to your device and try again with the local file</string>
     <string name="import_error_resolution_select_file">Open the file using your device’s file browser app</string>
+
+    <!-- Post-login dialog -->
+    <string name="login_successful">Login successful</string>
+    <string name="sync_now">Sync now?</string>
 </resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Auto syncs data when a user logs in via the settings page.

## Fixes
* Fixes #15460 

## Approach
We use a variable to track whether a user has logged in through the settings page 
var pendingSyncOnResume = false
Then onWindowFocusChanged() is overridden to tell us when the deck picker page is loaded, after this we can sync

## How Has This Been Tested?
[Screen_recording_20251210_012201.webm](https://github.com/user-attachments/assets/16b6e442-7330-454d-87de-c214c4524aea)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->