### PR TITLE
fix: missing media error on new study screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerViewModel.kt
@@ -148,6 +148,7 @@ abstract class CardViewerViewModel(
     protected open suspend fun showAnswer() {
         Timber.v("showAnswer()")
         showingAnswer.emit(true)
+        mediaErrorHandler.onCardSideChange()
 
         val card = currentCard.await()
         val answerData = withCol { card.answer(this) }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
In the new study screen, media errors were not being counted correctly. This caused the error snackbar to appear repeatedly, which could be annoying for users.
This was caused by `hasExecuted` not being reset on card side changes. This PR restores the previous behaviour by aligning the logic with the old screen implementation. Snackbar will no longer be displayed in after being missing media error counted twice.

## Fixes
* Fixes #20347

## Approach
To minimise unexpected side effects, the logic of the new study screen was aligned with the old screen.
When media errors occur, the previous logic follows these steps:
1. If a media file cannot be found, `processMissingMedia()` in `MediaErrorHandler.kt` is called.
2. Inside that function, the exposure count is checked and `missingMediaCount` may be incremented.
3. `hasExecuted` flag plays an role in above process and must be reset whenever the card side changes.
4. In the old screen, `hasExecuted` was reset via `onCardSideChange()` inside `displayCardAnswer()` in `AbstractFlashcardViewer.kt` when the card side changed.
5. In the new study screen, the call to `onCardSideChange()` was missing, so it has been added.

## How Has This Been Tested?
1. passed the existing unit test `MediaErrorHandlerTest`. (honestly the logic isn't changed)
6. compared with the old screen and checked the same actions. please check the below videos.
[Old Screen Recording](https://github.com/user-attachments/assets/3be30187-e8ce-49e0-8e2d-eeb535ed9ed5)
[Previous New Screen Recording](https://github.com/user-attachments/assets/e44486db-28d7-4cec-8107-e3792ae3098c)
[Fixed New Screen Recording](https://github.com/user-attachments/assets/f621e911-8789-48b8-9d3f-c2a06abf5774)

## Learning (optional, can help others)
- I considered moving the `hasExecuted` management into `MediaErrorHandler.kt` to avoid relying on external updates. However, this would be a larger change than required for this issue, so I limited the fix to the current logic.
- I also reflected on the purpose of `hasExecuted`. It seems that it was intended to manage media error counting per card rather than globally. While this could be improved, refactoring it would be exceed the scope of this issue. It may be better addressed in a separate task.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->