### PR TITLE
dev: ignore lint fixes in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -20,6 +20,9 @@ aff1bb87900f420ac5a717146d52c6df7b0d76b3
 d7f67ad091b76f83ac5dce0939656fd43d729e40
 cd444112f5098baf9899cd6a1349c1c29c56783f
 f86bf55c4063e0804cc1336dc0b8a54a5cef8a5f
+# copyright header lint fixes
+9aa3e1646a9393b0a5d6b793fb48bae4acbca399
+22c565c3bec6caae2ce5f1c0b8d7f9b8519ec1e3
 
 # Kotlin Migration
 # Only ignoring the `Java -> Kotlin` change, the file rename should not be visible in-IDE


### PR DESCRIPTION
The following commits were manual, but just updated the comment style on copyright headers

9aa3e1646a9393b0a5d6b793fb48bae4acbca399
22c565c3bec6caae2ce5f1c0b8d7f9b8519ec1e3

Not worthwhile including these in git blame

* Related to #19614 (ktlint)
* Fixes #19736

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)