### PR TITLE
refactor(CardTemplateEditor): add ViewModel + State infrastructure

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import com.ichi2.anki.libanki.CardOrdinal
+
+/**
+ * Which template editor view is currently displayed.
+ * The View layer handles mapping to actual View IDs.
+ */
+enum class EditorViewType {
+    FRONT,
+    BACK,
+    STYLING,
+}
+
+/** Encapsulates the entire state for [CardTemplateEditor] */
+sealed class CardTemplateEditorState {
+    /** Initial loading state, no data available yet */
+    data object Loading : CardTemplateEditorState()
+
+    /**
+     * Successfully loaded, all data is valid.
+     * This is the main working state where the user is editing templates.
+     */
+    data class Loaded(
+        /** The currently selected template ordinal (0-based index) */
+        val currentTemplateOrd: CardOrdinal = 0,
+        /** The currently selected editor view (front/back/styling) */
+        val currentEditorView: EditorViewType = EditorViewType.FRONT,
+        /** Simple transient messages in response to user actions or null for no message */
+        val message: UserMessage? = null,
+    ) : CardTemplateEditorState()
+
+    /** Error during loading */
+    data class InitializationError(
+        val exception: ReportableException,
+    ) : CardTemplateEditorState()
+
+    /** Finished, activity should close */
+    data object Finished : CardTemplateEditorState()
+
+    /** Simple message to be shown to the user */
+    enum class UserMessage {
+        CantDeleteLastTemplate,
+        CantAddTemplateToDynamic,
+        SaveSuccess,
+        DeletionWouldOrphanNote,
+    }
+
+    /**
+     * Wrapper around an exception produced in [CardTemplateEditor] with an extra flag about the
+     * exception being reportable or not.
+     */
+    data class ReportableException(
+        val source: Throwable,
+        /** true if this exception should be sent to [com.ichi2.anki.CrashReportService] */
+        val isReportable: Boolean = true,
+    )
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Snowiee <xenonnn4w@gmail.com>
+
+package com.ichi2.anki
+
+import com.ichi2.anki.exception.ReportableException
+import com.ichi2.anki.libanki.CardOrdinal
+
+/**
+ * Which template editor view is currently displayed.
+ * The View layer handles mapping to actual View IDs.
+ */
+enum class EditorViewType {
+    FRONT,
+    BACK,
+    STYLING,
+}
+
+/** Encapsulates the entire state for [CardTemplateEditor] */
+sealed class CardTemplateEditorState {
+    /**
+     * Loading the initial state, no data available yet.
+     * [exception] is null while loading and non-null if initialization failed.
+     */
+    data class Initializing(
+        val exception: ReportableException? = null,
+    ) : CardTemplateEditorState()
+
+    /**
+     * Successfully loaded, all data is valid.
+     * This is the main working state where the user is editing templates.
+     */
+    data class Loaded(
+        /** The currently selected template ordinal (0-based index) */
+        val currentTemplateOrd: CardOrdinal = 0,
+        /** The currently selected editor view (front/back/styling) */
+        val currentEditorView: EditorViewType = EditorViewType.FRONT,
+        /** Simple transient messages in response to user actions or null for no message */
+        val message: UserMessage? = null,
+        /**
+         * Transient, recoverable error raised while editing (e.g. a failed save) or null for no
+         * error. Unlike [Initializing.exception] this keeps the user in the editing screen with
+         * their data intact; the View consumes it and calls [CardTemplateEditorViewModel.clearError].
+         */
+        val error: ReportableException? = null,
+    ) : CardTemplateEditorState()
+
+    /** Finished, activity should close */
+    data object Finished : CardTemplateEditorState()
+
+    /** Simple message to be shown to the user */
+    enum class UserMessage {
+        CantDeleteLastTemplate,
+        CantAddTemplateToDynamic,
+        SaveSuccess,
+        DeletionWouldOrphanNote,
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorViewModel.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.libanki.CardOrdinal
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+
+class CardTemplateEditorViewModel : ViewModel() {
+    private val _state = MutableStateFlow<CardTemplateEditorState>(CardTemplateEditorState.Loading)
+    val state: StateFlow<CardTemplateEditorState> = _state.asStateFlow()
+
+    /**
+     * Transitions to the Loaded state.
+     * Called internally after data is successfully loaded.
+     */
+    @VisibleForTesting
+    internal fun onLoadComplete() {
+        _state.value = CardTemplateEditorState.Loaded()
+    }
+
+    /**
+     * Transitions to the Error state.
+     * Called internally when an error occurs.
+     */
+    internal fun onError(exception: CardTemplateEditorState.ReportableException) {
+        _state.value = CardTemplateEditorState.InitializationError(exception)
+    }
+
+    /**
+     * Transitions to the Finished state.
+     * Called internally when the activity should close.
+     */
+    internal fun onFinish() {
+        _state.value = CardTemplateEditorState.Finished
+    }
+
+    /**
+     * Updates the current template ordinal.
+     * Only valid when in Loaded state.
+     */
+    fun setCurrentTemplateOrd(ord: CardOrdinal) {
+        updateLoadedState { it.copy(currentTemplateOrd = ord) }
+    }
+
+    /**
+     * Updates the current editor view.
+     * Only valid when in Loaded state.
+     */
+    fun setCurrentEditorView(viewType: EditorViewType) {
+        updateLoadedState { it.copy(currentEditorView = viewType) }
+    }
+
+    /**
+     * Clears the current message.
+     * Only valid when in Loaded state.
+     */
+    fun clearMessage() {
+        updateLoadedState { it.copy(message = null) }
+    }
+
+    /**
+     * Helper to update only when in Loaded state.
+     * Ignores updates when in Loading, Error, or Finished states.
+     */
+    private inline fun updateLoadedState(transform: (CardTemplateEditorState.Loaded) -> CardTemplateEditorState.Loaded) {
+        _state.update { currentState ->
+            when (currentState) {
+                is CardTemplateEditorState.Loaded -> transform(currentState)
+                else -> currentState
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorViewModel.kt
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Snowiee <xenonnn4w@gmail.com>
+
+package com.ichi2.anki
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.ViewModel
+import com.ichi2.anki.exception.ReportableException
+import com.ichi2.anki.libanki.CardOrdinal
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import timber.log.Timber
+
+class CardTemplateEditorViewModel : ViewModel() {
+    private val _state = MutableStateFlow<CardTemplateEditorState>(CardTemplateEditorState.Initializing())
+    val state: StateFlow<CardTemplateEditorState> = _state.asStateFlow()
+
+    /**
+     * Transitions to the Loaded state.
+     * Called internally after data is successfully loaded.
+     */
+    @VisibleForTesting
+    internal fun onLoadComplete() {
+        _state.value = CardTemplateEditorState.Loaded()
+    }
+
+    /**
+     * Transitions to the [CardTemplateEditorState.Initializing] state carrying the failure.
+     * Called internally when initialization fails.
+     */
+    internal fun onError(exception: ReportableException) {
+        _state.value = CardTemplateEditorState.Initializing(exception)
+    }
+
+    /**
+     * Transitions to the Finished state.
+     * Called internally when the activity should close.
+     */
+    internal fun onFinish() {
+        _state.value = CardTemplateEditorState.Finished
+    }
+
+    /**
+     * Updates the current template ordinal.
+     * Only valid when in Loaded state.
+     */
+    fun setCurrentTemplateOrd(ord: CardOrdinal) {
+        updateLoadedState { it.copy(currentTemplateOrd = ord) }
+    }
+
+    /**
+     * Updates the current editor view.
+     * Only valid when in Loaded state.
+     */
+    fun setCurrentEditorView(viewType: EditorViewType) {
+        updateLoadedState { it.copy(currentEditorView = viewType) }
+    }
+
+    /**
+     * Clears the current message.
+     * Only valid when in Loaded state.
+     */
+    fun clearMessage() {
+        updateLoadedState { it.copy(message = null) }
+    }
+
+    /**
+     * Clears the current transient error.
+     * Only valid when in Loaded state.
+     */
+    fun clearError() {
+        updateLoadedState { it.copy(error = null) }
+    }
+
+    /**
+     * Helper to update only when in Loaded state.
+     * Ignores updates when in Initializing or Finished states.
+     */
+    private inline fun updateLoadedState(transform: (CardTemplateEditorState.Loaded) -> CardTemplateEditorState.Loaded) {
+        _state.update { currentState ->
+            when (currentState) {
+                is CardTemplateEditorState.Loaded -> transform(currentState)
+                else -> {
+                    Timber.w("Ignoring Loaded-state update; current state is %s", currentState)
+                    currentState
+                }
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/ReportableException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/ReportableException.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 lukstbit <52494258+lukstbit@users.noreply.github.com>
+
+package com.ichi2.anki.exception
+
+/**
+ * Wrapper around an exception surfaced in a screen's state, with an extra flag about the
+ * exception being reportable or not.
+ */
+data class ReportableException(
+    val source: Throwable,
+    /** true if this exception should be sent to [com.ichi2.anki.CrashReportService] */
+    val isReportable: Boolean = true,
+)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesState.kt
@@ -24,6 +24,7 @@ import anki.notetypes.NotetypeNameIdUseCount
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CardTemplateEditor
 import com.ichi2.anki.NoteTypeFieldEditor
+import com.ichi2.anki.exception.ReportableException
 import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.utils.Destination
 
@@ -56,16 +57,6 @@ data class ManageNoteTypesState(
         /** Message to inform that the last [Notetype] can't be removed */
         DeletingLastModel,
     }
-
-    /**
-     * Wrapper around an exception produced in [ManageNotetypes] with an extra flag about the
-     * exception being reportable or not.
-     */
-    data class ReportableException(
-        val source: Throwable,
-        /** true if this exception should be sent to [com.ichi2.anki.CrashReportService] */
-        val isReportable: Boolean = true,
-    )
 
     data class CardEditor(
         val ntid: NoteTypeId,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNoteTypesViewModel.kt
@@ -25,6 +25,7 @@ import anki.notetypes.Notetype
 import anki.notetypes.copy
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.exception.CombinedException
+import com.ichi2.anki.exception.ReportableException
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.libanki.getNotetype
@@ -33,7 +34,6 @@ import com.ichi2.anki.libanki.removeNotetype
 import com.ichi2.anki.libanki.updateNotetype
 import com.ichi2.anki.notetype.ManageNoteTypesState.CardEditor
 import com.ichi2.anki.notetype.ManageNoteTypesState.FieldsEditor
-import com.ichi2.anki.notetype.ManageNoteTypesState.ReportableException
 import com.ichi2.anki.notetype.ManageNoteTypesState.UserMessage
 import com.ichi2.anki.notetype.NoteTypeItemState.Companion.asModel
 import com.ichi2.anki.observability.undoableOp

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorViewModelTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025 Snowiee <xenonnn4w@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.JvmTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+@RunWith(AndroidJUnit4::class)
+class CardTemplateEditorViewModelTest : JvmTest() {
+    private lateinit var viewModel: CardTemplateEditorViewModel
+
+    @Before
+    override fun setUp() {
+        super.setUp()
+        viewModel = CardTemplateEditorViewModel()
+    }
+
+    @Test
+    fun `initial state is Loading`() {
+        assertIs<CardTemplateEditorState.Loading>(viewModel.state.value)
+    }
+
+    @Test
+    fun `onLoadComplete transitions to Loaded state`() {
+        viewModel.onLoadComplete()
+
+        val state = assertIs<CardTemplateEditorState.Loaded>(viewModel.state.value)
+        assertEquals(0, state.currentTemplateOrd)
+        assertEquals(EditorViewType.FRONT, state.currentEditorView)
+        assertNull(state.message)
+    }
+
+    @Test
+    fun `setCurrentTemplateOrd updates state when Loaded`() {
+        viewModel.onLoadComplete()
+
+        viewModel.setCurrentTemplateOrd(2)
+
+        val state = assertIs<CardTemplateEditorState.Loaded>(viewModel.state.value)
+        assertEquals(2, state.currentTemplateOrd)
+    }
+
+    @Test
+    fun `setCurrentTemplateOrd is ignored when Loading`() {
+        // Still in Loading state
+        viewModel.setCurrentTemplateOrd(2)
+
+        // Should still be Loading
+        assertIs<CardTemplateEditorState.Loading>(viewModel.state.value)
+    }
+
+    @Test
+    fun `setCurrentEditorView updates state when Loaded`() {
+        viewModel.onLoadComplete()
+
+        viewModel.setCurrentEditorView(EditorViewType.STYLING)
+
+        val state = assertIs<CardTemplateEditorState.Loaded>(viewModel.state.value)
+        assertEquals(EditorViewType.STYLING, state.currentEditorView)
+    }
+
+    @Test
+    fun `onFinish transitions to Finished state`() {
+        viewModel.onLoadComplete()
+        viewModel.onFinish()
+
+        assertIs<CardTemplateEditorState.Finished>(viewModel.state.value)
+    }
+
+    @Test
+    fun `onError transitions to Error state`() {
+        val exception = CardTemplateEditorState.ReportableException(RuntimeException("test"))
+
+        viewModel.onError(exception)
+
+        val state = assertIs<CardTemplateEditorState.InitializationError>(viewModel.state.value)
+        assertEquals(exception, state.exception)
+    }
+
+    @Test
+    fun `clearMessage resets message to null when Loaded`() {
+        viewModel.onLoadComplete()
+
+        viewModel.clearMessage()
+
+        val state = assertIs<CardTemplateEditorState.Loaded>(viewModel.state.value)
+        assertNull(state.message)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description/ Approach
This PR adds the foundational infrastructure without changing existing behavior:

- `CardTemplateEditorState`: Immutable data class holding UI state (loading, current template ordinal, editor view, errors, messages)
- `CardTemplateEditorViewModel`: Manages state via StateFlow with thread-safe updates
- `CardTemplateEditorViewModelTest`: Unit tests covering all state operations

This is Part 1 of a multiPR migration:

PR 1 (this): Infrastructure (ViewModel + State) [Done]
PR 2: Wire ViewModel to UI
PR 3: Load notetype + Template manipulation in-memory
PR 4: Atomic save with updateNotetype()
PR 5: Remove legacy code

## Links without closing (Part of)
*  #19956

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->