### PR TITLE
fix: Resolve flaky test in PrefsSearchBarTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.preferences
 
+import android.os.Looper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.bytehamster.lib.preferencesearch.PreferenceItem
 import com.bytehamster.lib.preferencesearch.SearchConfiguration
@@ -25,6 +26,7 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
+import org.robolectric.Shadows.shadowOf
 import kotlin.test.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
@@ -67,7 +69,8 @@ class PrefsSearchBarTest : RobolectricTest() {
         for (resId in allResIds) {
             val fragment = getFragmentFromXmlRes(resId)
 
-            assertNotNull(fragment)
+            val resourceName = targetContext.resources.getResourceEntryName(resId)
+            assertNotNull(fragment, "Fragment for resource '$resourceName' (ID: $resId) should not be null")
 
             // Special handling for ControlsSettingsFragment which handles multiple XML resources
             val expectedResourceId =
@@ -86,11 +89,17 @@ class PrefsSearchBarTest : RobolectricTest() {
 
     private fun getPreferencesActivity(): PreferencesActivity {
         val intent = PreferencesActivity.getIntent(targetContext)
-        return Robolectric
-            .buildActivity(PreferencesActivity::class.java, intent)
-            .create()
-            .start()
-            .resume()
-            .get()
+        val activity =
+            Robolectric
+                .buildActivity(PreferencesActivity::class.java, intent)
+                .create()
+                .start()
+                .resume()
+                .get()
+
+        // Core fix: Wait for asynchronous operations to complete
+        shadowOf(Looper.getMainLooper()).idle()
+
+        return activity
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The `PrefsSearchBarTest` was intermittently failing (flaky) because it didn't account for asynchronous operations during the `PreferencesActivity` initialization. This PR ensures the test environment is stable before assertions are run.

## Fixes
* Fixes #19918

## Approach
1. **Idle Main Looper**: Added `shadowOf(Looper.getMainLooper()).idle()` after building the activity. This ensures all pending tasks on the main thread (like fragment transactions or search indexing) are completed before the test proceeds.
2. **Improved Debugging**: Added a descriptive error message to `assertNotNull` that includes the resource name. This helps identify exactly which XML resource is failing if a similar issue occurs in the future.

## How Has This Been Tested?
I ran the `PrefsSearchBarTest` locally on my development machine.
- **OS**: Windows 11 (Galaxy Book 4 Ultra)
- **IDE**: Android Studio
- **Command**: Ran `PrefsSearchBarTest` using the IDE's test runner and verified it passes consistently.

## Learning (optional, can help others)
I learned that Robolectric tests can exhibit non-deterministic behavior if an Activity schedules work on the main looper during its lifecycle. Using shadowOf(Looper.getMainLooper()).idle() is a crucial step to synchronize the test execution with the Android main looper, ensuring consistent and reliable results.

## Checklist
_Please, go through these checks before submitting the PR._

- [ x ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ x ] You have commented your code, particularly in hard-to-understand areas
- [ x ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner]