### PR TITLE
feat: put field name on deletion dialog title

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -271,8 +271,12 @@ class NoteTypeFieldEditor : AnkiActivity(R.layout.note_type_field_editor) {
         } else {
             try {
                 getColUnsafe.modSchema()
+                val fieldName = noteFields[currentPos].name
                 ConfirmationDialog().let {
-                    it.setArgs(resources.getString(R.string.field_delete_warning))
+                    it.setArgs(
+                        title = fieldName,
+                        message = resources.getString(R.string.field_delete_warning),
+                    )
                     it.setConfirm(confirm)
                     showDialogFragment(it)
                 }


### PR DESCRIPTION
https://forums.ankiweb.net/t/show-the-name-of-the-field-to-be-deleted/67877

## How Has This Been Tested?

Emulator 31

<img width="427" height="641" alt="image" src="https://github.com/user-attachments/assets/4d06e2a1-4a4a-46de-8e07-512715a9855e" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->