### PR TITLE
feat(card-browser): highlight focused row in fragmented mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -281,10 +281,11 @@ class BrowserMultiColumnAdapter(
             }
             holder.setIsSelected(isSelected)
             val rowColor =
-                if (viewModel.focusedRow == id) {
-                    ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
-                } else {
-                    backendColorToColor(row.color)
+                when {
+                    // don't highlight the editor row if in multiselect mode
+                    viewModel.isInMultiSelectMode -> backendColorToColor(row.color)
+                    viewModel.editorRowId == id -> ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
+                    else -> backendColorToColor(row.color)
                 }
             holder.setColor(rowColor)
             holder.setIsDeleted(false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -197,7 +197,9 @@ class CardBrowserFragment :
             BrowserMultiColumnAdapter(
                 requireContext(),
                 activityViewModel,
-                onTap = ::onTap,
+                onTap = { rowId ->
+                    activityViewModel.handleRowTap(rowId.toRowSelection())
+                },
                 onLongPress = { rowId ->
                     activityViewModel.handleRowLongPress(rowId.toRowSelection())
                 },
@@ -637,25 +639,6 @@ class CardBrowserFragment :
             dialog.show(parentFragmentManager, ColumnSelectionDialogFragment.TAG)
         }
     }
-
-    // TODO: Move this to ViewModel and test
-    @VisibleForTesting
-    fun onTap(id: CardOrNoteId) =
-        launchCatchingTask {
-            activityViewModel.focusedRow = id
-            if (activityViewModel.isInMultiSelectMode) {
-                val wasSelected = activityViewModel.selectedRows.contains(id)
-                activityViewModel.toggleRowSelection(id.toRowSelection())
-                // Load NoteEditor on trailing side if card is selected
-                if (wasSelected) {
-                    activityViewModel.currentCardId = id.toCardId(activityViewModel.cardsOrNotes)
-                    requireCardBrowserActivity().loadNoteEditorFragmentIfFragmented()
-                }
-            } else {
-                val cardId = activityViewModel.queryDataForCardEdit(id)
-                requireCardBrowserActivity().openNoteEditorForCard(cardId)
-            }
-        }
 
     // TODO: This dialog should survive activity recreation
     fun showChangeDeckDialog() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/List.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/List.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 Sanjay Sargam <sargamsanjaykumar@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+/**
+ * Returns the index of the element if present, or null if not found.
+ */
+fun <T> List<T>.indexOfOrNull(element: T?): Int? {
+    element ?: return null
+    val index = indexOf(element)
+    return if (index >= 0) index else null
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1621,7 +1621,7 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     }
 }
 
-fun CardBrowser.clickRowAtPosition(pos: Int) = cardBrowserFragment.onTap(viewModel.cards[pos])
+fun CardBrowser.clickRowAtPosition(pos: Int) = viewModel.handleRowTap(viewModel.cards[pos].toRowSelection())
 
 fun CardBrowser.longClickRowAtPosition(pos: Int) = viewModel.handleRowLongPress(viewModel.cards[pos].toRowSelection())
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Focus selected card in cardbrowser in fragmented mode

## Fixes
* Fixes #19805  

## Approach
Created `flowOfFocusedRow` to keep tracking the selected row

## How Has This Been Tested?
Medium Tablet API 35
[Screen_recording_20251213_112018.webm](https://github.com/user-attachments/assets/38adbcbc-516a-47df-b573-a1830dd3f823)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)