### PR TITLE
fix(ci): stale bot interfering with conflict workflow

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -87,8 +87,13 @@ jobs:
                             if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
                                 console.log(`'Has Conflicts' label already exists on PR #${prNumber}`);
                             } else {
-                                console.log(`Adding 'Has Conflicts' label to PR #${prNumber}`);
-                                await addLabel(['Has Conflicts'], prNumber);
+                                // Only add label if PR is not already stale to prevent resetting stale timer
+                                if (!pullRequestData.data.labels.find(label => label.name === 'Stale')) {
+                                    console.log(`Adding 'Has Conflicts' label to PR #${prNumber} (not stale)`);
+                                    await addLabel(['Has Conflicts'], prNumber);
+                                } else {
+                                    console.warn(`PR #${prNumber} is stale, skipping label addition to prevent timer reset`);
+                                }
                             }
                         } else if (pullRequestData.data.mergeable_state === 'clean') {
                             // if PR has no conflicts, remove the label


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Conflict workflow was resetting stale timer when adding "Has Conflicts" label, preventing inactive PRs from being closed

## Fixes
* Fixes #19754

## Approach
Added a case in conflict workflow where it will only add `Has Conflicts` label if it already not `Stale`

## How Has This Been Tested?
Tested this workflow using act(https://github.com/nektos/act)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->