### PR TITLE
Fix: Unused variable warnings in parseBackupTimeString and CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackupManager.kt
@@ -166,10 +166,10 @@ open class BackupManager {
         fun parseBackupTimeString(timeString: String): Date? =
             try {
                 legacyDateFormat.parse(timeString)
-            } catch (e: ParseException) {
+            } catch (_: ParseException) {
                 try {
                     newDateFormat.parse(timeString)
-                } catch (e: ParseException) {
+                } catch (_: ParseException) {
                     null
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -137,7 +137,7 @@ open class CardBrowser :
 
     override var fragmented: Boolean
         get() = viewModel.isFragmented
-        set(value) {
+        set(_) {
             throw UnsupportedOperationException()
         }
 


### PR DESCRIPTION
## Purpose / Description
This PR resolves **unused variable** warnings in the codebase to clean up the code and adhere to Kotlin idioms.

- In `parseBackupTimeString`: the `ParseException` variable `e` was declared but never used.
- In `CardBrowser.kt`: the setter for `fragmented` had an unused parameter `value`.

## Fixes
* Fixes #13282 

## Approach
Renamed the unused variables to `_` (underscore).  
In Kotlin, the underscore is the idiomatic way to handle unused lambda parameters, setters, or catch variables, which suppresses compiler warnings while keeping the intent clear.

## How Has This Been Tested?
- Verified that the project compiles successfully with these changes.

**Test Configuration:**
- Build Type: Debug  
- Device: N/A (code refactor only)

## Learning (optional, can help others)
- Kotlin documentation on using underscore (`_`) for unused variables.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas. *(N/A: warning-only change; code is self-explanatory)*
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (not applicable).
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner (not applicable).
