### PR TITLE
fix(card-browser): [Split Browser] reset edit state after saving note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1386,9 +1386,16 @@ class NoteEditorFragment :
                     }
                 }
             }
-            closeNoteEditor()
+
+            closeNoteEditorAfterSave()
             return
         }
+    }
+
+    private fun closeNoteEditorAfterSave() {
+        isFieldEdited = false
+        isTagsEdited = false
+        closeNoteEditor()
     }
 
     /**
@@ -1407,8 +1414,9 @@ class NoteEditorFragment :
         }
         // refresh the note object to reflect the database changes
         withCol { editorNote!!.load(this@withCol) }
+
         // close note editor
-        closeNoteEditor()
+        closeNoteEditorAfterSave()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fix save dialog appearing after note is saved in CardBrowser fragmented mode

## Approach
Reset `isFieldEdited` and `isTagsEdited` to false before calling closeNoteEditor()

## How Has This Been Tested?
Emulator Tablet API 35
[Screen_recording_20251213_015527.webm](https://github.com/user-attachments/assets/6850a27a-f486-4cb2-90ab-73bc0800f882)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)