### PR TITLE
Fix unused parameter warning

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/CardMediaPlayer.kt
@@ -364,7 +364,7 @@ private fun Deferred<Closeable>.close(logPrefix: String) {
         try {
             this.getCompleted().close()
             Timber.d("$logPrefix closed")
-        } catch (e: CancellationException) {
+        } catch (_: CancellationException) {
             // Ignore: no value was produced, nothing to close
         } catch (e: Exception) {
             Timber.w(e, "$logPrefix close()")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Android Studio was flagging unused parameter warnings in the Kotlin codebase.
These warnings add noise during development and slow down contributors during code inspections and commits.

## Fixes
* Fixes part of #13282 

## Approach

- Replaced the unused exception parameter in a catch block with 
- Follows Kotlin’s idiomatic convention for intentionally unused parameters
- No behavior or control flow changes

## How Has This Been Tested?

I ran the app on emulator and it started with no errors and crashes

## Learning (optional, can help others)
-we can simply place _ in case of an un used exception argument in catch .
-how to remove commits

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->