### PR TITLE
chore: target milestone additions at upcoming 2.24 release

### DIFF
--- a/.github/workflows/milestone.yml
+++ b/.github/workflows/milestone.yml
@@ -51,7 +51,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: issue.number,
-              milestone: 71
+              milestone: 74
             });
           }
 

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -87,6 +87,7 @@ android {
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
         versionCode=22400100
+        // If you change this to a new version, you probably also want to update .gradle/workflows/milestone.yml for the new version...
         versionName="2.24.0alpha0"
         minSdk = libs.versions.minSdk.get().toInteger()
 


### PR DESCRIPTION
Does exactly what the title says

Reviewers: Here's the milestone link for verification that `74` is indeed the correct milestone number

https://github.com/ankidroid/Anki-Android/milestone/74

I updated the release procedure wiki to mention this always-forgotten-and-handled-afterwards step

https://github.com/ankidroid/Anki-Android/wiki/Release-procedure/_compare/2f8bbeb39dd2e53f9fdd52ad032515270f756cce...75c8a457629dca68caff64c6a45d33f1d460cc25

And I left myself a breadcrumb in the one spot I always touch to change versions, so I remember to update the milestone labeler