### PR TITLE
chore: convert KeyPicker to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/ui/KeyPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/KeyPicker.kt
@@ -19,9 +19,7 @@ package com.ichi2.ui
 import android.content.Context
 import android.view.KeyEvent
 import android.view.LayoutInflater
-import android.view.View
-import android.widget.TextView
-import com.ichi2.anki.R
+import com.ichi2.anki.databinding.DialogKeyPickerBinding
 import com.ichi2.anki.dialogs.WarningDisplay
 import com.ichi2.anki.reviewer.Binding
 import timber.log.Timber
@@ -33,19 +31,19 @@ typealias KeyCode = Int
  * This does not yet support bluetooth headsets.
  */
 class KeyPicker(
-    val rootLayout: View,
+    private val viewBinding: DialogKeyPickerBinding,
 ) : WarningDisplay {
-    private val textView: TextView = rootLayout.findViewById(R.id.key_picker_selected_key)
+    val rootLayout = viewBinding.root
 
-    override val warningTextView: FixedTextView = rootLayout.findViewById(R.id.warning)
+    override val warningTextView: FixedTextView = viewBinding.warning
 
     private val context: Context get() = rootLayout.context
 
     private var text: String
         set(value) {
-            textView.text = value
+            viewBinding.selectedKey.text = value
         }
-        get() = textView.text.toString()
+        get() = viewBinding.selectedKey.text.toString()
 
     private var onBindingChangedListener: ((Binding) -> Unit)? = null
     private var isValidKeyCode: ((KeyCode) -> Boolean)? = null
@@ -80,14 +78,15 @@ class KeyPicker(
     }
 
     init {
-        textView.requestFocus()
-        textView.setOnKeyListener { _, _, event -> dispatchKeyEvent(event) }
+        viewBinding.selectedKey.requestFocus()
+        viewBinding.selectedKey.setOnKeyListener { _, _, event -> dispatchKeyEvent(event) }
     }
 
     companion object {
         fun inflate(context: Context): KeyPicker {
-            val layout = LayoutInflater.from(context).inflate(R.layout.dialog_key_picker, null)
-            return KeyPicker(layout)
+            val layoutInflater = LayoutInflater.from(context)
+            val binding = DialogKeyPickerBinding.inflate(layoutInflater)
+            return KeyPicker(binding)
         }
     }
 }

--- a/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_key_picker.xml
@@ -34,7 +34,7 @@
         app:layout_constraintTop_toTopOf="parent">
 
         <com.ichi2.ui.FixedTextView
-            android:id="@+id/key_picker_selected_key"
+            android:id="@+id/selected_key"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:focusable="true"


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/dbfa11a14d0af3b8ec7470dd23afa79ad7c0d844

## How Has This Been Tested?
Brief test:

API 35 Phone Emulator

* can select a key to add


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)