### PR TITLE
feat(sync): add 'network timeout' preference

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -70,6 +70,7 @@ fun syncAuth(): SyncAuth? {
             if (resolvedEndpoint != null) {
                 this.endpoint = resolvedEndpoint
             }
+            this.ioTimeoutSecs = Prefs.networkTimeoutSecs
         }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/UsageAnalytics.kt
@@ -491,6 +491,7 @@ object UsageAnalytics {
             R.string.automatic_sync_choice_key, // Automatic synchronization
             R.string.sync_status_badge_key, // Display synchronization status
             R.string.metered_sync_key, // Allow sync on metered connections
+            R.string.sync_io_timeout_secs_key, // Network timeout
             R.string.one_way_sync_key, // One-way sync
             // ******************************** Backup *************************************************
             R.string.pref_minutes_between_automatic_backups_key,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SyncSettingsFragment.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.preferences
 
 import androidx.appcompat.app.AlertDialog
+import androidx.preference.EditTextPreference
 import androidx.preference.Preference
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager.TR
@@ -23,9 +24,11 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.runCatchingWithReport
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.ifNullOrEmpty
+import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.utils.show
 
 /**
@@ -43,6 +46,18 @@ class SyncSettingsFragment : SettingsFragment() {
 
         // Enable/disable one-way sync if the user is logged in
         updateOneWaySyncEnabledState()
+
+        // Configure 'Network timeout'
+        // TODO: add 'reset to default' functionality
+        requirePreference<NumberRangePreferenceCompat>(R.string.sync_io_timeout_secs_key).apply {
+            title = TR.preferencesNetworkTimeout()
+            summaryProvider =
+                Preference.SummaryProvider<EditTextPreference> {
+                    runCatchingWithReport("network_timeout") {
+                        TR.qtMiscSecond(this.getValue())
+                    }.getOrNull() ?: getString(R.string.pref__etc__summary__error)
+                }
+        }
 
         // Configure one-way sync option
         requirePreference<Preference>(R.string.one_way_sync_key).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -255,6 +255,8 @@ open class PrefsRepository(
     val shouldFetchMedia: ShouldFetchMedia
         get() = getEnum(R.string.sync_fetch_media_key, ShouldFetchMedia.ALWAYS)
 
+    var networkTimeoutSecs by intPref(R.string.sync_io_timeout_secs_key, defaultValue = 60)
+
     //region Custom sync server
 
     val customSyncCertificate by stringPref(R.string.custom_sync_certificate_key)

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -18,6 +18,7 @@
     <string name="pref_sync_screen_key">syncScreen</string>
     <string name="sync_account_key">syncAccount</string>
     <string name="sync_fetch_media_key">syncFetchMedia</string>
+    <string name="sync_io_timeout_secs_key">syncIoTimeoutSecs</string>
     <string name="automatic_sync_choice_key">automaticSyncMode</string>
     <string name="one_way_sync_key">one_way_sync</string>
     <string name="sync_status_badge_key">showSyncStatusBadge</string>

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -15,8 +15,9 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
+    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app1="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_sync"
     android:key="@string/pref_sync_screen_key"
     xmlns:tools="http://schemas.android.com/tools">
@@ -32,7 +33,7 @@
         android:entryValues="@array/sync_media_values"
         android:key="@string/sync_fetch_media_key"
         android:title="@string/sync_fetch_missing_media"
-        app:useSimpleSummaryProvider="true"/>
+        app1:useSimpleSummaryProvider="true"/>
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/automatic_sync_choice_key"
@@ -49,6 +50,19 @@
         android:title="@string/metered_sync_title"
         android:summary="@string/metered_sync_summary" />
     <PreferenceCategory android:title="@string/pref_cat_advanced">
+        <!-- Network timeout
+        Anki Desktop:
+        min is 30s
+        max is 99999s
+        https://github.com/ankitects/anki/blob/8f2144534bff6efedb22b7f052fba13ffe28cbc2/qt/aqt/profiles.py#L734-L735
+        https://github.com/ankitects/anki/blob/8f2144534bff6efedb22b7f052fba13ffe28cbc2/qt/aqt/forms/preferences.ui#L718-L742
+        -->
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
+            android:key="@string/sync_io_timeout_secs_key"
+            android:defaultValue="60"
+            app:min="30"
+            app:max="99999"
+            tools:title="Network timeout" />
         <!-- `search:ignore` is set so that we can add this preference manually in the search index.
         We want to add it manually because we provide the summary at run time instead of build time, because it comes from the backend.
         If we didn't ignore it, searching for the title would return this preference twice.-->


### PR DESCRIPTION
## Purpose / Description
Anki Desktop exposes 'Network timeout', we should do so as well.

https://forums.ankiweb.net/t/cant-sync-since-1-1-2026/68040/

## Fixes
* Fixes #20000

## Approach
Expose it as a `IncrementerNumberRangePreferenceCompat`:
* `@string/sync_io_timeout_secs_key` => `syncIoTimeoutSecs`
* Default: 60s
* Minimum: 30s
* Max: 99999s

## How Has This Been Tested?

**Set in SyncAuth after being set in the UI to 30**
<img width="1284" height="364" alt="Screenshot 2026-01-04 at 13 16 23" src="https://github.com/user-attachments/assets/c2cd7251-bbce-4fe9-879e-1207f25c271f" />

Truncated to avoid my hKey becoming public 😅

**UI**


<img width="598" height="161" alt="Screenshot 2026-01-05 at 00 24 05" src="https://github.com/user-attachments/assets/7a12885b-4476-4855-a9d9-61154db7bdb7" />
<img width="874" height="143" alt="Screenshot 2026-01-05 at 00 23 43" src="https://github.com/user-attachments/assets/eaf710a3-e61f-4874-9f1e-449cee39fb35" />

⚠️ I had a failure in PrefsSearchBarTest, but I don't believe this is related

* https://github.com/ankidroid/Anki-Android/pull/19922
* #19918

## Learning (optional, can help others)

Exposed as `SyncAuth.io_timeout_secs` in the backend

https://github.com/ankitects/anki/blob/8f2144534bff6efedb22b7f052fba13ffe28cbc2/proto/anki/sync.proto#L29-L33

Upstream exposes this as a '60 seconds' textbox with an up/down picker

https://github.com/ankitects/anki/blob/8f2144534bff6efedb22b7f052fba13ffe28cbc2/qt/aqt/profiles.py#L734-L735 https://github.com/ankitects/anki/blob/8f2144534bff6efedb22b7f052fba13ffe28cbc2/qt/aqt/forms/preferences.ui#L718-L742

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)