### PR TITLE
feat(reminders): database overhaul

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -154,6 +154,7 @@ import com.ichi2.anki.preferences.AdvancedSettingsFragment
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.receiver.SdCardReceiver
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import com.ichi2.anki.servicelayer.ScopedStorageService
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
@@ -588,6 +589,10 @@ open class DeckPicker :
         shortAnimDuration = resources.getInteger(android.R.integer.config_shortAnimTime)
 
         checkWebviewVersion(this)
+
+        // If a review reminder deserialization error has recently occurred
+        // (ex. on app boot, when the app opened, etc.), inform the user via a dialog
+        ReviewRemindersDatabase.checkDeserializationErrors(this)
 
         setFragmentResultListener(REQUEST_KEY) { _, bundle ->
             when (CustomStudyAction.fromBundle(bundle)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -197,7 +197,7 @@ data class ReviewReminder private constructor(
     val scope: ReviewReminderScope,
     var enabled: Boolean,
     val profileID: String,
-    val onlyNotifyIfNoReviews: Boolean = false,
+    val onlyNotifyIfNoReviews: Boolean,
 ) : Parcelable,
     ReviewReminderSchema {
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminder.kt
@@ -22,6 +22,7 @@ import android.text.format.DateFormat
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.libanki.EpochMilliseconds
 import com.ichi2.anki.settings.Prefs
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
@@ -185,6 +186,9 @@ sealed class ReviewReminderScope : Parcelable {
  * @param enabled Whether the review reminder's notifications are active or disabled.
  * @param profileID ID representing the profile which created this review reminder, as review reminders for
  * multiple profiles might be active simultaneously.
+ * @param latestNotifTime The time at which this review reminder last attempted to fire a routine daily (non-snooze)
+ * notification, in epoch milliseconds, or the time at which it was created if no notification has ever been fired.
+ * See [shouldImmediatelyFire].
  * @param onlyNotifyIfNoReviews If true, only notify the user if this scope has not been reviewed today yet.
  */
 @Serializable
@@ -196,6 +200,7 @@ data class ReviewReminder private constructor(
     val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
     val scope: ReviewReminderScope,
     var enabled: Boolean,
+    var latestNotifTime: EpochMilliseconds,
     val profileID: String,
     val onlyNotifyIfNoReviews: Boolean,
 ) : Parcelable,
@@ -219,9 +224,40 @@ data class ReviewReminder private constructor(
             cardTriggerThreshold,
             scope,
             enabled,
+            latestNotifTime = TimeManager.time.calendar().timeInMillis,
             profileID,
             onlyNotifyIfNoReviews,
         )
+    }
+
+    /**
+     * Updates [latestNotifTime] to the current time.
+     * This should be called whenever this review reminder attempts to fire a routine daily (non-snooze) notification.
+     */
+    fun updateLatestNotifTime() {
+        latestNotifTime = TimeManager.time.calendar().timeInMillis
+    }
+
+    /**
+     * Checks if this review reminder has tried to fire a routine daily (non-snooze) notification in the time between
+     * its latest scheduled firing time and now. If not, this method returns true, indicating that a notification
+     * should be immediately fired for this review reminder.
+     */
+    fun shouldImmediatelyFire(): Boolean {
+        val (hour, minute) = this.time
+
+        val currentTimestamp = TimeManager.time.calendar()
+        val latestScheduledTimestamp = currentTimestamp.clone() as Calendar
+        latestScheduledTimestamp.apply {
+            set(Calendar.HOUR_OF_DAY, hour)
+            set(Calendar.MINUTE, minute)
+            set(Calendar.SECOND, 0)
+            if (after(currentTimestamp)) {
+                add(Calendar.DAY_OF_YEAR, -1)
+            }
+        }
+
+        return latestNotifTime < latestScheduledTimestamp.timeInMillis
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderGroup.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderGroup.kt
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+
+/**
+ * A group of review reminders, all for the same [ReviewReminderScope],
+ * persisted as a single JSON string in SharedPreferences.
+ *
+ * Essentially a wrapper around a HashMap of [ReviewReminderId] to [ReviewReminder],
+ * explicitly defined to restrict what can be done with the interface and to eliminate the
+ * need to verbosely type out "HashMap<ReviewReminderId, ReviewReminder>" everywhere.
+ *
+ * A HashMap is used to allow for O(1) access to individual reminders by [ReviewReminderId].
+ */
+class ReviewReminderGroup(
+    private val underlyingMap: HashMap<ReviewReminderId, ReviewReminder>,
+) {
+    constructor() : this(HashMap())
+
+    constructor(map: Map<ReviewReminderId, ReviewReminder>) : this(HashMap(map))
+
+    /**
+     * Manually construct a [ReviewReminderGroup] from key-value pairs.
+     */
+    constructor(vararg pairs: Pair<ReviewReminderId, ReviewReminder>) : this(
+        buildMap { pairs.forEach { put(it.first, it.second) } },
+    )
+
+    /**
+     * Merge multiple [ReviewReminderGroup]s into one.
+     * [ReviewReminderId] should be unique, so there should be no collisions.
+     */
+    constructor(vararg groups: ReviewReminderGroup) : this(
+        buildMap { groups.forEach { putAll(it.underlyingMap) } },
+    )
+
+    /**
+     * Constructs a [ReviewReminderGroup] from a serialized JSON string.
+     *
+     * @throws SerializationException If the stored string is not a valid JSON string.
+     * @throws IllegalArgumentException If the decoded reminders map is not a HashMap<[ReviewReminderId], [ReviewReminder]>.
+     */
+    constructor(serializedString: String) : this(
+        Json.decodeFromString<HashMap<ReviewReminderId, ReviewReminder>>(serializedString),
+    )
+
+    /**
+     * Serializes this [ReviewReminderGroup] to a JSON string for storage.
+     */
+    fun serializeToString(): String = Json.encodeToString(underlyingMap)
+
+    /**
+     * Merge two [ReviewReminderGroup]s into one.
+     * [ReviewReminderId] should be unique, so there should be no collisions.
+     */
+    operator fun plus(other: ReviewReminderGroup): ReviewReminderGroup = ReviewReminderGroup(underlyingMap + other.underlyingMap)
+
+    operator fun get(id: ReviewReminderId) = underlyingMap[id]
+
+    operator fun set(
+        id: ReviewReminderId,
+        reminder: ReviewReminder,
+    ) {
+        underlyingMap[id] = reminder
+    }
+
+    fun isEmpty(): Boolean = underlyingMap.isEmpty()
+
+    fun remove(id: ReviewReminderId) {
+        underlyingMap.remove(id)
+    }
+
+    fun forEach(action: (ReviewReminderId, ReviewReminder) -> Unit) {
+        underlyingMap.forEach { (id, reminder) -> action(id, reminder) }
+    }
+
+    /**
+     * Get the values of the underlying map, removing the [ReviewReminderId] keys.
+     */
+    fun getRemindersList(): List<ReviewReminder> = underlyingMap.values.toList()
+
+    /**
+     * Toggles whether a [ReviewReminder] is enabled.
+     */
+    fun toggleEnabled(id: ReviewReminderId) {
+        underlyingMap[id]?.apply { enabled = !enabled }
+    }
+
+    override fun equals(other: Any?): Boolean = other is ReviewReminderGroup && other.underlyingMap == this.underlyingMap
+
+    override fun hashCode(): Int = underlyingMap.hashCode()
+}
+
+/**
+ * Convenience extension constructor for merging a list of [ReviewReminderGroup]s into one.
+ */
+fun List<ReviewReminderGroup>.mergeAll() = ReviewReminderGroup(*this.toTypedArray())
+
+/**
+ * Convenience typealias for the mutation functions passed to editors of [ReviewReminderGroup].
+ */
+typealias ReviewReminderGroupEditor = (ReviewReminderGroup) -> ReviewReminderGroup

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderSchema.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderSchema.kt
@@ -77,6 +77,31 @@ data class ReviewReminderSchemaV1(
     val onlyNotifyIfNoReviews: Boolean = false,
 ) : ReviewReminderSchema {
     override fun migrate(): ReviewReminderSchema =
+        ReviewReminderSchemaV2(
+            id = id,
+            time = time,
+            cardTriggerThreshold = cardTriggerThreshold,
+            scope = scope,
+            enabled = enabled,
+            profileID = profileID,
+            onlyNotifyIfNoReviews = onlyNotifyIfNoReviews,
+        )
+}
+
+/**
+ * Version 2 of [ReviewReminderSchema]. Updated to Version 3 by adding [ReviewReminder.latestNotifTime].
+ */
+@Serializable
+data class ReviewReminderSchemaV2(
+    override val id: ReviewReminderId,
+    val time: ReviewReminderTime,
+    val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
+    val scope: ReviewReminderScope,
+    var enabled: Boolean,
+    val profileID: String,
+    val onlyNotifyIfNoReviews: Boolean,
+) : ReviewReminderSchema {
+    override fun migrate(): ReviewReminderSchema =
         ReviewReminder.createReviewReminder(
             time = time,
             cardTriggerThreshold = cardTriggerThreshold,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderSchema.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewReminderSchema.kt
@@ -1,0 +1,159 @@
+/*
+ *  Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.reviewreminders
+
+import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase.StoredReviewReminderGroup
+import kotlinx.serialization.Serializable
+
+/**
+ * Inline value class for review reminder schema versions.
+ * @see [StoredReviewReminderGroup]
+ * @see [ReviewReminder]
+ */
+@JvmInline
+@Serializable
+value class ReviewReminderSchemaVersion(
+    val value: Int,
+) {
+    init {
+        require(value >= 1) { "Review reminder schema version must be >= 1" }
+        // We do not check that it is <= SCHEMA_VERSION here because then declaring SCHEMA_VERSION would be circular
+    }
+}
+
+/**
+ * When [ReviewReminder] is updated by a developer, implement this interface in a new data class which
+ * has the same fields as the old version of [ReviewReminder], then implement the [migrate] method which
+ * transforms old [ReviewReminder]s to new [ReviewReminder]s. Also ensure that the previous [ReviewReminderSchema]
+ * in the migration version chain ([ReviewRemindersDatabase.oldReviewReminderSchemasForMigration]) has its [migrate] method
+ * edited to return instances of the newly-created [ReviewReminderSchema]. Then, increment [ReviewRemindersDatabase.schemaVersion].
+ *
+ * Data classes implementing this interface should be marked as @Serializable. Any new types defined for ReviewReminderSchemas
+ * should also be marked as @Serializable.
+ *
+ * @see [ReviewRemindersDatabase.performSchemaMigration].
+ * @see [ReviewReminder]
+ */
+@Serializable
+sealed interface ReviewReminderSchema {
+    /**
+     * All review reminders must have an identifying ID.
+     * This is necessary to facilitate migrations. See the implementation of [ReviewRemindersDatabase.performSchemaMigration] for details.
+     */
+    val id: ReviewReminderId
+
+    /**
+     * Transforms this [ReviewReminderSchema] to the next version of the [ReviewReminderSchema].
+     */
+    fun migrate(): ReviewReminderSchema
+}
+
+/**
+ * Version 1 of [ReviewReminderSchema]. Updated to Version 2 by adding [ReviewReminder.onlyNotifyIfNoReviews].
+ */
+@Serializable
+data class ReviewReminderSchemaV1(
+    override val id: ReviewReminderId,
+    val time: ReviewReminderTime,
+    val cardTriggerThreshold: ReviewReminderCardTriggerThreshold,
+    val scope: ReviewReminderScope,
+    var enabled: Boolean,
+    val profileID: String,
+    val onlyNotifyIfNoReviews: Boolean = false,
+) : ReviewReminderSchema {
+    override fun migrate(): ReviewReminderSchema =
+        ReviewReminder.createReviewReminder(
+            time = time,
+            cardTriggerThreshold = cardTriggerThreshold,
+            scope = scope,
+            enabled = enabled,
+            profileID = profileID,
+            onlyNotifyIfNoReviews = onlyNotifyIfNoReviews,
+        )
+}
+
+/**
+ * Schema migration settings for testing purposes.
+ * Consult this as an example of how to save old schemas and define their [ReviewReminderSchema.migrate] methods.
+ */
+object TestingReviewReminderMigrationSettings {
+    /**
+     * A sample old review reminder schema. Perhaps this was how the [ReviewReminder] data class was originally implemented.
+     * We would like to test the code that checks if review reminders stored on the device adhere to an old, outdated schema.
+     * In particular, does the code correctly migrate the serialized data class strings to the updated, current version of [ReviewReminder]?
+     */
+    @Serializable
+    data class ReviewReminderTestSchemaVersionOne(
+        override val id: ReviewReminderId,
+        val hour: Int,
+        val minute: Int,
+        val cardTriggerThreshold: Int,
+        val did: DeckId,
+        val enabled: Boolean = true,
+    ) : ReviewReminderSchema {
+        override fun migrate(): ReviewReminderSchema =
+            ReviewReminderTestSchemaVersionTwo(
+                id = this.id,
+                time = VersionTwoDataClasses.ReviewReminderTime(hour, minute),
+                snoozeAmount = 1,
+                cardTriggerThreshold = this.cardTriggerThreshold,
+                did = this.did,
+                enabled = enabled,
+            )
+    }
+
+    /**
+     * Here's an example of how you can handle renamed fields in a data class stored as part of a [ReviewReminder].
+     * Otherwise, there's a namespace collision with [ReviewReminderTime].
+     *
+     * This class will be serialized into "ReviewReminderTime(timeHour=#, timeMinute=#)", which otherwise might conflict
+     * with the updated definition of [ReviewReminderTime], which is serialized as "ReviewReminderTime(hour=#, minute=#)".
+     * When we read the outdated schema from the disk, we need to tell the deserializer that it is reading a
+     * [VersionTwoDataClasses.ReviewReminderTime] rather than a [ReviewReminderTime], even though the names are the same.
+     *
+     * @see ReviewReminderTestSchemaVersionTwo
+     */
+    object VersionTwoDataClasses {
+        @Serializable
+        data class ReviewReminderTime(
+            val timeHour: Int,
+            val timeMinute: Int,
+        )
+    }
+
+    /**
+     * Another example of an old review reminder schema. See [ReviewReminderTestSchemaVersionOne] for more details.
+     */
+    @Serializable
+    data class ReviewReminderTestSchemaVersionTwo(
+        override val id: ReviewReminderId,
+        val time: VersionTwoDataClasses.ReviewReminderTime,
+        val snoozeAmount: Int,
+        val cardTriggerThreshold: Int,
+        val did: DeckId,
+        val enabled: Boolean = true,
+    ) : ReviewReminderSchema {
+        override fun migrate(): ReviewReminder =
+            ReviewReminder.createReviewReminder(
+                time = ReviewReminderTime(this.time.timeHour, this.time.timeMinute),
+                cardTriggerThreshold = ReviewReminderCardTriggerThreshold(this.cardTriggerThreshold),
+                scope = if (this.did == -1L) ReviewReminderScope.Global else ReviewReminderScope.DeckSpecific(this.did),
+                enabled = enabled,
+            )
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -374,3 +374,38 @@ object ReviewRemindersDatabase {
         }
     }
 }
+
+/**
+ * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
+ * [ReviewRemindersDatabase.editAllAppWideReminders] which deletes the given review reminder.
+ */
+fun deleteReminder(reminder: ReviewReminder) =
+    { reminders: ReviewReminderGroup ->
+        reminders.apply {
+            remove(reminder.id)
+        }
+    }
+
+/**
+ * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
+ * [ReviewRemindersDatabase.editAllAppWideReminders] which updates the given review reminder if it
+ * exists or inserts it if it doesn't (an "upsert" operation)
+ */
+fun upsertReminder(reminder: ReviewReminder) =
+    { reminders: ReviewReminderGroup ->
+        reminders.apply {
+            this[reminder.id] = reminder
+        }
+    }
+
+/**
+ * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
+ * [ReviewRemindersDatabase.editAllAppWideReminders] which toggles whether the given review reminder
+ * is enabled.
+ */
+fun toggleReminder(reminder: ReviewReminder) =
+    { reminders: ReviewReminderGroup ->
+        reminders.apply {
+            toggleEnabled(reminder.id)
+        }
+    }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabase.kt
@@ -107,12 +107,13 @@ object ReviewRemindersDatabase {
      *
      * Version 1: 3 August 2025 - Initial version
      * Version 2: 25 January 2026 - Added [ReviewReminder.onlyNotifyIfNoReviews]
+     * Version 3: 8 February 2026 - Added [ReviewReminder.latestNotifTime]
      *
      * @see [oldReviewReminderSchemasForMigration]
      * @see [ReviewReminder]
      */
     @VisibleForTesting
-    var schemaVersion = ReviewReminderSchemaVersion(2)
+    var schemaVersion = ReviewReminderSchemaVersion(3)
 
     /**
      * A map of all old [ReviewReminderSchema]s that [ReviewRemindersDatabase.performSchemaMigration] will attempt to migrate old
@@ -130,7 +131,8 @@ object ReviewRemindersDatabase {
     var oldReviewReminderSchemasForMigration: Map<ReviewReminderSchemaVersion, KClass<out ReviewReminderSchema>> =
         mapOf(
             ReviewReminderSchemaVersion(1) to ReviewReminderSchemaV1::class,
-            ReviewReminderSchemaVersion(2) to ReviewReminder::class, // Most up to date version
+            ReviewReminderSchemaVersion(2) to ReviewReminderSchemaV2::class,
+            ReviewReminderSchemaVersion(3) to ReviewReminder::class, // Most up to date version
         )
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -260,41 +260,6 @@ class ScheduleReminders :
     }
 
     /**
-     * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
-     * [ReviewRemindersDatabase.editAllAppWideReminders] which deletes the given review reminder.
-     */
-    private fun deleteReminder(reminder: ReviewReminder) =
-        { reminders: ReviewReminderGroup ->
-            reminders.apply {
-                remove(reminder.id)
-            }
-        }
-
-    /**
-     * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
-     * [ReviewRemindersDatabase.editAllAppWideReminders] which updates the given review reminder if it
-     * exists or inserts it if it doesn't (an "upsert" operation)
-     */
-    private fun upsertReminder(reminder: ReviewReminder) =
-        { reminders: ReviewReminderGroup ->
-            reminders.apply {
-                this[reminder.id] = reminder
-            }
-        }
-
-    /**
-     * Lambda that can be fed into [ReviewRemindersDatabase.editRemindersForDeck] or
-     * [ReviewRemindersDatabase.editAllAppWideReminders] which toggles whether the given review reminder
-     * is enabled.
-     */
-    private fun toggleReminder(reminder: ReviewReminder) =
-        { reminders: ReviewReminderGroup ->
-            reminders.apply {
-                toggleEnabled(reminder.id)
-            }
-        }
-
-    /**
      * Update the RecyclerView with the new or modified reminder.
      * @see handleAddEditDialogResult
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -224,7 +224,7 @@ class AlarmManagerService : BroadcastReceiver() {
             Timber.d("scheduleAllEnabledReviewReminderNotifications")
             val allReviewRemindersAsMap =
                 ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()
-            val enabledReviewReminders = allReviewRemindersAsMap.values.filter { it.enabled }
+            val enabledReviewReminders = allReviewRemindersAsMap.getRemindersList().filter { it.enabled }
             for (reviewReminder in enabledReviewReminders) {
                 scheduleReviewReminderNotification(context, reviewReminder)
             }
@@ -277,6 +277,7 @@ class AlarmManagerService : BroadcastReceiver() {
          * To extend the notifications created by AnkiDroid, add more functionality to the body of this method.
          */
         fun scheduleAllNotifications(context: Context) {
+            // currently, the only scheduled notifications supported by AnkiDroid are review reminder notifications
             scheduleAllEnabledReviewReminderNotifications(context)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -296,6 +296,14 @@ open class PrefsRepository(
      */
     var reminderNotifsRequestShown by booleanPref(R.string.reminder_notifs_request_shown_key, defaultValue = false)
 
+    /**
+     * A list of all recent deserialization errors that have occurred when trying to load review reminders from storage.
+     * For example, review reminders are deserialized and have their alarms scheduled when the device starts, but
+     * if the deserialization process fails and no valid migrations are available, the error can be put into this string
+     * so that the next time the user opens the app, an error dialog can be shown to inform them of the issue.
+     */
+    var reviewReminderDeserializationErrors by stringPref(R.string.review_reminder_deserialization_errors_key)
+
     // *************************************** Permissions ************************************** //
 
     // Flags for whether the system UI dialog for requesting certain permissions has been shown before.

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -217,6 +217,7 @@
     <string name="pref_review_reminders_screen_key">reviewRemindersScreen</string>
     <string name="review_reminders_next_free_id">reviewRemindersNextFreeId</string>
     <string name="reminder_notifs_request_shown_key">reminderNotifsRequestShown</string>
+    <string name="review_reminder_deserialization_errors_key">reviewReminderDeserializationErrors</string>
     <!-- Notifications -->
     <string name="notifications_permission_requested_key">notificationsPermissionRequested</string>
     <string name="record_audio_permission_requested_key">recordAudioPermissionRequested</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewReminderTest.kt
@@ -19,24 +19,52 @@ package com.ichi2.anki.reviewreminders
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.time.MockTime
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.settings.Prefs
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.Calendar
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 class ReviewReminderTest : RobolectricTest() {
+    companion object {
+        /**
+         * A mock time for a consistent date and a specific time: noon in the local time zone (not UTC! this is required because
+         * the subject-under-test calculates times based on the local time zone, hence the convoluted construction of this mock).
+         */
+        private val mockTime =
+            MockTime(
+                initTime =
+                    MockTime(2024, 0, 1, 0, 0, 0, 0, 0)
+                        .calendar()
+                        .apply {
+                            set(Calendar.HOUR_OF_DAY, 12)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0)
+                        }.timeInMillis,
+                step = 1000,
+            )
+    }
+
     @Before
     override fun setUp() {
         super.setUp()
+        Prefs.reviewReminderNextFreeId = 0
         ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
+        Prefs.reviewReminderNextFreeId = 0
         ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
 
@@ -46,5 +74,136 @@ class ReviewReminderTest : RobolectricTest() {
             val reminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(hour = i, minute = i))
             assertThat(reminder.id, equalTo(ReviewReminderId(i)))
         }
+    }
+
+    @Test
+    fun `latestNotifTime is set at creation`() {
+        val timeBeforeCreation = TimeManager.time.calendar().timeInMillis
+        val reviewReminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(hour = 1, minute = 0))
+        val timeAfterCreation = TimeManager.time.calendar().timeInMillis
+
+        assertThat(reviewReminder.latestNotifTime in timeBeforeCreation..timeAfterCreation, equalTo(true))
+    }
+
+    @Test
+    fun `updateLatestNotifTime works correctly`() {
+        val reviewReminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(hour = 1, minute = 0))
+
+        val timeBeforeUpdate = TimeManager.time.calendar().timeInMillis
+        reviewReminder.updateLatestNotifTime()
+        val timeAfterUpdate = TimeManager.time.calendar().timeInMillis
+
+        assertThat(reviewReminder.latestNotifTime in timeBeforeUpdate..timeAfterUpdate, equalTo(true))
+    }
+
+    @Test
+    fun `notification should immediately fire if there was no scheduled firing`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 6.hours.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = (-1).minutes.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = true,
+        )
+    }
+
+    @Test
+    fun `notification should not immediately fire if there was a scheduled firing`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 6.hours.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = 1.minutes.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = false,
+        )
+    }
+
+    @Test
+    fun `notification should immediately fire if scheduled firing time is recent and there was no scheduled firing`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 2.minutes.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = (-1).minutes.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = true,
+        )
+    }
+
+    @Test
+    fun `notification should not immediately fire if scheduled firing time is recent and there was a scheduled firing`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 1.minutes.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = 0,
+            shouldImmediatelyFire = false,
+        )
+    }
+
+    @Test
+    fun `notification should immediately fire if latest firing was a long time ago`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 0,
+            lastFiringOffsetFromWindowStartMs = (-2).days.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = true,
+        )
+    }
+
+    @Test
+    fun `notification should immediately fire even if next window is approaching if there was no scheduled firing`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = (-1).minutes.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = (-25).hours.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = true,
+        )
+    }
+
+    @Test
+    fun `notification should not immediately fire if scheduled firing was just late`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 23.hours.inWholeMilliseconds.toInt(),
+            lastFiringOffsetFromWindowStartMs = 22.hours.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = false,
+        )
+    }
+
+    @Test
+    fun `notification should immediately fire if scheduled firing is now and latest firing was in the past`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 0,
+            lastFiringOffsetFromWindowStartMs = (-1).minutes.inWholeMilliseconds.toInt(),
+            shouldImmediatelyFire = true,
+        )
+    }
+
+    @Test
+    fun `notification should not immediately fire if scheduled firing is now and latest firing was just now`() {
+        shouldImmediatelyFireTest(
+            currentTimeOffsetFromWindowStartMs = 0,
+            lastFiringOffsetFromWindowStartMs = 0,
+            shouldImmediatelyFire = false,
+        )
+    }
+
+    private fun shouldImmediatelyFireTest(
+        currentTimeOffsetFromWindowStartMs: Int,
+        lastFiringOffsetFromWindowStartMs: Int,
+        shouldImmediatelyFire: Boolean,
+    ) {
+        val reviewReminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(hour = 1, minute = 0))
+
+        val currentTime = mockTime.calendar().clone() as Calendar
+        currentTime.apply {
+            set(Calendar.HOUR_OF_DAY, 1)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            add(Calendar.MILLISECOND, currentTimeOffsetFromWindowStartMs)
+        }
+        TimeManager.resetWith(MockTime(currentTime.timeInMillis, step = 1000))
+
+        val lastFiring = mockTime.calendar().clone() as Calendar
+        lastFiring.apply {
+            set(Calendar.HOUR_OF_DAY, 1)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            add(Calendar.MILLISECOND, lastFiringOffsetFromWindowStartMs)
+        }
+        reviewReminder.latestNotifTime = lastFiring.timeInMillis
+
+        assertThat(reviewReminder.shouldImmediatelyFire(), equalTo(shouldImmediatelyFire))
+
+        TimeManager.reset()
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewreminders/ReviewRemindersDatabaseTest.kt
@@ -19,11 +19,12 @@ package com.ichi2.anki.reviewreminders
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.libanki.DeckId
-import kotlinx.serialization.Serializable
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.Json
-import org.hamcrest.CoreMatchers
+import kotlinx.serialization.serializer
 import org.hamcrest.Description
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
@@ -37,77 +38,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.reflect.full.memberProperties
-
-/**
- * Schema migration settings for testing purposes.
- * Consult this as an example of how to save old schemas and define their [ReviewReminderSchema.migrate] methods.
- */
-object TestingReviewReminderMigrationSettings {
-    /**
-     * A sample old review reminder schema. Perhaps this was how the [ReviewReminder] data class was originally implemented.
-     * We would like to test the code that checks if review reminders stored on the device adhere to an old, outdated schema.
-     * In particular, does the code correctly migrate the serialized data class strings to the updated, current version of [ReviewReminder]?
-     */
-    @Serializable
-    data class ReviewReminderSchemaVersionOne(
-        override val id: ReviewReminderId,
-        val hour: Int,
-        val minute: Int,
-        val cardTriggerThreshold: Int,
-        val did: DeckId,
-        val enabled: Boolean = true,
-    ) : ReviewReminderSchema {
-        override fun migrate(): ReviewReminderSchema =
-            ReviewReminderSchemaVersionTwo(
-                id = this.id,
-                time = VersionTwoDataClasses.ReviewReminderTime(hour, minute),
-                snoozeAmount = 1,
-                cardTriggerThreshold = this.cardTriggerThreshold,
-                did = this.did,
-                enabled = enabled,
-            )
-    }
-
-    /**
-     * Here's an example of how you can handle renamed fields in a data class stored as part of a [ReviewReminder].
-     * Otherwise, there's a namespace collision with [ReviewReminderTime].
-     *
-     * This class will be serialized into "ReviewReminderTime(timeHour=#, timeMinute=#)", which otherwise might conflict
-     * with the updated definition of [ReviewReminderTime], which is serialized as "ReviewReminderTime(hour=#, minute=#)".
-     * When we read the outdated schema from the disk, we need to tell the deserializer that it is reading a
-     * [VersionTwoDataClasses.ReviewReminderTime] rather than a [ReviewReminderTime], even though the names are the same.
-     *
-     * @see ReviewReminderSchemaVersionTwo
-     */
-    object VersionTwoDataClasses {
-        @Serializable
-        data class ReviewReminderTime(
-            val timeHour: Int,
-            val timeMinute: Int,
-        )
-    }
-
-    /**
-     * Another example of an old review reminder schema. See [ReviewReminderSchemaVersionOne] for more details.
-     */
-    @Serializable
-    data class ReviewReminderSchemaVersionTwo(
-        override val id: ReviewReminderId,
-        val time: VersionTwoDataClasses.ReviewReminderTime,
-        val snoozeAmount: Int,
-        val cardTriggerThreshold: Int,
-        val did: DeckId,
-        val enabled: Boolean = true,
-    ) : ReviewReminderSchema {
-        override fun migrate(): ReviewReminder =
-            ReviewReminder.createReviewReminder(
-                time = ReviewReminderTime(this.time.timeHour, this.time.timeMinute),
-                cardTriggerThreshold = ReviewReminderCardTriggerThreshold(this.cardTriggerThreshold),
-                scope = if (this.did == -1L) ReviewReminderScope.Global else ReviewReminderScope.DeckSpecific(this.did),
-                enabled = enabled,
-            )
-    }
-}
 
 /**
  * If tests in this file have failed, it may be because you have updated [ReviewReminder]!
@@ -370,18 +300,22 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
 
     /**
      * If this test has failed, please ensure the review reminder schema version and old schemas in the review reminder
-     * migration chain are set correctly.
+     * migration chain are set correctly. If you've written a new migration, please also write a new test in this file
+     * to prove your migration works!
+     *
+     * This test is designed to fail and be updated every time the schema is changed
+     * to ensure developers know what they are doing and to remind them to write migration tests.
      */
     @Test
     fun `current schema version points to ReviewReminder`() {
-        assertThat(ReviewRemindersDatabase.schemaVersion.value, equalTo(1))
+        assertThat(ReviewRemindersDatabase.schemaVersion.value, equalTo(2))
         assertThat(
             ReviewRemindersDatabase
                 .oldReviewReminderSchemasForMigration
                 .keys
                 .last()
                 .value,
-            equalTo(1),
+            equalTo(2),
         )
         assertThat(
             ReviewRemindersDatabase
@@ -389,6 +323,150 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
                 .values
                 .last(),
             equalTo(ReviewReminder::class),
+        )
+    }
+
+    /**
+     * If this test has failed, you have likely updated [ReviewReminder] without writing a migration!
+     * Please write a migration (see [ReviewReminder] and the tests in this file for more information),
+     * update the latest schema version (see [ReviewRemindersDatabase]), add a new test in this file
+     * to prove your migration works, and update this test to the new latest schema version.
+     *
+     * To get a raw string, add a log to [ReviewRemindersDatabase.decodeJson] to print out its input string.
+     *
+     * This test is designed to fail and be updated every time the schema is changed
+     * to ensure developers know what they are doing and to remind them to write migration tests.
+     */
+    @Test
+    fun `raw ReviewReminder string can be deserialized without throwing`() {
+        val rawString =
+            """
+            {
+              "version":2,
+              "remindersMapJson":"{\"0\":{\"id\":0,\"time\":{\"hour\":9,\"minute\":0},\"cardTriggerThreshold\":5,\"scope\":{\"type\":\"com.ichi2.anki.reviewreminders.ReviewReminderScope.DeckSpecific\",\"did\":12345},\"enabled\":false,\"profileID\":\"\",\"onlyNotifyIfNoReviews\":false},\"1\":{\"id\":1,\"time\":{\"hour\":10,\"minute\":30},\"cardTriggerThreshold\":10,\"scope\":{\"type\":\"com.ichi2.anki.reviewreminders.ReviewReminderScope.DeckSpecific\",\"did\":12345},\"enabled\":true,\"profileID\":\"\",\"onlyNotifyIfNoReviews\":false}}"
+            }
+            """.trimIndent()
+
+        val storedReviewRemindersMap = Json.decodeFromString<ReviewRemindersDatabase.StoredReviewRemindersMap>(rawString)
+        val mapSerializer = MapSerializer(ReviewReminderId.serializer(), ReviewReminder.serializer())
+        Json.decodeFromString(mapSerializer, storedReviewRemindersMap.remindersMapJson)
+    }
+
+    /**
+     * If this test has failed, you have likely updated [ReviewReminder]'s schema! Please ensure you've written
+     * a migration for this schema change (see [ReviewReminder]) and write a test in this file to prove your migration works.
+     *
+     * This test is designed to fail and be updated every time the schema is changed
+     * to ensure developers know what they are doing and to remind them to write migration tests.
+     */
+    @Test
+    fun `ReviewReminder properties and types are the expected values`() {
+        val expectedPropertiesWithTypes =
+            mapOf(
+                "id" to ReviewReminderId::class,
+                "time" to ReviewReminderTime::class,
+                "cardTriggerThreshold" to ReviewReminderCardTriggerThreshold::class,
+                "scope" to ReviewReminderScope::class,
+                "enabled" to Boolean::class,
+                "profileID" to String::class,
+                "onlyNotifyIfNoReviews" to Boolean::class,
+            )
+
+        val actualPropertiesWithTypes =
+            ReviewReminder::class
+                .memberProperties
+                .associate { it.name to it.returnType.classifier }
+
+        assertThat(actualPropertiesWithTypes, equalTo(expectedPropertiesWithTypes))
+    }
+
+    /**
+     * A single test case for migration testing.
+     * @see assertMigrationsWork
+     */
+    private data class MigrationTestCase(
+        val inputVersion: ReviewReminderSchemaVersion,
+        val input: ReviewReminderSchema,
+        val expectedOutput: ReviewReminder,
+    )
+
+    /**
+     * Helper function for performing migrations and asserting they work as expected.
+     *
+     * In order to create a unified helper function for doing this which can accept arbitrary subclasses
+     * of [ReviewReminderSchema] and get their serializers at runtime, we need to opt into
+     * the internal serialization API. Since this is a test-only function, this should be acceptable.
+     */
+    @OptIn(InternalSerializationApi::class)
+    private fun assertMigrationsWork(vararg testCases: MigrationTestCase) {
+        // Group
+        val groupedByScope =
+            testCases.groupBy {
+                when (val scope = it.expectedOutput.scope) {
+                    is ReviewReminderScope.DeckSpecific -> scope.did
+                    is ReviewReminderScope.Global -> null
+                }
+            }
+
+        // Write
+        groupedByScope.forEach { (did, casesInScope) ->
+            // Reading and writing is done per scope, so all test cases in a scope will have the same input version
+            if (casesInScope.map { it.inputVersion }.toSet().size != 1) {
+                throw IllegalArgumentException("All test cases in a scope must have the same input version and type")
+            }
+            val version = casesInScope.first().inputVersion
+            val inputType = ReviewRemindersDatabase.oldReviewReminderSchemasForMigration[version]!!
+
+            // We need an unchecked runtime cast to allow this helper to operate on arbitrary subclasses of ReviewReminderSchema
+            @Suppress("UNCHECKED_CAST")
+            val inputSerializer = inputType.serializer() as KSerializer<Any>
+            val mapSerializer = MapSerializer(ReviewReminderId.serializer(), inputSerializer)
+
+            val inputMap = casesInScope.associate { it.input.id to it.input }
+            val packagedInput =
+                ReviewRemindersDatabase.StoredReviewRemindersMap(
+                    version,
+                    Json.encodeToString(mapSerializer, inputMap),
+                )
+
+            val key =
+                if (did != null) {
+                    ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did
+                } else {
+                    ReviewRemindersDatabase.APP_WIDE_KEY
+                }
+            ReviewRemindersDatabase.remindersSharedPrefs.edit(commit = true) {
+                putString(key, Json.encodeToString(packagedInput))
+            }
+        }
+
+        // Read and assert
+        groupedByScope.forEach { (did, casesInScope) ->
+            val retrievedReminders =
+                if (did != null) {
+                    ReviewRemindersDatabase.getRemindersForDeck(did)
+                } else {
+                    ReviewRemindersDatabase.getAllAppWideReminders()
+                }
+
+            // We ignore ID because the migration process will generate new review reminders from scratch during the migration
+            // ID is a private, inaccessible property
+            // Instead, we only check that the ID matches the key in the map; all other properties can be compared normally
+            retrievedReminders.forEach { (id, reminder) ->
+                assertThat(id, equalTo(reminder.id))
+            }
+            assertThat(
+                retrievedReminders.values,
+                containsEqualReviewRemindersInAnyOrderIgnoringId(
+                    casesInScope.map { it.expectedOutput },
+                ),
+            )
+        }
+
+        // Shared Preferences should not contain any random corrupted keys after or due to the migration process
+        assertThat(
+            ReviewRemindersDatabase.remindersSharedPrefs.all.size,
+            equalTo(groupedByScope.size),
         )
     }
 
@@ -401,128 +479,142 @@ class ReviewRemindersDatabaseTest : RobolectricTest() {
         ReviewRemindersDatabase.schemaVersion = ReviewReminderSchemaVersion(3)
         ReviewRemindersDatabase.oldReviewReminderSchemasForMigration =
             mapOf(
-                ReviewReminderSchemaVersion(1) to TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionOne::class,
-                ReviewReminderSchemaVersion(2) to TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionTwo::class,
+                ReviewReminderSchemaVersion(1) to TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionOne::class,
+                ReviewReminderSchemaVersion(2) to TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionTwo::class,
                 ReviewReminderSchemaVersion(3) to ReviewReminder::class,
             )
-        // To spice things up, some will be version one...
-        val versionOneDummyDeckSpecificRemindersForDeckOne =
-            mapOf(
-                ReviewReminderId(0) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionOne(
-                        ReviewReminderId(0),
-                        9,
-                        0,
-                        5,
-                        did1,
-                        false,
-                    ),
-                ReviewReminderId(1) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionOne(
-                        ReviewReminderId(1),
-                        10,
-                        30,
-                        10,
-                        did1,
-                    ),
-            )
-        // ...and some will be version two
-        val versionTwoDummyDeckSpecificRemindersForDeckTwo =
-            mapOf(
-                ReviewReminderId(2) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionTwo(
-                        ReviewReminderId(2),
-                        TestingReviewReminderMigrationSettings.VersionTwoDataClasses.ReviewReminderTime(10, 30),
-                        1,
-                        10,
-                        did2,
-                    ),
-                ReviewReminderId(3) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionTwo(
-                        ReviewReminderId(3),
-                        TestingReviewReminderMigrationSettings.VersionTwoDataClasses.ReviewReminderTime(12, 30),
-                        1,
-                        20,
-                        did2,
-                    ),
-            )
-        val versionOneDummyAppWideReminders =
-            mapOf(
-                ReviewReminderId(4) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionOne(
-                        ReviewReminderId(4),
-                        9,
-                        0,
-                        5,
-                        -1L,
-                    ),
-                ReviewReminderId(5) to
-                    TestingReviewReminderMigrationSettings.ReviewReminderSchemaVersionOne(
-                        ReviewReminderId(5),
-                        10,
-                        30,
-                        10,
-                        -1L,
-                    ),
-            )
 
-        val packagedDeckOneReminders =
-            ReviewRemindersDatabase.StoredReviewRemindersMap(
-                ReviewReminderSchemaVersion(1),
-                Json.encodeToString(versionOneDummyDeckSpecificRemindersForDeckOne),
-            )
-        val packagedDeckTwoReminders =
-            ReviewRemindersDatabase.StoredReviewRemindersMap(
-                ReviewReminderSchemaVersion(2),
-                Json.encodeToString(versionTwoDummyDeckSpecificRemindersForDeckTwo),
-            )
-        val packagedGlobalReminders =
-            ReviewRemindersDatabase.StoredReviewRemindersMap(
-                ReviewReminderSchemaVersion(1),
-                Json.encodeToString(versionOneDummyAppWideReminders),
-            )
-
-        ReviewRemindersDatabase.remindersSharedPrefs.edit(commit = true) {
-            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did1, Json.encodeToString(packagedDeckOneReminders))
-            putString(ReviewRemindersDatabase.DECK_SPECIFIC_KEY + did2, Json.encodeToString(packagedDeckTwoReminders))
-            putString(ReviewRemindersDatabase.APP_WIDE_KEY, Json.encodeToString(packagedGlobalReminders))
-        }
-
-        val retrievedDeckOneReminders = ReviewRemindersDatabase.getRemindersForDeck(did1)
-        val retrievedDeckTwoReminders = ReviewRemindersDatabase.getRemindersForDeck(did2)
-        val retrievedGlobalReminders = ReviewRemindersDatabase.getAllAppWideReminders()
-
-        retrievedDeckOneReminders.forEach { (id, reminder) ->
-            assertThat(id, equalTo(reminder.id))
-        }
-        retrievedDeckTwoReminders.forEach { (id, reminder) ->
-            assertThat(id, equalTo(reminder.id))
-        }
-        retrievedGlobalReminders.forEach { (id, reminder) ->
-            assertThat(id, equalTo(reminder.id))
-        }
-
-        // We ignore ID because the migration process will generate new review reminders from scratch during the migration; ID is a private, inaccessible property
-        assertThat(
-            retrievedDeckOneReminders.values,
-            containsEqualReviewRemindersInAnyOrderIgnoringId(dummyDeckSpecificRemindersForDeckOne.values),
+        assertMigrationsWork(
+            // To spice things up, some will be version one...
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionOne(
+                        id = ReviewReminderId(0),
+                        hour = 9,
+                        minute = 0,
+                        cardTriggerThreshold = 5,
+                        did = did1,
+                        enabled = false,
+                    ),
+                expectedOutput = dummyDeckSpecificRemindersForDeckOne[ReviewReminderId(0)]!!,
+            ),
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionOne(
+                        id = ReviewReminderId(1),
+                        hour = 10,
+                        minute = 30,
+                        cardTriggerThreshold = 10,
+                        did = did1,
+                    ),
+                expectedOutput = dummyDeckSpecificRemindersForDeckOne[ReviewReminderId(1)]!!,
+            ),
+            // ...and some will be version two...
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(2),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionTwo(
+                        id = ReviewReminderId(2),
+                        time = TestingReviewReminderMigrationSettings.VersionTwoDataClasses.ReviewReminderTime(10, 30),
+                        snoozeAmount = 1,
+                        cardTriggerThreshold = 10,
+                        did = did2,
+                        enabled = true,
+                    ),
+                expectedOutput = dummyDeckSpecificRemindersForDeckTwo[ReviewReminderId(2)]!!,
+            ),
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(2),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionTwo(
+                        id = ReviewReminderId(3),
+                        time = TestingReviewReminderMigrationSettings.VersionTwoDataClasses.ReviewReminderTime(12, 30),
+                        snoozeAmount = 1,
+                        cardTriggerThreshold = 20,
+                        did = did2,
+                    ),
+                expectedOutput = dummyDeckSpecificRemindersForDeckTwo[ReviewReminderId(3)]!!,
+            ),
+            // ...and some will be app-wide for good measure
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionOne(
+                        id = ReviewReminderId(4),
+                        hour = 9,
+                        minute = 0,
+                        cardTriggerThreshold = 5,
+                        did = -1L,
+                    ),
+                expectedOutput = dummyAppWideReminders[ReviewReminderId(4)]!!,
+            ),
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    TestingReviewReminderMigrationSettings.ReviewReminderTestSchemaVersionOne(
+                        id = ReviewReminderId(5),
+                        hour = 10,
+                        minute = 30,
+                        cardTriggerThreshold = 10,
+                        did = -1L,
+                    ),
+                expectedOutput = dummyAppWideReminders[ReviewReminderId(5)]!!,
+            ),
         )
-        assertThat(
-            retrievedDeckTwoReminders.values,
-            containsEqualReviewRemindersInAnyOrderIgnoringId(dummyDeckSpecificRemindersForDeckTwo.values),
-        )
-        assertThat(
-            retrievedGlobalReminders.values,
-            containsEqualReviewRemindersInAnyOrderIgnoringId(dummyAppWideReminders.values),
-        )
-
-        // Shared Preferences should not contain any random corrupted keys after or due to the migration process
-        // There should be three: two for the specific decks, one for app-wide
-        val sharedPrefsSize = ReviewRemindersDatabase.remindersSharedPrefs.all.size
-        assertThat(sharedPrefsSize, CoreMatchers.equalTo(3))
 
         // Reset mocks
         ReviewRemindersDatabase.schemaVersion = savedSchemaVersion
         ReviewRemindersDatabase.oldReviewReminderSchemasForMigration = savedOldReviewReminderSchemasForMigration
+    }
+
+    @Test
+    fun `review reminder v1 to v2 migration works`() {
+        assertMigrationsWork(
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    ReviewReminderSchemaV1(
+                        id = ReviewReminderId(0),
+                        time = ReviewReminderTime(9, 0),
+                        cardTriggerThreshold = ReviewReminderCardTriggerThreshold(5),
+                        scope = ReviewReminderScope.DeckSpecific(did1),
+                        enabled = true,
+                        profileID = "",
+                    ),
+                expectedOutput =
+                    ReviewReminder.createReviewReminder(
+                        time = ReviewReminderTime(9, 0),
+                        cardTriggerThreshold = ReviewReminderCardTriggerThreshold(5),
+                        scope = ReviewReminderScope.DeckSpecific(did1),
+                        enabled = true,
+                        profileID = "",
+                        onlyNotifyIfNoReviews = false,
+                    ),
+            ),
+            MigrationTestCase(
+                inputVersion = ReviewReminderSchemaVersion(1),
+                input =
+                    ReviewReminderSchemaV1(
+                        id = ReviewReminderId(1),
+                        time = ReviewReminderTime(10, 30),
+                        cardTriggerThreshold = ReviewReminderCardTriggerThreshold(10),
+                        scope = ReviewReminderScope.Global,
+                        enabled = false,
+                        profileID = "",
+                        onlyNotifyIfNoReviews = true,
+                    ),
+                expectedOutput =
+                    ReviewReminder.createReviewReminder(
+                        time = ReviewReminderTime(10, 30),
+                        cardTriggerThreshold = ReviewReminderCardTriggerThreshold(10),
+                        scope = ReviewReminderScope.Global,
+                        enabled = false,
+                        profileID = "",
+                        onlyNotifyIfNoReviews = true,
+                    ),
+            ),
+        )
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -30,28 +30,47 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.time.MockTime
 import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.libanki.EpochMilliseconds
 import com.ichi2.anki.reviewreminders.ReviewReminder
-import com.ichi2.anki.reviewreminders.ReviewReminderGroup
-import com.ichi2.anki.reviewreminders.ReviewReminderId
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.services.NotificationService.Companion.EXTRA_REVIEW_REMINDER
+import com.ichi2.testutils.ext.storeReminders
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Calendar
+import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 class AlarmManagerServiceTest : RobolectricTest() {
     companion object {
-        private val mockTime = MockTime(2024, 0, 1, 12, 0, 0, 0, 0)
+        /**
+         * Set the mock time to a consistent date and a specific time: noon in the local time zone (not UTC! this is required because
+         * the subject-under-test calculates times based on the local time zone, hence the convoluted construction of this mock).
+         */
+        private val mockTime =
+            MockTime(
+                initTime =
+                    MockTime(2024, 0, 1, 0, 0, 0, 0, 0)
+                        .calendar()
+                        .apply {
+                            set(Calendar.HOUR_OF_DAY, 12)
+                            set(Calendar.MINUTE, 0)
+                            set(Calendar.SECOND, 0)
+                        }.timeInMillis,
+                step = 0,
+            )
     }
 
     private lateinit var context: Context
@@ -67,7 +86,10 @@ class AlarmManagerServiceTest : RobolectricTest() {
         notificationManager = mockk(relaxed = true)
         every { context.getSystemService<AlarmManager>() } returns alarmManager
         every { context.getSystemService<NotificationManager>() } returns notificationManager
+
         reviewReminder = ReviewReminder.createReviewReminder(time = ReviewReminderTime(20, 0))
+        reviewReminder.latestNotifTime = mockTime.intTimeMS() // Ensure the reminder is ready to have its future instance scheduled
+
         TimeManager.resetWith(mockTime)
         ReviewRemindersDatabase.remindersSharedPrefs.edit { clear() }
     }
@@ -91,7 +113,7 @@ class AlarmManagerServiceTest : RobolectricTest() {
             alarmManager.setWindow(
                 AlarmManager.RTC_WAKEUP,
                 expectedSchedulingTime.timeInMillis,
-                10.minutes.inWholeMilliseconds,
+                AlarmManagerService.WINDOW_LENGTH_MS,
                 any(),
             )
         }
@@ -111,7 +133,7 @@ class AlarmManagerServiceTest : RobolectricTest() {
             alarmManager.setWindow(
                 AlarmManager.RTC_WAKEUP,
                 expectedSchedulingTime.timeInMillis,
-                10.minutes.inWholeMilliseconds,
+                AlarmManagerService.WINDOW_LENGTH_MS,
                 any(),
             )
         }
@@ -135,38 +157,192 @@ class AlarmManagerServiceTest : RobolectricTest() {
         verify { alarmManager.cancel(pendingIntent) }
     }
 
+    /**
+     * A single test case for alarm scheduling testing.
+     * @see scheduleAllNotificationsTest
+     */
+    private data class ScheduleAllNotificationsTestCase(
+        val reminder: ReviewReminder,
+        val shouldImmediatelySetAlarm: Boolean,
+        val shouldImmediatelyFireNotif: Boolean,
+        val latestNotifTime: EpochMilliseconds? = null,
+    )
+
+    /**
+     * Helper function that tries scheduling multiple reminders and verifies the outcome for each.
+     */
+    private fun scheduleAllNotificationsTest(vararg testCases: ScheduleAllNotificationsTestCase) {
+        require(testCases.map { it.reminder.time }.toSet().size == testCases.size) {
+            "All test cases must have unique reminder times to facilitate alarm scheduling verification"
+        }
+
+        testCases.forEach { case ->
+            if (case.latestNotifTime != null) {
+                case.reminder.latestNotifTime = case.latestNotifTime
+            }
+        }
+        val previousLatestNotifTimes = testCases.associate { it.reminder.id to it.reminder.latestNotifTime }
+
+        ReviewRemindersDatabase.storeReminders(*testCases.map { it.reminder }.toTypedArray())
+        val currentTimestamp = mockTime.calendar().clone() as Calendar
+
+        AlarmManagerService.scheduleAllNotifications(context)
+
+        testCases.forEach { case ->
+            val expectedSchedulingTime = mockTime.calendar().clone() as Calendar
+            expectedSchedulingTime.apply {
+                set(Calendar.HOUR_OF_DAY, case.reminder.time.hour)
+                set(Calendar.MINUTE, case.reminder.time.minute)
+                set(Calendar.SECOND, 0)
+                if (before(currentTimestamp)) {
+                    add(Calendar.DAY_OF_YEAR, 1)
+                }
+            }
+
+            val alarmSettingCallsExpected = if (case.shouldImmediatelySetAlarm) 1 else 0
+            verify(exactly = alarmSettingCallsExpected) {
+                alarmManager.setWindow(
+                    AlarmManager.RTC_WAKEUP,
+                    expectedSchedulingTime.timeInMillis,
+                    10.minutes.inWholeMilliseconds,
+                    any(),
+                )
+            }
+        }
+
+        val (testCasesWithFiring, testCasesWithoutFiring) = testCases.partition { it.shouldImmediatelyFireNotif }
+        val expectedFired = testCasesWithFiring.map { it.reminder }.toSet()
+        val expectedNotFired = testCasesWithoutFiring.map { it.reminder }.toSet()
+
+        val capturedIntents = mutableListOf<Intent>()
+        verify(exactly = expectedFired.size) {
+            context.sendBroadcast(capture(capturedIntents))
+        }
+        val actuallyFired =
+            capturedIntents
+                .map { intent ->
+                    BundleCompat.getParcelable(
+                        intent.extras!!,
+                        EXTRA_REVIEW_REMINDER,
+                        ReviewReminder::class.java,
+                    )!!
+                }.toSet()
+        val actuallyFiredIds = actuallyFired.map { it.id }.toSet()
+        val notFired = testCases.map { it.reminder }.filterNot { it.id in actuallyFiredIds }.toSet()
+
+        // The actually fired reminders have a modified latestNotifTime, so we can't directly compare the reminder objects
+        assertThat((actuallyFired + notFired).map { it.id }.toSet(), equalTo(testCases.map { it.reminder.id }.toSet()))
+        assertThat(expectedFired.map { it.id }.toSet(), equalTo(actuallyFired.map { it.id }.toSet()))
+
+        // But we can compare unfired reminders directly since they should be unchanged
+        assertThat(expectedNotFired, equalTo(notFired))
+
+        // Validate latestNotifTime has changed for fired reminders
+        val expectedFiredCreationTimes = expectedFired.associate { it.id to previousLatestNotifTimes[it.id]!! }
+        val notificationTimes = actuallyFired.associate { it.id to it.latestNotifTime }
+        assertThat(expectedFiredCreationTimes.keys.toSet(), equalTo(notificationTimes.keys.toSet()))
+        expectedFiredCreationTimes.forEach { (id, createdAt) ->
+            val notifTime = notificationTimes[id]!!
+            assertThat(notifTime > createdAt, equalTo(true))
+        }
+
+        // Validate stored reminders
+        val stored = ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()
+        val (storedFired, storedNotFired) = stored.getRemindersList().partition { it.id in actuallyFired.map { r -> r.id } }
+        assertThat(storedFired.toSet(), equalTo(actuallyFired))
+        assertThat(storedNotFired.toSet(), equalTo(notFired))
+    }
+
     @Test
     fun `scheduleAllNotifications schedules reminders for all enabled reminders in database`() =
         runTest {
             val did1 = addDeck("Deck1")
             val did2 = addDeck("Deck2")
-            val reminder1 =
-                ReviewReminder.createReviewReminder(
-                    time = ReviewReminderTime(9, 0),
-                    scope = ReviewReminderScope.DeckSpecific(did1),
-                )
-            val reminder2 =
-                ReviewReminder.createReviewReminder(
-                    time = ReviewReminderTime(10, 0),
-                    scope = ReviewReminderScope.DeckSpecific(did2),
-                )
-            val reminder3 = ReviewReminder.createReviewReminder(time = ReviewReminderTime(11, 0))
-            val disabledReminder =
-                ReviewReminder.createReviewReminder(
-                    time = ReviewReminderTime(11, 0),
-                    enabled = false,
-                )
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reminder1) }
-            ReviewRemindersDatabase.editRemindersForDeck(did2) { ReviewReminderGroup(ReviewReminderId(1) to reminder2) }
-            ReviewRemindersDatabase.editAllAppWideReminders {
-                ReviewReminderGroup(
-                    ReviewReminderId(2) to reminder3,
-                    ReviewReminderId(3) to disabledReminder,
-                )
-            }
+            scheduleAllNotificationsTest(
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(9, 0),
+                            scope = ReviewReminderScope.DeckSpecific(did1),
+                        ),
+                    shouldImmediatelySetAlarm = true,
+                    shouldImmediatelyFireNotif = false,
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(10, 0),
+                            scope = ReviewReminderScope.DeckSpecific(did2),
+                        ),
+                    shouldImmediatelySetAlarm = true,
+                    shouldImmediatelyFireNotif = false,
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(11, 0),
+                        ),
+                    shouldImmediatelySetAlarm = true,
+                    shouldImmediatelyFireNotif = false,
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(12, 0),
+                            enabled = false,
+                        ),
+                    shouldImmediatelySetAlarm = false,
+                    shouldImmediatelyFireNotif = false,
+                ),
+            )
+        }
 
-            AlarmManagerService.scheduleAllNotifications(context)
-            verify(exactly = 3) { alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), 10.minutes.inWholeMilliseconds, any()) }
+    @Test
+    fun `scheduleAllNotifications immediately fires notification for reminders which missed scheduled firings`() =
+        runTest {
+            val did1 = addDeck("Deck1")
+            scheduleAllNotificationsTest(
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(11, 58), // Last scheduled at 2 minutes earlier
+                            scope = ReviewReminderScope.DeckSpecific(did1),
+                        ),
+                    shouldImmediatelySetAlarm = false,
+                    shouldImmediatelyFireNotif = true, // Should fire immediately, because...
+                    latestNotifTime = mockTime.intTimeMS() - 10.minutes.inWholeMilliseconds, // ...latest firing was 10 minutes ago
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(11, 59), // Last scheduled at 1 minute earlier
+                            scope = ReviewReminderScope.Global,
+                        ),
+                    shouldImmediatelySetAlarm = true,
+                    shouldImmediatelyFireNotif = false, // Should not fire immediately, because...
+                    latestNotifTime = mockTime.intTimeMS(), // ...a notification just fired
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(12, 1), // Last scheduled almost a full day ago
+                            scope = ReviewReminderScope.Global,
+                        ),
+                    shouldImmediatelySetAlarm = true,
+                    shouldImmediatelyFireNotif = false, // Should not fire immediately, because...
+                    latestNotifTime = mockTime.intTimeMS() - 10.minutes.inWholeMilliseconds, // ...latest firing was 10 minutes ago
+                ),
+                ScheduleAllNotificationsTestCase(
+                    reminder =
+                        ReviewReminder.createReviewReminder(
+                            time = ReviewReminderTime(12, 2), // Last scheduled almost a full day ago
+                            scope = ReviewReminderScope.DeckSpecific(did1),
+                        ),
+                    shouldImmediatelySetAlarm = false,
+                    shouldImmediatelyFireNotif = true, // Should fire immediately, because...
+                    latestNotifTime = mockTime.intTimeMS() - 2.days.inWholeMilliseconds, // ...latest firing was 2 days ago
+                ),
+            )
         }
 
     @Test
@@ -183,7 +359,7 @@ class AlarmManagerServiceTest : RobolectricTest() {
             alarmManager.setWindow(
                 AlarmManager.RTC_WAKEUP,
                 mockTime.intTimeMS() + 5.minutes.inWholeMilliseconds,
-                10.minutes.inWholeMilliseconds,
+                AlarmManagerService.WINDOW_LENGTH_MS,
                 any(),
             )
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -31,7 +31,9 @@ import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.common.time.MockTime
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderGroup
 import com.ichi2.anki.reviewreminders.ReviewReminderId
+import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import io.mockk.every
@@ -138,18 +140,26 @@ class AlarmManagerServiceTest : RobolectricTest() {
         runTest {
             val did1 = addDeck("Deck1")
             val did2 = addDeck("Deck2")
-            val reminder1 = ReviewReminder.createReviewReminder(time = ReviewReminderTime(9, 0))
-            val reminder2 = ReviewReminder.createReviewReminder(time = ReviewReminderTime(10, 0))
+            val reminder1 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(9, 0),
+                    scope = ReviewReminderScope.DeckSpecific(did1),
+                )
+            val reminder2 =
+                ReviewReminder.createReviewReminder(
+                    time = ReviewReminderTime(10, 0),
+                    scope = ReviewReminderScope.DeckSpecific(did2),
+                )
             val reminder3 = ReviewReminder.createReviewReminder(time = ReviewReminderTime(11, 0))
             val disabledReminder =
                 ReviewReminder.createReviewReminder(
                     time = ReviewReminderTime(11, 0),
                     enabled = false,
                 )
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reminder1) }
-            ReviewRemindersDatabase.editRemindersForDeck(did2) { mapOf(ReviewReminderId(1) to reminder2) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reminder1) }
+            ReviewRemindersDatabase.editRemindersForDeck(did2) { ReviewReminderGroup(ReviewReminderId(1) to reminder2) }
             ReviewRemindersDatabase.editAllAppWideReminders {
-                mapOf(
+                ReviewReminderGroup(
                     ReviewReminderId(2) to reminder3,
                     ReviewReminderId(3) to disabledReminder,
                 )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/NotificationServiceTest.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.reviewreminders.ReviewReminder
 import com.ichi2.anki.reviewreminders.ReviewReminderCardTriggerThreshold
+import com.ichi2.anki.reviewreminders.ReviewReminderGroup
 import com.ichi2.anki.reviewreminders.ReviewReminderId
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
@@ -82,13 +83,13 @@ class NotificationServiceTest : RobolectricTest() {
 
     private fun createAndSaveDummyDeckSpecificReminder(did: DeckId): ReviewReminder {
         val reviewReminder = createTestReminder(deckId = did, thresholdInt = 1)
-        ReviewRemindersDatabase.editRemindersForDeck(did) { mapOf(ReviewReminderId(0) to reviewReminder) }
+        ReviewRemindersDatabase.editRemindersForDeck(did) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminder) }
         return reviewReminder
     }
 
     private fun createAndSaveDummyAppWideReminder(): ReviewReminder {
         val reviewReminder = createTestReminder(thresholdInt = 1)
-        ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminder) }
+        ReviewRemindersDatabase.editAllAppWideReminders { ReviewReminderGroup(ReviewReminderId(1) to reviewReminder) }
         return reviewReminder
     }
 
@@ -111,8 +112,8 @@ class NotificationServiceTest : RobolectricTest() {
             }
             val reviewReminderDeckSpecific = createTestReminder(deckId = did1, thresholdInt = 3)
             val reviewReminderAppWide = createTestReminder(thresholdInt = 3)
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
-            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { ReviewReminderGroup(ReviewReminderId(1) to reviewReminderAppWide) }
 
             triggerDummyReminderNotification(reviewReminderDeckSpecific)
             triggerDummyReminderNotification(reviewReminderAppWide)
@@ -191,8 +192,8 @@ class NotificationServiceTest : RobolectricTest() {
             col.sched.answerCard(col.sched.card!!, CardAnswer.Rating.GOOD)
             val reviewReminderDeckSpecific = createTestReminder(deckId = did1, thresholdInt = 1, onlyNotifyIfNoReviews = true)
             val reviewReminderAppWide = createTestReminder(thresholdInt = 1, onlyNotifyIfNoReviews = true)
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
-            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { ReviewReminderGroup(ReviewReminderId(1) to reviewReminderAppWide) }
 
             triggerDummyReminderNotification(reviewReminderDeckSpecific)
             triggerDummyReminderNotification(reviewReminderAppWide)
@@ -208,8 +209,8 @@ class NotificationServiceTest : RobolectricTest() {
             }
             val reviewReminderDeckSpecific = createTestReminder(deckId = did1, thresholdInt = 1, onlyNotifyIfNoReviews = true)
             val reviewReminderAppWide = createTestReminder(thresholdInt = 1, onlyNotifyIfNoReviews = true)
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
-            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { ReviewReminderGroup(ReviewReminderId(1) to reviewReminderAppWide) }
 
             triggerDummyReminderNotification(reviewReminderDeckSpecific)
             triggerDummyReminderNotification(reviewReminderAppWide)
@@ -240,8 +241,8 @@ class NotificationServiceTest : RobolectricTest() {
 
             val reviewReminderDeckSpecific = createTestReminder(deckId = did1, thresholdInt = 1, onlyNotifyIfNoReviews = true)
             val reviewReminderAppWide = createTestReminder(thresholdInt = 1, onlyNotifyIfNoReviews = true)
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderDeckSpecific) }
-            ReviewRemindersDatabase.editAllAppWideReminders { mapOf(ReviewReminderId(1) to reviewReminderAppWide) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminderDeckSpecific) }
+            ReviewRemindersDatabase.editAllAppWideReminders { ReviewReminderGroup(ReviewReminderId(1) to reviewReminderAppWide) }
 
             triggerDummyReminderNotification(reviewReminderDeckSpecific)
             triggerDummyReminderNotification(reviewReminderAppWide)
@@ -365,8 +366,8 @@ class NotificationServiceTest : RobolectricTest() {
             }
             val reviewReminderOne = createTestReminder(deckId = did1, thresholdInt = 1)
             val reviewReminderTwo = createTestReminder(deckId = did2, thresholdInt = 1)
-            ReviewRemindersDatabase.editRemindersForDeck(did1) { mapOf(ReviewReminderId(0) to reviewReminderOne) }
-            ReviewRemindersDatabase.editRemindersForDeck(did2) { mapOf(ReviewReminderId(1) to reviewReminderTwo) }
+            ReviewRemindersDatabase.editRemindersForDeck(did1) { ReviewReminderGroup(ReviewReminderId(0) to reviewReminderOne) }
+            ReviewRemindersDatabase.editRemindersForDeck(did2) { ReviewReminderGroup(ReviewReminderId(1) to reviewReminderTwo) }
 
             val slotOne = slot<Notification>()
             val slotTwo = slot<Notification>()

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/ext/ReviewRemindersDatabase.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/ext/ReviewRemindersDatabase.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2026 Eric Li <ericli3690@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.testutils.ext
+
+import com.ichi2.anki.reviewreminders.ReviewReminder
+import com.ichi2.anki.reviewreminders.ReviewReminderGroup
+import com.ichi2.anki.reviewreminders.ReviewReminderScope.DeckSpecific
+import com.ichi2.anki.reviewreminders.ReviewReminderScope.Global
+import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+
+fun ReviewRemindersDatabase.storeReminders(vararg reminders: ReviewReminder) {
+    reminders.forEach { reminder ->
+        when (reminder.scope) {
+            is DeckSpecific -> {
+                editRemindersForDeck(reminder.scope.did) { reminders ->
+                    reminders + ReviewReminderGroup(reminder.id to reminder)
+                }
+            }
+            is Global -> {
+                editAllAppWideReminders { reminders ->
+                    reminders + ReviewReminderGroup(reminder.id to reminder)
+                }
+            }
+        }
+    }
+}

--- a/libanki/src/testFixtures/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/src/testFixtures/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -230,6 +230,43 @@ interface AnkiTest {
         front: String = "Front",
     ): List<Note> = List(count) { addBasicNote(front = front) }
 
+    /**
+     * Adds [count] notes into the specified [queueType] of the provided deck.
+     */
+    fun addNoteToDeck(
+        deckId: DeckId,
+        count: Int = 1,
+        queueType: QueueType = QueueType.New,
+    ) = addNotes(count).forEach {
+        it.firstCard().update {
+            did = deckId
+            queue = queueType
+        }
+    }
+
+    /**
+     * Convenience method for chaining [addDeck] and [addNoteToDeck].
+     *
+     * Usage: `val deckId = addDeck("My Deck").withNotes(count = 5, queueType = QueueType.New)`
+     */
+    fun DeckId.withNotes(
+        count: Int,
+        queueType: QueueType = QueueType.New,
+    ): DeckId =
+        this.apply {
+            addNoteToDeck(this, count = count, queueType = queueType)
+        }
+
+    /**
+     * Convenience method for chaining [addDeck] and [addNoteToDeck].
+     *
+     * Usage: `val deckId = addDeck("My Deck").withNote(queueType = QueueType.New)`
+     */
+    fun DeckId.withNote(queueType: QueueType = QueueType.New): DeckId =
+        this.apply {
+            addNoteToDeck(this, count = 1, queueType = queueType)
+        }
+
     fun Note.moveToDeck(
         deckName: String,
         createDeckIfMissing: Boolean = true,


### PR DESCRIPTION
A bit of a big PR, but in my defense most of this is tests!

Error dialog (this is not going to be very user-facing, if all goes well no end users will ever need to see this dialog):
<img width="466" height="1007" alt="image" src="https://github.com/user-attachments/assets/a1c7850e-41b0-453d-b3da-54d688513b81" />

## Purpose / Description
1. Implements a long-term solution for https://github.com/ankidroid/Anki-Android/issues/20163 by adding a review reminder schema migration from v1 to v2.
2. Implements fallbacks so that even if a migration fails or review reminders become corrupted, the app doesn't become 100% blocked.
3. Abstracts the `HashMap<ReviewReminderId, ReviewReminder>` type in ReviewRemindersDatabase into a new interface, ReviewReminderGroup.
4. Fixes a bug where opening the app during the firing window of a review reminder when it hadn't fired yet would skip a notification. Makes it so that when the app is launched, any review reminder notifications that have been skipped for some reason (ex. the device was off) are immediately fired. To do this, the review reminder schema was migrated again from v2 to v3.
5. Cleans up and adds a lot of unit tests.

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/20163
* Fixes https://github.com/ankidroid/Anki-Android/issues/20170

## Approach
Major reorganization of the ReviewReminderDatabase file. Creating a `ReviewReminderGroup` class was Arthur's idea!
For immediately firing missed notifications, the method employed is the standard one after discussing with Mike (i.e. store the timestamp every time a reminder's notifications attempt to fire, if no scheduled firing is detected while the app is scheduling reminders ex. on boot up, then immediately fire). We're not going to provide this as a configurable option like some other notification apps do because instantly firing missed notifications is a good default. 

## How Has This Been Tested?
Incrementally installing:
1. Before the `onlyNotifyIfNoReviews` change, then these changes, and
2. After the `onlyNotifyIfNoReviews` change, then these changes
all works.
Intentionally corrupting the reminders does not block the app, the offending review reminders are just deleted.
Tested on a physical Samsung S23, API 34.

## Learning
Ran into a bunch of headaches around testing, Kotlin's deserialization library and type safety. Went through three separate ideas for solving the "opening the app causes a notification to be dropped" bug, got 90% of the way to the optimal solution independently, then asked Mike and realized I should have asked Mike earlier haha

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->