### PR TITLE
fix #17922: enable auto advance with long-press

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -925,9 +925,9 @@ abstract class AbstractFlashcardViewer :
         }
         flipCardLayout = findViewById(R.id.flashcard_layout_flip)
         flipCardLayout?.let { layout ->
-            if (minimalClickSpeed == 0) {
-                layout.setOnClickListener(flipCardListener)
-            } else {
+            layout.setOnClickListener(flipCardListener)
+
+            if (minimalClickSpeed > 0) {
                 val handler = Handler(Looper.getMainLooper())
                 layout.setOnTouchListener { view, event ->
                     when (event.action) {
@@ -937,19 +937,19 @@ abstract class AbstractFlashcardViewer :
                             }, minimalClickSpeed.toLong())
 
                             showMinimalClickHint()
-                            false
+                            true
                         }
 
                         MotionEvent.ACTION_MOVE -> {
                             if (!view.isTouchWithinBounds(event)) {
                                 handler.removeCallbacksAndMessages(null)
                             }
-                            false
+                            true
                         }
 
                         MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL, MotionEvent.ACTION_HOVER_ENTER -> {
                             handler.removeCallbacksAndMessages(null)
-                            false
+                            true
                         }
 
                         else -> false


### PR DESCRIPTION
## Purpose / Description

Auto Advance stops working when "Show answer long-press time" is set to anything other than 0 in Accessibility settings.

## Fixes
* Fixes #17922

## Approach

When long-press time is enabled, the show-answer button was only getting an `OnTouchListener` — the `OnClickListener` was skipped entirely. Auto Advance triggers the button via [performClick()](cci:1://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt:1850:4-1859:5), which only fires the `OnClickListener`, so it silently did nothing.

The fix is straightforward: always set the `OnClickListener`. When long-press is also enabled, the `OnTouchListener` intercepts manual touches (returning `true` to consume them), while [performClick()](cci:1://file:///e:/opensource/Anki-Android/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt:1850:4-1859:5) still works through the click listener as expected.

## How Has This Been Tested?

Tested manually on an emulator (API 30):
- Auto Advance with long-press disabled — works as before
- Auto Advance with long-press set to 500ms — now correctly flips the card
- Manual tap with long-press enabled — still respects the delay
- Manual tap with long-press disabled — unchanged

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)