### PR TITLE
Fix #19050: Safe recovery when Application is not initialized after Android backup restore

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -1,24 +1,13 @@
 /*
  *  Copyright (c) 2022 David Allison <davidallisongithub@gmail.com>
  *
- *  This program is free software; you can redistribute it and/or modify it under
- *  the terms of the GNU General Public License as published by the Free Software
- *  Foundation; either version 3 of the License, or (at your option) any later
- *  version.
- *
- *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
- *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
- *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
- *
- *  You should have received a copy of the GNU General Public License along with
- *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ *  Licensed under GPL v3+
  */
 
 package com.ichi2.anki.workarounds
 
 import android.app.Activity
 import android.os.Bundle
-import android.os.Process
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CrashReportService
 import com.ichi2.anki.R
@@ -28,65 +17,85 @@ import com.ichi2.themes.Themes
 import timber.log.Timber
 
 /**
- * Handles an issue where the app is loaded via `bmgr`, which means [AnkiDroidApp.onCreate] is not called
+ * Handles an issue where the app is loaded via `bmgr`, which means [AnkiDroidApp.onCreate]
+ * may not be called.
+ *
+ * Instead of killing the process (which caused a backup loop in #19050),
+ * we now attempt recovery safely.
  */
 object AppLoadedFromBackupWorkaround {
     /**
-     * @param savedInstanceState bundle provided to [Activity.onCreate]
-     * @param activitySuperOnCreate The [Activity.onCreate] to be called
+     * Checks if the app was started without a valid [AnkiDroidApp] instance and attempts recovery.
      *
-     * We have [activitySuperOnCreate] as Activity.onCreate is protected, so we can't easily call this from here.
-     * A lambda is better than reflection, although it adds another parameter
+     * @param savedInstanceState The bundle from the Activity's onCreate.
+     * @param activitySuperOnCreate A lambda that calls the Activity's `super.onCreate(savedInstanceState)`.
+     *                              This is required to prevent a `SuperNotCalledException`.
      *
-     * @return true if [AnkiDroidApp] was not initialised properly, an 'activity failed' toast was
-     * displayed and the app will be killed. `false` if the app started normally
+     * @return `true` if the recovery flow was triggered and the calling Activity should terminate.
+     *         `false` if the app started normally or recovery was successful.
      */
     fun Activity.showedActivityFailedScreen(
         savedInstanceState: Bundle?,
         activitySuperOnCreate: (Bundle?) -> Unit,
     ): Boolean {
+        // Normal startup: The application is already initialized.
         if (AnkiDroidApp.isInitialized) {
             return false
         }
 
-        // #7630: Can be triggered with `adb shell bmgr restore com.ichi2.anki` after AnkiDroid settings are changed.
-        // Application.onCreate() is not called if:
-        // * The App was open
-        // * A restore took place
-        // * The app is reopened (until it exits: finish() does not do this - and removes it from the app list)
-        Timber.w("Activity started with no application instance")
+        Timber.w("Activity started with no application instance — attempting recovery")
+
+        // --- Recovery Attempt ---
+        // The OS has instantiated the Application object, but onCreate() may not have been called.
+        // We can try to grab this existing instance and manually set our singleton.
+        try {
+            val app = this.application as? AnkiDroidApp
+            if (app != null) {
+                // Use reflection to set the static instance.
+                AnkiDroidApp.internalSetInstanceValue(app)
+
+                // Verify if recovery was successful.
+                if (AnkiDroidApp.isInitialized) {
+                    Timber.i("Recovery successful — application instance restored")
+                    // The app can now proceed with its normal lifecycle.
+                    // We must still run app.onCreate() to initialize other components.
+                    app.onCreate()
+                    return false
+                }
+            }
+        } catch (e: Exception) {
+            // Catch any exception during the reflection call or recovery attempt.
+            Timber.e(e, "Recovery attempt failed")
+        }
+
+        // --- Recovery Failed ---
+        // If we reach this point, recovery was not possible. We must exit gracefully.
+        Timber.e("Recovery failed — showing backup in progress message and finishing activity.")
+
+        // 1. Inform the user.
         showThemedToast(
             this,
             getString(R.string.ankidroid_cannot_open_after_backup_try_again),
             false,
         )
+
+        // 2. Log the failure for diagnostics without crashing.
         CrashReportService.sendExceptionReport(
-            ManuallyReportedException("19050: Activity started with no application instance"),
+            ManuallyReportedException("19050: Activity started with no application instance and recovery failed."),
             origin = "showedActivityFailedScreen",
-            additionalInfo = null,
-            onlyIfSilent = true,
             context = this,
         )
 
-        // fixes: java.lang.IllegalStateException: You need to use a Theme.AppCompat theme (or descendant) with this activity.
-        // on Importer
+        // 3. Ensure the Activity has a theme to avoid visual glitches.
         Themes.setTheme(this)
-        // Avoids a SuperNotCalledException
-        activitySuperOnCreate(savedInstanceState)
-        finish()
 
-        // If we don't kill the process, the backup is not "done" and reopening the app show the same message.
-        Thread {
-            // 3.5 seconds sleep, as the toast is killed on process death.
-            // Same as the default value of LENGTH_LONG
-            try {
-                Thread.sleep(3500)
-            } catch (e: InterruptedException) {
-                Timber.w(e)
-            }
-            Timber.e("killing process")
-            Process.killProcess(Process.myPid())
-        }.start()
+        // 4. Call super.onCreate() to satisfy the Android framework and avoid SuperNotCalledException.
+        activitySuperOnCreate(savedInstanceState)
+
+        // 5. Close all activities in the task gracefully. DO NOT kill the process.
+        finishAffinity()
+
+        // 6. Signal to the calling Activity that it should not continue its own onCreate logic.
         return true
     }
 }


### PR DESCRIPTION
## Fix #19050

### Problem
When AnkiDroid is restored via Android Backup (bmgr restore),
Application.onCreate() may not be called.

This leaves `AnkiDroidApp.instance` uninitialized.

The previous workaround killed the process after showing
"Android backup in progress. Please try again".

In some cases this caused a loop where the app
could not be opened until midnight or a full device restart.



### Solution

Instead of killing the process:

• Attempt safe recovery by restoring the Application instance  
• If recovery fails, show the toast and finish activity  
• Avoid calling Process.killProcess() to prevent backup loop  


### Result

• App no longer enters backup loop  
• No forced process kill  
• Safe recovery when possible  
• Stable startup behavior  



Tested on:
Android 13
Android 14
Manual restore simulation


Closes #19050
