### PR TITLE
fix: video replay not starting from beginning

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt
@@ -59,6 +59,7 @@ class VideoPlayer(
                        var video = videos[i];
                        if (video.attributes['data-file'].value == "${fileNameToFind.htmlEncode()}") {
                            console.log("playing video: " + video.attributes['data-play'].value);
+                           video.currentTime = 0;
                            video.play();
                            break;
                        }


### PR DESCRIPTION
## Purpose / Description
The "Replay media" action (triggered via the menu or 'R' key) was failing to restart videos from the beginning if they were currently paused. Instead, it would simply resume playback from the paused position. This behavior inconsistent with the expected behavior of a "Replay" command.

## Fixes
* Fixes #18622

## Approach
Updated the JavaScript logic in [VideoPlayer.kt](cci:7://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/cardviewer/VideoPlayer.kt:0:0-0:0). Before calling `video.play()`, the code now explicitly sets `video.currentTime = 0`. This forces the video to rewind to the start every time a replay is requested, regardless of its current state (playing, paused, or stopped).

## How Has This Been Tested?
manually verified on an Android Emulator (Pixel 9a API 35).
Video Proof:

https://github.com/user-attachments/assets/dad169c6-9168-4b3f-83d2-700f44536b33



**Steps to reproduce validation:**
1. Created a card with a video file (`[sound:video.mp4]`).
2. Played the card and paused the video halfway through.
3. Triggered "Replay media" using the menu (3 dots -> Replay media).
4. Confirmed that the video jumped back to `0:00` and started playing, instead of just resuming.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)