### PR TITLE
fix(legacy-tts): fix most languages

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ReadText.kt
@@ -26,7 +26,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.common.annotations.NeedsTest
-import com.ichi2.anki.i18n.iso3Code
+import com.ichi2.anki.i18n.getIso3LanguageOrNull
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
@@ -125,8 +125,8 @@ object ReadText {
                     val (validLocales, invalidLocales) =
                         availableLocales()
                             .sortedWith(compareBy { it.displayName })
-                            .map { Pair(it.iso3Code, it.displayName) }
-                            // iso3Code returns null if invalid
+                            .map { Pair(it.getIso3LanguageOrNull(), it.displayName) }
+                            // getIso3LanguageOrNull returns null if invalid
                             // we could work around this, but ReadText is deprecated
                             .partition { it.first != null }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/i18n/LocaleCodes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/i18n/LocaleCodes.kt
@@ -100,3 +100,29 @@ val Locale.iso3Code: String?
             // example: MissingResourceException: Couldn't find 3-letter language code for cz
             null
         }
+
+/**
+ * Returns a three-letter abbreviation of this locale's language, or `null` if a three-letter
+ * language abbreviation is not available for this locale.
+ *
+ * WARN: This is lossy, as the two-letter-code was usable.
+ *
+ * If the language matches an ISO 639-1 two-letter code, the corresponding ISO 639-2/T three-letter
+ * lowercase code is returned.
+ *
+ * The ISO 639-2 language codes can be found on-line, see "Codes for the Representation of Names of
+ * Languages Part 2: Alpha-3 Code".
+ *
+ * If the locale specifies a three-letter language, the language is returned as is.
+ *
+ * If the locale does not specify a language the empty string is returned.
+ */
+fun Locale.getIso3LanguageOrNull(): String? =
+    try {
+        // use Java-style 'get' methods; `val` properties are badly named: 'isO3Language'
+        this.getISO3Language()
+    } catch (_: Exception) {
+        // MissingResourceException can be thrown, in which case return null
+        // example: MissingResourceException: Couldn't find 3-letter language code for cz
+        null
+    }


### PR DESCRIPTION
## Purpose / Description
Any language with a 'country' no longer worked as I used `iso3Code`, which also included a country in the result


## Fixes
* Fixes #19996

## Approach
* define `getIso3LanguageOrNull`

## How Has This Been Tested?

Tested with albanian: `sq-al` => `sqi` on a Google Pixel 9 Pro

I didn't add a regression test as we want to remove this code

## Learning (optional, can help others)

Broken in 036707c5a6d47f20250a8de43d154c8893fea335
I tested Arabic in the bad commit, one of the very few which are not affected 🤦 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)