### PR TITLE
Fix(Card Browser): ANR on using scrollbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Double.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Double.kt
@@ -1,0 +1,25 @@
+/*
+ *  Copyright (c) 2026 Shaan Narendran <shaannaren06@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import kotlin.Double
+
+fun Double.wholeAndFraction(): Pair<Long, Double> {
+    val whole = this.toLong()
+    val fraction = this - whole
+    return Pair(whole, fraction)
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/WholeAndFractionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/WholeAndFractionTest.kt
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2026 Shaan Narendran <shaannaren06@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/** Tests for wholeAndFraction in Double.kt */
+class WholeAndFractionTest {
+    @Test
+    fun wholeAndFraction_zero() {
+        val (whole, fraction) = (0.0).wholeAndFraction()
+        assertEquals(0L, whole)
+        assertEquals(0.0, fraction)
+    }
+
+    @Test
+    fun wholeAndFraction_positive() {
+        val (whole, fraction) = (1.5).wholeAndFraction()
+        assertEquals(1L, whole)
+        assertEquals(0.5, fraction)
+    }
+
+    @Test
+    fun wholeAndFraction_negative() {
+        val (whole, fraction) = (-1.5).wholeAndFraction()
+        // -1 + (-0.5) = -1.5
+        assertEquals(-1L, whole)
+        assertEquals(-0.5, fraction)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
ANR when the scrollbar was dragged or tapped in larger collections, arose due to the addition of pr #19980

* #19980

## Fixes
* Fixes #20173 

## Approach
I deleted the previous delta based logic implemented and let the new function handle dragging and tapping which doesn't cause ANRs, for extra optimisation added a scrolltopositionwithoffset.

## How Has This Been Tested?
Tested the scrolling with a deck of 100k cards and found no issue on rapid scrolling for 30 seconds along with taps throughout the browser

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->