### PR TITLE
feat: Persist scroll position when flipping cards

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -513,6 +513,7 @@ object UsageAnalytics {
             R.string.show_audio_play_buttons_key, // Show play buttons on cards with audio (reversed in collection: HIDE_AUDIO_PLAY_BUTTONS)
             R.string.pref_display_filenames_in_browser_key, // Display filenames in card browser
             R.string.show_deck_title_key, // Show deck title
+            R.string.keep_scroll_position, // Keep the scroll position after flipping the card
             // ******************************** Controls *********************************************
             R.string.gestures_preference, // Enable gestures
             R.string.gestures_corner_touch_preference, // 9-point touch

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
@@ -110,6 +110,21 @@ open class SafeWebViewLayout :
     @MainThread
     fun focusOnWebView() = webView.requestFocus()
 
+    /**
+     * Scroll the underlying WebView (NOT this FrameLayout wrapper).
+     * Calling FrameLayout.scrollTo() will move the WebView out of view and show blank space.
+     */
+    @MainThread
+    fun scrollWebViewTo(
+        x: Int = 0,
+        y: Int,
+    ) {
+        webView.scrollTo(x, y)
+    }
+
+    val webViewScrollY: Int
+        get() = webView.scrollY
+
     @MainThread
     fun destroy() = webView.destroy()
 

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -14,6 +14,8 @@
     <string name="time_limit_preference">timeLimit</string>
     <string name="keep_screen_on_preference">keepScreenOn</string>
     <string name="double_tap_timeout_pref_key">doubleTapTimeout</string>
+    <string name="keep_scroll_position" maxLength="41">Keep scroll position</string>
+    <string name="keep_scroll_position_summ">Keep the scroll position when showing the answer side</string>
     <!-- Sync -->
     <string name="pref_sync_screen_key">syncScreen</string>
     <string name="sync_account_key">syncAccount</string>

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -72,6 +72,14 @@
             android:icon="@drawable/ic_play_circle_white"
             />
 
+        <SwitchPreferenceCompat
+            android:key="@string/keep_scroll_position"
+            android:title="@string/keep_scroll_position"
+            android:summary="@string/keep_scroll_position_summ"
+            android:defaultValue="false"
+            android:icon="@drawable/ic_link"
+            />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
## Purpose / Description
As of right now, whenever studying vertically long Cloze cards, if the cloze to be completed is in the middle or closer to the bottom and one scrolls down to the cloze to complete to know the blank that needs to be filled, as soon as the card is flipped (i.e. the answer is shown), the view is "scrolled" immediately to the top (not really scrolled, more like rendered from top to bottom and redrawn, but the effect is as if the window scrolled back up).

This means that, in order to check your answer, you need to scroll down again. This is a little piece of inefficiency that, over and over, can end up accumulate precious review time and mental frustration and tediousness capacity.

## Approach
This change tries to give an optional escape hatch to this situation, by adding a new option for the new study screen which allows Anki to "remember" where it was scrolled down to before the card was flipped, so that when the card is flipped, it scrolls back down to it to immediately show if the given answer is correct. The changes are mostly confined to the `ReviewerFragment.kt` file, some resources files, and the `SafeWebViewLayout.kt` file.

![photo_5909123642472205560_y](https://github.com/user-attachments/assets/362938d4-3de6-4d9d-8172-c1813d16e0ea)

## Disclaimer

The code for this PR was completely generated using LLMs (rest assured, it took many attempts, iterations, and running out of tokens various times to get to something barely working, so no, LLMs can't do this independently yet :grin:). I'm neither a Kotlin nor an Android developer, nor I aspire to, but I'm a avid user of Anki and a software engineer, and I really wanted to have this feature. Rather than waiting on some kind-hearted soul to pick up on my feature suggestion (https://forums.ankiweb.net/t/keeping-the-viewport-in-the-same-place-when-showing-answers-in-cloze-completions/67725), I decided to take things in my own hands and try to get a draft of a working solution. I obviously expect this attempt to be flawed and that it will need a lot of steering and adjustment from actual people and veterans of this codebase, but I hope I made it easier for somebody to pick up on these first steps and help pushing this effort over the goal line if they feel inclined to do so :slightly_smiling_face: 

## How Has This Been Tested?

I basically built a debug build and ran it on my personal device to verify functionality. I also ran the full unit test suite, which seems to pass fine, except for a couple of flaky tests (`PrefsSearchBarTest > All indexed XML resIDs lead to the correct fragments on getFragmentFromXmlRes FAILED` and `CardBrowserTest > FindReplace - replaces text in all fields of selected note if 'All fields' is selected FAILED
`). It seems to be related to the new resources/preferences, but I can't figure out exactly the connection and how to deal with it.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)