### PR TITLE
feat(study-screen): keep whiteboard drawing when toggled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -538,12 +538,11 @@ class ReviewerFragment :
         viewModel.whiteboardEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
             childFragmentManager.commit {
                 val whiteboardFragment = childFragmentManager.findFragmentByTag(WhiteboardFragment::class.jvmName)
-                if (isEnabled) {
-                    if (whiteboardFragment != null) return@commit
-                    add(R.id.web_view_container, WhiteboardFragment::class.java, null, WhiteboardFragment::class.jvmName)
-                } else {
-                    whiteboardFragment?.let { remove(it) }
+                if (whiteboardFragment == null && isEnabled) {
+                    add(R.id.whiteboard_container, WhiteboardFragment::class.java, null, WhiteboardFragment::class.jvmName)
+                    return@commit
                 }
+                binding.whiteboardContainer.isVisible = isEnabled
             }
         }
         viewModel.onCardUpdatedFlow.collectIn(lifecycleScope) {

--- a/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
@@ -33,6 +33,11 @@
                 android:layout_height="match_parent"
                 tools:backgroundTint="@color/white" />
 
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/whiteboard_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -117,6 +117,11 @@
                 android:layout_height="match_parent"
                 tools:backgroundTint="@color/white" />
 
+            <androidx.fragment.app.FragmentContainerView
+                android:id="@+id/whiteboard_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"/>
+
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
One of the behaviors of the old study screen people missed. It is reasonable if you want to quickly check something below the drawing then keep drawing

## How Has This Been Tested?

Emulator 31

https://github.com/user-attachments/assets/83235278-38b2-4ca5-8372-0ac3cd200a3c

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->