### PR TITLE
Fix: DB access on UI thread in processReviewResults(DeckPicker.kt)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1425,8 +1425,15 @@ open class DeckPicker :
 
     private fun processReviewResults(resultCode: Int) {
         if (resultCode == AbstractFlashcardViewer.RESULT_NO_MORE_CARDS) {
-            CongratsPage.onReviewsCompleted(this, getColUnsafe.sched.totalCount() == 0)
-            fragment?.refreshInterface()
+            launchCatchingTask {
+                val isCollectionEmpty =
+                    withContext(Dispatchers.IO) {
+                        // reading db using coroutine
+                        withCol { sched.totalCount() == 0 }
+                    }
+                CongratsPage.onReviewsCompleted(this@DeckPicker, isCollectionEmpty)
+                fragment?.refreshInterface()
+            }
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes a threading violation in `DeckPicker.processReviewResults`. 

Previously, `sched.totalCount()` was called directly on the main (UI) thread when a user finished reviewing a deck. Since this method reads from the database, it triggered an error `Method totalCount must be called from the worker thread, currently inferred thread is UI thread` in Android Studio.

## Fixes
* Fixes #13282 

## Approach
* Wrapped the logic in `launchCatchingTask` to ensure it is lifecycle-aware.
* Moved the database operation (`sched.totalCount()`) to the background thread using `withContext(Dispatchers.IO)`.
* Updated the database access method from `getColUnsafe` to the safer `withCol { ... }` pattern.
* The UI updates (`CongratsPage` and `refreshInterface`) automatically resume on the Main thread after the database read is complete.

## How Has This Been Tested?

I manually tested this on a physical Android device.

**Steps:**
1. Completed a review session on a deck.
2. Verified that the app correctly returned to the DeckPicker screen.
3. Verified that the "Congratulations" message still appears correctly.
4. **Verified that the error/warning in Android Studio is gone.**

**Result:**
The app returns to the home screen smoothly, the "Congratulations" message appears, and no threading errors are thrown.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

