### PR TITLE
chore: convert AlertDialogFacade to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -30,9 +30,6 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.EditText
 import android.widget.FrameLayout
-import android.widget.ImageView
-import android.widget.ListView
-import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
@@ -42,8 +39,11 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.AlertDialogCheckboxBinding
+import com.ichi2.anki.databinding.AlertDialogTitleWithHelpBinding
+import com.ichi2.anki.databinding.DialogGenericRecyclerViewBinding
+import com.ichi2.anki.databinding.DialogListviewMessageBinding
 import com.ichi2.themes.Themes
-import com.ichi2.ui.FixedTextView
 import com.ichi2.utils.HandlerUtils.executeOnMainThread
 import timber.log.Timber
 
@@ -206,8 +206,8 @@ fun AlertDialog.Builder.checkBoxPrompt(
     if (stringRes == null && text == null) {
         throw IllegalArgumentException("either `stringRes` or `text` must be set")
     }
-    val checkBoxView = View.inflate(this.context, R.layout.alert_dialog_checkbox, null)
-    val checkBox = checkBoxView.findViewById<CheckBox>(R.id.checkbox)
+    val binding = AlertDialogCheckboxBinding.inflate(LayoutInflater.from(context))
+    val checkBox = binding.checkbox
 
     val checkBoxLabel = if (stringRes != null) context.getString(stringRes) else text
     checkBox.text = checkBoxLabel
@@ -217,7 +217,7 @@ fun AlertDialog.Builder.checkBoxPrompt(
         onToggle(isChecked)
     }
 
-    return this.setView(checkBoxView)
+    return this.setView(binding.root)
 }
 
 fun AlertDialog.getCheckBoxPrompt(): CheckBox =
@@ -260,10 +260,11 @@ fun AlertDialog.Builder.customView(
 }
 
 fun AlertDialog.Builder.customListAdapter(adapter: RecyclerView.Adapter<*>) {
-    val recyclerView = LayoutInflater.from(context).inflate(R.layout.dialog_generic_recycler_view, null, false) as RecyclerView
+    val binding = DialogGenericRecyclerViewBinding.inflate(LayoutInflater.from(context))
+    val recyclerView = binding.dialogRecyclerView
     recyclerView.adapter = adapter
     recyclerView.layoutManager = LinearLayoutManager(context)
-    this.setView(recyclerView)
+    this.setView(binding.root)
 }
 
 /**
@@ -275,12 +276,13 @@ fun AlertDialog.Builder.customListAdapterWithDecoration(
     adapter: RecyclerView.Adapter<*>,
     context: Context,
 ) {
-    val recyclerView = LayoutInflater.from(context).inflate(R.layout.dialog_generic_recycler_view, null, false) as RecyclerView
+    val binding = DialogGenericRecyclerViewBinding.inflate(LayoutInflater.from(context))
+    val recyclerView = binding.dialogRecyclerView
     recyclerView.adapter = adapter
     recyclerView.layoutManager = LinearLayoutManager(context)
     val dividerItemDecoration = DividerItemDecoration(recyclerView.context, LinearLayoutManager.VERTICAL)
     recyclerView.addItemDecoration(dividerItemDecoration)
-    this.setView(recyclerView)
+    this.setView(binding.root)
 }
 
 /**
@@ -404,17 +406,15 @@ fun AlertDialog.Builder.listItemsAndMessage(
     items: List<CharSequence>,
     onClick: (dialog: DialogInterface, index: Int) -> Unit,
 ): AlertDialog.Builder {
-    val dialogView = View.inflate(this.context, R.layout.dialog_listview_message, null)
-    dialogView.findViewById<FixedTextView>(R.id.dialog_message).text = message
-
-    val listView = dialogView.findViewById<ListView>(R.id.dialog_list_view)
-    listView.adapter = ArrayAdapter(context, android.R.layout.simple_list_item_1, items)
+    val binding = DialogListviewMessageBinding.inflate(LayoutInflater.from(context))
+    binding.message.text = message
+    binding.listView.adapter = ArrayAdapter(context, android.R.layout.simple_list_item_1, items)
 
     val dialog = this.create()
-    listView.setOnItemClickListener { _, _, index, _ ->
+    binding.listView.setOnItemClickListener { _, _, index, _ ->
         onClick(dialog, index)
     }
-    return this.setView(dialogView)
+    return this.setView(binding.root)
 }
 
 /**
@@ -438,20 +438,18 @@ fun AlertDialog.Builder.titleWithHelpIcon(
     block: View.OnClickListener,
 ) {
     // setup the view for the dialog
-    val customTitleView = LayoutInflater.from(context).inflate(R.layout.alert_dialog_title_with_help, null, false)
-    setCustomTitle(customTitleView)
+    val binding = AlertDialogTitleWithHelpBinding.inflate(LayoutInflater.from(context))
+    setCustomTitle(binding.root)
 
     // apply a custom title
-    val titleTextView = customTitleView.findViewById<TextView>(android.R.id.title)
-
     if (stringRes != null) {
-        titleTextView.setText(stringRes)
+        binding.title.setText(stringRes)
     } else if (text != null) {
-        titleTextView.text = text
+        binding.title.text = text
     }
 
     // set the action when clicking the help icon
-    customTitleView.findViewById<ImageView>(R.id.help_icon).setOnClickListener { v ->
+    binding.helpIcon.setOnClickListener { v ->
         Timber.i("dialog help icon click")
         block.onClick(v)
     }

--- a/AnkiDroid/src/main/res/layout/dialog_listview_message.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_listview_message.xml
@@ -25,7 +25,7 @@
 
     <!--Dialog Message-->
     <com.ichi2.ui.FixedTextView
-        android:id="@+id/dialog_message"
+        android:id="@+id/message"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:paddingStart="@dimen/side_margin"
@@ -36,7 +36,7 @@
 
     <!--Dialog ListItem-->
     <ListView
-        android:id="@+id/dialog_list_view"
+        android:id="@+id/list_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:clipToPadding="false"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/utils/AlertDialogUtils.kt
@@ -47,7 +47,7 @@ val AlertDialog.message
 
 val AlertDialog.ankiListView
     get() =
-        requireNotNull(this.listView ?: findViewById(R.id.dialog_list_view)) { "ankiListView not found" }
+        requireNotNull(this.listView ?: findViewById(R.id.list_view)) { "ankiListView not found" }
 
 fun AlertDialog.performPositiveClick() {
     // This exists as callOnClick did not call the listener


### PR DESCRIPTION


* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/9c2dde3d06986b5a3808b1e2859dd0c62ed141d0
* De-conflicted and renamed to `binding`

## How Has This Been Tested?
Brief test:

API 35 Phone Emulator

* Brief test of various functionality


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)