### PR TITLE
fix(Reviewer): Prevent double auto-advance trigger when answering manually

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -189,6 +189,8 @@ class ReviewerViewModel(
     fun onShowAnswer() {
         Timber.v("ReviewerViewModel::onShowAnswer")
         launchCatchingIO {
+            val wasEnabled = autoAdvance.isEnabled
+            if (wasEnabled) autoAdvance.isEnabled = false
             mutationSignal.await()
 
             val typedAnswerResult = CompletableDeferred<String>()
@@ -204,6 +206,7 @@ class ReviewerViewModel(
             updateNextTimes()
             showAnswer()
             loadAndPlayMedia(CardSide.ANSWER)
+            if (wasEnabled) autoAdvance.isEnabled = true
             if (!autoAdvance.shouldWaitForAudio()) {
                 autoAdvance.onShowAnswer()
             } // else wait for onMediaGroupCompleted


### PR DESCRIPTION
## Purpose / Description
Fixes a race condition in the new study screen where manually answering a card while audio is playing causes the next card to auto-advance immediately.

## Fixes
* Fixes #20242

## Approach
Temporarily disabled `autoAdvance` in `ReviewerViewModel.onShowAnswer()` during the manual transition. This prevents the "audio stopped" event from the previous card from triggering the auto-advance timer for the new card.

## How Has This Been Tested?
Tested manually on an emulator with Auto Advance enabled (5s) and a deck with audio. Confirmed that answering quickly no longer causes double playback or immediate skipping.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)