### PR TITLE
feat(study-screen): reduce feedback "hold" time

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
@@ -61,7 +61,7 @@ class AnswerFeedbackView : AppCompatImageView {
                         Runnable {
                             startAnimation(fadeOut)
                         }.also {
-                            handler.postDelayed(it, 600)
+                            handler.postDelayed(it, 400)
                         }
                 }
 


### PR DESCRIPTION
1000ms felt a bit too long on personal usage. The new 800ms is still 60% higher than the old 500ms of the bottom feedback, and probably more than 2 times longer than AnkiMobile's delay

## How Has This Been Tested?

Galaxy S23, Android 16

https://github.com/user-attachments/assets/2004a57c-2928-4a7c-9ccf-79bc67f03ed4

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->