### PR TITLE
fix:pronunciation of abbreviated time in ease buttons

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewer/EaseButton.kt
@@ -25,6 +25,7 @@ import androidx.annotation.StringRes
 import androidx.core.view.isVisible
 import anki.scheduler.CardAnswer.Rating
 import com.ichi2.anki.AbstractFlashcardViewer
+import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 
 /**
@@ -54,7 +55,42 @@ class EaseButton(
         get() = easeTimeView.text.toString()
         set(value) {
             easeTimeView.text = value
+            val easeName = easeTextView.text.toString()
+            val formattedTime = formatTimeForAccessibility(value)
+            layout.contentDescription = "$formattedTime $easeName"
         }
+
+    private fun formatTimeForAccessibility(timeString: String): String {
+        if (timeString.isBlank()) return timeString
+
+        val cleaned =
+            timeString
+                .replace(Regex("[\u200E\u200F\u202A-\u202E\u2066-\u2069<>⁨⁩]"), "")
+                .trim()
+
+        val regex = Regex("""^(\d+(?:\.\d+)?)(s|m|h|d|mo|y)$""")
+        val match = regex.find(cleaned) ?: return timeString
+
+        val (number, unit) = match.destructured
+
+        val numValue = number.toFloatOrNull() ?: return timeString
+        val quantity = numValue.toInt()
+
+        val context = layout.context
+        val unitWord =
+            when (unit) {
+                "s" -> context.resources.getQuantityString(R.plurals.time_span_seconds_plurals, quantity)
+                "m" -> context.resources.getQuantityString(R.plurals.time_span_minutes_plurals, quantity)
+                "h" -> context.resources.getQuantityString(R.plurals.time_span_hours_plurals, quantity)
+                "d" -> context.resources.getQuantityString(R.plurals.time_span_days_plurals, quantity)
+                "mo" -> context.resources.getQuantityString(R.plurals.time_span_months_plurals, quantity)
+                "y" -> context.resources.getQuantityString(R.plurals.time_span_years_plurals, quantity)
+                else -> unit
+            }
+
+        val result = "$number $unitWord"
+        return result
+    }
 
     fun hideNextReviewTime() {
         easeTimeView.visibility = View.GONE

--- a/AnkiDroid/src/main/res/values/strings.xml
+++ b/AnkiDroid/src/main/res/values/strings.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Accessibility time unit plurals for TalkBack -->
+    <plurals name="time_span_seconds_plurals">
+        <item quantity="one">second</item>
+        <item quantity="other">seconds</item>
+    </plurals>
+    <plurals name="time_span_minutes_plurals">
+        <item quantity="one">minute</item>
+        <item quantity="other">minutes</item>
+    </plurals>
+    <plurals name="time_span_hours_plurals">
+        <item quantity="one">hour</item>
+        <item quantity="other">hours</item>
+    </plurals>
+    <plurals name="time_span_days_plurals">
+        <item quantity="one">day</item>
+        <item quantity="other">days</item>
+    </plurals>
+    <plurals name="time_span_months_plurals">
+        <item quantity="one">month</item>
+        <item quantity="other">months</item>
+    </plurals>
+    <plurals name="time_span_years_plurals">
+        <item quantity="one">year</item>
+        <item quantity="other">years</item>
+    </plurals>
+</resources>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In talkback mode, the text "<1m" on the ease button is pronounced as "less than one **metre**" instead of "less than one **minute**". Same goes for the other ease buttons.
## Fixes
* Fixes #19726

## Approach
- Added string resources for time units (seconds, minutes, hours, etc.) 
- Added a helper method that converts abbreviated time strings (such as "1m") to full words
- 
## How Has This Been Tested?
- Enable talkback mode in android settings
- View a Card in Ankidroid
- Hover on the ease buttons to hear the correct pronounciations

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->