### PR TITLE
fix: use system timeout for double tap interval

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AccessibilitySettingsFragment.kt
@@ -50,6 +50,7 @@ class AccessibilitySettingsFragment : SettingsFragment() {
                 R.string.show_large_answer_buttons_preference,
                 R.string.pref_card_minimal_click_time,
                 R.string.answer_button_size_preference,
+                R.string.double_tap_timeout_pref_key, // TODO implement it in the new study screen
             )
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/GestureParser.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.ui.windows.reviewer
 
 import android.net.Uri
+import android.view.ViewConfiguration
 import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.cardviewer.Gesture
@@ -38,12 +39,12 @@ class GestureParser(
     private val scope: CoroutineScope,
     private val isDoubleTapEnabled: Boolean,
     private val gestureMode: TapGestureMode = Prefs.tapGestureMode,
-    private val doubleTapTimeout: Long = Prefs.doubleTapInterval.toLong(),
     swipeSensitivity: Float = Prefs.swipeSensitivity,
 ) {
     private val swipeThresholdBase = 100 / swipeSensitivity
     private var lastTapTime = 0L
     private var singleTapJob: Job? = null
+    private val doubleTapTimeout = ViewConfiguration.getDoubleTapTimeout().toLong()
 
     @VisibleForTesting
     fun parseInternal(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/GestureParserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/GestureParserTest.kt
@@ -16,11 +16,16 @@
 package com.ichi2.anki.ui.windows.reviewer
 
 import android.net.Uri
+import android.view.ViewConfiguration
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.cardviewer.TapGestureMode
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import kotlinx.coroutines.test.TestScope
+import org.junit.AfterClass
+import org.junit.BeforeClass
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -64,7 +69,6 @@ class GestureParserTest {
                 scope = TestScope(),
                 swipeSensitivity = swipeSensitivity,
                 gestureMode = gestureMode,
-                doubleTapTimeout = 200,
                 isDoubleTapEnabled = false,
             )
         val webViewState = GestureParser.WebViewState(scale, scrollX, scrollY, measuredWidth, measuredHeight)
@@ -319,4 +323,19 @@ class GestureParserTest {
         assertEquals(Gesture.SWIPE_UP, gesture2)
     }
     //endregion
+
+    companion object {
+        @BeforeClass
+        @JvmStatic // required for @BeforeClass
+        fun before() {
+            mockkStatic(ViewConfiguration::class)
+            every { ViewConfiguration.getDoubleTapTimeout() } answers { 300 }
+        }
+
+        @JvmStatic // required for @AfterClass
+        @AfterClass
+        fun after() {
+            unmockkStatic(ViewConfiguration::class)
+        }
+    }
 }


### PR DESCRIPTION
instead of using the `Accessibility` setting.

Using the accessibility setting as reference for the gesture behavior became a source of confusion.

Since the setting doesn't do anything else in the new study screen, I'm hiding it for now

## How Has This Been Tested?

Emulator 31:
1. Single taps still work
2. Double taps still work
3. If double tap is not set, single taps are immediate

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->