### PR TITLE
fix(grade-now): handle binding when view is reused

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
@@ -104,16 +104,21 @@ private class GradeNowListAdapter(
         position: Int,
         convertView: View?,
         parent: ViewGroup,
-    ): View =
-        convertView ?: GradeNowListItemBinding
-            .inflate(LayoutInflater.from(context), parent, false)
-            .also { binding ->
-                val grade = getItem(position)!!
-                binding.gradeTextView.apply {
-                    text = grade.getLabel()
-                    setCompoundDrawablesRelativeWithIntrinsicBoundsKt(start = grade.iconRes)
-                }
-            }.root
+    ): View {
+        val binding =
+            if (convertView != null) {
+                GradeNowListItemBinding.bind(convertView)
+            } else {
+                GradeNowListItemBinding.inflate(LayoutInflater.from(context), parent, false)
+            }
+
+        val grade = getItem(position)!!
+        binding.gradeTextView.apply {
+            text = grade.getLabel()
+            setCompoundDrawablesRelativeWithIntrinsicBoundsKt(start = grade.iconRes)
+        }
+        return binding.root
+    }
 }
 
 private enum class Grade(


### PR DESCRIPTION
## Purpose / Description
Previously the binding was only updated if `convertView` was `null`

## Fixes
* Last part of #11116

## How Has This Been Tested?

<img width="331" height="387" alt="Screenshot 2026-03-04 at 14 35 41" src="https://github.com/user-attachments/assets/37d6d05b-6eea-4046-8369-e8a37ca3ff5b" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)