### PR TITLE
fix: use standard res-auto namespace for app attributes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -396,7 +396,6 @@ open class AnkiDroidApp :
         /** Running under instrumentation. a "/androidTest" directory will be created which contains a test collection  */
         @Suppress("ktlint:standard:property-naming")
         var INSTRUMENTATION_TESTING = false
-        const val XML_CUSTOM_NAMESPACE = "http://arbitrary.app.namespace/com.ichi2.anki"
         const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
 
         // Tag for logging messages.

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -20,7 +20,7 @@ import android.text.InputFilter.LengthFilter
 import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
-import com.ichi2.anki.AnkiDroidApp
+import com.ichi2.anki.R
 import timber.log.Timber
 
 @Suppress(
@@ -115,7 +115,9 @@ open class NumberRangePreference :
      * This method should only be called once from the constructor.
      */
     private fun getMinFromAttributes(attrs: AttributeSet?): Int =
-        attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "min", 0) ?: 0
+        context.obtainStyledAttributes(attrs, R.styleable.NumberRangePreference).use {
+            it.getInt(R.styleable.NumberRangePreference_min, 0)
+        }
 
     /**
      * Returns the value of the max attribute, or its default value if not specified
@@ -124,8 +126,9 @@ open class NumberRangePreference :
      * This method should only be called once from the constructor.
      */
     private fun getMaxFromAttributes(attrs: AttributeSet?): Int =
-        attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "max", Int.MAX_VALUE)
-            ?: Int.MAX_VALUE
+        context.obtainStyledAttributes(attrs, R.styleable.NumberRangePreference).use {
+            it.getInt(R.styleable.NumberRangePreference_max, Int.MAX_VALUE)
+        }
 
     /**
      * Update settings to only allow integer input and set the maximum number of digits allowed in the text field based

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -26,7 +26,6 @@ import android.widget.EditText
 import androidx.core.content.withStyledAttributes
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.utils.getFormattedStringOrPlurals
@@ -49,8 +48,10 @@ open class NumberRangePreferenceCompat
             private set
 
         init {
-            min = attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "min", 0) ?: 0
-            max = attrs?.getAttributeIntValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "max", Int.MAX_VALUE) ?: Int.MAX_VALUE
+            context.withStyledAttributes(attrs, R.styleable.NumberRangePreferenceCompat) {
+                min = getInt(R.styleable.NumberRangePreferenceCompat_min, 0)
+                max = getInt(R.styleable.NumberRangePreferenceCompat_max, Int.MAX_VALUE)
+            }
             defaultValue = attrs?.getAttributeValue("http://schemas.android.com/apk/res/android", "defaultValue")
 
             context.withStyledAttributes(attrs, R.styleable.CustomPreference) {
@@ -124,7 +125,7 @@ open class NumberRangePreferenceCompat
         private fun getDefaultValue(): Int {
             return try {
                 return defaultValue?.toInt() ?: min
-            } catch (e: Exception) {
+            } catch (_: Exception) {
                 min
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/StepsPreference.kt
@@ -20,7 +20,6 @@ import android.content.Context
 import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.ext.stringIterable
 import com.ichi2.anki.showThemedToast
@@ -105,8 +104,9 @@ class StepsPreference :
     }
 
     private fun getAllowEmptyFromAttributes(attrs: AttributeSet?): Boolean =
-        attrs?.getAttributeBooleanValue(AnkiDroidApp.XML_CUSTOM_NAMESPACE, "allowEmpty", true)
-            ?: true
+        context.obtainStyledAttributes(attrs, R.styleable.StepsPreference).use {
+            it.getBoolean(R.styleable.StepsPreference_allowEmpty, true)
+        }
 
     companion object {
         /**

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -25,7 +25,8 @@
 
     <!-- Custom preferences -->
     <attr name="allowEmpty" format="boolean" />
-
+    <attr name="min" format="integer" />
+    <attr name="max" format="integer" />
 
     <declare-styleable name="CustomPreference">
         <!-- Whether the preference should automatically set its summary to the value saved for the
@@ -35,6 +36,20 @@
              The placeholder is replaced by the preference value, and it must be only one placeholder.
              If the preference value is updated, the summary is automatically updated as well. -->
         <attr name="summaryFormat" format="string"/>
+    </declare-styleable>
+
+    <declare-styleable name="NumberRangePreference">
+        <attr name="min"/>
+        <attr name="max"/>
+    </declare-styleable>
+
+    <declare-styleable name="StepsPreference">
+        <attr name="allowEmpty"/>
+    </declare-styleable>
+
+    <declare-styleable name="NumberRangePreferenceCompat">
+        <attr name="min"/>
+        <attr name="max"/>
     </declare-styleable>
 
     <declare-styleable name="HtmlHelpPreference">

--- a/AnkiDroid/src/main/res/xml/cram_deck_options.xml
+++ b/AnkiDroid/src/main/res/xml/cram_deck_options.xml
@@ -16,7 +16,7 @@
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki" >
+    xmlns:app="http://schemas.android.com/apk/res-auto" >
 
     <PreferenceCategory android:title="@string/deck_conf_cram_filter" >
         <com.ichi2.preferences.AutoFocusEditTextPreference

--- a/AnkiDroid/src/main/res/xml/preferences_advanced.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_advanced.xml
@@ -22,14 +22,14 @@
 
 <!-- Advanced Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app1="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_advanced"
     android:key="@string/pref_advanced_screen_key">
         <EditTextPreference
             android:defaultValue="/sdcard/AnkiDroid"
             android:key="@string/pref_ankidroid_directory_key"
             android:title="@string/col_path"
-            app1:useSimpleSummaryProvider="true"/>
+            app:useSimpleSummaryProvider="true"/>
         <Preference
             android:summary="@string/reset_languages_summ"
             android:title="@string/reset_languages"

--- a/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/button_backup"
     android:key="@string/pref_backups_screen_key">
     <!-- Includes modified text from `TR.preferencesBackupExplanation()`

--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
@@ -19,8 +19,7 @@
 ~ at developers, who are assumed to speak English.
 -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-    xmlns:app1="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_dev_options"
     android:key="@string/pref_dev_options_screen_key">
     <SwitchPreferenceCompat
@@ -66,7 +65,7 @@
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/pref_fill_default_deck_number_key"
             android:title="Number of notes to generate"
-            app1:useSimpleSummaryProvider="true"
+            app:useSimpleSummaryProvider="true"
             android:defaultValue="200"
             app:min="1"
             />
@@ -81,14 +80,14 @@
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/pref_fill_collection_number_file_key"
             android:title="Number of files to generate"
-            app1:useSimpleSummaryProvider="true"
+            app:useSimpleSummaryProvider="true"
             android:defaultValue="20"
             app:min="1"
             />
         <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/pref_fill_collection_size_file_key"
             android:title="Size of the files to generate (in byte)"
-            app1:useSimpleSummaryProvider="true"
+            app:useSimpleSummaryProvider="true"
             android:defaultValue="1000000"
             app:min="1"
             />

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -22,8 +22,7 @@
 
 <!-- Reviewing Preferences -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-    xmlns:app1="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:title="@string/pref_cat_reviewing"
     android:key="@string/pref_reviewing_screen_key"
@@ -34,20 +33,20 @@
             android:valueFrom="0"
             android:valueTo="23"
             android:title="@string/day_offset_with_description"
-            app1:persistent="false"
-            app1:summaryFormat="@plurals/day_offset_summ"/>
+            app:persistent="false"
+            app:summaryFormat="@plurals/day_offset_summ"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0"
-            app1:summaryFormat="@plurals/pref_summ_minutes"/>
+            app:summaryFormat="@plurals/pref_summ_minutes"/>
         <com.ichi2.preferences.NumberRangePreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
             app:max="9999"
             app:min="0"
-            app1:summaryFormat="@plurals/pref_summ_minutes"/>
+            app:summaryFormat="@plurals/pref_summ_minutes"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/pref_cat_advanced">
         <SwitchPreferenceCompat


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Some preference XML files used a deprecated custom app namespace URI (http://arbitrary.app.namespace/com.ichi2.anki) instead of the standard http://schemas.android.com/apk/res-auto and/or a non\-standard prefix (`app1`) for custom attributes.
This caused aapt to fail resolving custom attributes and resulted in build errors like attribute max not found.

## Fixes

* Fixes #20018

## Approach

Replaced the deprecated `app` namespace URI with the standard `xmlns:app="http://schemas.android.com/apk/res-auto"` in affected preference XML files.
Renamed the custom attribute prefix from `app1` to `app` so the custom attributes resolve consistently via `res-auto`.

## How Has This Been Tested?

Tested on Android Studio emulator: Medium Phone, API 29 (Android 10).
Verified the affected preference screens load correctly and the app builds without aapt attribute/namespace errors.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->