### PR TITLE
fix: Added tap outside to dismiss dialog (deck-description)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EditDeckDescriptionDialog.kt
@@ -40,6 +40,7 @@ import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard
 import com.ichi2.utils.AndroidUiUtils.setFocusAndOpenKeyboard
 import com.ichi2.utils.create
+import com.ichi2.utils.handleOutsideTouch
 import com.ichi2.utils.moveCursorToEnd
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -85,6 +86,7 @@ class EditDeckDescriptionDialog : DialogFragment() {
                 setOnShowListener {
                     positiveButton.setOnClickListener { viewModel.saveAndExit() }
                     negativeButton.setOnClickListener { viewModel.onBackRequested() }
+                    handleOutsideTouch(binding) { viewModel.onBackRequested() }
                 }
                 setCanceledOnTouchOutside(false)
                 setCancelable(false)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -24,6 +24,7 @@ import android.content.DialogInterface.OnClickListener
 import android.text.InputFilter
 import android.view.KeyEvent
 import android.view.LayoutInflater
+import android.view.MotionEvent
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.Button
@@ -40,6 +41,7 @@ import androidx.core.widget.doOnTextChanged
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.R
 import com.ichi2.themes.Themes
@@ -377,6 +379,30 @@ val AlertDialog.negativeButton: Button
     get() = getButton(DialogInterface.BUTTON_NEGATIVE)
 val AlertDialog.neutralButton: Button?
     get() = getButton(DialogInterface.BUTTON_NEUTRAL)
+
+/**
+ * Executes [block] when a touch outside the dialog occurs
+ *
+ * This MUST be called after [show] or inside [AlertDialog.setOnShowListener]
+ *
+ * This will not call [AlertDialog.cancel]
+ */
+fun AlertDialog.handleOutsideTouch(
+    binding: ViewBinding,
+    block: () -> Unit,
+) {
+    val dialogContentView =
+        findViewById(com.google.android.material.R.id.contentPanel)
+            ?: binding.root.parent as? View
+            ?: binding.root
+
+    window?.decorView?.setOnTouchListener { _, event ->
+        if (event.action != MotionEvent.ACTION_DOWN) return@setOnTouchListener false
+        if (dialogContentView.rawHitTest(event)) return@setOnTouchListener false
+        block()
+        true
+    }
+}
 
 /**
  * Extension function for AlertDialog.Builder to set a list of items.


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The deck description dialog does not dismiss when tapping outside it. This adds tap outside to dismiss functionality.

## Fixes
* Fixes #19077 

## Approach
Added a touch listener that detects taps outside the dialog and calls `viewModel.onBackRequested()`. This closes the dialog if no changes were made, or shows the discard confirmation if there are unsaved changes.

## How Has This Been Tested?

https://github.com/user-attachments/assets/9e1bf09e-4d39-41c8-8a52-8c350e169bd2

Tested on: OnePlus Nord CE2 lite









## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->