### PR TITLE
fix: crash when showing snackbar after removing deck in widget config

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -216,7 +216,7 @@ class DeckPickerWidgetConfig :
     }
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
-        anchorView = binding.fabWidgetDeckPicker
+        anchorView = binding.fabWidgetDeckPicker.takeIf { it.isVisible }
     }
 
     /**


### PR DESCRIPTION
## Purpose / Description
The `baseSnackbarBuilder` always anchored the snackbar to the FAB, even when `updateFabVisibility()` had already hidden it. In debug builds this threw `IllegalArgumentException` ("anchorView was notvisible").

## Fixes
* Fixes #20301 

## Approach
Only anchor to the FAB when it is actually visible; otherwise fall back to default positioning.

## How Has This Been Tested?
Tested by adding n number of decks( given n are maximum number of decks present) and adding all of them in the widget, then removing any one.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->