### PR TITLE
chore: convert ControlPreferenceDialogFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -20,15 +20,14 @@ import android.app.Dialog
 import android.content.Context
 import android.os.Bundle
 import android.util.AttributeSet
-import android.view.View
 import android.widget.ArrayAdapter
-import android.widget.ListView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.view.isVisible
 import androidx.fragment.app.DialogFragment
 import androidx.preference.DialogPreference
 import androidx.preference.PreferenceFragmentCompat
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.ControlPreferenceBinding
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils
 import com.ichi2.anki.dialogs.GestureSelectionDialogUtils.onGestureChanged
 import com.ichi2.anki.dialogs.KeySelectionDialogUtils
@@ -232,21 +231,21 @@ class ControlPreferenceDialogFragment : DialogFragment() {
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val view = requireActivity().layoutInflater.inflate(R.layout.control_preference, null)
+        val binding = ControlPreferenceBinding.inflate(requireActivity().layoutInflater)
 
-        setupAddBindingDialogs(view)
-        setupRemoveControlEntries(view)
+        setupAddBindingDialogs(binding)
+        setupRemoveControlEntries(binding)
 
         return AlertDialog.Builder(requireContext()).create {
             setTitle(preference.title)
             setIcon(preference.icon)
-            customView(view, paddingTop = 16.dp.toPx(context))
+            customView(binding.root, paddingTop = 16.dp.toPx(context))
             negativeButton(R.string.dialog_cancel)
         }
     }
 
-    private fun setupAddBindingDialogs(view: View) {
-        view.findViewById<View>(R.id.add_gesture).apply {
+    private fun setupAddBindingDialogs(binding: ControlPreferenceBinding) {
+        binding.addGesture.apply {
             setOnClickListener {
                 preference.showGesturePickerDialog()
                 dismiss()
@@ -254,29 +253,28 @@ class ControlPreferenceDialogFragment : DialogFragment() {
             isVisible = preference.areGesturesEnabled
         }
 
-        view.findViewById<View>(R.id.add_key).setOnClickListener {
+        binding.addKey.setOnClickListener {
             preference.showKeyPickerDialog()
             dismiss()
         }
 
-        view.findViewById<View>(R.id.add_axis).setOnClickListener {
+        binding.addAxis.setOnClickListener {
             preference.showAddAxisDialog()
             dismiss()
         }
     }
 
-    private fun setupRemoveControlEntries(view: View) {
+    private fun setupRemoveControlEntries(binding: ControlPreferenceBinding) {
         val bindings = preference.getMappableBindings().toMutableList()
-        val listView = view.findViewById<ListView>(R.id.list_view)
         if (bindings.isEmpty()) {
-            listView.isVisible = false
+            binding.listView.isVisible = false
             return
         }
         val titles =
             bindings.map {
                 getString(R.string.binding_remove_binding, it.toDisplayString(requireContext()))
             }
-        listView.apply {
+        binding.listView.apply {
             adapter = ArrayAdapter(requireContext(), R.layout.control_preference_list_item, titles)
             setOnItemClickListener { _, _, index, _ ->
                 bindings.removeAt(index)

--- a/AnkiDroid/src/main/res/layout/control_preference.xml
+++ b/AnkiDroid/src/main/res/layout/control_preference.xml
@@ -57,5 +57,6 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:divider="@null"
+        tools:listitem="@layout/control_preference_list_item"
         />
 </LinearLayout>


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/6e7b826344d840e147babb31e6b4b2c574c9ab06
* Noticed a minor improvement for the previewer

<img width="218" height="382" alt="Screenshot 2026-01-18 at 12 48 10" src="https://github.com/user-attachments/assets/5dda4b12-5c94-4af9-8c42-bd2ac23cfe04" />


## How Has This Been Tested?
Brief test:

API 35 Phone Emulator & API 34 Tablet emulaotr

* Brief test: Controls Preference opens. Added and removed a key on the tablet


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)