### PR TITLE
fix(study-options): load local images in deck description

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CollectionMediaImageGetter.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2025 Rakshita Chauhan <chauhanrakshita64@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.LevelListDrawable
+import android.text.Html
+import android.widget.TextView
+import androidx.annotation.CheckResult
+import androidx.core.graphics.drawable.toDrawable
+import com.ichi2.utils.BitmapUtil.decodeSampledBitmap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.File
+import java.lang.ref.WeakReference
+
+/**
+ * Async ImageGetter for Deck Descriptions.
+ * Resolves local images from the collection media directory and downsamples them to prevent OOM.
+ */
+class CollectionMediaImageGetter(
+    private val context: Context,
+    view: TextView,
+    private val mediaDir: File,
+    private val scope: CoroutineScope,
+) : Html.ImageGetter {
+    private val containerRef = WeakReference(view)
+    private var imageCount = 0
+
+    override fun getDrawable(source: String): Drawable {
+        // Return a transparent placeholder
+        val wrapper = createWrapper()
+
+        // limit the number of images loaded to prevent ANRs/OOMs
+        if (imageCount >= MAX_IMAGE_COUNT) {
+            return wrapper
+        }
+        imageCount++
+
+        scope.launch {
+            val bitmap = loadBitmap(source) ?: return@launch
+            updateWrapper(wrapper, bitmap)
+        }
+
+        return wrapper
+    }
+
+    private fun createWrapper(): LevelListDrawable {
+        val wrapper = LevelListDrawable()
+        val empty = Color.TRANSPARENT.toDrawable()
+        wrapper.addLevel(0, 0, empty)
+        wrapper.setBounds(0, 0, 0, 0)
+        return wrapper
+    }
+
+    @CheckResult
+    private suspend fun loadBitmap(source: String): Bitmap? =
+        withContext(Dispatchers.IO) {
+            try {
+                // Skip remote images
+                if (source.startsWith("http://") || source.startsWith("https://")) {
+                    return@withContext null
+                }
+
+                val localFile = File(mediaDir, source)
+
+                // Prevent path traversal to ensure file is inside media directory
+                if (!localFile.canonicalPath.startsWith(mediaDir.canonicalPath + File.separator)) {
+                    Timber.w("CollectionMediaImageGetter: Path traversal attempt detected: %s", source)
+                    return@withContext null
+                }
+
+                if (localFile.exists()) {
+                    // Use view width or fallback to screen width
+                    val reqWidth =
+                        (containerRef.get()?.width ?: 0)
+                            .coerceAtLeast(context.resources.displayMetrics.widthPixels)
+                    decodeSampledBitmap(localFile, reqWidth)
+                } else {
+                    null
+                }
+            } catch (e: Throwable) {
+                Timber.w(e, "Failed to load deck description image: %s", source)
+                null
+            }
+        }
+
+    private fun updateWrapper(
+        wrapper: LevelListDrawable,
+        bitmap: Bitmap,
+    ) {
+        val textView =
+            containerRef.get() ?: run {
+                Timber.w("CollectionMediaImageGetter: TextView reference lost")
+                return
+            }
+
+        val d = bitmap.toDrawable(context.resources)
+
+        var viewWidth = textView.width
+        if (viewWidth <= 0) viewWidth = context.resources.displayMetrics.widthPixels
+
+        val scale = viewWidth.toFloat() / bitmap.width
+        var w = bitmap.width
+        var h = bitmap.height
+
+        // Downscale to fit view if necessary
+        if (scale < 1.0f) {
+            w = viewWidth
+            h = (h * scale).toInt()
+        }
+
+        d.setBounds(0, 0, w, h)
+        wrapper.addLevel(1, 1, d)
+        wrapper.setBounds(0, 0, w, h)
+        wrapper.level = 1
+
+        // Force a re-layout to fit the new image dimensions
+        textView.text = textView.text
+    }
+
+    companion object {
+        private const val MAX_IMAGE_COUNT = 10
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/BitmapUtil.kt
@@ -23,6 +23,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.drawable.BitmapDrawable
 import android.widget.ImageView
+import androidx.annotation.CheckResult
 import com.ichi2.anki.CrashReportService
 import timber.log.Timber
 import java.io.File
@@ -89,5 +90,53 @@ object BitmapUtil {
         } catch (e: Exception) {
             Timber.e(e)
         }
+    }
+
+    /**
+     * Decodes a file, downsampling it to fit within the reqWidth.
+     */
+    @CheckResult
+    fun decodeSampledBitmap(
+        file: File,
+        reqWidth: Int,
+    ): Bitmap? {
+        // First decode with inJustDecodeBounds=true to check dimensions
+        val options = BitmapFactory.Options()
+        options.inJustDecodeBounds = true
+        BitmapFactory.decodeFile(file.absolutePath, options)
+
+        // Calculate inSampleSize
+        options.inSampleSize = calculateInSampleSize(options, reqWidth)
+
+        // Decode bitmap with inSampleSize set
+        options.inJustDecodeBounds = false
+        return BitmapFactory.decodeFile(file.absolutePath, options)
+    }
+
+    /**
+     * Calculate the largest inSampleSize value that is a power of 2 and keeps
+     * width larger than the requested width.
+     *
+     * @param options The Options object, which must have been populated by a previous
+     * decoding call with inJustDecodeBounds=true.
+     * @param reqWidth The target width to fit the image into.
+     */
+    @CheckResult
+    fun calculateInSampleSize(
+        options: BitmapFactory.Options,
+        reqWidth: Int,
+    ): Int {
+        // Raw width of image
+        val width = options.outWidth
+        var inSampleSize = 1
+
+        if (width <= reqWidth) {
+            return 1
+        }
+        val halfWidth = width / 2
+        while ((halfWidth / inSampleSize) >= reqWidth) {
+            inSampleSize *= 2
+        }
+        return inSampleSize
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Enables the loading of local images within the Deck Description (Study Options screen).

Currently, the standard `Html.fromHtml` implementation does not know how to resolve relative paths against the `collection.media` directory. This PR implements a custom image getter to locate and display these local files correctly.

Note: Remote images (http/https) are explicitly ignored to prioritize security and user privacy

## Fixes
* Related to #6669
## Approach
* Created `DeckDescriptionImageGetter` implementing `Html.ImageGetter`
* Resolves image source filenames against the `collection.media` directory
* Implemented asynchronous image loading using Kotlin Coroutines
* Applied bitmap downsampling to handle high-resolution images efficiently

## How Has This Been Tested?

**Manual Verification Steps:**
1. Open the "Add Note" screen and use the attachment icon to insert an image from the gallery
2. Copy the generated `<img src="...">` tag
3. Go to the Deck Picker, long-press a deck, and select **Edit description**
4. Paste the tag into the description dialog and save
5. Opened the **Study Options** screen and verified the local image displays correctly

**Performance Note**
Tested successfully with typical usage scenarios (5-10 images in the description) with no UI lag

**Automated Tests:**
* Ran `./gradlew jacocoUnitTestReport` (passed)
* Ran `./gradlew ktlintFormat` (passed)


https://github.com/user-attachments/assets/61247106-f232-4d90-b553-99e93702083b



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->