### PR TITLE
Add help icon to the sync error dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SyncErrorDialog.kt
@@ -38,6 +38,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog.Type.DIALOG_SYNC_SANITY_ERROR_CONF
 import com.ichi2.anki.dialogs.SyncErrorDialog.Type.DIALOG_USER_NOT_LOGGED_IN_SYNC
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.openUrl
+import com.ichi2.utils.titleWithHelpIcon
 
 class SyncErrorDialog : AsyncDialogFragment() {
     interface SyncErrorDialogListener {
@@ -93,8 +94,12 @@ class SyncErrorDialog : AsyncDialogFragment() {
             DIALOG_SYNC_CONFLICT_RESOLUTION -> {
                 // Sync conflict; allow user to cancel, or choose between local and remote versions
                 dialog
-                    .setIcon(R.drawable.ic_sync_problem)
-                    .setPositiveButton(R.string.sync_conflict_keep_local_new) { _, _ ->
+                    .titleWithHelpIcon(
+                        text = getString(R.string.sync_conflict_title_new),
+                        startIcon = R.drawable.ic_sync_problem,
+                    ) {
+                        requireContext().openUrl(getString(R.string.link_sync_conflict_help))
+                    }.setPositiveButton(R.string.sync_conflict_keep_local_new) { _, _ ->
                         requireSyncErrorDialogListener().showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_LOCAL)
                     }.setNegativeButton(R.string.sync_conflict_keep_remote_new) { _, _ ->
                         requireSyncErrorDialogListener().showSyncErrorDialog(DIALOG_SYNC_CONFLICT_CONFIRM_KEEP_REMOTE)

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AlertDialogFacade.kt
@@ -455,17 +455,23 @@ fun AlertDialog.Builder.listItemsAndMessage(
  * }
  * ```
  *
- * @param block action executed when the help icon is clicked
- *
+ * @param onHelpClick action executed when the help icon is clicked
+ * @param startIcon optional icon to display at the start of the title
  */
 fun AlertDialog.Builder.titleWithHelpIcon(
     @StringRes stringRes: Int? = null,
     text: String? = null,
-    block: View.OnClickListener,
-) {
+    @DrawableRes startIcon: Int? = null,
+    onHelpClick: View.OnClickListener,
+): AlertDialog.Builder {
     // setup the view for the dialog
     val binding = AlertDialogTitleWithHelpBinding.inflate(LayoutInflater.from(context))
     setCustomTitle(binding.root)
+
+    if (startIcon != null) {
+        binding.titleIcon.setImageResource(startIcon)
+        binding.titleIcon.visibility = View.VISIBLE
+    }
 
     // apply a custom title
     if (stringRes != null) {
@@ -477,8 +483,9 @@ fun AlertDialog.Builder.titleWithHelpIcon(
     // set the action when clicking the help icon
     binding.helpIcon.setOnClickListener { v ->
         Timber.i("dialog help icon click")
-        block.onClick(v)
+        onHelpClick.onClick(v)
     }
+    return this
 }
 
 /** Calls [AlertDialog.dismiss], ignoring errors */

--- a/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
+++ b/AnkiDroid/src/main/res/layout/alert_dialog_title_with_help.xml
@@ -1,24 +1,38 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     style="?attr/materialAlertDialogTitlePanelStyle"
-    android:orientation="horizontal"
     android:paddingStart="24dp"
     android:paddingEnd="8dp"
     android:paddingTop="24dp"
     android:paddingBottom="8dp">
+
+    <ImageView
+        android:id="@+id/title_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        style="?attr/materialAlertDialogTitleIconStyle"
+        android:visibility="gone"
+        tools:src="@drawable/ic_sync_problem"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@android:id/title"
+        app:layout_constraintBottom_toBottomOf="@android:id/title"/>
 
     <androidx.appcompat.widget.DialogTitleView
         android:id="@android:id/title"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
-        android:textColor="?attr/colorOnSurface"
-        app:layout_constraintEnd_toStartOf="@+id/help_icon"
-        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginStart="12dp"
+        app:layout_goneMarginStart="0dp"
+        app:layout_constraintStart_toEndOf="@id/title_icon"
+        app:layout_constraintEnd_toStartOf="@id/help_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Reset Card Progress" />
 
     <ImageView
@@ -26,7 +40,6 @@
         style="?attr/materialAlertDialogTitleIconStyle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="8dp"
         android:background="?attr/selectableItemBackground"
         android:padding="8dp"
         android:src="@drawable/ic_help_black_24dp"

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -116,6 +116,7 @@
     <string name="link_manual_ar">https://docs.ankidroid.org/manual-ar.html</string>
     <string name="link_manual_note_format_toolbar">https://docs.ankidroid.org/manual.html#noteFormattingToolbar</string>
     <string name="link_manual_browser_find_replace">https://docs.ankiweb.net/browsing.html#find-and-replace</string>
+    <string name="link_sync_conflict_help">https://ankidroid.org/#AnkiWebConflicts</string>
     <string name="link_user_actions_help">https://docs.ankidroid.org/#userActions</string>
     <string name="link_faq_tts">https://github.com/ankidroid/Anki-Android/wiki/FAQ#tts--text-to-speech-is-not-speaking</string>
     <string name="link_faq_missing_media" tools:ignore="Typos">https://github.com/ankidroid/Anki-Android/wiki/FAQ#why-doesnt-my-sound-or-image-work-on-ankidroid</string>


### PR DESCRIPTION
## Purpose / Description
Add help icon to the sync dialog in order to avoid confusion for users.

## Fixes
* This fixes #17544 

## Approach

1.SyncErrorDialog.kt :Refactored the DIALOG_SYNC_CONFLICT_RESOLUTION block to use the titleWithHelpIcon  extension from AlertDialogFacade.kt

2.AlertDialogFacade.kt: Updated the extension function to use optional icon parameter.

3.alert_dialog_with_xml :Added the title_icon ImageView to alert_dialog_title_with_help.xml and added adjustment so that the title aligns when no icon is present.

4.Constants.xml: added the link_sync_conflict_help string pointing to the url: https://docs.ankiweb.net/syncing.html#conflicts

## How Has This Been Tested?
Ran the app on the phone
and verified that the sync dialog shows both the dialog icon on the left and the help_icon on the right.
Verified that the icons are visible on both light and dark theme.





## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)




https://github.com/user-attachments/assets/f12db80d-e962-46ba-9481-f3019c2ef8bc




