### PR TITLE
feat: add 'Needs Author Reply' label when CI fails

### DIFF
--- a/.github/workflows/ci_failure_label.yml
+++ b/.github/workflows/ci_failure_label.yml
@@ -1,0 +1,38 @@
+name: Label PR on CI Failure
+
+on:
+  workflow_run:
+    workflows:
+      - Lint
+      - Unit Tests
+      - Emulator Tests
+      - CodeQL
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  label-pr:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get PR number
+        id: pr
+        run: |
+          echo "PR_NUMBER=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
+
+      - name: Add label if CI failed
+        if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.PR_NUMBER }},
+              labels: ['Needs Author Reply']
+            })


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Automatically adds the "Needs Author Reply" label to pull requests when a CI workflow fails, helping maintainers quickly identify PRs that require author action.

## Fixes
* Fixes #20070

## Approach
Triggered via workflow_run on failed CI jobs

## How Has This Been Tested?
Tested via Node Script  test

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)