### PR TITLE
Fix (note editor): App crashing after performing multiple clicks on add button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -153,6 +153,7 @@ import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.setupNoteTypeSpinner
+import com.ichi2.anki.utils.RunOnlyOnce
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.ext.window
@@ -224,7 +225,7 @@ class NoteEditorFragment :
     private var changed = false
     private var isTagsEdited = false
     private var isFieldEdited = false
-
+    private var addNoteJob = RunOnlyOnce(scope = lifecycleScope)
     private var multimediaActionJob: Job? = null
 
     private val getColUnsafe: Collection
@@ -1338,7 +1339,8 @@ class NoteEditorFragment :
 
             reloadRequired = true
 
-            lifecycleScope.launch {
+            // Use addNoteJob to ignore any requests made after the initial add note request, this prevents multiple clicks from crashing the app
+            addNoteJob.launch {
                 val noteFieldsCheck = checkNoteFieldsResponse(editorNote!!)
                 if (noteFieldsCheck is NoteFieldsCheckResult.Failure) {
                     addNoteErrorMessage = noteFieldsCheck.localizedMessage ?: getString(R.string.something_wrong)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/OnlyOnce.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/OnlyOnce.kt
@@ -16,7 +16,9 @@
 
 package com.ichi2.anki.utils
 
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 /**
@@ -49,5 +51,24 @@ object OnlyOnce {
             Timber.v("completed $name")
             blockedFunctions.remove(name)
         }
+    }
+}
+
+/**
+ * Enforces single execution of a coroutine task
+ * if a task is running, ignore any other requests till it finishes
+ * @param scope The coroutine scope where the task is launched
+ */
+class RunOnlyOnce(
+    private val scope: CoroutineScope,
+) {
+    private var job: Job? = null
+
+    fun launch(block: suspend CoroutineScope.() -> Unit) {
+        if (job?.isActive == true) {
+            Timber.d("skipped multiple executions of job")
+            return
+        }
+        job = scope.launch(block = block)
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This bug happens when you tap add too many times in a small window, it ends up crashing ankidroid

## Fixes
* Fixes #17375 

## Approach
Tried different approaches like using a boolean variable and mutex before realising that the issue was with the lifecycle in savenote()

## How Has This Been Tested?
I used an auto clicker to simulate a lot of clicks a second (1 ms interval) and the app would just crash immediately, after applying the change however it just takes the first click and performs the add

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->