### PR TITLE
chore: convert ReviewerMenuSettingsFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuSettingsFragment.kt
@@ -23,12 +23,12 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.PreferencesReviewerMenuBinding
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.sharedPrefs
+import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
 
 class ReviewerMenuSettingsFragment :
@@ -37,22 +37,22 @@ class ReviewerMenuSettingsFragment :
     ActionMenuView.OnMenuItemClickListener {
     private lateinit var repository: ReviewerMenuRepository
 
+    private val binding by viewBinding(PreferencesReviewerMenuBinding::bind)
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
         repository = ReviewerMenuRepository(sharedPrefs())
-        setupRecyclerView(view)
-        view.findViewById<MaterialToolbar>(R.id.toolbar).setNavigationOnClickListener {
+        setupRecyclerView()
+        binding.toolbar.setNavigationOnClickListener {
             requireActivity().onBackPressedDispatcher.onBackPressed()
         }
-        view.findViewById<ReviewerMenuView>(R.id.reviewer_menu_view).apply {
-            setOnMenuItemClickListener(this@ReviewerMenuSettingsFragment)
-        }
+        binding.reviewerMenuView.setOnMenuItemClickListener(this@ReviewerMenuSettingsFragment)
     }
 
-    private fun setupRecyclerView(view: View) {
+    private fun setupRecyclerView() {
         val menuItems = repository.getActionsByMenuDisplayTypes()
 
         fun section(displayType: MenuDisplayType): List<ReviewerMenuSettingsRecyclerItem> =
@@ -72,7 +72,7 @@ class ReviewerMenuSettingsFragment :
                 }
             }
 
-        view.findViewById<RecyclerView>(R.id.recycler_view).apply {
+        binding.recyclerView.apply {
             setHasFixedSize(true)
             layoutManager = LinearLayoutManager(requireContext())
             this.adapter = adapter
@@ -108,7 +108,7 @@ class ReviewerMenuSettingsFragment :
         )
 
         lifecycleScope.launch {
-            val menu = requireView().findViewById<ReviewerMenuView>(R.id.reviewer_menu_view)
+            val menu = binding.reviewerMenuView
             menu.clear()
             menu.addActions(alwaysShowActions, menuOnlyActions)
             menu.setFlagTitles()


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/030e55c701255637ae38d5954ffad827ec1ba163
* Fixed to use `vbpd`

## How Has This Been Tested?
Brief test:

* API33-ext5 (Medium Tablet)
 
<img width="860" height="222" alt="Screenshot 2026-01-05 at 09 37 54" src="https://github.com/user-attachments/assets/9e66f696-d476-44ea-b5cd-cd3bcce2692e" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)