### PR TITLE
Fix(WhiteBoard): Prevent Integer display wrapping

### DIFF
--- a/AnkiDroid/src/main/res/layout/view_whiteboard_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/view_whiteboard_toolbar.xml
@@ -44,9 +44,9 @@
             <com.ichi2.anki.ui.windows.reviewer.whiteboard.EraserButton
                 android:id="@+id/eraser_button"
                 style="@style/Widget.Material3.Button.TextButton"
-                android:layout_width="?minTouchTargetSize"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:minWidth="0dp"
+                android:minWidth="?minTouchTargetSize"
                 android:contentDescription="@string/eraser"
                 android:textColor="?attr/colorControlNormal"
                 android:textSize="12sp"


### PR DESCRIPTION
## Purpose / Description
#20332 When Android Device Font Size is set to Largest with Default View, Eraser Size Integer wraps at 3 digit numbers

## Fixes
Fixes #20332 

## Approach
1. Changed reviewer.whiteboard.EraserButton layout_width from ?minTouchTargetSize to wrap_content
2. Changed minWidth from 0dp to ?minTouchTargetSize

This approach negates the clipping from the static width of 48dp from minTouchTargetSize and allows for wrapping in case of large fonts, and sets minWidth to minTouchTargetSize to meet Accessibility Criteria

## How Has This Been Tested?

This has been tested on a local Android Device of 17.06cm display, width accessibility has been confirmed using Layout Inspector in Android Studio

## Learning (optional, can help others)
While considering small texts, setting static widths may cause issues with large default fonts in Accessibility

_Links to blog posts, patterns, libraries or addons used to solve this problem_
N/A

## Checklist
_Please, go through these checks before submitting the PR._

- [✓] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [✓] You have performed a self-review of your own code
- [✓] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [✓ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)