### PR TITLE
refactor: fixes to allow for Kotlin 2.3.0

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -123,7 +123,7 @@ class ContentProviderTest : InstrumentedTest() {
                 /* If parent already exists, don't add the deck, so
                  * that we are sure it won't get deleted at
                  * set-down, */
-                val did = col.decks.byName(partialName!!)?.id ?: col.decks.id(partialName)
+                val did = col.decks.byName(partialName)?.id ?: col.decks.id(partialName)
                 testDeckIds.add(did)
                 createdNotes.add(setupNewNote(col, noteTypeId, did, dummyFields, TEST_TAG))
                 partialName += "::"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2204,7 +2204,7 @@ open class DeckPicker :
     @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
     fun updateDeckList() {
         launchCatchingTask {
-            withProgress { viewModel.updateDeckList()?.join() }
+            withProgress { viewModel.updateDeckList().join() }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -153,7 +153,7 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
             SavedBrowserSearchesDialogFragment().apply {
                 arguments =
                     Bundle().also {
-                        it.putSerializable(ARG_SAVED_FILTERS, savedFilters.let(::HashMap))
+                        it.putSerializable(ARG_SAVED_FILTERS, HashMap(savedFilters))
                     }
             }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -85,6 +85,7 @@ abstract class MultimediaFragment(
 
         if (arguments != null) {
             Timber.d("Getting MultimediaActivityExtra values from arguments")
+            @Suppress("USELESS_CAST")
             val multimediaActivityExtra =
                 arguments?.getSerializableCompat(
                     MultimediaActivity.MULTIMEDIA_ARGS_EXTRA,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/RemoveAccountFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/RemoveAccountFragment.kt
@@ -106,6 +106,8 @@ class RemoveAccountFragment :
                 return shouldOverrideUrlLoading(view, request?.url.toString())
             }
 
+            @Suppress("OVERRIDE_DEPRECATION")
+            @Deprecated("Deprecated in Java")
             override fun shouldOverrideUrlLoading(
                 view: WebView?,
                 url: String?,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AppearanceSettingsFragment.kt
@@ -101,7 +101,7 @@ class AppearanceSettingsFragment : SettingsFragment() {
             // Only restart if theme has changed
             if (newValue != appThemePref.value) {
                 val previousThemeId = Themes.currentTheme.id
-                appThemePref.value = newValue.toString()
+                appThemePref.value = newValue
                 updateCurrentTheme(requireContext())
 
                 if (previousThemeId != Themes.currentTheme.id) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/web/HttpFetcher.kt
@@ -98,7 +98,7 @@ object HttpFetcher {
                 val reader =
                     BufferedReader(
                         InputStreamReader(
-                            response.body!!.byteStream(),
+                            response.body.byteStream(),
                             Charset.forName(encoding),
                         ),
                     )

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -89,9 +89,7 @@ fun AlertDialog.Builder.message(
  */
 fun AlertDialog.Builder.iconAttr(
     @DrawableRes res: Int,
-) = apply {
-    return this.setIcon(Themes.getResFromAttr(this.context, res))
-}
+): AlertDialog.Builder = this.setIcon(Themes.getResFromAttr(this.context, res))
 
 fun AlertDialog.Builder.positiveButton(
     @StringRes stringRes: Int? = null,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -595,7 +595,7 @@ class CardBrowserViewModelTest : JvmTest() {
     fun `suspend - notes - some cards suspended`() =
         runViewModelNotesTest(notes = 2) {
             // this suspends o single cid from a nid
-            suspendCards(cards.first().toCardId(cardsOrNotes) as CardId)
+            suspendCards(cards.first().toCardId(cardsOrNotes))
             ensureOpsExecuted(1) {
                 selectAll()
                 toggleSuspendCards()

--- a/libanki/src/main/java/com/ichi2/anki/libanki/DB.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/DB.kt
@@ -136,7 +136,7 @@ class DB(
 
     @KotlinCleanup("""Use Kotlin string. Change split so that there is no empty string after last ";".""")
     fun executeScript(sql: String) {
-        val queries = java.lang.String(sql).split(";")
+        val queries = sql.split(";")
         for (query in queries) {
             database.execSQL(query)
         }


### PR DESCRIPTION
* Use `String` instead of `java.lang.string`
* Unnecessary safe call on a non-null receiver of type
* No cast needed.
* Redundant call of conversion method.
* This declaration overrides a deprecated member but is not marked as deprecated itself. Add the `@Deprecated`annotation or suppress the diagnostic.
* Unnecessary non-null assertion (!!) on a non-null receiver of type 'ResponseBody'.
* Java type mismatch: inferred type is 'KFunction1<MutableMap<out String!, out String!>, HashMap<String!, String!>>', but 'Function1<Map<String, String>, HashMap<String!, String!>>' was expected.

## Fixes
* Prep for #19826

## How Has This Been Tested?
I briefly tested saved searched, as the HashMap change looked risky
I ran tests/androidTests

CI passes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)