### PR TITLE
feat(whiteboard): erase on stylus press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -85,6 +85,7 @@ class WhiteboardFragment :
         observeViewModel(binding.whiteboardView)
 
         binding.whiteboardView.onNewPath = viewModel::addPath
+        binding.whiteboardView.onStylusButtonStateChanged = viewModel::setStylusButtonPressed
         binding.whiteboardView.onEraseGestureStart = viewModel::startPathEraseGesture
         binding.whiteboardView.onEraseGestureMove = viewModel::erasePathsAtPoint
         binding.whiteboardView.onEraseGestureEnd = viewModel::endPathEraseGesture
@@ -136,24 +137,17 @@ class WhiteboardFragment :
     private fun observeViewModel(whiteboardView: WhiteboardView) {
         viewModel.paths.onEach(whiteboardView::setHistory).launchIn(lifecycleScope)
 
-        combine(
-            viewModel.brushColor,
-            viewModel.activeStrokeWidth,
-        ) { color, width ->
-            whiteboardView.setCurrentBrush(color, width)
-        }.launchIn(lifecycleScope)
+        viewModel.effectiveTool
+            .onEach { tool ->
+                whiteboardView.setTool(tool)
+            }.launchIn(lifecycleScope)
 
         combine(
             viewModel.isEraserActive,
-            viewModel.eraserMode,
-            viewModel.eraserDisplayWidth,
-        ) { isActive, mode, width ->
-            whiteboardView.isEraserActive = isActive
-            binding.eraserButton.updateState(isActive, mode, width)
-            whiteboardView.eraserMode = mode
-            if (!isActive) {
-                eraserPopup?.dismiss()
-            }
+            viewModel.eraserTool,
+        ) { isActive, eraser ->
+            binding.eraserButton.updateState(isActive, eraser.mode, eraser.width)
+            if (!isActive) eraserPopup?.dismiss()
         }.launchIn(lifecycleScope)
 
         viewModel.brushes
@@ -388,7 +382,7 @@ class WhiteboardFragment :
         val inflater = LayoutInflater.from(requireContext())
         val eraserWidthBinding = PopupEraserOptionsBinding.inflate(inflater)
 
-        eraserWidthBinding.eraserWidthSlider.value = viewModel.eraserDisplayWidth.value
+        eraserWidthBinding.eraserWidthSlider.value = viewModel.eraserTool.value.width
         eraserWidthBinding.eraserWidthSlider.addOnChangeListener { _, value, fromUser ->
             if (fromUser) viewModel.setActiveStrokeWidth(value)
         }


### PR DESCRIPTION
## Purpose / Description

Adds the old whiteboard behavior of erasing while the stylus button is pressed

## Approach

1. Combine the eraser properties into an eraserTool flow
2. combine the tool properties into a WhiteboardTool class and flow
3. add an isStylusButtonPressed flow
4. setup the view to listen for stylus button presses
5. do some minor cleanups

## How Has This Been Tested?

Galaxy Tab S9, Android 16, with an S-Pen

https://github.com/user-attachments/assets/27a5d5ab-60e3-472e-8fdd-79a7869e7e92

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->