### PR TITLE
fix: don't crash if activity started under backup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CrashReportService.kt
@@ -272,11 +272,12 @@ object CrashReportService {
         origin: String?,
         additionalInfo: String? = null,
         onlyIfSilent: Boolean = false,
+        context: Context = application.applicationContext,
     ) {
         sendAnalyticsException(e, false)
         AnkiDroidApp.sentExceptionReportHack = true
         val reportMode =
-            application.applicationContext
+            context
                 .sharedPrefs()
                 .getString(FEEDBACK_REPORT_KEY, FEEDBACK_REPORT_ASK)
         if (onlyIfSilent) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -65,6 +65,7 @@ object AppLoadedFromBackupWorkaround {
             origin = "showedActivityFailedScreen",
             additionalInfo = null,
             onlyIfSilent = true,
+            context = this,
         )
 
         // fixes: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.


### PR DESCRIPTION
e8569467be398cb893df45164f67f8f6e9f3c1b6

## Fixes
* Related to #19781

## Approach
Use the current context if the application context is corrupt

## How Has This Been Tested?
This fixed unit tests

## Learning (optional, can help others)
⚠️ Test was not run in CI (or unexpectedly passed), find out why


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->