### PR TITLE
Fix #19225: Fix undo error after editing note template

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -737,6 +737,7 @@ class ReviewerViewModel(
             when {
                 changes.studyQueues -> updateCurrentCard()
                 changes.noteText -> {
+                    updateCurrentCard()
                     val card = currentCard.await()
                     withCol { card.load(this) }
                     cardMediaPlayer.loadCardAvTags(card)


### PR DESCRIPTION
## Purpose / Description
Fixes #19225

When editing a note template in the new reviewer, the queue state wasn't successfully updating, which caused errors when trying to undo.

## Approach
The [ReviewerViewModel](cci:2://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt:80:0-763:1) wasn't refreshing the queue state when `changes.noteText` occurred. I added a call to [updateCurrentCard()](cci:1://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt:1204:4-1214:5) in that block to ensure the local state stays in sync with the backend.

## How Has This Been Tested?
Tested manually on the New Study Screen:
1. Edited a card template during review.
2. Answered the card.
3. Pressed Undo.

Previously this errored out ("card modified without updating queue"), now it works correctly.

https://github.com/user-attachments/assets/594ac2e8-c72e-43d6-9071-109b080ff204


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code