### PR TITLE
Convert FindAndReplaceDialogFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/res/layout/fragment_find_replace.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_find_replace.xml
@@ -99,7 +99,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent" />
         <CheckBox
-            android:id="@+id/check_only_selected_notes"
+            android:id="@+id/only_selected_notes_check_box"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
@@ -111,22 +111,22 @@
             app:layout_constraintHorizontal_bias="0.0"
             tools:text="Selected notes only"/>
         <CheckBox
-            android:id="@+id/check_ignore_case"
+            android:id="@+id/ignore_case_check_box"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:checked="true"
             android:layout_marginStart="2dp"
-            app:layout_constraintTop_toBottomOf="@id/check_only_selected_notes"
+            app:layout_constraintTop_toBottomOf="@id/only_selected_notes_check_box"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
             tools:text="Ignore case"/>
         <CheckBox
-            android:id="@+id/check_input_as_regex"
+            android:id="@+id/input_as_regex_check_box"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="2dp"
-            app:layout_constraintTop_toBottomOf="@id/check_ignore_case"
+            app:layout_constraintTop_toBottomOf="@id/ignore_case_check_box"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.0"
@@ -137,7 +137,7 @@
             android:id="@+id/content_views_group"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            app:constraint_referenced_ids="label_find,input_search,label_replace,input_replace,label_in,fields_selector,check_only_selected_notes,check_ignore_case,check_input_as_regex"
+            app:constraint_referenced_ids="label_find,input_search,label_replace,input_replace,label_in,fields_selector,only_selected_notes_check_box,ignore_case_check_box,input_as_regex_check_box"
             tools:visibility="visible"/>
 
         <com.google.android.material.progressindicator.CircularProgressIndicator

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1248,11 +1248,11 @@ class CardBrowserTest : RobolectricTest() {
         withBrowser {
             showFindAndReplaceDialog()
             // nothing selected so checkbox 'Only selected notes' is not available
-            onView(withId(R.id.check_only_selected_notes)).inRoot(isDialog()).check(matches(isNotEnabled()))
-            onView(withId(R.id.check_only_selected_notes)).inRoot(isDialog()).check(matches(isNotChecked()))
+            onView(withId(R.id.only_selected_notes_check_box)).inRoot(isDialog()).check(matches(isNotEnabled()))
+            onView(withId(R.id.only_selected_notes_check_box)).inRoot(isDialog()).check(matches(isNotChecked()))
             val fieldSelectorAdapter = getFindReplaceFieldsAdapter()
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).check(matches(isChecked()))
-            onView(withId(R.id.check_input_as_regex)).inRoot(isDialog()).check(matches(isNotChecked()))
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).check(matches(isChecked()))
+            onView(withId(R.id.input_as_regex_check_box)).inRoot(isDialog()).check(matches(isNotChecked()))
             // as nothing is selected the fields selector has only the two default options
             assertNotNull(fieldSelectorAdapter, "Fields adapter was not set")
             assertEquals(2, fieldSelectorAdapter.count)
@@ -1317,12 +1317,12 @@ class CardBrowserTest : RobolectricTest() {
             openFindAndReplace()
             onView(withId(R.id.input_search)).inRoot(isDialog()).perform(ViewActions.typeText("k"))
             onView(withId(R.id.input_replace)).inRoot(isDialog()).perform(ViewActions.typeText("X"))
-            onView(withId(R.id.check_input_as_regex)).inRoot(isDialog()).perform(scrollCompletelyTo())
+            onView(withId(R.id.input_as_regex_check_box)).inRoot(isDialog()).perform(scrollCompletelyTo())
             onData(allOf(`is`(instanceOf(String::class.java)), `is`("Afield0")))
                 .inAdapterView(withId(R.id.fields_selector))
                 .perform(click())
             onView(withId(R.id.fields_selector)).check(matches(withSpinnerText(containsString("Afield0"))))
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).check(matches(isChecked()))
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).check(matches(isChecked()))
             // although the positive button exists, clicking it with Espresso doesn't work
             //     onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click())
             // so simulate clicking the positive button by running the associated method directly
@@ -1351,14 +1351,14 @@ class CardBrowserTest : RobolectricTest() {
             openFindAndReplace()
             onView(withId(R.id.input_search)).inRoot(isDialog()).perform(ViewActions.typeText("k"))
             onView(withId(R.id.input_replace)).inRoot(isDialog()).perform(ViewActions.typeText("X"))
-            onView(withId(R.id.check_input_as_regex)).inRoot(isDialog()).perform(scrollCompletelyTo())
+            onView(withId(R.id.input_as_regex_check_box)).inRoot(isDialog()).perform(scrollCompletelyTo())
             onData(allOf(`is`(instanceOf(String::class.java)), `is`("Afield0")))
                 .inAdapterView(withId(R.id.fields_selector))
                 .perform(click())
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).perform(scrollCompletelyTo())
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).check(matches(isChecked()))
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).perform(click())
-            onView(withId(R.id.check_ignore_case)).inRoot(isDialog()).check(matches(isNotChecked()))
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).perform(scrollCompletelyTo())
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).check(matches(isChecked()))
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).perform(click())
+            onView(withId(R.id.ignore_case_check_box)).inRoot(isDialog()).check(matches(isNotChecked()))
             // although the positive button exists, clicking it with Espresso doesn't work
             //     onView(withId(android.R.id.button1)).inRoot(isDialog()).perform(click())
             // so simulate clicking the positive button by running the associated method directly


### PR DESCRIPTION
## Purpose / Description

Changes FindAndReplaceDialogFragment to use ViewBinding before moving to production. 

<img width="270" height="600" alt="Screenshot_20251227_150742" src="https://github.com/user-attachments/assets/cc3491e8-330b-4935-9efe-92e44b3dda41" /><img width="270" height="600" alt="Screenshot_20251227_150613" src="https://github.com/user-attachments/assets/7ad9f33b-2d6f-492c-b98f-3628780cf00c" />

<img width="270" height="600" alt="Screenshot_20251227_150635" src="https://github.com/user-attachments/assets/403998b2-d0c7-4c33-a16d-131b09ab4d62" /><img width="270" height="600" alt="Screenshot_20251227_150657" src="https://github.com/user-attachments/assets/588e2902-c085-4d2f-bb25-3077f31ec026" />

## Fixes
* Related to #19929
* Related to #11116

## How Has This Been Tested?

Tested again the behavior of the dialog, ran tests, verified appearance in all themes.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
