### PR TITLE
build: the token used for gradle update needs more permissions

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Update Gradle Wrapper
         uses: gradle-update/update-gradle-wrapper-action@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.MACHINE_ACCOUNT_PAT }}
           set-distribution-checksum: false
           base-branch: dependency-updates
           target-branch: dependency-updates


### PR DESCRIPTION
## Purpose / Description

re-use the machine account PAT I made that allows pull requests to be created *and trigger workflows* for strings sync, it is the same use case here

This did not fail before because the gradle wrapper hadn't updated since the workflow token permissions change I made

Previously it worked because the token was unrestricted and had write access. However, CI never ran on these workflows which was frustrating - and it was for the same reason CI didn't used to run on strings sync unless you closed/opened it - the default GITHUB_TOKEN cannot be used to create PRs that run workflows because it could create a recursive workflow run infinite loop (workflow runs which creates PR which runs workflow which creates PR, etc)

## Fixes

Hopefully fixes the last workflow run that failed:

https://github.com/ankidroid/Anki-Android/actions/runs/21102876243/job/60689482181#step:4:218

## Approach

Read the docs, realize the token we were using has insufficient power to run or trigger workflows - and we need a custom PAT to both create PR and run workflows when the PR is created

## How Has This Been Tested?

How does one test workflows before merge? Well, this has a workflow dispatch trigger so I can test a bit at least, I hope

## Learning (optional, can help others)

Should have fixed all "CI doesn't run on auto-created PR" issues when I fixed strings sync a while back, but forgot this one

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->