### PR TITLE
style(crowdin): fix ESLint 10 issues

### DIFF
--- a/tools/localization/src/update.ts
+++ b/tools/localization/src/update.ts
@@ -163,7 +163,7 @@ export async function updateI18nFiles() {
         // but this comment hopefully clarifies for the reader that BCP47 / ISO-639-2 3-letter language tags do work in practice.
         //
         // The codes are not case-sensitive; the r prefix is used to distinguish the region portion. You cannot specify a region alone.
-        let androidLanguages = [];
+        let androidLanguages: string[];
         const languageCode = language.split("-", 1)[0];
         if (LOCALIZED_REGIONS.includes(languageCode)) {
             androidLanguages = [language.replace("-", "-r")]; // zh-CN becomes zh-rCN


### PR DESCRIPTION
## Purpose / Description

```
/home/runner/work/Anki-Android/Anki-Android/tools/localization/src/update.ts
  166:13  error  This assigned value is not used in subsequent statements  no-useless-assignment
```

## Fixes
* Unblocks PR #20313

## Approach
Removed unused assignment

## How Has This Been Tested?

apply this patch on top of #20313
`cd tools/localization && yarn lint`


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)