### PR TITLE
chore: convert SchedulerReminders to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.View
-import android.widget.LinearLayout
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.BundleCompat
 import androidx.core.view.isVisible
@@ -29,14 +28,12 @@ import androidx.fragment.app.setFragmentResult
 import androidx.fragment.app.setFragmentResultListener
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.google.android.material.appbar.MaterialToolbar
-import com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.CrashReportData.Companion.toCrashReportData
 import com.ichi2.anki.R
 import com.ichi2.anki.SingleFragmentActivity
 import com.ichi2.anki.canUserAccessDeck
+import com.ichi2.anki.databinding.FragmentScheduleRemindersBinding
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
@@ -48,6 +45,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.withProgress
+import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.serialization.SerializationException
 import timber.log.Timber
 
@@ -70,12 +68,12 @@ class ScheduleReminders :
         ) ?: ReviewReminderScope.Global
     }
 
-    private lateinit var toolbar: MaterialToolbar
-    private lateinit var recyclerView: RecyclerView
+    private val binding by viewBinding(FragmentScheduleRemindersBinding::bind)
+
     private lateinit var adapter: ScheduleRemindersAdapter
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        anchorView = requireView().findViewById<ExtendedFloatingActionButton>(R.id.schedule_reminders_add_reminder_fab)
+        anchorView = binding.floatingActionButtonAdd
     }
 
     /**
@@ -99,19 +97,21 @@ class ScheduleReminders :
         super.onViewCreated(view, savedInstanceState)
 
         // Set up toolbar
-        toolbar = view.findViewById(R.id.toolbar)
         reloadToolbarText()
-        (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
+        (requireActivity() as AppCompatActivity).setSupportActionBar(binding.toolbar)
 
         // Set up add button
-        val addButton = view.findViewById<ExtendedFloatingActionButton>(R.id.schedule_reminders_add_reminder_fab)
-        addButton.setOnClickListener { addReminder() }
+        binding.floatingActionButtonAdd.setOnClickListener { addReminder() }
 
         // Set up recycler view
-        recyclerView = view.findViewById(R.id.schedule_reminders_recycler_view)
         val layoutManager = LinearLayoutManager(requireContext())
-        recyclerView.layoutManager = layoutManager
-        recyclerView.addItemDecoration(DividerItemDecoration(requireContext(), layoutManager.orientation))
+        binding.recyclerView.layoutManager = layoutManager
+        binding.recyclerView.addItemDecoration(
+            DividerItemDecoration(
+                requireContext(),
+                layoutManager.orientation,
+            ),
+        )
 
         // Set up adapter, pass functionality to it
         adapter =
@@ -121,7 +121,7 @@ class ScheduleReminders :
                 ::toggleReminderEnabled,
                 ::editReminder,
             )
-        recyclerView.adapter = adapter
+        binding.recyclerView.adapter = adapter
 
         // Retrieve reminders based on the editing scope
         launchCatchingTask { loadDatabaseRemindersIntoUI() }
@@ -149,12 +149,12 @@ class ScheduleReminders :
 
     private fun reloadToolbarText() {
         Timber.d("Reloading toolbar text")
-        toolbar.title = getString(R.string.schedule_reminders_do_not_translate)
+        binding.toolbar.title = getString(R.string.schedule_reminders_do_not_translate)
         when (val scope = scheduleRemindersScope) {
             is ReviewReminderScope.Global -> {}
             is ReviewReminderScope.DeckSpecific ->
                 launchCatchingTask {
-                    toolbar.subtitle = scope.getDeckName()
+                    binding.toolbar.subtitle = scope.getDeckName()
                 }
         }
     }
@@ -429,7 +429,7 @@ class ScheduleReminders :
                 .sortedBy { it.time.toSecondsFromMidnight() }
                 .toList()
         adapter.submitList(listToDisplay)
-        view?.findViewById<LinearLayout>(R.id.no_reminders_placeholder)?.isVisible = listToDisplay.isEmpty()
+        binding.noRemindersPlaceholder.isVisible = listToDisplay.isEmpty()
     }
 
     companion object {

--- a/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
@@ -26,7 +26,7 @@
             android:layout_height="match_parent">
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/schedule_reminders_recycler_view"
+                android:id="@+id/recycler_view"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="?android:attr/colorBackground"
@@ -68,7 +68,7 @@
     </LinearLayout>
 
     <com.google.android.material.floatingactionbutton.ExtendedFloatingActionButton
-        android:id="@+id/schedule_reminders_add_reminder_fab"
+        android:id="@+id/floating_action_button_add"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/e1248eb9fbc82288782e7e9afcfda7e49f3653a5
* De-conflict & convert to `vbpd`

## How Has This Been Tested?
Brief test:

* API33-ext5 (Medium Tablet)

Fragment loads and the 'add reminder' button works


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)