### PR TITLE
feat(study-screen): change 'Plain' answer feedback colors

### DIFF
--- a/AnkiDroid/src/main/res/drawable/ic_ease_again.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_ease_again.xml
@@ -1,3 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?againTextColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?againIconColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
     <path android:fillColor="@android:color/white" android:pathData="M18.3,5.71c-0.39,-0.39 -1.02,-0.39 -1.41,0L12,10.59 7.11,5.7c-0.39,-0.39 -1.02,-0.39 -1.41,0 -0.39,0.39 -0.39,1.02 0,1.41L10.59,12 5.7,16.89c-0.39,0.39 -0.39,1.02 0,1.41 0.39,0.39 1.02,0.39 1.41,0L12,13.41l4.89,4.89c0.39,0.39 1.02,0.39 1.41,0 0.39,-0.39 0.39,-1.02 0,-1.41L13.41,12l4.89,-4.89c0.38,-0.38 0.38,-1.02 0,-1.4z"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_ease_easy.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_ease_easy.xml
@@ -1,4 +1,4 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?easyTextColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?easyIconColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
       
     <path android:fillColor="@android:color/white" android:pathData="M18,7l-1.41,-1.41 -6.34,6.34 1.41,1.41L18,7zM22.24,5.59L11.66,16.17 7.48,12l-1.41,1.41L11.66,19l12,-12 -1.42,-1.41zM0.41,13.41L6,19l1.41,-1.41L1.83,12 0.41,13.41z"/>
     

--- a/AnkiDroid/src/main/res/drawable/ic_ease_good.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_ease_good.xml
@@ -1,3 +1,3 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?goodTextColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?goodIconColor" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
     <path android:fillColor="@android:color/white" android:pathData="M9,16.2L4.8,12l-1.4,1.4L9,19 21,7l-1.4,-1.4L9,16.2z"/>
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_ease_hard.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_ease_hard.xml
@@ -3,7 +3,7 @@
     android:height="24dp"
     android:viewportWidth="960"
     android:viewportHeight="960"
-    android:tint="?hardTextColor">
+    android:tint="?hardIconColor">
   <path
       android:pathData="M400,656 L240,496l56,-56 104,104 264,-264 56,56 -320,320Z"
       android:fillColor="#FFF"/>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -135,6 +135,10 @@
     <attr name="hardBackgroundColor" format="color"/>
     <attr name="goodBackgroundColor" format="color"/>
     <attr name="easyBackgroundColor" format="color"/>
+    <attr name="againIconColor" format="color"/>
+    <attr name="hardIconColor" format="color"/>
+    <attr name="goodIconColor" format="color"/>
+    <attr name="easyIconColor" format="color"/>
     <!-- Card Browser Colors -->
     <attr name="cardBrowserDivider" format="color"/>
     <!-- Study Screen other colors -->

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -87,6 +87,10 @@
         <item name="hardBackgroundColor">#4e3122</item>
         <item name="goodBackgroundColor">#2c3b2c</item>
         <item name="easyBackgroundColor">#223946</item>
+        <item name="againIconColor">?againTextColor</item>
+        <item name="hardIconColor">?hardTextColor</item>
+        <item name="goodIconColor">?goodTextColor</item>
+        <item name="easyIconColor">?easyTextColor</item>
         <!-- Study Screen button drawables -->
         <item name="showAnswerColor">@color/material_blue_grey_800</item>
         <item name="againButtonRef">@drawable/footer_button_again_dark</item>

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -78,6 +78,10 @@
         <item name="hardBackgroundColor">#FFE0B2</item>
         <item name="goodBackgroundColor">#C8E6C9</item>
         <item name="easyBackgroundColor">@color/material_light_blue_100</item>
+        <item name="againIconColor">?againTextColor</item>
+        <item name="hardIconColor">?hardTextColor</item>
+        <item name="goodIconColor">?goodTextColor</item>
+        <item name="easyIconColor">?easyTextColor</item>
         <!-- Study Screen button drawables -->
         <item name="showAnswerButtonBackground">@color/material_blue_700</item>
         <item name="showAnswerColor">@color/material_blue_grey_700</item>

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -33,6 +33,10 @@
         <item name="hardBackgroundColor">@color/material_grey_300</item>
         <item name="goodBackgroundColor">@color/material_grey_300</item>
         <item name="easyBackgroundColor">@color/material_grey_300</item>
+        <item name="againIconColor">@color/material_red_900</item>
+        <item name="hardIconColor">#B33800</item>
+        <item name="goodIconColor">@color/material_green_900</item>
+        <item name="easyIconColor">@color/material_light_blue_900</item>
         <!-- Study Screen button drawables -->
         <item name="showAnswerButtonBackground">@color/theme_plain_primary</item>
         <item name="showAnswerColor">@color/theme_plain_primary</item>


### PR DESCRIPTION
having all the icons gray made difficult to distinguish the icons

## How Has This Been Tested?

Emulator 31

https://github.com/user-attachments/assets/ea2d83f2-03fa-4bfa-a95a-a82374b2dfb8

https://github.com/user-attachments/assets/4b9d89af-1170-4782-a97c-29ccd4913a7a

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->