### PR TITLE
test: split screenshot tests into a separate gradle action

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -245,6 +245,18 @@ android {
                 freeCompilerArgs.add("-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
             }
         }
+        unitTests {
+            all { test ->
+                test.useJUnitPlatform {
+                    // ./gradlew testFullDebugUnitTest -Pscreenshot
+                    if (project.hasProperty("screenshot")) {
+                        includeTags "com.ichi2.anki.ScreenshotTestCategory"
+                    } else {
+                        excludeTags "com.ichi2.anki.ScreenshotTestCategory"
+                    }
+                }
+            }
+        }
     }
 
     compileOptions {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
@@ -15,10 +15,14 @@
  */
 package com.ichi2.anki
 
+import org.junit.experimental.categories.Category
 import org.robolectric.annotation.GraphicsMode
+
+interface ScreenshotTestCategory
 
 /**
  * Base class for [roborazzi](https://github.com/takahirom/roborazzi) screenshot tests
  */
+@Category(ScreenshotTestCategory::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-open class ScreenshotTest : RobolectricTest()
+abstract class ScreenshotTest : RobolectricTest()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
@@ -23,13 +23,11 @@ import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.FrameStyle
 import com.ichi2.anki.settings.enums.ToolbarPosition
-import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
-@Ignore("screenshots tests should be separated from the general unit tests task")
 @RunWith(ParameterizedRobolectricTestRunner::class)
 class StudyScreenScreenshotTest(
     private val config: TestConfig,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

If someone is doing a change restricted to the UI style, such as changing theme colors, running only the screenshot tests is more efficient, so I'm splitting screenshot tests from default unit tests

## Approach

https://github.com/takahirom/roborazzi?tab=readme-ov-file#q-how-can-i-run-only-screenshot-tests-using-roborazzi

## How Has This Been Tested?

`./gradlew testFullDebugUnitTest -Pscreenshot` -> only the screenshot tests are run.

## Learning

https://junit.org/junit4/javadoc/4.12/org/junit/experimental/categories/Categories.html

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->