### PR TITLE
fix(Browser): 'Change note type' is available if there is no selection

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -960,6 +960,7 @@ open class CardBrowser :
             isVisible = viewModel.hasSelectedAnyRows()
         }
         actionBarMenu.findItem(R.id.action_change_deck).isVisible = viewModel.hasSelectedAnyRows()
+        actionBarMenu.findItem(R.id.action_change_note_type).isVisible = viewModel.hasSelectedAnyRows()
         actionBarMenu.findItem(R.id.action_reposition_cards).isVisible = viewModel.hasSelectedAnyRows()
         actionBarMenu.findItem(R.id.action_grade_now).isVisible = viewModel.hasSelectedAnyRows()
         actionBarMenu.findItem(R.id.action_reschedule_cards).isVisible = viewModel.hasSelectedAnyRows()


### PR DESCRIPTION


<!--- Please fill the necessary details below -->
## Purpose / Description
- Fixes the issue where 'Change note type' is available as an option when no note is selected.

## Fixes
* Fixes #20223

## Approach
- Needed to add visibility update for the change note type action in updateMultiselectMenu()

## How Has This Been Tested?
Pixel Tablet Emulator API level 36:
[Screen_recording_20260127_011339.webm](https://github.com/user-attachments/assets/52ae0725-a9dd-45b4-adc4-ec9c97c756fe)


## Checklist


- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->