### PR TITLE
Fix: Image not adjusting in card viewer

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -110,9 +110,19 @@ abstract class CardViewerFragment(
                 // allow videos to autoplay via our JavaScript eval
                 mediaPlaybackRequiresUserGesture = false
             }
+            val css = "<style>img { max-width: 100% !important; height: auto !important; object-fit: contain; }</style>"
+            val rawHtml = onLoadInitialHtml()
+            val html =
+                if (rawHtml.contains("</head>")) {
+                    rawHtml.replace("</head>", "$css</head>")
+                } else if (rawHtml.contains("<body>")) {
+                    rawHtml.replace("<body>", "<body>$css")
+                } else {
+                    css + rawHtml
+                }
             loadDataWithBaseURL(
                 viewModel.baseUrl(),
-                onLoadInitialHtml(),
+                html,
                 "text/html",
                 null,
                 null,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When an image is exceeding the width of the screen, it does not fit in 1 frame (regardless of the max-width attribute being set to 100%), instead the user has to move right to see it fully. This is unlike before 2.23.0 where it fit in 1 frame.

## Fixes
* Fixes #19769 

## Approach
I'm not sure why this bug has occurred since to me it doesn't seem like this should've broken itself over the update but I added a definite css style that sets max width to 100% when a html is loaded.

## How Has This Been Tested?
Tested using the same card as the initial user had used.
[Screen_recording_20251213_002508.webm](https://github.com/user-attachments/assets/12cd728d-0db0-413b-9255-c717ef758127)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->