### PR TITLE
Added tests for export dialog options

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -38,7 +38,6 @@ import com.ichi2.anki.ALL_DECKS_ID
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
 import com.ichi2.anki.databinding.DialogExportOptionsBinding
@@ -185,7 +184,6 @@ class ExportDialogFragment : DialogFragment() {
     /**
      * Initializes the views representing the extra options available when exporting a collection.
      */
-    @NeedsTest("Checkbox value is provided to the correct export functions (true/false)")
     private fun DialogExportOptionsBinding.initializeCollectionExportUi() =
         with(CollectionManager.TR) {
             collectionIncludeMedia.text = exportingIncludeMedia()
@@ -195,7 +193,6 @@ class ExportDialogFragment : DialogFragment() {
     /**
      * Initializes the views representing the extra options available when exporting an Anki package.
      */
-    @NeedsTest("Checkbox value is provided to the correct export functions (true/false)")
     private fun DialogExportOptionsBinding.initializeApkgExportUi() =
         with(CollectionManager.TR) {
             apkgIncludeMedia.text = exportingIncludeMedia()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/export/ExportDialogFragmentTest.kt
@@ -22,6 +22,7 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isChecked
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
@@ -33,6 +34,70 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class ExportDialogFragmentTest : RobolectricTest() {
+    @Test
+    fun `collection export options are initialized correctly`() {
+        launchFragment<ExportDialogFragment>(
+            themeResId = R.style.Theme_Light,
+        ).onFragment {
+            // Select export type as anki collection package.
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingAnkiCollectionPackage()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+
+            // Check that the UI elements are displayed and have the correct text and default values for checkboxes.
+            onView(withId(R.id.collection_include_media))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingIncludeMedia())))
+                .check(matches(isChecked()))
+
+            onView(withId(R.id.collection_export_legacy))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingSupportOlderAnkiVersions())))
+                .check(matches(not(isChecked())))
+        }
+    }
+
+    @Test
+    fun `apkg export options are initialized correctly`() {
+        launchFragment<ExportDialogFragment>(
+            themeResId = R.style.Theme_Light,
+        ).onFragment {
+            // Select export type as anki deck package.
+            onView(withId(R.id.export_type_selector)).inRoot(isDialog()).perform(click())
+            onData(containsString(TR.exportingAnkiDeckPackage()))
+                .inAdapterView(withId(R.id.export_type_selector))
+                .perform(click())
+
+            // Check that the UI elements are displayed and have the correct text and default values for checkboxes.
+            onView(withId(R.id.apkg_include_media))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingIncludeMedia())))
+                .check(matches(isChecked()))
+
+            onView(withId(R.id.apkg_include_deck_configs))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingIncludeDeckConfigs())))
+                .check(matches(not(isChecked())))
+
+            onView(withId(R.id.apkg_include_schedule))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingIncludeSchedulingInformation())))
+                .check(matches(isChecked()))
+
+            onView(withId(R.id.apkg_export_legacy))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()))
+                .check(matches(withText(TR.exportingSupportOlderAnkiVersions())))
+                .check(matches(not(isChecked())))
+        }
+    }
+
     @Test
     fun `Legacy export checkbox(default false) is shown only for collection and apkg`() {
         launchFragment<ExportDialogFragment>(


### PR DESCRIPTION
## Description
Adds tests for export options available on export dialogue for exporting as Anki Collection Package and as Anki Deck Package.

## Fixes
* Fixes #13283 

## Approach
Implemented tests check for the expected visibility and values of the options when user tires to export as Anki Deck or as Anki Collection packages.

## How Has This Been Tested?
I modified the default values for the visibility of the options and values for the check boxes in the xml file. Then ran the tests to validate the logic. 

## Learning (optional, can help others)
I learnt how we can automate test and make sure our that if futures changes do something out of order then we can alert ourselves without the user facing any issue. I learnt that isolated parts can also be checked without depending on parts which a user would need to use while using an actual app.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->