### PR TITLE
Fix: Relevant toast message displayed #19876

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -525,7 +525,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
                 activity?.onBackPressedDispatcher?.onBackPressed()
             } else {
                 Timber.i("Download failed, update UI and provide option to retry")
-                context?.let { showThemedToast(it, R.string.something_wrong, false) }
+                context?.let { showThemedToast(it, R.string.shared_decks_login_required, false) }
                 // Update UI if download could not be successful
                 tryAgainButton.visibility = View.VISIBLE
                 openInBrowserButton.visibility = View.VISIBLE


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Adds the "Please log in to download more decks" toast message when trying to download shared decks through ankiweb on the 2nd try

## Fixes
* Fixes #19876

## How Has This Been Tested?
Tested via my Samsung S22, do not have a video for it but can confirm it displayed the correct toast message after applying the fix.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->