### PR TITLE
fix(study-screen): audio button being clipped

### DIFF
--- a/AnkiDroid/src/main/res/layout/reviewer2.xml
+++ b/AnkiDroid/src/main/res/layout/reviewer2.xml
@@ -143,11 +143,15 @@
 
         </com.google.android.material.card.MaterialCardView>
 
+        <!-- The elevation should be higher than the one used by the WebView
+             container, so the voice recording button can be dragged above it -->
         <LinearLayout
             android:id="@+id/bottom_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical"
+            android:elevation="1dp"
+            android:clipChildren="false"
             android:showDividers="middle|beginning|end"
             android:divider="@drawable/vertical_spacer_8dp"
             android:layout_marginHorizontal="@dimen/reviewer_side_margin">


### PR DESCRIPTION
## Fixes

The recording button being clipped, as below:

[Screen_recording_20260117_184902.webm](https://github.com/user-attachments/assets/318d3718-7e5e-4743-95a6-a97795d7b00d)

## How Has This Been Tested?

Emulator 36

[Screen_recording_20260117_181740.webm](https://github.com/user-attachments/assets/f420a90b-21b8-4b52-9abb-991873b71c98)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->