### PR TITLE
refactor: use MaterialTextView for review reminders UI

### DIFF
--- a/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
+++ b/AnkiDroid/src/main/res/layout/add_edit_reminder_dialog.xml
@@ -42,7 +42,7 @@
                     android:orientation="horizontal"
                     android:layout_marginBottom="8dp">
 
-                    <com.ichi2.ui.FixedTextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/add_edit_reminder_time_label"
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
@@ -71,7 +71,7 @@
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
-                    <com.ichi2.ui.FixedTextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/add_edit_reminder_deck_label"
                         android:layout_width="0dp"
                         android:layout_height="match_parent"
@@ -81,7 +81,7 @@
                         android:textSize="18sp"
                         tools:ignore="HardcodedText" />
 
-                    <com.ichi2.ui.FixedTextView
+                    <com.google.android.material.textview.MaterialTextView
                         android:id="@+id/add_edit_reminder_deck_name"
                         android:layout_width="0dp"
                         android:layout_weight="3"
@@ -119,7 +119,7 @@
                             android:layout_gravity="center_vertical"
                             android:layout_marginEnd="8dp" />
 
-                        <com.ichi2.ui.FixedTextView
+                        <com.google.android.material.textview.MaterialTextView
                             android:id="@+id/add_edit_reminder_advanced_label"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
@@ -152,7 +152,7 @@
                                 android:paddingVertical="4dp"
                                 android:orientation="vertical">
 
-                                <com.ichi2.ui.FixedTextView
+                                <com.google.android.material.textview.MaterialTextView
                                     android:id="@+id/add_edit_reminder_card_threshold_label"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -161,7 +161,7 @@
                                     android:text="Card threshold:"
                                     tools:ignore="HardcodedText" />
 
-                                <com.ichi2.ui.FixedTextView
+                                <com.google.android.material.textview.MaterialTextView
                                     android:id="@+id/add_edit_reminder_card_threshold_description"
                                     android:layout_width="wrap_content"
                                     android:layout_height="wrap_content"
@@ -200,7 +200,7 @@
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content" />
 
-                            <com.ichi2.ui.FixedTextView
+                            <com.google.android.material.textview.MaterialTextView
                                 android:id="@+id/add_edit_reminder_only_notify_if_no_reviews_label"
                                 android:layout_width="0dp"
                                 android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/fragment_all_permissions_explanation.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_all_permissions_explanation.xml
@@ -8,7 +8,7 @@
     android:orientation="vertical"
     tools:context=".ui.windows.permissions.AllPermissionsExplanationFragment">
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/heading_required_permissions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -29,7 +29,7 @@
         tools:visibility="visible"
         />
 
-    <TextView
+    <com.google.android.material.textview.MaterialTextView
         android:id="@+id/heading_optional_permissions"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_schedule_reminders.xml
@@ -53,7 +53,7 @@
                     android:layout_gravity="center_horizontal"
                     app:srcCompat="@drawable/outline_notifications_off_24" />
 
-                <com.ichi2.ui.FixedTextView
+                <com.google.android.material.textview.MaterialTextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="8dp"

--- a/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
+++ b/AnkiDroid/src/main/res/layout/schedule_reminders_list_item.xml
@@ -29,7 +29,7 @@
             android:textStyle="bold"
             tools:text="12:00 a.m." />
 
-        <TextView
+        <com.google.android.material.textview.MaterialTextView
             android:id="@+id/reminders_list_deck_text"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
## Purpose / Description
Changing all the UI files I've ever touched to consistently use MaterialTextView rather than TextView or even FixedTextView, as discussed with David. (See [this comment](https://github.com/ankidroid/Anki-Android/pull/19157#discussion_r2667212592))

## How Has This Been Tested?
Tested on a physical Samsung S23, API 34. All UI looks the same as it currently does.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->