### PR TITLE
feat(whiteboard): move "Clear" to menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -349,12 +349,7 @@ class WhiteboardFragment :
             }
         }
 
-        eraserWidthBinding.clearButton.setOnClickListener {
-            viewModel.clearCanvas()
-            eraserPopup?.dismiss()
-        }
-
-        eraserPopup = PopupWindow(eraserWidthBinding.root, 360.dp.toPx(requireContext()), ViewGroup.LayoutParams.WRAP_CONTENT, true)
+        eraserPopup = PopupWindow(eraserWidthBinding.root, 280.dp.toPx(requireContext()), ViewGroup.LayoutParams.WRAP_CONTENT, true)
         eraserPopup?.elevation = 8f
         eraserPopup?.setOnDismissListener {
             binding.whiteboardToolbar.updateSelection(viewModel.activeBrushIndex.value, viewModel.isEraserActive.value)
@@ -390,6 +385,7 @@ class WhiteboardFragment :
             R.id.action_align_left -> viewModel.setToolbarAlignment(ToolbarAlignment.LEFT)
             R.id.action_align_bottom -> viewModel.setToolbarAlignment(ToolbarAlignment.BOTTOM)
             R.id.action_align_right -> viewModel.setToolbarAlignment(ToolbarAlignment.RIGHT)
+            R.id.action_clear -> viewModel.clearCanvas()
             else -> return false
         }
         return true

--- a/AnkiDroid/src/main/res/layout/popup_eraser_options.xml
+++ b/AnkiDroid/src/main/res/layout/popup_eraser_options.xml
@@ -2,23 +2,20 @@
 <com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="360dp"
+    android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     style="@style/CardView.ViewerStyle">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
         android:layout_margin="8dp">
 
         <com.google.android.material.button.MaterialButtonToggleGroup
             android:id="@+id/eraser_mode_toggle_group"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            app:layout_constraintEnd_toStartOf="@id/clear_button"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:selectionRequired="true"
             app:singleSelection="true"
             tools:checkedButton="@id/eraser_mode_ink">
@@ -26,7 +23,7 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/eraser_mode_ink"
                 style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:backgroundTint="@color/selector_tool_background"
@@ -37,7 +34,7 @@
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/eraser_mode_stroke"
                 style="?attr/materialButtonOutlinedStyle"
-                android:layout_width="wrap_content"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:backgroundTint="@color/selector_tool_background"
@@ -46,20 +43,6 @@
                 app:iconGravity="textStart" />
         </com.google.android.material.button.MaterialButtonToggleGroup>
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/clear_button"
-            style="?attr/materialButtonOutlinedStyle"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/whiteboard_clear"
-            android:textColor="?android:textColor"
-            app:icon="@drawable/ic_clear_white"
-            app:iconGravity="textStart"
-            app:iconTint="?attr/colorControlNormal"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
-
-
         <com.google.android.material.slider.Slider
             android:id="@+id/eraser_width_slider"
             android:layout_width="match_parent"
@@ -67,9 +50,8 @@
             android:stepSize="5.0"
             android:valueFrom="5.0"
             android:valueTo="200.0"
-            app:layout_constraintTop_toBottomOf="@id/eraser_mode_toggle_group"
             app:thumbHeight="24dp"
             app:tickVisible="false" />
-    </androidx.constraintlayout.widget.ConstraintLayout>
+    </LinearLayout>
 </com.google.android.material.card.MaterialCardView>
 

--- a/AnkiDroid/src/main/res/menu/whiteboard.xml
+++ b/AnkiDroid/src/main/res/menu/whiteboard.xml
@@ -8,6 +8,12 @@
         app:showAsAction="never"
         />
     <item
+        android:id="@+id/action_clear"
+        android:title="@string/clear_whiteboard"
+        android:icon="@drawable/ic_clear_white"
+        app:showAsAction="never"
+        />
+    <item
         android:id="@+id/action_toggle_stylus"
         android:title="@string/stylus_mode"
         android:checkable="true"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -54,7 +54,6 @@
         >Bottom</string>
     <string name="whiteboard_align_right" comment="Option to align the whiteboard toolbar on the right" maxLength="28"
         >Right</string>
-    <string name="whiteboard_clear" comment="Button text to clear the whiteboard" maxLength="28">Clear</string>
     <string name="whiteboard_more_options" comment="Tooltip of the whiteboard 'More' button" maxLength="28"
         >More options</string>
     <string name="whiteboard_remove_brush_message">Are you sure you want to remove this brush from your palette?</string>


### PR DESCRIPTION
1. it reduces the maximum number of taps for clearing the whiteboard from 3 to 2
2. it doesn't need to change the current tool to the eraser
3. the eraser popup becomes cleaner

## How Has This Been Tested?

Emulator 36

https://github.com/user-attachments/assets/03725ced-9b1c-4597-994b-ee0f14d81c73

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->