### PR TITLE
Fix ConcurrentModificationException in UpgradeAnswerControls

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -866,9 +866,10 @@ object PreferenceUpgradeService {
 
                 for ((key, newKey) in keysMap.entries) {
                     val value = preferences.getString(key, null) ?: continue
-                    val bindings = fromPreferenceString(value).toMutableList()
+                    val currentBindings = fromPreferenceString(value).toMutableList()
+                    val bindings = currentBindings.toMutableList()
 
-                    bindings.forEach { binding ->
+                    currentBindings.forEach { binding ->
                         when (binding.side) {
                             CardSide.QUESTION -> {
                                 if (!showAnswerBindings.any { it.binding == binding.binding }) {


### PR DESCRIPTION
## Purpose / Description

Add a new copy list to be modified in the problematic _forEach_ loop in _UpgradeAnswerControls_.

## Fixes
* Fixes #20340
* Fixes #20338

## How Has This Been Tested?

Ran tests, verified the reproduction behavior:

_Checkout and run a commit before UpgradeAnswerControls was introduced -> Add a new Question & answer key -> Checkout and run the latest code_

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
