### PR TITLE
Fix: (ANR) Input Dispatching Timed Out in Split CardBrowser

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -103,8 +103,6 @@ import com.ichi2.ui.CardBrowserSearchView
 import com.ichi2.utils.AndroidUiUtils.hideKeyboard
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.increaseHorizontalPaddingOfOverflowMenuIcons
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.RustCleanup
 import timber.log.Timber
@@ -152,8 +150,6 @@ open class CardBrowser :
     private var actionBarTitle: TextView? = null
 
     private var searchView: CardBrowserSearchView? = null
-
-    private var cardSelectionJob: Job? = null
 
     lateinit var tagsDialogFactory: TagsDialogFactory
     private var searchItem: MenuItem? = null
@@ -455,23 +451,15 @@ open class CardBrowser :
         if (!fragmented) {
             return
         }
+        // Show note editor frame
+        binding.noteEditorFrame!!.isVisible = true
 
-        cardSelectionJob?.cancel()
-
-        cardSelectionJob =
-            lifecycleScope.launch {
-                delay(150)
-
-                // Show note editor frame
-                binding.noteEditorFrame!!.isVisible = true
-
-                // If there are unsaved changes in NoteEditor then show dialog for confirmation
-                if (fragment?.hasUnsavedChanges() == true) {
-                    showSaveChangesDialog(editNoteLauncher)
-                } else {
-                    loadNoteEditorFragment(editNoteLauncher)
-                }
-            }
+        // If there are unsaved changes in NoteEditor then show dialog for confirmation
+        if (fragment?.hasUnsavedChanges() == true) {
+            showSaveChangesDialog(editNoteLauncher)
+        } else {
+            loadNoteEditorFragment(editNoteLauncher)
+        }
     }
 
     @Suppress("UNUSED_PARAMETER")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -638,24 +638,11 @@ class CardBrowserFragment :
         }
     }
 
-    // TODO: Move this to ViewModel and test
     @VisibleForTesting
-    fun onTap(id: CardOrNoteId) =
-        launchCatchingTask {
-            activityViewModel.focusedRow = id
-            if (activityViewModel.isInMultiSelectMode) {
-                val wasSelected = activityViewModel.selectedRows.contains(id)
-                activityViewModel.toggleRowSelection(id.toRowSelection())
-                // Load NoteEditor on trailing side if card is selected
-                if (wasSelected) {
-                    activityViewModel.currentCardId = id.toCardId(activityViewModel.cardsOrNotes)
-                    requireCardBrowserActivity().loadNoteEditorFragmentIfFragmented()
-                }
-            } else {
-                val cardId = activityViewModel.queryDataForCardEdit(id)
-                requireCardBrowserActivity().openNoteEditorForCard(cardId)
-            }
-        }
+    fun onTap(id: CardOrNoteId) {
+        val topOffset = calculateTopOffset(activityViewModel.getPositionOfId(id) ?: 0)
+        activityViewModel.onTap(id, topOffset)
+    }
 
     // TODO: This dialog should survive activity recreation
     fun showChangeDeckDialog() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -580,6 +580,26 @@ class CardBrowserViewModel(
         }
     }
 
+    @VisibleForTesting
+    fun onTap(
+        id: CardOrNoteId,
+        topOffset: Int = 0,
+    ) = viewModelScope.launch {
+        focusedRow = id
+        if (isInMultiSelectMode) {
+            val wasSelected = selectedRows.contains(id)
+            toggleRowSelection(RowSelection(rowId = id, topOffset = topOffset))
+            // Load NoteEditor on trailing side if card is now selected (wasn't before)
+            if (!wasSelected) {
+                currentCardId = id.toCardId(cardsOrNotes)
+                cardSelectionEventFlow.emit(Unit)
+            }
+        } else {
+            val cardId = id.toCardId(cardsOrNotes)
+            openNoteEditorForCard(cardId)
+        }
+    }
+
     // on a row tap
     fun openNoteEditorForCard(cardId: CardId) {
         currentCardId = cardId


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Describe the problem or feature and motivation_

In Tablet/Chromebook when enabling split mode in CardBrower from Settings -> Developer Options and going to CardBrowser, and then scrolling through decks or clicking different decks multiple times causes ANR.

## Fixes
* Fixes #19737

## Approach
_How does this change address the problem?_

I have created `cardSelectionJob` in `loadNoteEditorFragmentIfFragmented` which opens the split editor after 150ms delay so it prevents opening it multiple times when there are various clicks on the decks, so the final one only opens. It also ensures that the previous `cardSelectionJob` is cancelled before creating a new `cardSelectionJob`.

## How Has This Been Tested?

Have Tablet/Chromebook
Enable split mode in CardBrower from Settings -> Developer Options
Go to Cardbrowser
then scroll to decks and click them, It should remain responsive without blocking UI thread

I have tested on
Device: Medium Tablet
Android version: 13
API Level: 33

Shared Deck I used: [4000 Essential English Words (all books) [en-en]](https://ankiweb.net/shared/info/1104981491)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->