### PR TITLE
refactor(CardTemplateEditor): wire ViewModel to Activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -35,6 +35,7 @@ import android.widget.LinearLayout
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
@@ -50,6 +51,7 @@ import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.commitNow
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import anki.notetypes.StockNotetype
 import anki.notetypes.StockNotetype.OriginalStockKind.ORIGINAL_STOCK_KIND_UNKNOWN_VALUE
@@ -132,6 +134,7 @@ private typealias BackendCardTemplate = com.ichi2.anki.libanki.CardTemplate
 @KotlinCleanup("lateinit wherever possible")
 open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_editor) {
     private val binding by viewBinding(ActivityCardTemplateEditorBinding::bind)
+    private val viewModel by viewModels<CardTemplateEditorViewModel>()
 
     @VisibleForTesting
     val topBinding: IncludeCardTemplateEditorTopBinding
@@ -243,12 +246,61 @@ open class CardTemplateEditor : AnkiActivity(R.layout.activity_card_template_edi
         loadTemplatePreviewerFragmentIfFragmented()
         onBackPressedDispatcher.addCallback(this, displayDiscardChangesCallback)
 
+        setupStateCollection()
+
         topBinding.slidingTabs.doOnTabSelected { tab ->
             Timber.i("selected card index: %s", tab.position)
+            viewModel.setCurrentTemplateOrd(tab.position)
             loadTemplatePreviewerFragmentIfFragmented(tab.position)
         }
 
         registerDeckSelectedHandler(action = ::onDeckSelected)
+    }
+
+    private fun setupStateCollection() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.state.collect { state ->
+                    when (state) {
+                        is CardTemplateEditorState.Initializing -> {
+                            val exception = state.exception
+                            if (exception != null) {
+                                AlertDialog.Builder(this@CardTemplateEditor).show {
+                                    setTitle(R.string.vague_error)
+                                    setMessage(exception.source.localizedMessage ?: getString(R.string.something_wrong))
+                                    setPositiveButton(R.string.dialog_ok) { _, _ -> finish() }
+                                    setCancelable(false)
+                                }
+                            }
+                        }
+                        is CardTemplateEditorState.Loaded -> {
+                            if (state.message != null) {
+                                val messageText =
+                                    when (state.message) {
+                                        CardTemplateEditorState.UserMessage.CantDeleteLastTemplate ->
+                                            getString(R.string.card_template_editor_cant_delete)
+                                        CardTemplateEditorState.UserMessage.CantAddTemplateToDynamic ->
+                                            getString(R.string.multimedia_editor_something_wrong)
+                                        CardTemplateEditorState.UserMessage.SaveSuccess ->
+                                            getString(R.string.card_template_editor_changes_saved)
+                                        CardTemplateEditorState.UserMessage.DeletionWouldOrphanNote ->
+                                            getString(R.string.orphan_note_message)
+                                    }
+                                showSnackbar(messageText)
+                                viewModel.clearMessage()
+                            }
+                            if (state.error != null) {
+                                showSnackbar(state.error.source.localizedMessage ?: getString(R.string.something_wrong))
+                                viewModel.clearError()
+                            }
+                        }
+                        is CardTemplateEditorState.Finished -> {
+                            finish()
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -123,6 +123,7 @@
         <item quantity="other">Delete the “%2$s” card type, and its %1$d cards?</item>
     </plurals>
     <string name="card_template_editor_save_error">Unable to save card template changes: %s</string>
+    <string name="card_template_editor_changes_saved">Changes saved</string>
     <string name="template_for_current_card_deleted">The card type for the current card was deleted.</string>
 
     <!-- Permissions -->


### PR DESCRIPTION
 <!--- Please fill the necessary details below -->
  ## Purpose / Description / Approach
  Wire `CardTemplateEditorViewModel` into the `CardTemplateEditor` Activity.
  - Obtain the ViewModel via `viewModels<CardTemplateEditorViewModel>()`
  - Collect state with `lifecycleScope.launch { repeatOnLifecycle(STARTED) { ... } }`
  - Render each state:
    - `Initializing` : show an error dialog only when `exception != null` (null while loading)
    - `Loaded` : surface transient `message` and `error` via snackbar, then consume them with `clearMessage()` / `clearError()`
    - `Finished` : `finish()` the activity
  - Wire tab selection to the ViewModel via `setCurrentTemplateOrd(tab.position)`

  This PR only wires the ViewModel up; no existing editor behaviour is replaced yet.

  ## Links without closing (Part of)
  * #19956

  ## Based on
  * #20103



  ## Checklist
  _Please, go through these checks before submitting the PR._

  - [x] You have a descriptive commit message with a short title (first line, max 50 chars).
  - [x] You have commented your code, particularly in hard-to-understand areas
  - [x] You have performed a self-review of your own code
  - [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
  - [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)