### PR TITLE
fix(custom-study): `deferredDefaults` has not been initialized

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -55,6 +55,7 @@ import com.ichi2.anki.asyncIO
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.databinding.FragmentCustomStudyBinding
+import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.Companion.deferredDefaults
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_NEW
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.EXTEND_REV
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption.STUDY_AHEAD
@@ -123,7 +124,6 @@ import timber.log.Timber
  * @see TagLimitFragment
  */
 @KotlinCleanup("remove 'runBlocking' call'")
-@NeedsTest("deferredDefaults")
 class CustomStudyDialog : AnalyticsDialogFragment() {
     @VisibleForTesting(otherwise = PRIVATE)
     lateinit var binding: FragmentCustomStudyBinding
@@ -180,7 +180,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         super.onCreate(savedInstanceState)
         val option = selectedSubDialog
-        return if (option == null) {
+        return if (option == null || !defaultsAreInitialized()) {
             Timber.i("Showing Custom Study main menu")
             deferredDefaults = loadCustomStudyDefaults()
             // Select the specified deck
@@ -723,6 +723,13 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
          * This exists so we don't need to pass an unbounded object between fragments
          */
         private lateinit var deferredDefaults: Deferred<CustomStudyDefaults>
+
+        /**
+         * Whether [deferredDefaults] is initialized; false on restoring the dialog from process
+         * death
+         */
+        // This exists as `isInitialized` can't be checked in an instance of CustomStudyDialog
+        private fun defaultsAreInitialized(): Boolean = ::deferredDefaults.isInitialized
 
         /**
          * Creates an instance of the Custom Study Dialog: a user can select a custom study type

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ReflectionUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ReflectionUtils.kt
@@ -31,6 +31,11 @@ inline fun <reified T : Any> requireAccessibleJavaField(fieldName: String): Fiel
     )
 
 /**
+ * Reverts a `lateinit` field to uninitialized
+ */
+inline fun <reified T : Any> uninitializeField(fieldName: String) = requireAccessibleJavaField<T>(fieldName).set(null, null)
+
+/**
  * @param clazz Java class to get the field
  * @param methodName name of the method
  * @return a [Field] object with `isAccessible` set to true


### PR DESCRIPTION
## Purpose / Description
On restore from process death, the global variable is not set

We have two choices: 
* block the collection on obtaining the defaults
* go to the main 'custom study' menu


## Fixes
* Fixes #19905

## Approach
The operation can be slow, so we prefer to show the main menu

## How Has This Been Tested?
Unit test

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)