### PR TITLE
refactor: use `BrowserColumnCellBinding`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -29,7 +29,6 @@ import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.annotation.ColorInt
-import androidx.annotation.IdRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.ThemeUtils
 import androidx.core.graphics.drawable.toDrawable
@@ -40,6 +39,8 @@ import com.ichi2.anki.AnkiDroidApp.Companion.sharedPrefs
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.utils.ext.replaceWith
+import com.ichi2.anki.databinding.BrowserColumnCellBinding
 import com.ichi2.anki.databinding.CardItemBrowserBinding
 import com.ichi2.anki.utils.android.darkenColor
 import com.ichi2.anki.utils.android.lightenColorAbsolute
@@ -86,23 +87,15 @@ class BrowserMultiColumnAdapter(
                 field = value
                 // remove the past set of columns
                 binding.root.removeChildren { it !is CheckBox }
-                columnViews.clear()
 
                 val layoutInflater = LayoutInflater.from(context)
 
-                // inflates and returns the inflated view
-                fun inflate(
-                    @IdRes id: Int,
-                ) = layoutInflater.inflate(id, binding.root, false).apply {
-                    binding.root.addView(this)
-                }
-
                 // recreate the columns and the dividers
-                (1..value).map { index ->
-                    inflate(R.layout.browser_column_cell).apply {
-                        columnViews.add(this as TextView)
-                    }
-                }
+                columnViews.replaceWith(
+                    (1..value).map { index ->
+                        BrowserColumnCellBinding.inflate(layoutInflater, binding.root, true).root
+                    },
+                )
 
                 columnViews.forEach { it.setupTextSize() }
             }

--- a/common/src/main/java/com/ichi2/anki/common/utils/ext/MutableList.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/ext/MutableList.kt
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.common.utils.ext
+
+/**
+ * Replaces the contents of the list with [items].
+ *
+ * @param items the new contents of the list
+ */
+fun <T> MutableList<T>.replaceWith(items: Collection<T>) {
+    clear()
+    addAll(items)
+}

--- a/common/src/test/java/com/ichi2/anki/common/utils/ext/MutableListTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/utils/ext/MutableListTest.kt
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2025 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.common.utils.ext
+
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.contains
+import org.hamcrest.Matchers.empty
+import org.junit.Test
+
+class MutableListTest {
+    @Test
+    fun `replaceWith replaces contents`() {
+        val list = mutableListOf(1, 2, 3)
+        list.replaceWith(listOf(4, 5))
+
+        assertThat(list, contains(4, 5))
+    }
+
+    @Test
+    fun `replaceWith works on empty list`() {
+        val list = mutableListOf<String>()
+        list.replaceWith(listOf("a", "b"))
+
+        assertThat(list, contains("a", "b"))
+    }
+
+    @Test
+    fun `replaceWith works with empty input`() {
+        val list = mutableListOf(1, 2, 3)
+        list.replaceWith(emptyList())
+
+        assertThat(list, empty())
+    }
+}


### PR DESCRIPTION
* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/9447fe89651839095b65af05d6f4912b5425973a

## How Has This Been Tested?
Brief test:

* Pixel 9 Pro: I can still manage columns 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)