### PR TITLE
Fix: Remove unused variables in CardTest.kt and DeckNodeTest.kt.

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/DeckNodeTest.kt
@@ -66,7 +66,6 @@ class DeckNodeTest {
         val group = makeNode("Group", 4, 4)
         val algebra = makeNode("Algebra", 3, 3, children = listOf(group))
         val math = makeNode("Math", 2, 2, collapsed = true, children = listOf(algebra))
-        val science = makeNode("Science", 1, 1, children = listOf(math))
 
         val results = math.filterAndFlatten(null)
         assertEquals(1, results.size)

--- a/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/CardTest.kt
@@ -284,8 +284,7 @@ class CardTest : InMemoryAnkiTest() {
         assertEquals(expectedTimeLimit, timeLimit)
 
         // Verify it's using currentDeckId() by checking it matches original deck's config, not filtered deck's
-        val configDictForDeckId = col.decks.configDictForDeckId(filteredDeckId)
-        // Both decks share the same config, so verify we're looking at the right deck ID
+        // Both decks share the same config, so verify we're looking at     the right deck ID
         assertEquals(originalDeckId, card.currentDeckId())
         assertNotEquals(filteredDeckId, card.currentDeckId())
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Removed unused variables in test files as identified by Android Studio inspection.

## Fixes
* Fixes #13282 

## Approach
Used Android Studio's inspection tool (Code → Inspect Code) to identify unused variable warnings, then removed the unused variable declarations from CardTest.kt, DeckNodeTest.kt.

## How Has This Been Tested?

Ran `./gradlew lintPlayDebug ktLintCheck` successfully on Windows with JDK 21


## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->