### PR TITLE
fix(study-screen): fix note types that relied on "mathjax-rendered"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerHelpers.kt
@@ -82,10 +82,14 @@ fun stdHtml(
         """.trimIndent()
 }
 
-/** @return body classes used when showing a card */
+/**
+ * "mathjax-rendered" is a legacy class kept only to support old note types.
+ *
+ * @return body classes used when showing a card
+ */
 fun bodyClassForCardOrd(
     cardOrd: Int,
     nightMode: Boolean = Themes.currentTheme.isNightMode,
-): String = "card card${cardOrd + 1} ${bodyClass(nightMode)}"
+): String = "card card${cardOrd + 1} ${bodyClass(nightMode)} mathjax-rendered"
 
 private fun bodyClass(nightMode: Boolean = Themes.currentTheme.isNightMode): String = if (nightMode) "nightMode night_mode" else ""


### PR DESCRIPTION
## Purpose / Description

Some note types like depending too much on some stuff, such as hiding the whole card based on an undocumented CSS class, which include the note types that rely on the [closet](https://github.com/hgiesel/closet) add-on. And that includes the Anking add-ons.

Given their popularity, it's easier to keep supporting them here than telling people to fix it.

## Fixes
* Fixes #19784

## How Has This Been Tested?

Use this note type: https://github.com/AnKing-VIP/AnKing-Note-Types/releases/tag/IO-one_by_one-3ff1197

Emulator 31:
1. Open the deck with the note
2. The notet is shown (before it got hidden because of this rule: `.android .card:not(.mathjax-rendered) {  visibility: hidden; }{ )


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->