### PR TITLE
Revert "deprecation(libanki): prefer `defaultsForAdding()` over `current()`

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/InstrumentedTest.kt
@@ -31,7 +31,6 @@ import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardType
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Note
-import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.testutil.addNote
@@ -215,15 +214,6 @@ abstract class InstrumentedTest {
     }
 
     val notetypes get() = col.notetypes
-
-    /**
-     * Returns the current default notetype for adding new cards.
-     *
-     * @see Collection.defaultNotetype
-     */
-    @DuplicatedCode("From AnkiTest")
-    val Notetypes.current: NotetypeJson
-        get() = this.get(col.defaultsForAdding().notetypeId)!!
 
     val Notetypes.basic
         get() = byName("Basic")!!

--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/libanki/MediaTest.kt
@@ -102,12 +102,12 @@ class MediaTest : InstrumentedTest() {
         val file = createNonEmptyFile("fake.png")
         testCol.media.addFile(file)
         // add a note which references it
-        var f = testCol.newNote(testCol.notetypes.current)
+        var f = testCol.newNote(testCol.notetypes.current())
         f.setField(0, "one")
         f.setField(1, "<img src='fake.png'>")
         testCol.addNote(f)
         // and one which references a non-existent file
-        f = testCol.newNote(testCol.notetypes.current)
+        f = testCol.newNote(testCol.notetypes.current())
         f.setField(0, "one")
         f.setField(1, "<img src='fake2.png'>")
         testCol.addNote(f)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2370,8 +2370,9 @@ class NoteEditorFragment :
             }
 
             if (!getColUnsafe.config.getBool(ConfigKey.Bool.ADDING_DEFAULTS_TO_CURRENT_DECK)) {
-                return getColUnsafe.defaultsForAdding().deckId.also { deckId ->
-                    Timber.d("Adding to configured default deck: %d", deckId)
+                return getColUnsafe.notetypes.current().let {
+                    Timber.d("Adding to deck of note type, noteType: %s", it.name)
+                    return@let it.did
                 }
             }
 
@@ -2408,8 +2409,8 @@ class NoteEditorFragment :
         editorNote =
             if (note == null || addNote) {
                 getColUnsafe.run {
-                    val notetypeId = defaultsForAdding().notetypeId
-                    Note.fromNotetypeId(this@run, notetypeId)
+                    val notetype = notetypes.current()
+                    Note.fromNotetypeId(this@run, notetype.id)
                 }
             } else {
                 note
@@ -2772,7 +2773,7 @@ class NoteEditorFragment :
     }
 
     private fun changeNoteType(newId: NoteTypeId) {
-        val oldNoteTypeId = getColUnsafe.defaultsForAdding().notetypeId
+        val oldNoteTypeId = getColUnsafe.notetypes.current().id
         Timber.i("Changing note type to '%d", newId)
 
         if (oldNoteTypeId == newId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
@@ -29,7 +29,6 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.dialogs.TtsVoicesDialogFragment
 import com.ichi2.anki.launchCatchingTask
-import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
@@ -235,9 +234,8 @@ class DevOptionsFragment : SettingsFragment() {
                     }
                     withCol {
                         val deck = decks.addNormalDeckWithName(deckName(i))
-                        val ntid = defaultsForAdding().notetypeId
                         addNote(
-                            Note.fromNotetypeId(this, ntid).apply { setField(0, "$i") },
+                            newNote(notetypes.current()).apply { setField(0, "$i") },
                             deck.id,
                         )
                     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1312,7 +1312,7 @@ class CardContentProvider : ContentProvider() {
         col: Collection,
     ): NoteTypeId =
         if (uri.pathSegments[1] == FlashCardsContract.Model.CURRENT_MODEL_ID) {
-            col.defaultsForAdding().notetypeId
+            col.notetypes.current().id
         } else {
             try {
                 uri.pathSegments[1].toLong()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -455,7 +455,7 @@ class ReviewerTest : RobolectricTest() {
     @Throws(ConfirmModSchemaException::class)
     @KotlinCleanup("use a assertNotNull which returns rather than !!")
     private fun addNoteWithThreeCards() {
-        var notetype = col.notetypes.copy(col.notetypes.current)
+        var notetype = col.notetypes.copy(col.notetypes.current())
         notetype.name = "Three"
         col.notetypes.add(notetype)
         notetype = col.notetypes.byName("Three")!!

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/NoteTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/NoteTypeTest.kt
@@ -39,7 +39,7 @@ class NoteTypeTest : JvmTest() {
     @Test
     fun test_frontSide_field() {
         // #8951 - Anki Special-cases {{FrontSide}} on the front to return empty string
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         noteType.templates[0].qfmt = "{{Front}}{{FrontSide}}"
         col.notetypes.save(noteType)
         val note = col.newNote()
@@ -62,7 +62,7 @@ class NoteTypeTest : JvmTest() {
     @Test
     fun test_field_named_frontSide() {
         // #8951 - A field named "FrontSide" is ignored - this matches Anki 2.1.34 (8af8f565)
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
 
         // Add a field called FrontSide and FrontSide2 (to ensure that fields are added correctly)
         col.notetypes.addFieldModChanged(noteType, col.notetypes.newField("FrontSide"))
@@ -95,13 +95,13 @@ class NoteTypeTest : JvmTest() {
         note.setItem("Back", "2")
         col.addNote(note)
         assertEquals(1, col.cardCount())
-        col.notetypes.remove(col.notetypes.current.id)
+        col.notetypes.remove(col.notetypes.current().id)
         assertEquals(0, col.cardCount())
     }
 
     @Test
     fun test_modelCopy() {
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         val noteType2 = col.notetypes.copy(noteType)
         assertEquals("Basic copy", noteType2.name)
         assertNotEquals(noteType2.id, noteType.id)
@@ -120,7 +120,7 @@ class NoteTypeTest : JvmTest() {
         note.setItem("Front", "1")
         note.setItem("Back", "2")
         col.addNote(note)
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         // make sure renaming a field updates the templates
         col.notetypes.renameFieldLegacy(noteType, noteType.fields[0], "NewFront")
         assertThat(noteType.templates[0].qfmt, containsString("{{NewFront}}"))
@@ -228,7 +228,7 @@ class NoteTypeTest : JvmTest() {
     @Test
     @Throws(ConfirmModSchemaException::class)
     fun test_templates() {
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
@@ -283,7 +283,7 @@ class NoteTypeTest : JvmTest() {
     @Throws(ConfirmModSchemaException::class)
     fun test_cloze_ordinals() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
 
         // We replace the default Cloze template
         val t =
@@ -312,7 +312,7 @@ class NoteTypeTest : JvmTest() {
     @Test
     fun test_text() {
         val noteType =
-            col.notetypes.current.apply {
+            col.notetypes.current().apply {
                 templates[0].qfmt = "{{text:Front}}"
             }
         col.notetypes.save(noteType)
@@ -393,7 +393,7 @@ class NoteTypeTest : JvmTest() {
     @Suppress("SpellCheckingInspection") // chaine
     fun test_chained_mods() {
         col.notetypes.setCurrent(col.notetypes.byName("Cloze")!!)
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
 
         // We replace the default Cloze template
         val t =
@@ -427,7 +427,7 @@ class NoteTypeTest : JvmTest() {
     fun test_modelChange() {
         val cloze = col.notetypes.byName("Cloze")
         // enable second template and add a note
-        val basic = col.notetypes.current
+        val basic = col.notetypes.current()
         val t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"
@@ -555,7 +555,7 @@ class NoteTypeTest : JvmTest() {
 
     @Test
     fun test_updateNotetype_clears_cache() {
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         val originalName = noteType.name
         val noteTypeId = noteType.id
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
@@ -32,7 +32,6 @@
 package com.ichi2.anki.libanki
 
 import androidx.annotation.CheckResult
-import androidx.annotation.VisibleForTesting
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithId
 import anki.notetypes.ChangeNotetypeInfo
@@ -146,8 +145,7 @@ class Notetypes(
      */
 
     /** Get current model.*/
-    @VisibleForTesting
-    @Deprecated("Use col.defaultsForAdding()")
+    @RustCleanup("Should use defaultsForAdding() instead")
     fun current(forDeck: Boolean = true): NotetypeJson {
         var noteType = get(col.decks.current().getLongOrNull("mid"))
         if (!forDeck || noteType == null) {

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
@@ -73,7 +73,7 @@ class CardTest : InMemoryAnkiTest() {
         note.setItem("Back", "2")
         col.addNote(note)
         val c = note.cards()[0]
-        col.notetypes.current.id
+        col.notetypes.current().id
         assertEquals(0, c.template().ord)
     }
 
@@ -84,7 +84,7 @@ class CardTest : InMemoryAnkiTest() {
         note.setItem("Back", "")
         col.addNote(note)
         assertEquals(1, note.numberOfCards())
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         // adding a new template should automatically create cards
         var t =
             Notetypes.newTemplate("rev").apply {

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CollectionTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CollectionTest.kt
@@ -109,7 +109,7 @@ class CollectionTest : InMemoryAnkiTest() {
         var n = col.addNote(note)
         assertEquals(1, n)
         // test multiple cards - add another template
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         val t = Notetypes.newTemplate("Reverse")
         t.qfmt = "{{Back}}"
         t.afmt = "{{Front}}"
@@ -189,7 +189,7 @@ class CollectionTest : InMemoryAnkiTest() {
     @Test
     @Ignore("Pending port of media search from Rust code")
     fun test_furigana() {
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         // filter should work
         noteType.templates[0].qfmt = "{{kana:Front}}"
         col.notetypes.save(noteType)

--- a/libanki/src/test/java/com/ichi2/anki/libanki/FinderTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/FinderTest.kt
@@ -126,7 +126,7 @@ class FinderTest : InMemoryAnkiTest() {
         note.setItem("Back", "sheep")
         col.addNote(note)
         val catCard = note.cards()[0]
-        var noteType = col.notetypes.current
+        var noteType = col.notetypes.current()
         noteType = col.notetypes.copy(noteType)
         val t =
             Notetypes.newTemplate("Reverse").apply {

--- a/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/SchedulerTest.kt
@@ -887,7 +887,7 @@ open class SchedulerTest : InMemoryAnkiTest() {
     @Throws(Exception::class)
     fun test_ordcycleV2() {
         // add two more templates and set second active
-        val noteType = col.notetypes.current
+        val noteType = col.notetypes.current()
         var t =
             Notetypes.newTemplate("Reverse").apply {
                 qfmt = "{{Back}}"

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -336,14 +336,6 @@ interface AnkiTest {
         testBody()
     }
 
-    /**
-     * Returns the current default notetype for adding new cards.
-     *
-     * @see Collection.defaultNotetype
-     */
-    val Notetypes.current: NotetypeJson
-        get() = this.get(col.defaultsForAdding().notetypeId)!!
-
     val Notetypes.basic
         get() = byName("Basic")!!
 

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/ext/Collection.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/ext/Collection.kt
@@ -68,5 +68,4 @@ fun Collection.createBasicTypingNoteType(name: String): NotetypeJson {
  * the configuration (curModel)
  * @return The new note
  */
-@Suppress("DEPRECATION")
 fun Collection.newNote(forDeck: Boolean = true): Note = newNote(notetypes.current(forDeck))


### PR DESCRIPTION
This reverts commit 48482b3ddcd9d6b9ed4bc586b0cf5ba489a5227a.

Under some circumstances, this broke changing note type

## Fixes
* Issue #19751

## How Has This Been Tested?
Tested on API 36 emulator using the provided test collection, this fixes the linked issue

⚠️ I did not test for other regressions


## Learning (optional, can help others)
This needs a regression test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)