### PR TITLE
 fix: batch shortcut disabling to avoid TransactionTooLargeException

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -168,6 +168,7 @@ import com.ichi2.anki.ui.animations.fadeIn
 import com.ichi2.anki.ui.animations.fadeOut
 import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
+import com.ichi2.anki.utils.ShortcutUtils
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.getSizeOfBitmapFromCollection
 import com.ichi2.anki.utils.ext.setFragmentResultListener
@@ -2249,10 +2250,9 @@ open class DeckPicker :
     /** Disables the shortcut of the deck and the children belonging to it.*/
     @NeedsTest("ensure collapsed decks are also deleted")
     private fun disableDeckAndChildrenShortcuts(did: DeckId) {
-        // Get the DeckId and all child DeckIds
         val deckTreeDids = dueTree?.find(did)?.map { it.did.toString() } ?: listOf()
         val errorMessage: CharSequence = getString(R.string.deck_shortcut_doesnt_exist)
-        ShortcutManagerCompat.disableShortcuts(this, deckTreeDids, errorMessage)
+        ShortcutUtils.disableShortcuts(this, deckTreeDids, errorMessage)
     }
 
     fun renameDeckDialog(did: DeckId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ShortcutUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ShortcutUtils.kt
@@ -1,0 +1,56 @@
+/*
+ *  Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils
+
+import android.content.Context
+import androidx.core.content.pm.ShortcutManagerCompat
+import com.ichi2.anki.runCatchingWithReport
+import timber.log.Timber
+
+/**
+ * Wrapper around [ShortcutManagerCompat] to handle platform-specific issues.
+ */
+object ShortcutUtils {
+    /**
+     * Batch size for shortcut operations to avoid [android.os.TransactionTooLargeException].
+     * Android's Binder IPC has a 1MB transaction limit.
+     */
+    private const val BATCH_SIZE = 100
+
+    /**
+     * Disables shortcuts by their IDs, handling large lists by batching to avoid
+     * [android.os.TransactionTooLargeException].
+     *
+     * @param context The context to use
+     * @param shortcutIds List of shortcut IDs to disable
+     * @param disabledMessage Message shown when user tries to use a disabled shortcut
+     */
+    fun disableShortcuts(
+        context: Context,
+        shortcutIds: List<String>,
+        disabledMessage: CharSequence,
+    ) {
+        if (shortcutIds.isEmpty()) return
+
+        shortcutIds.chunked(BATCH_SIZE).forEach { batch ->
+            runCatchingWithReport(
+                "Failed to disable shortcuts batch",
+            ) { ShortcutManagerCompat.disableShortcuts(context, batch, disabledMessage) }
+                .onFailure { e -> Timber.w(e, "Failed to disable shortcuts batch") }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 Fix crash when deleting a deck with many subdecks due to `TransactionTooLargeException.`

## Fixes
* Fixes #19800 

## Approach
 When deleting a deck, `disableDeckAndChildrenShortcuts()` was calling `ShortcutManagerCompat.disableShortcuts()` with all deck IDs at once. For decks with many children, this exceeded Android's 1MB Binder IPC transaction limit (~3.5MB in this case).

The fix batches the shortcut disabling into chunks of 100 IDs at a time, keeping each transaction well under the limit.



## How Has This Been Tested?

Tested by deleting a deck with a large number of subdecks(that i created through the developer options) that previously caused the crash.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->