### PR TITLE
Add 'Use default collection folder' recovery option for collection path mismatch

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/CollectionPathMismatchRecoveryTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/dialogs/CollectionPathMismatchRecoveryTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Sumit Singh <sumitsinghkoranga7@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.core.content.edit
+import androidx.test.core.app.ActivityScenario
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper
+import com.ichi2.anki.CollectionHelper.getDefaultAnkiDroidDirectory
+import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.DeckPicker
+import com.ichi2.anki.R
+import com.ichi2.anki.preferences.sharedPrefs
+import com.ichi2.anki.tests.InstrumentedTest
+import com.ichi2.anki.testutil.disableIntroductionSlide
+import com.ichi2.anki.testutil.discardPreliminaryViews
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+/**
+ * When the stored collection path is wrong or missing, the error-handling dialog must offer
+ * "Use default collection folder" so the user can recover.
+ */
+@RunWith(AndroidJUnit4::class)
+class CollectionPathMismatchRecoveryTest : InstrumentedTest() {
+    private lateinit var nonDefaultDir: File
+    private lateinit var effectiveCollectionDir: File
+    private var savedPath: String? = null
+
+    @Before
+    fun setUp() {
+        disableIntroductionSlide()
+        CollectionManager.closeCollectionBlocking()
+        val defaultDir = getDefaultAnkiDroidDirectory(testContext)
+        nonDefaultDir = File(testContext.cacheDir, "CollectionPathMismatchRecoveryTest").apply { mkdirs() }
+        require(nonDefaultDir.absolutePath != defaultDir.absolutePath) {
+            "Need non-default dir; default=$defaultDir, test=$nonDefaultDir"
+        }
+        val prefs = testContext.applicationContext.sharedPrefs()
+        savedPath = prefs.getString(CollectionHelper.PREF_COLLECTION_PATH, null)
+        prefs.edit {
+            putString(CollectionHelper.PREF_COLLECTION_PATH, nonDefaultDir.absolutePath)
+        }
+        effectiveCollectionDir = File(nonDefaultDir, "androidTest").apply { mkdirs() }
+        // Use invalid bytes so opening this "collection" fails and triggers the recovery dialog
+        File(effectiveCollectionDir, "collection.anki2").writeBytes("not_sqlite".toByteArray())
+
+        ActivityScenario.launch(DeckPicker::class.java)
+        discardPreliminaryViews()
+    }
+
+    @Test
+    fun errorHandlingShowsUseDefaultFolderOption() {
+        onView(withText(R.string.open_collection_failed_title))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withText(R.string.error_handling_options)).inRoot(isDialog()).perform(click())
+        onView(withText(R.string.error_handling_title))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+        onView(withText(R.string.backup_use_default_folder))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @After
+    fun tearDown() {
+        CollectionManager.closeCollectionBlocking()
+        testContext.applicationContext.sharedPrefs().edit {
+            // Restore original collection path preference (or clear it if it didn't exist)
+            savedPath?.let { putString(CollectionHelper.PREF_COLLECTION_PATH, it) }
+                ?: remove(CollectionHelper.PREF_COLLECTION_PATH)
+        }
+        File(effectiveCollectionDir, "collection.anki2").takeIf { it.exists() }?.delete()
+        effectiveCollectionDir.takeIf { it.exists() }?.delete()
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DatabaseErrorDialog.kt
@@ -151,8 +151,8 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
             DIALOG_ERROR_HANDLING -> {
                 // The user has asked to see repair options; allow them to choose one of the repair options or go back
                 // to the previous dialog
-                val options = ArrayList<String>(7)
-                val values = ArrayList<ErrorHandlingEntries>(7)
+                val options = ArrayList<String>(8)
+                val values = ArrayList<ErrorHandlingEntries>(8)
                 if (!requireAnkiActivity().colIsOpenUnsafe()) {
                     // retry
                     options.add(res.getString(R.string.backup_retry_opening))
@@ -171,6 +171,23 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                     options.add(res.getString(R.string.backup_one_way_sync_from_server))
                     values.add(ErrorHandlingEntries.ONE_WAY)
                 }
+
+                val activity = requireActivity()
+                val shouldOfferResetToDefaultDirectory =
+                    try {
+                        val currentDir = CollectionHelper.getCurrentAnkiDroidDirectory(activity)
+                        val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(activity)
+                        currentDir.absolutePath != defaultDir.absolutePath
+                    } catch (e: Throwable) {
+                        Timber.w(e, "Failed to determine whether to offer reset-to-default directory option")
+                        false
+                    }
+
+                if (shouldOfferResetToDefaultDirectory) {
+                    options.add(res.getString(R.string.backup_use_default_folder))
+                    values.add(ErrorHandlingEntries.RESET_TO_DEFAULT_DIRECTORY)
+                }
+
                 // delete old collection and build new one
                 options.add(res.getString(R.string.backup_del_collection))
                 values.add(ErrorHandlingEntries.NEW)
@@ -198,6 +215,18 @@ class DatabaseErrorDialog : AsyncDialogFragment() {
                             }
                             ErrorHandlingEntries.ONE_WAY -> {
                                 showDatabaseErrorDialog(DIALOG_ONE_WAY_SYNC_FROM_SERVER)
+                                return@listItems
+                            }
+                            ErrorHandlingEntries.RESET_TO_DEFAULT_DIRECTORY -> {
+                                try {
+                                    val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(activity)
+                                    CollectionManager.closeCollectionBlocking()
+                                    CollectionHelper.resetAnkiDroidDirectory(activity, defaultDir)
+                                    closeCollectionAndFinish()
+                                } catch (e: Throwable) {
+                                    Timber.w(e, "Failed to reset AnkiDroid directory to default")
+                                    showDatabaseErrorDialog(DIALOG_LOAD_FAILED)
+                                }
                                 return@listItems
                             }
                             ErrorHandlingEntries.NEW -> {
@@ -747,6 +776,7 @@ private enum class ErrorHandlingEntries {
     REPAIR,
     RESTORE,
     ONE_WAY,
+    RESET_TO_DEFAULT_DIRECTORY,
     NEW,
     DEBUG_INFO,
 }

--- a/AnkiDroid/src/main/res/values/09-backup.xml
+++ b/AnkiDroid/src/main/res/values/09-backup.xml
@@ -26,6 +26,7 @@
     <string name="backup_del_collection">Delete collection and create new one</string>
     <string name="backup_del_collection_question">Delete the collection and create a new one? This will drop all your learning progress and delete all cards.</string>
     <string name="backup_one_way_sync_from_server">One-way sync from server</string>
+    <string name="backup_use_default_folder">Use default collection folder</string>
     <string name="backup_full_sync_from_server_question">Overwrite your collection with the one from AnkiWeb? This will drop all your learning progress and added information since your last sync.</string>
     <string name="error_handling_title">Error handling</string>
     <string name="error_handling_options" comment="In a warning message, the label of the suggested action that the user should take">Options</string>


### PR DESCRIPTION
## Purpose / Description
When the stored collection path is wrong or no longer exists (e.g. legacy vs app-specific path), the "Error handling" screen had no way to fix it. This change adds a "Use default collection folder" option on that screen so the user can reset the path to the default and exit. On the next launch the app opens from the correct folder or creates a new collection there.

## Fixes
* Fixes #17524

## Approach
When the database error dialog appears, we show a new "use default folder" option only if the current folder is not already the default one. If the user taps it, we close the collection, reset the folder path back to default, and exit the app. Next time the app opens, it uses the default folder. This follows the same close-reset-finish pattern already used elsewhere in the app.

## How Has This Been Tested?

Reproduced the bug by setting a wrong path in prefs and a fake DB at that path on emulator.

## Screen Recording 
[Screen_recording_20260225_172356.webm](https://github.com/user-attachments/assets/6a3df7e6-2b9a-4193-9834-d03b9389d27f)


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->