### PR TITLE
Fix: Add missing 'minutes' unit to reviewer time estimate

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Time.kt
@@ -56,6 +56,15 @@ fun remainingTime(
         res.getQuantityString(R.plurals.reviewer_window_title, timeX, timeX)
         // It used to be minutes only. So the word "minutes" is not
         // explicitly written in the resource name.
+        /*
+         * NOTE:
+         * The reviewer ETA intentionally omits the "minutes" unit when displaying
+         * values such as "4 hours 12".
+         * Android plural resources support only a single quantity, but this ETA
+         * combines two quantities (hours and minutes). Adding a second unit would
+         * break proper internationalization.
+         * See PR #20033, issues #5626 and #5829.
+         */
     } else if (timeSeconds < TIME_DAY_LONG) {
         timeX = (timeSeconds / TIME_HOUR_LONG).toInt()
         remainingSeconds = (timeSeconds % TIME_HOUR_LONG).toInt()


### PR DESCRIPTION
### Description
This PR adds a code comment explaining why the "minutes" unit is omitted in the reviewer time estimate (e.g., displaying "4 hours 12" instead of "4 hours 12 minutes").

### Rationale
As discussed in the related issue, adding the "minutes" unit creates complexity for internationalization (translations) due to Android's pluralization rules handling two different quantities (hours and minutes) simultaneously.

The omission is intentional to keep the UI concise and translation-friendly. This comment is added to prevent future attempts to "fix" this behavior, ensuring developers understand the context (referencing PR #5626).

### Changes
- Reverted the logic change that added "minutes".
- Added an explanatory comment to the code.
