### PR TITLE
feat(whiteboard): two-finger scroll

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -40,6 +40,8 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
@@ -489,6 +491,22 @@ class ReviewerFragment :
     }
 
     private fun setupWhiteboard() {
+        childFragmentManager.registerFragmentLifecycleCallbacks(
+            object : FragmentManager.FragmentLifecycleCallbacks() {
+                override fun onFragmentViewCreated(
+                    fm: FragmentManager,
+                    f: Fragment,
+                    v: View,
+                    savedInstanceState: Bundle?,
+                ) {
+                    if (f !is WhiteboardFragment) return
+                    f.setOnScrollByListener { y ->
+                        webViewLayout.scrollVerticallyBy(y)
+                    }
+                }
+            },
+            false,
+        )
         viewModel.whiteboardEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
             binding.whiteboardContainer.isVisible = isEnabled
             val whiteboardFragment = childFragmentManager.findFragmentById(binding.whiteboardContainer.id)
@@ -499,7 +517,7 @@ class ReviewerFragment :
             }
         }
         viewModel.onCardUpdatedFlow.collectIn(lifecycleScope) {
-            val whiteboardFragment = childFragmentManager.findFragmentByTag(WhiteboardFragment::class.jvmName)
+            val whiteboardFragment = childFragmentManager.findFragmentById(binding.whiteboardContainer.id)
             (whiteboardFragment as? WhiteboardFragment)?.resetCanvas()
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -391,6 +391,15 @@ class WhiteboardFragment :
         return true
     }
 
+    /**
+     * Sets a listener to when the whiteboard is scrolled vertically,
+     * which can happen by scrolling with two fingers, or with just one
+     * if the `Stylus mode` is enabled.
+     */
+    fun setOnScrollByListener(listener: OnScrollByListener) {
+        binding.whiteboardView.setOnScrollByListener(listener)
+    }
+
     fun resetCanvas() = viewModel.reset()
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
@@ -114,6 +114,13 @@ open class SafeWebViewLayout :
     fun destroy() = webView.destroy()
 
     @MainThread
+    fun scrollVerticallyBy(y: Int) {
+        if (webView.canScrollVertically(y)) {
+            webView.scrollBy(0, y)
+        }
+    }
+
+    @MainThread
     fun createPrintDocumentAdapter(documentName: String) = webView.createPrintDocumentAdapter(documentName)
 
     override fun setOnScrollChangeListener(l: OnScrollChangeListener?) = webView.setOnScrollChangeListener(l)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Feature present in the old whiteboard that people missed

## Approach

I didn't want to think too much, so I followed the approach used by the old whiteboard https://github.com/ankidroid/Anki-Android/blob/2afb4ade6c8f4e5acb7979dc38e231697e9957df/AnkiDroid/src/main/java/com/ichi2/anki/Whiteboard.kt#L324

After that, I added support for interacting with the screen with just one finger if stylus mode is enabled

## How Has This Been Tested?

Galaxy Tab S9, Android 16

https://github.com/user-attachments/assets/7513951d-c83d-469e-b1c7-a3e0b88ba203

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->