### PR TITLE
chore: convert AnkiDroidCrashReportDialog to ViewBinding

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidCrashReportDialog.kt
@@ -21,11 +21,10 @@ import android.app.AlertDialog
 import android.content.DialogInterface
 import android.os.Bundle
 import android.view.View
-import android.widget.CheckBox
-import android.widget.EditText
 import androidx.core.content.edit
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
+import com.ichi2.anki.databinding.DialogFeedbackBinding
 import com.ichi2.anki.preferences.sharedPrefs
 import org.acra.dialog.CrashReportDialog
 import org.acra.dialog.CrashReportDialogHelper
@@ -36,13 +35,14 @@ import org.acra.dialog.CrashReportDialogHelper
  *
  * See [AnkiDroid Wiki: Crash-Reports](https://github.com/ankidroid/Anki-Android/wiki/Crash-Reports)
  */
-@SuppressLint("Registered") // we are sufficiently registered in this special case
+// Registered: we are sufficiently registered in this special case
+// ActivityLayoutPrefix: technically we are an activity, but use the 'dialog_' prefix
+@SuppressLint("Registered", "ActivityLayoutPrefix")
 class AnkiDroidCrashReportDialog :
     CrashReportDialog(),
     DialogInterface.OnClickListener,
     DialogInterface.OnDismissListener {
-    private var alwaysReportCheckBox: CheckBox? = null
-    private var userComment: EditText? = null
+    private lateinit var binding: DialogFeedbackBinding
     private var helper: CrashReportDialogHelper? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -64,20 +64,14 @@ class AnkiDroidCrashReportDialog :
      * Build the custom view used by the dialog
      */
     override fun buildCustomView(savedInstanceState: Bundle?): View {
-        val inflater = layoutInflater
+        binding = DialogFeedbackBinding.inflate(layoutInflater)
 
-        @SuppressLint("InflateParams")
-        val rootView = // when you inflate into an alert dialog, you have no parent view
-            inflater.inflate(R.layout.feedback, null)
-        alwaysReportCheckBox = rootView.findViewById(R.id.alwaysReportCheckbox)
-        alwaysReportCheckBox?.isChecked = sharedPrefs().getBoolean("autoreportCheckboxValue", true)
-        userComment = rootView.findViewById(R.id.etFeedbackText)
+        binding.alwaysReport.isChecked = this.sharedPrefs().getBoolean("autoreportCheckboxValue", true)
         // Set user comment if reloading after the activity has been stopped
         savedInstanceState?.getString(STATE_COMMENT)?.let { savedComment ->
-            userComment?.setText(savedComment)
+            binding.userComment.setText(savedComment)
         }
-
-        return rootView
+        return binding.root
     }
 
     override fun onClick(
@@ -86,7 +80,7 @@ class AnkiDroidCrashReportDialog :
     ) {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             // Next time don't tick the auto-report checkbox by default
-            val autoReport = alwaysReportCheckBox!!.isChecked
+            val autoReport = binding.alwaysReport.isChecked
             val preferences = this.sharedPrefs()
             preferences.edit { putBoolean("autoreportCheckboxValue", autoReport) }
             // Set the autoreport value to true if ticked
@@ -100,7 +94,7 @@ class AnkiDroidCrashReportDialog :
                 CrashReportService.setAcraReportingMode(CrashReportService.FEEDBACK_REPORT_ALWAYS)
             }
             // Send the crash report
-            helper!!.sendCrash(userComment!!.text.toString(), "")
+            helper!!.sendCrash(binding.userComment.text.toString(), "")
         } else {
             // If the user got to the dialog, they were not limited.
             // The limiter persists it's limit info *before* the user cancels.
@@ -118,8 +112,8 @@ class AnkiDroidCrashReportDialog :
 
     override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
-        if (userComment != null && userComment!!.text != null) {
-            outState.putString(STATE_COMMENT, userComment!!.text.toString())
+        binding.userComment.text?.let { comment ->
+            outState.putString(STATE_COMMENT, comment.toString())
         }
     }
 

--- a/AnkiDroid/src/main/res/layout/dialog_feedback.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_feedback.xml
@@ -16,7 +16,7 @@
 
         <!-- We are using EditText as FixedEditText fails here (#8380) -->
         <EditText
-            android:id="@+id/etFeedbackText"
+            android:id="@+id/user_comment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:gravity="top"
@@ -26,7 +26,7 @@
     </ScrollView>
 
     <CheckBox
-        android:id="@+id/alwaysReportCheckbox"
+        android:id="@+id/always_report"
         android:text="@string/feedback_report_automatically"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"


### PR DESCRIPTION

* Part of #11116

## Approach

* Cherry picked https://github.com/david-allison/Anki-Android/pull/44/commits/5b712ec74c8f72909e83b4230174f1917e3c805d
* Renamed layout to `dialog_`

## How Has This Been Tested?
Brief test:
* Send troubleshooting report on Pixel 9 Pro

## Learning
Technically `CrashReportDialog` is an activity, not a dialog

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)