### PR TITLE
chore(ci): forward-port update-gradle-wrapper workflow to actions/checkout@v6

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure JDK
         uses: actions/setup-java@v5


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

there is a new interaction there that requires a workaround so that credentials work correctly

See https://github.com/gradle-update/update-gradle-wrapper-action/issues/988#issuecomment-3707440717

The specific change was that actions/checkout from v5 to v6 split credentials storage out to a separate file, and update gradle wrapper action was expecting to be able to clobber it directly in git config, so they conflicted

https://github.com/actions/checkout?tab=readme-ov-file#whats-new


## Fixes

Unlogged, but I've had my on these workflow failed notifications for a while

Example:

https://github.com/ankidroid/Anki-Android/actions/runs/20869134826/job/59966989275#step:4:19

## Approach

Should remove the duplicate authorization header by turning off the one persisted by actions/checkout@v6

That should leave the desired github token (from our workflow secrets, with correct permissions) as the "winning" token sent in the authorization header, so we stop getting a duplicate header warning, and we stop getting a 400 / unauthorized response code, and the workflow starts working again

## How Has This Been Tested?

Untested. Already failing, will see if it works post-merge via the workflow_dispatch trigger

## Learning (optional, can help others)

We are all on the inevitable path to the heat death of the universe (that is, "entropy")

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->