### PR TITLE
auto-add 'Needs Review' label to non-draft PRs( #19958)

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -175,6 +175,23 @@ jobs:
               }
             }
 
+  add_needs_review_label:
+    if: github.event.action == 'opened' && github.event.pull_request.draft == false
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs Review']
+            })
+
   add_new_contributor_label:
     if: github.event.action == 'opened'
     permissions:


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
Automatically adds the "Needs Review" label to newly opened pull requests that are not drafts.
This streamlines the PR review process by ensuring all non-draft PRs are immediately flagged for review, reducing manual labeling overhead for maintainers.


## Fixes
Fixes #19958

## Approach
Added a new job `add_needs_review_label` to the [.github/workflows/label.yml](cci:7://file:///Users/gurnoor/StudioProjects/Anki-Android/.github/workflows/label.yml:0:0-0:0) workflow that:
1. Triggers when a pull request is opened (`github.event.action == 'opened'`)
2. Checks that the PR is not a draft (`github.event.pull_request.draft == false`)
3. Automatically applies the `Needs Review` label using the GitHub REST API
The implementation follows the existing pattern used in the `add_new_contributor_label` job and uses the same trusted `actions/github-script@v8` action already present in the workflow.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration (SDK version(s), emulator or physical, etc)

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [Y ] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ Y] You have commented your code, particularly in hard-to-understand areas
- [ Y] You have performed a self-review of your own code
- [ NA] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ NA] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->