### PR TITLE
chore: convert AboutFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/AboutFragment.kt
@@ -21,17 +21,14 @@ import android.os.Bundle
 import android.text.format.DateFormat
 import android.text.method.LinkMovementMethod
 import android.view.View
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.text.parseAsHtml
 import androidx.fragment.app.Fragment
-import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.Info
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.AboutLayoutBinding
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.scheduling.Fsrs
@@ -42,6 +39,7 @@ import com.ichi2.utils.IntentUtil
 import com.ichi2.utils.VersionUtils.pkgVersionName
 import com.ichi2.utils.copyToClipboard
 import com.ichi2.utils.show
+import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
@@ -50,42 +48,32 @@ import java.util.Locale
 import net.ankiweb.rsdroid.BuildConfig as BackendBuildConfig
 
 class AboutFragment : Fragment(R.layout.about_layout) {
+    private val binding by viewBinding(AboutLayoutBinding::bind)
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
-        view.findViewById<MaterialToolbar>(R.id.toolbar).apply {
-            setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
-        }
+        binding.toolbar.setNavigationOnClickListener { requireActivity().onBackPressedDispatcher.onBackPressed() }
 
-        // Version date
-        val apkBuildDate =
+        binding.buildDate.text =
             SimpleDateFormat(DateFormat.getBestDateTimePattern(Locale.getDefault(), "d MMM yyyy"))
                 .format(Date(BuildConfig.BUILD_TIME))
-        view.findViewById<TextView>(R.id.about_build_date).text = apkBuildDate
 
-        // Version text
-        view.findViewById<TextView>(R.id.about_version).text =
-            pkgVersionName
-
-        // Backend version text
-        view.findViewById<TextView>(R.id.about_backend).text =
+        binding.version.text = pkgVersionName
+        binding.backendVersion.text =
             "(anki " + BackendBuildConfig.ANKI_DESKTOP_VERSION + " / " + BackendBuildConfig.ANKI_COMMIT_HASH.subSequence(0, 8) + ")"
-
-        // FSRS version text
-        view.findViewById<TextView>(R.id.about_fsrs).text = Fsrs.displayVersion ?.let { version ->
+        binding.fsrsVersion.text = Fsrs.displayVersion ?.let { version ->
             "($version)"
         } ?: ""
 
         // Logo secret
-        view
-            .findViewById<ImageView>(R.id.about_app_logo)
-            .setOnClickListener(DevOptionsSecretClickListener(this))
+        binding.appLogo.setOnClickListener(DevOptionsSecretClickListener(this))
 
         // Contributors text
         val contributorsLink = getString(R.string.link_contributors)
         val contributingGuideLink = getString(R.string.link_contribution)
-        view.findViewById<TextView>(R.id.about_contributors_description).apply {
+        binding.contributorsDescription.apply {
             text = getString(R.string.about_contributors_description, contributorsLink, contributingGuideLink).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
@@ -95,7 +83,7 @@ class AboutFragment : Fragment(R.layout.about_layout) {
         val agplLicenseLink = getString(R.string.link_agpl_wiki)
         val sourceCodeLink = getString(R.string.link_source)
         val dependencyLicenseLink = getString(R.string.dependency_license_wiki)
-        view.findViewById<TextView>(R.id.about_license_description).apply {
+        binding.licenseDescription.apply {
             text =
                 (
                     getString(R.string.license_description, gplLicenseLink, agplLicenseLink, sourceCodeLink) + "<br>" +
@@ -106,18 +94,16 @@ class AboutFragment : Fragment(R.layout.about_layout) {
 
         // Donate text
         val donateLink = getString(R.string.link_opencollective_donate)
-        view.findViewById<TextView>(R.id.about_donate_description).apply {
+        binding.donateDescription.apply {
             text = getString(R.string.donate_description, donateLink).parseAsHtml()
             movementMethod = LinkMovementMethod.getInstance()
         }
 
-        // Rate Ankidroid button
-        view.findViewById<Button>(R.id.about_rate).setOnClickListener {
+        binding.rateAnkiDroid.setOnClickListener {
             IntentUtil.tryOpenIntent(requireAnkiActivity(), AnkiDroidApp.getMarketIntent(requireContext()))
         }
 
-        // Open changelog button
-        view.findViewById<Button>(R.id.about_open_changelog).setOnClickListener {
+        binding.openChangelog.setOnClickListener {
             val openChangelogIntent =
                 Intent(requireContext(), Info::class.java).apply {
                     putExtra(Info.TYPE_EXTRA, Info.TYPE_NEW_VERSION)
@@ -125,10 +111,7 @@ class AboutFragment : Fragment(R.layout.about_layout) {
             startActivity(openChangelogIntent)
         }
 
-        // Copy debug info button
-        view.findViewById<Button>(R.id.about_copy_debug).setOnClickListener {
-            copyDebugInfo()
-        }
+        binding.copyDebugInfo.setOnClickListener { copyDebugInfo() }
     }
 
     /**

--- a/AnkiDroid/src/main/res/layout/about_layout.xml
+++ b/AnkiDroid/src/main/res/layout/about_layout.xml
@@ -53,7 +53,7 @@
                 android:paddingHorizontal="12dp">
 
                 <ImageView
-                    android:id="@+id/about_app_logo"
+                    android:id="@+id/app_logo"
                     android:layout_width="96dp"
                     android:layout_height="96dp"
                     app:srcCompat="@drawable/ankidroid_logo" />
@@ -66,7 +66,7 @@
                     app:tint="?android:attr/textColor" />
 
                 <TextView
-                    android:id="@+id/about_version"
+                    android:id="@+id/version"
                     style="?android:textAppearanceSmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -74,21 +74,21 @@
                     tools:text="2.x" />
 
                 <TextView
-                    android:id="@+id/about_build_date"
+                    android:id="@+id/build_date"
                     style="?android:textAppearanceSmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="13 Apr 2023" />
 
                 <TextView
-                    android:id="@+id/about_backend"
+                    android:id="@+id/backend_version"
                     style="?android:textAppearanceSmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     tools:text="(anki 23.10.1 / be74babb0)" />
 
                 <TextView
-                    android:id="@+id/about_fsrs"
+                    android:id="@+id/fsrs_version"
                     style="?android:textAppearanceSmall"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
@@ -104,7 +104,7 @@
                     android:textSize="16sp" />
 
                 <TextView
-                    android:id="@+id/about_contributors_description"
+                    android:id="@+id/contributors_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="4dp"
@@ -122,7 +122,7 @@
                     android:textSize="16sp" />
 
                 <TextView
-                    android:id="@+id/about_license_description"
+                    android:id="@+id/license_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="4dp"
@@ -139,7 +139,7 @@
                     android:textSize="16sp" />
 
                 <TextView
-                    android:id="@+id/about_donate_description"
+                    android:id="@+id/donate_description"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="4dp"
@@ -153,21 +153,21 @@
                     android:orientation="vertical"
                     android:gravity="center">
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/about_rate"
+                        android:id="@+id/rate_anki_droid"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/info_rate"
                         style="@style/Widget.Material3.Button.TextButton"
                         android:textColor="?attr/colorAccent" />
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/about_open_changelog"
+                        android:id="@+id/open_changelog"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/open_changelog"
                         style="@style/Widget.Material3.Button.TextButton"
                         android:textColor="?attr/colorAccent"/>
                     <com.google.android.material.button.MaterialButton
-                        android:id="@+id/about_copy_debug"
+                        android:id="@+id/copy_debug_info"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/feedback_copy_debug"


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/205c62ae6abb3baf66022fa1866313ce8aefa6d7
* converted to `vbpd`

## How Has This Been Tested?
Brief test:

API 35 Phone Emulator

* Brief test: I can open the fragment and copy debug info

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)