### PR TITLE
feat(card-browser): redefine 'Sort Type' in preparation for sorting rework

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnKey.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserColumnKey.kt
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import android.os.Parcelable
+import anki.search.BrowserColumns
+import com.ichi2.anki.libanki.Collection
+import kotlinx.parcelize.Parcelize
+
+/**
+ * The key defining a column in the Card Browser: [BrowserColumns.Column.key]
+ *
+ * Example: `noteFld`
+ *
+ * @see Collection.getBrowserColumn
+ * @see Collection.allBrowserColumns
+ * @see Collection.loadBrowserCardColumns
+ * @see Collection.loadBrowserNoteColumns
+ * @see Collection.setBrowserCardColumns
+ * @see Collection.setBrowserNoteColumns
+ */
+@JvmInline
+@Parcelize
+value class BrowserColumnKey(
+    val value: String,
+) : Parcelable {
+    companion object {
+        fun from(column: BrowserColumns.Column) = BrowserColumnKey(column.key)
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -101,8 +101,8 @@ import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes.CARDS
+import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.model.SortType
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.requireAnkiActivity
@@ -1212,7 +1212,7 @@ class CardBrowserFragment :
             // TODO: move this into the ViewModel
             CardBrowserOrderDialog.newInstance { dialog: DialogInterface, which: Int ->
                 dialog.dismiss()
-                activityViewModel.changeCardOrder(SortType.fromCardBrowserLabelIndex(which))
+                activityViewModel.changeCardOrder(LegacySortType.fromCardBrowserLabelIndex(which))
             },
         )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -73,6 +73,7 @@ import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.model.SortType
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.CardInfoDestination
@@ -832,6 +833,24 @@ class CardBrowserViewModel(
     fun hasSelectedAllDecks(): Boolean =
         searchRequestFlow.value.filters.decks
             .isEmpty()
+
+    /**
+     * Updates the [SortType] and updates the search results
+     */
+    fun setSortType(sortType: SortType) =
+        viewModelScope.launch {
+            Timber.i("setting sort type: %s", sortType)
+
+            // Temporarily update legacy flows
+            sortTypeFlow.update { sortType.toLegacy() }
+            sortType.toLegacyReverse()?.let { newValue ->
+                reverseDirectionFlow.update { newValue }
+            }
+
+            sortType.save(cardsOrNotes)
+
+            launchSearchForCards()
+        }
 
     fun changeCardOrder(which: LegacySortType) {
         val changeType =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -71,8 +71,8 @@ import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
+import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.model.SortType
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.CardInfoDestination
@@ -192,7 +192,7 @@ class CardBrowserViewModel(
 
     val flowOfScrollRequest = MutableSharedFlow<RowSelection>()
 
-    private val sortTypeFlow = MutableStateFlow(SortType.NO_SORTING)
+    private val sortTypeFlow = MutableStateFlow(LegacySortType.NO_SORTING)
     val order get() = sortTypeFlow.value
 
     private val reverseDirectionFlow = MutableStateFlow(ReverseDirection(orderAsc = false))
@@ -494,7 +494,7 @@ class CardBrowserViewModel(
             flowOfCardsOrNotes.update { cardsOrNotes }
 
             withCol {
-                sortTypeFlow.update { SortType.fromCol(config, cardsOrNotes, prefs) }
+                sortTypeFlow.update { LegacySortType.fromCol(config, cardsOrNotes, prefs) }
                 reverseDirectionFlow.update { ReverseDirection.fromConfig(config) }
             }
             Timber.i("initCompleted")
@@ -833,12 +833,12 @@ class CardBrowserViewModel(
         searchRequestFlow.value.filters.decks
             .isEmpty()
 
-    fun changeCardOrder(which: SortType) {
+    fun changeCardOrder(which: LegacySortType) {
         val changeType =
             when {
                 which != order -> ChangeCardOrder.OrderChange(which)
                 // if the same element is selected again, reverse the order
-                which != SortType.NO_SORTING -> ChangeCardOrder.DirectionChange
+                which != LegacySortType.NO_SORTING -> ChangeCardOrder.DirectionChange
                 else -> null
             } ?: return
 
@@ -1435,7 +1435,7 @@ class CardBrowserViewModel(
 
     private sealed interface ChangeCardOrder {
         data class OrderChange(
-            val sortType: SortType,
+            val sortType: LegacySortType,
         ) : ChangeCardOrder
 
         data object DirectionChange : ChangeCardOrder

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CardBrowserOrderDialog.kt
@@ -25,10 +25,10 @@ import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.ReverseDirection
-import com.ichi2.anki.model.SortType
+import com.ichi2.anki.model.LegacySortType
 
 /**
- * Allows a user to set the [SortType] and [ReverseDirection]
+ * Allows a user to set the [LegacySortType] and [ReverseDirection]
  */
 class CardBrowserOrderDialog : AnalyticsDialogFragment() {
     private val viewModel: CardBrowserViewModel by activityViewModels()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
@@ -17,13 +17,20 @@
 package com.ichi2.anki.model
 
 import android.content.SharedPreferences
+import android.os.Parcelable
 import androidx.annotation.VisibleForTesting
+import anki.search.BrowserColumns.Column
 import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
+import com.ichi2.anki.browser.BrowserColumnKey
+import com.ichi2.anki.libanki.BrowserConfig
 import com.ichi2.anki.libanki.Config
 import com.ichi2.anki.libanki.SortOrder
+import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
+import kotlinx.parcelize.Parcelize
 import timber.log.Timber
 
 /**
@@ -38,7 +45,7 @@ import timber.log.Timber
  * @param cardBrowserLabelIndex The index into [R.array.card_browser_order_labels]
  */
 @Suppress("unused") // 'unused' entries are iterated over by .entries
-enum class SortType(
+enum class LegacySortType(
     val ankiSortType: String?,
     val cardBrowserLabelIndex: Int,
 ) {
@@ -68,7 +75,7 @@ enum class SortType(
         prefs.cardBrowserNoSorting = this == NO_SORTING
     }
 
-    /** Converts the [SortType] to a [SortOrder] */
+    /** Converts the [LegacySortType] to a [SortOrder] */
     fun toSortOrder(): SortOrder = if (this == NO_SORTING) SortOrder.NoOrdering else SortOrder.UseCollectionOrdering
 
     companion object {
@@ -76,7 +83,7 @@ enum class SortType(
             config: Config,
             cardsOrNotes: CardsOrNotes,
             prefs: PrefsRepository = Prefs,
-        ): SortType {
+        ): LegacySortType {
             val configKey = if (cardsOrNotes == CardsOrNotes.CARDS) "sortType" else "noteSortType"
             val colOrder = config.get<String>(configKey)
             val type = entries.firstOrNull { it.ankiSortType == colOrder } ?: NO_SORTING
@@ -86,7 +93,81 @@ enum class SortType(
             return type
         }
 
-        fun fromCardBrowserLabelIndex(index: Int): SortType = entries.firstOrNull { it.cardBrowserLabelIndex == index } ?: NO_SORTING
+        fun fromCardBrowserLabelIndex(index: Int): LegacySortType = entries.firstOrNull { it.cardBrowserLabelIndex == index } ?: NO_SORTING
+    }
+}
+
+/**
+ * How to sort the rows in the [CardBrowser]
+ *
+ * A parcelable subset of the [SortOrders][SortOrder] which AnkiDroid supports
+ *
+ * [NoOrdering] is not supported by the upstream browser.
+ * See: [Prefs.cardBrowserNoSorting]
+ *
+ * Other properties are stored in the collection config and synced:
+ * [getBrowserColumnKey], [getSortBackwards]; [BrowserConfig]
+ */
+@Parcelize
+sealed class SortType : Parcelable {
+    /**
+     * @see SortOrder.NoOrdering
+     */
+    data object NoOrdering : SortType()
+
+    /**
+     * @see SortOrder.UseCollectionOrdering
+     * @see SortOrder.BuiltinColumnSortKind
+     */
+    data class CollectionOrdering(
+        val key: BrowserColumnKey,
+        val reverse: Boolean,
+    ) : SortType()
+
+    suspend fun save(cardsOrNotes: CardsOrNotes) {
+        Timber.i("saving %s", this)
+
+        when (this) {
+            is NoOrdering -> Prefs.cardBrowserNoSorting = true
+            is CollectionOrdering -> {
+                val isNotesMode = cardsOrNotes == NOTES
+
+                val sortKey = BrowserConfig.sortColumnKey(isNotesMode)
+                val reverseKey = BrowserConfig.sortBackwardsKey(isNotesMode)
+
+                withCol { config.set(sortKey, this@SortType.key.value) }
+                withCol { config.set(reverseKey, this@SortType.reverse) }
+
+                Prefs.cardBrowserNoSorting = false
+            }
+        }
+    }
+
+    companion object {
+        suspend fun build(cardsOrNotes: CardsOrNotes) =
+            when (Prefs.cardBrowserNoSorting) {
+                true -> NoOrdering
+                false -> resolveColumnOrdering(cardsOrNotes)
+            }
+
+        private suspend fun resolveColumnOrdering(cardsOrNotes: CardsOrNotes): SortType {
+            val browserColumnKey = getBrowserColumnKey(cardsOrNotes)
+            val browserColumn: Column? = withCol { getBrowserColumn(browserColumnKey) }
+
+            return if (browserColumn == null) {
+                NoOrdering
+            } else {
+                val reverse = getSortBackwards(cardsOrNotes)
+                val key = BrowserColumnKey.from(browserColumn)
+                CollectionOrdering(key = key, reverse = reverse)
+            }
+        }
+
+        fun buildSortOrder(): SortOrder =
+            when (Prefs.cardBrowserNoSorting) {
+                true -> SortOrder.NoOrdering
+                false -> SortOrder.UseCollectionOrdering
+            }
     }
 }
 
@@ -103,3 +184,17 @@ var PrefsRepository.cardBrowserNoSorting: Boolean
     set(value) {
         putBoolean(R.string.pref_browser_no_sorting, value)
     }
+
+private suspend fun getBrowserColumnKey(cardsOrNotes: CardsOrNotes): String {
+    val isNotesMode = cardsOrNotes == NOTES
+    val sortKey = BrowserConfig.sortColumnKey(isNotesMode)
+
+    return withCol { config.get<String>(sortKey) } ?: "noteFld"
+}
+
+private suspend fun getSortBackwards(cardsOrNotes: CardsOrNotes): Boolean {
+    val isNotesMode = cardsOrNotes == NOTES
+    val sortBackwardsKey = BrowserConfig.sortBackwardsKey(isNotesMode)
+
+    return withCol { config.get<Boolean>(sortBackwardsKey) } ?: false
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/model/SortType.kt
@@ -24,6 +24,7 @@ import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.browser.BrowserColumnKey
+import com.ichi2.anki.browser.ReverseDirection
 import com.ichi2.anki.libanki.BrowserConfig
 import com.ichi2.anki.libanki.Config
 import com.ichi2.anki.libanki.SortOrder
@@ -142,6 +143,18 @@ sealed class SortType : Parcelable {
             }
         }
     }
+
+    fun toLegacy(): LegacySortType =
+        when (this) {
+            is NoOrdering -> LegacySortType.NO_SORTING
+            is CollectionOrdering -> LegacySortType.entries.firstOrNull { it.ankiSortType == this.key.value } ?: LegacySortType.NO_SORTING
+        }
+
+    fun toLegacyReverse(): ReverseDirection? =
+        when (this) {
+            is NoOrdering -> null
+            is CollectionOrdering -> ReverseDirection(orderAsc = this.reverse)
+        }
 
     companion object {
         suspend fun build(cardsOrNotes: CardsOrNotes) =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -89,8 +89,8 @@ import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.testutils.AnkiTest
 import com.ichi2.anki.model.CardsOrNotes.CARDS
 import com.ichi2.anki.model.CardsOrNotes.NOTES
+import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.model.SortType
 import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService
 import com.ichi2.anki.servicelayer.PreferenceUpgradeService.PreferenceUpgrade.UpgradeBrowserColumns.Companion.LEGACY_COLUMN1_KEYS
@@ -521,7 +521,7 @@ class CardBrowserTest : RobolectricTest() {
             )
 
             // reverse
-            b.viewModel.changeCardOrder(SortType.SORT_FIELD)
+            b.viewModel.changeCardOrder(LegacySortType.SORT_FIELD)
 
             b.replaceSelectionWith(intArrayOf(0))
             val intentAfterReverse = b.viewModel.queryPreviewIntentData()
@@ -820,7 +820,7 @@ class CardBrowserTest : RobolectricTest() {
         )
 
         // Change the display order of the card browser
-        cardBrowserController.get().viewModel.changeCardOrder(SortType.EASE)
+        cardBrowserController.get().viewModel.changeCardOrder(LegacySortType.EASE)
 
         // Kill and restart the activity and ensure that display order is preserved
         val outBundle = Bundle()
@@ -905,9 +905,9 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     fun checkDisplayOrderAfterTogglingCardsToNotes() =
         withBrowser {
-            viewModel.changeCardOrder(SortType.EASE) // order no. 7 corresponds to "cardEase"
+            viewModel.changeCardOrder(LegacySortType.EASE) // order no. 7 corresponds to "cardEase"
 
-            viewModel.changeCardOrder(SortType.EASE) // reverse the list
+            viewModel.changeCardOrder(LegacySortType.EASE) // reverse the list
 
             viewModel.setCardsOrNotes(NOTES)
             searchCards()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/BrowserColumnKeyTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/BrowserColumnKeyTest.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2026 Shaan Narendran <shaannaren06@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.JvmTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/** Tests for [BrowserColumnKey] */
+@RunWith(AndroidJUnit4::class)
+@Config(application = EmptyApplication::class)
+class BrowserColumnKeyTest : JvmTest() {
+    @Test
+    fun `browser column key test`() {
+        val column = assertNotNull(col.getBrowserColumn(("noteFld")))
+
+        val key = BrowserColumnKey.from(column)
+
+        assertEquals("noteFld", key.value)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -76,6 +76,7 @@ import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.LegacySortType.NO_SORTING
 import com.ichi2.anki.model.LegacySortType.SORT_FIELD
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.model.SortType
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
@@ -106,6 +107,7 @@ import timber.log.Timber
 import java.io.File
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.pathString
+import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -1451,6 +1453,67 @@ class CardBrowserViewModelTest : JvmTest() {
 
             assertThat("hello and hêllo are matched", rowCount, equalTo(2))
             assertThat("input is unchanged", searchTerms, equalTo("hello"))
+        }
+    }
+
+    @Test
+    fun `updating sort type launches search`() =
+        runViewModelTest {
+            flowOfSearchState.test {
+                expectNoEvents()
+
+                setSortType(SortType.NoOrdering)
+
+                expectMostRecentItem()
+            }
+        }
+
+    @Test
+    fun `updating sort type updates flows - no ordering`() =
+        runViewModelTest {
+            assertEquals(LegacySortType.SORT_FIELD, order)
+
+            setSortType(SortType.NoOrdering)
+
+            assertEquals(LegacySortType.NO_SORTING, order)
+        }
+
+    @Test
+    fun `updating sort type updates flows - known column`() =
+        runViewModelTest {
+            assertEquals(LegacySortType.SORT_FIELD, order)
+
+            setSortType(SortType.CollectionOrdering(BrowserColumnKey("cardDue"), true))
+
+            assertEquals(LegacySortType.DUE_TIME, order)
+        }
+
+    @Test
+    fun `updating sort type updates order`() =
+        runViewModelTest {
+            assertEquals(false, orderAsc)
+
+            setSortType(SortType.CollectionOrdering(BrowserColumnKey("cardDue"), true))
+
+            assertEquals(true, orderAsc)
+        }
+
+    @Test
+    fun `sort type integration test`() {
+        val firstId = addBasicNote("a").firstCard().id
+        addBasicNote("b")
+        val lastId = addBasicNote("c").firstCard().id
+
+        runViewModelTest {
+            assertEquals(firstId, this.cards[0].cardOrNoteId)
+
+            setSortType(SortType.CollectionOrdering(BrowserColumnKey("noteFld"), reverse = true))
+
+            assertEquals(lastId, this.cards[0].cardOrNoteId)
+
+            setSortType(SortType.CollectionOrdering(BrowserColumnKey("noteFld"), reverse = false))
+
+            assertEquals(firstId, this.cards[0].cardOrNoteId)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -72,10 +72,10 @@ import com.ichi2.anki.libanki.QueueType.New
 import com.ichi2.anki.libanki.testutils.AnkiTest
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.model.LegacySortType
+import com.ichi2.anki.model.LegacySortType.NO_SORTING
+import com.ichi2.anki.model.LegacySortType.SORT_FIELD
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.model.SortType
-import com.ichi2.anki.model.SortType.NO_SORTING
-import com.ichi2.anki.model.SortType.SORT_FIELD
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
@@ -606,17 +606,17 @@ class CardBrowserViewModelTest : JvmTest() {
                 assertThat("initial direction", !orderAsc)
 
                 // changing the order performs a search & changes order
-                changeCardOrder(SortType.EASE)
+                changeCardOrder(LegacySortType.EASE)
                 expectMostRecentItem()
-                assertThat("order changed", order, equalTo(SortType.EASE))
+                assertThat("order changed", order, equalTo(LegacySortType.EASE))
                 assertThat("changed direction is the default", !orderAsc)
 
                 waitForSearchResults()
 
                 // pressing 'ease' again changes direction
-                changeCardOrder(SortType.EASE)
+                changeCardOrder(LegacySortType.EASE)
                 expectMostRecentItem()
-                assertThat("order unchanged", order, equalTo(SortType.EASE))
+                assertThat("order unchanged", order, equalTo(LegacySortType.EASE))
                 assertThat("direction is changed", orderAsc)
             }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/SortTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/SortTypeTest.kt
@@ -1,0 +1,207 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.browser
+
+import androidx.core.content.edit
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.libanki.SortOrder
+import com.ichi2.anki.model.CardsOrNotes
+import com.ichi2.anki.model.SortType
+import com.ichi2.anki.model.SortType.CollectionOrdering
+import com.ichi2.anki.model.SortType.NoOrdering
+import com.ichi2.anki.model.cardBrowserNoSorting
+import com.ichi2.anki.settings.Prefs
+import org.junit.Before
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class SortTypeTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        Prefs.sharedPrefs.edit { remove("cardBrowserNoSorting") }
+    }
+
+    @Test
+    fun `default sort type - CARDS`() =
+        runTest {
+            val defaultCards = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+
+            val ordering = assertInstanceOf<CollectionOrdering>(defaultCards)
+
+            assertEquals("noteFld", ordering.key.value)
+            assertEquals(false, ordering.reverse)
+        }
+
+    @Test
+    fun `default sort type - NOTES`() =
+        runTest {
+            val defaultNotes = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+
+            val ordering = assertInstanceOf<CollectionOrdering>(defaultNotes)
+
+            assertEquals("noteFld", ordering.key.value)
+            assertEquals(false, ordering.reverse)
+        }
+
+    @Test
+    fun `build produces no ordering when column is corrupt`() =
+        runTest {
+            col.config.set("noteSortType", "blah")
+
+            val result = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+
+            assertInstanceOf<NoOrdering>(result)
+        }
+
+    @Test
+    fun `cardBrowserNoSorting controls build type`() =
+        runTest {
+            Prefs.cardBrowserNoSorting = true
+
+            SortType.build(cardsOrNotes = CardsOrNotes.NOTES).apply {
+                assertInstanceOf<NoOrdering>(this)
+            }
+
+            Prefs.cardBrowserNoSorting = false
+
+            SortType.build(cardsOrNotes = CardsOrNotes.NOTES).apply {
+                assertInstanceOf<CollectionOrdering>(this)
+            }
+        }
+
+    @Test
+    fun `collection controls build() results - NOTES`() =
+        runTest {
+            col.config.set("noteSortType", "noteTags")
+            col.config.set("browserNoteSortBackwards", true)
+
+            val sortType = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+            val collectionSortType = assertInstanceOf<CollectionOrdering>(sortType)
+
+            assertEquals("noteTags", collectionSortType.key.value)
+            assertEquals(true, collectionSortType.reverse)
+        }
+
+    @Test
+    fun `collection controls build() results - CARDS`() =
+        runTest {
+            col.config.set("sortType", "noteTags")
+            col.config.set("sortBackwards", true)
+
+            val sortType = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+            val collectionSortType = assertInstanceOf<CollectionOrdering>(sortType)
+
+            assertEquals("noteTags", collectionSortType.key.value)
+            assertEquals(true, collectionSortType.reverse)
+        }
+
+    @Test
+    fun `test buildSortOrder`() =
+        runTest {
+            NoOrdering.save(CardsOrNotes.NOTES)
+            assertInstanceOf<SortOrder.NoOrdering>(SortType.buildSortOrder())
+
+            CollectionOrdering(BrowserColumnKey("noteTags"), true).save(CardsOrNotes.CARDS)
+            assertInstanceOf<SortOrder.UseCollectionOrdering>(SortType.buildSortOrder())
+
+            NoOrdering.save(CardsOrNotes.CARDS)
+            assertInstanceOf<SortOrder.NoOrdering>(SortType.buildSortOrder())
+
+            CollectionOrdering(BrowserColumnKey("noteTags"), true).save(CardsOrNotes.NOTES)
+            assertInstanceOf<SortOrder.UseCollectionOrdering>(SortType.buildSortOrder())
+        }
+
+    @Test
+    fun `save no ordering - CARDS`() =
+        runTest {
+            NoOrdering.save(CardsOrNotes.CARDS)
+
+            val sortType = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+            assertInstanceOf<NoOrdering>(sortType)
+        }
+
+    @Test
+    fun `save no ordering - NOTES`() =
+        runTest {
+            NoOrdering.save(CardsOrNotes.NOTES)
+
+            val sortType = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+            assertInstanceOf<NoOrdering>(sortType)
+        }
+
+    @Test
+    fun `save collection - CARDS`() =
+        runTest {
+            CollectionOrdering(BrowserColumnKey("noteTags"), true).save(CardsOrNotes.NOTES)
+
+            val notesSortType = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+            assertInstanceOf<CollectionOrdering>(notesSortType).apply {
+                assertEquals("noteTags", key.value, "notes - key")
+                assertEquals(true, reverse, "notes - reverse")
+            }
+        }
+
+    @Test
+    fun `save collection - NOTES`() =
+        runTest {
+            CollectionOrdering(BrowserColumnKey("noteCrt"), false).save(CardsOrNotes.CARDS)
+
+            val cardsSortType = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+            assertInstanceOf<CollectionOrdering>(cardsSortType).apply {
+                assertEquals("noteCrt", key.value, "cards - key")
+                assertEquals(false, reverse, "cards - reverse")
+            }
+        }
+
+    @Test
+    fun `save different column - NOTES and CARDS`() =
+        runTest {
+            CollectionOrdering(BrowserColumnKey("noteTags"), true).save(CardsOrNotes.NOTES)
+            CollectionOrdering(BrowserColumnKey("noteCrt"), false).save(CardsOrNotes.CARDS)
+
+            val notesSortType = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+            assertInstanceOf<CollectionOrdering>(notesSortType).apply {
+                assertEquals("noteTags", key.value, "notes - key")
+                assertEquals(true, reverse, "notes - reverse")
+            }
+
+            val cardsSortType = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+            assertInstanceOf<CollectionOrdering>(cardsSortType).apply {
+                assertEquals("noteCrt", key.value, "cards - key")
+                assertEquals(false, reverse, "cards - reverse")
+            }
+        }
+
+    @Test
+    @Ignore("TODO: NoOrdering should not affect both")
+    fun `save types different - NOTES and CARDS`() =
+        runTest {
+            NoOrdering.save(CardsOrNotes.NOTES)
+
+            val notesSortType = SortType.build(cardsOrNotes = CardsOrNotes.NOTES)
+            assertInstanceOf<NoOrdering>(notesSortType)
+
+            val cardsSortType = SortType.build(cardsOrNotes = CardsOrNotes.CARDS)
+            assertInstanceOf<CollectionOrdering>(cardsSortType)
+        }
+}


### PR DESCRIPTION
## Fixes
* Prep for #17732

## Approach
This PR defines `BrowserColumnKey`, reimplements `SortType`, and defines a method in the ViewModel which accepts the new `SortType`

The `SortType` is small and parcelable, so can be used in a bundle as fragment args. The intention is that it represents "the currently selected sort type"

We improve the past type by making it a union: either `NoSelection` or `CollectionOrdering`

## How Has This Been Tested?
Unit tests only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)