### PR TITLE
refactor(card-browser): use SavedStateHandle flow for multi select mode events

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardOrNoteId.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardOrNoteId.kt
@@ -16,10 +16,12 @@
 
 package com.ichi2.anki.browser
 
+import android.os.Parcelable
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.model.CardsOrNotes
+import kotlinx.parcelize.Parcelize
 
 /**
  * Either a [CardId] or a [NoteId]. The ID of a row inside the 'Browser' can be either.
@@ -28,10 +30,11 @@ import com.ichi2.anki.model.CardsOrNotes
  * It is not included in the class as this class is primarily provided in a [BrowserRowCollection]
  * and storing the same value for every item in the list is a waste
  */
+@Parcelize
 @JvmInline
 value class CardOrNoteId(
     val cardOrNoteId: Long,
-) {
+) : Parcelable {
     override fun toString(): String = cardOrNoteId.toString()
 
     // TODO: We use this for 'Edit Note' or 'Card Info'. We should reconsider whether we ever want

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -48,6 +48,8 @@ import com.ichi2.anki.browser.CardBrowserColumn.SFLD
 import com.ichi2.anki.browser.CardBrowserColumn.TAGS
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.DeepLink
 import com.ichi2.anki.browser.CardBrowserLaunchOptions.SystemContextMenu
+import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode
+import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.MultiSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.STATE_MULTISELECT_VALUES
 import com.ichi2.anki.browser.CardBrowserViewModel.RowSelection
@@ -1115,15 +1117,15 @@ class CardBrowserViewModelTest : JvmTest() {
         val handle = SavedStateHandle()
         runViewModelTest(savedStateHandle = handle, notes = 1) {
             assertThat(isInMultiSelectMode, equalTo(false))
-            assertThat("initial multiselect state", handle.get<Boolean>("multiselect"), equalTo(false))
+            assertInstanceOf<SingleSelectCause.Other>(handle.multiselectMode, "initial multiselect state")
             selectAll()
-            assertThat("multiselect after select all", handle.get<Boolean>("multiselect"), equalTo(true))
+            assertInstanceOf<MultiSelectCause.Other>(handle.multiselectMode, "multiselect after select all")
         }
 
         runViewModelTest(savedStateHandle = handle) {
-            assertThat("multiselect state restoration", isInMultiSelectMode, equalTo(true))
+            assertInstanceOf<MultiSelectCause.Other>(handle.multiselectMode, "multiselect state restoration")
             endMultiSelectMode(SingleSelectCause.NavigateBack)
-            assertThat("multiselect after 'end multiselect'", handle.get<Boolean>("multiselect"), equalTo(false))
+            assertInstanceOf<SingleSelectCause.NavigateBack>(handle.multiselectMode, "initial multiselect state")
         }
     }
 
@@ -1380,3 +1382,6 @@ fun CardBrowserViewModel.selectRowAtPosition(position: Int) {
 }
 
 fun CardOrNoteId.toRowSelection() = RowSelection(rowId = this, topOffset = 0)
+
+private val SavedStateHandle.multiselectMode
+    get() = get<ChangeMultiSelectMode>("multiselect")


### PR DESCRIPTION
## Purpose / Description
We encountered a bug where the user was in the Note Editor editing and the previous state was the Card Browser in 'selection' mode this shouldn't occur, and I suspect that the later update of the saved state was to blame

Moving to directly serializing the enum may resolve this

## Fixes
* Maybe fixes part of issue #19572

## Approach
move to `savedStateHandle.getMutableStateFlow`

## How Has This Been Tested?
This is heavily unit tested, tests still pass.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)