### PR TITLE
Previewer: reset answer state on card navigation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -178,6 +178,9 @@ class PreviewerViewModel(
         launchCatchingIO {
             if (currentIndex.value > 0) {
                 currentIndex.update { it - 1 }
+                if (!backSideOnly.value) {
+                    showingAnswer.emit(false)
+                }
             } else if (showingAnswer.value && !backSideOnly.value) {
                 showQuestion()
             }
@@ -203,6 +206,9 @@ class PreviewerViewModel(
         if (index !in selectedCardIds.indices) return
         launchCatchingIO {
             currentIndex.emit(index)
+            if (!backSideOnly.value) {
+                showingAnswer.emit(false)
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description

While working on Previewer navigation, I noticed that moving between cards (using the previous button or the slider) could sometimes leave the card on the answer side instead of resetting back to the question.

This also caused the  
`next, slider and previous navigation integration` test to fail intermittently, making it flaky.

---

## Fixes

Fixes #19934

- Fixes flaky Previewer navigation behavior related to answer/question state

---

## Approach

The issue was that `showingAnswer` was not being reset when the current card index changed.

So when navigating using:
- the Previous button, or
- the slider

the ViewModel could stay in the “answer” state even though a different card was selected.

The fix makes sure that whenever the card index changes, the preview resets to the question side, unless `BackSideOnly` is enabled. This matches the expected Previewer behavior and what the tests assume.

---

## How Has This Been Tested?

- Ran unit tests locally:
  ```bash
  ./gradlew AnkiDroid:testPlayDebugUnitTest
