### PR TITLE
Cleanup: Fix getter warning in Toolbar

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/Toolbar.kt
@@ -257,7 +257,7 @@ class Toolbar : FrameLayout {
                         .windowManager
                         .currentWindowMetrics
                 val insets: Insets =
-                    windowMetrics.getWindowInsets().getInsetsIgnoringVisibility(
+                    windowMetrics.windowInsets.getInsetsIgnoringVisibility(
                         WindowInsets.Type.navigationBars()
                             or WindowInsets.Type.displayCutout(),
                     )


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This change follows Kotlin style recommendations. The goal is to reduce warnings shown in Android Studio.

## Fixes
* Fixes part of #13282 

## Approach
- Used Kotlin property access syntax instead of Java-style getter methods.
- Followed Kotlin idiomatic style where data access looks like a property.

## How Has This Been Tested?
I ran the app on an emulator and confirmed that the toolbar is displayed correctly.

## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->