### PR TITLE
Fix flaky PreviewerViewModelTest #20161

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -111,11 +111,11 @@ class PreviewerViewModelTest : JvmTest() {
             viewModel.showingAnswer.value = false
 
             // Click Prev -> Should move to Index 0
-            viewModel.onPreviousButtonClick()
+            onPreviousButtonClick()
             assertEquals(0, viewModel.currentIndex.value)
 
             // Click Prev on Index 0 (Question) -> Do nothing
-            viewModel.onPreviousButtonClick()
+            onPreviousButtonClick()
             assertFalse(viewModel.showingAnswer.value)
             assertEquals(0, viewModel.currentIndex.value)
         }
@@ -125,10 +125,10 @@ class PreviewerViewModelTest : JvmTest() {
         runTest {
             assertFalse(viewModel.backSideOnly.value) // initial state should be false
 
-            viewModel.toggleBackSideOnly()
+            toggleBackSideOnly()
             assertTrue(viewModel.backSideOnly.value)
 
-            viewModel.toggleBackSideOnly()
+            toggleBackSideOnly()
             assertFalse(viewModel.backSideOnly.value)
         }
 


### PR DESCRIPTION
## Purpose / Description
There were flaky tests in [PreviewerViewModelTest](cci:2://file:///e:/opensource/Anki-Android/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt:40:0-270:1) (specifically [previous button](cci:1://file:///e:/opensource/Anki-Android/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt:104:4-120:9) and [toggle back side only](cci:1://file:///e:/opensource/Anki-Android/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt:122:4-132:9)). The issue was caused by race conditions: the tests were calling the ViewModel methods directly (which launch coroutines) and then immediately asserting values without waiting for the coroutines to complete.

## Fixes
* Fixes #20161

## Approach
In PreviewerViewModelTest.kt, there is a helper extension function TestScope.onPreviousButtonClick() which calls the ViewModel method and correctly waits for the coroutine to finish.

## How Has This Been Tested?
I ran the specific test suite locally and verified that it passes consistently.

- Command: `./gradlew AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.previewer.PreviewerViewModelTest"`
- Result: `BUILD SUCCESSFUL`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)