### PR TITLE
test: unit test for CardTemplateEditor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -137,8 +137,9 @@ open class CardTemplateEditor :
     internal val mainBinding: CardTemplateEditorMainBinding
         get() = binding.templateEditor
 
+    // TODO: see if it is feasible to use mockk to cause a crash
+    @VisibleForTesting
     var tempNoteType: CardTemplateNotetype? = null
-        private set
     private var fieldNames: List<String>? = null
     private var noteTypeId: NoteTypeId = 0
     private var noteId: NoteId = 0
@@ -927,7 +928,6 @@ open class CardTemplateEditor :
             confirmAddCards(templateEditor.tempNoteType!!.notetype, numAffectedCards)
         }
 
-        @NeedsTest("Ensure save button is enabled in case of exception")
         fun saveNoteType(): Boolean {
             if (noteTypeHasChanged()) {
                 val confirmButton = templateEditor.findViewById<View>(R.id.action_confirm)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -20,6 +20,8 @@ import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.os.Looper
+import android.view.View
 import android.widget.EditText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CardTemplateEditor.CardTemplateFragment.CardTemplate
@@ -730,6 +732,23 @@ class CardTemplateEditorTest : RobolectricTest() {
     }
 
     @Test
+    fun testSaveButtonEnabledAfterException() {
+        withCardTemplateEditor(noteType = col.notetypes.cloze) {
+            editText.setText("New Random Template Text")
+
+            // throw an exception to simulate failure
+            this.tempNoteType = null
+
+            confirmButton.performClick()
+
+            shadowOf(Looper.getMainLooper()).idle()
+
+            assertTrue("Button should be clickable after failure", confirmButton.isClickable)
+            assertTrue("Button should be enabled after failure", confirmButton.isEnabled)
+        }
+    }
+
+    @Test
     fun testBottomNavigationViewLayoutTransition() {
         val noteTypeName = "Basic"
 
@@ -980,3 +999,6 @@ val CardTemplateEditor.previewer: TemplatePreviewerFragment
 
 val TemplatePreviewerFragment.ord: CardOrdinal
     get() = this.viewModel.ordFlow.value
+
+val CardTemplateEditor.confirmButton: View
+    get() = findViewById(R.id.action_confirm)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When a user attempted to save changes in the CardTemplateEditor, the save button was typically disabled to prevent double-submissions. However, if an unexpected exception occurs during the save logic, the button remained disabled, forcing the user to restart the activity. This change adds a regression test to ensure the button is always restored to an enabled state regardless of success or failure. resolves a TODO from my previous PR

## Fixes
NA

## Approach
NA

## How Has This Been Tested?
Local test 

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->