### PR TITLE
feat(resizable-divider): set backgroundColor onHover

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/ResizablePaneManager.kt
@@ -61,10 +61,12 @@ class ResizablePaneManager(
                             divider.context,
                             PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW,
                         )
+                    divider.setBackgroundColor(dragColor)
                     true
                 }
                 MotionEvent.ACTION_HOVER_EXIT -> {
                     divider.pointerIcon = null
+                    divider.setBackgroundColor(idleColor)
                     true
                 }
                 else -> false


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Resizable divider should have a onHover color

## Fixes
* Fixes #18960

## Approach
`divider.setBackgroudColor()` on `onHover`

## How Has This Been Tested?
Chromebook
[Screen recording 2026-01-07 11.25.29 AM.webm](https://github.com/user-attachments/assets/465542b9-a4cc-4e52-8f81-62297512b78c)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)