### PR TITLE
Refactor: Replace substring with take in LanguageUtils

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/LanguageUtils.kt
@@ -53,6 +53,7 @@ object LanguageUtils {
 
     private fun stripScriptAndExtensions(localeCodeStr: String): String {
         val hashPos = localeCodeStr.indexOf('#')
-        return if (hashPos >= 0) localeCodeStr.substring(0, hashPos) else localeCodeStr
+        // FIX: Use .take() instead of .substring()
+        return if (hashPos >= 0) localeCodeStr.take(hashPos) else localeCodeStr
     }
 }


### PR DESCRIPTION
## Purpose / Description
This PR resolves an Android Studio warning in `LanguageUtils.kt` by replacing a `substring()` call with the more idiomatic Kotlin extension function `take()`.

## Fixes
* Fixes #13282 (Fix Android Studio Warnings) - specifically the "substring call should be replaced with take call" warning.

## Approach
In the `stripScriptAndExtensions` function, I replaced:
`localeCodeStr.substring(0, hashPos)` 
with:
`localeCodeStr.take(hashPos)`

This makes the code cleaner and follows standard Kotlin conventions.

## How Has This Been Tested?
* Built the project successfully in Android Studio.
* Verified that the warning in `LanguageUtils.kt` is gone.
* Ran the app on an emulator to ensure basic functionality remains stable.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas (N/A - simple refactor).
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (N/A).
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner (N/A).