### PR TITLE
fix(new-study-screen): Set Due Date snackbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SingleFragmentActivity.kt
@@ -26,6 +26,8 @@ import com.ichi2.anki.SingleFragmentActivity.Companion.getIntent
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
+import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
+import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.ui.windows.managespace.ManageSpaceActivity
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.themes.setTransparentStatusBar
@@ -43,7 +45,13 @@ import kotlin.reflect.jvm.jvmName
  *
  * [getIntent] can be used as an easy way to build a [SingleFragmentActivity]
  */
-open class SingleFragmentActivity : AnkiActivity(R.layout.single_fragment_activity) {
+open class SingleFragmentActivity :
+    AnkiActivity(R.layout.single_fragment_activity),
+    BaseSnackbarBuilderProvider {
+    // delegate to the fragment in all cases
+    override val baseSnackbarBuilder: SnackbarBuilder
+        get() = (fragment as? BaseSnackbarBuilderProvider)?.baseSnackbarBuilder ?: { }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -57,6 +57,7 @@ import com.ichi2.anki.servicelayer.getFSRSStatus
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.utils.doOnImeHidden
 import com.ichi2.anki.utils.openUrl
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.AndroidUiUtils
@@ -430,7 +431,10 @@ private fun AnkiActivity.updateDueDate(
             return@asyncCatching null
         }
         Timber.d("updated %d cards", cardsUpdated)
-        showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
+        // Ensure the snackbar doesn't appear in the middle of the screen
+        doOnImeHidden {
+            showSnackbar(TR.schedulingSetDueDateDone(cardsUpdated), Snackbar.LENGTH_SHORT)
+        }
         return@asyncCatching cardsUpdated
     }
 


### PR DESCRIPTION
## Purpose / Description
Set Due Date snackbar was in the wrong place

## Fixes
* Fixes #19915

## Approach
* Handle `showSnackbar` on `SingleFragmentActivity`

## How Has This Been Tested?
Pixel 9 Pro - snackbar is in the correct location


## Learning (optional, can help others)
Lots of timing issues with the IME, showing the snackbar too early put it in the middle of the screen

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)