### PR TITLE
feat(decks): support spaces in search filters

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckFilters.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckFilters.kt
@@ -1,0 +1,190 @@
+/*
+ *  Copyright (c) 2026 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.deckpicker
+
+import android.annotation.SuppressLint
+import androidx.annotation.VisibleForTesting
+import com.ichi2.anki.common.utils.lastIndexOfOrNull
+import java.util.Locale
+import kotlin.collections.filter
+
+/**
+ * Represents a deck search typed by the user, used to filter a list of decks.
+ *
+ * Here is the list of constraints this search tool satisfies:
+ * * If the user tap a part of a name of a deck, we don't want to show its subdecks, due to constraint in space.
+ *   E.g. if the user tap "Alge", we want to show the deck "Math::Algebra" but not "Math::Algebra::Group". Indeed, if "Algebra" had a dozen subdecks, this would takes the wull screen.
+ *   Instead, if the user search for "group" we let them tap "alge group"
+ * * The list of deck is continuously updated while the user is typing their query.
+ *   E.g. if the user tap "Algebra", then adds one colon "Algebra:" we can't know whether the user wants to search for a subdeck of Algebra or for a deck whose name contains "Algebra:" with a single colon.
+ *   We thus still displays "Algebra:Group" (a deck with no subdeck relation), and "Algebra".
+ *   Once the user tab the second colon, we know the user is searching for a subgroup, and thus we remove "Algebra" and display instead all of its children.
+ * * Apart from that, exact matching is used.
+ *   E.g. "th::Alg" matches against  "Math::Algebra" but not against "Maths::Algebra" nor against "Maths::Abstract::Algebra"
+ * * The filter can contains multiple parts, separated by spaces. In this case, each part must matches against some part of the deck full name, and only one part needs to match against the last name.
+ *   E.g. "math group" matches against "maths::Algebra::group" but not against "math::Algebra::group::Finite" nor against "Math::Algebra".
+ */
+/*
+ * It must be noted that if "Algebra" had no subdeck, then "Algebra:" can't be completed into a filter that would match anything.
+ * So it would make sense to already remove "Math::Algebra" from the list of deck displayed. This is not done because this increase code complexity and
+ * probably does not improve the user experience in any realistic way. As soon as the user tap the next letter in the search bar, "Math::Algebra" deck will disappear from the screen.
+ */
+class DeckFilters
+    @VisibleForTesting
+    constructor(
+        private val filters: List<DeckFilter>,
+    ) {
+        /**
+         * Whether the user is searching something
+         */
+        fun isActive() = filters.isNotEmpty()
+
+        /**
+         * Whether all filter of [filters] appear in [name]
+         */
+        @VisibleForTesting
+        fun deckNamesMatchFilters(name: String) = filters.all { filter -> filter.deckNameMatchesFilter(name) }
+
+        /**
+         * Whether at least one of the filter matches the last name.
+         * @See [DeckFilter.deckLastNameMatchesFilter] to understand the exact meaning
+         */
+        @VisibleForTesting
+        fun deckLastNameMatchesAFilter(name: String) = filters.any { filter -> filter.deckLastNameMatchesFilter(name) }
+
+        /**
+         * Whether the deck with this full name must be kept for the current filter.
+         */
+        @VisibleForTesting
+        fun accept(name: String) =
+            !isActive() ||
+                (
+                    deckLastNameMatchesAFilter(name) &&
+                        deckNamesMatchFilters(name)
+                )
+
+        /**
+         * Represents a single filter
+         * @param filter a trimmed lower case string
+         */
+        class DeckFilter(
+            private val filter: String,
+        ) {
+            /**
+             * Whether there is a single : at the end. This case must be treated specially in order not to remove results from the deck list
+             * while the user starts typing "::subdeckName"
+             */
+            val endsWithSingleColon = filter.endsWith(":") && !filter.endsWith("::")
+
+            /**
+             * The filter without its last ":" if the deck name ends with exactly one ":"
+             */
+            val trimmedFilter = if (endsWithSingleColon) filter.trimEnd(':') else filter
+
+            /**
+             * Whether [filter] appears in [name].
+             */
+            @SuppressLint("LocaleRootUsage")
+            fun deckNameMatchesFilter(name: String) =
+                // If the filter is "foo:", two cases can occur:
+                // Either we actually have a deck with a single colon, "foo:bar" and we want to find it,
+                // or we have a deck "foo" with subdecks "bar" and "plop". We still want to matches against "foo" until
+                // we see whether the first letter of the subdeck searched by the user.
+                name.lowercase(Locale.getDefault()).contains(filter) ||
+                    name.lowercase(Locale.ROOT).contains(filter) ||
+                    name.lowercase(Locale.getDefault()).endsWith(trimmedFilter) ||
+                    name.lowercase(Locale.ROOT).endsWith(trimmedFilter)
+
+            /**
+             * Whether [filter] matches against the last part of [name] specifically.
+             * That is, if [filter] contains :: then the last suffix of the form "::foo", the name of the deck starts with "foo".
+             * Otherwise, the name contains "foo".
+             *
+             * For example, the filter "u" would accept "buz", "foo::buz", but not "buz::foo".
+             * The filters "u:" and "u::" would accept "bu", "foo::bu", but not "bu::foo".
+             * The filter "o::b" would accept "foo::bar", but not "foo" nor "foo::bar::buz".
+             *
+             * For more examples, @see testDeckLastNameMatchesFilter
+             */
+            @VisibleForTesting
+            fun deckLastNameMatchesFilter(name: String): Boolean {
+                // if "::" does not appear in the filter. Then the filter can be anywhere in
+                // the last part of the name
+                val indexOfSeparatorInFilter = filter.lastIndexOfOrNull("::") ?: return deckNameMatchesFilter(name.split("::").last())
+                // if "::" appears in the filter. Then it must be the same as the last "::" in the name.
+                val indexOfSeparatorInName = name.lastIndexOfOrNull("::") ?: return false
+
+                // We use trimmed filter. This way:
+                // * if the filter does not ends with a :, this is similar to the filter
+                // * if the filter ends with a single :, we're actually considering the parent name
+                // the deck list will contains the parent.
+                // * If the filter ends with ::, the last deck of the filter is empty, so this last deck is not considered, instead we just check against second to last deck name
+                return containsAtPosition(
+                    trimmedFilter,
+                    indexOfSeparatorInFilter,
+                    name,
+                    indexOfSeparatorInName,
+                )
+            }
+
+            companion object {
+                /**
+                 * Whether [containing] contains [contained] where the positions matches.
+                 * Position must be less than the length of the string.
+                 */
+                @VisibleForTesting
+                fun containsAtPosition(
+                    contained: String,
+                    positionContained: Int,
+                    containing: String,
+                    positionContaining: Int,
+                ): Boolean {
+                    val startOfContainingInContained = positionContaining - positionContained
+                    val endOfContainingInContained = startOfContainingInContained + contained.length
+                    val substringInContaining: String
+                    try {
+                        substringInContaining =
+                            containing.substring(startOfContainingInContained, endOfContainingInContained)
+                    } catch (_: IndexOutOfBoundsException) {
+                        return false
+                    }
+                    return substringInContaining.equals(contained, ignoreCase = true) ||
+                        substringInContaining.equals(
+                            contained,
+                            ignoreCase = true,
+                        )
+                }
+            }
+        }
+
+        companion object {
+            /**
+             * Returns a [DeckFilters] for the user input [filters]
+             */
+            fun create(filters: CharSequence) =
+                DeckFilters(
+                    filters
+                        .toString()
+                        .lowercase()
+                        .split("\\s+".toRegex())
+                        .map { it.trim() }
+                        .filter {
+                            it.isNotEmpty()
+                        }.map { DeckFilter(it) },
+                )
+        }
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -89,7 +89,7 @@ class DeckPickerViewModel :
         }
 
     /** User filter of the deck list. Shown as a search in the UI */
-    private val flowOfCurrentDeckFilter = MutableStateFlow("")
+    private val flowOfCurrentDeckFilter = MutableStateFlow(DeckFilters.create(""))
 
     /**
      * Keep track of which deck was last given focus in the deck list. If we find that this value
@@ -402,7 +402,7 @@ class DeckPickerViewModel :
 
     fun updateDeckFilter(filterText: String) {
         Timber.d("filter: %s", filterText)
-        flowOfCurrentDeckFilter.value = filterText
+        flowOfCurrentDeckFilter.value = DeckFilters.create(filterText)
     }
 
     fun toggleDeckExpand(deckId: DeckId) =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
@@ -17,12 +17,10 @@
 
 package com.ichi2.anki.deckpicker
 
-import android.annotation.SuppressLint
 import androidx.annotation.VisibleForTesting
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.libanki.utils.append
-import java.util.Locale
 
 /**
  * An immutable variant of a [DeckNode]. Instantiated right before
@@ -79,33 +77,27 @@ data class DisplayDeckNode private constructor(
 /** Convert the tree into a flat list of [DisplayDeckNode]s, where matching decks and the children/parents
  * are included. Decks inside collapsed decks are not considered. */
 fun DeckNode.filterAndFlattenDisplay(
-    filter: CharSequence?,
+    filter: DeckFilters,
     selectedDeckId: DeckId,
 ): List<DisplayDeckNode> {
-    val filterPattern =
-        if (filter.isNullOrBlank()) {
-            null
-        } else {
-            filter.toString().lowercase(Locale.getDefault()).trim()
-        }
     val list = mutableListOf<DisplayDeckNode>()
-    filterAndFlattenDisplayInner(filterPattern, list, parentMatched = false, selectedDeckId)
+    filterAndFlattenDisplayInner(filter, list, parentMatched = false, selectedDeckId)
     return list
 }
 
 private fun DeckNode.filterAndFlattenDisplayInner(
-    filter: CharSequence?,
+    filter: DeckFilters,
     list: MutableList<DisplayDeckNode>,
     parentMatched: Boolean,
     selectedDeckId: DeckId,
 ) {
-    if (!isSyntheticDeck && (nameMatchesFilter((filter)) || parentMatched)) {
+    if (!isSyntheticDeck && (filter.accept(fullDeckName) || parentMatched)) {
         this.addVisibleToList(list, matchesSearchOrChild = true, selectedDeckId)
         return
     }
 
     // When searching, ignore collapsed state and always search children
-    val searching = filter != null
+    val searching = filter.isActive()
     if (collapsed && !searching) {
         return
     }
@@ -151,11 +143,3 @@ fun DeckNode.addVisibleToList(list: MutableList<DeckNode>) {
         }
     }
 }
-
-@SuppressLint("LocaleRootUsage")
-private fun DeckNode.nameMatchesFilter(filter: CharSequence?): Boolean =
-    if (filter == null) {
-        true
-    } else {
-        node.name.lowercase(Locale.getDefault()).contains(filter) || node.name.lowercase(Locale.ROOT).contains(filter)
-    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -44,6 +44,7 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.databinding.DialogDeckPickerBinding
 import com.ichi2.anki.databinding.ItemDeckPickerDialogBinding
+import com.ichi2.anki.deckpicker.DeckFilters
 import com.ichi2.anki.dialogs.DeckSelectionDialog.DecksArrayAdapter.DecksFilter
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
@@ -57,7 +58,6 @@ import com.ichi2.utils.customView
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import timber.log.Timber
-import java.util.Locale
 
 /**
  * "Deck Search": A dialog allowing the user to select a deck from a list of decks.
@@ -398,13 +398,16 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         override fun getFilter(): Filter = DecksFilter()
 
         private inner class DecksFilter : TypedFilter<DeckNode>(allDecksList) {
+            /**
+             * Returns all the deck nodes of [items] that contains every pattern of the constraints.
+             * In the constraints, patterns are separated by any whitespace character.
+             */
             override fun filterResults(
                 constraint: CharSequence,
                 items: List<DeckNode>,
-            ): List<DeckNode> {
-                val filterPattern = constraint.toString().lowercase(Locale.getDefault()).trim()
-                return items.filter {
-                    it.fullDeckName.lowercase(Locale.getDefault()).contains(filterPattern)
+            ) = DeckFilters.create(constraint).let { deckFilters ->
+                items.filter { node ->
+                    deckFilters.accept(node.fullDeckName)
                 }
             }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckFiltersTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/deckpicker/DeckFiltersTest.kt
@@ -1,0 +1,169 @@
+/*
+ *  Copyright (c) 2026 Arthur Milchior <arthur@milchior.fr>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.deckpicker
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.deckpicker.DeckFilters.DeckFilter.Companion.containsAtPosition
+import com.ichi2.testutils.AndroidTest
+import com.ichi2.testutils.EmptyApplication
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class) // This is necessary, android and JVM differ on JSONObject.NULL
+@Config(application = EmptyApplication::class)
+class DeckFiltersTest : AndroidTest {
+    // The lowercase method implementation are sometime buggy for the dotless ı, so we must test them separately.
+    val upperDotlessI = "I"
+    val upperDottedI = "I"
+    val lowerDotlessI = "I"
+    val lowerDottedI = "i"
+
+    @Test
+    fun testIsActive() {
+        assertTrue(filters.isActive())
+        assertFalse(DeckFilters(listOf()).isActive())
+    }
+
+    @Test
+    @Config(qualifiers = "tr")
+    fun testContainsAtPosition() {
+        assertTrue(containsAtPosition("o::ba", 1, "foo::bar", 3))
+        assertTrue(containsAtPosition("o::ba", 1, "foo::ba", 3))
+        assertTrue(containsAtPosition("o::ba", 1, "o::bar", 1))
+        assertTrue(containsAtPosition("o::ba", 1, "o::ba", 1))
+
+        // Wrong position
+        assertFalse(containsAtPosition("o::ba", 1, "foo::bar", 1))
+        assertFalse(containsAtPosition("o::ba", 1, "foo::bar", 5))
+        assertFalse(containsAtPosition("o::ba", 1, "foo::bar", 5))
+
+        // Not enough characters in containing
+        assertFalse(containsAtPosition("o::ba", 1, "foo::", 3))
+        assertFalse(containsAtPosition("o::ba", 1, "::bar", 0))
+
+        // Test for dotless and dotted i.
+        // It seems both letters are considered equal (ignoring case). Which can cause too many results to be displayed, but at least all relevant results are displayed.
+        assertTrue(containsAtPosition(lowerDotlessI, 1, lowerDotlessI, 1))
+        assertTrue(containsAtPosition(lowerDotlessI, 1, upperDotlessI, 1))
+        assertTrue(containsAtPosition(lowerDotlessI, 1, upperDottedI, 1))
+        assertTrue(containsAtPosition(lowerDotlessI, 1, lowerDottedI, 1))
+        assertTrue(containsAtPosition(upperDotlessI, 1, upperDotlessI, 1))
+        assertTrue(containsAtPosition(upperDotlessI, 1, upperDottedI, 1))
+        assertTrue(containsAtPosition(upperDotlessI, 1, lowerDottedI, 1))
+        assertTrue(containsAtPosition(lowerDottedI, 1, upperDottedI, 1))
+        assertTrue(containsAtPosition(lowerDottedI, 1, lowerDottedI, 1))
+        assertTrue(containsAtPosition(upperDottedI, 1, upperDottedI, 1))
+    }
+
+    @Test
+    fun testDeckLastNameMatchesFilter() {
+        val nestedDecksFilter = DeckFilters.DeckFilter("o::ba")
+        assertTrue(nestedDecksFilter.deckLastNameMatchesFilter("foo::bar"))
+        assertFalse(nestedDecksFilter.deckLastNameMatchesFilter("foo::bar::buz"))
+        assertFalse(nestedDecksFilter.deckLastNameMatchesFilter("foo::buz::bar"))
+        assertFalse(nestedDecksFilter.deckLastNameMatchesFilter("foo::b"))
+
+        val singleDeckFilter = DeckFilters.DeckFilter("u")
+        assertFalse(singleDeckFilter.deckLastNameMatchesFilter("foo::bar"))
+        assertTrue(singleDeckFilter.deckLastNameMatchesFilter("foo::bar::buz"))
+        assertFalse(singleDeckFilter.deckLastNameMatchesFilter("foo::bu::bar"))
+        assertFalse(singleDeckFilter.deckLastNameMatchesFilter("foo::b"))
+
+        val partialFilterOne = DeckFilters.DeckFilter("u:")
+        assertFalse(partialFilterOne.deckLastNameMatchesFilter("foo::bar"))
+        // Ideally, this case should be true only if "foo::bar::bu" has a subdeck.
+        // Due to the extra complexity of the implementation, and how little it would improve the user experience,
+        // we decide to assume that all decks potentially have subdecks for this search filtering.
+        assertTrue(partialFilterOne.deckLastNameMatchesFilter("foo::bar::bu"))
+        assertFalse(partialFilterOne.deckLastNameMatchesFilter("foo::bu::bar"))
+        assertFalse(partialFilterOne.deckLastNameMatchesFilter("foo::b"))
+
+        val partialFilterTwo = DeckFilters.DeckFilter("u::")
+        assertFalse(partialFilterTwo.deckLastNameMatchesFilter("foo::bar"))
+        assertFalse(partialFilterTwo.deckLastNameMatchesFilter("foo::bar::bu"))
+        assertTrue(partialFilterTwo.deckLastNameMatchesFilter("foo::bar::bu::plop"))
+    }
+
+    @Test
+    fun testDeckNameMatchesFilter() {
+        val singleDeckFilter = DeckFilters.DeckFilter("u")
+        assertTrue(singleDeckFilter.deckNameMatchesFilter("foo::buz::bar"))
+        assertTrue(singleDeckFilter.deckNameMatchesFilter("auie"))
+        assertFalse(singleDeckFilter.deckNameMatchesFilter("aie"))
+
+        val partialFilterOne = DeckFilters.DeckFilter("u:")
+        assertTrue(partialFilterOne.deckNameMatchesFilter("foo::bu::plop"))
+        assertTrue(partialFilterOne.deckNameMatchesFilter("foo::bu"))
+    }
+
+    val nestedDecksFilter = DeckFilters.DeckFilter("o::ba")
+    val partialFilterTwo = DeckFilters.DeckFilter("u::")
+    val filters = DeckFilters(listOf(DeckFilters.DeckFilter("u"), nestedDecksFilter))
+
+    @Test
+    fun testDeckLastNameMatchesAFilter() {
+        assertTrue(filters.deckLastNameMatchesAFilter("foo::bar"))
+        assertFalse(filters.deckLastNameMatchesAFilter("foo::buz::bar"))
+        assertTrue(filters.deckLastNameMatchesAFilter("foo::bar::buz"))
+        assertTrue(filters.deckLastNameMatchesAFilter("buz::foo::bar"))
+        assertFalse(filters.deckLastNameMatchesAFilter("buz::foo::b"))
+    }
+
+    @Test
+    fun testDeckNamesMatchFilter() {
+        assertFalse(filters.deckNamesMatchFilters("foo::buz::bar"))
+        assertTrue(filters.deckNamesMatchFilters("foo::bar::buz"))
+        assertTrue(filters.deckNamesMatchFilters("buz::foo::bar"))
+        assertFalse(filters.deckNamesMatchFilters("buz::foo::b"))
+        assertFalse(filters.deckNamesMatchFilters("foo::bar::bz"))
+    }
+
+    @Test
+    fun testAccept() {
+        // Accepts exactly decks that either:
+        // * ends with a deck containing "u", and another position contains "o::ba"
+        // * ends with a deck starting with "ba", and second to last decks ends with "o", and some position contains a u
+        assertTrue(DeckFilters(listOf()).accept("foo"))
+        assertTrue(filters.accept("foo::bar::buz"))
+        assertFalse(filters.accept("foo::bar::buz::plop"))
+        assertTrue(filters.accept("buz::foo::bar"))
+        assertTrue(filters.accept("buz::plop::foo::bar"))
+        assertFalse(filters.accept("buz::plop::foo::plop::bar"))
+        assertFalse(filters.accept("buz"))
+
+        // Accepts exactly decks that either:
+        // * ends with a deck ending in "u", and another position contains "o::ba"
+        // * ends with a deck starting with "ba", and second to last decks ends with "o", and some parent deck name ends with a "u"
+        val partialFiltersOne = DeckFilters(listOf(DeckFilters.DeckFilter("u:"), nestedDecksFilter))
+        assertTrue(partialFiltersOne.accept("bu::foo::bar"))
+        assertFalse(partialFiltersOne.accept("buz::foo::bar"))
+        assertTrue(partialFiltersOne.accept("foo::bar::bu"))
+        assertFalse(partialFiltersOne.accept("foo::bar::buz"))
+
+        // Accepts exactly decks that either:
+        // * second to last deck ends with a "u", and another position contains "o::ba"
+        // * ends with a deck starting with "ba", and second to last decks ends with "o", and some parent deck name ends with a "u"
+        val partialFiltersTwo = DeckFilters(listOf(partialFilterTwo, nestedDecksFilter))
+        assertFalse(partialFiltersTwo.accept("foo::bar::bu"))
+        assertFalse(partialFiltersOne.accept("foo::bar::buz"))
+        assertTrue(partialFiltersTwo.accept("foo::bar::bu::plop"))
+        assertTrue(partialFiltersTwo.accept("bu::foo::bar"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
@@ -18,8 +18,10 @@
 package com.ichi2.anki.libanki
 
 import anki.decks.deckTreeNode
+import com.ichi2.anki.deckpicker.DeckFilters
 import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
 import com.ichi2.anki.libanki.sched.DeckNode
+import org.apache.commons.collections4.map.ListOrderedMap
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
@@ -68,7 +70,7 @@ class DeckNodeTest {
         val math = makeNode("Math", 2, 2, collapsed = true, children = listOf(algebra))
         val science = makeNode("Science", 1, 1, children = listOf(math))
 
-        val results = math.filterAndFlatten(null)
+        val results = math.filterAndFlatten("")
         assertEquals(1, results.size)
         assertEquals("Math", results[0].lastDeckNameComponent)
     }
@@ -98,6 +100,31 @@ class DeckNodeTest {
     }
 
     @Test
+    fun `search for deck with correct parent shows appropriate decks`() {
+        // Science::Math::Algebra::Group
+        val analysis = makeNode("Analysis", 4, 4)
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group, analysis))
+        val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = science.filterAndFlatten("th::al")
+        assertEquals(listOf("Science", "Math", "Algebra", "Group", "Analysis"), results.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `search for deck with incorrect parent shows no deck`() {
+        // Science::Math::Algebra::Group
+        val group = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
+        val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
+        val science = makeNode("Science", 1, 1, children = listOf(math))
+
+        val results = science.filterAndFlatten("science::al")
+        assertEquals(listOf<String>(), results.map { it.lastDeckNameComponent })
+    }
+
+    @Test
     fun `search for non-existent path pattern returns no results`() {
         // Science::Math::Algebra::Group
         val group = makeNode("Group", 4, 4)
@@ -105,9 +132,31 @@ class DeckNodeTest {
         val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
         val science = makeNode("Science", 1, 1, children = listOf(math))
 
-        val results = science.filterAndFlatten("th::alg")
+        val results = science.filterAndFlatten("foo")
         assertEquals(emptyList<String>(), results.map { it.lastDeckNameComponent })
+    }
+
+    @Test
+    fun `search for multiple-term`() {
+        // Science::Math::Algebra::Group
+        // Science::Chemistry::Group
+        val mathGroup = makeNode("Group", 4, 4)
+        val algebra = makeNode("Algebra", 3, 3, children = listOf(mathGroup))
+        val math = makeNode("Math", 2, 2, collapsed = false, children = listOf(algebra))
+        val chemistryGroup = makeNode("Group", deckId = 6, level = 3)
+        val chemistry = makeNode("Chemistry", deckId = 7, level = 2, children = listOf(chemistryGroup))
+        val science = makeNode("Science", 1, 1, children = listOf(math, chemistry))
+
+        val results = science.filterAndFlatten("ma gr")
+        // Chemistry::group should not be found
+        assertEquals(listOf<String>("Science", "Math", "Algebra", "Group"), results.map { it.lastDeckNameComponent })
+        val results2 = science.filterAndFlatten("ist gr")
+        // Math::group should not be found
+        assertEquals(listOf<String>("Science", "Chemistry", "Group"), results2.map { it.lastDeckNameComponent })
     }
 }
 
-fun DeckNode.filterAndFlatten(filter: CharSequence?) = this.filterAndFlattenDisplay(filter, selectedDeckId = 1337).map { it.deckNode }
+fun DeckNode.filterAndFlatten(filter: CharSequence) =
+    this.filterAndFlattenDisplay(DeckFilters.create(filter), selectedDeckId = 1337).map {
+        it.deckNode
+    }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/DeckAdapterTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/DeckAdapterTest.kt
@@ -15,21 +15,14 @@
  */
 package com.ichi2.anki.widget
 
-import android.content.Context
-import android.view.ContextThemeWrapper
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.deckpicker.DisplayDeckNode
+import com.ichi2.anki.deckpicker.DeckFilters
 import com.ichi2.anki.deckpicker.filterAndFlattenDisplay
-import com.ichi2.anki.widgets.DeckAdapter
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.shadows.ShadowLooper
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.test.fail
 
 @RunWith(AndroidJUnit4::class)
 class DeckAdapterTest : RobolectricTest() {
@@ -41,7 +34,7 @@ class DeckAdapterTest : RobolectricTest() {
 
         val node =
             col.sched.deckDueTree().filterAndFlattenDisplay(
-                null,
+                DeckFilters.create(""),
                 deck1Id,
             )
 

--- a/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/utils/StringUtils.kt
@@ -74,6 +74,16 @@ fun String.lastIndexOfOrNull(
         else -> index
     }
 
+fun String.lastIndexOfOrNull(
+    s: String,
+    startIndex: Int = lastIndex,
+    ignoreCase: Boolean = false,
+): Int? =
+    when (val index = this.lastIndexOf(s, startIndex, ignoreCase)) {
+        -1 -> null
+        else -> index
+    }
+
 fun emptyStringMutableList(size: Int): MutableList<String> = MutableList(size) { "" }
 
 fun emptyStringArray(size: Int): Array<String> = Array(size) { "" }


### PR DESCRIPTION
Anki deck search features allows to enter multiple part of the filter. For example "math catego" allows to find the deck "category" as a subdeck of "math", and exclude "category" in any deck that don't also contains the word "math".

The same search on ankidroid would only return a deck whose name contains "math catego" literally.

Also, a search for "h::cat" won't show the deck math::category as ankidroid search for the string in the name of the deck not considering the parents.

This commit tries to be as close as possible to anki behaviour. However, anki deck selection uses a submenu that is very different from ankidroid filtering process. So this commit tries to keep the logic of ankidroid filtering process by ensuring that if we search for "math::alge" we still shows "math::algebra" without showing "math::algebra::group" in the deck picker.

A last complexity was that, when the user tap "math:", we don't want to remove the deck "math" from the search result (as it'll reappear as soon as the user has tapped "math::a", since "math" is a parent of "math::algebra" and that we show parents of shown decks). So the search feature considers in this case that "math:" can be either a part of a name of a deck, or that "math" can be the suffix of a deck's parent name.

A bunch of unit tests was added to help understand the behavior of the search feature in mulitple cases.

* Fixes #20306