### PR TITLE
fix(sync): notification can get stuck.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncMediaWorker.kt
@@ -83,20 +83,23 @@ class SyncMediaWorker(
                 monitorProgress(backend)
             }
         } catch (cancellationException: CancellationException) {
-            Timber.w(cancellationException)
+            Timber.w(cancellationException, "SyncMediaWorker cancelled (user tapped Cancel or WorkManager cancelled)")
+            notificationManager?.cancel(NotificationId.SYNC_MEDIA)
+            Timber.d("SyncMediaWorker: progress notification cancelled after worker cancellation")
             cancelMediaSync(CollectionManager.getBackend())
             throw cancellationException
         } catch (throwable: Throwable) {
-            Timber.w(throwable)
+            Timber.w(throwable, "SyncMediaWorker failed")
             notify {
                 setContentTitle(CollectionManager.TR.syncMediaFailed())
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
                 }
             }
+            Timber.d("SyncMediaWorker: showing failure notification")
             return Result.failure()
         }
-        Timber.d("SyncMediaWorker: cancelling notification")
+        Timber.d("SyncMediaWorker: cancelling progress notification (sync completed)")
         notificationManager?.cancel(NotificationId.SYNC_MEDIA)
 
         Timber.d("SyncMediaWorker: success")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/worker/SyncWorker.kt
@@ -99,19 +99,23 @@ class SyncWorker(
         try {
             syncCollection(auth, shouldSyncMedia)
         } catch (cancellationException: CancellationException) {
+            Timber.w(cancellationException, "SyncWorker cancelled (user tapped Cancel or WorkManager cancelled)")
+            notificationManager?.cancel(NotificationId.SYNC)
+            Timber.d("SyncWorker: progress notification cancelled after worker cancellation")
             cancelSync(CollectionManager.getBackend())
             throw cancellationException
         } catch (throwable: Throwable) {
-            Timber.w(throwable)
+            Timber.w(throwable, "SyncWorker failed")
             notify {
                 setContentTitle(applicationContext.getString(R.string.sync_error))
                 throwable.localizedMessage?.let { message ->
                     setContentText(message)
                 }
             }
+            Timber.d("SyncWorker: showing failure notification")
             return Result.failure()
         }
-        Timber.d("SyncWorker: cancelling notification")
+        Timber.d("SyncWorker: cancelling progress notification (sync completed)")
         notificationManager?.cancel(NotificationId.SYNC)
 
         Timber.d("SyncWorker: success")


### PR DESCRIPTION
## Purpose / Description
This change makes sure the sync notifications (“Syncing…” and “Syncing media…”) are always removed, even when sync is cancelled or fails with an error. Previously they were only cleared on a clean, successful sync, so in rare cases they could stay stuck for a long time.

## Fixes
* Related to #19830 

## Approach
When the main sync worker and the media sync worker finish, we now always call notificationManager.cancel(...) from a finally block. This runs no matter how the work ends: success, error, or when the user presses the Cancel button on the notification, so the ongoing sync notifications are reliably dismissed.

## How Has This Been Tested?
Verified that both sync workers now always cancel their notifications from a finally block on all exit paths (success, error, and user cancel), and that the project builds and ktlint passes locally.

but i haven’t been able to reliably reproduce the original stuck-notification issue, so I’d really appreciate it if someone who has seen it could help confirm the fix end to end, or share the exact steps to reproduce it.

## Related:

* #17639

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->