### PR TITLE
feat(whiteboard): move 'Add brush' to menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -202,17 +202,6 @@ class WhiteboardFragment :
             configureBrushButton(buttonVertical, brush, index)
             binding.brushToolbarContainerVertical.addView(buttonVertical)
         }
-
-        fun addBrushButton() =
-            MaterialButton(requireContext(), null, com.google.android.material.R.attr.materialIconButtonStyle).apply {
-                setIconResource(R.drawable.ic_add)
-                setTooltipTextCompat(getString(R.string.add_brush))
-                val color = ThemeUtils.getThemeAttrColor(requireContext(), androidx.appcompat.R.attr.colorControlNormal)
-                iconTint = ColorStateList.valueOf(color)
-                setOnClickListener { showAddColorDialog() }
-            }
-        binding.brushToolbarContainerHorizontal.addView(addBrushButton())
-        binding.brushToolbarContainerVertical.addView(addBrushButton())
     }
 
     /**
@@ -507,6 +496,7 @@ class WhiteboardFragment :
     override fun onMenuItemClick(item: MenuItem): Boolean {
         Timber.i("WhiteboardFragment::onMenuItemClick %s", item.title)
         when (item.itemId) {
+            R.id.action_add_brush -> showAddColorDialog()
             R.id.action_toggle_stylus -> {
                 item.isChecked = !item.isChecked
                 viewModel.toggleStylusOnlyMode()

--- a/AnkiDroid/src/main/res/layout/fragment_whiteboard.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_whiteboard.xml
@@ -87,12 +87,14 @@
 
             <FrameLayout
                 android:layout_width="wrap_content"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                >
 
                 <HorizontalScrollView
                     android:id="@+id/brush_scroll_view_horizontal"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:paddingEnd="4dp"
                     android:scrollbars="none">
 
                     <LinearLayout
@@ -109,6 +111,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:visibility="gone"
+                    android:paddingBottom="4dp"
                     android:scrollbars="none">
 
                     <LinearLayout

--- a/AnkiDroid/src/main/res/menu/whiteboard.xml
+++ b/AnkiDroid/src/main/res/menu/whiteboard.xml
@@ -2,6 +2,12 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
+        android:id="@+id/action_add_brush"
+        android:title="@string/add_brush"
+        android:icon="@drawable/ic_add"
+        app:showAsAction="never"
+        />
+    <item
         android:id="@+id/action_toggle_stylus"
         android:title="@string/stylus_mode"
         android:checkable="true"


### PR DESCRIPTION
It is less discoverable, but the `Add` button isn't a frequent action, so it's better to avoid occupying screen space if the user doesn't have many brushes.

## How Has This Been Tested?

Emulator 31

https://github.com/user-attachments/assets/fb4c03ee-9e51-4cbe-9573-ee6b72ec8033

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->