### PR TITLE
feat(content-provider): supports search cards and access card details by id

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -257,6 +257,198 @@ class ContentProviderTest : InstrumentedTest() {
         }
     }
 
+    @Test
+    fun testSearchCards_singleCardNote_returnsOneCard() {
+        // Basic note types produce exactly one card
+        val card = getFirstCardFromScheduler(col)
+        val noteId = card!!.nid
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                "nid:$noteId",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertEquals(
+                "basic note should produce exactly one card",
+                1,
+                it.count,
+            )
+
+            assertTrue(it.moveToFirst())
+            val returnedNoteId =
+                it.getLong(it.getColumnIndex(FlashCardsContract.Card.NOTE_ID))
+
+            assertEquals(
+                "returned card belongs to searched note",
+                noteId,
+                returnedNoteId,
+            )
+        }
+    }
+
+    @Test
+    fun testSearchCards_multiCardNote_returnsAllCards() {
+        // Cloze note with two cards
+        val note =
+            addTempClozeNote("{{c1::A}} {{c2::B}}")
+
+        val expectedCardCount = note.numberOfCards(col)
+        assertThat("sanity check", expectedCardCount, greaterThan(1))
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                "nid:${note.id}",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertEquals(
+                "all cards for the note should be returned",
+                expectedCardCount,
+                it.count,
+            )
+
+            while (it.moveToNext()) {
+                val returnedNoteId =
+                    it.getLong(it.getColumnIndex(FlashCardsContract.Card.NOTE_ID))
+                assertEquals(
+                    "each returned card belongs to the searched note",
+                    note.id,
+                    returnedNoteId,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testSearchCards_onlyIdProjection() {
+        val card = getFirstCardFromScheduler(col)
+
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                arrayOf(FlashCardsContract.Card._ID),
+                "cid:${card!!.id}",
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertEquals("single column", 1, it.columnCount)
+            assertEquals("_id", FlashCardsContract.Card._ID, it.getColumnName(0))
+            assertEquals("one result", 1, it.count)
+
+            it.moveToFirst()
+            assertEquals("correct card id", card.id, it.getLong(0))
+        }
+    }
+
+    @Test
+    fun testQueryCardById() {
+        val card = getFirstCardFromScheduler(col)
+
+        val cardUri =
+            Uri.withAppendedPath(
+                FlashCardsContract.Card.CONTENT_URI,
+                card!!.id.toString(),
+            )
+
+        val cursor =
+            contentResolver.query(
+                cardUri,
+                null,
+                null,
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertEquals("one row", 1, it.count)
+            assertTrue(it.moveToFirst())
+
+            val returnedCardId =
+                it.getLong(it.getColumnIndex(FlashCardsContract.Card._ID))
+            val returnedNoteId =
+                it.getLong(it.getColumnIndex(FlashCardsContract.Card.NOTE_ID))
+            val returnedOrd =
+                it.getInt(it.getColumnIndex(FlashCardsContract.Card.CARD_ORD))
+
+            assertEquals(card.id, returnedCardId)
+            assertEquals(card.nid, returnedNoteId)
+            assertEquals(card.ord, returnedOrd)
+        }
+    }
+
+    @Test
+    fun testQueryCardsRoot_returnsCards() {
+        val cursor =
+            contentResolver.query(
+                FlashCardsContract.Card.CONTENT_URI,
+                null,
+                null,
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertThat("at least one card returned", it.count, greaterThan(0))
+        }
+    }
+
+    @Test
+    fun testQueryCardById_invalidIdThrows() {
+        val invalidCardUri =
+            Uri.withAppendedPath(
+                FlashCardsContract.Card.CONTENT_URI,
+                "999999999",
+            )
+
+        val exception =
+            assertThrows<RuntimeException> {
+                contentResolver.query(
+                    invalidCardUri,
+                    null,
+                    null,
+                    null,
+                    null,
+                )
+            }
+        // error message (as observed when writing this test): "No such card: '999999999'"
+        assertThat(exception.message, containsString("card"))
+    }
+
+    @Test
+    fun testSearchCards_invalidQueryAndThrows() {
+        val exception =
+            assertThrows<IllegalArgumentException> {
+                contentResolver.query(
+                    FlashCardsContract.Card.CONTENT_URI,
+                    null,
+                    "and",
+                    null,
+                    null,
+                )
+            }
+
+        assertThat(
+            exception.message,
+            containsString("Invalid Anki search query"),
+        )
+    }
+
     /**
      * Check that inserting a note with an invalid noteTypeId returns a reasonable exception
      */

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -78,6 +78,12 @@ import com.ichi2.anki.api.Ease
  * notes/<note_id>/cards/<ord> | NoteCard `ord` (with ord = 0... num_cards-1) belonging to note `note_id` as high level data (Deck name, question, answer).
  *                             | Supports update(), query(). For code examples see class description of [Card].
  * --------------------------------------------------------------------------------------------------------------------
+ * cards                       | All cards as high level data (Deck name, question, answer).
+ *                             | Supports query(). For code examples see class description of [Card].
+ * --------------------------------------------------------------------------------------------------------------------
+ * cards/<ord>                 | Card `ord` (with ord = 0... num_cards-1) as high level data (Deck name, question, answer).
+ *                             | Supports update(), query(). For code examples see class description of [Card].
+ * --------------------------------------------------------------------------------------------------------------------
  * models                      | All note types as JSONObjects.
  *                             | Supports query(). For code examples see class description of [Model].
  * --------------------------------------------------------------------------------------------------------------------
@@ -576,6 +582,12 @@ public object FlashCardsContract {
      */
     public object Card {
         /**
+         * The ID of the card in the Anki database.
+         */
+        @Suppress("ConstPropertyName", "ktlint:standard:backing-property-naming")
+        public const val _ID: String = "_id"
+
+        /**
          * This is the ID of the note that this card belongs to (i.e. [Note._ID]).
          */
         public const val NOTE_ID: String = "note_id"
@@ -622,9 +634,17 @@ public object FlashCardsContract {
          */
         public const val ANSWER_PURE: String = "answer_pure"
 
+        /**
+         * The content:// style URI for cards. Can be used to search for cards or access specific cards.
+         * For examples on how to use the URI for queries see the overview in [FlashCardsContract].
+         */
+        @JvmField // required for Java API
+        public val CONTENT_URI: Uri = Uri.withAppendedPath(AUTHORITY_URI, "cards")
+
         @JvmField // required for Java API
         public val DEFAULT_PROJECTION: Array<String> =
             arrayOf(
+                _ID,
                 NOTE_ID,
                 CARD_ORD,
                 CARD_NAME,

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Collection.kt
@@ -80,6 +80,7 @@ import com.ichi2.anki.libanki.utils.NotInPyLib
 import net.ankiweb.rsdroid.Backend
 import net.ankiweb.rsdroid.BackendException.BackendSearchException
 import net.ankiweb.rsdroid.RustCleanup
+import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import timber.log.Timber
 import java.io.File
 
@@ -576,6 +577,11 @@ class Collection(
      * ***********************************************************
      */
 
+    /**
+     * Return the card with the given ID.
+     *
+     * @throws BackendNotFoundException if the card does not exist
+     */
     @CheckResult
     @LibAnkiAlias("get_card")
     fun getCard(id: CardId): Card = Card(this, id)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Expand CardContentProvider to return card IDs and cardinfo details

## Fixes
* Fixes #20112 
* Fixes #17345

## Approach
I copy-pasted the proposed solution by @joaquintoral. And understood how it works on external app like AnkiConnectAndroid and test it properly. 

## How Has This Been Tested?
1. Run AnkiConnectAndroid locally - https://github.com/sanjaysargam/AnkiconnectAndroid/tree/card
2. Run AnkiDroid.

**FindCards - /cards**
```powershell
curl -X POST http://192.168.0.101:8765 \
  -H "Content-Type: application/json" \
  -d '{
    "action": "findCards",
    "version": 6,
    "params": {
      "query": "deck:current"
    }
  }'
``` 

response in logcat: 
```
2026-01-20 13:50:07.435  3211-8481  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  received json:
{"action":"findCards","version":6,"params":{"query":"deck:current"}}

2026-01-20 13:50:07.437  3211-8481  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  Processing findCards with query: deck:current

2026-01-20 13:50:07.437  3211-8481  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  findCards query: deck:current

2026-01-20 13:50:07.484  3211-8481  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  findCards found 1 cards for query: deck:current

2026-01-20 13:50:07.486  3211-8481  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  response json:
{"result":[1768897186292],"error":null}
```

**FindCardByID - /cards/#**

```powershell
curl -X POST http://192.168.0.101:8765 \
  -H "Content-Type: application/json" \
  -d '{
    "action": "cardsInfo",
    "version": 6,
    "params": {
      "notes": [1768897186292]
    }
  }'
``` 
response in logcat: 
```
2026-01-20 13:59:09.410  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  received json:
{"action":"cardsInfo","version":6,"params":{"notes":[1768897186292]}}

2026-01-20 13:59:09.412  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  Processing cardsInfo for IDs: [1768897186292]

2026-01-20 13:59:09.413  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  cardsInfo requested for card IDs: [1768897186292]

2026-01-20 13:59:09.425  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  Processed card ID: 1768897186292

2026-01-20 13:59:09.425  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  cardsInfo returning 1 card(s)

2026-01-20 13:59:09.428  3211-9024  AnkiConnectAndroid  com.kamwithk.ankiconnectandroid  D  response json:
{"result":[{"id":1768897186292,"noteId":1768897186292,"deckId":0,"templateIndex":0,"question":"Card 1768897186292 question","answer":"Card 1768897186292 answer","flags":0,"tags":[]}],"error":null}
```


## Learning (optional, can help others)
This was completely new for me. I haven’t worked on scenarios where an external app consumes our APIs before, so exploring this is really interesting

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)