### PR TITLE
fix(card-template-editor): prevent button flickering with 4+ card types

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -319,6 +319,14 @@ open class CardTemplateEditor :
         fieldNames = tempNoteType!!.notetype.fieldsNames
         // Set up the ViewPager with the sections adapter.
         mainBinding.cardTemplateEditorPager.adapter = TemplatePagerAdapter(this@CardTemplateEditor)
+
+        // Keep more fragments in memory to reduce menu flickering during tab switches (issue #18555).
+        // When switching between non-adjacent tabs, ViewPager2's default behavior destroys fragments,
+        // causing their MenuProviders to fire and create visual flicker.
+        // Capped at 7 (keeping up to 15 fragments total) to balance flicker reduction with memory usage,
+        // as templates can contain large content (JS bundles, CSS frameworks, etc.).
+        mainBinding.cardTemplateEditorPager.offscreenPageLimit = 7
+
         TabLayoutMediator(
             topBinding.slidingTabs,
             mainBinding.cardTemplateEditorPager,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorTest.kt
@@ -790,7 +790,8 @@ class CardTemplateEditorTest : RobolectricTest() {
 
         val firstFragment = testEditor.currentFragment
         assertNotNull("First fragment should exist", firstFragment)
-        val firstTemplateEditText = testEditor.findViewById<EditText>(R.id.edit_text)
+        // Use fragment's view to get EditText (activity.findViewById may return wrong view with offscreenPageLimit)
+        val firstTemplateEditText = firstFragment!!.requireView().findViewById<EditText>(R.id.edit_text)
         val originalFirstContent = firstTemplateEditText.text.toString()
 
         // Navigate to second fragment (Card 2)
@@ -799,7 +800,8 @@ class CardTemplateEditorTest : RobolectricTest() {
 
         val secondFragment = testEditor.currentFragment
         assertNotNull("Second fragment should exist", secondFragment)
-        val secondTemplateEditText = testEditor.findViewById<EditText>(R.id.edit_text)
+        // Use fragment's view to get EditText (activity.findViewById may return wrong view with offscreenPageLimit)
+        val secondTemplateEditText = secondFragment!!.requireView().findViewById<EditText>(R.id.edit_text)
         val originalSecondContent = secondTemplateEditText.text.toString()
 
         // Navigate back to first fragment
@@ -838,7 +840,10 @@ class CardTemplateEditorTest : RobolectricTest() {
         testEditor.viewPager.currentItem = 1
         advanceRobolectricLooper()
 
-        val secondTemplateEditTextAfter = testEditor.findViewById<EditText>(R.id.edit_text)
+        // Use currentFragment's view to get EditText
+        val secondFragmentAfter = testEditor.currentFragment
+        assertNotNull("Second fragment should exist after navigation", secondFragmentAfter)
+        val secondTemplateEditTextAfter = secondFragmentAfter!!.requireView().findViewById<EditText>(R.id.edit_text)
         val secondContentAfter = secondTemplateEditTextAfter.text.toString()
 
         assertEquals(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Template editor buttons (BottomNavigationView with Front/Back/Styling options) flicker and sometimes disappear when switching between card types in note types with 4+ cards.

## Fixes
* Fixes #18555

## Approach
Set `ViewPager2.offscreenPageLimit = 3` to prevent fragment destruction during tab transitions. The flicker occurs because both old and new fragments' MenuProviders are active simultaneously during ViewPager2 transitions, and lifecycle-based fixes don't work since both fragments remain in RESUMED state. Bounded at 3 to balance flicker prevention with memory usage, keeping up to 7 fragments alive..

## How Has This Been Tested?

- Created a note type with 5+ card templates
- Opened the Card Template Editor
- Rapidly switched between distant tabs 
### Tested on -
<img width="470" height="42" alt="image" src="https://github.com/user-attachments/assets/abc98189-9b94-469e-9e14-57b63b3e440a" />


## Learning (optional, can help others)
ViewPager2 uses RecyclerView internally with a default caching strategy that only keeps adjacent pages
https://developer.android.com/reference/androidx/viewpager2/widget/ViewPager2#setOffscreenPageLimit(int)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->