### PR TITLE
fix: flicker when adding a new note

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/FieldState.kt
@@ -27,7 +27,6 @@ import com.ichi2.anki.libanki.Field
 import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.Notetypes
 import com.ichi2.utils.MapUtil.getKeyByValue
-import java.util.ArrayList
 import kotlin.math.min
 
 /** Responsible for recreating EditFieldLines after NoteEditor operations
@@ -129,6 +128,8 @@ class FieldState private constructor(
 
             fun onActivityCreation(replaceNewlines: Boolean): FieldChangeType = fromType(Type.INIT, replaceNewlines)
 
+            fun onNoteAdded(replaceNewlines: Boolean): FieldChangeType = fromType(Type.NOTE_ADDED, replaceNewlines)
+
             private fun fromType(
                 type: Type,
                 replaceNewlines: Boolean,
@@ -142,6 +143,7 @@ class FieldState private constructor(
         CHANGE_FIELD_COUNT,
         REFRESH,
         REFRESH_WITH_MAP,
+        NOTE_ADDED,
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/FixedEditText.kt
@@ -136,8 +136,10 @@ open class FixedEditText : AppCompatEditText {
 
     /**
      * Focuses the edit text and opens the soft keyboard.
+     *
+     * @param runnable runnable executed after the field has focus
      */
-    fun focusWithKeyboard() {
-        setFocusAndOpenKeyboard(this)
+    fun focusWithKeyboard(runnable: Runnable? = null) {
+        setFocusAndOpenKeyboard(this, runnable)
     }
 }


### PR DESCRIPTION
## Purpose / Description
When adding a new note when there were 3 fields, there was an awkward flicker on the screen

## Fixes
* Unintentionally fixes #19916

## Approach
When adding a note, the note type does not update, 

This means we can avoid recreating the fields, which stops the keyboard being closed and opened.

One this was fixed, there was an separate visual issue: 

* fields are cleared
* then, focus moves to the first field

If the current field had text, this caused two 'selection changed' visual updates, which was distracting.

So I added & used an extension to handle this

## How Has This Been Tested?
Pixel 9 Pro, Android 16

* Add a note with first field
* Add a note with pinned fields (1st/2nd/1st & 2nd)

----

There are a few flaky tests, I /think/ these are generally flaky, and I'll need to look into them

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)