### PR TITLE
chore: convert LocaleSelectionDialog to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LocaleSelectionDialog.kt
@@ -31,6 +31,7 @@ import androidx.core.os.bundleOf
 import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.databinding.LocaleSelectionDialogBinding
 import com.ichi2.anki.dialogs.LocaleSelectionDialog.LocaleListAdapter.TextViewHolder
 import com.ichi2.anki.servicelayer.LanguageHintService
 import com.ichi2.ui.AccessibleSearchView
@@ -53,16 +54,13 @@ class LocaleSelectionDialog : AnalyticsDialogFragment() {
                 Locale.getAvailableLocales() + IPALanguage,
                 ::sendSelectionResult,
             )
-        val dialogView = layoutInflater.inflate(R.layout.locale_selection_dialog, null)
-        dialogView
-            .findViewById<RecyclerView>(R.id.locale_dialog_selection_list)
-            .adapter = localeAdapter
-        dialogView
-            .findViewById<Toolbar>(R.id.locale_dialog_selection_toolbar)
-            .setupMenuWith(localeAdapter)
+
+        val binding = LocaleSelectionDialogBinding.inflate(layoutInflater)
+        binding.localeDialogSelectionList.adapter = localeAdapter
+        binding.localeDialogSelectionToolbar.setupMenuWith(localeAdapter)
         return AlertDialog.Builder(requireContext()).show {
             cancelable(true)
-            customView(dialogView)
+            customView(binding.root)
         }
     }
 


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/8bf66d9bc13dd3549cadb38c8aa9b414352f182f

## How Has This Been Tested?
Brief test:

Open Dialog and set a languafge

Small Desktop API 34 Emulator

## Learning

This is where the refactoring starts to shine

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)