### PR TITLE
feat(card-browser): serialize filters [chip state]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchHistory.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/SearchHistory.kt
@@ -16,13 +16,22 @@
 
 package com.ichi2.anki.browser
 
+import com.ichi2.anki.Flag
 import com.ichi2.anki.R
+import com.ichi2.anki.browser.search.CardState
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.libanki.NoteTypeId
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.json.Json
 import timber.log.Timber
+
+private typealias Tag = String
 
 /**
  * The user's past searches in the Card Browser.
@@ -88,21 +97,48 @@ class SearchHistory(
     /**
      * An entry in the history of the card browser.
      * This is user-supplied, so may contain PII.
+     *
+     * Contains the minimal values needed for persistent serialization:
+     * Deck IDs are stored, rather than deck names. See [deckIds]
+     *
      * @see SearchHistory
      */
     // !! When updating this, consider equality in addRecent
+    // TODO: opt-in may no longer be needed in kotlinx-serialization 1.10.0
+    @OptIn(ExperimentalSerializationApi::class)
     @Serializable
     data class SearchHistoryEntry(
         @SerialName("q")
         val query: String,
+        // Use IDs so we can handle a rename.
+        // Tradeoff: a query to get the deck names is needed to produce a search string or display
+        // the selected deck name in the UI
+        @SerialName("did")
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        val deckIds: List<DeckId> = emptyList(),
+        @SerialName("f")
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        val flags: List<Flag> = emptyList(),
+        @SerialName("t")
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        val tags: List<Tag> = emptyList(),
+        @SerialName("ntid")
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        val noteTypes: List<NoteTypeId> = emptyList(),
+        @SerialName("s")
+        @EncodeDefault(EncodeDefault.Mode.NEVER)
+        val cardStates: List<CardState> = emptyList(),
     ) {
+        @Transient
+        private val allFilters = listOf(deckIds, flags, tags, noteTypes, cardStates)
+
         override fun toString() = query
 
         /**
          * Whether there is no set search - effectively a search for the default search:
          * `deck:*`
          */
-        fun isSearchEmpty() = query.isBlank()
+        fun isSearchEmpty() = query.isBlank() && allFilters.all { it.isEmpty() }
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description
In #18709, I want chips. Storing the state of these chips in `SearchHistory` allows a user to click a search history entry and restore their filters, rather than putting a verbose text string into the search field

This PR exists to sync the implementation of 'SearchHistory' with how it evolved in my 'new search view' branch

## Issue
* For #18709

## How Has This Been Tested?
Test only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)