### PR TITLE
Fix cloze numbering in Instant Note when text already contains clozes

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -180,9 +180,7 @@ class InstantEditorViewModel :
             }
     }
 
-    /** Sync cloze counter with actual text.
-     When shared text already contains {{cX::}}, we must detect existing indices and start from max + 1.
-     Also update intClozeList so undo/reset logic works correctly. */
+    /** Make cloze counter and intClozeList consistent with actual text.  */
     private fun syncClozeState(text: String?) {
         if (text.isNullOrEmpty()) {
             intClozeList.clear()
@@ -190,18 +188,18 @@ class InstantEditorViewModel :
             return
         }
 
-        val existingNumbers =
-            clozePattern
-                .findAll(text)
-                .mapNotNull { it.groups[2]?.value?.toIntOrNull() }
-                .toList()
-
-        // Sync the list of indices
         intClozeList.clear()
-        intClozeList.addAll(existingNumbers)
 
-        // Set the next cloze number to max + 1
-        _currentClozeNumber.value = (existingNumbers.maxOrNull() ?: 0) + 1
+        var max = 0
+        clozePattern.findAll(text).forEach {
+            val value = it.groups[2]?.value?.toIntOrNull()
+            if (value != null) {
+                intClozeList.add(value)
+                if (value > max) max = value
+            }
+        }
+
+        _currentClozeNumber.value = max + 1
     }
 
     /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Instant Note was not handling cloze numbering properly when the shared text already had clozes like `{{c1::}}`, `{{c2::}}`, etc._

_This PR fixes it._

## Fixes
* Fixes #20350 

## Approach
- The fix ensures that the cloze counter is derived from the actual text instead of assuming it always starts from `1`.

- Mode switching was simplified so that changing modes does not change the counter by itself.

**Flow Summary:**

```
setClozeFieldText(text)
        ↓
syncClozeState(text)
        ↓
Extract existing cloze indices
        ↓
Update intClozeList
        ↓
Set counter = max(existing) + 1
```

**During Selection:**

```
If INCREMENT ([...]+):
   - Use current counter
   - Then increment counter

If NO_INCREMENT ([...]):
   - Use highest existing cloze index
   - Do not change counter 
```

## How Has This Been Tested?
- Verified that existing unit tests pass (`InstantEditorViewModelTest.kt`).

- Tested on my phone (Android 14, Xiaomi / HyperOS) using a debug build.

Used the following two texts for testing:

```
This is the {{c1::first cloze}}. This should be the second cloze.
```
```
This is the {{c1::first cloze}}. This should be the {{c2::second cloze}}. Similarly, this one as {{c3::third cloze}}.
```

Two screen recording attached as evidence.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->

https://github.com/user-attachments/assets/3780f55f-b6d3-4d25-a93a-e2ad1aa46efc


https://github.com/user-attachments/assets/7a5771f1-f76a-4ded-9835-e0d0490737a4

