### PR TITLE
feat(study-screen): alert users about unsupported JS features

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid.js
@@ -175,3 +175,118 @@ document.addEventListener("focusout", event => {
         return null;
     }
 })();
+
+// region TEMPORARY
+// those functions should be removed once the new API is implemented.
+// they only exist in the new study screen so the user is warned that they are not supported.
+
+function taFocus() {
+    window.location.href = "signal:typefocus";
+}
+
+function showAnswer() {
+    window.location.href = "signal:show_answer";
+}
+function buttonAnswerEase1() {
+    window.location.href = "signal:answer_ease1";
+}
+function buttonAnswerEase2() {
+    window.location.href = "signal:answer_ease2";
+}
+function buttonAnswerEase3() {
+    window.location.href = "signal:answer_ease3";
+}
+function buttonAnswerEase4() {
+    window.location.href = "signal:answer_ease4";
+}
+
+function reloadPage() {
+    window.location.href = "signal:reload_card_html";
+}
+
+const jsApiList = {
+    ankiGetNewCardCount: "newCardCount",
+    ankiGetLrnCardCount: "lrnCardCount",
+    ankiGetRevCardCount: "revCardCount",
+    ankiGetETA: "eta",
+    ankiGetCardMark: "cardMark",
+    ankiGetCardFlag: "cardFlag",
+    ankiGetNextTime1: "nextTime1",
+    ankiGetNextTime2: "nextTime2",
+    ankiGetNextTime3: "nextTime3",
+    ankiGetNextTime4: "nextTime4",
+    ankiGetCardReps: "cardReps",
+    ankiGetCardInterval: "cardInterval",
+    ankiGetCardFactor: "cardFactor",
+    ankiGetCardMod: "cardMod",
+    ankiGetCardId: "cardId",
+    ankiGetCardNid: "cardNid",
+    ankiGetCardType: "cardType",
+    ankiGetCardDid: "cardDid",
+    ankiGetCardLeft: "cardLeft",
+    ankiGetCardODid: "cardODid",
+    ankiGetCardODue: "cardODue",
+    ankiGetCardQueue: "cardQueue",
+    ankiGetCardLapses: "cardLapses",
+    ankiGetCardDue: "cardDue",
+    ankiIsInFullscreen: "isInFullscreen",
+    ankiIsTopbarShown: "isTopbarShown",
+    ankiIsInNightMode: "isInNightMode",
+    ankiIsDisplayingAnswer: "isDisplayingAnswer",
+    ankiGetDeckName: "deckName",
+    ankiIsActiveNetworkMetered: "isActiveNetworkMetered",
+    ankiTtsFieldModifierIsAvailable: "ttsFieldModifierIsAvailable",
+    ankiTtsIsSpeaking: "ttsIsSpeaking",
+    ankiTtsStop: "ttsStop",
+    ankiBuryCard: "buryCard",
+    ankiBuryNote: "buryNote",
+    ankiSuspendCard: "suspendCard",
+    ankiSuspendNote: "suspendNote",
+    ankiAddTagToCard: "addTagToCard",
+    ankiResetProgress: "resetProgress",
+    ankiMarkCard: "markCard",
+    ankiToggleFlag: "toggleFlag",
+    ankiSearchCard: "searchCard",
+    ankiSearchCardWithCallback: "searchCardWithCallback",
+    ankiTtsSpeak: "ttsSpeak",
+    ankiTtsSetLanguage: "ttsSetLanguage",
+    ankiTtsSetPitch: "ttsSetPitch",
+    ankiTtsSetSpeechRate: "ttsSetSpeechRate",
+    ankiEnableHorizontalScrollbar: "enableHorizontalScrollbar",
+    ankiEnableVerticalScrollbar: "enableVerticalScrollbar",
+    ankiSetCardDue: "setCardDue",
+    ankiShowNavigationDrawer: "showNavigationDrawer",
+    ankiShowOptionsMenu: "showOptionsMenu",
+    ankiShowToast: "showToast",
+    ankiShowAnswer: "showAnswer",
+    ankiAnswerEase1: "answerEase1",
+    ankiAnswerEase2: "answerEase2",
+    ankiAnswerEase3: "answerEase3",
+    ankiAnswerEase4: "answerEase4",
+    ankiSttSetLanguage: "sttSetLanguage",
+    ankiSttStart: "sttStart",
+    ankiSttStop: "sttStop",
+    ankiAddTagToNote: "addTagToNote",
+    ankiSetNoteTags: "setNoteTags",
+    ankiGetNoteTags: "getNoteTags",
+};
+
+class AnkiDroidJS {
+    constructor({ developer, version }) {
+        this.developer = developer;
+        this.version = version;
+    }
+
+    handleRequest = (endpoint, data) => {
+        // route all methods to `signal` so the warning is shown
+        window.location.href = "signal:jsapi";
+    };
+}
+
+Object.keys(jsApiList).forEach(method => {
+    AnkiDroidJS.prototype[method] = async function (data) {
+        const endpoint = jsApiList[method];
+        return this.handleRequest(endpoint, data);
+    };
+});
+// endregion

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -687,6 +687,7 @@ class ReviewerFragment :
                 isDoubleTapEnabled = bindingMap.isBound(Gesture.DOUBLE_TAP),
             )
         }
+        private var hasShownUnsupportedFeatureWarning = false
 
         init {
             webViewLayout.setOnScrollChangeListener { _, _, _, _, _ ->
@@ -719,6 +720,15 @@ class ReviewerFragment :
                         "focusin" -> webviewHasFocus = true
                         "focusout" -> webviewHasFocus = false
                         "show-answer" -> viewModel.onShowAnswer()
+                    }
+                    true
+                }
+                "signal" -> {
+                    if (hasShownUnsupportedFeatureWarning) return true
+                    hasShownUnsupportedFeatureWarning = true
+                    AlertDialog.Builder(requireContext()).show {
+                        setMessage(R.string.feature_not_supported_by_study_screen)
+                        setPositiveButton(R.string.dialog_ok) { _, _ -> }
                     }
                     true
                 }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -442,6 +442,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string name="edit_browser_appearance" comment="Description of the shortcut that edits the browser appearance of card template">Edit browser appearance</string>
 
     <string name="missing_user_action_dialog_message" comment="%s is the user action number">User action %s is not set in this notetype. Please configure it</string>
+    <string name="feature_not_supported_by_study_screen">This card has features that are not yet supported by the new study screen.</string>
 
     <string name="directory_inaccessible_info">Learn more about how to restore access here %s or go to settings to update collection folder.</string>
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Reduces the amount of support for templates that don't work

Kudos to David for the idea

## Approach

1. Make all JS API methods do a `signal:` request
2. Make all `signal:` requests show a "this is not supported" dialog

## How Has This Been Tested?

Emulator 31

(I forgot to stop the recording, so the video is longer than necessary😅)

https://github.com/user-attachments/assets/28a70189-e639-4ff0-ab64-3a2df20d7cbd

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->