### PR TITLE
fix(release): parallel builds have no prefix

### DIFF
--- a/tools/release.sh
+++ b/tools/release.sh
@@ -243,10 +243,8 @@ else
   BUILDNAMES='A B' # For alpha releases just post a couple parallel builds
 fi
 for BUILD in $BUILDNAMES; do
-  PREFIX=""
   echo "Adding parallel build $BUILD to Github release"
-  cp AnkiDroid-"$VERSION".parallel."$BUILD".apk "$PREFIX"AnkiDroid-"$VERSION".parallel."$BUILD".apk
-  gh release upload v"$VERSION" "$PREFIX"AnkiDroid-"$VERSION".parallel."$BUILD".apk
+  gh release upload v"$VERSION" AnkiDroid-"$VERSION".parallel."$BUILD".apk
 done
 
 # For publishing the draft release and making it immutable;


### PR DESCRIPTION
## Purpose / Description

- if you attempt to do a copy with no prefix it is a copy to same file and `cp` rightly complains

Noticed this while examining all script output to verify new draft release process for immutable releases was working:

- #19804 
- and also really scrutinizing after seeing #20060 

## Fixes

Nothing logged. Saw it in log output. We got "lucky" (given `cp` failure here had no negative effect) this didn't fail the workflow at the end, if `set -e` had been used in the file it would have failed the workflow

```

Adding parallel build A to Github release
cp: 'AnkiDroid-2.24.0alpha1.parallel.A.apk' and 'AnkiDroid-2.24.0alpha1.parallel.A.apk' are the same file
Adding parallel build B to Github release
cp: 'AnkiDroid-2.24.0alpha1.parallel.B.apk' and 'AnkiDroid-2.24.0alpha1.parallel.B.apk' are the same file

```

## Approach

- Carefully verify that an empty prefix will generate a `cp` command from same file name to same file name
- Carefully note that PREFIX in this area will always be empty
- Carefully remove all PREFIX stuff in this area

## How Has This Been Tested?

Can't really be tested easily without running a release

## Learning (optional, can help others)

When you constructing a house no single surface will be flat. No line will be straight. No angle will be square.

But the house in the end will probably stand just fine.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->