### PR TITLE
feat(card-browser): delegate Menu to SearchBar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -38,10 +38,14 @@ import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.ThemeUtils
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.fragment.app.commit
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import anki.collection.OpChanges
@@ -115,7 +119,8 @@ open class CardBrowser :
     NavigationDrawerActivity(),
     DeckSelectionListener,
     TagsDialogListener,
-    ChangeManager.Subscriber {
+    ChangeManager.Subscriber,
+    MenuHost {
     /**
      * Provides an instance of NoteEditorLauncher for adding a note
      */
@@ -181,6 +186,16 @@ open class CardBrowser :
     // TODO: Broken currently; needs R.layout.activity_card_browser_searchview
     val useSearchView: Boolean
         get() = Prefs.devUsingCardBrowserSearchView
+
+    // delegate the menu to the SearchBar in the fragment
+
+    val menuHost: MenuHost?
+        get() =
+            if (useSearchView) {
+                if (this::cardBrowserFragment.isInitialized) cardBrowserFragment else null
+            } else {
+                null
+            }
 
     @Suppress("unused")
     @get:LayoutRes
@@ -1350,6 +1365,53 @@ open class CardBrowser :
             findViewById<TextView>(R.id.deck_name)?.text = deckName
         }
     }
+
+    // region MenuHost delegation
+
+    // This only supports delegation of menus defined using MenuProvider, not `onCreateOptionsMenu`
+    //
+    // When delegating a MenuHost to a fragment, the fragment is attached after `super.onCreate`
+    // of the activity.
+    //
+    // As the activity calls `addMenuProvider` inside `super.onCreate()`, the fragment would not be
+    //  initialized
+    //
+    // Calls to activity.addMenuProvider are done after the fragment is initialized
+    // so this delegation works as long as the activity is using `onCreateOptionsMenu`
+
+    override fun addMenuProvider(provider: MenuProvider) {
+        menuHost?.addMenuProvider(provider) ?: super.addMenuProvider(provider)
+    }
+
+    override fun addMenuProvider(
+        provider: MenuProvider,
+        owner: LifecycleOwner,
+    ) {
+        menuHost?.addMenuProvider(provider, owner) ?: super.addMenuProvider(provider, owner)
+    }
+
+    override fun addMenuProvider(
+        provider: MenuProvider,
+        owner: LifecycleOwner,
+        state: Lifecycle.State,
+    ) {
+        menuHost?.addMenuProvider(provider, owner, state) ?: super.addMenuProvider(provider, owner, state)
+    }
+
+    override fun removeMenuProvider(provider: MenuProvider) {
+        menuHost?.removeMenuProvider(provider) ?: super.removeMenuProvider(provider)
+    }
+
+    override fun invalidateMenu() {
+        menuHost?.invalidateMenu() ?: super.invalidateMenu()
+    }
+
+    override fun invalidateOptionsMenu() {
+        super.invalidateOptionsMenu()
+        menuHost?.invalidateMenu()
+    }
+
+    // endregion
 
     companion object {
         // Keys for saving pane weights in SharedPreferences

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/menu/SearchBarMenuHost.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/menu/SearchBarMenuHost.kt
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.android.menu
+
+import android.view.Menu
+import android.view.MenuInflater
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuHostHelper
+import androidx.core.view.MenuItemCompat
+import androidx.core.view.MenuProvider
+import androidx.core.view.forEach
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
+import com.google.android.material.search.SearchBar
+import com.ichi2.ui.RtlCompliantActionProvider
+import timber.log.Timber
+
+/**
+ * Simplifies the implementation of a [MenuHost] delegating to a Material 3 [SearchBar]
+ */
+interface SearchBarMenuHost : MenuHost {
+    /**
+     * Required implementation of [MenuHost] functionality.
+     *
+     * Build using:
+     * ```kotlin
+     * MenuHostHelper { invalidateMenu() }
+     * ```
+     */
+    val menuHostHelper: MenuHostHelper
+
+    val searchBar: SearchBar?
+
+    /**
+     * Used to instantiate menu XML files into Menu objects.
+     *
+     * Typically `activity?.menuInflater`
+     */
+    val menuInflater: MenuInflater?
+
+    override fun addMenuProvider(provider: MenuProvider) = menuHostHelper.addMenuProvider(provider)
+
+    override fun addMenuProvider(
+        provider: MenuProvider,
+        owner: LifecycleOwner,
+    ) = menuHostHelper.addMenuProvider(provider, owner)
+
+    override fun addMenuProvider(
+        provider: MenuProvider,
+        owner: LifecycleOwner,
+        state: Lifecycle.State,
+    ) = menuHostHelper.addMenuProvider(provider, owner, state)
+
+    override fun removeMenuProvider(provider: MenuProvider) = menuHostHelper.removeMenuProvider(provider)
+
+    override fun invalidateMenu() = invalidateSearchBarMenu()
+
+    // alias to make `MenuHostHelper { invalidateMenu() }` more readable
+    // now: `MenuHostHelper { invalidateSearchBarMenu() }`
+    fun invalidateSearchBarMenu() {
+        searchBar?.menu?.rebuild(menuHostHelper, menuInflater)
+    }
+}
+
+private fun Menu.rebuild(
+    menuHostHelper: MenuHostHelper,
+    menuInflater: MenuInflater?,
+) {
+    clear()
+
+    // invalidateMenu may be called after `onDestroy`
+    if (menuInflater == null) {
+        Timber.d("unable to rebuild menu - no inflater")
+        return
+    }
+
+    menuHostHelper.onCreateMenu(this, menuInflater)
+    menuHostHelper.onPrepareMenu(this)
+
+    forEach { menuItem ->
+        // Setup RtlCompliantActionProvider (undo)
+        val rtlActionProvider = MenuItemCompat.getActionProvider(menuItem) as? RtlCompliantActionProvider
+        rtlActionProvider?.clickHandler = { _, menuItem -> menuHostHelper.onMenuItemSelected(menuItem) }
+
+        menuItem.setOnMenuItemClickListener { item ->
+            menuHostHelper.onMenuItemSelected(item)
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -32,6 +32,7 @@ import androidx.annotation.LayoutRes
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuHost
+import androidx.core.view.MenuHostHelper
 import androidx.core.view.MenuProvider
 import androidx.core.view.isVisible
 import androidx.core.widget.doAfterTextChanged
@@ -60,6 +61,7 @@ import com.ichi2.anki.Flag
 import com.ichi2.anki.R
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.android.menu.SearchBarMenuHost
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.MultiSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
@@ -127,7 +129,8 @@ class CardBrowserFragment :
     Fragment(),
     AnkiActivityProvider,
     ChangeManager.Subscriber,
-    TagsDialogListener {
+    TagsDialogListener,
+    SearchBarMenuHost {
     val activityViewModel: CardBrowserViewModel by activityViewModels()
     val viewModel: CardBrowserFragmentViewModel by viewModels()
     val searchViewModel: CardBrowserSearchViewModel by activityViewModels()
@@ -164,11 +167,16 @@ class CardBrowserFragment :
         get() = requireCardBrowserActivity().useSearchView
 
     // only usable if 'useSearchView' is set
-    private var searchBar: SearchBar? = null
+    override var searchBar: SearchBar? = null
     private var searchView: SearchView? = null
     private var deckChip: Chip? = null
 
     private var toggleAdvancedSearch: Button? = null
+
+    // region SearchBarMenuHost
+    override val menuInflater: MenuInflater? get() = activity?.menuInflater
+    override val menuHostHelper = MenuHostHelper { invalidateSearchBarMenu() }
+    // endregion
 
     @get:LayoutRes
     private val layout: Int


### PR DESCRIPTION
This is a no-op in PROD, and will work in dev once CardBrowser is updated to use MenuProvider

The current implementation was designed to produce the intended effect with minimal modification to the activity and Fragment.

An alternate would be to define `activity.menuHost` via an interface, but I deemed this to be unintuitive: `NoteEditorActivity` would need to implement it for no current reason.

## Fixes
* Part of #18709

## Approach
* Enable `MenuHost` delegation in `CardBrowser`
* Use `MenuHostHelper` to delegate to the Menu of the SearchBar
* Define an interface with a default implementation so `CardBrowserFragment` stays lean

## How Has This Been Tested?
Right now, this is effectively a no-op, I have a (messy) branch which has converted the Card Browser to use MenuProvider and this works as expected.


Tested briefly on a tablet emulator, in both legacy and `SearchView` implementations of the Card Browser

## Learning (optional, can help others)

`super.onCreate` on an activity adds `MenuProviders`, therefore delegation is more complicated than expected

`onDestroy` invalidates a `MenuHost`, but a fragment may no longer be attached to a context at this point

Using the incorrect `MenuInflater` means `showIfRoom` has no effect

`MenuProvider/MenuHost` 

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/view/MenuHost.java?q=MenuHost

https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:core/core/src/main/java/androidx/core/view/MenuHostHelper.java?q=MenuHost

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->