### PR TITLE
fix(card-browser): restore scrollbar scrolling

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -197,7 +197,7 @@ class RecyclerFastScroller
 
                         onHandleTouchListener?.onTouch(v, event)
                         when (event.actionMasked) {
-                            event.actionMasked -> {
+                            MotionEvent.ACTION_DOWN -> {
                                 handle.isPressed = true
                                 recyclerView.stopScroll()
 
@@ -210,7 +210,7 @@ class RecyclerFastScroller
                                 lastPressedYAdjustedToInitial = event.y + handle.y + bar.y
                                 lastAppBarLayoutOffset = appBarLayoutOffset
                             }
-                            event.actionMasked -> {
+                            MotionEvent.ACTION_MOVE -> {
                                 val newHandlePressedY = event.y + handle.y + bar.y
                                 val barHeight = bar.height
                                 val newHandlePressedYAdjustedToInitial =
@@ -231,7 +231,7 @@ class RecyclerFastScroller
                                 lastPressedYAdjustedToInitial = newHandlePressedYAdjustedToInitial
                                 lastAppBarLayoutOffset = appBarLayoutOffset
                             }
-                            event.actionMasked -> {
+                            MotionEvent.ACTION_UP -> {
                                 lastPressedYAdjustedToInitial = -1f
 
                                 recyclerView.stopNestedScroll()


### PR DESCRIPTION
## Purpose / Description
The scrollbar in the Card Browser didn't work, this fixes it

## Fixes
* Fixes #19757

## Approach
* bisected to find cause
  * #19693 
  * 59aeb915d230e4aa5c1ed4bb9e355c04fcf365f1
* Fixed forwards

## How Has This Been Tested?
Pixel 9 Pro: scrollbar now works

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)