### PR TITLE
UI: use sentence case for browser options

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -360,7 +360,7 @@
     <!-- Browser Options Dialog -->
     <string name="show_cards" comment="Label for toggle cards button in BrowserOptionsDialog">Cards</string>
     <string name="show_notes" comment="Label for toggle notes button in BrowserOptionsDialog">Notes</string>
-    <string name="toggle_cards_notes">Toggle Cards/Notes</string>
+    <string name="toggle_cards_notes">Toggle cards/notes</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3&#160;lines of content</string>
     <string name="browser_options_dialog_heading">Browser options</string>
 


### PR DESCRIPTION
## Purpose / Description

The Browser Options dialog contains text using inconsistent capitalization (e.g. title case instead of sentence case), which differs from surrounding UI text and affects visual consistency.

This PR aligns Browser Options strings with the established sentence case style used across the app.

Fixes #15760


## Approach

- Identified strings used directly by the **Browser Options dialog**
- Updated only those strings to **sentence case**
- Left adjacent and unrelated strings unchanged to avoid expanding scope


## How Has This Been Tested?

- Manually verified the Browser Options dialog UI
- Confirmed no other screens or features are affected

## Checklist

- [x] Descriptive commit message with a short title
- [x] Self-reviewed the changes
- [x] Scope limited strictly to Browser Options
- [x] No functional or behavioral changes
- [x] UI change verified manually
