### PR TITLE
refactor(custom-study): use userInputValue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -68,7 +68,6 @@ import com.ichi2.anki.dialogs.tags.TagsDialogListener.Companion.ON_SELECTED_TAGS
 import com.ichi2.anki.dialogs.tags.TagsDialogListener.Companion.ON_SELECTED_TAGS__SELECTED_TAGS
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
-import com.ichi2.anki.libanki.Tags
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
@@ -374,7 +373,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
                 // Get the value selected by user
                 val n =
-                    binding.detailsEditText2.textAsIntOrNull() ?: run {
+                    userInputValue ?: run {
                         Timber.w("Non-numeric user input was provided")
                         Timber.d("value: %s", binding.detailsEditText2.text.toString())
                         allowSubmit = true
@@ -423,8 +422,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
 
         binding.detailsEditText2.doAfterTextChanged {
-            val num = binding.detailsEditText2.textAsIntOrNull()
-            dialog.positiveButton.isEnabled = num != null && num != 0
+            dialog.positiveButton.isEnabled = userInputValue != null && userInputValue != 0
         }
 
         // Show soft keyboard


### PR DESCRIPTION
A refactoring I noticed while doing #11116

https://github.com/ankidroid/Anki-Android/blob/4e2b20d89ab73592d5a3f1f89753f91f0e174020/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt#L142-L143

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)