### PR TITLE
fix(preferences): Improve validation logic in IncrementerNumberRangeP…

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -281,9 +281,12 @@
     <string name="menu_scroll_toolbar" comment="Checkbox stating whether note editor toolbar is scrollable or stacked. Checked: Scroll" maxLength="28">Scroll toolbar</string>
 
 
-    <!-- Symbols used as Button text in IncrementNumberRangePreference -->
+    <!-- IncrementNumberRangePreference -->
     <string name="plus_sign" comment="Label for increment button in IncrementerNumberRangePreference">+</string>
     <string name="minus_sign" comment="Label for decrement button in IncrementerNumberRangePreference">-</string>
+    <string name="invalid_value" comment="Error message in IncrementerNumberRangePreference when input is not a valid number">Invalid value</string>
+    <string name="maximum_value_is" comment="Error message in IncrementerNumberRangePreference. %d is the maximum allowed value">Maximum value is %d</string>
+    <string name="minimum_value_is" comment="Error message in IncrementerNumberRangePreference. %d is the minimum allowed value">Minimum value is %d</string>
 
     <!-- Used for credential empty warning message -->
     <string name="invalid_email">Enter a valid email</string>

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompatTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompatTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Rakshita Chauhan <chauhanrakshita64@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.preferences
+
+import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat.Companion.ValidationResult
+import com.ichi2.preferences.IncrementerNumberRangePreferenceCompat.Companion.validate
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.core.IsEqual
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class IncrementerNumberRangePreferenceCompatTest {
+    @Test
+    fun testValidationLogic() {
+        val min = 30
+        val max = 99999
+
+        assertThat(
+            "A number within the min/max range should be VALID",
+            validate("60", 60, min, max),
+            IsEqual(ValidationResult.VALID),
+        )
+
+        assertThat(
+            "An empty string should return EMPTY state",
+            validate("", null, min, max),
+            IsEqual(ValidationResult.EMPTY),
+        )
+
+        assertThat(
+            "A number greater than the maximum should return OVERFLOW",
+            validate("100000", 100000, min, max),
+            IsEqual(ValidationResult.OVERFLOW),
+        )
+
+        assertThat(
+            "A number less than the minimum should return UNDERFLOW",
+            validate("29", 29, min, max),
+            IsEqual(ValidationResult.UNDERFLOW),
+        )
+
+        assertThat(
+            "A number exceeding Integer limits should return INVALID",
+            validate("9999999999", null, min, max),
+            IsEqual(ValidationResult.INVALID),
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This implements input validation and button state management for `IncrementerNumberRangePreferenceCompat`, addressing the functional issues from #20005

## Fixes
* Related to #20005

## Approach
Implemented a `TextWatcher` to validate the user input against the preference's min/max limits and check for overflow. The `updateButtonState` method now disables the increment/decrement buttons and the dialog's "OK" button when the input is invalid or out of range. I used `EditText.setError()` to provide specific feedback (e.g. "Maximum value is 10") without modifying the view hierarchy, ensuring compatibility with upcoming UI refactors

## How Has This Been Tested?
<img src="https://github.com/user-attachments/assets/3db1d6f6-3fcc-4abe-838b-5c3a448e645f" width="300" >
<img src="https://github.com/user-attachments/assets/b8e077a6-052e-49aa-920e-d65816075a54" width="300" >
<img src="https://github.com/user-attachments/assets/896c01aa-3c2f-4b41-9cdc-670a2458330f" width="300" />

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->