### PR TITLE
Improve error reporting in PrefsSearchBarTest (#19918)

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
@@ -67,7 +67,9 @@ class PrefsSearchBarTest : RobolectricTest() {
         for (resId in allResIds) {
             val fragment = getFragmentFromXmlRes(resId)
 
-            assertNotNull(fragment)
+            val resName = targetContext.resources.getResourceName(resId)
+
+            assertNotNull(fragment, message = "Could not resolve fragment for resource: $resName")
 
             // Special handling for ControlsSettingsFragment which handles multiple XML resources
             val expectedResourceId =


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The current PrefsSearchBarTest fails with a generic AssertionError: expected not <null> when a resource ID cannot be resolved to a fragment. This makes it difficult to identify which XML resource is causing flaky test failures. This PR improves error reporting by including resource name and ID in the assertion message.

## Fixes
* Fixes #19918 

## Approach
-> Added a try-catch block to get name of the resource tested.
-> Updated assertNotNull to include a descriptive message

## How Has This Been Tested?
Environment: macOS, Android Studio
-> Run tests to check it passes under normal conditions
-> Reproducing of Error: Forced a error by passing null
Before:
<img width="1336" height="143" alt="Screenshot 2025-12-25 at 1 24 57 AM" src="https://github.com/user-attachments/assets/988f100d-976b-4ad1-9b3b-2ee252d92b73" />
After:
<img width="1324" height="112" alt="Screenshot 2025-12-25 at 1 33 13 AM" src="https://github.com/user-attachments/assets/29995418-1918-43de-97a9-54949ed43508" />


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->