### PR TITLE
test: verify default back callback state in DeckOptions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -113,7 +113,6 @@ class DeckOptions : PageFragment() {
     /**
      * Callback used when a modal is opened in the webview. It requests the webview to close it.
      */
-    @NeedsTest("disabled by default")
     @NeedsTest("enabled if a modal is displayed")
     @NeedsTest("disabled if a modal is hidden")
     @NeedsTest("disabled if back button is pressed: no error")

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/DeckOptionsTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Harsh Somankar <harshsomankar123@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.pages
+
+import androidx.activity.OnBackPressedCallback
+import org.junit.Assert.assertFalse
+import org.junit.Test
+
+class DeckOptionsTest {
+    @Test
+    fun backCallback_isDisabledByDefault() {
+        val deckOptions = DeckOptions()
+
+        val callbackField =
+            DeckOptions::class.java.getDeclaredField("onBackFromModal")
+        callbackField.isAccessible = true
+
+        val callback =
+            callbackField.get(deckOptions) as OnBackPressedCallback
+
+        assertFalse(
+            "Back callback should be disabled by default",
+            callback.isEnabled,
+        )
+    }
+}


### PR DESCRIPTION
## Purpose / Description

Add a focused unit test to document and verify the default back callback behavior in `DeckOptions`.

This ensures the `onBackFromModal` callback starts in a disabled state and makes the intended default behavior explicit and protected by a test.

## Fixes

- Fix #13283

## Approach

A small unit test was added to inspect the `onBackFromModal` callback using reflection and assert that it is disabled by default.

To make the behavior explicit and testable, the default state is defined directly in `DeckOptions`.  
This resolves the existing `@NeedsTest("disabled by default")` annotation with a minimal and targeted test.

## How Has This Been Tested?

Ran  ./gradlew :AnkiDroid:testFullDebugUnitTest \--tests "com.ichi2.anki.pages.DeckOptionsTest"

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas.
- [x] You have performed a self-review of your own code.
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings).
- [ ] UI changes: You have tested your change using the Google Accessibility Scanner.
