### PR TITLE
fix: Show red text if the tag already exists and disable the button

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -22,6 +22,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
+import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -372,6 +373,8 @@ class TagsDialog : AnalyticsDialogFragment {
      * @param prefixTag: The tag to be prefilled into the EditText section. A trailing '::' will be appended.
      */
     @NeedsTest("The prefixTag should be prefilled properly")
+    @NeedsTest("Entering an existing tag should show an error and disable the OK button")
+    @NeedsTest("Entering a new valid tag should clear the error and enable the OK button")
     private fun createAddTagDialog(prefixTag: String?) {
         val addTagDialog =
             AlertDialog
@@ -396,6 +399,46 @@ class TagsDialog : AnalyticsDialogFragment {
             inputET.setText("$prefixTag ")
         }
         inputET.moveCursorToEnd()
+        val positiveButton =
+            addTagDialog.getButton(AlertDialog.BUTTON_POSITIVE)
+
+        positiveButton.isEnabled = false
+
+        val textInputLayout =
+            inputET.parent?.parent
+                as? com.google.android.material.textfield.TextInputLayout
+
+        inputET.doAfterTextChanged { text ->
+
+            val rawTag = text?.toString()?.trim()
+
+            if (rawTag.isNullOrEmpty()) {
+                textInputLayout?.error = null
+                positiveButton.isEnabled = false
+                return@doAfterTextChanged
+            }
+
+            lifecycleScope.launch {
+                val tags = viewModel.tags.await()
+
+                val normalized =
+                    TagsUtil.getUniformedTag(rawTag)
+
+                val exists =
+                    tags.contains(normalized)
+
+                if (exists) {
+                    textInputLayout?.error =
+                        getString(R.string.tag_already_exists)
+
+                    positiveButton.isEnabled = false
+                } else {
+                    textInputLayout?.error = null
+
+                    positiveButton.isEnabled = true
+                }
+            }
+        }
         addTagDialog.show()
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -190,6 +190,7 @@
     <string name="dyn_deck_desc">This is a special deck for studying outside of the normal schedule. Cards will be automatically returned to their original decks after you review them. Deleting this deck from the deck list will return all remaining cards to their original deck.</string>
     <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
     <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>
+    <string name="tag_already_exists">Tag already exists</string>
     <!-- Time spans -->
 
     <!-- Currently only used if exporting APKG fails -->


### PR DESCRIPTION
## Purpose / Description
The PR fixes the issue where adding an already existing tag does not provide proper validation feedback.
Now the Add Tag dialog shows a red error message and disables the OK button when a duplicate tag is entered.

## Fixes
* Fixes part of #18553 

## Approach
Added validation in `TagsDialog.kt` to check whether the entered tag already exists.

- Normalizes user input using `TagsUtil.getUniformedTag()`
- Displays inline error text when a duplicate tag is detected
- Disables the OK button until a valid unique tag is entered

## How Has This Been Tested?

Ran the app and verified that when entering an existing tag in the Add Tag dialog, a red error message is displayed and the OK button remains disabled.

Also verified that entering a new unique tag enables the OK button and allows the tag to be added successfully.

before:
<img width="440" height="847" alt="Screenshot From 2026-02-28 00-47-51" src="https://github.com/user-attachments/assets/283c567d-0050-49e7-aa48-934cbc6aa263" />

<img width="440" height="847" alt="Screenshot From 2026-02-28 00-48-01" src="https://github.com/user-attachments/assets/08c36066-e5c2-4d2f-a40c-8b1c2cc7d133" />



after:
<img width="440" height="847" alt="image" src="https://github.com/user-attachments/assets/1cb434d1-ac6c-46c7-98ff-5cb2bcac5ff0" />




## Learning (optional, can help others)
None

Links to blog posts, patterns, libraries or addons used to solve this problem

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->