### PR TITLE
chore: 'searchpreference' is not a typo

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -90,6 +90,7 @@
       <w>rerender</w>
       <w>resync</w>
       <w>retryable</w>
+      <w>searchpreference</w>
       <w>servicelayer</w>
       <w>sinh</w>
       <w>spacebar</w>


### PR DESCRIPTION
`@drawable/searchpreference_ic_history` is OK - obtained from dependency.


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)