### PR TITLE
Fix false “Android backup in progress” error when app starts without initialization. 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -49,6 +49,16 @@ object AppLoadedFromBackupWorkaround {
             return false
         }
 
+        // Attempt to initialise the application once if backup/restore skipped Application.onCreate.
+        (application as? AnkiDroidApp)?.let { app ->
+            runCatching { app.onCreate() }.onFailure {
+                Timber.w(it, "Manual AnkiDroidApp initialization failed")
+            }
+        }
+        if (AnkiDroidApp.isInitialized) {
+            return false
+        }
+
         // #7630: Can be triggered with `adb shell bmgr restore com.ichi2.anki` after AnkiDroid settings are changed.
         // Application.onCreate() is not called if:
         // * The App was open


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This change makes sure AnkiDroidApp is properly initialized when an Activity starts in a process where Application.onCreate() was skipped (for example after Android backup or restore). In that case we now try to initialize the app once instead of immediately showing “Android backup in progress. Please try again” and killing the process. If initialization works, the app starts normally; if it still fails, we keep the existing behavior (toast + process kill).

## Fixes
* Fixes #19050 

## Approach

- In AppLoadedFromBackupWorkaround.showedActivityFailedScreen, when AnkiDroidApp.isInitialized is false, we call AnkiDroidApp.onCreate() on the current application instance, wrapped in runCatching so any failure is logged but does not crash.

- After that call we check AnkiDroidApp.isInitialized again:

       • If it is now true, we return false so the calling onCreate continues as normal.
       • If it is still false, we keep the previous behavior: show the existing “Android backup in progress” toast, finish the activity, and kill the process after a short delay.


## How Has This Been Tested?

- Verified that the new logic only runs when AnkiDroidApp.isInitialized is false and that normal launches behave exactly as before.

- I was not able to reliably reproduce the original bug on my own device (it depends on Android backup/restore timing and device behavior), so I would appreciate guidance or help from someone who can reproduce it or run this build under those conditions to confirm the fix end‑to‑end.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [ ] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->