### PR TITLE
fix(review-reminders): crash on startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -197,7 +197,7 @@ data class ReviewReminder private constructor(
     val scope: ReviewReminderScope,
     var enabled: Boolean,
     val profileID: String,
-    val onlyNotifyIfNoReviews: Boolean,
+    val onlyNotifyIfNoReviews: Boolean = false,
 ) : Parcelable,
     ReviewReminderSchema {
     companion object {


### PR DESCRIPTION
## Purpose / Description
A breaking schema change was made to `ReviewReminder`

* 2.24alpha1
  * Create a few reminders with various parameters
* Update to 2.24alpha3
  * Crash on open

This caused `MissingFieldException: Field 'onlyNotifyIfNoReviews' is required for type with serial name 'com.ichi2.anki.reviewreminders.ReviewReminder', but it was missing`

## Fixes
* Fixes #20163

## Approach
Provide the default value of `false` to fix this

## How Has This Been Tested?

API 35 phone emulator

* Trigger the bug via `alpha1`
* Open the app on `main`: crash
* Apply the patch: app opens as normal

## Learning (optional, can help others)
Maybe 5 issues need to be created to better handle this in future... but let's get this fixed first.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)