### PR TITLE
build(ci): Add 'Needs Review' label to opened PRs

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -206,3 +206,21 @@ jobs:
               repo: context.repo.repo,
               labels: ['New contributor']
             })
+  
+  # Add 'Needs Review' label to newly opened, non-draft PRs
+  add_needs_review_label:
+    if: github.event.action == 'opened' && !github.event.pull_request.draft
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['Needs Review']
+            })

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,7 +155,7 @@ If you feel your PR is no longer reviewable because it requires significant work
 #### Label guide
 
 * **No label**
-  * Please ping a maintainer to add a '**Needs Review**' label 
+  * PRs should not be unlabeled, please ping a maintainer if this occurs. 
 * **[Needs Author Reply](https://github.com/ankidroid/Anki-Android/labels/Needs%20Author%20Reply)**
   * The PR will unlikely be looked at until requested changes are made.
 * **[Has Conflicts](https://github.com/ankidroid/Anki-Android/labels/Has%20Conflicts)**


### PR DESCRIPTION
⚠️ This change affects a `pull_request_target` workflow which is security critical. Please review carefully.

-----

... unless they are drafts

This automates a task which maintainers could be pinged for

## Fixes
* Fixes #19958

## Approach
Add a workflow to `labels.yml`

Code is from 

* https://github.com/ankidroid/Anki-Android/pull/19959/
* f0b7671cf4a56552b099cca40ca50681b87b59ff
* With thanks to @aladdin-afk


## How Has This Been Tested?

* Added 'Needs Review' to my fork
* Pushed this commit to `main`
* non-draft: https://github.com/david-allison/Anki-Android/pull/46 ✅  label added
* draft: https://github.com/david-allison/Anki-Android/pull/47 ✅ no label
* If the label already exists
  * https://github.com/david-allison/Anki-Android/actions/runs/20724944845/job/59498055490?pr=48
  * https://github.com/david-allison/Anki-Android/pull/48 ✅ no error

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)