### PR TITLE
fix: hide preview action in split mode

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -855,8 +855,8 @@ open class CardBrowser :
             showBackIcon()
             increaseHorizontalPaddingOfOverflowMenuIcons(menu)
         }
-        // Remove save note and preview note options if there are no notes
-        if (fragmented && viewModel.rowCount == 0) {
+        // Remove save note and preview note options if there are no notes or in fragmented mode
+        if (fragmented || viewModel.rowCount == 0) {
             menu.removeItem(R.id.action_save)
             menu.removeItem(R.id.action_preview)
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Preview action was appearing twice in the toolbar menu.This happened because the menu items were only removed when both conditions were true

## Fixes
* Fixes #20206

## Approach
Switched to `||` so menu items are removed as soon as either condition met

## How Has This Been Tested?
Chromebook

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)