### PR TITLE
fix(study-options): NullPointerException - onPrepareMenu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -272,24 +272,24 @@ class StudyOptionsFragment :
         try {
             // Switch on or off rebuild/empty/custom study depending on whether or not filtered deck
             if (col != null && col!!.decks.isFiltered(col!!.decks.selected())) {
-                menu.findItem(R.id.action_rebuild).isVisible = true
-                menu.findItem(R.id.action_empty).isVisible = true
-                menu.findItem(R.id.action_custom_study).isVisible = false
-                menu.findItem(R.id.action_deck_or_study_options).setTitle(R.string.menu__study_options)
+                menu.findItem(R.id.action_rebuild)?.isVisible = true
+                menu.findItem(R.id.action_empty)?.isVisible = true
+                menu.findItem(R.id.action_custom_study)?.isVisible = false
+                menu.findItem(R.id.action_deck_or_study_options)?.setTitle(R.string.menu__study_options)
             } else {
-                menu.findItem(R.id.action_rebuild).isVisible = false
-                menu.findItem(R.id.action_empty).isVisible = false
-                menu.findItem(R.id.action_custom_study).isVisible = true
-                menu.findItem(R.id.action_deck_or_study_options).setTitle(R.string.menu__deck_options)
+                menu.findItem(R.id.action_rebuild)?.isVisible = false
+                menu.findItem(R.id.action_empty)?.isVisible = false
+                menu.findItem(R.id.action_custom_study)?.isVisible = true
+                menu.findItem(R.id.action_deck_or_study_options)?.setTitle(R.string.menu__deck_options)
             }
             // Don't show custom study icon if congrats shown
             if (currentContentView == CONTENT_CONGRATS) {
-                menu.findItem(R.id.action_custom_study).isVisible = false
+                menu.findItem(R.id.action_custom_study)?.isVisible = false
             }
             // Use new review reminders system if enabled
-            menu.findItem(R.id.action_schedule_reminders).isVisible = Prefs.newReviewRemindersEnabled
+            menu.findItem(R.id.action_schedule_reminders)?.isVisible = Prefs.newReviewRemindersEnabled
             // Switch on or off unbury depending on if there are cards to unbury
-            menu.findItem(R.id.action_unbury).isVisible = col != null && col!!.sched.haveBuried()
+            menu.findItem(R.id.action_unbury)?.isVisible = col != null && col!!.sched.haveBuried()
         } catch (e: IllegalStateException) {
             if (!CollectionManager.isOpenUnsafe()) {
                 // This will allow a maximum of one invalidate menu attempt in order to workaround


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This occurs in slower chromebook/tablet devices. There is timing condition `onPrepareMenu` is calling before menu is inflated. To reproduce this bug I added some delay manually 500ms. Also tried with this fix, there is no crash

## Fixes
* Fixes #19761 

## Approach
Add safe call operator `?.` to all menu.findItem()

## How Has This Been Tested?
Tested by adding delay 500ms

    override fun onCreateMenu(
        menu: Menu,
        menuInflater: MenuInflater,
    ) {
        GlobalScope.launch {
            delay(500)
            withContext(Dispatchers.Main) {
                menuInflater.inflate(R.menu.study_options_fragment, menu)
            }
        }
    }   

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)