### PR TITLE
feat: verify webview version and prevent loading blank screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -186,7 +186,6 @@ import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils
-import com.ichi2.utils.checkWebviewVersion
 import com.ichi2.utils.configureView
 import com.ichi2.utils.customView
 import com.ichi2.utils.dp
@@ -194,6 +193,7 @@ import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
+import com.ichi2.utils.showDialogIfWebViewOutdated
 import com.ichi2.utils.title
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -554,7 +554,7 @@ open class DeckPicker :
 
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
-        checkWebviewVersion(this)
+        with(this) { showDialogIfWebViewOutdated() }
 
         // If a review reminder deserialization error has recently occurred
         // (ex. on app boot, when the app opened, etc.), inform the user via a dialog

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiPackageImporterFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiPackageImporterFragment.kt
@@ -25,12 +25,16 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.hideShowButtonCss
+import com.ichi2.utils.OLDEST_WORKING_WEBVIEW_VERSION
+import com.ichi2.utils.WebViewVersion
 
 class AnkiPackageImporterFragment : PageFragment() {
     override val pagePath: String by lazy {
         val filePath = requireArguments().getString(KEY_FILE_PATH)
         "import-anki-package$filePath"
     }
+
+    override val minimumWebViewVersion: WebViewVersion = OLDEST_WORKING_WEBVIEW_VERSION
 
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
         // the back callback is only enabled when import is running and showing progress

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/CsvImporter.kt
@@ -27,6 +27,8 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.hideShowButtonCss
+import com.ichi2.utils.OLDEST_WORKING_WEBVIEW_VERSION
+import com.ichi2.utils.WebViewVersion
 
 /**
  * Anki page used to import text/csv files
@@ -36,6 +38,8 @@ class CsvImporter : PageFragment() {
         val filePath = requireArguments().getString(KEY_FILE_PATH)
         "import-csv$filePath"
     }
+
+    override val minimumWebViewVersion: WebViewVersion = OLDEST_WORKING_WEBVIEW_VERSION
 
     override fun onCreateWebViewClient(savedInstanceState: Bundle?): PageWebViewClient {
         // the back callback is only enabled when import is running and showing progress

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PageFragment.kt
@@ -30,6 +30,8 @@ import com.ichi2.anki.R
 import com.ichi2.anki.workarounds.OnWebViewRecreatedListener
 import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.themes.Themes
+import com.ichi2.utils.WebViewVersion
+import com.ichi2.utils.showDialogIfWebViewOutdated
 import timber.log.Timber
 
 /**
@@ -63,6 +65,8 @@ abstract class PageFragment(
     protected open fun onCreateWebViewClient(savedInstanceState: Bundle?) = PageWebViewClient()
 
     protected open fun onWebViewCreated() { }
+
+    protected open val minimumWebViewVersion: WebViewVersion? = null
 
     /**
      * When the webview calls `BridgeCommand("foo")`, the PageFragment execute `bridgeCommands["foo"]`.
@@ -103,10 +107,21 @@ abstract class PageFragment(
         server = AnkiServer(this).also { it.start() }
         webViewLayout = view.findViewById(R.id.webview_layout)
 
+        minimumWebViewVersion?.let { minVersion ->
+            val isOutdated =
+                with(requireContext()) {
+                    showDialogIfWebViewOutdated(minVersion) {
+                        requireActivity().finish()
+                    }
+                }
+            if (isOutdated) {
+                Timber.w("${this::class.simpleName} requires modern WebView version, aborting load")
+                return
+            }
+        }
         view.findViewById<MaterialToolbar>(R.id.toolbar)?.setNavigationOnClickListener {
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
-
         setupWebView(savedInstanceState)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/WebViewUtils.kt
@@ -27,33 +27,52 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.pm.PackageInfoCompat
 import androidx.webkit.WebViewCompat
-import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.utils.openUrl
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
-internal const val OLDEST_WORKING_WEBVIEW_VERSION_CODE = 418306960L
-internal const val OLDEST_WORKING_WEBVIEW_VERSION = 85
+@JvmInline
+value class WebViewVersion(
+    val value: Int,
+)
+
+@JvmInline
+value class WebViewVersionCode(
+    val value: Long,
+)
+
+/** The Android package version code which corresponds to the Webview version. */
+internal val OLDEST_WORKING_WEBVIEW_VERSION_CODE = WebViewVersionCode(418306960L)
+
+/** The minimum supported Webview version(Human readable). */
+internal val OLDEST_WORKING_WEBVIEW_VERSION = WebViewVersion(85)
 
 /**
  * Shows a dialog if the current WebView version is older than the last supported version.
  */
-fun checkWebviewVersion(activity: AnkiActivity) {
-    val userVisibleCode = getChromeLikeWebViewVersionIfOutdated(activity) ?: return
+
+context(context: Context)
+fun showDialogIfWebViewOutdated(
+    minimumWebViewVersion: WebViewVersion = OLDEST_WORKING_WEBVIEW_VERSION,
+    onOutdated: () -> Unit = {},
+): Boolean {
+    val userVisibleCode = getChromeLikeWebViewVersionIfOutdated(context, minimumWebViewVersion) ?: return false
 
     // Provide guidance to the user if the WebView is outdated
-    val webviewPackageInfo = getAndroidSystemWebViewPackageInfo(activity.packageManager)
-    val legacyWebViewPackageInfo = getLegacyWebViewPackageInfo(activity.packageManager)
+    val webviewPackageInfo = WebViewCompat.getCurrentWebViewPackage(context)
+    val legacyWebViewPackageInfo = getLegacyWebViewPackageInfo(context.packageManager)
     // TODO modify the alert dialog text to handle the usage of developer builds for system WebView
     if (legacyWebViewPackageInfo != null) {
         Timber.w("WebView is outdated. %s: %s", legacyWebViewPackageInfo.packageName, legacyWebViewPackageInfo.versionName)
-        showOutdatedWebViewDialog(activity, userVisibleCode, R.string.link_legacy_webview_update)
+        showOutdatedWebViewDialog(context, userVisibleCode, R.string.link_legacy_webview_update, onOutdated)
     } else {
         Timber.w("WebView is outdated. %s: %s", webviewPackageInfo?.packageName, webviewPackageInfo?.versionName)
-        showOutdatedWebViewDialog(activity, userVisibleCode, R.string.link_webview_update)
+        showOutdatedWebViewDialog(context, userVisibleCode, R.string.link_webview_update, onOutdated)
     }
+    return true
 }
 
 @MainThread
@@ -77,16 +96,25 @@ fun getWebviewUserAgent(context: Context): String? {
  * Returns a Chrome-like WebView version if it is outdated, otherwise null if
  * cannot be determined at all or if okay
  */
-private fun getChromeLikeWebViewVersionIfOutdated(activity: AnkiActivity): Int? {
+private fun getChromeLikeWebViewVersionIfOutdated(
+    context: Context,
+    minimumWebViewVersion: WebViewVersion,
+): Int? {
     // If we cannot get the package information at all, return null
-    val webviewPackageInfo = getAndroidSystemWebViewPackageInfo(activity.packageManager) ?: return null
+    val webviewPackageInfo = WebViewCompat.getCurrentWebViewPackage(context) ?: return null
     val webviewVersion =
         webviewPackageInfo.versionName ?: run {
             Timber.w("Failed to obtain WebView version")
             return null
         }
     val versionCode = PackageInfoCompat.getLongVersionCode(webviewPackageInfo)
-    return checkWebViewVersionComponents(webviewPackageInfo.packageName, webviewVersion, versionCode, getWebviewUserAgent(activity))
+    return checkWebViewVersionComponents(
+        webviewPackageInfo.packageName,
+        webviewVersion,
+        versionCode,
+        getWebviewUserAgent(context),
+        minimumWebViewVersion,
+    )
 }
 
 @VisibleForTesting
@@ -95,9 +123,26 @@ fun checkWebViewVersionComponents(
     webviewVersion: String,
     versionCode: Long,
     userAgent: String?,
+    minimumWebViewVersion: WebViewVersion = OLDEST_WORKING_WEBVIEW_VERSION,
 ): Int? {
+    // Sometimes the webview version code appears too old, and the package name does as well,
+    // but it's a webview that advertises modern capabilities via User-Agent in "Chrome" section
+    // Our warning is purely advisory, so, let's let those through if User-Agent looks okay
+    userAgent?.let {
+        val chromeRegex = """Chrome/(\d+)""".toRegex()
+        val matchResult = chromeRegex.find(userAgent)?.groupValues?.get(1)
+        matchResult?.toInt()?.let {
+            if (it >= minimumWebViewVersion.value) {
+                // If the User-Agent says we are modern, trust it and skip further checks.
+                return null
+            } else {
+                // If the User-Agent is explicitly below the floor, return it immediately.
+                return it
+            }
+        }
+    }
     // Checking the version code works for most webview packages
-    if (versionCode >= OLDEST_WORKING_WEBVIEW_VERSION_CODE) {
+    if (versionCode >= OLDEST_WORKING_WEBVIEW_VERSION_CODE.value) {
         Timber.d(
             "WebView is up to date. %s: %s(%s)",
             packageName,
@@ -106,23 +151,7 @@ fun checkWebViewVersionComponents(
         )
         return null
     }
-
-    // Sometimes the webview version code appears too old, and the package name does as well,
-    // but it's a webview that advertises modern capabilities via User-Agent in "Chrome" section
-    // Our warning is purely advisory, so, let's let those through if User-Agent looks okay
-    userAgent?.let {
-        val chromeRegex = """Chrome/(\d+)""".toRegex()
-        val matchResult = chromeRegex.find(userAgent)?.groupValues?.get(1)
-        matchResult?.toInt()?.let {
-            if (it < OLDEST_WORKING_WEBVIEW_VERSION) {
-                // If we got here, even the User-Agent says it's incompatible, return something
-                // potentially useful to the user as a browser version
-                return it
-            }
-        }
-    }
-
-    return null
+    return webviewVersion.split('.').firstOrNull()?.toIntOrNull()
 }
 
 data class WebViewInfo(
@@ -153,15 +182,17 @@ suspend fun getWebViewInfo(context: Context): WebViewInfo =
     }
 
 private fun showOutdatedWebViewDialog(
-    activity: AnkiActivity,
+    context: Context,
     installedVersion: Int,
     @StringRes learnMoreUrl: Int,
+    onDismiss: () -> Unit = {},
 ) {
-    AlertDialog.Builder(activity).show {
-        setMessage(activity.getString(R.string.webview_update_message, installedVersion, OLDEST_WORKING_WEBVIEW_VERSION))
+    AlertDialog.Builder(context).show {
+        setMessage(context.getString(R.string.webview_update_message, installedVersion, OLDEST_WORKING_WEBVIEW_VERSION.value))
         setPositiveButton(R.string.scoped_storage_learn_more) { _, _ ->
-            activity.openUrl(learnMoreUrl)
+            context.openUrl(learnMoreUrl)
         }
+        setOnDismissListener { onDismiss() }
     }
 }
 
@@ -171,26 +202,6 @@ private fun getLegacyWebViewPackageInfo(packageManager: PackageManager): Package
     } catch (_: PackageManager.NameNotFoundException) {
         null
     }
-
-/**
- * Returns a [PackageInfo] from the current system WebView, or `null` if unavailable
- */
-private fun getAndroidSystemWebViewPackageInfo(packageManager: PackageManager): PackageInfo? {
-    fun getPackage(packageName: String): PackageInfo? =
-        try {
-            packageManager.getPackageInfo(packageName, 0)
-        } catch (_: PackageManager.NameNotFoundException) {
-            null
-        }
-
-    // The WebView is called com.android.webview by default.
-    // Partner devices which ship with Google applications ship the Google-specific version
-    // of the WebView called com.google.android.webview.
-    // https://issues.chromium.org/issues/40419837#comment10
-
-    return getPackage("com.google.android.webview")
-        ?: getPackage("com.android.webview") // com.android.webview is used on API 24
-}
 
 /**
  * Enables debugging of web contents (HTML / CSS / JavaScript)

--- a/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/WebViewUtilsTest.kt
@@ -28,7 +28,7 @@ class WebViewUtilsTest {
             checkWebViewVersionComponents(
                 "com.google.android.webview",
                 "53.0.2785.124",
-                OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1,
+                OLDEST_WORKING_WEBVIEW_VERSION_CODE.value - 1,
                 "Mozilla/5.0 (Linux; Android 7.0; Android SDK built for arm64 Build/NYC; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36",
             ),
             equalTo(53),
@@ -50,10 +50,20 @@ class WebViewUtilsTest {
             checkWebViewVersionComponents(
                 "com.google.android.webview",
                 "74.0.0.0",
-                OLDEST_WORKING_WEBVIEW_VERSION_CODE - 1,
+                OLDEST_WORKING_WEBVIEW_VERSION_CODE.value - 1,
                 "Mozilla/5.0 (Linux; Android 9; SM-A730F Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/130.0.6723.102 Mobile Safari/537.36",
             ),
             equalTo(null),
+        )
+        assertThat(
+            "Known old huawei webview determined correctly",
+            checkWebViewVersionComponents(
+                "com.huawei.webview",
+                "unknown",
+                356L,
+                "Mozilla/5.0 (Linux; Android 10; CDY-AN90 Build/HUAWEICDY-AN90; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36",
+            ),
+            equalTo(78),
         )
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This is enhancement to prevent the Blank Screen bug on devices with an outdated WebView (e.g-old huawei models) by checking the  WebView version. It will show the alert dialog when the user with an outdated webview tries to import decks.

## Fixes
* Fixes #19914 

## Approach
1. implemented logic to extract the Chromium version from the User-Agent string. This correctly identifies outdated engines even when OEMs report inflated versionCode values (e.g., version code 356  (provided by the user's debug info))

2. Added a requiresModernWebView() hook in PageFragment (defaulting to false) and removed checkWebViewVersion(this) from DeckPicker as it was causing dialog to show on app launch in main screen

3. Changed checkWebviewVersion function in WebViewUtils.kt to return a Boolean. It returns true only if the webview is outdated and a warning dialog is displayed.

4. In PageFragment.onViewCreated, if the guard triggers, the app immediately calls onBackPressed() and returns. This physically prevents the WebView from initializing, avoiding the "White Screen" crash on incompatible devices.

## How Has This Been Tested?
Unit Testing:
Included  a test case using the  version code from the debug info provided by the huawei user to ensure the User-Agent audit correctly identifies outdated webviews
 All the tests pass:
```
./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.utils.WebViewUtilsTest"
Parallel Configuration Cache is an incubating feature.
[Incubating] Problems report is available at: file:///home/dhanush/Anki-Android/build/reports/problems/problems-report.html
Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.
You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.
For more on this, please refer to https://docs.gradle.org/9.2.1/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.
BUILD SUCCESSFUL in 12s
135 actionable tasks: 8 executed, 127 up-to-date
```


## Learning (optional, can help others)
None


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->