### PR TITLE
chore: enable context parameters

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks.Companion.CURRENT_DECK
 import com.ichi2.anki.libanki.Note
 import com.ichi2.anki.libanki.NotetypeJson
+import com.ichi2.anki.libanki.testutils.AnkiTest
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.testutils.getString
@@ -805,10 +806,8 @@ private var NoteEditorFragment.noteType: NotetypeJson
     set(value) = this.setCurrentlySelectedNoteType(value.id)
 
 /** Select a deck by Id */
-private fun NoteEditorFragment.selectDeck(
-    deckId: DeckId,
-    name: String = "Undefined",
-) {
-    // TODO: get name from collection and make this 'suspend fun' after Context Parameters (#19614)
+context(testContext: AnkiTest)
+private fun NoteEditorFragment.selectDeck(deckId: DeckId) {
+    val name = testContext.col.decks.name(deckId)
     onDeckSelected(SelectableDeck.Deck(deckId, name))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -102,6 +102,7 @@ subprojects {
                 )
                 if (project.name != "api") {
                     compilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+                    compilerArgs += "-Xcontext-parameters"
                 }
                 freeCompilerArgs = compilerArgs
             }


### PR DESCRIPTION
## Purpose / Description
I've been wanting this for a while. If you know, you know 

Experimental; I'm responsible for the full revert if changes are required

## Fixes
* Fixes #19614

## Approach
Now ktlint-gradle supports it, enable `-Xcontext-parameters`

## How Has This Been Tested?
Trusting CI on this one - and a test-only change 

## Learning (optional, can help others)
https://kotlinlang.org/docs/context-parameters.html

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)