### PR TITLE
Fix resizing divider visibility when side-by-side editor is disabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -340,6 +340,7 @@ open class CardBrowser :
             )
         } else {
             binding.noteEditorFrame?.isVisible = false
+            binding.cardBrowserResizingDivider?.isVisible = false
         }
 
         // must be called once we have an accessible collection


### PR DESCRIPTION
The resizing divider was incorrectly remaining visible on tablets and ChromeOS even when the 'Side-by-side browser and editor' option was disabled. This change updates the initialization logic to explicitly hide the divider in that scenario, restoring the expected UI behavior.

<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes a UI inconsistency where the resizing divider was visible on Tablet/ChromeOS layouts even when the "Side-by-Side browser and editor" developer option was disabled.

## Fixes
* Fixes  #19852

## Approach
Updated CardBrowser initialization logic in onCreate.
When split-view (fragmented) mode is false (due to device config or user preference), the cardBrowserResizingDivider is explicitly set to View.GONE.
Ensures the divider is hidden when not needed, correcting default visibility in the xlarge layout XML.

## How Has This Been Tested?
Verified card_browser.xml (xlarge) defines the divider as visible by default.
I performed a logic verification and code search to ensure safety across different layouts.
Null-safe operator (?.) ensures no crashes on phone layouts.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->