### PR TITLE
Cleanup: Fix Android Studio warnings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/SliderPreference.kt
@@ -87,7 +87,7 @@ class SliderPreference(
             if (field == value) {
                 return
             }
-            if (value < valueFrom || value > valueTo) {
+            if (value !in valueFrom..valueTo) {
                 throw IllegalArgumentException("value $value should be between the min of $valueFrom and max of $valueTo")
             }
             field = value

--- a/AnkiDroid/src/main/java/com/ichi2/ui/AxisPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/AxisPicker.kt
@@ -81,7 +81,7 @@ class AxisPicker : ConstraintLayout {
 
         // when adding the first control, we want to make the
         // available axes visible, so the user can see their current values
-        binding.availableAxesContainer.visibility = View.VISIBLE
+        binding.availableAxesContainer.visibility = VISIBLE
         // we also want to hide the TextView, but we can't make it invisible as it's
         // providing our input events. Blanking the text has the same effect
         binding.selectedAxisTextView.text = ""

--- a/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/ui/CheckBoxTriStates.kt
@@ -19,7 +19,6 @@ import android.content.Context
 import android.os.Parcel
 import android.os.Parcelable
 import android.util.AttributeSet
-import android.widget.CompoundButton.OnCheckedChangeListener
 import androidx.appcompat.widget.AppCompatCheckBox
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup

--- a/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/FileUtil.kt
@@ -167,7 +167,7 @@ data class FileNameAndExtension private constructor(
                 null
             } else {
                 FileNameAndExtension(
-                    fileName = fileName.substring(0, index),
+                    fileName = fileName.take(index),
                     extensionWithDot = fileName.substring(index),
                 )
             }

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -278,7 +278,7 @@ object ImportUtils {
                     Timber.d("Filename was longer than %d, shortening", FILE_NAME_SHORTENING_THRESHOLD)
                     // take 90 instead of 100 so we don't get the extension
                     val substringLength = FILE_NAME_SHORTENING_THRESHOLD - 10
-                    val shortenedFileName = encoded.substring(0, substringLength) + "..." + getExtension(fileName)
+                    val shortenedFileName = encoded.take(substringLength) + "..." + getExtension(fileName)
                     Timber.d("Shortened filename '%s' to '%s'", fileName, shortenedFileName)
                     // if we don't decode, % is double-encoded
                     URLDecoder.decode(shortenedFileName, "UTF-8")


### PR DESCRIPTION
## Purpose / Description
Cleanup: Address Android Studio inspection warnings by applying small Kotlin/IDE suggested refactors and removing unused imports.

## Fixes
N/A (no issue number)

## Approach
- Replaced `substring` usage with `take` where appropriate
- Removed redundant qualifiers
- Removed unused imports / minor cleanup

## How Has This Been Tested?
- Built project successfully in Android Studio
- Ran the app configuration: `AnkiDroid` (Sync + Build)

## Learning 
First contribution to AnkiDroid — focusing on small cleanup tasks to get familiar with the codebase and workflow.
