### PR TITLE
fix (tablet): Resizing divider visibility

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -338,6 +338,7 @@ open class CardBrowser :
             )
         } else {
             binding.noteEditorFrame?.isVisible = false
+            binding.cardBrowserResizingDivider?.isVisible = false
         }
 
         // must be called once we have an accessible collection


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes the resizing divider being visible in the card browser screen
## Fixes
* Fixes #19852 

## Approach
binding.cardBrowserResizingDivider?.isVisible = false
This line was to be added.

## How Has This Been Tested?
Before:
<img width="1280" height="806" alt="image" src="https://github.com/user-attachments/assets/df347eda-3cb3-4be2-ab00-d64c739d866c" />
After:
<img width="1280" height="807" alt="image" src="https://github.com/user-attachments/assets/3080db37-e02f-4798-8a1e-437d009c4f6d" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->