### PR TITLE
Reapply `imeHintLocales` on text change to prevent IME override mid-session.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -20,6 +20,8 @@ import android.content.Intent
 import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
@@ -272,6 +274,31 @@ class ReviewerFragment :
                         if (autoFocusTypeAnswer) {
                             requestFocus()
                         }
+
+                        addTextChangedListener(
+                            object : TextWatcher {
+                                override fun afterTextChanged(s: Editable?) {
+                                    if (s.isNullOrEmpty()) return
+
+                                    val imm = context.getSystemService(InputMethodManager::class.java)
+                                    imm?.restartInput(this@apply)
+                                }
+
+                                override fun beforeTextChanged(
+                                    s: CharSequence?,
+                                    start: Int,
+                                    count: Int,
+                                    after: Int,
+                                ) {}
+
+                                override fun onTextChanged(
+                                    s: CharSequence?,
+                                    start: Int,
+                                    before: Int,
+                                    count: Int,
+                                ) {}
+                            },
+                        )
                     }
                 }
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_When a field has a configured `imeHintLocales`, the IME may override it mid-session after learning from typed characters (e.g., switching from Arabic to English)._
_As a result, the keyboard no longer respects the configured hint for that field._

_This PR ensures that the configured `imeHintLocales` continues to be respected while typing._

## Fixes
* Fixes #19839

## Approach
A `TextWatcher` was added to the type-answer `EditText` in `setupTypeAnswer()`.

Inside `afterTextChanged`, `InputMethodManager.restartInput()` is invoked.
This reinitializes the input connection and causes the IME to re-read the configured `imeHintLocales` on text change.

In testing, this prevents the IME from persisting the overridden language mid-session.

## How Has This Been Tested?

**Test Setup:**

- Android Emulator ( Pixel 6 API 33)
- Gboard

**Steps:**

- Set imeHintLocales of a field to Arabic.
- Start typing in the field (Arabic layout shown).
- Manually switch keyboard to English.
- Type in English.
- Click on 'Back' and come again on 'Front' field.

**Observed:**

- The keyboard automatically switches back to Arabic even though we typed in English earlier.
- No visible flicker.
- No keyboard dismissal.
- No composition reset.
- No typing lag.

Video is attached as evidence.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

https://github.com/user-attachments/assets/c1095519-f7ff-40a9-bf60-2925db35e1be


https://github.com/user-attachments/assets/df4a90a6-109e-4240-a700-e72d616cf2ab


https://github.com/user-attachments/assets/c2da0fb4-85dc-4aea-b157-c6f625cacadc


* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->

https://github.com/user-attachments/assets/519997e3-142b-45db-8a8c-6eef3c1e3782



