### PR TITLE
feat: match AlertDialog with MaterialAlertDialog

### DIFF
--- a/AnkiDroid/src/main/res/drawable/material_dialog_background.xml
+++ b/AnkiDroid/src/main/res/drawable/material_dialog_background.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+  ~
+  ~  This program is free software; you can redistribute it and/or modify it under
+  ~  the terms of the GNU General Public License as published by the Free Software
+  ~  Foundation; either version 3 of the License, or (at your option) any later
+  ~  version.
+  ~
+  ~  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+  ~  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+  ~  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+  ~
+  ~  You should have received a copy of the GNU General Public License along with
+  ~  this program.  If not, see <http://www.gnu.org/licenses/>.
+  -->
+
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="24dp"
+    android:insetTop="16dp"
+    android:insetRight="24dp"
+    android:insetBottom="16dp">
+
+    <shape android:shape="rectangle">
+        <corners android:radius="@dimen/m3_alert_dialog_corner_size"/>
+        <solid android:color="?attr/colorSurfaceContainerHigh"/>
+    </shape>
+
+</inset>

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -222,6 +222,7 @@
     <style name="ThemeOverlay.AnkiDroid.AlertDialog" parent="ThemeOverlay.Material3.MaterialAlertDialog">
         <item name="dialogCornerRadius">@dimen/m3_alert_dialog_corner_size</item>
         <item name="materialAlertDialogBodyTextStyle">@style/AnkiDroid.AlertDialog.Body.Text</item>
+        <item name="android:windowBackground">@drawable/material_dialog_background</item>
     </style>
 
     <style name="ThemeOverlay.AnkiDroid.AlertDialog.FullScreen" parent="ThemeOverlay.AnkiDroid.AlertDialog">

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -26,7 +26,7 @@
         <item name="android:windowBackground">@color/material_theme_grey</item>
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
-        <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
+        <item name="colorSurfaceContainerHigh">#424C54</item>
         <item name="colorSurfaceContainer">#0F42A5F5</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
         <!-- Widget colors -->

--- a/AnkiDroid/src/main/res/values/theme_light.xml
+++ b/AnkiDroid/src/main/res/values/theme_light.xml
@@ -12,7 +12,7 @@
         <item name="colorOnPrimaryContainer">@color/white</item> <!-- FAB icons -->
 
         <item name="colorSurfaceContainerHighest">?attr/colorSurfaceContainer</item>
-        <item name="colorSurfaceContainerHigh">?android:attr/colorBackground</item>
+        <item name="colorSurfaceContainerHigh">#E4F5FD</item>
         <item name="colorSurfaceContainer">#0F03A9F4</item>
         <item name="colorSurfaceContainerLow">?android:attr/colorBackground</item>
 

--- a/AnkiDroid/src/main/res/values/theme_plain.xml
+++ b/AnkiDroid/src/main/res/values/theme_plain.xml
@@ -12,6 +12,7 @@
         <item name="colorPrimaryDark">@color/theme_plain_primary_dark</item>
         <item name="colorAccent">@color/theme_plain_accent</item>
         <item name="colorSurfaceContainer">#0F9E9E9E</item>
+        <item name="colorSurfaceContainerHigh">#F4F4F4</item>
         <item name="android:textColor">@color/text_color_light</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_light</item>
         <item name="preferenceCategoryTitleTextColor">?attr/colorAccent</item>


### PR DESCRIPTION
## Purpose / Description
Our Material Dialogs and AlertDialogs were inconsistent

## Fixes
* Fixes lots of #18553

## Approach

`android:windowBackground` only affects the window, whereas `android:background` affects all controls in the theme

So define a `windowBackground` for the old theme, using `colorSurfaceContainerHigh`.
Since before this change, it was only blended into themes (changing `colorSurface` removed the value), I found the current color using a color picker:

* #424C54 for dark themes
* #E4F5FD for the light theme
* #F4F4F4 for the plain theme


## How Has This Been Tested?

 I confirmed two dialogs looked equivalent with the equivalent padding

<details>

```patch
Subject: [PATCH] 
---
Index: AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt	(revision c52573174ceff6108ca972e8f3d2b3263dc94a1e)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/DevOptionsFragment.kt	(revision ea6044966007f94f082a10a66acc81025666bec0)
@@ -20,6 +20,7 @@
 import androidx.core.content.edit
 import androidx.preference.Preference
 import androidx.preference.SwitchPreferenceCompat
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.CollectionHelper
@@ -191,6 +192,24 @@
             ActivityCompat.recreate(requireActivity())
             true
         }
+
+        requirePreference<Preference>(R.string.dev_a).setOnPreferenceClickListener {
+            AlertDialog.Builder(requireContext()).show {
+                setTitle("a")
+                setMessage("b")
+            }
+            Timber.w("a")
+            true
+        }
+
+        requirePreference<Preference>(R.string.dev_b).setOnPreferenceClickListener {
+            MaterialAlertDialogBuilder(requireContext()).show {
+                setTitle("a")
+                setMessage("b")
+            }
+            Timber.w("b")
+            true
+        }
 
         setupWebDebugPreference()
     }
Index: AnkiDroid/src/main/res/values/preferences.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/values/preferences.xml b/AnkiDroid/src/main/res/values/preferences.xml
--- a/AnkiDroid/src/main/res/values/preferences.xml	(revision c52573174ceff6108ca972e8f3d2b3263dc94a1e)
+++ b/AnkiDroid/src/main/res/values/preferences.xml	(revision ea6044966007f94f082a10a66acc81025666bec0)
@@ -234,6 +234,8 @@
     <string name="dev_card_browser_fragmented">cardBrowserFragmented</string>
     <string name="dev_card_browser_search_view">cardBrowserSearchView</string>
     <string name="dev_open_tts_voices">openTtsVoices</string>
+    <string name="dev_a">a</string>
+    <string name="dev_b">b</string>
     <!-- Developer options > Create fake notes -->
     <string name="pref_fill_default_deck_number_key">FillDefaultNumberDeck</string>
     <string name="pref_fill_default_deck_key">FillDefaultDeck</string>
Index: AnkiDroid/src/main/res/xml/preferences_dev_options.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml
--- a/AnkiDroid/src/main/res/xml/preferences_dev_options.xml	(revision c52573174ceff6108ca972e8f3d2b3263dc94a1e)
+++ b/AnkiDroid/src/main/res/xml/preferences_dev_options.xml	(revision ea6044966007f94f082a10a66acc81025666bec0)
@@ -59,6 +59,14 @@
         android:title="Open TTS voice selection"
         android:summary="shortcut for {{tts-voices:}}"
         android:key="@string/dev_open_tts_voices"/>
+
+    <Preference
+        android:title="Dialog"
+        android:key="@string/dev_a"/>
+
+    <Preference
+        android:title="Material Dialog"
+        android:key="@string/dev_b"/>
     <PreferenceCategory
         android:title="Create meaningless cards notes"
         >
```

</details>


**before**
<img width="592" height="192" alt="Screenshot 2026-01-31 at 20 29 04" src="https://github.com/user-attachments/assets/40faaae4-b3d2-44d2-a2e5-cfad2cba1316" />
<img width="577" height="205" alt="Screenshot 2026-01-31 at 20 28 56" src="https://github.com/user-attachments/assets/7f7802ae-9759-404d-9457-e604b34d40c3" />
<img width="579" height="228" alt="Screenshot 2026-01-31 at 20 28 47" src="https://github.com/user-attachments/assets/9de03933-1926-40d0-9d88-cb5e9172344d" />
<img width="626" height="168" alt="Screenshot 2026-01-31 at 20 28 38" src="https://github.com/user-attachments/assets/038676c2-00b5-47e7-a237-867d549874f9" />


**after (Material & AlertDialog)**
<img width="606" height="246" alt="Screenshot 2026-01-31 at 20 26 35" src="https://github.com/user-attachments/assets/3493a566-d721-40bd-a378-3a30c15f84b6" />
<img width="594" height="240" alt="Screenshot 2026-01-31 at 20 26 32" src="https://github.com/user-attachments/assets/b1d73494-da4d-4a7f-b076-4b1a7fab2d63" />
<img width="586" height="207" alt="Screenshot 2026-01-31 at 20 26 08" src="https://github.com/user-attachments/assets/1e3a24b3-e827-4266-b1d3-0cda2894fed6" />
<img width="606" height="242" alt="Screenshot 2026-01-31 at 20 26 05" src="https://github.com/user-attachments/assets/4c594699-fa8a-4a78-92f9-ac81b16af347" />
<img width="590" height="223" alt="Screenshot 2026-01-31 at 20 25 47" src="https://github.com/user-attachments/assets/5978133d-928d-43f7-b280-b11c4b3cd132" />
<img width="590" height="208" alt="Screenshot 2026-01-31 at 20 25 44" src="https://github.com/user-attachments/assets/a0837c55-a5b3-4107-b3e7-250407fcaece" />
<img width="630" height="282" alt="Screenshot 2026-01-31 at 20 25 33" src="https://github.com/user-attachments/assets/71362098-a203-4049-a3ef-40abf4a17822" />
<img width="607" height="249" alt="Screenshot 2026-01-31 at 20 25 30" src="https://github.com/user-attachments/assets/d14f1cc6-907c-4e55-96cf-7b8744560a7c" />


## Learning

We're doing material 3 colors wrong; they should dynamically be generated using `colorPrimary`

* https://github.com/ankidroid/Anki-Android/issues/18767

Material 3: Surface
https://m3.material.io/styles/color/roles#89f972b1-e372-494c-aabc-69aea34ed591


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)