### PR TITLE
Prevent progress dialog dismissal via outside touch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -429,6 +429,7 @@ suspend fun <T> withProgressDialog(
         val dialog =
             android.app.ProgressDialog(context, R.style.AppCompatProgressDialogStyle).apply {
                 setCancelable(onCancel != null)
+                setCanceledOnTouchOutside(false)
                 if (manualCancelButton != null) {
                     setCancelable(false)
                     setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(manualCancelButton)) { _, _ ->


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Tapping outside the progress dialog during a forced one-way / full sync can dismiss the dialog and trigger cancellation, interrupting the sync._

## Fixes
* Fixes #20073->

## Approach
_Prevent outside-touch from dismissing the progress dialog by explicitly disabling outside-touch cancellation with **setCanceledOnTouchOutside(false)**._

_This keeps existing cancel behavior (back button or explicit cancel button where provided) unchanged, while avoiding accidental cancellation from background taps._

## How Has This Been Tested?

**Bug reproduction (physical device)**

- Forced full sync was triggered via schema change and conflict resolution (“Select collection to keep”).
- Tapping outside the progress dialog consistently cancelled the sync.

**Test environment (reproduction)**

- Device: Redmi K50i
- Android: 14 (UP1A.231005.007)

**Local validation**:

- Emulator: Pixel 6
- Android: 13 (API 33)
- System image: Google APIs

In this configuration, outside-touch did not cancel the sync. However, the change is defensive and explicitly prevents outside-touch dismissal of the progress dialog, directly addressing the behavior reported on Android 16 devices.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Update based on Review

The latest change disables outside touch on all the dialogue boxes via the shared withProgressDialog() helper. This is undesirable.
In the next PR, the scope will be restricted only to 'Sync' dialogue box.

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->