### PR TITLE
refactor(browse): extract saved searches

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/SavedSearches.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/SavedSearches.kt
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser.search
+
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.libanki.Config
+import timber.log.Timber
+
+/**
+ * A named query for the Card Browser
+ *
+ * Selecting a saved search quickly allows a user to either:
+ * - search the given query
+ * - add additional terms to the query before searching
+ *
+ * @see SavedSearches
+ */
+data class SavedSearch(
+    val name: String,
+    val query: String,
+)
+
+/**
+ * Manages saved searches (named search queries in the Card Browser)
+ *
+ * Named 'Saved Searches' in Anki Desktop
+ *
+ * Searches are shared between all Anki clients in the collection, are unordered and are
+ * case-sensitive: 'A' and 'a' are different searches with the ordering: `["A", "Z", "a"]`
+ *
+ * @see SavedSearch
+ * @see savedFilters
+ */
+object SavedSearches {
+    /**
+     * Returns the list of [saved searches][SavedSearch] stored in the Anki collection config.
+     */
+    suspend fun loadFromConfig(): List<SavedSearch> = withCol { config.savedFilters }
+
+    /**
+     * Updates the list of [saved searches][SavedSearch] stored in the Anki collection config.
+     *
+     * Ordering is NOT preserved
+     */
+    suspend fun saveToConfig(values: List<SavedSearch>) = withCol { config.savedFilters = values }
+
+    /**
+     * Adds a saved search to the Anki collection config
+     *
+     * @return a pair: `false` if a search with the given name already exists,
+     * `true` if the search was added.
+     *
+     * The second element of the pair is the updated list of saved searches.
+     */
+    suspend fun add(savedSearch: SavedSearch): Pair<Boolean, List<SavedSearch>> {
+        Timber.i("saving user search")
+        val values = loadFromConfig()
+        if (values.any { it.name == savedSearch.name }) return false to values
+        val updatedValues = values + savedSearch
+        saveToConfig(updatedValues)
+        return true to loadFromConfig()
+    }
+
+    /**
+     * Removes a saved search from the Anki collection by name
+     *
+     * @return a pair: `true` if the searches were updated, `false` if the name was not found
+     *
+     * The second element of the pair is the updated list of saved searches.
+     */
+    suspend fun removeByName(searchName: String): Pair<Boolean, List<SavedSearch>> {
+        Timber.i("removing saved search")
+        val originalValues = loadFromConfig()
+        val updatedValues = originalValues.filter { it.name != searchName }
+        // early return if no changes occurred
+        if (updatedValues.size == originalValues.size) return false to originalValues
+        saveToConfig(updatedValues)
+        return true to updatedValues
+    }
+
+    /** Removes all saved searches from the Anki collection */
+    suspend fun clear() = saveToConfig(emptyList())
+}
+
+/**
+ * The list of saved searches in the Anki Collection
+ *
+ * Ordering is NOT preserved in Anki Desktop. Searches are ordered based on the name and are
+ * case-sensitive
+ */
+var Config.savedFilters: List<SavedSearch>
+    get() =
+        get<Map<String, String>>("savedFilters")
+            .orEmpty()
+            .map { (key, value) -> SavedSearch(name = key, query = value) }
+    set(value) {
+        set("savedFilters", value.toMap())
+    }
+
+fun List<SavedSearch>.toMap(): Map<String, String> = associate { it.name to it.query }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SaveBrowserSearchDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SaveBrowserSearchDialogFragment.kt
@@ -24,6 +24,7 @@ import androidx.fragment.app.setFragmentResult
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
+import com.ichi2.anki.browser.search.SavedSearch
 import com.ichi2.anki.dialogs.SaveBrowserSearchDialogFragment.Companion.ARG_SEARCH_QUERY
 import com.ichi2.anki.dialogs.SaveBrowserSearchDialogFragment.Companion.ARG_SEARCH_QUERY_NAME
 import com.ichi2.anki.launchCatchingTask
@@ -112,12 +113,14 @@ fun CardBrowser.registerSaveSearchHandler() {
             )
             return@setFragmentResultListener
         }
-        val savedSearchQuery =
-            bundle.getString(ARG_SEARCH_QUERY)
-                ?: return@setFragmentResultListener
+        val toSave =
+            SavedSearch(
+                name = savedSearchName,
+                query = bundle.getString(ARG_SEARCH_QUERY) ?: return@setFragmentResultListener,
+            )
 
         launchCatchingTask {
-            val saveStatus = viewModel.saveSearch(savedSearchName, savedSearchQuery)
+            val saveStatus = viewModel.saveSearch(toSave)
             updateAfterUserSearchIsSaved(saveStatus)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -24,6 +24,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.browser.search.SavedSearch
+import com.ichi2.anki.browser.search.toMap
 import com.ichi2.anki.databinding.CardBrowserItemMySearchesDialogBinding
 import com.ichi2.anki.dialogs.SavedBrowserSearchesDialogFragment.Companion.ARG_SAVED_SEARCH
 import com.ichi2.anki.dialogs.SavedBrowserSearchesDialogFragment.Companion.TYPE_SEARCH_REMOVED
@@ -146,11 +148,11 @@ class SavedBrowserSearchesDialogFragment : AnalyticsDialogFragment() {
         const val ARG_TYPE = "arg_type"
         private const val ARG_SAVED_FILTERS = "arg_saved_filters"
 
-        fun newInstance(savedFilters: Map<String, String>): SavedBrowserSearchesDialogFragment =
+        fun newInstance(savedFilters: List<SavedSearch>): SavedBrowserSearchesDialogFragment =
             SavedBrowserSearchesDialogFragment().apply {
                 arguments =
                     Bundle().also {
-                        it.putSerializable(ARG_SAVED_FILTERS, HashMap(savedFilters))
+                        it.putSerializable(ARG_SAVED_FILTERS, HashMap(savedFilters.toMap()))
                     }
             }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -58,6 +58,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_A
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_NONE
 import com.ichi2.anki.browser.RepositionCardsRequest.ContainsNonNewCardsError
 import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
+import com.ichi2.anki.browser.search.SavedSearch
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.flagCardForNote
 import com.ichi2.anki.libanki.Card
@@ -116,7 +117,17 @@ class CardBrowserViewModelTest : JvmTest() {
             }
             savedSearches().also { searches ->
                 assertThat("filters after saving", searches.size, equalTo(1))
-                assertThat("filters after saving", searches["hello"], equalTo("aa"))
+                val search = searches.single()
+                assertThat(
+                    "filters after saving",
+                    search,
+                    equalTo(
+                        SavedSearch(
+                            "hello",
+                            "aa",
+                        ),
+                    ),
+                )
             }
             removeSavedSearch("hello")
             assertThat("filters should be empty after removing", savedSearches().size, equalTo(0))
@@ -1553,3 +1564,8 @@ private fun CardBrowserViewModelTest.moveToReviewQueue(card: Card) {
         due = 50
     }
 }
+
+suspend fun CardBrowserViewModel.saveSearch(
+    title: String,
+    query: String,
+) = saveSearch(SavedSearch(title, query))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/SavedSearchesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/SavedSearchesTest.kt
@@ -1,0 +1,104 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser.search
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.JvmTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SavedSearchesTest : JvmTest() {
+    @Test
+    fun `matches Anki Desktop ordering`() =
+        withSavedSearches {
+            add("red")
+            add("blue")
+            val (_, result) = add("green")
+
+            assertThat(result.map { it.name }, equalTo(listOf("blue", "green", "red")))
+        }
+
+    @Test
+    fun `searches are case sensitive`() =
+        withSavedSearches {
+            add("a")
+            add("A")
+            val (_, result) = add("Z")
+
+            assertThat(result.map { it.name }, equalTo(listOf("A", "Z", "a")))
+        }
+
+    @Test
+    fun `add fails on name clash`() =
+        withSavedSearches {
+            add(SavedSearch("a", "b")).also { (success, values) ->
+                assertTrue(success)
+                assertThat(values, hasSize(1))
+                assertThat(values.single(), equalTo(SavedSearch("a", "b")))
+            }
+
+            // success: false; no change in values
+            add(SavedSearch("a", "c")).also { (success, values) ->
+                assertFalse(success)
+                assertThat(values, hasSize(1))
+                assertThat(values.single(), equalTo(SavedSearch("a", "b")))
+            }
+        }
+
+    @Test
+    fun `remove by name - found`() =
+        withSavedSearches {
+            add("a")
+            add("b")
+            val (success, values) = removeByName("a")
+            assertTrue(success)
+            assertThat(values, hasSize(1))
+            assertThat(values.single(), equalTo(SavedSearch("b", "b")))
+        }
+
+    @Test
+    fun `remove by name - missing`() =
+        withSavedSearches {
+            val (success, _) = removeByName("not found")
+            assertFalse(success)
+        }
+
+    @Test
+    fun `test clear`() =
+        withSavedSearches {
+            clear()
+            add("a")
+            add("b")
+            clear()
+            assertThat(loadFromConfig(), empty())
+        }
+
+    private fun withSavedSearches(block: suspend SavedSearches.() -> Unit) =
+        runTest {
+            block(SavedSearches)
+        }
+}
+
+context(_: SavedSearches)
+suspend fun add(data: String) = SavedSearches.add(SavedSearch(data, data))


### PR DESCRIPTION
## Purpose / Description
"savedFilters" in Anki Desktop

This extracts & documents the API in preparation for improving the UI when we move to a Material 3 SearchView

## Fixes
* Part of #18709

## Approach
Extracts funtionality from `CardBrowserViewModel` into a class

## How Has This Been Tested?
Unit tested, very brief test on my Pixel 9 Pro (API 36)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)