### PR TITLE
fix: whiteboard clears on next card

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -494,7 +494,7 @@ class ReviewerFragment :
             val whiteboardFragment = childFragmentManager.findFragmentById(binding.whiteboardContainer.id)
             if (whiteboardFragment == null && isEnabled) {
                 childFragmentManager.commit {
-                    add(R.id.whiteboard_container, WhiteboardFragment::class.java, null)
+                    add(R.id.whiteboard_container, WhiteboardFragment::class.java, null, WhiteboardFragment::class.jvmName)
                 }
             }
         }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Whiteboard does not clear automatically on next card
Root cause: the fragment was added with no tag, `findFragmentByTag()` returns null, and `resetCanvas()` is never called

## Fixes
* Fixes #20287

## Approach
added tag name while adding whiteboard fragment

## How Has This Been Tested?
Redmi Note 9 Pro 5G

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)