### PR TITLE
test: verify login redirection on HTTP 429 using Robolectric

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/SharedDecksActivity.kt
@@ -29,10 +29,10 @@ import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.activity.OnBackPressedCallback
+import androidx.annotation.VisibleForTesting
 import androidx.core.os.bundleOf
 import androidx.fragment.app.commit
 import com.google.android.material.snackbar.BaseTransientBottomBar.LENGTH_INDEFINITE
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.databinding.ActivitySharedDecksBinding
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.workarounds.SafeWebViewLayout
@@ -68,143 +68,148 @@ class SharedDecksActivity : AnkiActivity(R.layout.activity_shared_decks) {
      * History should not be cleared before the page finishes loading otherwise there would be
      * an extra entry in the history since the previous page would not get cleared.
      */
-    private val webViewClient =
-        object : WebViewClient() {
-            private var redirectTimes = 0
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal inner class SharedDeckWebViewClient : WebViewClient() {
+        private var redirectTimes = 0
 
-            override fun doUpdateVisitedHistory(
-                view: WebView?,
-                url: String?,
-                isReload: Boolean,
-            ) {
-                super.doUpdateVisitedHistory(view, url, isReload)
-                onBackPressedCallback.isEnabled = binding.webView.canGoBack()
-            }
+        override fun doUpdateVisitedHistory(
+            view: WebView?,
+            url: String?,
+            isReload: Boolean,
+        ) {
+            super.doUpdateVisitedHistory(view, url, isReload)
+            onBackPressedCallback.isEnabled = binding.webView.canGoBack()
+        }
 
-            override fun onPageFinished(
-                view: WebView?,
-                url: String?,
-            ) {
-                // Clear history if mShouldHistoryBeCleared is true and set it to false
-                if (shouldHistoryBeCleared) {
-                    binding.webView.clearHistory()
-                    shouldHistoryBeCleared = false
-                }
-                super.onPageFinished(view, url)
-            }
-
-            /**
-             * Prevent the WebView from loading urls which arent needed for importing shared decks.
-             * This is to prevent potential misuse, such as bypassing content restrictions or
-             * using the AnkiDroid WebView as a regular browser to bypass browser blocks,
-             * which could lead to procrastination.
-             */
-            override fun shouldOverrideUrlLoading(
-                view: WebView?,
-                request: WebResourceRequest?,
-            ): Boolean {
-                val host = request?.url?.host
-                if (host != null) {
-                    if (allowedHosts.any { regex -> regex.matches(host) }) {
-                        return super.shouldOverrideUrlLoading(view, request)
-                    }
-                }
-
-                request?.url?.let { super@SharedDecksActivity.openUrl(it) }
-
-                return true
-            }
-
-            private val cookieManager: CookieManager by lazy {
-                CookieManager.getInstance()
-            }
-
-            private val isLoggedInToAnkiWeb: Boolean
-                get() {
-                    try {
-                        // cookies are null after the user logs out, or if the site is first visited
-                        val cookies = cookieManager.getCookie("https://ankiweb.net") ?: return false
-                        // ankiweb currently (2024-09-25) sets two cookies:
-                        // * `ankiweb`, which is base64-encoded JSON
-                        // * `has_auth`, which is 1
-                        return cookies.contains("has_auth=1")
-                    } catch (e: Exception) {
-                        Timber.w(e, "Could not determine login status")
-                        return false
-                    }
-                }
-
-            @NeedsTest("A user is not redirected to login/signup if they are logged in to AnkiWeb")
-            override fun onReceivedHttpError(
-                view: WebView?,
-                request: WebResourceRequest?,
-                errorResponse: WebResourceResponse?,
-            ) {
-                super.onReceivedHttpError(view, request, errorResponse)
-
-                if (errorResponse?.statusCode != HTTP_STATUS_TOO_MANY_REQUESTS) return
-
-                // If a user is logged in, they see: "Daily limit exceeded; please try again tomorrow."
-                // We have nothing we can do here
-                if (isLoggedInToAnkiWeb) return
-
-                // The following cases are handled below:
-                // "Please log in to download more decks." - on clicking "Download"
-                // "Please log in to perform more searches" - on searching
-                redirectUserToSignUpOrLogin()
-            }
-
-            override fun onReceivedError(
-                view: WebView?,
-                request: WebResourceRequest?,
-                error: WebResourceError?,
-            ) {
-                // Set mShouldHistoryBeCleared to false if error occurs since it might have been true
+        override fun onPageFinished(
+            view: WebView?,
+            url: String?,
+        ) {
+            // Clear history if mShouldHistoryBeCleared is true and set it to false
+            if (shouldHistoryBeCleared) {
+                binding.webView.clearHistory()
                 shouldHistoryBeCleared = false
-                super.onReceivedError(view, request, error)
+            }
+            super.onPageFinished(view, url)
+        }
+
+        /**
+         * Prevent the WebView from loading urls which arent needed for importing shared decks.
+         * This is to prevent potential misuse, such as bypassing content restrictions or
+         * using the AnkiDroid WebView as a regular browser to bypass browser blocks,
+         * which could lead to procrastination.
+         */
+        override fun shouldOverrideUrlLoading(
+            view: WebView?,
+            request: WebResourceRequest?,
+        ): Boolean {
+            val host = request?.url?.host
+            if (host != null) {
+                if (allowedHosts.any { regex -> regex.matches(host) }) {
+                    return super.shouldOverrideUrlLoading(view, request)
+                }
             }
 
-            /**
-             * Redirects the user to a login page
-             *
-             * A message is shown informing the user they need to log in to download more decks
-             *
-             * If the user has not logged in **inside AnkiDroid** then the message provides
-             * the user with an action to sign up
-             *
-             * The redirect is not performed if [redirectTimes] is 3 or more
-             */
-            private fun redirectUserToSignUpOrLogin() {
-                // inform the user they need to log in as they've hit a rate limit
-                showSnackbar(R.string.shared_decks_login_required, LENGTH_INDEFINITE) {
-                    if (isLoggedIn()) return@showSnackbar
+            request?.url?.let { super@SharedDecksActivity.openUrl(it) }
 
-                    // If a user is not logged in inside AnkiDroid, assume they have no AnkiWeb account
-                    // and give them the option to sign up
-                    setAction(R.string.sign_up) {
-                        binding.webView.loadUrl(getString(R.string.shared_decks_sign_up_url))
-                    }
+            return true
+        }
+
+        private val cookieManager: CookieManager by lazy {
+            CookieManager.getInstance()
+        }
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        internal val isLoggedInToAnkiWeb: Boolean
+            get() {
+                try {
+                    // cookies are null after the user logs out, or if the site is first visited
+                    val cookies = cookieManager.getCookie("https://ankiweb.net") ?: return false
+                    // ankiweb currently (2024-09-25) sets two cookies:
+                    // * `ankiweb`, which is base64-encoded JSON
+                    // * `has_auth`, which is 1
+                    return cookies.contains("has_auth=1")
+                } catch (e: Exception) {
+                    Timber.w(e, "Could not determine login status")
+                    return false
                 }
+            }
 
-                // redirect user to /account/login
-                // TODO: the result of login is typically redirecting the user to their decks
-                // this should be improved
+        override fun onReceivedHttpError(
+            view: WebView?,
+            request: WebResourceRequest?,
+            errorResponse: WebResourceResponse?,
+        ) {
+            super.onReceivedHttpError(view, request, errorResponse)
 
-                if (redirectTimes++ < 3) {
-                    val url = getString(R.string.shared_decks_login_url)
-                    Timber.i("HTTP 429, redirecting to login: '$url'")
-                    binding.webView.loadUrl(url)
-                } else {
-                    // Ensure that we do not have an infinite redirect
-                    Timber.w("HTTP 429 redirect limit exceeded, only displaying message")
+            if (errorResponse?.statusCode != HTTP_STATUS_TOO_MANY_REQUESTS) return
+
+            // If a user is logged in, they see: "Daily limit exceeded; please try again tomorrow."
+            // We have nothing we can do here
+            if (isLoggedInToAnkiWeb) return
+
+            // The following cases are handled below:
+            // "Please log in to download more decks." - on clicking "Download"
+            // "Please log in to perform more searches" - on searching
+            redirectUserToSignUpOrLogin()
+        }
+
+        override fun onReceivedError(
+            view: WebView?,
+            request: WebResourceRequest?,
+            error: WebResourceError?,
+        ) {
+            // Set mShouldHistoryBeCleared to false if error occurs since it might have been true
+            shouldHistoryBeCleared = false
+            super.onReceivedError(view, request, error)
+        }
+
+        /**
+         * Redirects the user to a login page
+         *
+         * A message is shown informing the user they need to log in to download more decks
+         *
+         * If the user has not logged in **inside AnkiDroid** then the message provides
+         * the user with an action to sign up
+         *
+         * The redirect is not performed if [redirectTimes] is 3 or more
+         */
+        private fun redirectUserToSignUpOrLogin() {
+            // inform the user they need to log in as they've hit a rate limit
+            showSnackbar(R.string.shared_decks_login_required, LENGTH_INDEFINITE) {
+                if (isLoggedIn()) return@showSnackbar
+
+                // If a user is not logged in inside AnkiDroid, assume they have no AnkiWeb account
+                // and give them the option to sign up
+                setAction(R.string.sign_up) {
+                    binding.webView.loadUrl(getString(R.string.shared_decks_sign_up_url))
                 }
+            }
+
+            // redirect user to /account/login
+            // TODO: the result of login is typically redirecting the user to their decks
+            // this should be improved
+
+            if (redirectTimes++ < 3) {
+                val url = getString(R.string.shared_decks_login_url)
+                Timber.i("HTTP 429, redirecting to login: '$url'")
+                binding.webView.loadUrl(url)
+            } else {
+                // Ensure that we do not have an infinite redirect
+                Timber.w("HTTP 429 redirect limit exceeded, only displaying message")
             }
         }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal val webViewClient = SharedDeckWebViewClient()
 
     companion object {
         const val SHARED_DECKS_DOWNLOAD_FRAGMENT = "SharedDecksDownloadFragment"
         const val DOWNLOAD_FILE = "DownloadFile"
-        private const val HTTP_STATUS_TOO_MANY_REQUESTS = 429
+
+        @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+        const val HTTP_STATUS_TOO_MANY_REQUESTS = 429
     }
 
     // Show WebView with AnkiWeb shared decks with the functionality to capture downloads and import decks.

--- a/AnkiDroid/src/test/java/com/ichi2/anki/SharedDecksActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/SharedDecksActivityTest.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: Copyright (c) 2026 YongWoo Shin <onlym6659@gmail.com>
+
+package com.ichi2.anki
+
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.SharedDecksActivity.Companion.HTTP_STATUS_TOO_MANY_REQUESTS
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.robolectric.Robolectric
+import org.robolectric.Shadows
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class SharedDecksActivityTest : RobolectricTest() {
+    @Test
+    fun redirectWhenUserIsNotLogin() {
+        val controller = Robolectric.buildActivity(SharedDecksActivity::class.java).create()
+        val activity = controller.get()
+        saveControllerForCleanup(controller)
+
+        val webView = activity.findViewById<WebView>(R.id.web_view)
+        val spyWebClient = spy(activity.webViewClient)
+        doReturn(false).whenever(spyWebClient).isLoggedInToAnkiWeb
+        webView.webViewClient = spyWebClient
+
+        controller.start().resume().visible()
+
+        val mockRequest = mock<WebResourceRequest>()
+        val mockErrorResponse = mock<WebResourceResponse>()
+        whenever(mockErrorResponse.statusCode).thenReturn(HTTP_STATUS_TOO_MANY_REQUESTS)
+
+        spyWebClient.onReceivedHttpError(webView, mockRequest, mockErrorResponse)
+
+        val expectedUrl = getResourceString(R.string.shared_decks_login_url)
+        val actualUrl = Shadows.shadowOf(webView).lastLoadedUrl
+        assertEquals(expectedUrl, actualUrl)
+    }
+
+    @Test
+    fun isNotRedirectWhenUserLogin() {
+        val controller = Robolectric.buildActivity(SharedDecksActivity::class.java).create()
+        val activity = controller.get()
+        saveControllerForCleanup(controller)
+
+        val webView = activity.findViewById<WebView>(R.id.web_view)
+        val spyWebClient = spy(activity.webViewClient)
+        doReturn(true).whenever(spyWebClient).isLoggedInToAnkiWeb
+        webView.webViewClient = spyWebClient
+
+        controller.start().resume().visible()
+
+        val mockRequest = mock<WebResourceRequest>()
+        val mockErrorResponse = mock<WebResourceResponse>()
+        whenever(mockErrorResponse.statusCode).thenReturn(HTTP_STATUS_TOO_MANY_REQUESTS)
+
+        spyWebClient.onReceivedHttpError(webView, mockRequest, mockErrorResponse)
+
+        val expectedUrl = getResourceString(R.string.shared_decks_url)
+        val lastUrl = Shadows.shadowOf(webView).lastLoadedUrl
+        assertEquals(expectedUrl, lastUrl)
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This pr is test for user is not redirected to login/signup if they are logged in to AnkiWeb

## Fixes
None

## Approach
Structure Refactoring for Testability:

- Changed 'object' to ‘internal inner class’ to access the webclient properties. Because it can only be used in same module and use Activity’s properties

Test code strategy:

1. Robolectric and Lifecycle management: Injected the `spyWebClient` before calling `start()` and `resume()`.
2. Partial Mocking: Used Mockito Spy to control  `isLoggedInToAnkiWeb`
3. assert expected url is equal to last url

Test isolation:

Used the `saveControllerForCleanup` function in the RobolectricTest file to prevent the previous test from being transferred to the next test.

## How Has This Been Tested?

- Command: .\gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.SharedDecksActivityTest”
- Result: BUILD SUCCESSFUL

## Learning (optional, can help others)

- Test code should clearly define what it is I want to test and separate everything else from it.
    - Leave the rest outside the test boundary as Mocks or spies, and focus only on the logic you want to test.
    - If the behavior of an external object such as webclient is required, use a spy instead of a mock to make it perform the same behavior as a real object, and intercept it by manipulating the values in the middle.
    - To prevent previous tests from affecting the next test, clean up after each test.
- Learn how to use `RobolectricTest`
- How to Refactor into a Testable Structure
    - Use the internal and @VisibleForTesting annotations to specify that object and private objects have been changed to be used in the same module for testing purposes.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)