### PR TITLE
Fix #19968: Note type search is case sensitive and can't be deleted quickly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesViewModel.kt
@@ -75,7 +75,7 @@ class ManageNoteTypesViewModel : ViewModel() {
         _state.update { oldState ->
             val matchedNoteTypes =
                 oldState.noteTypes.map {
-                    it.copy(shouldBeDisplayed = it.name.contains(query))
+                    it.copy(shouldBeDisplayed = it.name.contains(query, ignoreCase = true))
                 }
             oldState.copy(isLoading = false, noteTypes = matchedNoteTypes, searchQuery = query)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -177,7 +177,10 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
             val searchMenuItem =
                 findViewById<Toolbar>(R.id.toolbar).menu?.findItem(R.id.search_item)
             val searchView = searchMenuItem?.actionView as? AccessibleSearchView
-            searchView?.setQuery(state.searchQuery, false)
+            // Avoid resetting cursor position if query hasn't changed
+            if (searchView?.query.toString() != state.searchQuery) {
+                searchView?.setQuery(state.searchQuery, false)
+            }
         }
         binding.selectionToolbar.isVisible = state.isInMultiSelectMode
         val selectedCount = state.noteTypes.count { it.isSelected }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNoteTypesViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNoteTypesViewModelTest.kt
@@ -160,6 +160,20 @@ class ManageNoteTypesViewModelTest : RobolectricTest() {
         }
 
     @Test
+    fun `filtering is case insensitive`() =
+        runTest {
+            val testName = "MixedCaseName"
+            addStandardNoteType(testName, arrayOf("front", "back"), "", "")
+            val viewModel = ManageNoteTypesViewModel()
+            viewModel.filter("mixedcasename")
+            val currentlyDisplayed =
+                viewModel.state.value.noteTypes
+                    .filter { it.shouldBeDisplayed }
+            assertThat(currentlyDisplayed, hasSize(1))
+            assertThat(currentlyDisplayed.map { it.name }, hasItems(testName))
+        }
+
+    @Test
     fun `removal failure in multiple selection returns expected exception`() =
         runTest {
             mockkStatic(Collection::removeNotetype)


### PR DESCRIPTION
## Purpose / Description
Fixes two issues in the "Manage note types" screen:
1.  **Case Sensitivity:** The search filter was case-sensitive, making it hard to find types like "Basic" if typing "basic".
2.  **Typing Interruption:** The search input was being reset loosely on every state update, interrupting the soft keyboard loop and preventing the "long press delete" key from working effectively.

## Fixes
* Fixes #19968

## Approach
- Updated the search filter to use `ignoreCase = true`.
- Added a check to the `SearchView` binding to only update the query text if it has actually changed. This prevents the keyboard/input loop from being reset unnecessarily.

## How Has This Been Tested?
I tested this manually on an emulator:
1.  **Search Test:** Typed "bAsIc" (mixed case) and verified it correctly found "Basic" (see attached video).
2.  **Delete Test:** Typed a long string and long-pressed the backspace key. Verified that deletion is now rapid and smooth without interruption.

https://github.com/user-attachments/assets/e416a071-9f13-4372-81d6-f47252d476ec



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)