### PR TITLE
fix(study-screen): Double back not implemented

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -29,6 +29,7 @@ import android.view.inputmethod.InputMethodManager
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.LinearLayout
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.ActionMenuView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -49,10 +50,12 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import anki.scheduler.CardAnswer.Rating
+import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
+import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.databinding.Reviewer2Binding
@@ -158,9 +161,14 @@ class ReviewerFragment :
         savedInstanceState: Bundle?,
     ) {
         super.onViewCreated(view, savedInstanceState)
-
+        val ankiActivity = requireActivity() as? AnkiActivity
+        val dispatcher = requireActivity().onBackPressedDispatcher
+        val doubleBackCallback = ankiActivity?.exitViaDoubleTapBackCallback()
+        if (doubleBackCallback != null) {
+            dispatcher.addCallback(viewLifecycleOwner, doubleBackCallback)
+        }
         binding.backButton.setOnClickListener {
-            requireActivity().finish()
+            dispatcher.onBackPressed()
         }
 
         setupBindings()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The new study screen had not implemented the press back twice to exit feature that should work when the option is toggled.

## Fixes
* Fixes #20322

## Approach
Used the current approach in AbstractFlashcardViewer.kt, previously we just binded the back button to finishing the activity.

## How Has This Been Tested?
[Screen_recording_20260214_231916.webm](https://github.com/user-attachments/assets/399d6be6-8d2d-47ce-829b-226eef92aa1a)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->