### PR TITLE
fix: keep deck selection dialog open for multi-select in widget config

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -77,6 +77,7 @@ import java.util.Locale
 open class DeckSelectionDialog : AnalyticsDialogFragment() {
     private lateinit var binding: DialogDeckPickerBinding
     private var dialog: AlertDialog? = null
+    private lateinit var decksAdapter: DecksArrayAdapter
     private lateinit var expandImage: Drawable
     private lateinit var collapseImage: Drawable
     private lateinit var decksRoot: DeckNode
@@ -113,9 +114,9 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val dividerItemDecoration = DividerItemDecoration(binding.list.context, DividerItemDecoration.VERTICAL)
         binding.list.addItemDecoration(dividerItemDecoration)
         val decks: List<SelectableDeck> = getDeckNames(arguments)
-        val adapter = DecksArrayAdapter(decks)
-        binding.list.adapter = adapter
-        adjustToolbar(binding.root, adapter)
+        decksAdapter = DecksArrayAdapter(decks)
+        binding.list.adapter = decksAdapter
+        adjustToolbar(binding.root, decksAdapter)
         dialog =
             AlertDialog.Builder(requireActivity()).create {
                 negativeButton(R.string.dialog_cancel)
@@ -239,13 +240,27 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
 
     var deckCreationListener: DeckCreationListener? = null
 
+    private val isMultiSelect: Boolean
+        get() = requireArguments().getBoolean(MULTI_SELECT)
+
     /**
      * Same action as pressing on the deck in the list. I.e. send the deck to listener and close the dialog.
+     * When [isMultiSelect] is true, the dialog stays open and removes the selected deck from the list.
      */
     protected fun selectDeckAndClose(deck: SelectableDeck) {
         Timber.d("selected deck '%s'", deck)
         onDeckSelected(deck)
-        dialog!!.dismiss()
+        if (isMultiSelect) {
+            if (deck is SelectableDeck.Deck) {
+                decksAdapter.removeDeck(deck.deckId)
+            }
+            // dismiss dialog when all decks have been selected
+            if (decksAdapter.itemCount == 0) {
+                dialog!!.dismiss()
+            }
+        } else {
+            dialog!!.dismiss()
+        }
     }
 
     protected fun displayErrorAndCancel() {
@@ -306,6 +321,13 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             currentlyDisplayedDecks.clear()
             currentlyDisplayedDecks.addAll(allDecksList.filter(::isViewable))
             notifyDataSetChanged()
+        }
+
+        fun removeDeck(deckId: DeckId) {
+            val idsToRemove = mutableSetOf(deckId)
+            decksRoot.find(deckId)?.forEach { idsToRemove.add(it.did) }
+            allDecksList.removeAll { it.did in idsToRemove }
+            updateCurrentlyDisplayedDecks()
         }
 
         private val allDecksList = ArrayList<DeckNode>()
@@ -437,6 +459,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         private const val TITLE = "title"
         private const val KEEP_RESTORE_DEFAULT_BUTTON = "keepRestoreDefaultButton"
         private const val DECK_NAMES = "deckNames"
+        private const val MULTI_SELECT = "multiSelect"
 
         /**
          * A dialog which handles selecting a deck
@@ -446,6 +469,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             summaryMessage: String?,
             keepRestoreDefaultButton: Boolean,
             decks: List<SelectableDeck>,
+            isMultiSelect: Boolean = false,
         ): DeckSelectionDialog {
             val f = DeckSelectionDialog()
             val args = Bundle()
@@ -453,6 +477,7 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
             args.putString(TITLE, title)
             args.putBoolean(KEEP_RESTORE_DEFAULT_BUTTON, keepRestoreDefaultButton)
             args.putParcelableArrayList(DECK_NAMES, ArrayList(decks))
+            args.putBoolean(MULTI_SELECT, isMultiSelect)
             f.arguments = args
             return f
         }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt
@@ -154,8 +154,6 @@ class DeckPickerWidgetConfig :
 
         setupDoneButton()
 
-        // TODO: Implement multi-select functionality so that user can select desired decks in once.
-        // TODO: Implement a functionality to hide already selected deck.
         binding.fabWidgetDeckPicker.setOnClickListener {
             showDeckSelectionDialog()
         }
@@ -302,10 +300,10 @@ class DeckPickerWidgetConfig :
         }
     }
 
-    /** Asynchronously displays the list of deck in the selection dialog. */
+    /** Displays the deck selection dialog, filtering out already-selected decks. */
     private fun showDeckSelectionDialog() {
         lifecycleScope.launch {
-            val decks = fetchDecks()
+            val decks = fetchDecks().filter { it.deckId !in deckAdapter.deckIds }
             displayDeckSelectionDialog(decks)
         }
     }
@@ -324,8 +322,13 @@ class DeckPickerWidgetConfig :
                 summaryMessage = null,
                 keepRestoreDefaultButton = false,
                 decks = decks,
+                isMultiSelect = true,
             )
-        dialog.show(supportFragmentManager, "DeckSelectionDialog")
+        dialog.show(supportFragmentManager, DECK_SELECTION_DIALOG_TAG)
+    }
+
+    private fun dismissDeckSelectionDialog() {
+        (supportFragmentManager.findFragmentByTag(DECK_SELECTION_DIALOG_TAG) as? DeckSelectionDialog)?.dismiss()
     }
 
     /** Called when a deck is selected from the deck selection dialog. */
@@ -338,7 +341,6 @@ class DeckPickerWidgetConfig :
         val isDeckAlreadySelected = deckAdapter.deckIds.contains(deck.deckId)
 
         if (isDeckAlreadySelected) {
-            // TODO: Eventually, ensure that the user can't select a deck that is already selected.
             showSnackbar(getString(R.string.deck_already_selected_message))
             return
         }
@@ -350,19 +352,19 @@ class DeckPickerWidgetConfig :
                 showSnackbar(resources.getQuantityString(R.plurals.deck_limit_reached, MAX_DECKS_ALLOWED, MAX_DECKS_ALLOWED))
             }
             // The FAB visibility should be handled in updateFabVisibility()
-        } else {
-            // Add the deck and update views
-            deckAdapter.addDeck(deck)
-            updateViewVisibility()
-            updateFabVisibility()
-            setupDoneButton()
-            hasUnsavedChanges = true
-            setUnsavedChanges(true)
-
-            // Show snackbar if the deck is the 5th deck
-            if (deckAdapter.itemCount == MAX_DECKS_ALLOWED) {
-                showSnackbar(resources.getQuantityString(R.plurals.deck_limit_reached, MAX_DECKS_ALLOWED, MAX_DECKS_ALLOWED))
-            }
+            return
+        }
+        // Add the deck and update views
+        deckAdapter.addDeck(deck)
+        updateViewVisibility()
+        updateFabVisibility()
+        setupDoneButton()
+        hasUnsavedChanges = true
+        setUnsavedChanges(true)
+        // Show snackbar and dismiss the selection dialog once the 5th deck is reached
+        if (deckAdapter.itemCount == MAX_DECKS_ALLOWED) {
+            showSnackbar(resources.getQuantityString(R.plurals.deck_limit_reached, MAX_DECKS_ALLOWED, MAX_DECKS_ALLOWED))
+            dismissDeckSelectionDialog()
         }
     }
 
@@ -463,5 +465,6 @@ class DeckPickerWidgetConfig :
          * Maximum number of decks allowed in the widget.
          */
         private const val MAX_DECKS_ALLOWED = 5
+        private const val DECK_SELECTION_DIALOG_TAG = "DeckSelectionDialog"
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
@@ -16,12 +16,17 @@
 
 package com.ichi2.anki.dialogs
 
+import anki.decks.deckTreeNode
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.model.SelectableDeck
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.not
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
@@ -50,5 +55,58 @@ class DeckSelectionDialogTest : RobolectricTest() {
         assertNotNull(dialog)
         assertEquals(dialogTitle, dialog.arguments?.getString("title"))
         assertEquals(summaryMessage, dialog.arguments?.getString("summaryMessage"))
+    }
+
+    @Test
+    fun `selecting child deck does not collect parent or sibling ids`() {
+        // Build tree: Parent (id=1) -> Child1 (id=2), Child2 (id=3)
+        val child1 = makeNode("Child1", deckId = 2, level = 2)
+        val child2 = makeNode("Child2", deckId = 3, level = 2)
+        val parent = makeNode("Parent", deckId = 1, level = 1, children = listOf(child1, child2))
+
+        val selectedChild = parent.find(2L)!!
+        val idsToRemove = mutableSetOf(selectedChild.did)
+        selectedChild.forEach { idsToRemove.add(it.did) }
+
+        assertThat(idsToRemove, containsInAnyOrder(2L))
+        assertThat(idsToRemove, not(hasItem(1L)))
+        assertThat(idsToRemove, not(hasItem(3L)))
+    }
+
+    @Test
+    fun `selecting parent deck with nested children collects all descendants`() {
+        // Build tree: A (id=1) -> B (id=2) -> C (id=3)
+        //                      -> D (id=4)
+        val c = makeNode("C", deckId = 3, level = 3)
+        val b = makeNode("B", deckId = 2, level = 2, children = listOf(c))
+        val d = makeNode("D", deckId = 4, level = 2)
+        val a = makeNode("A", deckId = 1, level = 1, children = listOf(b, d))
+
+        val idsToRemove = mutableSetOf(a.did)
+        a.forEach { idsToRemove.add(it.did) }
+
+        assertThat(idsToRemove, containsInAnyOrder(1L, 2L, 3L, 4L))
+    }
+
+    private fun makeNode(
+        name: String,
+        deckId: Long,
+        level: Int,
+        collapsed: Boolean = false,
+        children: List<DeckNode> = emptyList(),
+    ): DeckNode {
+        val treeNode =
+            deckTreeNode {
+                this.name = name
+                this.deckId = deckId
+                this.level = level
+                this.collapsed = collapsed
+                children.forEach { this.children.add(it.node) }
+                this.reviewCount = 0
+                this.newCount = 0
+                this.learnCount = 0
+                this.filtered = false
+            }
+        return DeckNode(treeNode, name)
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Resolves the TODOs in 
https://github.com/ankidroid/Anki-Android/blob/5fbbe836761f65f7d391c7ec9252a4461b581cda/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt#L157-L158 
and the related TODO at 
https://github.com/ankidroid/Anki-Android/blob/e6104eb900d1c8101e57fd3304a81b90d203377a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidgetConfig.kt#L341
  - Users had to repeatedly open/close the deck selection dialog to add multiple
  decks to the widget
  - Already selected decks were still visible in the dialog, leading to a "already selected" error

## Approach
- Added a `keepOpen` parameter (default false) to `DeckSelectionDialog.newInstance()` so existing callers are unaffected
- When `keepOpen` is true, selecting a deck notifies the listener and removes the deck from the dialog list instead of dismissing
- The dialog auto-dismisses when the list is empty or the 5-deck limit is reached
- `DeckPickerWidgetConfig` now filters out already-selected decks before showing the dialog and passes keepOpen = true

## How Has This Been Tested?

- Existing DeckSelectionDialogTest - 2/2 tests passing
- Manual testing on a physical Android 15 device:
    - Verified dialog stays open after each deck selection
    - Verified selected decks are removed from the dialog list
    - Verified dialog auto-closes on reaching the 5-deck limit
    - Verified previously selected decks reappear in the dialog after removal from widget config
    - Verified Cancel/back button dismisses dialog correctly
    
### Before
https://github.com/user-attachments/assets/509921fd-291a-413b-b45f-3e49b2940d8b

### After
https://github.com/user-attachments/assets/99531c82-4d05-4967-b3a6-379a2201d29a

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->