### PR TITLE
fix(study-screen): require bigger window for "tablet" layout

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -86,7 +86,6 @@ import com.ichi2.anki.utils.ext.collectLatestIn
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.window
-import com.ichi2.anki.utils.isWindowCompact
 import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.themes.Themes
 import com.ichi2.utils.dp
@@ -117,6 +116,7 @@ class ReviewerFragment :
     private lateinit var bindingMap: BindingMap<ReviewerBinding, ViewerAction>
     private var shakeDetector: ShakeDetector? = null
     private val sensorManager get() = ContextCompat.getSystemService(requireContext(), SensorManager::class.java)
+    private val isBigScreen: Boolean get() = binding.complementsLayout != null
     private var webviewHasFocus = false
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
@@ -124,7 +124,7 @@ class ReviewerFragment :
             when {
                 binding.typeAnswerContainer.isVisible -> binding.typeAnswerContainer
                 binding.answerArea.isVisible -> binding.answerArea
-                (Prefs.toolbarPosition == ToolbarPosition.BOTTOM || !resources.isWindowCompact()) ->
+                (Prefs.toolbarPosition == ToolbarPosition.BOTTOM || isBigScreen) ->
                     binding.toolsLayout
 
                 else -> null
@@ -451,7 +451,7 @@ class ReviewerFragment :
         }
 
         val minTopPadding =
-            if (Prefs.frameStyle == FrameStyle.CARD && (!resources.isWindowCompact() || Prefs.toolbarPosition != ToolbarPosition.TOP)) {
+            if (Prefs.frameStyle == FrameStyle.CARD && (isBigScreen || Prefs.toolbarPosition != ToolbarPosition.TOP)) {
                 8F.dp.toPx(requireContext())
             } else {
                 0
@@ -479,7 +479,7 @@ class ReviewerFragment :
     }
 
     private fun setupToolbarPosition() {
-        if (!resources.isWindowCompact()) return
+        if (isBigScreen) return
         when (Prefs.toolbarPosition) {
             ToolbarPosition.TOP -> return
             ToolbarPosition.NONE -> binding.toolsLayout.isVisible = false
@@ -517,7 +517,7 @@ class ReviewerFragment :
     private fun setupToolbarOnBigWindows() {
         val hideAnswerButtons = !Prefs.showAnswerButtons
         // In big screens, let the menu expand if there are no answer buttons
-        if (hideAnswerButtons && !resources.isWindowCompact()) {
+        if (hideAnswerButtons && isBigScreen) {
             with(ConstraintSet()) {
                 clone(binding.toolsLayout)
                 clear(R.id.reviewer_menu_view, ConstraintSet.START)

--- a/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
@@ -203,7 +203,7 @@
                 android:id="@+id/answer_area"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintWidth_percent="0.40"
+                app:layout_constraintWidth_percent="0.6"
                 app:layout_constraintWidth_max="480dp"
                 app:layout_constraintTop_toTopOf="parent"
                 app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
increase the required minimum smallest screen width from 600dp to 720dp

The answer buttons got cramped in smaller screens.

Also, it increases the buttons width to 60% of the screen, while keeping the 480dp limit

* Fixes #19764

## How Has This Been Tested?

Emulator 36 (resizable):

(Foldable)
<img width="2208" height="1840" alt="Screenshot_20251213_180657" src="https://github.com/user-attachments/assets/0232aa47-afe4-4651-b008-5b68d3a952fc" />

(Tablet)
<img width="1920" height="1200" alt="Screenshot_20251213_181502" src="https://github.com/user-attachments/assets/69b01016-944f-4de9-93a9-441aaf25914b" />

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->