### PR TITLE
fix(set due date dialog): set TabLayout background to transparent

### DIFF
--- a/AnkiDroid/src/main/res/layout/dialog_set_due_date.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_set_due_date.xml
@@ -30,6 +30,7 @@
 
         <com.google.android.material.tabs.TabLayout
             android:id="@+id/tab_layout"
+            android:background="@android:color/transparent"
             android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes tab layout color inconsistency in set due date dialog when theme is black/dark

## Fixes
* Fixes #19936 

## Approach
Sets background color of tab layout to transparent

## How Has This Been Tested?
Tested on the following Android Emulators:
Pixel Tablet API 36

Before:
<img width="2560" height="1600" alt="Screenshot_20251227_152813" src="https://github.com/user-attachments/assets/1da6c387-b55a-4075-bea8-d777ad6eb904" />

After:
<img width="2560" height="1600" alt="Screenshot_20251227_153031" src="https://github.com/user-attachments/assets/b0872320-8816-4346-8f35-830a6f4e34ee" />


## Learning (optional, can help others)
-  First encountered during #18602 
- caused by commit [`42450f1`](https://github.com/ankidroid/Anki-Android/commit/42450f1386cc21a68964dccf154d21c457ea177b)

 **Why the TabLayout background changed**
- ViewBinding requires us to inflate the layout manually. In commit [`42450f1`](https://github.com/ankidroid/Anki-Android/commit/42450f1386cc21a68964dccf154d21c457ea177b), this changed *who* provides the `LayoutInflater`.
- Previously, we used `setView(R.layout.dialog_set_due_date)`, which allows `MaterialAlertDialog` to inflate the layout using its **dialog theme overlay**.
- After migrating to ViewBinding, we now call `DialogSetDueDateBinding.inflate(layoutInflater)`. This uses a plain inflater **without** the dialog’s theme overlay.
- `TabLayout` derives its default background color from the currently applied theme/overlay. Because the dialog overlay was no longer applied during inflation, it fell back to the app’s surface color, resulting in the visible theme-colored bar.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->