### PR TITLE
Remove redundant references, fixes warnings of Android Studio

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/IntroductionSlide.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/testutil/IntroductionSlide.kt
@@ -21,7 +21,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntroductionActivity
 
 fun disableIntroductionSlide() {
-    AnkiDroidApp.Companion.sharedPrefs().edit {
-        putBoolean(IntroductionActivity.Companion.INTRODUCTION_SLIDES_SHOWN, true)
+    AnkiDroidApp.sharedPrefs().edit {
+        putBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, true)
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/BundleUtilsTest.kt
@@ -49,7 +49,7 @@ class BundleUtilsTest {
 
     @Test
     fun test_GetNullableLong_Found_ReturnIt() {
-        val expected = Random.Default.nextLong()
+        val expected = Random.nextLong()
         val b = mock(Bundle::class.java)
 
         whenever(b.containsKey(anyString())).thenReturn(true)
@@ -76,7 +76,7 @@ class BundleUtilsTest {
 
     @Test
     fun test_RequireLong_Found_ReturnIt() {
-        val expected = Random.Default.nextLong()
+        val expected = Random.nextLong()
         val mockedBundle = mock(Bundle::class.java)
 
         whenever(mockedBundle.containsKey(anyString())).thenReturn(true)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixed some redundant references warnings from Android Studio

## Fixes
* Fixes #13282

## Approach
Android Studio flagged redundant references, removed them as recommended to get rid of warnings 

## How Has This Been Tested?
Verified that the code built and ran successfully with the changes

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->