### PR TITLE
fix(change-note-types): don't discard undo queue

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -68,7 +68,7 @@ import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.showError
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.sync.launchCatchingRequiringOneWaySyncDiscardUndo
+import com.ichi2.anki.sync.launchCatchingRequiringOneWaySync
 import com.ichi2.anki.ui.BasicItemSelectedListener
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.InitStatus
@@ -637,7 +637,7 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
  * Changes note type of multiple notes, displaying a message on success
  */
 private fun AnkiActivity.changeNoteType(viewModel: ChangeNoteTypeViewModel) =
-    this.launchCatchingRequiringOneWaySyncDiscardUndo {
+    this.launchCatchingRequiringOneWaySync {
         try {
             val notesUpdated =
                 withProgress {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeViewModel.kt
@@ -316,8 +316,6 @@ class ChangeNoteTypeViewModel(
             Timber.d("Field map: %s", fieldChangeMap)
             Timber.d("Card map: %s", templateChangeMap)
 
-            withCol { modSchema(check = true) }
-
             val changes =
                 changeNoteTypeOfNotes(
                     noteIds = noteIds,

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Notetypes.kt
@@ -561,10 +561,12 @@ class Notetypes(
      *
      * Each value represents the index in the previous notetype.
      * -1 indicates the original value will be discarded.
+     *
+     * **This method updates the schema without confirmation**
      */
     @LibAnkiAlias("change_notetype_of_notes")
     fun changeNotetypeOfNotes(input: ChangeNotetypeRequest): OpChanges {
-        val opBytes = this.col.backend.changeNotetypeRaw(input.toByteArray())
+        val opBytes = col.backend.changeNotetypeRaw(input.toByteArray())
         return OpChanges.parseFrom(opBytes)
     }
 


### PR DESCRIPTION
## Purpose / Description
The backend method `changeNotetypeOfNotes` internally updates the schema does not not discard the undo queue.

https://github.com/ankitects/anki/blob/83c615cc7f9aef3c336936fa797671965538f89c/rslib/src/notetype/notetypechange.rs#L216-L222

Before this PR, we called `modSchema()`, which updated the schema and discarded the undo/study queues

## Fixes
* Fixes #20172

## Approach
Upstream Anki relies on implicit knowledge to handle backend methods which update the schema: they show a dialog if a schema change is needed, then call the backend method

I attempted to introduce a 'guard context' (my terminology), using Kotlin's experimental context parameters so this check was enforced by code, but there was a dex issue:

* #20247

> [!NOTE]
> We can now add an issue, this should be fized in Kotlin 2.3.0


So I continued using Anki's approach: call `launchCatchingRequiringOneWaySync` before a backend method which modifies the collection

I then removed the `modSchema(check = true)` call

## How Has This Been Tested?
<img width="202" height="109" alt="Screenshot 2026-01-28 at 17 12 04" src="https://github.com/user-attachments/assets/d87f4359-0162-4ea7-a146-8316ac793676" />

## Learning (optional, can help others)
Loads of stuff in the stacked PR

* https://github.com/ankidroid/Anki-Android/pull/20248

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)