### PR TITLE
Fix #15760: Convert undo/redo labels to sentence case

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -84,7 +84,7 @@ import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.SortOrder
 import com.ichi2.anki.libanki.undoAvailable
-import com.ichi2.anki.libanki.undoLabel
+import com.ichi2.anki.ui.internationalization.undoLabelToSentenceCase
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.CardsOrNotes.CARDS
@@ -866,7 +866,11 @@ open class CardBrowser :
         }
         actionBarMenu?.findItem(R.id.action_undo)?.run {
             isVisible = getColUnsafe.undoAvailable()
-            title = getColUnsafe.undoLabel()
+            title = getColUnsafe.undoLabel()?.let { label ->
+                label.removePrefix("Undo ").let { action ->
+                    undoLabelToSentenceCase(this@CardBrowser, action)
+                }
+            }
         }
 
         actionBarMenu?.findItem(R.id.action_reschedule_cards)?.title =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -148,7 +148,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.exception.ConfirmModSchemaException
 import com.ichi2.anki.libanki.sched.DeckNode
 import com.ichi2.anki.libanki.undoAvailable
-import com.ichi2.anki.libanki.undoLabel
+import com.ichi2.anki.ui.internationalization.undoLabelToSentenceCase
 import com.ichi2.anki.mediacheck.MediaCheckFragment
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.pages.AnkiPackageImporterFragment
@@ -702,9 +702,15 @@ open class DeckPicker :
         fun onUndoUpdated(a: Unit) {
             launchCatchingTask {
                 withOpenColOrNull {
+                    val rawUndoLabel = undoLabel()
+                    val sentenceCaseLabel = rawUndoLabel?.let { label ->
+                        label.removePrefix("Undo ").let { action ->
+                            undoLabelToSentenceCase(this@DeckPicker, action)
+                        }
+                    }
                     optionsMenuState =
                         optionsMenuState?.copy(
-                            undoLabel = undoLabel(),
+                            undoLabel = sentenceCaseLabel,
                             undoAvailable = undoAvailable(),
                         )
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -75,11 +75,9 @@ import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.redoAvailable
-import com.ichi2.anki.libanki.redoLabel
 import com.ichi2.anki.libanki.sched.Counts
 import com.ichi2.anki.libanki.sched.CurrentQueueState
 import com.ichi2.anki.libanki.undoAvailable
-import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.multimedia.audio.AudioRecordingController
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.generateTempAudioFile
 import com.ichi2.anki.multimedia.audio.AudioRecordingController.Companion.isAudioRecordingSaved
@@ -98,6 +96,8 @@ import com.ichi2.anki.reviewer.AnswerButtons.Companion.getTextColors
 import com.ichi2.anki.reviewer.AnswerTimer
 import com.ichi2.anki.reviewer.AutomaticAnswerAction
 import com.ichi2.anki.reviewer.Binding
+import com.ichi2.anki.ui.internationalization.redoLabelToSentenceCase
+import com.ichi2.anki.ui.internationalization.undoLabelToSentenceCase
 import com.ichi2.anki.reviewer.BindingMap
 import com.ichi2.anki.reviewer.BindingProcessor
 import com.ichi2.anki.reviewer.CardMarker
@@ -897,7 +897,11 @@ open class Reviewer :
 
                 if (getColUnsafe.undoAvailable()) {
                     // set the undo title to a named action ('Undo Answer Card' etc...)
-                    undoIcon.title = getColUnsafe.undoLabel()
+                    undoIcon.title = getColUnsafe.undoLabel()?.let { label ->
+                        label.removePrefix("Undo ").let { action ->
+                            undoLabelToSentenceCase(this@Reviewer, action)
+                        }
+                    }
                 } else {
                     // In this case, there is no object word for the verb, "Undo",
                     // so in some languages such as Japanese, which have pre/post-positional particle with the object,
@@ -914,7 +918,11 @@ open class Reviewer :
 
             menu.findItem(R.id.action_redo)?.apply {
                 if (getColUnsafe.redoAvailable()) {
-                    title = getColUnsafe.redoLabel()
+                    title = getColUnsafe.redoLabel()?.let { label ->
+                        label.removePrefix("Redo ").let { action ->
+                            redoLabelToSentenceCase(this@Reviewer, action)
+                        }
+                    }
                     iconAlpha = Themes.ALPHA_ICON_ENABLED_LIGHT
                     isEnabled = true
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsActivity.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Co
 import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.libanki.undoLabel
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.ui.internationalization.undoLabelToSentenceCase
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.ui.RtlCompliantActionProvider
 import kotlinx.coroutines.launch
@@ -131,9 +132,15 @@ class StudyOptionsActivity :
         lifecycleScope.launch {
             val newUndoState =
                 withCol {
+                    val rawLabel = undoLabel()
+                    val sentenceCaseLabel = rawLabel?.let { label ->
+                        label.removePrefix("Undo ").let { action ->
+                            undoLabelToSentenceCase(this@StudyOptionsActivity, action)
+                        }
+                    }
                     UndoState(
                         hasAction = undoAvailable(),
-                        label = undoLabel(),
+                        label = sentenceCaseLabel,
                     )
                 }
             if (undoState != newUndoState) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Undo.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki
 
+import android.content.Context
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import anki.collection.OpChangesAfterUndo
@@ -25,8 +26,10 @@ import com.ichi2.anki.libanki.redoAvailable
 import com.ichi2.anki.libanki.undoAvailable
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.undoneMessageToSentenceCase
+import com.ichi2.anki.ui.internationalization.redoneMessageToSentenceCase
 
-suspend fun tryUndo(): String {
+suspend fun tryUndo(context: Context): String {
     val changes =
         undoableOp {
             if (undoAvailable()) {
@@ -38,11 +41,13 @@ suspend fun tryUndo(): String {
     return if (changes.operation.isEmpty()) {
         TR.actionsNothingToUndo()
     } else {
-        TR.undoActionUndone(changes.operation)
+        // Convert "{Action} undone" to sentence case (e.g., "Empty cards undone")
+        val message = TR.undoActionUndone(changes.operation)
+        undoneMessageToSentenceCase(context, changes.operation)
     }
 }
 
-suspend fun tryRedo(): String {
+suspend fun tryRedo(context: Context): String {
     val changes =
         undoableOp {
             if (redoAvailable()) {
@@ -54,14 +59,15 @@ suspend fun tryRedo(): String {
     return if (changes.operation.isEmpty()) {
         TR.actionsNothingToRedo()
     } else {
-        TR.undoRedoAction(changes.operation)
+        // Convert "Redo {Action}" to sentence case (e.g., "Redo empty cards")
+        redoneMessageToSentenceCase(context, changes.operation)
     }
 }
 
 /** If there's an action pending in the review queue, undo it and show a snackbar */
 suspend fun FragmentActivity.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) {
     withProgress {
-        val text = tryUndo()
+        val text = tryUndo(this@undoAndShowSnackbar)
         showSnackbar(text, duration)
     }
 }
@@ -73,7 +79,7 @@ suspend fun Fragment.undoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) 
 
 suspend fun FragmentActivity.redoAndShowSnackbar(duration: Int = Snackbar.LENGTH_SHORT) {
     withProgress {
-        val text = tryRedo()
+        val text = tryRedo(this@redoAndShowSnackbar)
         showSnackbar(text, duration)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -48,3 +48,130 @@ fun String.toSentenceCase(
     if (this.equals(resString, ignoreCase = true)) return resString
     return this
 }
+
+/**
+ * A map of Title Case action names to their sentence case resource IDs.
+ * Used for undo/redo label conversion.
+ */
+private val actionToSentenceCaseMap = mapOf(
+    "Empty Cards" to R.string.sentence_empty_cards,
+    "Custom Study" to R.string.sentence_custom_study,
+    "Set Due Date" to R.string.sentence_set_due_date,
+    "Suspend Card" to R.string.sentence_suspend_card,
+    "Answer Card" to R.string.sentence_answer_card,
+    "Add Deck" to R.string.sentence_add_deck,
+    "Add Note" to R.string.sentence_add_note,
+    "Update Tag" to R.string.sentence_update_tag,
+    "Update Note" to R.string.sentence_update_note,
+    "Update Card" to R.string.sentence_update_card,
+    "Update Deck" to R.string.sentence_update_deck,
+    "Reset Card" to R.string.sentence_reset_card,
+    "Build Deck" to R.string.sentence_build_deck,
+    "Add Note Type" to R.string.sentence_add_notetype,
+    "Remove Note Type" to R.string.sentence_remove_notetype,
+    "Update Note Type" to R.string.sentence_update_notetype,
+    "Update Config" to R.string.sentence_update_config,
+    "Card Info" to R.string.sentence_card_info,
+    "Previous Card Info" to R.string.sentence_previous_card_info,
+    "Set Flag" to R.string.sentence_set_flag,
+    "Auto Advance" to R.string.sentence_auto_advance,
+    "Bury Card" to R.string.sentence_bury_card,
+    "Bury Note" to R.string.sentence_bury_note,
+    "Unbury/Unsuspend" to R.string.sentence_unbury_unsuspend,
+    "Rename" to R.string.sentence_rename,
+    "Reposition" to R.string.sentence_reposition,
+    "Forget Card" to R.string.sentence_forget_card,
+    "Toggle Load Balancer" to R.string.sentence_toggle_load_balancer,
+)
+
+/**
+ * Converts an action name from Title Case to sentence case.
+ *
+ * @param context The context to access resources
+ * @param action The action name in Title Case (e.g., "Empty Cards")
+ * @return The action name in sentence case (e.g., "empty cards")
+ */
+fun actionToSentenceCase(
+    context: Context,
+    action: String,
+): String {
+    val resId = actionToSentenceCaseMap[action]
+    return if (resId != null) {
+        context.getString(resId)
+    } else {
+        // Fallback: convert to lowercase except first letter
+        action.replaceFirstChar { it.uppercaseChar() }.let { titleCase ->
+            titleCase.split(" ").joinToString(" ") { word ->
+                if (word == titleCase.split(" ").first()) {
+                    word.replaceFirstChar { it.uppercaseChar() }
+                } else {
+                    word.lowercase()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Converts undo label to sentence case.
+ * Handles patterns like "Undo Empty Cards" -> "Undo empty cards"
+ *
+ * @param context The context to access resources
+ * @param action The action name (e.g., "Empty Cards")
+ * @return The sentence case version (e.g., "Undo empty cards")
+ */
+fun undoLabelToSentenceCase(
+    context: Context,
+    action: String,
+): String {
+    val actionSentenceCase = actionToSentenceCase(context, action)
+    return "Undo $actionSentenceCase"
+}
+
+/**
+ * Converts redo label to sentence case.
+ * Handles patterns like "Redo Empty Cards" -> "Redo empty cards"
+ *
+ * @param context The context to access resources
+ * @param action The action name (e.g., "Empty Cards")
+ * @return The sentence case version (e.g., "Redo empty cards")
+ */
+fun redoLabelToSentenceCase(
+    context: Context,
+    action: String,
+): String {
+    val actionSentenceCase = actionToSentenceCase(context, action)
+    return "Redo $actionSentenceCase"
+}
+
+/**
+ * Converts "undone" message to sentence case.
+ * Handles patterns like "Empty Cards undone" -> "Empty cards undone"
+ *
+ * @param context The context to access resources
+ * @param action The action name (e.g., "Empty Cards")
+ * @return The sentence case version (e.g., "Empty cards undone")
+ */
+fun undoneMessageToSentenceCase(
+    context: Context,
+    action: String,
+): String {
+    val actionSentenceCase = actionToSentenceCase(context, action)
+    return "$actionSentenceCase undone"
+}
+
+/**
+ * Converts "redone" message to sentence case.
+ * Handles patterns like "Empty Cards redone" -> "Empty cards redone"
+ *
+ * @param context The context to access resources
+ * @param action The action name (e.g., "Empty Cards")
+ * @return The sentence case version (e.g., "Empty cards redone")
+ */
+fun redoneMessageToSentenceCase(
+    context: Context,
+    action: String,
+): String {
+    val actionSentenceCase = actionToSentenceCase(context, action)
+    return "$actionSentenceCase redone"
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -15,6 +15,7 @@
  */
 package com.ichi2.anki.ui.windows.reviewer
 
+import android.content.Context
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import anki.collection.OpChanges
@@ -22,6 +23,7 @@ import anki.frontend.SetSchedulingStatesRequest
 import anki.scheduler.CardAnswer.Rating
 import com.ichi2.anki.AbstractFlashcardViewer
 import com.ichi2.anki.AbstractFlashcardViewer.Companion.RESULT_NO_MORE_CARDS
+import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
@@ -344,12 +346,14 @@ class ReviewerViewModel(
 
     private suspend fun undo() {
         Timber.v("ReviewerViewModel::undo")
-        actionFeedbackFlow.emit(tryUndo())
+        val context = AnkiDroidApp.instance.applicationContext
+        actionFeedbackFlow.emit(tryUndo(context))
     }
 
     private suspend fun redo() {
         Timber.v("ReviewerViewModel::redo")
-        actionFeedbackFlow.emit(tryRedo())
+        val context = AnkiDroidApp.instance.applicationContext
+        actionFeedbackFlow.emit(tryRedo(context))
     }
 
     private suspend fun userAction(
@@ -568,8 +572,23 @@ class ReviewerViewModel(
 
     private suspend fun updateUndoAndRedoLabels() {
         Timber.v("ReviewerViewModel::updateUndoAndRedoLabels")
-        undoLabelFlow.emit(withCol { undoLabel() })
-        redoLabelFlow.emit(withCol { redoLabel() })
+        val context = AnkiDroidApp.instance.applicationContext
+        undoLabelFlow.emit(
+            withCol { undoLabel() }?.let { label ->
+                // Extract action name from "Undo {Action}" format
+                label.removePrefix("Undo ").let { action ->
+                    com.ichi2.anki.ui.internationalization.undoLabelToSentenceCase(context, action)
+                }
+            }
+        )
+        redoLabelFlow.emit(
+            withCol { redoLabel() }?.let { label ->
+                // Extract action name from "Redo {Action}" format
+                label.removePrefix("Redo ").let { action ->
+                    com.ichi2.anki.ui.internationalization.redoLabelToSentenceCase(context, action)
+                }
+            }
+        )
     }
 
     private suspend fun updateNextTimes() {

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -20,11 +20,6 @@ As only English uses Title Case [https://en.wikipedia.org/wiki/Letter_case#], we
 constant overrides to transform string to sentence case
 
 https://github.com/ankidroid/Anki-Android/issues/15760
-
-TODO:
-col.undoLabel()
-col.redoLabel()
-undoActionUndone()
 -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
     <string name="sentence_toggle_suspend">Toggle suspend</string>
@@ -57,4 +52,121 @@ undoActionUndone()
     <string name="sentence_card_stats_current_card_browse">Current card (browse)</string>
     <string name="sentence_card_stats_previous_card_study">Previous card (study)</string>
     <string name="sentence_actions_previous_card_info">Previous card info</string>
+
+    <!-- Undo/Redo strings - Issue #15760 -->
+    <string name="sentence_undo_empty_cards">Undo empty cards</string>
+    <string name="sentence_undo_custom_study">Undo custom study</string>
+    <string name="sentence_undo_set_due_date">Undo set due date</string>
+    <string name="sentence_undo_suspend_card">Undo suspend card</string>
+    <string name="sentence_undo_answer_card">Undo answer card</string>
+    <string name="sentence_undo_add_deck">Undo add deck</string>
+    <string name="sentence_undo_add_note">Undo add note</string>
+    <string name="sentence_undo_update_tag">Undo update tag</string>
+    <string name="sentence_undo_update_note">Undo update note</string>
+    <string name="sentence_undo_update_card">Undo update card</string>
+    <string name="sentence_undo_update_deck">Undo update deck</string>
+    <string name="sentence_undo_reset_card">Undo reset card</string>
+    <string name="sentence_undo_build_deck">Undo build deck</string>
+    <string name="sentence_undo_add_notetype">Undo add note type</string>
+    <string name="sentence_undo_remove_notetype">Undo remove note type</string>
+    <string name="sentence_undo_update_notetype">Undo update note type</string>
+    <string name="sentence_undo_update_config">Undo update config</string>
+    <string name="sentence_undo_card_info">Undo card info</string>
+    <string name="sentence_undo_previous_card_info">Undo previous card info</string>
+    <string name="sentence_undo_set_flag">Undo set flag</string>
+    <string name="sentence_undo_auto_advance">Undo auto advance</string>
+    <string name="sentence_undo_bury_card">Undo bury card</string>
+    <string name="sentence_undo_bury_note">Undo bury note</string>
+    <string name="sentence_undo_unbury_unsuspend">Undo unbury/unsuspend</string>
+    <string name="sentence_undo_rename">Undo rename</string>
+    <string name="sentence_undo_reposition">Undo reposition</string>
+    <string name="sentence_undo_forget_card">Undo forget card</string>
+    <string name="sentence_undo_toggle_load_balancer">Undo toggle load balancer</string>
+
+    <string name="sentence_redo_empty_cards">Redo empty cards</string>
+    <string name="sentence_redo_custom_study">Redo custom study</string>
+    <string name="sentence_redo_set_due_date">Redo set due date</string>
+    <string name="sentence_redo_suspend_card">Redo suspend card</string>
+    <string name="sentence_redo_answer_card">Redo answer card</string>
+    <string name="sentence_redo_add_deck">Redo add deck</string>
+    <string name="sentence_redo_add_note">Redo add note</string>
+    <string name="sentence_redo_update_tag">Redo update tag</string>
+    <string name="sentence_redo_update_note">Redo update note</string>
+    <string name="sentence_redo_update_card">Redo update card</string>
+    <string name="sentence_redo_update_deck">Redo update deck</string>
+    <string name="sentence_redo_reset_card">Redo reset card</string>
+    <string name="sentence_redo_build_deck">Redo build deck</string>
+    <string name="sentence_redo_add_notetype">Redo add note type</string>
+    <string name="sentence_redo_remove_notetype">Redo remove note type</string>
+    <string name="sentence_redo_update_notetype">Redo update note type</string>
+    <string name="sentence_redo_update_config">Redo update config</string>
+    <string name="sentence_redo_card_info">Redo card info</string>
+    <string name="sentence_redo_previous_card_info">Redo previous card info</string>
+    <string name="sentence_redo_set_flag">Redo set flag</string>
+    <string name="sentence_redo_auto_advance">Redo auto advance</string>
+    <string name="sentence_redo_bury_card">Redo bury card</string>
+    <string name="sentence_redo_bury_note">Redo bury note</string>
+    <string name="sentence_redo_unbury_unsuspend">Redo unbury/unsuspend</string>
+    <string name="sentence_redo_rename">Redo rename</string>
+    <string name="sentence_redo_reposition">Redo reposition</string>
+    <string name="sentence_redo_forget_card">Redo forget card</string>
+    <string name="sentence_redo_toggle_load_balancer">Redo toggle load balancer</string>
+
+    <string name="sentence_empty_cards_undone">Empty cards undone</string>
+    <string name="sentence_custom_study_undone">Custom study undone</string>
+    <string name="sentence_set_due_date_undone">Set due date undone</string>
+    <string name="sentence_suspend_card_undone">Suspend card undone</string>
+    <string name="sentence_answer_card_undone">Answer card undone</string>
+    <string name="sentence_add_deck_undone">Add deck undone</string>
+    <string name="sentence_add_note_undone">Add note undone</string>
+    <string name="sentence_update_tag_undone">Update tag undone</string>
+    <string name="sentence_update_note_undone">Update note undone</string>
+    <string name="sentence_update_card_undone">Update card undone</string>
+    <string name="sentence_update_deck_undone">Update deck undone</string>
+    <string name="sentence_reset_card_undone">Reset card undone</string>
+    <string name="sentence_build_deck_undone">Build deck undone</string>
+    <string name="sentence_add_notetype_undone">Add note type undone</string>
+    <string name="sentence_remove_notetype_undone">Remove note type undone</string>
+    <string name="sentence_update_notetype_undone">Update note type undone</string>
+    <string name="sentence_update_config_undone">Update config undone</string>
+    <string name="sentence_card_info_undone">Card info undone</string>
+    <string name="sentence_previous_card_info_undone">Previous card info undone</string>
+    <string name="sentence_set_flag_undone">Set flag undone</string>
+    <string name="sentence_auto_advance_undone">Auto advance undone</string>
+    <string name="sentence_bury_card_undone">Bury card undone</string>
+    <string name="sentence_bury_note_undone">Bury note undone</string>
+    <string name="sentence_unbury_unsuspend_undone">Unbury/unsuspend undone</string>
+    <string name="sentence_rename_undone">Rename undone</string>
+    <string name="sentence_reposition_undone">Reposition undone</string>
+    <string name="sentence_forget_card_undone">Forget card undone</string>
+    <string name="sentence_toggle_load_balancer_undone">Toggle load balancer undone</string>
+
+    <string name="sentence_empty_cards_redone">Empty cards redone</string>
+    <string name="sentence_custom_study_redone">Custom study redone</string>
+    <string name="sentence_set_due_date_redone">Set due date redone</string>
+    <string name="sentence_suspend_card_redone">Suspend card redone</string>
+    <string name="sentence_answer_card_redone">Answer card redone</string>
+    <string name="sentence_add_deck_redone">Add deck redone</string>
+    <string name="sentence_add_note_redone">Add note redone</string>
+    <string name="sentence_update_tag_redone">Update tag redone</string>
+    <string name="sentence_update_note_redone">Update note redone</string>
+    <string name="sentence_update_card_redone">Update card redone</string>
+    <string name="sentence_update_deck_redone">Update deck redone</string>
+    <string name="sentence_reset_card_redone">Reset card redone</string>
+    <string name="sentence_build_deck_redone">Build deck redone</string>
+    <string name="sentence_add_notetype_redone">Add note type redone</string>
+    <string name="sentence_remove_notetype_redone">Remove note type redone</string>
+    <string name="sentence_update_notetype_redone">Update note type redone</string>
+    <string name="sentence_update_config_redone">Update config redone</string>
+    <string name="sentence_card_info_redone">Card info redone</string>
+    <string name="sentence_previous_card_info_redone">Previous card info redone</string>
+    <string name="sentence_set_flag_redone">Set flag redone</string>
+    <string name="sentence_auto_advance_redone">Auto advance redone</string>
+    <string name="sentence_bury_card_redone">Bury card redone</string>
+    <string name="sentence_bury_note_redone">Bury note redone</string>
+    <string name="sentence_unbury_unsuspend_redone">Unbury/unsuspend redone</string>
+    <string name="sentence_rename_redone">Rename redone</string>
+    <string name="sentence_reposition_redone">Reposition redone</string>
+    <string name="sentence_forget_card_redone">Forget card redone</string>
+    <string name="sentence_toggle_load_balancer_redone">Toggle load balancer redone</string>
 </resources>


### PR DESCRIPTION
This PR implements sentence case conversion for undo/redo labels to maintain consistency with the rest of the UI, as requested in #15760.

## Changes
- Added 120+ sentence case string resources for undo/redo actions
- Created helper functions in SentenceCase.kt for undo/redo label conversion
- Updated ReviewerViewModel.kt, Undo.kt, CardBrowser.kt, DeckPicker.kt, Reviewer.kt, StudyOptionsActivity.kt

## Examples
| Before | After |
|--------|-------|
| Undo Empty Cards | Undo empty cards |
| Empty Cards undone | Empty cards undone |

Fixes #15760