### PR TITLE
Refactor: Remove redundant qualifier in FilteredDeckOptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/FilteredDeckOptions.kt
@@ -69,7 +69,7 @@ class FilteredDeckOptions :
             "{'search'=\"\", 'steps'=\"1 10 20\", 'order'=0}",
         )
 
-    inner class DeckPreferenceHack : AppCompatPreferenceActivity<FilteredDeckOptions.DeckPreferenceHack>.AbstractPreferenceHack() {
+    inner class DeckPreferenceHack : AppCompatPreferenceActivity<DeckPreferenceHack>.AbstractPreferenceHack() {
         var secondFilter = false
 
         override fun cacheValues() {
@@ -100,7 +100,7 @@ class FilteredDeckOptions :
             values["previewGoodSecs"] = deck.getString("previewGoodSecs")
         }
 
-        inner class Editor : AppCompatPreferenceActivity<FilteredDeckOptions.DeckPreferenceHack>.AbstractPreferenceHack.Editor() {
+        inner class Editor : AppCompatPreferenceActivity<DeckPreferenceHack>.AbstractPreferenceHack.Editor() {
             override fun commit(): Boolean {
                 Timber.d("commit() changes back to database")
                 for ((key, value) in update.valueSet()) {


### PR DESCRIPTION
## Purpose / Description
This PR resolves an Android Studio warning in `FilteredDeckOptions.kt` by removing redundant qualifier names. This cleans up the code and aligns with Kotlin coding conventions.

## Fixes
* Fixes a "Remove redundant qualifier name" warning in Android Studio.
* Part of https://github.com/ankidroid/Anki-Android/issues/13282

## Approach
I removed the explicit `FilteredDeckOptions.` prefix from inner class references (e.g., `DeckPreferenceHack`) inside the `FilteredDeckOptions` class, as they are not needed when already inside the class scope.

## How Has This Been Tested?
* Built the project successfully in Android Studio.
* Verified that `FilteredDeckOptions.kt` no longer shows the "redundant qualifier" warning.
* Ran the app on an emulator to ensure no crashes occurred on startup.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas (N/A - simple refactor).
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots (N/A - no UI changes).
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner (N/A).