### PR TITLE
chore: convert DeckPickerFloatingActionMenu to ViewBinding

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/DeckPicker.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/DeckPicker.kt
@@ -61,7 +61,7 @@ fun createDeckWithUniqueName(): String {
     val testString = System.currentTimeMillis().toString()
     val deckName = "TestDeck$testString"
     onView(withId(R.id.fab_main)).perform(click())
-    onView(withId(R.id.add_deck_action)).perform(click())
+    onView(withId(R.id.add_deck_button)).perform(click())
     onView(withId(R.id.dialog_text_input)).perform(typeText(deckName))
     onView(withText(R.string.dialog_ok)).perform(click())
     return deckName

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -554,9 +554,6 @@ open class DeckPicker :
         decksLayoutManager = LinearLayoutManager(this)
         deckPickerBinding.decks.layoutManager = decksLayoutManager
 
-        // Add background to Deckpicker activity
-        val view = binding.deckpickerXlView ?: binding.rootLayout
-
         deckListAdapter =
             DeckAdapter(
                 this,
@@ -590,7 +587,7 @@ open class DeckPicker :
             }
         // Setup the FloatingActionButtons
         floatingActionMenu =
-            DeckPickerFloatingActionMenu(this, view, this).apply {
+            DeckPickerFloatingActionMenu(this, binding, this).apply {
                 toggleListener =
                     FloatingActionBarToggleListener { isOpening ->
                         closeFloatingActionBarBackPressCallback.isEnabled = isOpening

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -22,31 +22,28 @@ import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
-import android.widget.TextView
 import com.google.android.material.color.MaterialColors
-import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.ichi2.anki.databinding.ActivityHomescreenBinding
+import com.ichi2.anki.databinding.FloatingAddButtonBinding
 import com.ichi2.anki.ui.DoubleTapListener
 import com.ichi2.anki.utils.AnimationUtils.areSystemAnimationsEnabled
 import timber.log.Timber
 
 class DeckPickerFloatingActionMenu(
     private val context: Context,
-    view: View,
+    homescreenBinding: ActivityHomescreenBinding,
     private val deckPicker: DeckPicker,
 ) {
-    private val fabMain: FloatingActionButton = view.findViewById(R.id.fab_main)
-    private val addSharedLayout: LinearLayout = view.findViewById(R.id.add_shared_layout)
-    private val addDeckLayout: LinearLayout = view.findViewById(R.id.add_deck_layout)
-    private val addFilteredDeckLayout: LinearLayout = view.findViewById(R.id.add_filtered_deck_layout)
-    private val fabBGLayout: View = view.findViewById(R.id.fabBGLayout)
-    private val linearLayout: LinearLayout =
-        view.findViewById(R.id.deckpicker_view) // Layout deck_picker.xml is attached here
-    private val studyOptionsFrame: View? = view.findViewById(R.id.studyoptions_fragment)
-    private val addNoteLabel: TextView = view.findViewById(R.id.add_note_label)
+    // TODO: refactor this to decouple with Homescreen & DeckPicker
+    private val binding: FloatingAddButtonBinding = homescreenBinding.deckPickerPane.floatingActionButton
+
+    /** Layout deck_picker.xml is attached here */
+    private val linearLayout: LinearLayout = homescreenBinding.deckPickerPane.deckpickerView
+    private val studyOptionsFrame: View? = homescreenBinding.studyoptionsFrame
 
     // Colors values obtained from attributes
-    private val fabNormalColor = MaterialColors.getColor(fabMain, R.attr.fab_normal)
-    private val fabPressedColor = MaterialColors.getColor(fabMain, R.attr.fab_pressed)
+    private val fabNormalColor = MaterialColors.getColor(binding.fabMain, R.attr.fab_normal)
+    private val fabPressedColor = MaterialColors.getColor(binding.fabMain, R.attr.fab_pressed)
 
     // Add Note Drawable Icon
     private val addNoteIcon: Int = R.drawable.ic_add_note
@@ -70,20 +67,20 @@ class DeckPickerFloatingActionMenu(
         isFABOpen = true
         if (deckPicker.animationEnabled()) {
             // Show with animation
-            addSharedLayout.visibility = View.VISIBLE
-            addDeckLayout.visibility = View.VISIBLE
-            addFilteredDeckLayout.visibility = View.VISIBLE
-            fabBGLayout.visibility = View.VISIBLE
-            addNoteLabel.visibility = View.VISIBLE
-            fabMain.animate().apply {
+            binding.addSharedLayout.visibility = View.VISIBLE
+            binding.addDeckLayout.visibility = View.VISIBLE
+            binding.addFilteredDeckLayout.visibility = View.VISIBLE
+            binding.fabBGLayout.visibility = View.VISIBLE
+            binding.addNoteLabel.visibility = View.VISIBLE
+            binding.fabMain.animate().apply {
                 /*
                  * If system animations are true changes the FAB color otherwise it remains the same
                  */
                 if (areSystemAnimationsEnabled(context)) {
-                    fabMain.backgroundTintList = ColorStateList.valueOf(fabPressedColor)
+                    binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabPressedColor)
                 } else {
                     // Changes the background color of FAB
-                    fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
+                    binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
                 }
                 duration = 90
                 // Rise FAB animation
@@ -91,9 +88,9 @@ class DeckPickerFloatingActionMenu(
                 scaleY(1.3f)
                 withEndAction {
                     // At the end the Image is changed to Add Note Icon
-                    fabMain.setImageResource(addNoteIcon)
+                    binding.fabMain.setImageResource(addNoteIcon)
                     // Shrink back FAB
-                    fabMain
+                    binding.fabMain
                         .animate()
                         .setDuration(70)
                         .scaleX(1f)
@@ -102,32 +99,34 @@ class DeckPickerFloatingActionMenu(
                 }.start()
             }
 
-            addNoteLabel.animate().translationX(0f).duration = 70
-            addSharedLayout.animate().translationY(0f).duration = 100
-            addDeckLayout.animate().translationY(0f).duration = 70
-            addFilteredDeckLayout.animate().translationY(0f).duration = 100
-            addNoteLabel.animate().alpha(1f).duration = 70
-            addSharedLayout.animate().alpha(1f).duration = 100
-            addDeckLayout.animate().alpha(1f).duration = 70
-            addFilteredDeckLayout.animate().alpha(1f).duration = 100
+            with(binding) {
+                addNoteLabel.animate().translationX(0f).duration = 70
+                addSharedLayout.animate().translationY(0f).duration = 100
+                addDeckLayout.animate().translationY(0f).duration = 70
+                addFilteredDeckLayout.animate().translationY(0f).duration = 100
+                addNoteLabel.animate().alpha(1f).duration = 70
+                addSharedLayout.animate().alpha(1f).duration = 100
+                addDeckLayout.animate().alpha(1f).duration = 70
+                addFilteredDeckLayout.animate().alpha(1f).duration = 100
+            }
         } else {
             // Show without animation
-            addSharedLayout.visibility = View.VISIBLE
-            addDeckLayout.visibility = View.VISIBLE
-            addFilteredDeckLayout.visibility = View.VISIBLE
-            fabBGLayout.visibility = View.VISIBLE
-            addNoteLabel.visibility = View.VISIBLE
-            addSharedLayout.alpha = 1f
-            addDeckLayout.alpha = 1f
-            addFilteredDeckLayout.alpha = 1f
-            addNoteLabel.alpha = 1f
-            addSharedLayout.translationY = 0f
-            addDeckLayout.translationY = 0f
-            addFilteredDeckLayout.translationY = 0f
-            addNoteLabel.translationX = 0f
+            binding.addSharedLayout.visibility = View.VISIBLE
+            binding.addDeckLayout.visibility = View.VISIBLE
+            binding.addFilteredDeckLayout.visibility = View.VISIBLE
+            binding.fabBGLayout.visibility = View.VISIBLE
+            binding.addNoteLabel.visibility = View.VISIBLE
+            binding.addSharedLayout.alpha = 1f
+            binding.addDeckLayout.alpha = 1f
+            binding.addFilteredDeckLayout.alpha = 1f
+            binding.addNoteLabel.alpha = 1f
+            binding.addSharedLayout.translationY = 0f
+            binding.addDeckLayout.translationY = 0f
+            binding.addFilteredDeckLayout.translationY = 0f
+            binding.addNoteLabel.translationX = 0f
 
             // During without animation maintain the original color of FAB
-            fabMain.apply {
+            binding.fabMain.apply {
                 backgroundTintList = ColorStateList.valueOf(fabNormalColor)
                 setImageResource(addNoteIcon)
             }
@@ -150,22 +149,22 @@ class DeckPickerFloatingActionMenu(
             linearLayout.alpha = 1f
             studyOptionsFrame?.let { it.alpha = 1f }
             isFABOpen = false
-            fabBGLayout.visibility = View.GONE
-            addNoteLabel.visibility = View.GONE
+            binding.fabBGLayout.visibility = View.GONE
+            binding.addNoteLabel.visibility = View.GONE
             if (deckPicker.animationEnabled()) {
                 // Changes the background color of FAB to default
-                fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
+                binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
                 // Close with animation
-                fabMain.animate().apply {
+                binding.fabMain.animate().apply {
                     duration = 90
                     // Rise FAB animation
                     scaleX(1.3f)
                     scaleY(1.3f)
                     withEndAction {
                         // At the end the image is changed to Add White Icon
-                        fabMain.setImageResource(addWhiteIcon)
+                        binding.fabMain.setImageResource(addWhiteIcon)
                         // Shrink back FAB
-                        fabMain
+                        binding.fabMain
                             .animate()
                             .setDuration(60)
                             .scaleX(1f)
@@ -174,156 +173,160 @@ class DeckPickerFloatingActionMenu(
                     }.start()
                 }
 
-                addSharedLayout.animate().alpha(0f).duration = 50
-                addNoteLabel.animate().alpha(0f).duration = 70
-                addDeckLayout.animate().alpha(0f).duration = 100
-                addFilteredDeckLayout.animate().alpha(0f).duration = 100
-                addSharedLayout.animate().translationY(400f).duration = 100
-                addNoteLabel.animate().translationX(180f).duration = 70
-                addDeckLayout
-                    .animate()
-                    .translationY(300f)
-                    .setDuration(50)
-                    .setListener(
-                        object : Animator.AnimatorListener {
-                            override fun onAnimationStart(animator: Animator) {}
+                with(binding) {
+                    addSharedLayout.animate().alpha(0f).duration = 50
+                    addNoteLabel.animate().alpha(0f).duration = 70
+                    addDeckLayout.animate().alpha(0f).duration = 100
+                    addFilteredDeckLayout.animate().alpha(0f).duration = 100
+                    addSharedLayout.animate().translationY(400f).duration = 100
+                    addNoteLabel.animate().translationX(180f).duration = 70
+                    addDeckLayout
+                        .animate()
+                        .translationY(300f)
+                        .setDuration(50)
+                        .setListener(
+                            object : Animator.AnimatorListener {
+                                override fun onAnimationStart(animator: Animator) {}
 
-                            override fun onAnimationEnd(animator: Animator) {
-                                if (!isFABOpen) {
-                                    addSharedLayout.visibility = View.GONE
-                                    addDeckLayout.visibility = View.GONE
-                                    addFilteredDeckLayout.visibility = View.GONE
-                                    addNoteLabel.visibility = View.GONE
+                                override fun onAnimationEnd(animator: Animator) {
+                                    if (!isFABOpen) {
+                                        addSharedLayout.visibility = View.GONE
+                                        addDeckLayout.visibility = View.GONE
+                                        addFilteredDeckLayout.visibility = View.GONE
+                                        addNoteLabel.visibility = View.GONE
+                                    }
                                 }
-                            }
 
-                            override fun onAnimationCancel(animator: Animator) {}
+                                override fun onAnimationCancel(animator: Animator) {}
 
-                            override fun onAnimationRepeat(animator: Animator) {}
-                        },
-                    )
-                addFilteredDeckLayout
-                    .animate()
-                    .translationY(400f)
-                    .setDuration(100)
-                    .setListener(
-                        object : Animator.AnimatorListener {
-                            override fun onAnimationStart(animator: Animator) {}
+                                override fun onAnimationRepeat(animator: Animator) {}
+                            },
+                        )
+                    addFilteredDeckLayout
+                        .animate()
+                        .translationY(400f)
+                        .setDuration(100)
+                        .setListener(
+                            object : Animator.AnimatorListener {
+                                override fun onAnimationStart(animator: Animator) {}
 
-                            override fun onAnimationEnd(animator: Animator) {
-                                if (!isFABOpen) {
-                                    addSharedLayout.visibility = View.GONE
-                                    addDeckLayout.visibility = View.GONE
-                                    addFilteredDeckLayout.visibility = View.GONE
-                                    addNoteLabel.visibility = View.GONE
+                                override fun onAnimationEnd(animator: Animator) {
+                                    if (!isFABOpen) {
+                                        addSharedLayout.visibility = View.GONE
+                                        addDeckLayout.visibility = View.GONE
+                                        addFilteredDeckLayout.visibility = View.GONE
+                                        addNoteLabel.visibility = View.GONE
+                                    }
                                 }
-                            }
 
-                            override fun onAnimationCancel(animator: Animator) {}
+                                override fun onAnimationCancel(animator: Animator) {}
 
-                            override fun onAnimationRepeat(animator: Animator) {}
-                        },
-                    )
+                                override fun onAnimationRepeat(animator: Animator) {}
+                            },
+                        )
+                }
             } else {
                 // Close without animation
-                addSharedLayout.visibility = View.GONE
-                addDeckLayout.visibility = View.GONE
-                addFilteredDeckLayout.visibility = View.GONE
-                addNoteLabel.visibility = View.GONE
+                binding.addSharedLayout.visibility = View.GONE
+                binding.addDeckLayout.visibility = View.GONE
+                binding.addFilteredDeckLayout.visibility = View.GONE
+                binding.addNoteLabel.visibility = View.GONE
 
-                fabMain.setImageResource(addWhiteIcon)
+                binding.fabMain.setImageResource(addWhiteIcon)
             }
         } else {
             linearLayout.alpha = 1f
             studyOptionsFrame?.let { it.alpha = 1f }
             isFABOpen = false
-            fabBGLayout.visibility = View.GONE
-            addNoteLabel.visibility = View.GONE
+            binding.fabBGLayout.visibility = View.GONE
+            binding.addNoteLabel.visibility = View.GONE
             if (deckPicker.animationEnabled()) {
                 // Changes the background color of FAB to default
-                fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
+                binding.fabMain.backgroundTintList = ColorStateList.valueOf(fabNormalColor)
                 // Close with animation
-                fabMain.animate().apply {
+                binding.fabMain.animate().apply {
                     duration = 90
                     withEndAction {
                         // At the end the image is changed to Add White Icon
-                        fabMain.setImageResource(addWhiteIcon)
+                        binding.fabMain.setImageResource(addWhiteIcon)
                     }.start()
                 }
 
-                addSharedLayout.animate().alpha(0f).duration = 70
-                addDeckLayout.animate().alpha(0f).duration = 50
-                addFilteredDeckLayout.animate().alpha(0f).duration = 50
-                addNoteLabel.animate().alpha(0f).duration = 50
-                addNoteLabel.animate().translationX(180f).duration = 70
-                addSharedLayout.animate().translationY(600f).duration = 100
-                addDeckLayout
-                    .animate()
-                    .translationY(400f)
-                    .setDuration(50)
-                    .setListener(
-                        object : Animator.AnimatorListener {
-                            override fun onAnimationStart(animator: Animator) {}
+                with(binding) {
+                    addSharedLayout.animate().alpha(0f).duration = 70
+                    addDeckLayout.animate().alpha(0f).duration = 50
+                    addFilteredDeckLayout.animate().alpha(0f).duration = 50
+                    addNoteLabel.animate().alpha(0f).duration = 50
+                    addNoteLabel.animate().translationX(180f).duration = 70
+                    addSharedLayout.animate().translationY(600f).duration = 100
+                    addDeckLayout
+                        .animate()
+                        .translationY(400f)
+                        .setDuration(50)
+                        .setListener(
+                            object : Animator.AnimatorListener {
+                                override fun onAnimationStart(animator: Animator) {}
 
-                            override fun onAnimationEnd(animator: Animator) {
-                                if (!isFABOpen) {
-                                    addSharedLayout.visibility = View.GONE
-                                    addDeckLayout.visibility = View.GONE
-                                    addFilteredDeckLayout.visibility = View.GONE
-                                    addNoteLabel.visibility = View.GONE
+                                override fun onAnimationEnd(animator: Animator) {
+                                    if (!isFABOpen) {
+                                        addSharedLayout.visibility = View.GONE
+                                        addDeckLayout.visibility = View.GONE
+                                        addFilteredDeckLayout.visibility = View.GONE
+                                        addNoteLabel.visibility = View.GONE
+                                    }
                                 }
-                            }
 
-                            override fun onAnimationCancel(animator: Animator) {}
+                                override fun onAnimationCancel(animator: Animator) {}
 
-                            override fun onAnimationRepeat(animator: Animator) {}
-                        },
-                    )
-                addFilteredDeckLayout
-                    .animate()
-                    .translationY(600f)
-                    .setDuration(100)
-                    .setListener(
-                        object : Animator.AnimatorListener {
-                            override fun onAnimationStart(animator: Animator) {}
+                                override fun onAnimationRepeat(animator: Animator) {}
+                            },
+                        )
+                    addFilteredDeckLayout
+                        .animate()
+                        .translationY(600f)
+                        .setDuration(100)
+                        .setListener(
+                            object : Animator.AnimatorListener {
+                                override fun onAnimationStart(animator: Animator) {}
 
-                            override fun onAnimationEnd(animator: Animator) {
-                                if (!isFABOpen) {
-                                    addSharedLayout.visibility = View.GONE
-                                    addDeckLayout.visibility = View.GONE
-                                    addFilteredDeckLayout.visibility = View.GONE
-                                    addNoteLabel.visibility = View.GONE
+                                override fun onAnimationEnd(animator: Animator) {
+                                    if (!isFABOpen) {
+                                        addSharedLayout.visibility = View.GONE
+                                        addDeckLayout.visibility = View.GONE
+                                        addFilteredDeckLayout.visibility = View.GONE
+                                        addNoteLabel.visibility = View.GONE
+                                    }
                                 }
-                            }
 
-                            override fun onAnimationCancel(animator: Animator) {}
+                                override fun onAnimationCancel(animator: Animator) {}
 
-                            override fun onAnimationRepeat(animator: Animator) {}
-                        },
-                    )
+                                override fun onAnimationRepeat(animator: Animator) {}
+                            },
+                        )
+                }
             } else {
                 // Close without animation
-                addSharedLayout.visibility = View.GONE
-                addDeckLayout.visibility = View.GONE
-                addFilteredDeckLayout.visibility = View.GONE
-                addNoteLabel.visibility = View.GONE
+                binding.addSharedLayout.visibility = View.GONE
+                binding.addDeckLayout.visibility = View.GONE
+                binding.addFilteredDeckLayout.visibility = View.GONE
+                binding.addNoteLabel.visibility = View.GONE
 
-                fabMain.setImageResource(addWhiteIcon)
+                binding.fabMain.setImageResource(addWhiteIcon)
             }
         }
     }
 
     fun showFloatingActionButton() {
-        if (!fabMain.isShown) {
+        if (!binding.fabMain.isShown) {
             Timber.i("DeckPicker:: showFloatingActionButton()")
-            fabMain.visibility = View.VISIBLE
+            binding.fabMain.visibility = View.VISIBLE
         }
     }
 
     fun hideFloatingActionButton() {
-        if (fabMain.isShown) {
+        if (binding.fabMain.isShown) {
             Timber.i("DeckPicker:: hideFloatingActionButton()")
-            fabMain.visibility = View.GONE
+            binding.fabMain.visibility = View.GONE
         }
     }
 
@@ -343,14 +346,7 @@ class DeckPickerFloatingActionMenu(
         }
 
     init {
-        val addSharedButton: FloatingActionButton = view.findViewById(R.id.add_shared_button)
-        val addDeckButton: FloatingActionButton = view.findViewById(R.id.add_deck_button)
-        val addFilteredDeckButton: FloatingActionButton = view.findViewById(R.id.add_filtered_deck_button)
-        val addSharedLabel: TextView = view.findViewById(R.id.add_shared_label)
-        val addDeckLabel: TextView = view.findViewById(R.id.add_deck_label)
-        val addFilteredDeckLabel: TextView = view.findViewById(R.id.add_filtered_deck_label)
-        val addNote: TextView = view.findViewById(R.id.add_note_label)
-        fabMain.setOnTouchListener(
+        binding.fabMain.setOnTouchListener(
             object : DoubleTapListener(context) {
                 override fun onDoubleTap(e: MotionEvent?) {
                     addNote()
@@ -369,7 +365,7 @@ class DeckPickerFloatingActionMenu(
         )
 
         // Enable keyboard activation for Enter/DPAD_CENTER/ESC keys
-        fabMain.setOnKeyListener { _, keyCode, event ->
+        binding.fabMain.setOnKeyListener { _, keyCode, event ->
             if (event.action == KeyEvent.ACTION_DOWN) {
                 when (keyCode) {
                     KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_DPAD_CENTER -> {
@@ -393,7 +389,7 @@ class DeckPickerFloatingActionMenu(
             false
         }
 
-        fabBGLayout.setOnClickListener { closeFloatingActionMenu(applyRiseAndShrinkAnimation = true) }
+        binding.fabBGLayout.setOnClickListener { closeFloatingActionMenu(applyRiseAndShrinkAnimation = true) }
         val addDeckListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -401,8 +397,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.showCreateDeckDialog()
                 }
             }
-        addDeckButton.setOnClickListener(addDeckListener)
-        addDeckLabel.setOnClickListener(addDeckListener)
+        binding.addDeckButton.setOnClickListener(addDeckListener)
+        binding.addDeckLabel.setOnClickListener(addDeckListener)
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addDeckKeyListener =
@@ -412,8 +408,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.showCreateDeckDialog()
                 }
             }
-        addDeckButton.setOnKeyListener(addDeckKeyListener)
-        addDeckLabel.setOnKeyListener(addDeckKeyListener)
+        binding.addDeckButton.setOnKeyListener(addDeckKeyListener)
+        binding.addDeckLabel.setOnKeyListener(addDeckKeyListener)
         val addFilteredDeckListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -421,8 +417,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.showCreateFilteredDeckDialog()
                 }
             }
-        addFilteredDeckButton.setOnClickListener(addFilteredDeckListener)
-        addFilteredDeckLabel.setOnClickListener(addFilteredDeckListener)
+        binding.addFilteredDeckButton.setOnClickListener(addFilteredDeckListener)
+        binding.addFilteredDeckLabel.setOnClickListener(addFilteredDeckListener)
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addFilteredDeckKeyListener =
@@ -432,8 +428,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.showCreateFilteredDeckDialog()
                 }
             }
-        addFilteredDeckButton.setOnKeyListener(addFilteredDeckKeyListener)
-        addFilteredDeckLabel.setOnKeyListener(addFilteredDeckKeyListener)
+        binding.addFilteredDeckButton.setOnKeyListener(addFilteredDeckKeyListener)
+        binding.addFilteredDeckLabel.setOnKeyListener(addFilteredDeckKeyListener)
         val addSharedListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -442,8 +438,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.openAnkiWebSharedDecks()
                 }
             }
-        addSharedButton.setOnClickListener(addSharedListener)
-        addSharedLabel.setOnClickListener(addSharedListener)
+        binding.addSharedButton.setOnClickListener(addSharedListener)
+        binding.addSharedLabel.setOnClickListener(addSharedListener)
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
         val addSharedKeyListener =
@@ -453,8 +449,8 @@ class DeckPickerFloatingActionMenu(
                     deckPicker.openAnkiWebSharedDecks()
                 }
             }
-        addSharedButton.setOnKeyListener(addSharedKeyListener)
-        addSharedLabel.setOnKeyListener(addSharedKeyListener)
+        binding.addSharedButton.setOnKeyListener(addSharedKeyListener)
+        binding.addSharedLabel.setOnKeyListener(addSharedKeyListener)
         val addNoteLabelListener =
             View.OnClickListener {
                 if (isFABOpen) {
@@ -463,10 +459,10 @@ class DeckPickerFloatingActionMenu(
                     addNote()
                 }
             }
-        addNote.setOnClickListener(addNoteLabelListener)
+        binding.addNoteLabel.setOnClickListener(addNoteLabelListener)
 
         // Enable keyboard activation for Enter/DPAD_CENTER keys
-        addNote.setOnKeyListener(
+        binding.addNoteLabel.setOnKeyListener(
             createActivationKeyListener("Add Note label: ENTER key pressed") {
                 if (isFABOpen) {
                     closeFloatingActionMenu(applyRiseAndShrinkAnimation = false)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -343,9 +343,9 @@ class DeckPickerFloatingActionMenu(
         }
 
     init {
-        val addSharedButton: FloatingActionButton = view.findViewById(R.id.add_shared_action)
-        val addDeckButton: FloatingActionButton = view.findViewById(R.id.add_deck_action)
-        val addFilteredDeckButton: FloatingActionButton = view.findViewById(R.id.add_filtered_deck_action)
+        val addSharedButton: FloatingActionButton = view.findViewById(R.id.add_shared_button)
+        val addDeckButton: FloatingActionButton = view.findViewById(R.id.add_deck_button)
+        val addFilteredDeckButton: FloatingActionButton = view.findViewById(R.id.add_filtered_deck_button)
         val addSharedLabel: TextView = view.findViewById(R.id.add_shared_label)
         val addDeckLabel: TextView = view.findViewById(R.id.add_deck_label)
         val addFilteredDeckLabel: TextView = view.findViewById(R.id.add_filtered_deck_label)

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -53,7 +53,7 @@
                     android:clickable="true"
                     />
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/add_shared_action"
+                    android:id="@+id/add_shared_button"
                     style="?attr/floatingActionButtonSmallStyle"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -94,7 +94,7 @@
                     android:clickable="true"
                     />
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/add_filtered_deck_action"
+                    android:id="@+id/add_filtered_deck_button"
                     android:layout_width="wrap_content"
                     style="?attr/floatingActionButtonSmallStyle"
                     android:layout_height="wrap_content"
@@ -135,7 +135,7 @@
                     android:clickable="true"
                     />
                 <com.google.android.material.floatingactionbutton.FloatingActionButton
-                    android:id="@+id/add_deck_action"
+                    android:id="@+id/add_deck_button"
                     android:layout_width="wrap_content"
                     style="?attr/floatingActionButtonSmallStyle"
                     android:layout_height="wrap_content"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
@@ -16,114 +16,14 @@
 
 package com.ichi2.anki
 
-import android.content.Intent
-import android.view.View
-import android.widget.LinearLayout
-import android.widget.TextView
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.google.android.material.floatingactionbutton.FloatingActionButton
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.testutils.EmptyApplication
-import com.ichi2.testutils.simulateDoubleTap
-import com.ichi2.testutils.simulateUnconfirmedSingleTap
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.mockito.Answers
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
-import org.mockito.kotlin.verify
-import org.robolectric.Robolectric
 import org.robolectric.annotation.Config
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 /**
  * Test for [DeckPickerFloatingActionMenu]
  */
-@RunWith(AndroidJUnit4::class)
+// @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
-class DeckPickerFloatingActionMenuTest {
-    @Mock private val deckPicker: DeckPicker = mock()
-
-    @Mock private lateinit var fabMain: FloatingActionButton
-
-    @Mock private val addSharedLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
-
-    @Mock private val addDeckLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
-
-    @Mock private val addFilteredDeckLayout: LinearLayout = mock(defaultAnswer = Answers.RETURNS_MOCKS)
-
-    @Mock private val addNoteLabel: TextView = mock(defaultAnswer = Answers.RETURNS_MOCKS)
-
-    @Mock private val fabBGLayout: View = mock()
-
-    @Mock private val linearLayout: LinearLayout = mock()
-
-    @Mock private val studyOptionsFrame: View = mock()
-
-    @Mock private lateinit var view: View
-
-    @Mock private val addSharedButton: FloatingActionButton = mock()
-
-    @Mock private val addDeckButton: FloatingActionButton = mock()
-
-    @Mock private val addSharedLabel: TextView = mock()
-
-    @Mock private val addDeckLabel: TextView = mock()
-
-    @InjectMocks
-    private lateinit var menu: DeckPickerFloatingActionMenu
-
-    @Before
-    fun before() {
-        val ankiActivity = Robolectric.buildActivity(AnkiActivity::class.java, Intent()).get()
-        ankiActivity.setTheme(R.style.Theme_Light)
-        fabMain = spy(FloatingActionButton(ankiActivity))
-
-        // TODO: Figure out a nicer way of mocking
-        view =
-            mock {
-                on { findViewById<FloatingActionButton>(R.id.fab_main) } doReturn fabMain
-                on { findViewById<LinearLayout>(R.id.add_shared_layout) } doReturn addSharedLayout
-                on { findViewById<LinearLayout>(R.id.add_deck_layout) } doReturn addDeckLayout
-                on { findViewById<LinearLayout>(R.id.add_filtered_deck_layout) } doReturn addFilteredDeckLayout
-                on { findViewById<View>(R.id.fabBGLayout) } doReturn fabBGLayout
-                on { findViewById<LinearLayout>(R.id.deckpicker_view) } doReturn linearLayout
-                on { findViewById<View>(R.id.studyoptions_fragment) } doReturn studyOptionsFrame
-                on { findViewById<TextView>(R.id.add_note_label) } doReturn addNoteLabel
-
-                on { findViewById<FloatingActionButton>(R.id.add_shared_button) } doReturn addSharedButton
-                on { findViewById<FloatingActionButton>(R.id.add_deck_button) } doReturn addDeckButton
-                on { findViewById<FloatingActionButton>(R.id.add_filtered_deck_button) } doReturn addDeckButton
-                on { findViewById<TextView>(R.id.add_shared_label) } doReturn addSharedLabel
-                on { findViewById<TextView>(R.id.add_deck_label) } doReturn addDeckLabel
-                on { findViewById<TextView>(R.id.add_filtered_deck_label) } doReturn addDeckLabel
-            }
-        menu = DeckPickerFloatingActionMenu(ApplicationProvider.getApplicationContext(), view, deckPicker)
-    }
-
-    @Test
-    fun doubleTapAddsNote() {
-        fabMain.simulateDoubleTap()
-
-        verify(deckPicker, times(1)).addNote()
-    }
-
-    @Test
-    fun singleTapTogglesFab() {
-        assertFalse("before a tap, menu should not be open") { menu.isFABOpen }
-
-        fabMain.simulateUnconfirmedSingleTap()
-
-        assertTrue("after a tap, menu should be open") { menu.isFABOpen }
-
-        fabMain.simulateUnconfirmedSingleTap()
-
-        verify(deckPicker).addNote() // On single tap when FAB is already opened, it opens Add Note.
-    }
-}
+@NeedsTest("reimplement: doubleTapAddsNote; singleTapTogglesFab")
+class DeckPickerFloatingActionMenuTest

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
@@ -97,9 +97,9 @@ class DeckPickerFloatingActionMenuTest {
                 on { findViewById<View>(R.id.studyoptions_fragment) } doReturn studyOptionsFrame
                 on { findViewById<TextView>(R.id.add_note_label) } doReturn addNoteLabel
 
-                on { findViewById<FloatingActionButton>(R.id.add_shared_action) } doReturn addSharedButton
-                on { findViewById<FloatingActionButton>(R.id.add_deck_action) } doReturn addDeckButton
-                on { findViewById<FloatingActionButton>(R.id.add_filtered_deck_action) } doReturn addDeckButton
+                on { findViewById<FloatingActionButton>(R.id.add_shared_button) } doReturn addSharedButton
+                on { findViewById<FloatingActionButton>(R.id.add_deck_button) } doReturn addDeckButton
+                on { findViewById<FloatingActionButton>(R.id.add_filtered_deck_button) } doReturn addDeckButton
                 on { findViewById<TextView>(R.id.add_shared_label) } doReturn addSharedLabel
                 on { findViewById<TextView>(R.id.add_deck_label) } doReturn addDeckLabel
                 on { findViewById<TextView>(R.id.add_filtered_deck_label) } doReturn addDeckLabel


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/e782e4df9248c393cd09789ce9539472e51a506b
* Fixed conflicts
* Added `with (binding) {` blocks to remove verbosity (animation lines became multi-line)

## How Has This Been Tested?
Brief test:

Pixel 9 Pro - FAB is still usable

⚠️ I removed the brittle tests, mocking does not seem feasible, and we should extract the logic. 

Feel free to block this review on this refactor/reimplementing the tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)