### PR TITLE
perf(changelog): use system fonts for changelog vs web fonts

### DIFF
--- a/AnkiDroid/src/main/assets/changelog.html
+++ b/AnkiDroid/src/main/assets/changelog.html
@@ -6,7 +6,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="generator" content="Asciidoctor 2.0.26">
 <title>AnkiDroid Changelog</title>
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
 <style>
 /*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Uncomment the following line when using as a custom stylesheet */

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -50,7 +50,7 @@ if [ "$PUBLIC" = "public" ]; then
 
   # Render the new changelog
   echo "Rendering changelog..."
-  if ! asciidoctor ../ankidroiddocs/changelog.asc -o "$CHANGELOG"
+  if ! asciidoctor -a webfonts! ../ankidroiddocs/changelog.asc -o "$CHANGELOG"
   then
     echo "Failed to render changelog?"
     exit 1


### PR DESCRIPTION
Asciidoctor includes web fonts by default:

https://docs.asciidoctor.org/asciidoctor/latest/html-backend/default-stylesheet/#web-fonts

But you can disable them and just use system fonts, which should be adequate for us:


- Fixes #19747


I can see the difference, sure. But I don't care *nearly* enough to increase app size to prefer one over the other. They both seem just fine to me, but one doesn't require network or bundled font, so why not go with system fonts?


[changelog.systemfonts.html](https://github.com/user-attachments/files/24111163/changelog.systemfonts.html)
[changelog.webfonts.html](https://github.com/user-attachments/files/24111164/changelog.webfonts.html)


System Fonts (that is, "after this PR")

<img width="658" height="569" alt="image" src="https://github.com/user-attachments/assets/0aec2185-32ea-485e-a3ff-1d3ec8ad8f00" />


Web Fonts (that is, current, requires network to get fonts)

<img width="772" height="572" alt="image" src="https://github.com/user-attachments/assets/fd3aaaee-0da7-4293-b2cd-4d3e61816041" />
