### PR TITLE
fix(DeckPicker): improve accessibility of DeckPicker FAB

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -43,6 +43,9 @@
     <string name="no_cards_placeholder_title" comment="Text shown the first time AnkiDroid is opened, to explain to the user why they can't yet review.">Collection is empty</string>
     <string name="no_cards_placeholder_description" comment="Text shown the first time AnkiDroid is opened, to explain what should be their first action.">Start adding cards\nusing the + icon.</string>
 
+    <!-- Floating Action Button Accessibility -->
+    <string name="toggle_fab_menu" comment="Accessibility action to open the Floating Action Button menu">Toggle FAB menu</string>
+
     <!-- Reviewer -->
     <plurals name="reviewer_window_title" comment="Header of the reviewer, telling the users how many minutes remains before they have seen all cards.">
         <item quantity="one">%d minute left</item>


### PR DESCRIPTION
## Purpose
This PR improves the accessibility of the Floating Action Menu on the Deck Picker Screen. At present, when the TalkBack is enabled, the Floating Action Menu Button (FAB) does not toggle properly as the FAB is not supported by the accessibility services and also due to focus management issues. This locks out the user from getting shared decks, creating decks and filtered decks the normal way.

## Related 
- Related #7913 

## Approach
Dynamic State Management: Implemented `updateAccessibilityState()` which uses `ViewCompat.replaceAccessibilityAction` to update the `ACTION_CLICK` label based on the state of FAB menu. It ensures that TalkBack announces the options correctly.

Focus Management: Used `.post` to set the focus and send a `TYPE_VIEW_FOCUSED` event to the first menu item (addNoteLabel) when the menu is opened. This ensures that the user gets acknowledgement of the state change.

## How Has This Been Tested?

https://github.com/user-attachments/assets/58299f12-fa57-4378-91d1-b02b9c48f66b

To test the changes you can follow the following steps: 
1. Turn on the [TalkBack](https://support.google.com/accessibility/android/answer/6007100) accessibility feature.
2. Open AnkiDroid.
3. The set the focus on the FAB (single tap).
4. Double tap to toggle the fab menu.
5. You can either choose the available options or tap on elements outside the FAB wrapper and then double tap to close the menu.

This test was conducted on a physical device (Samsung Galaxy A54, API 36) .

## Learning (can help others)
I read about [Making custom views more accessible](https://developer.android.com/guide/topics/ui/accessibility/custom-views)
 and learnt about mimicking the accessibility reader service when using a work around like the FAB menu.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

> [!NOTE]
> The Google Accessibility Scanner stills shows that the FAB button is unsupported as this solution uses a work around.
 
<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->
