### PR TITLE
fix(note-editor): 'discard changes' incorrectly shown

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1228,6 +1228,17 @@ class NoteEditorFragment :
             return false
         }
 
+        fun fieldsEdited(): Boolean {
+            // Editing an existing note: Check to see if the fields are changed
+            if (!addNote) {
+                return editFields!!.map { it.text?.toString() } != editorNote!!.fields.toList()
+            }
+
+            if (!isFieldEdited) return false
+            // BUG: Does not account for sticky fields
+            return editFields!!.any { it.text.toString() != "" }
+        }
+
         // changed note type?
         if (!addNote && currentEditedCard != null) {
             val newNoteType = currentlySelectedNotetype
@@ -1240,18 +1251,14 @@ class NoteEditorFragment :
         if (!addNote && currentEditedCard != null && currentEditedCard!!.currentDeckId() != deckId) {
             return true
         }
+
         // changed fields?
-        if (isFieldEdited) {
-            for (value in editFields!!) {
-                if (value.text.toString() != "") {
-                    return true
-                }
-            }
-            return false
-        } else {
-            return isTagsEdited
+        if (fieldsEdited()) {
+            return true
         }
+
         // changed tags?
+        return isTagsEdited
     }
 
     private fun collectionHasLoaded(): Boolean = allNoteTypeIds != null


### PR DESCRIPTION
## Purpose / Description
* Enable 'Don't Keep Activities'
* Edit Note
* Restore Activity
* Press Back
* 'Discard changes' incorrectly shown

This was caused as 'isFieldEdited' was incorrectly set


Broken in abcfcce8e4b46c5102641d8369bbd7723e922c3d

## Fixes
* Fixes #20059

## Approach
`isFieldEdited` wasn't required if we were editing a note ... just check if the note's fields were changed


## How Has This Been Tested?
Pixel 9 Pro, while editing

* Press back, with no changes => no dialog
* Press back, with changes => dialog
* Restore state, with no changes => no dialog
* Restore state, with changes => dialog


## Learning
I want to refactor, but the screen is in maintenance mode

I didn't realize Kotlin made `List == List` work correctly (vs how java handled it).

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)