### PR TITLE
card-browser: Make focused row lighten in Dark themes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -45,6 +45,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.utils.android.darkenColor
 import com.ichi2.anki.utils.android.lightenColorAbsolute
 import com.ichi2.anki.utils.ext.findViewById
+import com.ichi2.themes.Themes
 import com.ichi2.utils.removeChildren
 import net.ankiweb.rsdroid.BackendException
 import timber.log.Timber
@@ -163,16 +164,17 @@ class BrowserMultiColumnAdapter(
         fun setColor(
             @ColorInt color: Int,
         ) {
-            var pressedColor = darkenColor(color, 0.85f)
-            var focusedColor = darkenColor(color, 0.4f)
+            val nightMode = Themes.currentTheme.isNightMode
+            val pressedColor: Int
+            val focusedColor: Int
 
-            if (pressedColor == color) {
-                // if the color is black, we can't darken it.
-                // A non-black background looks unusual, so the 'press' should lighten the color
-
+            if (nightMode) {
                 // 25% was determined by visual inspection
-                pressedColor = lightenColorAbsolute(pressedColor, 0.25f)
+                pressedColor = lightenColorAbsolute(color, 0.25f)
                 focusedColor = pressedColor
+            } else {
+                pressedColor = darkenColor(color, 0.85f)
+                focusedColor = darkenColor(color, 0.4f)
             }
 
             require(pressedColor != color)


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
Currently, in keyboarding the Card browser's list with the dark themes (Black and Dark), only the row with the black background lightens when focused, while the other colored rows darkens. This behavior is not consistent within the list, nor with common Material Design's one (consistently lightening), including the behavior when the row is tapped.

A blue row unfocused/focused in the Black theme:
<img width="1502" height="341" alt="image" src="https://github.com/user-attachments/assets/f9ca7873-f994-4be3-99d9-f8ab836f33b9" />

In Black theme:

https://github.com/user-attachments/assets/14f1a043-1030-4a10-8c6c-c807be2c2ce2

In Dark theme:

https://github.com/user-attachments/assets/e096dc13-8c22-47ca-99ad-6b09795426f5



With this PR, the focused row consistently lightens in the dark themes.



## Approach

Determine if a row is to be lightened by `currentTheme.isNightMode`, not by whether the row is black or not.　

## How Has This Been Tested?

Checked on a physical device (Android 15)

In Black theme:

https://github.com/user-attachments/assets/7c9bdc51-c195-499f-a2ee-d8eee322cc45

In Dark theme:


https://github.com/user-attachments/assets/ea3023ec-ca57-4516-8b26-d033143319cf



## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->