### PR TITLE
perf(study-screen): only initialize check pronunciation after requested

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -78,6 +78,7 @@ import com.ichi2.anki.settings.enums.ToolbarPosition
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.windows.reviewer.audiorecord.CheckPronunciationFragment
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardFragment
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.anki.utils.ext.collectIn
@@ -558,6 +559,11 @@ class ReviewerFragment :
 
     private fun setupCheckPronunciation() {
         viewModel.voiceRecorderEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
+            if (isEnabled && binding.checkPronunciationContainer.getFragment<CheckPronunciationFragment?>() == null) {
+                childFragmentManager.commit {
+                    add(binding.checkPronunciationContainer.id, CheckPronunciationFragment())
+                }
+            }
             binding.checkPronunciationContainer.isVisible = isEnabled
         }
     }

--- a/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw600dp/reviewer2.xml
@@ -104,7 +104,6 @@
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/check_pronunciation_container"
-            android:name="com.ichi2.anki.ui.windows.reviewer.audiorecord.CheckPronunciationFragment"
             android:layout_width="match_parent"
             android:layout_height="56dp"
             android:clipChildren="false"

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -199,7 +199,6 @@
 
             <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/check_pronunciation_container"
-                android:name="com.ichi2.anki.ui.windows.reviewer.audiorecord.CheckPronunciationFragment"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:clipChildren="false"


### PR DESCRIPTION
before, the fragment was created and hidden in the study screen initialization, which made the initialization slower.

## How Has This Been Tested?

Emulator 31

https://github.com/user-attachments/assets/73a17200-ba8e-4092-9286-4f673e7d5982

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->