### PR TITLE
feat: implement draft workflow for immutable releases

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -187,7 +187,7 @@ SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 # Read the content of the markdown file using the absolute path
 RELEASE_NOTES="$SCRIPT_DIR/release-description.md"
 echo "Creating new Github release"
-gh release create v"$VERSION" --title "AnkiDroid $VERSION" -F "$RELEASE_NOTES" $RELEASE_TYPE
+gh release create v"$VERSION" --title "AnkiDroid $VERSION" -F "$RELEASE_NOTES" $RELEASE_TYPE --draft
 
 echo "Sleeping 30s to make sure the release exists, see issue 11746"
 sleep 30
@@ -248,3 +248,12 @@ for BUILD in $BUILDNAMES; do
   cp AnkiDroid-"$VERSION".parallel."$BUILD".apk "$PREFIX"AnkiDroid-"$VERSION".parallel."$BUILD".apk
   gh release upload v"$VERSION" "$PREFIX"AnkiDroid-"$VERSION".parallel."$BUILD".apk
 done
+
+# For publishing the draft release and making it immutable;
+echo "Publishing release (making it immutable)"
+if ! gh release edit v"$VERSION" --draft=false;
+then
+  echo "Failed to publish release"
+  exit 1
+fi
+echo "Release published successfully"


### PR DESCRIPTION
- Create releases as drafts initially with --draft flag
- Upload all assets to draft release
- Publish release after all assets are uploaded
- Ensures releases follow immutable release best practices

Addresses ankidroid/Anki-Android#19640

## Purpose / Description
Implements the draft → upload → publish workflow for immutable releases as requested in issue #19640. This ensures that when repository immutability is enabled, all release assets are uploaded before the release becomes immutable and unmodifiable.


## Fixes
* Fixes #19640

## Approach
Modified `tools/release.sh` to follow GitHub's immutable release best practices:

1. **Create draft release** (Line 190): Added `--draft` flag to `gh release create` command
2. **Upload all assets**: Existing upload logic remains unchanged - all APKs and files are uploaded to the draft
3. **Publish release** (New section at end): Added final step with `gh release edit --draft=false` to publish the release after all uploads complete
This prevents the issue where assets are uploaded after the release is already published and potentially immutable.

**Workflow change:**
- **Before**: Create published release → upload assets (assets added after publish)
- **After**: Create draft → upload assets → publish (all assets present before immutable)

## How Has This Been Tested?
- ✅ Syntax validation using `shellcheck tools/release.sh` - no errors
- ✅ Code review of bash script logic - proper error handling included
- ✅ Verified changes follow existing script patterns and conventions

**Testing limitations:**
- ⚠️ Cannot test actual release creation without maintainer permissions and release credentials
- ⚠️ Requires maintainer to verify during next alpha/beta release cycle
- The changes are minimal and isolated to the release workflow only


## Learning (optional, can help others)
**Research:**
- GitHub Immutable Releases Documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases
- GitHub CLI release commands: `gh release create`, `gh release edit`, `gh release upload`
- Best practice: Create drafts, upload all artifacts, then publish to ensure complete immutable releases

**Key insight:** Once a release is published with immutability enabled, it cannot be modified. Using the draft workflow ensures all assets are ready before the immutable state is triggered.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: **N/A: No UI changes only backend shell script changes**

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->