### PR TITLE
Mark notificationsPermissionRequested preference property used in reflection as keep in Proguard

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -29,6 +29,7 @@
 -keep class androidx.core.app.ActivityCompat$* { *; }
 -keep class androidx.concurrent.futures.** { *; }
 -keep class androidx.appcompat.view.menu.MenuItemImpl { *; } # .utils.ext.MenuItemImpl
+-keep class com.ichi2.anki.settings.PrefsRepository { *; } # PrefsRepository.notificationsPermissionRequested
 
 # Ignore unused packages
 -dontwarn javax.naming.**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

We have quite a few reports for:

<details>
<summary>Stacktrace</summary>

```
kotlin.jvm.KotlinReflectionNotSupportedError: Property 'notificationsPermissionRequested' (JVM signature: getNotificationsPermissionRequested()Z) not resolved in class bb.a
  at kotlin.reflect.jvm.internal.KDeclarationContainerImpl.findPropertyDescriptor(KDeclarationContainerImpl.kt:88)
  at kotlin.reflect.jvm.internal.KPropertyImpl._descriptor$lambda$5(KPropertyImpl.kt:126)
  at kotlin.reflect.jvm.internal.KPropertyImpl.accessor$KPropertyImpl$lambda1(KPropertyImpl.kt)
  at kotlin.reflect.jvm.internal.KPropertyImpl$$Lambda$1.invoke(KPropertyImpl.java)
  at kotlin.reflect.jvm.internal.ReflectProperties$LazySoftVal.invoke(ReflectProperties.java:70)
  at kotlin.reflect.jvm.internal.KPropertyImpl.getDescriptor(KPropertyImpl.kt:129)
  at kotlin.reflect.jvm.internal.KPropertyImplKt.computeCallerForAccessor(KPropertyImpl.kt:252)
  at kotlin.reflect.jvm.internal.KPropertyImplKt.access$computeCallerForAccessor(KPropertyImpl.kt:1)
  at kotlin.reflect.jvm.internal.KPropertyImpl$Getter.caller_delegate$lambda$1(KPropertyImpl.kt:180)
  at kotlin.reflect.jvm.internal.KPropertyImpl$Getter.accessor$KPropertyImpl$Getter$lambda1(KPropertyImpl.kt)
  at kotlin.reflect.jvm.internal.KPropertyImpl$Getter$$Lambda$1.invoke(KPropertyImpl.java)
  at kotlin.SafePublicationLazyImpl.getValue(LazyJVM.kt:125)
  at kotlin.reflect.jvm.internal.KPropertyImpl$Getter.getCaller(KPropertyImpl.kt:179)
  at kotlin.reflect.jvm.internal.KCallableImpl.call(KCallableImpl.kt:108)
  at com.ichi2.utils.Permissions.canPermissionBeRequested(Permissions.kt:86)
  at com.ichi2.utils.Permissions.showNotificationsPermissionBottomSheetIfNeeded(Permissions.kt:141)
  at com.ichi2.utils.Permissions.requestNotificationPermissionsForSyncing(Permissions.kt:163)
  at com.ichi2.anki.DeckPicker.refreshState(DeckPicker.kt:1453)
  at com.ichi2.anki.DeckPicker.onResume(DeckPicker.kt:1443)
  at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1717)
  at android.app.Activity.performResume(Activity.java:9315)
  at android.app.ActivityThread.performResumeActivity(ActivityThread.java:5605)
  at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:5648)
  at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:73)
  at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:63)
  at android.app.servertransaction.TransactionExecutor.executeLifecycleItem(TransactionExecutor.java:169)
  at android.app.servertransaction.TransactionExecutor.executeTransactionItems(TransactionExecutor.java:101)
  at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:80)
  at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2823)
  at android.os.Handler.dispatchMessage(Handler.java:110)
  at android.os.Looper.loopOnce(Looper.java:248)
  at android.os.Looper.loop(Looper.java:338)
  at android.app.ActivityThread.main(ActivityThread.java:9067)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:593)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:932)
```
</details>

The property was added relatively recent and it was used in reflection but the Progurad rules were not also updated. This results in the app crashing when logging in, example:

_Uninstall the current app and install one of the parallel apks-> allow the permission request and go to DeckPicker -> Try to sync and login when asked -> Crash with the above exception_

## How Has This Been Tested?

Used the Proguard playground and this seems to keep the problematic property.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
