### PR TITLE
fix: prevent memory leak in SharedDecksActivity by destroying WebView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -35,6 +35,7 @@ import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFI
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.databinding.ActivitySharedDecksBinding
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.utils.FileNameAndExtension
 import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
@@ -264,6 +265,11 @@ class SharedDecksActivity : AnkiActivity(R.layout.activity_shared_decks) {
             onBackPressedCallback.isEnabled = false
         }
         return super.onOptionsItemSelected(item)
+    }
+
+    override fun onDestroy() {
+        SafeWebViewLayout.destroyWebView(binding.webView)
+        super.onDestroy()
     }
 }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR addresses the memory leak issues in SharedDecksActivity related to WebView usage, as identified in #19965.

Following the experimental fix suggestions, I implemented the `onDestroy()` method in SharedDecksActivity  and incorporated the cleanup logic based on the pattern found in SafeWebViewLayout.safeDestroy()

## Fixes
* Fixes #19965 

## Approach
The focus of this change is to ensure that the WebView  is properly disposed of when the Activity is destroyed. I ported the cleanup sequence from SafeWebViewLayout:

- Stopped ongoing loading and cleared the WebView by loading `about:blank`.
- Nullified `WebChromeClient` and `OnScrollChangeListener` to break reference cycles.
- Detached the WebView from its parent `ViewGroup` before final destruction.
- Wrapped the `destroy()` call in `runCatchingWithReport` for safe execution and logging.


## How Has This Been Tested?

To verify the fix, I navigated between SharedDecksActivity and DeckPicker 10 times consecutively.

**Result**:

API 34: Some leaks still persist, but these are attributed to the Context issue as discussed in the issue thread.
However, the specific leaks related to improper WebView teardown have been significantly mitigated.

API 35: leaks are fully resolved with this cleanup in place.

API 34

<img width="1424" height="722" alt="Image" src="https://github.com/user-attachments/assets/2cf1eafc-eb5e-4313-8995-1e902561f22f" />

API 35

<img width="2864" height="1538" alt="Image" src="https://github.com/user-attachments/assets/2d375c38-58bb-4e00-960d-4af1dafd4a90" />

## Learning (optional, can help others)
Confirmed that applying the SafeWebViewLayout.safeDestroy() pattern directly within an Activity's onDestroy() is an effective experimental approach to mitigate WebView-related memory leaks in AnkiDroid.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)