### PR TITLE
refactor: remove `merge` from toolbar.xml

### DIFF
--- a/AnkiDroid/src/main/res/layout/toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/toolbar.xml
@@ -1,32 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
-<merge xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<androidx.appcompat.widget.Toolbar
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/toolbar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentTop="true"
+    android:background="?attr/appBarColor"
+    android:minHeight="?attr/actionBarSize"
+    android:theme="@style/ActionBarStyle"
+    app:navigationContentDescription="@string/abc_action_bar_up_description"
+    app:navigationIcon="?attr/homeAsUpIndicator">
 
-    <androidx.appcompat.widget.Toolbar
-        android:id="@+id/toolbar"
+    <com.ichi2.ui.FixedTextView
+        android:id="@+id/toolbar_title"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:textColor="@color/white"
+        android:textSize="20sp"
+        android:visibility="gone" />
+
+    <Spinner
+        android:id="@+id/toolbar_spinner"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentTop="true"
-        android:background="?attr/appBarColor"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="@style/ActionBarStyle"
-        app:navigationContentDescription="@string/abc_action_bar_up_description"
-        app:navigationIcon="?attr/homeAsUpIndicator">
-
-        <com.ichi2.ui.FixedTextView
-            android:id="@+id/toolbar_title"
-            android:layout_width="wrap_content"
-            android:layout_height="match_parent"
-            android:textColor="@color/white"
-            android:textSize="20sp"
-            android:visibility="gone" />
-
-        <Spinner
-            android:id="@+id/toolbar_spinner"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="?attr/selectableItemBackground"
-            android:visibility="gone"
-            app:popupTheme="@style/ActionBar.Popup" />
-    </androidx.appcompat.widget.Toolbar>
-</merge>
+        android:background="?attr/selectableItemBackground"
+        android:visibility="gone"
+        app:popupTheme="@style/ActionBar.Popup" />
+</androidx.appcompat.widget.Toolbar>


### PR DESCRIPTION
It's not needed (we already have a single view as root and we don't append this included layout to a Toolbar view)

It also breaks ViewBinding: "Missing required view with ID: `com.ichi2.anki.debug:id/toolbar`".

## Fixes
* Issue #11116

## How Has This Been Tested?

Tablet emulator (API 33): 

* Reviewer
* Deck Picker
* Note Editor
* Card Browser Appearance
* Info
* Note Field Editor
* Study Options

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)