### PR TITLE
chore: convert RepositionCardFragment to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -19,19 +19,15 @@ import android.app.Dialog
 import android.content.res.Configuration
 import android.os.Bundle
 import android.view.WindowManager
-import android.widget.CheckBox
-import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.setFragmentResult
-import com.google.android.material.textfield.TextInputEditText
-import com.google.android.material.textfield.TextInputLayout
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.FragmentRepositionCardBinding
 import com.ichi2.anki.ui.internationalization.toSentenceCase
-import com.ichi2.anki.utils.ext.window
 import com.ichi2.utils.create
 import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
@@ -47,33 +43,28 @@ import com.ichi2.utils.title
  */
 class RepositionCardFragment : DialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val dialogView = layoutInflater.inflate(R.layout.fragment_reposition_card, null)
-        dialogView.findViewById<TextView>(R.id.queue_limits_label).text =
+        val binding = FragmentRepositionCardBinding.inflate(layoutInflater)
+        binding.queueLimitsLabel.text =
             """
             ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_TOP))}
             ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_BOTTOM))} 
             """.trimIndent()
-        dialogView.findViewById<TextInputLayout>(R.id.start_input_layout).hint =
+        binding.startInputLayout.hint =
             TR.browsingStartPosition().removeSuffix(":")
-        dialogView.findViewById<TextInputLayout>(R.id.step_input_layout).hint =
+        binding.stepInputLayout.hint =
             TR.browsingStep().removeSuffix(":")
 
-        val startInputEditText = dialogView.findViewById<TextInputEditText>(R.id.start_input)
-        val stepInputEditText = dialogView.findViewById<TextInputEditText>(R.id.step_input)
+        binding.startInputEditText.requestFocus()
+        binding.startInputEditText.selectAll()
 
-        startInputEditText.requestFocus()
-        startInputEditText.selectAll()
-
-        val randomCheck =
-            dialogView.findViewById<CheckBox>(R.id.randomize_order_check)?.apply {
-                text = TR.browsingRandomizeOrder()
-                isChecked = requireArguments().getBoolean(ARG_RANDOM)
-            } ?: error("Unexpected missing random checkbox!")
-        val shiftPositionCheck =
-            dialogView.findViewById<CheckBox>(R.id.shift_position_check)?.apply {
-                text = TR.browsingShiftPositionOfExistingCards()
-                isChecked = requireArguments().getBoolean(ARG_SHIFT)
-            } ?: error("Unexpected missing shift position checkbox!")
+        binding.randomizeOrderCheck.apply {
+            text = TR.browsingRandomizeOrder()
+            isChecked = requireArguments().getBoolean(ARG_RANDOM)
+        }
+        binding.shiftPositionCheck.apply {
+            text = TR.browsingShiftPositionOfExistingCards()
+            isChecked = requireArguments().getBoolean(ARG_SHIFT)
+        }
         val title =
             TR
                 .browsingRepositionNewCards()
@@ -81,20 +72,20 @@ class RepositionCardFragment : DialogFragment() {
         val dialog =
             AlertDialog.Builder(requireContext()).create {
                 title(text = title)
-                customView(dialogView)
+                customView(binding.root)
                 negativeButton(R.string.dialog_cancel)
                 positiveButton(R.string.dialog_ok) {
                     val position =
-                        startInputEditText.textAsIntOrNull() ?: return@positiveButton
+                        binding.startInputEditText.textAsIntOrNull() ?: return@positiveButton
                     val step =
-                        stepInputEditText.textAsIntOrNull() ?: return@positiveButton
+                        binding.stepInputEditText.textAsIntOrNull() ?: return@positiveButton
                     setFragmentResult(
                         REQUEST_REPOSITION_NEW_CARDS,
                         bundleOf(
                             ARG_POSITION to position,
                             ARG_STEP to step,
-                            ARG_RANDOM to randomCheck.isChecked,
-                            ARG_SHIFT to shiftPositionCheck.isChecked,
+                            ARG_RANDOM to binding.randomizeOrderCheck.isChecked,
+                            ARG_SHIFT to binding.shiftPositionCheck.isChecked,
                         ),
                     )
                 }

--- a/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reposition_card.xml
@@ -35,7 +35,7 @@
         app:layout_constraintTop_toBottomOf="@id/queue_limits_label">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/start_input"
+            android:id="@+id/start_input_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawablePadding="8dp"
@@ -60,7 +60,7 @@
         app:layout_constraintEnd_toEndOf="parent">
 
         <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/step_input"
+            android:id="@+id/step_input_edit_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:drawablePadding="8dp"


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/eec25e5ce1f77cee72c03eb7e406e2a782a6d429

## How Has This Been Tested?
Brief test:

API 35 phone emulator

* I can reposition a card

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)