### PR TITLE
test: ignore flaky card browser FindReplace test

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1419,6 +1419,7 @@ class CardBrowserTest : RobolectricTest() {
 
     @Test
     @Flaky(OS.ALL)
+    @Ignore("flaking locally as well now; see 19021")
     fun `FindReplace - replaces text in all notes if 'Only in selected notes' is unchecked`() {
         val note0 = createFindReplaceTestNote("A", "kart", "kilogram")
         val note1 = createFindReplaceTestNote("B", "pink", "chicken")


### PR DESCRIPTION
this began flaking on my locally against API36 emulator:

`FindReplace - replaces text in all notes if 'Only in selected notes' is unchecked`

See 19021 - was already ignored in CI

This is impeding my ability to qualify release branch picks locally for a couple days and I've already got it picked into my local release-2.23 branch as I test picks - needs to merge ASAP 🙏 