### PR TITLE
fix(libanki-testutils): more than one META-INF/LICENSE

### DIFF
--- a/libanki/testutils/build.gradle.kts
+++ b/libanki/testutils/build.gradle.kts
@@ -39,6 +39,15 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+
+        packaging {
+            resources {
+                // testutils is not compiled into the public apk
+                excludes += "META-INF/DEPENDENCIES"
+                excludes += "META-INF/LICENSE.md"
+                excludes += "META-INF/LICENSE-notice.md"
+            }
+        }
     }
     kotlin {
         compilerOptions {


### PR DESCRIPTION
I got a `libanki:testutils: more than one META-INF/LICENSE` error while rebuilding the project.

to fix it, I copied the same exclusions of :testlib

## How Has This Been Tested?

The project now builds

## Learning (optional, can help others)

I didn't know that those files where excluded.

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->