### PR TITLE
feat: remove numeric type in answer IME

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/ReviewerFragmentTest.kt
@@ -121,55 +121,6 @@ class ReviewerFragmentTest : InstrumentedTest() {
         ensureAnswerButtonsAreDisplayed()
     }
 
-    @Test
-    fun testSelectedKeyboardType() {
-        setNewReviewer()
-        closeGetStartedScreenIfExists()
-        closeBackupCollectionDialogIfExists()
-
-        val inputTypeNumber =
-            InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or InputType.TYPE_NUMBER_FLAG_SIGNED
-        val inputTypeText = InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-
-        val testValues: List<Pair<String, Int>> =
-            listOf(
-                "123" to inputTypeNumber,
-                "-123.45" to inputTypeNumber,
-                "123.45" to inputTypeNumber,
-                "123,45" to inputTypeNumber,
-                "<b>123</b>" to inputTypeNumber,
-                "AnkiDroid" to inputTypeText,
-                "123abc" to inputTypeText,
-                "" to inputTypeText,
-            )
-
-        testValues.forEachIndexed { index, (typedAnswer, _) ->
-            addTypedAnswerNote(answer = typedAnswer).firstCard(col).update {
-                did = col.decks.id("Default$index")
-            }
-        }
-
-        // Check decks after adding all notes to ensure that the deck list is updated with the new cards
-        testValues.forEachIndexed { index, (_, expectedInputType) ->
-            // Ensures that we are in the deckpicker screen to make reviewDeckWithName work
-            if (index > 0) onView(withId(R.id.back_button)).perform(click())
-            checkInputType(expectedInputType, index)
-        }
-    }
-
-    fun checkInputType(
-        expectedInputType: Int,
-        index: Int,
-    ) {
-        reviewDeckWithName("Default$index")
-        ensureKeyboardIsDisplayed()
-        onView(withId(R.id.type_answer_edit_text)).check { view, _ ->
-            val editText = view as TextInputEditText
-            val inputType = editText.inputType
-            assertThat(inputType, equalTo(expectedInputType))
-        }
-    }
-
     private fun clickShowAnswerAndAnswerGood() {
         clickShowAnswer()
         ensureAnswerButtonsAreDisplayed()
@@ -178,14 +129,6 @@ class ReviewerFragmentTest : InstrumentedTest() {
 
     private fun clickShowAnswer() {
         onView(withId(R.id.show_answer_button)).perform(click())
-    }
-
-    private fun ensureKeyboardIsDisplayed() {
-        onView(withId(R.id.type_answer_edit_text)).checkWithTimeout(
-            matches(isDisplayed()),
-            100,
-            30.seconds.inWholeMilliseconds,
-        )
     }
 
     private fun ensureAnswerButtonsAreDisplayed() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -267,8 +267,6 @@ class ReviewerFragment :
 
                     binding.typeAnswerContainer.isVisible = true
                     binding.typeAnswerEditText.apply {
-                        inputType = chooseInputType(typeInAnswer)
-
                         if (imeHintLocales != typeInAnswer.imeHintLocales) {
                             imeHintLocales = typeInAnswer.imeHintLocales
                             context?.getSystemService<InputMethodManager>()?.restartInput(this)
@@ -300,15 +298,6 @@ class ReviewerFragment :
                 }
             }
     }
-
-    /** Chooses the input type based on whether the expected answer is a number or text */
-    @VisibleForTesting
-    fun chooseInputType(typeAnswer: TypeAnswer): Int =
-        if (stripHtml(typeAnswer.expectedAnswer).matches(Regex("^-?\\d+([.,]\\d*)?$"))) {
-            InputType.TYPE_CLASS_NUMBER or InputType.TYPE_NUMBER_FLAG_DECIMAL or InputType.TYPE_NUMBER_FLAG_SIGNED
-        } else {
-            InputType.TYPE_CLASS_TEXT or InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS
-        }
 
     private fun resetZoom() {
         webViewLayout.settings.loadWithOverviewMode = false


### PR DESCRIPTION
Some popular decks have hacks trigger the "numeric mode" despite the answer not being a number.

* Fixes #20069 

## How Has This Been Tested?

Emulator 31: use the deck in the issue (#20069) and try to type something

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->