### PR TITLE
fix(study-screen): timer on big screens

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -339,7 +339,7 @@ open class PrefsRepository(
         get() = getBoolean(R.string.dev_options_enabled_by_user_key, false) || BuildConfig.DEBUG
         set(value) = putBoolean(R.string.dev_options_enabled_by_user_key, value)
 
-    val isNewStudyScreenEnabled by booleanPref(R.string.new_reviewer_options_key, false)
+    var isNewStudyScreenEnabled by booleanPref(R.string.new_reviewer_options_key, false)
 
     val devIsCardBrowserFragmented: Boolean
         get() = getBoolean(R.string.dev_card_browser_fragmented, false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -483,7 +483,7 @@ class ReviewerFragment :
                 connect(
                     R.id.reviewer_menu_view,
                     ConstraintSet.START,
-                    R.id.counts_flow,
+                    R.id.counts_barrier,
                     ConstraintSet.END,
                 )
                 applyTo(binding.toolsLayout)

--- a/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout-sw720dp/reviewer2.xml
@@ -152,6 +152,9 @@
                 android:id="@+id/study_counts"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintBottom_toTopOf="@id/timer"
                 />
 
             <!-- Timer below counts means UI elements may jump if timer is selectively enabled.
@@ -161,23 +164,20 @@
                 android:id="@+id/timer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintEnd_toEndOf="@id/counts_barrier"
+                app:layout_constraintTop_toBottomOf="@id/study_counts"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:visibility="gone"
                 tools:visibility="visible"
                 />
 
-            <androidx.constraintlayout.helper.widget.Flow
-                android:id="@+id/counts_flow"
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/counts_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="study_counts,timer"
-                app:flow_wrapMode="chain"
-                app:flow_verticalStyle="packed"
-                app:flow_verticalGap="4dp"
-                app:flow_maxElementsWrap="1"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/back_button"
-                />
+                app:barrierDirection="end"
+                app:constraint_referenced_ids="study_counts, timer"/>
 
             <com.ichi2.anki.ui.windows.reviewer.AnswerAreaView
                 android:id="@+id/answer_area"

--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -43,6 +43,9 @@
                 android:id="@+id/study_counts"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintBottom_toTopOf="@id/timer"
                 />
 
             <!-- Timer below counts means UI elements may jump if timer is selectively enabled.
@@ -52,23 +55,20 @@
                 android:id="@+id/timer"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                app:layout_constraintStart_toEndOf="@id/back_button"
+                app:layout_constraintEnd_toStartOf="@id/counts_barrier"
+                app:layout_constraintTop_toBottomOf="@id/study_counts"
+                app:layout_constraintBottom_toBottomOf="parent"
                 android:visibility="gone"
                 tools:visibility="visible"
                 />
 
-            <androidx.constraintlayout.helper.widget.Flow
-                android:id="@+id/counts_flow"
+            <androidx.constraintlayout.widget.Barrier
+                android:id="@+id/counts_barrier"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="study_counts,timer"
-                app:flow_wrapMode="chain"
-                app:flow_verticalStyle="packed"
-                app:flow_verticalGap="4dp"
-                app:flow_maxElementsWrap="1"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintStart_toEndOf="@id/back_button"
-                />
+                app:barrierDirection="end"
+                app:constraint_referenced_ids="study_counts, timer"/>
 
             <com.ichi2.anki.preferences.reviewer.ReviewerMenuView
                 android:id="@+id/reviewer_menu_view"
@@ -76,7 +76,7 @@
                 android:layout_height="0dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/counts_flow"
+                app:layout_constraintStart_toEndOf="@id/counts_barrier"
                 app:layout_constraintTop_toTopOf="parent"
                 android:layout_marginStart="12dp"/>
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
@@ -35,6 +35,7 @@ class StudyScreenScreenshotTest(
     private val config: TestConfig,
 ) : ScreenshotTest() {
     init {
+        Prefs.isNewStudyScreenEnabled = true
         Prefs.toolbarPosition = config.toolbarPosition
         Prefs.showAnswerButtons = config.showAnswerButtons
         Prefs.frameStyle = config.frameStyle


### PR DESCRIPTION
if `Show answer buttons` was disabled, the timer was visible even if disabled

Discovered by looking over the reviewer screenshot tests

## Approach

For some reason, a ConstraintLayout Flow resets its children visibility if a new constraint is applied, such as when the answer buttons are hidden on tablets.

## How Has This Been Tested?

Sreenshot semi-automated tests

<details>
<img width="1078" height="2399" alt="Phone_toolbar=BOTTOM_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/0711c74e-eb58-446c-945a-24131ef4f5ae" />

<img width="2560" height="1600" alt="Tablet_toolbar=TOP_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/09b139fc-38af-4695-8fdb-0675ad3991ce" />
<img width="1078" height="2399" alt="Phone_toolbar=BOTTOM_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/47c1d1f6-e231-4620-94b5-4a7033824296" />
<img width="1078" height="2399" alt="Phone_toolbar=NONE_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/a9063d0c-6434-4d4d-9b6f-812812760112" />
<img width="1078" height="2399" alt="Phone_toolbar=NONE_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/75dcb939-f7e3-4333-a69e-3c3d368267e6" />
<img width="1078" height="2399" alt="Phone_toolbar=TOP_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/6a57d902-1c8e-4b0d-851c-36e5aad56552" />
<img width="1078" height="2399" alt="Phone_toolbar=TOP_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/1f60c3f3-8e52-491c-8acf-abff1d5ce20a" />
<img width="2560" height="1600" alt="Tablet_toolbar=BOTTOM_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/ca7fd519-cbd8-4e4e-bc1a-b93590c16f2e" />
<img width="2560" height="1600" alt="Tablet_toolbar=BOTTOM_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/2c6baac9-a2dc-4d08-8941-b97cd2ab0653" />
<img width="2560" height="1600" alt="Tablet_toolbar=NONE_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/8f1b5cfb-05ae-4557-ae0d-6132ee92bd09" />
<img width="2560" height="1600" alt="Tablet_toolbar=NONE_frameStyle=BOX_buttons=true" src="https://github.com/user-attachments/assets/22715a35-203d-4a68-8479-0564dd744d1f" />
<img width="2560" height="1600" alt="Tablet_toolbar=TOP_frameStyle=BOX_buttons=false" src="https://github.com/user-attachments/assets/ffe7b1fc-cc1c-4d5c-9eef-c0c32567ab1d" />

</details>


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->