### PR TITLE
fix(deck-selection): use `SelectableDeck.AllDecks`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -486,8 +486,6 @@ open class CardBrowser :
         }
 
         fun onDeckIdChanged(deckId: DeckId?) {
-            if (deckId == null) return
-            // this handles ALL_DECKS_ID
             updateAppBarInfo(deckId)
         }
 
@@ -593,7 +591,7 @@ open class CardBrowser :
         registerReceiver()
 
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
-        updateAppBarInfo(viewModel.deckId ?: ALL_DECKS_ID)
+        updateAppBarInfo(viewModel.deckId)
     }
 
     override fun onKeyUp(
@@ -1336,11 +1334,12 @@ open class CardBrowser :
      * Sets the selected deck name and current selection count based on [numberOfCardsOrNoteShown]
      */
     private fun updateAppBarInfo(deckId: DeckId?) {
-        if (deckId == null || useSearchView) return
+        if (useSearchView) return
         findViewById<TextView>(R.id.subtitle)?.text = numberOfCardsOrNoteShown
         launchCatchingTask {
             val deckName =
                 when (deckId) {
+                    null -> getString(R.string.card_browser_all_decks)
                     ALL_DECKS_ID -> getString(R.string.card_browser_all_decks)
                     else -> withCol { decks.getLegacy(deckId)?.name }
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -328,7 +328,8 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             val isDeckViewable = isViewable(deck)
             holder.itemView.isVisible = isDeckViewable
             if (isDeckViewable) {
-                holder.setDeck(SelectableDeck.Deck(deck.did, deck.fullDeckName))
+                val model = if (deck.did == ALL_DECKS_ID) SelectableDeck.AllDecks else SelectableDeck.Deck(deck.did, deck.fullDeckName)
+                holder.setDeck(model)
             }
             setDeckExpander(holder.expander, holder.indentView, deck)
         }


### PR DESCRIPTION
`setDeck` accepted a proto `deckNode`, which could represent 'AllDecks' But we did not convert back to the correct form, instead producing
 `Deck(0, 'All Decks')`

## How Has This Been Tested?

The two affected screens are the Card Browser and the Add/Remove reminders dialog, both handle this case

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)