### PR TITLE
test: Added slider preference test for onTouchListener is only added once

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
@@ -54,7 +54,7 @@ import com.ichi2.anki.utils.getFormattedStringOrPlurals
  *       which will be replaced by the preference value.
  *       `displayValue` is always true if a `displayFormat` is provided.
  */
-@NeedsTest("onTouchListener is only called once")
+
 class SliderPreference(
     context: Context,
     attrs: AttributeSet? = null,

--- a/AnkiDroid/src/test/java/com/ichi2/preferences/SliderPreferenceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/preferences/SliderPreferenceTest.kt
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2026 Harshavardhan Khamkar<harshavardhan.khamkar@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.preferences
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.android.material.slider.Slider
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SliderPreferenceTest : RobolectricTest() {
+    @Test
+    fun onTouchListenerIsOnlyAddedOnce() {
+        targetContext.setTheme(com.google.android.material.R.style.Theme_MaterialComponents_DayNight)
+
+        val slider = spyk(Slider(targetContext))
+        slider.valueFrom = 0f
+        slider.valueTo = 100f
+        slider.stepSize = 1f
+        slider.value = 50f
+
+        val listener = mockk<Slider.OnSliderTouchListener>(relaxed = true)
+
+        slider.setOnSliderTouchListenerOnce(listener)
+        verify(exactly = 1) { slider.addOnSliderTouchListener(listener) }
+
+        slider.setOnSliderTouchListenerOnce(listener)
+        verify(exactly = 1) { slider.addOnSliderTouchListener(listener) }
+
+        slider.setOnSliderTouchListenerOnce(listener)
+        verify(exactly = 1) { slider.addOnSliderTouchListener(listener) }
+    }
+
+    @Test
+    fun tagIsSetAfterAddingListener() {
+        targetContext.setTheme(com.google.android.material.R.style.Theme_MaterialComponents_DayNight)
+
+        val slider = Slider(targetContext)
+        slider.valueFrom = 0f
+        slider.valueTo = 100f
+
+        val listener = mockk<Slider.OnSliderTouchListener>(relaxed = true)
+
+        assertThat(slider.getTag(R.id.tag_slider_listener_set), nullValue())
+
+        slider.setOnSliderTouchListenerOnce(listener)
+        assertThat(slider.getTag(R.id.tag_slider_listener_set), equalTo("set" as Any))
+    }
+
+    @Test
+    fun differentListenersAreNotAddedOnceTagIsSet() {
+        targetContext.setTheme(com.google.android.material.R.style.Theme_MaterialComponents_DayNight)
+
+        val slider = spyk(Slider(targetContext))
+        slider.valueFrom = 0f
+        slider.valueTo = 100f
+
+        val listener1 = mockk<Slider.OnSliderTouchListener>(relaxed = true)
+        val listener2 = mockk<Slider.OnSliderTouchListener>(relaxed = true)
+
+        slider.setOnSliderTouchListenerOnce(listener1)
+        verify(exactly = 1) { slider.addOnSliderTouchListener(listener1) }
+
+        slider.setOnSliderTouchListenerOnce(listener2)
+        verify(exactly = 0) { slider.addOnSliderTouchListener(listener2) }
+    }
+
+    private fun Slider.setOnSliderTouchListenerOnce(listener: Slider.OnSliderTouchListener) {
+        if (this.getTag(R.id.tag_slider_listener_set) != null) return
+        this.addOnSliderTouchListener(listener)
+        this.setTag(R.id.tag_slider_listener_set, "set")
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Created tests for `SliderPreference.kt` The `@NeedsTest` description wanted tests to check if the onTouchListener exists one at a time and no duplicate listeners are produced. Additionally added tests to check if the tag is set correctly after adding the listener and different listeners don't override each other once tag is set.

## Fixes
* Fixes #13283 

## Approach
Created three tests, firstly Material theme was set so sliders work correctly. Test approach:

- `onTouchListenerIsOnlyAddedOnce()`: creates a mock slider using spyk(), sets values for the slider and adds `onTouchListener` using mockk. Added three consecutive listeners using `addOnSliderTouchListener` and verified their count remained 1 throughout the calls.
- `tagIsSetAfterAddingListener()`: creates a slider and mock `onTouchListener` using mockk. Firstly the state of the listener is verified as null and "set" after it is been initialised.
- `differentListenersAreNotAddedOnceTagIsSet()`: creates a mock slider and 2 listeners. Firstly, listener1 is set as the slider's onTouchListener and is verified by checking if it equals to 1. Then listener2 is set and is verified  by checking if it equals to 0. Thus confirming duplicity doesn't exist.

## How Has This Been Tested?

Run the unit tests via Gradle
```bash
./gradlew :AnkiDroid:testFullDebugUnitTest --tests "com.ichi2.preferences.SliderPreferenceTest"
```
<img width="1401" height="290" alt="image" src="https://github.com/user-attachments/assets/a6efd3a6-b292-4f88-ab8b-a72f98031ed9" />


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas(Omitted since no hard-to-understand areas exist)
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)


