### PR TITLE
refactor(CardTemplateEditor): load notetype into ViewModel 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditorState.kt
@@ -38,6 +38,8 @@ sealed class CardTemplateEditorState {
      * This is the main working state where the user is editing templates.
      */
     data class Loaded(
+        /** The notetype being edited */
+        val tempNotetype: CardTemplateNotetype,
         /** The currently selected template ordinal (0-based index) */
         val currentTemplateOrd: CardOrdinal = 0,
         /** The currently selected editor view (front/back/styling) */
@@ -46,12 +48,12 @@ sealed class CardTemplateEditorState {
         val message: UserMessage? = null,
     ) : CardTemplateEditorState()
 
-    /** Error during loading */
+    /** Error during loading or operation */
     data class Error(
         val exception: ReportableException,
     ) : CardTemplateEditorState()
 
-    /** Finished, activity should close */
+    /** Finished - activity should close */
     data object Finished : CardTemplateEditorState()
 
     /** Simple message to be shown to the user */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardTemplateEditorViewModelTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.testutils.JvmTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -35,29 +36,6 @@ class CardTemplateEditorViewModelTest : JvmTest() {
     }
 
     @Test
-    fun `onLoadComplete transitions to Loaded state`() {
-        val viewModel = createViewModel()
-        viewModel.onLoadComplete()
-
-        val state = viewModel.state.value
-        assertTrue(state is CardTemplateEditorState.Loaded)
-        assertEquals(0, (state as CardTemplateEditorState.Loaded).currentTemplateOrd)
-        assertEquals(EditorViewType.FRONT, state.currentEditorView)
-        assertNull(state.message)
-    }
-
-    @Test
-    fun `setCurrentTemplateOrd updates state when Loaded`() {
-        val viewModel = createViewModel()
-        viewModel.onLoadComplete()
-
-        viewModel.setCurrentTemplateOrd(2)
-
-        val state = viewModel.state.value as CardTemplateEditorState.Loaded
-        assertEquals(2, state.currentTemplateOrd)
-    }
-
-    @Test
     fun `setCurrentTemplateOrd is ignored when Loading`() {
         val viewModel = createViewModel()
         // Still in Loading state
@@ -68,45 +46,30 @@ class CardTemplateEditorViewModelTest : JvmTest() {
     }
 
     @Test
-    fun `setCurrentEditorView updates state when Loaded`() {
-        val viewModel = createViewModel()
-        viewModel.onLoadComplete()
-
-        viewModel.setCurrentEditorView(EditorViewType.STYLING)
-
-        val state = viewModel.state.value as CardTemplateEditorState.Loaded
-        assertEquals(EditorViewType.STYLING, state.currentEditorView)
-    }
-
-    @Test
     fun `onFinish transitions to Finished state`() {
         val viewModel = createViewModel()
-        viewModel.onLoadComplete()
         viewModel.onFinish()
 
         assertTrue(viewModel.state.value is CardTemplateEditorState.Finished)
     }
 
     @Test
-    fun `onError transitions to Error state`() {
+    fun `addTemplate returns false when not in Loaded state`() {
         val viewModel = createViewModel()
-        val exception = CardTemplateEditorState.ReportableException(RuntimeException("test"))
-
-        viewModel.onError(exception)
-
-        val state = viewModel.state.value
-        assertTrue(state is CardTemplateEditorState.Error)
-        assertEquals(exception, (state as CardTemplateEditorState.Error).exception)
+        assertFalse(viewModel.addTemplate())
     }
 
     @Test
-    fun `clearMessage resets message to null when Loaded`() {
+    fun `removeTemplate returns false when not in Loaded state`() {
         val viewModel = createViewModel()
-        viewModel.onLoadComplete()
+        assertFalse(viewModel.removeTemplate(0))
+    }
 
-        viewModel.clearMessage()
-
-        val state = viewModel.state.value as CardTemplateEditorState.Loaded
-        assertNull(state.message)
+    @Test
+    fun `updateTemplateContent does nothing when not in Loaded state`() {
+        val viewModel = createViewModel()
+        // Should not crash
+        viewModel.updateTemplateContent(0, EditorViewType.FRONT, "test content")
+        assertTrue(viewModel.state.value is CardTemplateEditorState.Loading)
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Third PR in the CardTemplateEditor migration series.
- Added `tempNotetype` property to `CardTemplateEditorState`
- Implemented `loadNotetype()` in ViewModel
- Implemented `updateTemplateContent()`
- Added placeholder `addTemplate()` and `removeTemplate()` methods
- Fragment now shares `ViewModel` with Activity via `activityViewModels()`
- `TextWatcher` calls ViewModel in parallel with legacy code path during this transitional phase

## Links without closing (Part of)
*  #19956

## Based on 
* #20107

## How Has This Been Tested?

No regressions obtained, and all `TemplateEditorViewModelTest` passes.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->