### PR TITLE
fix: support legacy `showAnswer` js calls

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
@@ -185,7 +185,7 @@ function taFocus() {
 }
 
 function showAnswer() {
-    window.location.href = "signal:show_answer";
+    window.location.href = "ankidroid://show-answer";
 }
 function buttonAnswerEase1() {
     window.location.href = "signal:answer_ease1";


### PR DESCRIPTION
## Fixes
* Fixes #19783

## How Has This Been Tested?

Emulator 36:
1. call `showAnswer()` in the template -> the answer is shown

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->