### PR TITLE
refactor: use context parameters for `toSentenceCase`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -867,15 +867,15 @@ open class CardBrowser :
         }
 
         actionBarMenu?.findItem(R.id.action_reschedule_cards)?.title =
-            TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date)
+            TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
 
         actionBarMenu?.findItem(R.id.action_grade_now)?.title =
-            TR.actionsGradeNow().toSentenceCase(this, R.string.sentence_grade_now)
+            TR.actionsGradeNow().toSentenceCase(R.string.sentence_grade_now)
 
         val isFindReplaceEnabled = sharedPrefs().getBoolean(getString(R.string.pref_browser_find_replace), false)
         menu.findItem(R.id.action_find_replace)?.apply {
             isVisible = isFindReplaceEnabled
-            title = TR.browsingFindAndReplace().toSentenceCase(this@CardBrowser, R.string.sentence_find_and_replace)
+            title = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
         }
 
         previewItem = menu.findItem(R.id.action_preview)
@@ -946,13 +946,13 @@ open class CardBrowser :
 
         actionBarMenu.findItem(R.id.action_flag).isVisible = viewModel.hasSelectedAnyRows()
         actionBarMenu.findItem(R.id.action_suspend_card).apply {
-            title = TR.browsingToggleSuspend().toSentenceCase(this@CardBrowser, R.string.sentence_toggle_suspend)
+            title = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
             // TODO: I don't think this icon is necessary
             setIcon(R.drawable.ic_suspend)
             isVisible = viewModel.hasSelectedAnyRows()
         }
         actionBarMenu.findItem(R.id.action_toggle_bury).apply {
-            title = TR.browsingToggleBury().toSentenceCase(this@CardBrowser, R.string.sentence_toggle_bury)
+            title = TR.browsingToggleBury().toSentenceCase(R.string.sentence_toggle_bury)
             isVisible = viewModel.hasSelectedAnyRows()
         }
         actionBarMenu.findItem(R.id.action_mark_card).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -861,7 +861,7 @@ open class Reviewer :
 
         // Anki Desktop Translations
         menu.findItem(R.id.action_reschedule_card).title =
-            CollectionManager.TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date)
+            CollectionManager.TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
 
         // Undo button
         @DrawableRes val undoIconId: Int

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -433,7 +433,7 @@ class StudyOptionsFragment :
             if (!isDynamic) {
                 deckInfoLayout.visibility = View.GONE
                 buttonStart.visibility = View.VISIBLE
-                buttonStart.text = TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study)
+                buttonStart.text = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study)
             } else {
                 buttonStart.visibility = View.GONE
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoggedInFragment.kt
@@ -41,7 +41,6 @@ import com.ichi2.anki.utils.ext.isCompactWidth
 import com.ichi2.anki.utils.ext.removeFragmentFromContainer
 import com.ichi2.anki.utils.ext.showDialogFragment
 import timber.log.Timber
-import kotlin.getValue
 
 class LoggedInFragment : Fragment(R.layout.my_account_logged_in) {
     // if the 'remove account' fragment is open, close it first
@@ -67,7 +66,7 @@ class LoggedInFragment : Fragment(R.layout.my_account_logged_in) {
         activity.setSupportActionBar(toolbar)
 
         activity.supportActionBar?.apply {
-            title = TR.preferencesAccount().toSentenceCase(requireContext(), R.string.sync_account)
+            title = TR.preferencesAccount().toSentenceCase(R.string.sync_account)
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/account/LoginFragment.kt
@@ -82,7 +82,7 @@ class LoginFragment : Fragment(R.layout.my_account) {
         activity.setSupportActionBar(toolbar)
 
         activity.supportActionBar?.apply {
-            title = TR.preferencesAccount().toSentenceCase(requireContext(), R.string.sync_account)
+            title = TR.preferencesAccount().toSentenceCase(R.string.sync_account)
             setDisplayHomeAsUpEnabled(true)
             setDisplayShowHomeEnabled(true)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -72,10 +72,7 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = FragmentFindReplaceBinding.inflate(layoutInflater)
         setupLabels()
-        val title =
-            TR
-                .browsingFindAndReplace()
-                .toSentenceCase(requireContext(), R.string.sentence_find_and_replace)
+        val title = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
         return AlertDialog
             .Builder(requireContext())
             .show {
@@ -112,12 +109,7 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
             binding.onlySelectedNotesCheckBox.isEnabled = noteIds.isNotEmpty()
             val fieldsNames =
                 buildList {
-                    add(
-                        TR.browsingAllFields().toSentenceCase(
-                            this@FindAndReplaceDialogFragment,
-                            R.string.sentence_all_fields,
-                        ),
-                    )
+                    add(TR.browsingAllFields().toSentenceCase(R.string.sentence_all_fields))
                     add(TR.editingTags())
                     addAll(withCol { fieldNamesForNoteIds(noteIds) })
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -65,10 +65,7 @@ class RepositionCardFragment : DialogFragment() {
             text = TR.browsingShiftPositionOfExistingCards()
             isChecked = requireArguments().getBoolean(ARG_SHIFT)
         }
-        val title =
-            TR
-                .browsingRepositionNewCards()
-                .toSentenceCase(requireContext(), R.string.sentence_reposition_new_cards)
+        val title = TR.browsingRepositionNewCards().toSentenceCase(R.string.sentence_reposition_new_cards)
         val dialog =
             AlertDialog.Builder(requireContext()).create {
                 title(text = title)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -115,11 +115,7 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
         return MaterialAlertDialogBuilder(requireContext())
             .create {
                 title(
-                    text =
-                        TR.browsingChangeNotetype().toSentenceCase(
-                            this@ChangeNoteTypeDialog,
-                            R.string.sentence_change_note_type,
-                        ),
+                    text = TR.browsingChangeNotetype().toSentenceCase(R.string.sentence_change_note_type),
                 )
                 positiveButton(R.string.dialog_ok)
                 negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -86,11 +86,7 @@ class EmptyCardsDialogFragment : DialogFragment() {
         return AlertDialog
             .Builder(requireContext())
             .show {
-                setTitle(
-                    TR
-                        .emptyCardsWindowTitle()
-                        .toSentenceCase(context, R.string.sentence_empty_cards),
-                )
+                setTitle(TR.emptyCardsWindowTitle().toSentenceCase(R.string.sentence_empty_cards))
                 setPositiveButton(R.string.dialog_ok) { _, _ ->
                     val state = viewModel.uiState.value
                     if (state is EmptyCardsSearchResult) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -273,7 +273,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
         return AlertDialog
             .Builder(requireActivity())
-            .title(text = TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study))
+            .title(text = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study))
             .cancelable(true)
             .customView(customMenuView)
             .create()
@@ -338,7 +338,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
-                TR.customStudyChooseTags().toSentenceCase(requireContext(), R.string.sentence_choose_tags)
+                TR.customStudyChooseTags().toSentenceCase(R.string.sentence_choose_tags)
             } else {
                 getString(R.string.dialog_ok)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
@@ -80,7 +80,7 @@ class TagLimitFragment : DialogFragment() {
         val title =
             TR
                 .customStudySelectiveStudy()
-                .toSentenceCase(requireContext(), R.string.sentence_selective_study)
+                .toSentenceCase(R.string.sentence_selective_study)
         val dialog =
             AlertDialog
                 .Builder(requireContext())

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -66,7 +66,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
         super.onViewCreated(view, savedInstanceState)
 
         binding.toolbar.apply {
-            setTitle(TR.mediaCheckCheckMediaAction().toSentenceCase(requireContext(), R.string.check_media))
+            setTitle(TR.mediaCheckCheckMediaAction().toSentenceCase(R.string.check_media))
             setNavigationOnClickListener {
                 requireActivity().onBackPressedDispatcher.onBackPressed()
             }
@@ -105,11 +105,11 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
                     menuInflater.inflate(R.menu.media_check_menu, menu)
                     menu.findItem(R.id.action_restore_trash).apply {
                         isVisible = true
-                        title = TR.mediaCheckRestoreTrash().toSentenceCase(requireContext(), R.string.sentence_restore_deleted)
+                        title = TR.mediaCheckRestoreTrash().toSentenceCase(R.string.sentence_restore_deleted)
                     }
                     menu.findItem(R.id.action_empty_trash).apply {
                         isVisible = true
-                        title = TR.mediaCheckEmptyTrash().toSentenceCase(requireContext(), R.string.sentence_empty_trash)
+                        title = TR.mediaCheckEmptyTrash().toSentenceCase(R.string.sentence_empty_trash)
                     }
                 }
 
@@ -152,7 +152,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
             text =
                 TR
                     .mediaCheckAddTag()
-                    .toSentenceCase(requireContext(), R.string.sentence_tag_missing)
+                    .toSentenceCase(R.string.sentence_tag_missing)
 
             setOnClickListener {
                 launchCatchingTask {
@@ -168,11 +168,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
         }
 
         binding.deleteUsedMediaButton.apply {
-            text =
-                TR.mediaCheckDeleteUnused().toSentenceCase(
-                    requireContext(),
-                    R.string.sentence_check_media_delete_unused,
-                )
+            text = TR.mediaCheckDeleteUnused().toSentenceCase(R.string.sentence_check_media_delete_unused)
 
             setOnClickListener {
                 deleteConfirmationDialog()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -16,7 +16,6 @@
 package com.ichi2.anki.preferences
 
 import android.content.res.Configuration
-import androidx.annotation.StringRes
 import androidx.annotation.XmlRes
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.withResumed
@@ -167,10 +166,6 @@ class ControlsSettingsFragment :
             it.title = getString(R.string.gesture_flag_remove).toSentenceCase(R.string.sentence_gesture_flag_remove)
         }
     }
-
-    private fun String.toSentenceCase(
-        @StringRes resId: Int,
-    ): String = this.toSentenceCase(this@ControlsSettingsFragment, resId)
 
     private fun setupNewStudyScreenSettings() {
         if (!Prefs.isNewStudyScreenEnabled) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -143,7 +143,7 @@ class SetDueDateDialog : DialogFragment() {
                     text =
                         TR
                             .actionsSetDueDate()
-                            .toSentenceCase(this@SetDueDateDialog, R.string.sentence_set_due_date),
+                            .toSentenceCase(R.string.sentence_set_due_date),
                 )
                 positiveButton(R.string.dialog_ok) { launchUpdateDueDate() }
                 negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -29,6 +29,16 @@ import androidx.fragment.app.Fragment
  * "Toggle Suspend".toSentenceCase(R.string.sentence_toggle_suspend) // "Toggle suspend"
  * ```
  */
+context(context: Context)
+fun String.toSentenceCase(
+    @StringRes resId: Int,
+) = toSentenceCase(context, resId)
+
+context(fragment: Fragment)
+fun String.toSentenceCase(
+    @StringRes resId: Int,
+): String = toSentenceCase(fragment.requireContext(), resId)
+
 fun String.toSentenceCase(
     context: Context,
     @StringRes resId: Int,
@@ -38,8 +48,3 @@ fun String.toSentenceCase(
     if (this.lowercase() == resString.lowercase()) return resString
     return this
 }
-
-fun String.toSentenceCase(
-    fragment: Fragment,
-    @StringRes resId: Int,
-): String = toSentenceCase(fragment.requireContext(), resId)


### PR DESCRIPTION
I wanted to refactor the menu code of the Browser, and this was a mild improvement

```diff
- TR.actionsSetDueDate().toSentenceCase(requireContext(), R.string.sentence_set_due_date)
+ TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
```

## How Has This Been Tested?
Trusting unit tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->