### PR TITLE
"Fixes 20133. Fix back navigation after canceled multimedia attachment"

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -330,7 +330,6 @@ class NoteEditorFragment :
                 if (result.resultCode == RESULT_CANCELED) {
                     Timber.d("Multimedia result canceled")
                     val index = result.data?.extras?.getInt(MULTIMEDIA_RESULT_FIELD_INDEX) ?: return@NoteEditorActivityResultCallback
-                    showMultimediaBottomSheet()
                     handleMultimediaActions(index)
                     return@NoteEditorActivityResultCallback
                 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fix back navigation after canceled multimedia attachment in Note editor.

## Fixes
Remove the multimedia bottom sheet when in onActivityResult is coming as cancelled. Now Note editor correctly handled back navigation 

* Fixes #20133

## Approach
The regression was caused by re-invoking showMultimediaBottomSheet() when the multimedia activity result was cancelled.
This caused the bottom sheet to be displayed again when navigating back, preserving an invalid selection state.
The fix removes the redundant call to re-show the bottom sheet and allows the existing back-navigation logic to proceed normally by handling only the selected multimedia action.
Regression analysis:
First bad commit: 7cc16f79
Last good commit: 2bbcf6b0
The issue was identified using git blame and confirmed via git bisect.

## How Has This Been Tested?

Open Note Editor
Tap Attach
Select Add Audio Clip
Press Back (cancel selection)
Press Back again
Result
Before fix: Multimedia bottom sheet reappears and selection state remains active
After fix: Returns cleanly to Note Editor with no residual selection


## Learning (optional, can help others)
Using git blame together with git bisect helped identify the exact regression commit and understand how navigation state was unintentionally preserved.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->