### PR TITLE
fix(previewer): media config not initialized

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -1470,7 +1470,7 @@ abstract class AbstractFlashcardViewer :
             Timber.w("media is not played as the activity is inactive")
             return
         }
-        if (!cardMediaPlayer.config.autoplay && !doMediaReplay) return
+        if (cardMediaPlayer.config?.autoplay != true && !doMediaReplay) return
         // Use TTS if TTS preference enabled and no other media source
         val useTTS = tts.enabled && !cardMediaPlayer.hasMedia(displayAnswer)
         // We need to play the media from the proper side of the card
@@ -1485,7 +1485,7 @@ abstract class AbstractFlashcardViewer :
             return
         }
 
-        val replayQuestion = cardMediaPlayer.config.replayQuestion
+        val replayQuestion = cardMediaPlayer.config?.replayQuestion == true
         // Text to speech is in effect here
         // If the question is displayed or if the question should be replayed, read the question
         if (ttsInitialized) {
@@ -1554,7 +1554,7 @@ abstract class AbstractFlashcardViewer :
         content: String,
     ) {
         if (card != null) {
-            card.settings.mediaPlaybackRequiresUserGesture = !cardMediaPlayer.config.autoplay
+            card.settings.mediaPlaybackRequiresUserGesture = cardMediaPlayer.config?.autoplay != true
             card.loadDataWithBaseURL(
                 server.baseUrl(),
                 content,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -103,7 +103,6 @@ class PreviewerViewModelTest : JvmTest() {
         }
 
     @Test
-    @Flaky(OS.ALL, "assumed to be #19729")
     fun `previous button`() =
         runTest {
             // Start at Index 1
@@ -122,7 +121,6 @@ class PreviewerViewModelTest : JvmTest() {
         }
 
     @Test
-    @Flaky(OS.ALL, "#19729")
     fun `toggle back side only`() =
         runTest {
             assertFalse(viewModel.backSideOnly.value) // initial state should be false
@@ -178,7 +176,6 @@ class PreviewerViewModelTest : JvmTest() {
         }
 
     @Test
-    @Flaky(OS.ALL, "#19729")
     fun `next, slider and previous navigation integration`() =
         runTest {
             // 1. Start at Index 0 (Question)


### PR DESCRIPTION
## Fixes
* Fixes #19729

## Approach

used a nullable config and empty av tags lists instead of lateinit properties.

This avoids crashes. There's still the rare chance  of the previewer requesting a sound before it's loaded, which would result in playing nothing. Making that foolproof requires a bigger refactor, which I intend to do later

## How Has This Been Tested?

Flaky hammer™: https://github.com/BrayanDSO/Anki-Android/actions/runs/21093913315

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->