### PR TITLE
fix: discard changes was shown if note contained a newline

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -149,6 +149,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerArguments
 import com.ichi2.anki.previewer.TemplatePreviewerPage
 import com.ichi2.anki.servicelayer.LanguageHintService.languageHint
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.anki.servicelayer.NoteService.convertToHtmlNewline
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
@@ -1233,7 +1234,10 @@ class NoteEditorFragment :
         fun fieldsEdited(): Boolean {
             // Editing an existing note: Check to see if the fields are changed
             if (!addNote) {
-                return editFields!!.map { it.text?.toString() } != editorNote!!.fields.toList()
+                fun normalizeNewlines(s: String) = convertToHtmlNewline(s, replaceNewlines = true)
+                val currentStrings = editFields!!.map { it.text?.toString() ?: "" }
+                val originalStrings = editorNote!!.fields.toList()
+                return currentStrings.map(::normalizeNewlines) != originalStrings.map(::normalizeNewlines)
             }
 
             if (!isFieldEdited) return false

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -631,12 +631,45 @@ class NoteEditorTest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `hasUnsavedChanges - note is unchanged`() =
+        withNoteEditorEditing(addBasicNote("hello world")) {
+            this.setField(0, "hello world")
+            assertFalse(hasUnsavedChanges())
+        }
+
+    @Test
+    fun `hasUnsavedChanges - note is changed`() =
+        withNoteEditorEditing(addBasicNote("hello world")) {
+            this.setField(0, "hi")
+            assertTrue(hasUnsavedChanges())
+        }
+
+    @Test
+    fun `hasUnsavedChanges - note contained a newline`() =
+        withNoteEditorEditing(addBasicNote("hello\nworld")) {
+            assertFalse(hasUnsavedChanges())
+        }
+
+    @Test
+    fun `hasUnsavedChanges - note contained a HTML newline - 20174`() =
+        withNoteEditorEditing(addBasicNote("hello<br>world")) {
+            assertFalse(hasUnsavedChanges())
+        }
+
     private suspend fun withNoteEditorAdding(
         from: FromScreen = FromScreen.DECK_LIST,
         block: suspend NoteEditorFragment.() -> Unit,
     ) {
         val editor = getNoteEditorAddingNote(from)
         editor.block()
+    }
+
+    private fun withNoteEditorEditing(
+        note: Note,
+        block: suspend NoteEditorFragment.() -> Unit,
+    ) = runTest {
+        block(getNoteEditorEditingExistingBasicNote(note, from = REVIEWER))
     }
 
     private fun moveToDynamicDeck(note: Note): DeckId {


### PR DESCRIPTION
## Purpose / Description

`<br>` in the collection was converted to `\n` in the EditText, these weren't comparable

## Fixes
* Fixes #20174

## Approach
`git bisect`
Then write a test
Then fix a test
Then write more tests

## How Has This Been Tested?
Tests

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)