### PR TITLE
fix(study-screen): whiteboard display at first toggle

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -20,7 +20,6 @@ import android.content.Intent
 import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Bundle
-import android.text.InputType
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
@@ -62,7 +61,6 @@ import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.preferences.reviewer.ViewerAction
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.previewer.CardViewerFragment
-import com.ichi2.anki.previewer.TypeAnswer
 import com.ichi2.anki.previewer.setFrameStyle
 import com.ichi2.anki.previewer.stdHtml
 import com.ichi2.anki.reviewer.BindingMap
@@ -87,13 +85,11 @@ import com.ichi2.anki.workarounds.SafeWebViewLayout
 import com.ichi2.themes.Themes
 import com.ichi2.utils.dp
 import com.ichi2.utils.show
-import com.ichi2.utils.stripHtml
 import com.squareup.seismic.ShakeDetector
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import org.jetbrains.annotations.VisibleForTesting
 import timber.log.Timber
 import kotlin.math.max
 import kotlin.math.roundToInt
@@ -494,13 +490,12 @@ class ReviewerFragment :
 
     private fun setupWhiteboard() {
         viewModel.whiteboardEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
-            childFragmentManager.commit {
-                val whiteboardFragment = childFragmentManager.findFragmentByTag(WhiteboardFragment::class.jvmName)
-                if (whiteboardFragment == null && isEnabled) {
-                    add(R.id.whiteboard_container, WhiteboardFragment::class.java, null, WhiteboardFragment::class.jvmName)
-                    return@commit
+            binding.whiteboardContainer.isVisible = isEnabled
+            val whiteboardFragment = childFragmentManager.findFragmentById(binding.whiteboardContainer.id)
+            if (whiteboardFragment == null && isEnabled) {
+                childFragmentManager.commit {
+                    add(R.id.whiteboard_container, WhiteboardFragment::class.java, null)
                 }
-                binding.whiteboardContainer.isVisible = isEnabled
             }
         }
         viewModel.onCardUpdatedFlow.collectIn(lifecycleScope) {


### PR DESCRIPTION

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/20215#issuecomment-3796849791

## Approach

Improved the logic inside the Flow collector

## How Has This Been Tested?

Emulator 36:
1. Open the new study screen
2. Tap `Toggle whiteboard`in the menu

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->