### PR TITLE
refactor(previewer): Add doOnTabSelected extension for TabLayout

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -96,6 +96,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
+import com.ichi2.anki.utils.ext.doOnTabSelected
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.postDelayed
 import com.ichi2.compat.CompatHelper.Companion.getSerializableCompat
@@ -168,19 +169,6 @@ open class CardTemplateEditor :
     /**
      * Triggered when a card template ('Card 1') is selected in the top tab view
      */
-    private val onCardTemplateSelectedListener: TabLayout.OnTabSelectedListener =
-        object : TabLayout.OnTabSelectedListener {
-            override fun onTabSelected(tab: TabLayout.Tab) {
-                Timber.i("selected card index: %s", tab.position)
-                loadTemplatePreviewerFragmentIfFragmented()
-            }
-
-            override fun onTabUnselected(tab: TabLayout.Tab) {
-            }
-
-            override fun onTabReselected(tab: TabLayout.Tab) {
-            }
-        }
 
     // ----------------------------------------------------------------------------
     // Listeners
@@ -241,7 +229,10 @@ open class CardTemplateEditor :
         loadTemplatePreviewerFragmentIfFragmented()
         onBackPressedDispatcher.addCallback(this, displayDiscardChangesCallback)
 
-        topBinding.slidingTabs.addOnTabSelectedListener(onCardTemplateSelectedListener)
+        topBinding.slidingTabs.doOnTabSelected { tab ->
+            Timber.i("selected card index: %s", tab.position)
+            loadTemplatePreviewerFragmentIfFragmented()
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerPage.kt
@@ -26,9 +26,9 @@ import androidx.fragment.app.commitNow
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.tabs.TabLayout
-import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import com.ichi2.anki.R
 import com.ichi2.anki.previewer.TemplatePreviewerFragment.Companion.ARGS_KEY
+import com.ichi2.anki.utils.ext.doOnTabSelected
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -72,22 +72,10 @@ class TemplatePreviewerPage : Fragment(R.layout.template_previewer_container) {
                 tabLayout.addTab(newTab)
             }
             tabLayout.selectTab(tabLayout.getTabAt(viewModel.getCurrentTabIndex()))
-            tabLayout.addOnTabSelectedListener(
-                object : OnTabSelectedListener {
-                    override fun onTabSelected(tab: TabLayout.Tab) {
-                        Timber.v("Selected tab %d", tab.position)
-                        viewModel.onTabSelected(tab.position)
-                    }
-
-                    override fun onTabUnselected(tab: TabLayout.Tab) {
-                        // do nothing
-                    }
-
-                    override fun onTabReselected(tab: TabLayout.Tab) {
-                        // do nothing
-                    }
-                },
-            )
+            tabLayout.doOnTabSelected { tab ->
+                Timber.v("Selected tab %d", tab.position)
+                viewModel.onTabSelected(tab.position)
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/TabLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/TabLayout.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2025 Rakshita Chauhan <chauhanrakshita64@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils.ext
+
+import com.google.android.material.tabs.TabLayout
+
+/**
+ * Performs the given action when a tab is selected.
+ * @param action The callback to be invoked when a tab is selected.
+ * @return The created [TabLayout.OnTabSelectedListener], which can be used to remove the listener if needed.
+ */
+inline fun TabLayout.doOnTabSelected(crossinline action: (tab: TabLayout.Tab) -> Unit) =
+    object : TabLayout.OnTabSelectedListener {
+        override fun onTabSelected(tab: TabLayout.Tab) = action(tab)
+
+        override fun onTabUnselected(tab: TabLayout.Tab) {}
+
+        override fun onTabReselected(tab: TabLayout.Tab) {}
+    }.also { addOnTabSelectedListener(it) }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Refactors the `TabLayout.OnTabSelectedListener` implementation in `TemplatePreviewerPage`.

## Fixes
* Fixes #19832

## Approach
* Created a new utility file: `com.ichi2.utils.TabLayoutExtensions.kt`.
* Added the `doOnTabSelected` extension function which wraps the `OnTabSelectedListener` boilerplate.
* Refactored `TemplatePreviewerPage` to use this new extension function.
* The extension function returns the listener instance, ensuring it can still be removed by the caller if necessary.

## How Has This Been Tested?

I verified these changes on a physical Android device.

**Manual Verification Steps:**
1. Open AnkiDroid and go to **Manage Note Types**.
2. Select a note type with multiple cards (e.g., "Basic (and reversed card)") and tap **Edit cards**.
3. Tap the **Preview (Eye)** icon to open the Template Previewer.
4. Tapped between "Card 1" and "Card 2" tabs.
5. Confirmed that the view updates correctly and no crashes occur.

**Automated Tests:**
* Ran `./gradlew testDebugUnitTest` (passed)
* Ran `./gradlew ktlintFormat` (passed)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->