### PR TITLE
Cleaned up substring warnings using methods dropLast and take

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -880,7 +880,7 @@ class NoteEditorFragment :
                     contents =
                         sourceText!![1]!!
                             .replaceFirst("\\[".toRegex(), "\u001f" + sourceText!![0] + "\u001f")
-                    contents = contents.substring(0, contents.length - 1)
+                    contents = contents.dropLast(1)
                 } else if (!editFields!!.isEmpty()) {
                     editFields!![0].setText(sourceText!![0])
                     if (editFields!!.size > 1) {
@@ -1027,7 +1027,7 @@ class NoteEditorFragment :
         val text = textBox.text?.toString() ?: ""
 
         // Split the text in the places where the formatting will take place
-        val beforeText = text.substring(0, start)
+        val beforeText = text.take(start)
         val selectedText = text.substring(start, end)
         val afterText = text.substring(end)
         val (newText, newStart, newEnd) = formatter.format(selectedText)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Cleans up warnings found in NoteEditorFragment.kt by replacing substring methods with specific use cases (i.e dropLast and take)

## Fixes
* Related to #13282

## Approach
Cleaned up syntax warnings in this file (as of v2.23.2) using suggestions by Android Studio as well as reading documentation to check if functionality would remain the same from original code. Although I think there may be an off by one error using dropLast, but would like suggestions for line 883. 

## How Has This Been Tested?
Emulated on a Pixel 9 Pro API 36.0, no crashes seen

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->