### PR TITLE
fix(SharedDecks): Fix freeze when cancelling download

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksDownloadFragment.kt
@@ -561,7 +561,7 @@ class SharedDecksDownloadFragment : Fragment(R.layout.fragment_shared_decks_down
                     unregisterReceiver()
                     isDownloadInProgress = false
                     onBackPressedCallback.isEnabled = isDownloadInProgress
-                    activity?.onBackPressedDispatcher?.onBackPressed()
+                    parentFragmentManager.popBackStack()
                 }
                 setNegativeButton(R.string.dialog_no) { _, _ ->
                     downloadCancelConfirmationDialog?.dismiss()


### PR DESCRIPTION
## Purpose / Description
Fixes #20077

The download screen was freezing when I clicked "Cancel" passing "Yes".
It seems `onBackPressed()` wasn't reliably closing the screen.

## Fixes
I replaced `onBackPressed()` with `popBackStack()`. This makes sure the fragment is removed immediately.

## Approach
I verified this on the emulator and the freeze is gone.

https://github.com/user-attachments/assets/ad63bae7-e9a2-4029-bda6-e9f9ee7b281f

