### PR TITLE
style(lint): fix missing space in text concatenation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -173,7 +173,7 @@ class TagsDialog : AnalyticsDialogFragment {
 
     @NeedsTest(
         "In EDIT_TAGS dialog, long-clicking a tag should open the add tag dialog with the clicked tag" +
-            "filled as prefix properly. In other dialog types, long-clicking a tag behaves like a short click.",
+            " filled as prefix properly. In other dialog types, long-clicking a tag behaves like a short click.",
     )
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         binding = DialogTagsBinding.inflate(layoutInflater)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1266,7 +1266,7 @@ class CardContentProvider : ContentProvider() {
         } else {
             Timber.e(
                 "Requested deck with id %d was not found in deck list. Either the deckID provided was wrong" +
-                    "or the deck has been deleted in the meantime.",
+                    " or the deck has been deleted in the meantime.",
                 did,
             )
             false


### PR DESCRIPTION
## Purpose / Description
Cleanup: Address Android Studio inspection warnings by applying small Kotlin/IDE suggested refactors and adding spaces between string concatenations

## Fixes
* Fixes some of #13282 

## Approach
Added space bar to the second string in the concatenated string

## How Has This Been Tested?

Code Cleanup Rebuilt in Android Studio
-> Error Removed

## Learning (optional, can help others)
N/A