### PR TITLE
CI: Automatically add 'Needs Review' label to newly opened PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -206,3 +206,21 @@ jobs:
               repo: context.repo.repo,
               labels: ['New contributor']
             })
+  
+  # Add 'Needs Review' label to newly opened, non-draft PRs
+  add_needs_review_label:
+    if: github.event.action == 'opened' && !github.event.pull_request.draft
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs Review']
+            })


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Automated adding the Needs Review label to new opened, nondraft  prs. This removes the need for maintainers to be pinged or check manually.

## Fixes
* Fixes #19958 

## Approach
Added a new job that uses github script to automatically add the Needs Review label when a new pr is opened or is not a draft.

## How Has This Been Tested?

Verified the workflow logic in YAML file.
Confirmed the job only triggers for newly opened,  undrafted prs

## Learning (optional, can help others)
 
referenced GitHub Actions documentation for workflow conditions.
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax
https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->