### PR TITLE
fix(card-browser): tint of 'add' icon

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -49,7 +49,7 @@ class DeckPickerFloatingActionMenu(
     private val addNoteIcon: Int = R.drawable.ic_add_note
 
     // Add White Icon
-    private val addWhiteIcon: Int = R.drawable.ic_add_white
+    private val addWhiteIcon: Int = R.drawable.ic_add
 
     var isFABOpen = false
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -314,7 +314,7 @@ class TagsDialog : AnalyticsDialogFragment {
         toolbar.setTitle(titleRes)
 
         val toolbarAddItem = toolbar.menu.findItem(R.id.tags_dialog_action_add)
-        val drawable = ContextCompat.getDrawable(requireContext(), R.drawable.ic_add_white)
+        val drawable = ContextCompat.getDrawable(requireContext(), R.drawable.ic_add)
         drawable?.setTint(requireContext().getColor(R.color.white))
         toolbarAddItem.icon = drawable
 

--- a/AnkiDroid/src/main/res/drawable/ic_add_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_add_white.xml
@@ -1,9 +1,0 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
-    android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:pathData="M19,13L13,13L13,19L11,19L11,13L5,13L5,11L11,11L11,5L13,5L13,11L19,11L19,13Z"
-      android:fillColor="#ffffff"/>
-</vector>

--- a/AnkiDroid/src/main/res/layout/activity_manage_note_types.xml
+++ b/AnkiDroid/src/main/res/layout/activity_manage_note_types.xml
@@ -99,7 +99,7 @@
         android:layout_marginBottom="32dp"
         android:layout_marginEnd="32dp"
         app:fabSize="normal"
-        app:srcCompat="@drawable/ic_add_white"
+        app:srcCompat="@drawable/ic_add"
         android:contentDescription="@string/cd_manage_notetypes_add"
         app:backgroundTint="?attr/fab_normal"
         tools:ignore="HardcodedText" />

--- a/AnkiDroid/src/main/res/layout/floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/floating_add_button.xml
@@ -180,7 +180,7 @@
                     android:layout_marginStart="10dp"
                     android:layout_marginBottom="17dp"
                     android:layout_marginTop="10dp"
-                    app:srcCompat="@drawable/ic_add_white"
+                    app:srcCompat="@drawable/ic_add"
                     app:backgroundTint="?attr/fab_normal"
                     app:fabSize="normal"
                     android:contentDescription="@string/menu_add"

--- a/AnkiDroid/src/main/res/layout/note_type_field_editor.xml
+++ b/AnkiDroid/src/main/res/layout/note_type_field_editor.xml
@@ -48,7 +48,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             app:fabSize="normal"
-            app:srcCompat="@drawable/ic_add_white"
+            app:srcCompat="@drawable/ic_add"
             android:contentDescription="@string/model_field_editor_add"
             app:backgroundTint="?attr/fab_normal"
             android:layout_marginEnd="32dp"

--- a/AnkiDroid/src/main/res/layout/widget_deck_picker_config.xml
+++ b/AnkiDroid/src/main/res/layout/widget_deck_picker_config.xml
@@ -74,6 +74,6 @@
             android:layout_alignParentEnd="true"
             android:layout_margin="16dp"
             android:layout_marginBottom="40dp"
-            android:src="@drawable/ic_add_white" />
+            android:src="@drawable/ic_add" />
     </RelativeLayout>
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -5,7 +5,7 @@
 
     <item
         android:id="@+id/action_add_note_from_card_browser"
-        android:icon="@drawable/ic_add_white"
+        android:icon="@drawable/ic_add"
         android:title="@string/menu_add"
         ankidroid:showAsAction="ifRoom"/>
 

--- a/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker_dialog_menu.xml
@@ -25,7 +25,7 @@
         ankidroid:showAsAction="always|collapseActionView"/>
     <item
         android:id="@+id/deck_picker_dialog_action_add_deck"
-        android:icon="@drawable/ic_add_white"
+        android:icon="@drawable/ic_add"
         android:title="@string/menu_add"
         ankidroid:showAsAction="always" />
 </menu>

--- a/AnkiDroid/src/main/res/menu/reviewer.xml
+++ b/AnkiDroid/src/main/res/menu/reviewer.xml
@@ -106,7 +106,7 @@
     <item
         android:id="@+id/action_add_note_reviewer"
         android:title="@string/menu_add_note"
-        android:icon="@drawable/ic_add_white"
+        android:icon="@drawable/ic_add"
         ankidroid:showAsAction="never"/>
     <item
         android:id="@+id/action_card_info"

--- a/AnkiDroid/src/main/res/menu/tags_dialog_menu.xml
+++ b/AnkiDroid/src/main/res/menu/tags_dialog_menu.xml
@@ -11,7 +11,7 @@
 
     <item
         android:id="@+id/tags_dialog_action_add"
-        android:icon="@drawable/ic_add_white"
+        android:icon="@drawable/ic_add"
         android:title="@string/add_tag"
         ankidroid:showAsAction="ifRoom"/>
 


### PR DESCRIPTION
## Purpose / Description

Before this change, 'add' was the wrong color

<img width="1157" height="251" alt="Screenshot 2026-01-26 at 10 42 04" src="https://github.com/user-attachments/assets/f752783e-83bf-4870-bfda-5b653610bd48" />
<img width="1144" height="115" alt="Screenshot 2026-01-26 at 10 43 05" src="https://github.com/user-attachments/assets/afacb5d2-e79c-4290-9cb9-fee64800638e" />

## Fixes
* Tiny part of #18709

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)