### PR TITLE
fix(ci): add retry logic for GitHub API errors

### DIFF
--- a/.github/workflows/conflict.yaml
+++ b/.github/workflows/conflict.yaml
@@ -19,40 +19,83 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
+            // Helper function for retrying GitHub API calls
+            async function withRetry(apiCall, operation = 'API call') {
+              const retries = 3;
+              const retryInitialDelay = 5000;
+
+              for (let attempt = 1; attempt <= retries; attempt++) {
+                try {
+                  return await apiCall();
+                } catch (error) {
+                  // Don't retry client errors (4xx)
+                  if (error.status >= 400 && error.status < 500) {
+                    throw error;
+                  }
+
+                  // If this is the last attempt, throw the error
+                  if (attempt === retries) {
+                    throw new Error(`${operation} failed after ${retries} attempts: ${error.message}`);
+                  }
+
+                  // Wait with linear backoff before retrying                  
+                  const delay = retryInitialDelay * attempt;
+                  console.warn(
+                    `${operation} failed (attempt ${attempt}/${retries}). Retrying in ${delay}ms... ` +
+                    `Error: ${error.status} ${error.message}`
+                  );
+                  await wait(delay);
+                }
+              }
+            }
+            
             async function getPullRequestList() {
-                return await github.rest.pulls.list({
+                return withRetry( () =>
+                  github.rest.pulls.list({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     state: 'open',
                     sort: 'created',
                     per_page: 100,
-                });
+                  }),
+                "List pull requests"
+              );
             }
 
             async function getPullRequest(prNumber) {
-                return await github.rest.pulls.get({
+                return withRetry(() =>
+                  github.rest.pulls.get({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: prNumber,
-                });
+                  }),
+                `Get PR #${prNumber}`
+              );
             }
 
             async function addLabel(labels, issue_number) {
-                await github.rest.issues.addLabels({
+                return withRetry(() =>
+                  github.rest.issues.addLabels({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue_number,
                     labels: labels,
-                });
+                  }),
+                `Add labels to PR #${issue_number}`
+              );
             }
 
             async function removeLabel(labels, issue_number) {
-                await github.rest.issues.removeLabel({
+                return withRetry(() =>
+                  github.rest.issues.removeLabel({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: issue_number,
                     name: labels,
-                });
+                  }),
+                `Remove label from PR #${issue_number}`
+              );
+
             }
 
             async function wait(ms) {
@@ -68,59 +111,65 @@ jobs:
                         const prNumber = pullRequest.number;
                         console.log(`Checking PR #${prNumber}`);
 
-                        let pullRequestData;
-                        let iterations = 0;
-                        do {
-                            pullRequestData = await getPullRequest(prNumber);
-                            // introduce 1-second delay before the next check
-                            await wait(1000);
-                            iterations++;
+                        try {
+                            let pullRequestData;
+                            let iterations = 0;
+                            do {
+                                pullRequestData = await getPullRequest(prNumber);
+                                // introduce 1-second delay before the next check
+                                await wait(1000);
+                                iterations++;
 
-                            // Check for terminal conditions
-                            if (pullRequestData.data.mergeable_state !== 'unknown' || iterations >= maxIterations) {
-                              break;
-                            }
-                        } while (pullRequestData.data.mergeable_state === 'unknown');
-
-                        if (pullRequestData.data.mergeable_state === 'dirty') {
-                            console.log(`Conflict exists in PR #${prNumber}`);
-                            if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
-                                console.log(`'Has Conflicts' label already exists on PR #${prNumber}`);
-                            } else {
-                                // Only add label if PR is not already stale to prevent resetting stale timer
-                                if (!pullRequestData.data.labels.find(label => label.name === 'Stale')) {
-                                    console.log(`Adding 'Has Conflicts' label to PR #${prNumber} (not stale)`);
-                                    await addLabel(['Has Conflicts'], prNumber);
-                                } else {
-                                    console.warn(`PR #${prNumber} is stale, skipping label addition to prevent timer reset`);
+                                // Check for terminal conditions
+                                if (pullRequestData.data.mergeable_state !== 'unknown' || iterations >= maxIterations) {
+                                  break;
                                 }
-                            }
-                        } else if (pullRequestData.data.mergeable_state === 'clean') {
-                            // if PR has no conflicts, remove the label
-                            if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
-                                console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
-                                await removeLabel(['Has Conflicts'], prNumber);
-                            }
-                        } else if (pullRequestData.data.mergeable_state === 'unstable') {
-                            console.log(`PR #${prNumber} is unstable`);
-                            const mergeable = pullRequestData.data.mergeable;
-                            if (mergeable) {
-                                console.log(`PR #${prNumber} is mergeable`);
+                            } while (pullRequestData.data.mergeable_state === 'unknown');
+
+                            if (pullRequestData.data.mergeable_state === 'dirty') {
+                                console.log(`Conflict exists in PR #${prNumber}`);
+                                if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
+                                    console.log(`'Has Conflicts' label already exists on PR #${prNumber}`);
+                                } else {
+                                    // Only add label if PR is not already stale to prevent resetting stale timer
+                                    if (!pullRequestData.data.labels.find(label => label.name === 'Stale')) {
+                                        console.log(`Adding 'Has Conflicts' label to PR #${prNumber} (not stale)`);
+                                        await addLabel(['Has Conflicts'], prNumber);
+                                    } else {
+                                        console.warn(`PR #${prNumber} is stale, skipping label addition to prevent timer reset`);
+                                    }
+                                }
+                            } else if (pullRequestData.data.mergeable_state === 'clean') {
                                 // if PR has no conflicts, remove the label
                                 if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
                                     console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
-                                    try {
-                                        await removeLabel(['Has Conflicts'], prNumber);
-                                    } catch(err) {
-                                        if (err.status === 404) {
-                                            console.warn("(Has Conflicts) label no longer found when trying to remove it");
-                                        } else {
-                                            console.log("Unexpected error while removing (Has Conflicts) label: " + err);
-                                            throw err;
+                                    await removeLabel(['Has Conflicts'], prNumber);
+                                }
+                            } else if (pullRequestData.data.mergeable_state === 'unstable') {
+                                console.log(`PR #${prNumber} is unstable`);
+                                const mergeable = pullRequestData.data.mergeable;
+                                if (mergeable) {
+                                    console.log(`PR #${prNumber} is mergeable`);
+                                    // if PR has no conflicts, remove the label
+                                    if (pullRequestData.data.labels.find(label => label.name === 'Has Conflicts')) {
+                                        console.log(`Removing 'Has Conflicts' label from PR #${prNumber}`);
+                                        try {
+                                            await removeLabel(['Has Conflicts'], prNumber);
+                                        } catch(err) {
+                                            if (err.status === 404) {
+                                                console.warn("(Has Conflicts) label no longer found when trying to remove it");
+                                            } else {
+                                                console.log("Unexpected error while removing (Has Conflicts) label: " + err);
+                                                throw err;
+                                            }
                                         }
                                     }
                                 }
                             }
+                        } catch (err) {
+                            console.error(`Error while processing PR #${prNumber}`);
+                            console.error(err);
+                            throw err;
                         }
                     }
                 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Job that checks for merge conflicts was crashing when GitHub's servers had problems.

## Fixes
* Fixes #19808

## Approach
A reusable wrapper function that can call Github API calls with retry logic

## How Has This Been Tested?
Tested this workflow using act(https://github.com/nektos/act)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)