### PR TITLE
Tests / adding tests to TimeUtils.kt

### DIFF
--- a/common/src/main/java/com/ichi2/anki/common/time/TimeUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/TimeUtils.kt
@@ -33,11 +33,9 @@ const val TIME_DAY = 24.0 * TIME_HOUR
 // private const val TIME_MONTH = 30.0 * TIME_DAY
 // private const val TIME_YEAR = 12.0 * TIME_MONTH
 
-@NeedsTest("untested")
 fun getTimestamp(time: Time): String = SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(time.currentDate)
 
 /** Formats the time as '00:00.00' (m:s:ms), OR 00:00:00.00 (h:m:s.ms) */
-@NeedsTest("untested")
 fun Duration.formatAsString(): String {
     val milliseconds = this.inWholeMilliseconds
     val ms = milliseconds % 1000
@@ -51,11 +49,11 @@ fun Duration.formatAsString(): String {
     }
 }
 
-@NeedsTest("untested")
 fun getDayStart(time: Time): Long {
     val cal = time.calendar()
     if (cal[Calendar.HOUR_OF_DAY] < 4) {
-        cal.roll(Calendar.DAY_OF_YEAR, -1)
+        // Changed from roll() to add() to handle year boundaries correctly (e.g., Jan 1 -> Dec 31)
+        cal.add(Calendar.DAY_OF_YEAR, -1)
     }
     cal[Calendar.HOUR_OF_DAY] = 4
     cal[Calendar.MINUTE] = 0

--- a/common/src/test/java/com/ichi2/anki/common/time/TimeUtilsTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/time/TimeUtilsTest.kt
@@ -1,0 +1,237 @@
+/*
+ *  Copyright (c) 2026 ialwaysbeatmywifi <ialwaysbeatmywifi@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.common.time
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.matchesPattern
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.util.Calendar
+import java.util.TimeZone
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class TimeUtilsTest {
+    private val originalTimeZone = TimeZone.getDefault()
+
+    @Before
+    fun setUp() {
+        // We set GMT timezone for consistent test results
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT"))
+    }
+
+    @After
+    fun tearDown() {
+        // We restore original timezone
+        TimeZone.setDefault(originalTimeZone)
+    }
+
+    private val mockTime =
+        MockTime(
+            year = 2023,
+            month = 0, // We use January (0-based)
+            date = 15,
+            hourOfDay = 10,
+            minute = 30,
+            second = 45,
+            milliseconds = 500,
+            step = 0,
+        )
+
+    @Test
+    fun getTimestamp_format_is_correct() {
+        val timestamp = getTimestamp(mockTime)
+        // We expect format: yyyyMMddHHmmss
+        assertThat(timestamp, matchesPattern("^\\d{14}$"))
+        // We verify it starts with 20230115 for the date we set
+        assertThat(timestamp.startsWith("20230115"), equalTo(true))
+    }
+
+    @Test
+    fun formatAsString_less_than_one_hour() {
+        val duration = 5.minutes + 30.seconds + 200.milliseconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("05:30.20"))
+    }
+
+    @Test
+    fun formatAsString_one_hour_or_more() {
+        val duration = 1.hours + 5.minutes + 30.seconds + 200.milliseconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("01:05:30.20"))
+    }
+
+    @Test
+    fun formatAsString_zero_duration() {
+        val duration = 0.milliseconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("00:00.00"))
+    }
+
+    @Test
+    fun formatAsString_milliseconds_only() {
+        val duration = 500.milliseconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("00:00.50"))
+    }
+
+    @Test
+    fun formatAsString_seconds_only() {
+        val duration = 45.seconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("00:45.00"))
+    }
+
+    @Test
+    fun formatAsString_multiple_hours() {
+        val duration = 3.hours + 15.minutes + 45.seconds + 100.milliseconds
+        val formatted = duration.formatAsString()
+        assertThat(formatted, equalTo("03:15:45.10"))
+    }
+
+    @Test
+    fun getDayStart_before_cutoff_returns_yesterday() {
+        // We create a mock time at 3:00 AM (before 4:00 AM cutoff)
+        val earlyMorningTime =
+            MockTime(
+                year = 2023,
+                month = 0,
+                date = 15,
+                hourOfDay = 3, // 3 AM - before 4 AM cutoff
+                minute = 30,
+                second = 0,
+                milliseconds = 0,
+                step = 0,
+            )
+        val dayStart = getDayStart(earlyMorningTime)
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+        calendar.timeInMillis = dayStart
+
+        // We expect it to be set to 4:00 AM of the previous day (14th)
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), equalTo(14))
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), equalTo(4))
+        assertThat(calendar.get(Calendar.MINUTE), equalTo(0))
+        assertThat(calendar.get(Calendar.SECOND), equalTo(0))
+        assertThat(calendar.get(Calendar.MILLISECOND), equalTo(0))
+    }
+
+    @Test
+    fun getDayStart_after_cutoff_returns_today() {
+        // We create a mock time at 5:00 AM (after 4:00 AM cutoff)
+        val lateTime =
+            MockTime(
+                year = 2023,
+                month = 0,
+                date = 15,
+                hourOfDay = 5, // 5 AM - after 4 AM cutoff
+                minute = 30,
+                second = 0,
+                milliseconds = 0,
+                step = 0,
+            )
+        val dayStart = getDayStart(lateTime)
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+        calendar.timeInMillis = dayStart
+
+        // We expect it to be set to 4:00 AM of the same day (15th)
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), equalTo(15))
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), equalTo(4))
+        assertThat(calendar.get(Calendar.MINUTE), equalTo(0))
+        assertThat(calendar.get(Calendar.SECOND), equalTo(0))
+        assertThat(calendar.get(Calendar.MILLISECOND), equalTo(0))
+    }
+
+    @Test
+    fun getDayStart_at_exactly_cutoff_time() {
+        // We create a mock time at exactly 4:00 AM
+        val cutoffTime =
+            MockTime(
+                year = 2023,
+                month = 0,
+                date = 15,
+                hourOfDay = 4, // Exactly 4 AM
+                minute = 0,
+                second = 0,
+                milliseconds = 0,
+                step = 0,
+            )
+        val dayStart = getDayStart(cutoffTime)
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+        calendar.timeInMillis = dayStart
+
+        // We expect it to be set to 4:00 AM of the same day (15th)
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), equalTo(15))
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), equalTo(4))
+    }
+
+    @Test
+    fun getDayStart_with_late_hour() {
+        // We create a mock time at 23:59 (11:59 PM)
+        val lateTime =
+            MockTime(
+                year = 2023,
+                month = 0,
+                date = 15,
+                hourOfDay = 23,
+                minute = 59,
+                second = 59,
+                milliseconds = 999,
+                step = 0,
+            )
+        val dayStart = getDayStart(lateTime)
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+        calendar.timeInMillis = dayStart
+
+        // We expect it to be set to 4:00 AM of the same day (15th)
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), equalTo(15))
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), equalTo(4))
+        assertThat(calendar.get(Calendar.MINUTE), equalTo(0))
+    }
+
+    @Test
+    fun getDayStart_on_new_years_day_before_cutoff() {
+        // We create a mock time at Jan 1st, 2026 at 3:00 AM GMT
+        val newYearsMorning =
+            MockTime(
+                year = 2026,
+                month = 0, // January
+                date = 1,
+                hourOfDay = 3,
+                minute = 0,
+                second = 0,
+                milliseconds = 0,
+                step = 0,
+            )
+
+        val dayStart = getDayStart(newYearsMorning)
+        val calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT"))
+        calendar.timeInMillis = dayStart
+
+        // We expect Dec 31st, 2025 at 4:00 AM GMT
+        assertThat(calendar.get(Calendar.YEAR), equalTo(2025))
+        assertThat(calendar.get(Calendar.MONTH), equalTo(11)) // December (0-based)
+        assertThat(calendar.get(Calendar.DAY_OF_MONTH), equalTo(31))
+        assertThat(calendar.get(Calendar.HOUR_OF_DAY), equalTo(4))
+        assertThat(calendar.get(Calendar.MINUTE), equalTo(0))
+        assertThat(calendar.get(Calendar.SECOND), equalTo(0))
+        assertThat(calendar.get(Calendar.MILLISECOND), equalTo(0))
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added comprehensive unit tests in TimeUtils.kt utility functions and fixed a critical bug in getDayStart() where Calendar.roll() failed to handle year boundaries correctly.

## Bug: 
Basically, the old code used roll(), which is lazy and doesn't update the year so "yesterday" from Jan 1st ended up being Dec 31st of the same year. Switched to add() so it actually goes back to the previous year like it should.

## Fixes
* Fixes #13283 

## Approach
Swapped roll for add in getDayStart to fix a year boundary bug previously, checking the day start on Jan 1st (before 4 AM) would keep the current year instead of rolling back to Dec 31st of the previous year. Also added a full test suite for TimeUtils that enforces GMT to prevent local timezone flakes, covering everything from timestamp formats to the New Year edge case.

## How Has This Been Tested?

 ./gradlew :common:testDebugUnitTest --tests "com.ichi2.anki.common.time.TimeUtilsTest"

<img width="622" height="57" alt="image" src="https://github.com/user-attachments/assets/9f40a0d0-a314-4de0-947f-8813bcae33e3" />

 ./gradlew ktlintFormat
 ./gradlew Libanki:test




## Learning (optional, can help others)

Calendar.roll() only modifies the specified field without affecting larger fields (year styas the same)
Calendar.add() properly changes to larger fields when boundaries are crossed.

##  NOTE
Assisted-by: chat gpt

## _Links to blog posts, patterns, libraries or addons used to solve this problem_
https://stackoverflow.com/questions/11882926/how-to-subtract-x-day-from-a-date-object-in-java?newreg=1ef94f66e4494187a3e7dba0bf7ba182
https://stackoverflow.com/questions/2504141/calendar-add-vs-roll-when-do-we-use-it
## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->