### PR TITLE
fix(study-screen): counts reset on process death

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -388,13 +388,13 @@ class ReviewerFragment :
     private fun setupCounts() {
         viewModel.countsFlow
             .flowWithLifecycle(lifecycle)
-            .collectLatestIn(lifecycleScope) { (counts, countsType) ->
-                binding.newCount.text = counts.new.toString()
-                binding.learnCount.text = counts.lrn.toString()
-                binding.reviewCount.text = counts.rev.toString()
+            .collectLatestIn(lifecycleScope) { counts ->
+                binding.newCount.text = counts.new
+                binding.learnCount.text = counts.learn
+                binding.reviewCount.text = counts.review
 
                 val currentCount =
-                    when (countsType) {
+                    when (counts.activeQueue) {
                         Counts.Queue.NEW -> binding.newCount
                         Counts.Queue.LRN -> binding.learnCount
                         Counts.Queue.REV -> binding.reviewCount

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -102,7 +102,7 @@ class ReviewerViewModel(
     val canSuspendNoteFlow = MutableStateFlow(true)
     val undoLabelFlow = MutableStateFlow<String?>(null)
     val redoLabelFlow = MutableStateFlow<String?>(null)
-    val countsFlow = MutableStateFlow(Counts() to Counts.Queue.NEW)
+    val countsFlow = savedStateHandle.getMutableStateFlow(KEY_COUNTS, StudyCounts())
     val typeAnswerFlow = MutableStateFlow<TypeAnswer?>(null)
     val onTypedAnswerResultFlow = MutableSharedFlow<CompletableDeferred<String>>()
     val onCardUpdatedFlow = MutableSharedFlow<Unit>()
@@ -535,7 +535,7 @@ class ReviewerViewModel(
         loadAndPlayMedia(CardSide.QUESTION)
         canBuryNoteFlow.emit(isBuryNoteAvailable(card))
         canSuspendNoteFlow.emit(isSuspendNoteAvailable(card))
-        countsFlow.emit(state.counts to state.countsIndex)
+        countsFlow.emit(StudyCounts(state))
     }
 
     override suspend fun typeAnsFilter(text: String): String {
@@ -751,5 +751,6 @@ class ReviewerViewModel(
 
     companion object {
         private const val KEY_PREVIOUS_CARD_ID = "key_previous_card_id"
+        private const val KEY_COUNTS = "counts"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/StudyCounts.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/StudyCounts.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025 Brayan Oliveira <69634269+brayandso@users.noreply.github.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer
+
+import android.os.Parcelable
+import com.ichi2.anki.libanki.sched.Counts
+import com.ichi2.anki.libanki.sched.CurrentQueueState
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Parcelable wrapper around [Counts] to be used in the study screen.
+ */
+@Parcelize
+data class StudyCounts(
+    private val newCount: Int = 0,
+    private val learnCount: Int = 0,
+    private val reviewCount: Int = 0,
+    val activeQueue: Counts.Queue = Counts.Queue.NEW,
+) : Parcelable {
+    constructor(state: CurrentQueueState) : this(
+        newCount = state.counts.new,
+        learnCount = state.counts.lrn,
+        reviewCount = state.counts.rev,
+        activeQueue = state.countsIndex,
+    )
+
+    val new: String get() = newCount.toString()
+    val learn: String get() = learnCount.toString()
+    val review: String get() = reviewCount.toString()
+}


### PR DESCRIPTION
by using savedStateHandle for persisting the current counts

* Fixes #19930

## How Has This Been Tested?

Emulator 36

1. Enable Don't keep activities
2. Open the reviewer
3. Put the app in the background
4. Open the app again
5. Check if the counts numbers persist

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->