### PR TITLE
fix(shared-decks): crash on checking progress

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -38,6 +38,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.SharedDecksActivity.Companion.DOWNLOAD_FILE
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.openUrl
@@ -429,7 +430,15 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
         val query = DownloadManager.Query()
         query.setFilterById(downloadId)
 
-        val cursor = downloadManager.query(query)
+        val cursor =
+            try {
+                downloadManager.query(query)
+            } catch (_: IllegalArgumentException) {
+                // 19812: column local_filename is not allowed in queries
+                downloadPercentageText.text = TR.syncDownloadingFromAnkiweb()
+                downloadProgressBar.progress = 0
+                return
+            }
 
         cursor.use {
             // Return if cursor is empty.


### PR DESCRIPTION
## Purpose / Description
`query` produced:
`java.lang.IllegalArgumentException: column local_filename is not allowed in queries`

on a Xiaomi Redmi Note 12 Pro 5G


## Fixes
* Fixes #19812

## Approach
`try ... catch`

## How Has This Been Tested?

<img width="736" height="142" alt="Screenshot 2025-12-15 at 14 35 04" src="https://github.com/user-attachments/assets/d176d104-74a6-4481-a18b-55916c827406" />


```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt	(revision b1002bd2f0f1b582856f0161f4ec772686821b31)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt	(date 1765784020220)
@@ -422,6 +422,10 @@
         isProgressCheckerRunning = false
     }
 
+    fun aa(): Cursor {
+        throw IllegalArgumentException("column local_filename is not allowed in queries")
+    }
+
     /**
      * Checks download progress and sets the current progress in ProgressBar.
      */
@@ -431,7 +435,7 @@
 
         val cursor =
             try {
-                downloadManager.query(query)
+                aa()
             } catch (_: Exception) {
                 // 19812: column local_filename is not allowed in queries
                 downloadPercentageText.text = getString(R.string.download_percentage_unknown)

```


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)