### PR TITLE
fix(split-cardbrowser): list is empty when toggling to notes only mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -799,7 +799,7 @@ abstract class AbstractFlashcardViewer :
         }
         val animation = fromGesture.toAnimationTransition().invert()
         Timber.i("Launching 'edit card'")
-        val editCardIntent = NoteEditorLauncher.EditCard(currentCard!!.id, animation).toIntent(this)
+        val editCardIntent = NoteEditorLauncher.EditSelection(currentCard!!.id, animation).toIntent(this)
         editCurrentCardLauncher.launch(editCardIntent)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -653,7 +653,7 @@ class CardBrowserFragment :
                 }
             } else {
                 val cardId = activityViewModel.queryDataForCardEdit(id)
-                requireCardBrowserActivity().openNoteEditorForCard(cardId)
+                requireCardBrowserActivity().setNoteEditorCard(cardId)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -168,7 +168,22 @@ class CardBrowserViewModel(
     val cardsOrNotes get() = flowOfCardsOrNotes.value
 
     // card that was clicked (not marked)
-    var currentCardId: CardId = 0
+    var currentCardId: CardId? = null
+
+    /**
+     * Computes and stores the current card ID used by the note editor.
+     */
+    suspend fun updateCurrentCardId(): CardId? {
+        currentCardId =
+            // Early return if no cards available
+            if (cards.isEmpty()) {
+                null
+            } else {
+                focusedRow?.toCardId(cardsOrNotes)
+                    ?: cards.firstOrNull()?.toCardId(cardsOrNotes)
+            }
+        return currentCardId
+    }
 
     var cardIdToBeScrolledTo: CardId? = null
         private set
@@ -332,7 +347,7 @@ class CardBrowserViewModel(
         return CardInfoDestination(firstSelectedCard, TR.currentCardBrowse())
     }
 
-    suspend fun queryDataForCardEdit(id: CardOrNoteId): CardId = id.toCardId(cardsOrNotes)
+    suspend fun queryDataForCardEdit(id: CardOrNoteId): CardId? = id.toCardId(cardsOrNotes)
 
     private suspend fun getInitialDeck(): SelectableDeck {
         // TODO: Handle the launch intent
@@ -564,8 +579,13 @@ class CardBrowserViewModel(
         }
     }
 
-    // on a row tap
-    fun openNoteEditorForCard(cardId: CardId) {
+    /**
+     * Opens the note editor for the given card.
+     *
+     * @param cardId The ID of the card to open in the note editor.
+     * Passing `null` indicates that no card is selected and will close the note editor
+     */
+    fun setNoteEditorCard(cardId: CardId?) {
         currentCardId = cardId
         if (!isFragmented) {
             endMultiSelectMode(SingleSelectCause.OpenNoteEditorActivity)
@@ -1236,7 +1256,7 @@ class CardBrowserViewModel(
 
     suspend fun queryCardIdAtPosition(index: Int): CardId = cards.queryCardIdsAt(index).first()
 
-    suspend fun querySelectedCardIdAtPosition(index: Int): CardId = selectedRows.toList()[index].toCardId(cardsOrNotes)
+    suspend fun querySelectedCardIdAtPosition(index: Int): CardId? = selectedRows.toList()[index].toCardId(cardsOrNotes)
 
     /**
      * Obtains two lists of column headings with preview data

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardOrNoteId.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardOrNoteId.kt
@@ -39,9 +39,16 @@ value class CardOrNoteId(
 
     // TODO: We use this for 'Edit Note' or 'Card Info'. We should reconsider whether we ever want
     //  to move from NoteId to CardId. Our move to 'Notes' mode wasn't well thought-through
-    suspend fun toCardId(type: CardsOrNotes): CardId =
+
+    // TODO: Notes without cards likely indicate an invalid or corrupted collection state.
+    //  We currently handle this gracefully by returning an empty list,
+    //  we may want to surface this as a warning or integrity check for the user.
+    suspend fun toCardId(type: CardsOrNotes): CardId? =
         when (type) {
             CardsOrNotes.CARDS -> cardOrNoteId
-            CardsOrNotes.NOTES -> withCol { cardIdsOfNote(cardOrNoteId).first() }
+            // A note can map to multiple cards or none at all.
+            // See [cardIdsOfNote] for the full explanation and edge cases
+            // (empty templates, orphaned notes, etc).
+            CardsOrNotes.NOTES -> withCol { cardIdsOfNote(cardOrNoteId).firstOrNull() }
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -164,12 +164,12 @@ sealed interface NoteEditorLauncher : Destination {
     }
 
     /**
-     * Represents editing a card in the NoteEditor.
-     * @property cardId The ID of the card to edit.
+     * Opens the NoteEditor for the current selection (card or note).
+     * @property cardId The selected card ID, or null when editing a note.
      * @property animation The animation direction.
      */
-    data class EditCard(
-        val cardId: CardId,
+    data class EditSelection(
+        val cardId: CardId?,
         val animation: ActivityTransitionAnimation.Direction,
         val inCardBrowserActivity: Boolean = false,
     ) : NoteEditorLauncher {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -719,7 +719,7 @@ class NoteEditorTest : RobolectricTest() {
     ): NoteEditorFragment {
         val bundle =
             when (from) {
-                REVIEWER -> NoteEditorLauncher.EditCard(n.firstCard().id, DEFAULT).toBundle()
+                REVIEWER -> NoteEditorLauncher.EditSelection(n.firstCard().id, DEFAULT).toBundle()
                 DECK_LIST -> NoteEditorLauncher.AddNote().toBundle()
             }
         return openNoteEditorWithArgs(bundle)

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -683,6 +683,16 @@ class Collection(
         backend.removeNotes(noteIds = emptyList(), cardIds = cardIds)
     }
 
+    /**
+     * Returns all card IDs linked to the given note.
+     *
+     * IMPORTANT:
+     * A note may not always have cards.
+     *
+     * This can happen in cases like:
+     * - The note type has no card templates (empty cards).
+     * - Cards were deleted but the note still exists (orphaned notes).
+     */
     @CheckResult
     @LibAnkiAlias("card_ids_of_note")
     fun cardIdsOfNote(nid: NoteId): List<CardId> = backend.cardsOfNote(nid = nid)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
java.util.NoSuchElementException: List is empty when toggling Card/Notes

## Fixes
* Fixes #19924

## Approach
Moved logic to ViewModel with safe handling

## How Has This Been Tested?
Chromebook

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)