### PR TITLE
Add unit tests for NumberRangePreferenceCompat dialog behavior (#13283)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -28,7 +28,6 @@ import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.utils.getFormattedStringOrPlurals
 import timber.log.Timber
 
@@ -124,7 +123,7 @@ open class NumberRangePreferenceCompat
         private fun getDefaultValue(): Int {
             return try {
                 return defaultValue?.toInt() ?: min
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 min
             }
         }
@@ -186,7 +185,6 @@ open class NumberRangePreferenceCompat
                 super.onBindDialogView(view)
             }
 
-            @NeedsTest("value is set to preference previous value if text is blank")
             override fun onDialogClosed(positiveResult: Boolean) {
                 // don't change the value if the dialog was cancelled or closed without any text
                 if (!positiveResult || editText.text.isEmpty()) {

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/NumberRangePreferenceCompatTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/NumberRangePreferenceCompatTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2025 Pankaj Gupta <pankajgupta0695@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.preferences
+
+import android.content.Context
+import android.widget.EditText
+import androidx.preference.PreferenceDialogFragmentCompat
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NumberRangePreferenceCompatTest : RobolectricTest() {
+    private val preference = TestableNumberRangePreferenceCompat(targetContext)
+    private val preferenceMock: NumberRangePreferenceCompat = mockk(relaxed = true)
+
+    @Test
+    fun getValidatedRangeFromIntWithinRangeReturnsInput() {
+        preference.setMinValue(0)
+        assertThat(preference.getValidatedRangeFromInt(50), equalTo(50))
+    }
+
+    @Test
+    fun getValidatedRangeFromIntBelowMinReturnsMin() {
+        preference.setMinValue(10)
+        assertThat(preference.getValidatedRangeFromInt(5), equalTo(10))
+    }
+
+    @Test
+    fun getValidatedRangeFromStringEmptyStringReturnsMin() {
+        preference.setMinValue(5)
+        assertThat(preference.getValidatedRangeFromString(""), equalTo(5))
+    }
+
+    @Test
+    fun getValidatedRangeFromStringValidNumberReturnsValidatedNumber() {
+        preference.setMinValue(0)
+        assertThat(preference.getValidatedRangeFromString("50"), equalTo(50))
+    }
+
+    @Test
+    fun getValidatedRangeFromStringInvalidNumberReturnsMin() {
+        preference.setMinValue(5)
+        assertThat(preference.getValidatedRangeFromString("abc"), equalTo(5))
+    }
+
+    @Test
+    fun onDialogClosedWithBlankTextDoesNotCallSetValue() {
+        clearMocks(preferenceMock)
+        every { preferenceMock.getValidatedRangeFromString(any()) } answers { 0 }
+        every { preferenceMock.callChangeListener(any()) } returns true
+
+        val dialogFragment = createDialogWithText("", preferenceMock)
+        dialogFragment.onDialogClosed(true)
+
+        verify(exactly = 0) { preferenceMock.setValue(any<Int>()) }
+    }
+
+    @Test
+    fun onDialogClosedWithCancelledDialogDoesNotCallSetValue() {
+        clearMocks(preferenceMock)
+        every { preferenceMock.getValidatedRangeFromString(any()) } answers { 99 }
+        every { preferenceMock.callChangeListener(any()) } returns true
+
+        val dialogFragment = createDialogWithText("99", preferenceMock)
+        dialogFragment.onDialogClosed(false)
+
+        verify(exactly = 0) { preferenceMock.setValue(any<Int>()) }
+    }
+
+    @Test
+    fun onDialogClosedWithValidTextCallsSetValue() {
+        clearMocks(preferenceMock)
+        every { preferenceMock.getValidatedRangeFromString("75") } returns 75
+        every { preferenceMock.callChangeListener(75) } returns true
+
+        val dialogFragment = createDialogWithText("75", preferenceMock)
+        dialogFragment.onDialogClosed(true)
+
+        verify(exactly = 1) { preferenceMock.setValue(75) }
+    }
+
+    private fun createDialogWithText(
+        text: String,
+        pref: NumberRangePreferenceCompat,
+    ): NumberRangePreferenceCompat.NumberRangeDialogFragmentCompat {
+        val dialogFragment = NumberRangePreferenceCompat.NumberRangeDialogFragmentCompat()
+
+        val preferenceField = PreferenceDialogFragmentCompat::class.java.getDeclaredField("mPreference")
+        preferenceField.isAccessible = true
+        preferenceField.set(dialogFragment, pref)
+
+        val editText = EditText(targetContext)
+        editText.setText(text)
+        dialogFragment.editText = editText
+
+        return dialogFragment
+    }
+
+    // Test subclass to allow setting min value for testing
+    private class TestableNumberRangePreferenceCompat(
+        context: Context,
+    ) : NumberRangePreferenceCompat(context) {
+        fun setMinValue(value: Int) {
+            min = value
+        }
+
+        override fun callChangeListener(newValue: Any?): Boolean = true
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR adds missing unit test coverage for NumberRangePreferenceCompat, specifically the behavior marked with @NeedsTest where the preference value should remain unchanged when the dialog is confirmed with blank input. It also adds coverage for range validation helpers to prevent regressions.

## Fixes
* Fixes somme of #13283

## Approach
- Added a new Robolectric test class at AnkiDroid/src/test/java/com/ichi2/preferences/NumberRangePreferenceCompatTest.kt.
- Implemented focused unit tests for:
  - getValidatedRangeFromInt: values within range and below min clamping.
  - getValidatedRangeFromString: empty string, valid numeric string and invalid string handling.
  - onDialogClosed: ensures blank input and cancelled dialog do not trigger value updates, while valid input does.

## How Has This Been Tested?
Run the unit tests via Gradle
```kotlin
./gradlew :AnkiDroid:testDebugUnitTest --tests "com.ichi2.preferences.NumberRangePreferenceCompatTest"
```
<img width="1325" height="324" alt="Screenshot 2025-12-28 at 6 31 34 PM" src="https://github.com/user-attachments/assets/e49d972c-b516-4826-80cc-3414eb19ffbf" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->