### PR TITLE
release: fixup main with failed-push commit from release "Bumped version to 2.24.0alpha2"

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -89,9 +89,9 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode=22400101
+        versionCode=22400102
         // If you change this to a new version, you probably also want to update .gradle/workflows/milestone.yml for the new version...
-        versionName="2.24.0alpha1"
+        versionName="2.24.0alpha2"
         minSdk = libs.versions.minSdk.get().toInteger()
 
         // After #13695: change .tests_emulator.yml


### PR DESCRIPTION
## Purpose / Description

Unfortunately there was a rare event while publishing AnkiDroid 2.24.0alpha2 - a commit landed on main from a PR merge at the same time the publish was running, so pushing the version bump commit failed.

We still have a viable artifact that people can pull with the correct commit hash, but it's not on main, and the version bump itself is not on main.

This PR will fix that by cherrypicking the version commit that couldn't push

```
To github.com:ankidroid/Anki-Android
 ! [rejected]        main -> main (fetch first)
error: failed to push some refs to 'github.com:ankidroid/Anki-Android'
hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
To github.com:ankidroid/Anki-Android
 * [new tag]         v2.24.0alpha2 -> v2.24.0alpha2
```

(cherry picked from commit a0e65b9054ff4a4da5fa410a834cd0528518c0a6)

## Fixes

Nothing logged, and I didn't realize it was a problem until I was doing some release prep work, so it's been a few days. 

Problem: There is no active notification this happen

## Approach

Cherry-picking the commit from the commit ref visible in the logs and on the release page and connected to the git tag (verified each way, same commit)

## How Has This Been Tested?

Not testable

## Learning (optional, can help others)

Automated releases continue to just be difficult, there are exceptional cases to handle *still* after years.

1- there should be some notification that this failed, but we have had problems in this area before and we continue for a reason. We MUST NOT fail the whole workflow because this is *after* it's gone out to Google Play, we've consumed this version from a public perspective and should continue with the release with all artifacts generated. It has a valid commit ref so may be rebuilt as well. It is a serviceable release.

But the version number for next release will be off unless the version is trued up like this PR

  --> perhaps it could try (with error handling) to create an issue on github for fixup? That could work 🤔 

2- maybe....maybe there is a way to use concurrency controls or temporarily disable the merge queue while the critical phase ("check out commit" -> "build and upload to google play" -> "push the version bump + tag") phase of the release script is working? Can you disable a merge queue temporarily ? No idea.

3- perhaps it could detect this specific case, and *if we decide this fixup style is okay as policy* it could automatically rebase current main, edit the commit message to indicate the release was built from a previous (specific) commit SHA and commit. Or pull main clean, `cherry-pick -x` (for SHA cross reference) the failed commit with a descriptive message and push that?


This problem is rare enough (once every few years) that it has never been solved except manually by me.

Option 2 would be perfect. Block merge until publish critical section done.
If not possible, I kind of like option 3 if and only if this PR is generally acceptable as a fixup style.
Option 1 just kicks the can down the road - but should be used if option 1 not possible and option 2 not acceptable or fails


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->