### PR TITLE
sync: add help icon to conflict resolution dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog.Type.DIALOG_SYNC_SANITY_ERROR_CONF
 import com.ichi2.anki.dialogs.SyncErrorDialog.Type.DIALOG_USER_NOT_LOGGED_IN_SYNC
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.openUrl
+import com.ichi2.utils.titleWithHelpIcon
 
 class SyncErrorDialog : AsyncDialogFragment() {
     interface SyncErrorDialogListener {
@@ -93,8 +94,9 @@ class SyncErrorDialog : AsyncDialogFragment() {
             DIALOG_SYNC_CONFLICT_RESOLUTION -> {
                 // Sync conflict; allow user to cancel, or choose between local and remote versions
                 dialog
-                    .setIcon(R.drawable.ic_sync_problem)
-                    .setPositiveButton(R.string.sync_conflict_keep_local_new) { _, _ ->
+                    .titleWithHelpIcon(stringRes = R.string.sync_conflict_title_new, iconRes = R.drawable.ic_sync_problem) {
+                        requireContext().openUrl(R.string.link_sync_conflict_help)
+                    }.setPositiveButton(R.string.sync_conflict_keep_local_new) { _, _ ->
                         requireSyncErrorDialogListener().showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL)
                     }.setNegativeButton(R.string.sync_conflict_keep_remote_new) { _, _ ->
                         requireSyncErrorDialogListener().showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -36,6 +36,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.widget.doOnTextChanged
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -435,8 +436,9 @@ fun AlertDialog.Builder.listItemsAndMessage(
 fun AlertDialog.Builder.titleWithHelpIcon(
     @StringRes stringRes: Int? = null,
     text: String? = null,
+    @DrawableRes iconRes: Int? = null,
     block: View.OnClickListener,
-) {
+): AlertDialog.Builder {
     // setup the view for the dialog
     val customTitleView = LayoutInflater.from(context).inflate(R.layout.alert_dialog_title_with_help, null, false)
     setCustomTitle(customTitleView)
@@ -450,11 +452,33 @@ fun AlertDialog.Builder.titleWithHelpIcon(
         titleTextView.text = text
     }
 
+    val iconView = customTitleView.findViewById<ImageView>(R.id.dialog_icon)
+    if (iconRes != null) {
+        iconView.setImageResource(iconRes)
+        iconView.visibility = View.VISIBLE
+        val params = iconView.layoutParams as ConstraintLayout.LayoutParams
+        params.marginEnd = (8 * context.resources.displayMetrics.density).toInt()
+        iconView.layoutParams = params
+        iconView.setColorFilter(Themes.getColorFromAttr(context, com.google.android.material.R.attr.colorOnSurface))
+    } else {
+        iconView.visibility = View.GONE
+        val params = titleTextView.layoutParams as ConstraintLayout.LayoutParams
+        params.startToStart = ConstraintLayout.LayoutParams.PARENT_ID
+        params.startToEnd = -1
+        params.marginStart = 0
+        titleTextView.layoutParams = params
+    }
+    customTitleView
+        .findViewById<ImageView>(
+            R.id.help_icon,
+        ).setColorFilter(Themes.getColorFromAttr(context, com.google.android.material.R.attr.colorOnSurface))
+
     // set the action when clicking the help icon
     customTitleView.findViewById<ImageView>(R.id.help_icon).setOnClickListener { v ->
         Timber.i("dialog help icon click")
         block.onClick(v)
     }
+    return this
 }
 
 /** Calls [AlertDialog.dismiss], ignoring errors */

--- a/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
+++ b/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
@@ -11,6 +11,18 @@
     android:paddingTop="24dp"
     android:paddingBottom="8dp">
 
+    <ImageView
+        android:id="@+id/dialog_icon"
+        style="?attr/materialAlertDialogTitleIconStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@android:id/title"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@android:id/title"
+        android:visibility="gone"
+        tools:src="@drawable/ic_sync_problem"
+        tools:visibility="visible" />
+
     <androidx.appcompat.widget.DialogTitleView
         android:id="@android:id/title"
         android:layout_width="0dp"
@@ -18,7 +30,8 @@
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
         android:textColor="?attr/colorOnSurface"
         app:layout_constraintEnd_toStartOf="@+id/help_icon"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/dialog_icon"
+        app:layout_constraintTop_toTopOf="parent"
         tools:text="Reset Card Progress" />
 
     <ImageView

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -148,6 +148,7 @@
     <string name="link_set_due_date_help">https://docs.ankiweb.net/browsing.html#cards</string>
     <string name="link_full_storage_access">https://github.com/ankidroid/Anki-Android/wiki/Full-Storage-Access</string>
     <string name="link_help_forget_cards">https://docs.ankiweb.net/studying.html#editing-and-more</string>
+    <string name="link_sync_conflict_help">https://docs.ankiweb.net/syncing.html#conflicts</string>
     <string name="link_scheduler_upgrade_faq">https://faqs.ankiweb.net/the-anki-2.1-scheduler.html#updating-to-v2-from-v1</string>
 
     <string-array name="add_to_cur_values">


### PR DESCRIPTION
## Purpose / Description
Add a help icon to the sync conflict dialog and link it to the Anki manual. 

## Fixes
Fixes #17544

## Approach
* **AlertDialogFacade**: Modified `titleWithHelpIcon` to return `AlertDialog.Builder` to allow method chaining. Added an optional `iconRes` parameter to support showing a main icon alongside the help icon.
* **Layout**: Added `dialog_icon` ImageView to [alert_dialog_title_with_help.xml](cci:7://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml:0:0-0:0) and handled constraint adjustment in code so the title aligns correctly when no icon is present.
* **Styling**: Applied `colorOnSurface` to both icons for theme compatibility.
* **Sync Conflict**: Updated context-specific logic in [SyncErrorDialog](cci:2://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt:42:0-359:1) to use the new utility with the sync problem icon and the help URL.

## How Has This Been Tested?
* Verified layout and icon alignment in Android Studio preview (Day/Night themes).
* Checked that existing dialogs using this utility (e.g. Forget Cards) still layout correctly.
* Confirmed successful build.

## Checklist
- [x] You have a descriptive commit message with a short title.
- [x] You have performed a self-review of your own code.
- [x] UI changes: include screenshots of all affected screens.

## Visuals
Night mode
<img width="307" height="547" alt="Screenshot 2026-01-18 005447" src="https://github.com/user-attachments/assets/bd36c546-c898-4e17-9ba7-4365ca7387de" />
Day mode
<img width="306" height="543" alt="Screenshot 2026-01-18 005420" src="https://github.com/user-attachments/assets/272bc68b-dd20-48d8-a2b2-7135a3eaed24" />

*(Note: Preview screenshots use placeholder title text; actual titles resolve correctly at runtime.)*