### PR TITLE
Fix `repairCollection` requiring the database to be opened

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -74,12 +74,10 @@ open class BackupManager {
          *
          * @return whether the repair was successful
          */
-        fun repairCollection(col: Collection): Boolean {
-            val colFile = col.colDb
+        fun repairCollection(colFile: File): Boolean {
             val colPath = colFile.absolutePath
             val time = TimeManager.time
-            Timber.i("BackupManager - RepairCollection - Closing Collection")
-            col.close()
+            Timber.i("BackupManager - RepairCollection")
 
             // repair file
             val execString = "sqlite3 $colPath .dump | sqlite3 $colPath.tmp"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1948,11 +1948,11 @@ open class DeckPicker :
             Timber.d("doInBackgroundRepairCollection")
             val result =
                 withProgress(resources.getString(R.string.backup_repair_deck_progress)) {
-                    withCol {
-                        Timber.i("RepairCollection: Closing collection")
-                        close()
-                        BackupManager.repairCollection(this@withCol)
-                    }
+                    Timber.i("RepairCollection: Closing collection")
+                    CollectionManager.ensureClosed()
+                    val colFile =
+                        CollectionManager.collectionPathInValidFolder().requireDiskBasedCollection().colDb
+                    BackupManager.repairCollection(colFile)
                 }
             if (!result) {
                 showThemedToast(this@DeckPicker, resources.getString(R.string.deck_repair_error), true)


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
See https://github.com/ankidroid/Anki-Android/pull/19692.
Accessing the collection object to pass into `repairCollection` necessarily requires opening the database (such as using `withCol` scope), which will throw an exception if the collection is corrupt, preventing the repair from executing.


## Fixes
* Fixes #19902

## Approach
Changes the method to accept a `File` instead of a `Collection`. 
## How Has This Been Tested?
Standard test suite.

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->