### PR TITLE
feat(browser): define CardState for searching

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardState.kt
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser.search
+
+import anki.search.SearchNode
+import anki.search.searchNode
+import com.ichi2.anki.CollectionManager.TR
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Available card states to select for searches.
+ *
+ * Represents a subset of available values in an `is:` search. Similar to [SearchNode.CardState].
+ *
+ * Excluding:
+ * - `is:due` - in [SearchNode.CardState], but not visible in the UI
+ * - `is:buried-sibling` - not in `SearchNode.CardState`
+ * - `is:buried-manually` - not in `SearchNode.CardState`
+ *
+ * **Documentation**
+ *
+ * - [Anki Protobuf (permalink)](https://github.com/ankitects/anki/blob/b8884bac72aa50fa1189fe0a5079a71574bc5043/proto/anki/search.proto#L58-L65)
+ * - [Anki Manual](https://docs.ankiweb.net/searching.html#card-state)
+ *
+ * @param code Used for serialization, do not update.
+ */
+@Serializable(with = CardStateSerializer::class)
+enum class CardState(
+    val code: Int,
+) {
+    New(0),
+    Learning(1),
+    Review(2),
+
+    // we deviate from Anki Desktop ordering here:
+    // the logical progression of card states is is 'bury', then 'suspend'
+    Buried(3),
+    Suspended(4),
+    ;
+
+    /**
+     * Internationalized, human readable label for the card state
+     *
+     * `CardState.New` => `"New"`
+     */
+    val label: String
+        get() =
+            when (this) {
+                New -> TR.statisticsCountsNewCards()
+                Learning -> TR.statisticsCountsLearningCards()
+                Review -> TR.browsingSidebarCardStateReview()
+                Buried -> TR.statisticsCountsBuriedCards()
+                Suspended -> TR.browsingSuspended()
+            }
+
+    /**
+     * Creates a [SearchNode.CardState] for use in a [SearchNode].
+     *
+     * Prefer [toSearchNode] for simple [SearchNode] creation.
+     *
+     * ```kotlin
+     * val review = CardState.Review
+     * val node = searchNode { cardState = review.toSearchValue() }
+     * ```
+     */
+    fun toSearchValue(): SearchNode.CardState =
+        when (this) {
+            New -> SearchNode.CardState.CARD_STATE_NEW
+            Learning -> SearchNode.CardState.CARD_STATE_LEARN
+            Review -> SearchNode.CardState.CARD_STATE_REVIEW
+            Buried -> SearchNode.CardState.CARD_STATE_BURIED
+            Suspended -> SearchNode.CardState.CARD_STATE_SUSPENDED
+        }
+
+    /**
+     * Creates a [SearchNode] for building a search string.
+     *
+     * Use [toSearchValue] when generating a complex `SearchNode`
+     *
+     * ```kotlin
+     * val searchNode = CardState.Review.toSearchNode()
+     * val searchString = col.buildSearchString(listOf(searchNode))
+     * ```
+     */
+    fun toSearchNode(): SearchNode = searchNode { cardState = toSearchValue() }
+
+    companion object {
+        fun fromCode(id: Int): CardState = CardState.entries.first { it.code == id }
+    }
+}
+
+/** Serializer for [CardState] */
+object CardStateSerializer : KSerializer<CardState> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("CardState", PrimitiveKind.INT)
+
+    override fun serialize(
+        encoder: Encoder,
+        value: CardState,
+    ) = encoder.encodeInt(value.code)
+
+    override fun deserialize(decoder: Decoder): CardState {
+        val code = decoder.decodeInt()
+        return CardState.fromCode(code)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateSerializerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateSerializerTest.kt
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser.search
+
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/** Test for [CardStateSerializer] */
+class CardStateSerializerTest {
+    @Test
+    fun `ensure mappings are unchanged`() {
+        // CardState is serialized, so codes may not change
+        val allKnownStates =
+            listOf(
+                CardState.New,
+                CardState.Learning,
+                CardState.Review,
+                CardState.Buried,
+                CardState.Suspended,
+            )
+        val encoded = Json.encodeToString(allKnownStates)
+        assertEquals("[0,1,2,3,4]", encoded)
+
+        // ensure no additional states were added
+        assertEquals(allKnownStates, CardState.entries)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateTest.kt
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser.search
+
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.libanki.testutils.AnkiTest
+import com.ichi2.testutils.EmptyApplication
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+
+/** Test for [CardState] */
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(application = EmptyApplication::class)
+class CardStateTest : RobolectricTest() {
+    @ParameterizedRobolectricTestRunner.Parameter(0)
+    @JvmField
+    var stateParam: CardState? = null
+
+    val state get() = stateParam!!
+
+    @Test
+    fun `search strings are valid`() {
+        fun CardState.toExpectedSearchString() =
+            when (this) {
+                CardState.New -> "is:new"
+                CardState.Learning -> "is:learn"
+                CardState.Review -> "is:review"
+                CardState.Buried -> "is:buried"
+                CardState.Suspended -> "is:suspended"
+            }
+
+        assertEquals(state.toSearchString(), state.toExpectedSearchString())
+    }
+
+    @Test
+    fun `backend label is unchanged`() {
+        fun CardState.toExpectedLabel() =
+            when (this) {
+                CardState.New -> "New"
+                CardState.Learning -> "Learning"
+                CardState.Review -> "Review"
+                CardState.Buried -> "Buried"
+                CardState.Suspended -> "Suspended"
+            }
+        assertEquals(state.label, state.toExpectedLabel())
+    }
+
+    companion object {
+        @JvmStatic
+        @ParameterizedRobolectricTestRunner.Parameters(name = "{0}")
+        fun parameters(): Collection<Array<Any>> = CardState.entries.map { arrayOf(it) }
+    }
+}
+
+context(test: AnkiTest)
+fun CardState.toSearchString() = test.col.buildSearchString(listOf(this.toSearchNode()))


### PR DESCRIPTION
To be used in 18709 - Material 3 SearchView in Browse

Represents Anki's sidebar

<img width="247" height="126" alt="Screenshot 2026-01-23 at 14 44 15" src="https://github.com/user-attachments/assets/1331948e-5bd5-4068-9c2c-bb2eddc834c8" />

## Fixes
* Small part of a chip for #18709

## Approach
Copied some code from a very old PR of mine:

* https://github.com/ankidroid/Anki-Android/pull/16859
* I fixed it up on a private branch, then made more improvements and documentation changes when improving this for production.
* I removed 'subtitle', as this would likely block the PR for a while over strings

## How Has This Been Tested?
Lots of tests 🤓

## Learning (optional, can help others)
https://github.com/ankitects/anki/blob/b8884bac72aa50fa1189fe0a5079a71574bc5043/proto/anki/search.proto#L58-L65

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->