### PR TITLE
Test for currentdeckid

### DIFF
--- a/libanki/src/main/java/com/ichi2/anki/libanki/Card.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Card.kt
@@ -18,7 +18,6 @@
 package com.ichi2.anki.libanki
 
 import androidx.annotation.VisibleForTesting
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.ext.ifZero
 import com.ichi2.anki.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
@@ -237,7 +236,6 @@ open class Card : Cloneable {
     }
 
     @LibAnkiAlias("current_deck_id")
-    @NeedsTest("Test functionality which calls this")
     fun currentDeckId() = oDid.ifZero { did }
 
     /**


### PR DESCRIPTION
## Purpose / Description
The tests fulfill the request by testing the methods that use currentDeckId() to ensure the correct deck configuration is applied in all scenarios

## Fixes
* completes one @needstest from #13283 

## Approach
1. Create a card
2. Call a function that uses currentDeckId()
3. Verify it got the right deck configuration either did or odid 
                  
  6 functions tested 

1.timelimit() for normal, filtered deck
2.shouldShowTimer()
3.autoplay()
4.replayQuestionAudioOnAnswerSide()
5.timeTaken() 
## How Has This Been Tested?

did use `./gradlew libanki:test`   `./gradlew ktlintFormat`

## Learning (optional, can help others)

https://youtu.be/9yre-M1XwVw?si=5UwsCUsnT8DDaIqc
can watch this playllist for basics
 usually we use 2 standard forms of decks, so 2 deck ids `did`, `oid` abbreviated as  deck id, original deck id 
`currentDeckId()` returns the correct deck ID to use for configuration by prioritizing `oDid` when non-zero, ensuring that deck settings always come from the original deck, not temporary filtered decks.

also to find needstests annotations in Android Studio :
Click on your project root in the Project panel
Press Ctrl+Shift+F or use menu: Edit → Find → Find in Files
now type: @NeedsTest
select Scope: Project Files 
cheers!

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: N/A (unit tests only)
- [ ] UI Changes: N/A (unit tests only)