### PR TITLE
fix(note-editor): issues with pinned fields

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2148,6 +2148,8 @@ class NoteEditorFragment :
     ) {
         if (currentFields[index].sticky) {
             toggleStickyText.getOrPut(index) { "" }
+        } else {
+            toggleStickyText.remove(index)
         }
         if (toggleStickyText[index] == null) {
             toggleStickyButton.background.alpha = 64
@@ -2445,7 +2447,9 @@ class NoteEditorFragment :
             }
         } else {
             populateEditFields(changeType, false)
-            updateFieldsFromStickyText()
+            if (changeType.type != Type.CHANGE_FIELD_COUNT) {
+                updateFieldsFromStickyText()
+            }
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -283,7 +283,6 @@ class NoteEditorTest : RobolectricTest() {
         }
 
     @Test
-    @Ignore("Fix this alongside 15086")
     fun `sticky fields do not impact current values`() =
         runTest {
             val basic = col.notetypes.basic
@@ -304,7 +303,6 @@ class NoteEditorTest : RobolectricTest() {
         }
 
     @Test
-    @Ignore("15086")
     fun `sticky fields are updated per note type`() =
         runTest {
             val basic = col.notetypes.basic


### PR DESCRIPTION
## Purpose / Description

There were various longstanding issues with pinned fields.

I don't use this feature, but I've been aware of the issues. Time to do something about it

## Fixes
* Fixes #15086

## Approach

Special case `CHANGE_FIELD_COUNT` => comes from using the spinner in the 'ADD' state.
* In this case, field values should not be removed due to sticky fields
* Remove the 'sticky' bit from the UI when it was previously set.

## How Has This Been Tested?
I added unit tests showcasing the issues before I fixed the issue.

I went through all possibilities of 'sticky fields' which I could think of on my Google Pixel 9 Pro (Android 16)

## Learning (optional, can help others)

In general, I'm unhappy with the note editor. 

This is mostly my own doing: badly structured code in Java, which I [we] added to, and never got around to simplifying with the Kotlin conversion as it was planned to be replaced. This bug should have been fixed, but there's always been other things to do.

In addition, much of the complexity stems from 'Change Note Type' functionality, which should be removed in 2.24

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)