### PR TITLE
Cleanup: replace deprecated kotlinOptions jvmTarget

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     // Gradle plugin portal
     alias(libs.plugins.tripletPlay)
@@ -249,9 +251,12 @@ android {
         targetCompatibility JavaVersion.VERSION_17
         coreLibraryDesugaringEnabled = true
     }
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
+    kotlin {
+        compilerOptions {
+            jvmTarget = JvmTarget.JVM_17
+        }
     }
+
 
     packagingOptions {
         resources {


### PR DESCRIPTION
## Purpose / Description
This PR removes the deprecated `kotlinOptions { jvmTarget }` configuration and
replaces it with the modern `compilerOptions` DSL as recommended by the Kotlin
Gradle plugin.

## Fixes
- N/A (cleanup; no issue number associated)

## Approach
Migrated the JVM target configuration to `compilerOptions` using
`JvmTarget.JVM_17`, which resolves Android Studio / Gradle deprecation warnings
without changing any runtime or build behavior.

## How Has This Been Tested?
- Project sync completed successfully.
- `./gradlew lintRelease` executed locally.

## Learning (optional, can help others)
- Kotlin Gradle Plugin migration guidance:
  https://kotlinlang.org/docs/gradle-compiler-options.html

## Checklist
- You have a descriptive commit message with a short title (first line, max 50 chars).
- You have performed a self-review of your own code.
- No UI changes.
- No new external resources or libraries added.