### PR TITLE
Warn user when adding media files exceeding the AnkiWeb size limit 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -79,6 +79,7 @@ import androidx.lifecycle.lifecycleScope
 import anki.config.ConfigKey
 import anki.notes.NoteFieldsCheckResponse
 import com.google.android.material.color.MaterialColors
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.CollectionManager.TR
@@ -98,6 +99,8 @@ import com.ichi2.anki.dialogs.IntegerDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
+import com.ichi2.anki.exception.MediaSizeLimitExceededException
+import com.ichi2.anki.exception.toBytesShortString
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardOrdinal
 import com.ichi2.anki.libanki.Collection
@@ -177,6 +180,7 @@ import com.ichi2.utils.KeyUtils
 import com.ichi2.utils.NoteFieldDecorator
 import com.ichi2.utils.TextViewUtil
 import com.ichi2.utils.configureView
+import com.ichi2.utils.iconAttr
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
@@ -187,6 +191,7 @@ import com.ichi2.utils.title
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import net.ankiweb.rsdroid.Backend
 import org.json.JSONArray
 import timber.log.Timber
 import java.io.File
@@ -2109,7 +2114,7 @@ class NoteEditorFragment :
 
         // Process successful result only if field has data
         if (field.type != EFieldType.TEXT || field.mediaFile != null) {
-            addMediaFileToField(index, field)
+            performAddMedia(index, field, skipSizeCheck = false)
         } else {
             Timber.i("field imagePath and audioPath are both null")
         }
@@ -2120,36 +2125,66 @@ class NoteEditorFragment :
      *
      * @param index The index of the field within the note to update.
      * @param field The `IField` object representing the media file and its details.
+     * @param skipSizeCheck Whether to bypass the AnkiWeb media size limit check.
      */
-    private fun addMediaFileToField(
+
+    private fun performAddMedia(
         index: Int,
         field: IField,
+        skipSizeCheck: Boolean,
     ) {
         launchCatchingTask {
-            val note = getCurrentMultimediaEditableNote()
-            note.setField(index, field)
-            val fieldEditText = editFields!![index]
-
             // Import field media
             // This goes before setting formattedValue to update
             // media paths with the checksum when they have the same name
-            withCol {
-                try {
-                    NoteService.importMediaToDirectory(this, field)
-                } catch (oomError: OutOfMemoryError) {
-                    // TODO: a 'retry' flow would be possible here
-                    throw Exception(oomError)
+            try {
+                withCol {
+                    NoteService.importMediaToDirectory(this, field, skipSizeCheck = skipSizeCheck)
                 }
-            }
 
-            // Completely replace text for text fields (because current text was passed in)
-            val formattedValue = field.formattedValue
-            if (field.type === EFieldType.TEXT) {
-                fieldEditText.setText(formattedValue)
-            } else if (fieldEditText.text != null) {
-                insertStringInField(fieldEditText, formattedValue)
+                // Update UI
+                val fieldEditText = editFields!![index]
+                // Completely replace text for text fields (because current text was passed in)
+                val formattedValue = field.formattedValue
+                if (field.type === EFieldType.TEXT) {
+                    fieldEditText.setText(formattedValue)
+                } else if (fieldEditText.text != null) {
+                    insertStringInField(fieldEditText, formattedValue)
+                }
+                changed = true
+            } catch (e: MediaSizeLimitExceededException) {
+                showLargeMediaFileWarning(
+                    e.fileName,
+                    e.fileSize,
+                    onForceAdd = {
+                        // Recursive call to bypass the size check if the user wants to add anyway
+                        performAddMedia(index, field, skipSizeCheck = true)
+                    },
+                )
+            } catch (oomError: OutOfMemoryError) {
+                // TODO: a 'retry' flow would be possible here
+                throw Exception(oomError)
             }
-            changed = true
+        }
+    }
+
+    private fun showLargeMediaFileWarning(
+        fileName: String,
+        fileSize: Long,
+        onForceAdd: () -> Unit,
+    ) {
+        val context = requireContext()
+        val fileSizeStr = fileSize.toBytesShortString(context)
+        val limitStr = Backend.MAX_INDIVIDUAL_MEDIA_FILE_SIZE.toBytesShortString(context)
+
+        MaterialAlertDialogBuilder(context).show {
+            title(R.string.media_file_size_warning_title)
+            iconAttr(R.drawable.ic_warning)
+            message(text = getString(R.string.media_file_size_warning_message, fileName, fileSizeStr, limitStr))
+            positiveButton(R.string.dialog_cancel)
+            negativeButton(R.string.media_file_size_add_anyway) {
+                onForceAdd()
+            }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/exception/MediaSizeLimitExceededException.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/exception/MediaSizeLimitExceededException.kt
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2026 Ujjol Chakrabarty <ujjol.uc@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.exception
+
+import android.content.Context
+
+fun Long.toBytesShortString(context: Context): String =
+    android.text.format.Formatter
+        .formatShortFileSize(context, this)
+
+class MediaSizeLimitExceededException(
+    val fileName: String,
+    val fileSize: Long,
+    val limit: Long,
+) : Exception("Media size limit exceeded: $fileName ($fileSize > $limit)")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/NoteService.kt
@@ -21,6 +21,7 @@ package com.ichi2.anki.servicelayer
 
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.FieldEditText
+import com.ichi2.anki.exception.MediaSizeLimitExceededException
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Note
@@ -36,6 +37,7 @@ import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.multimediacard.fields.TextField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.observability.undoableOp
+import net.ankiweb.rsdroid.Backend
 import org.json.JSONException
 import timber.log.Timber
 import java.io.File
@@ -128,7 +130,20 @@ object NoteService {
     fun importMediaToDirectory(
         col: Collection,
         field: IField,
+        skipSizeCheck: Boolean = false,
     ) {
+        val file = field.mediaFile ?: return
+
+        // > is the correct check: https://github.com/ankitects/anki/blob/5d9d864514b9a4ac7d4688fac390c22db91d4abe/rslib/src/sync/media/upload.rs#L87
+        // TODO: Move this check to the backend
+        if (!skipSizeCheck && file.length() > Backend.MAX_INDIVIDUAL_MEDIA_FILE_SIZE) {
+            throw MediaSizeLimitExceededException(
+                file.name,
+                file.length(),
+                Backend.MAX_INDIVIDUAL_MEDIA_FILE_SIZE,
+            )
+        }
+
         val inFile =
             when (field.type) {
                 EFieldType.AUDIO_RECORDING, EFieldType.MEDIA_CLIP, EFieldType.IMAGE -> field.mediaFile

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -218,6 +218,10 @@
     <string name="white_board_eraser_enabled">Eraser mode activated</string>
     <string name="white_board_eraser_disabled">Eraser mode deactivated</string>
 
+    <string name="media_file_size_warning_title">Media too large</string>
+    <string name="media_file_size_warning_message" comment="1$s: File name, 2$s: File size, 3$s: The size limit (e.g. 100MB)">The file \"%1$s\" (%2$s) exceeds the AnkiWeb limit of %3$s and cannot be synced. Add anyway?</string>
+    <string name="media_file_size_add_anyway">Add anyway</string>
+
     <!-- Whiteboard save image message in the Study Screen -->
     <string name="white_board_image_save_failed">Failed to save whiteboard image. %s</string>
     <string name="white_board_image_saved">Whiteboard image saved to %s</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,7 +62,7 @@ androidxWebkit = "1.15.0"
 # https://developer.android.com/jetpack/androidx/releases/work
 androidxWork = "2.11.1"
 # https://github.com/ankidroid/Anki-Android-Backend/
-ankiBackend = '0.1.63-anki25.09.2'
+ankiBackend = '0.1.64-anki25.09.2'
 autoService = "1.1.1"
 autoServiceAnnotations = "1.1.1"
 # https://github.com/skydoves/ColorPickerView/releases


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR implements a warning dialog when a user attempts to add a media file that exceeds the AnkiWeb synchronization limit (100MB).

## Fixes
* Fixes #19580


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->