### PR TITLE
Fix cloze number when existing clozes are present

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.anki.instantnoteeditor
 
+import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -26,6 +27,7 @@ import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NoteFieldsCheckResult
 import com.ichi2.anki.OnErrorListener
 import com.ichi2.anki.checkNoteFieldsResponse
+import com.ichi2.anki.common.utils.ext.replaceWith
 import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity.DialogType
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Note
@@ -181,6 +183,18 @@ class InstantEditorViewModel :
     }
 
     /**
+     * Extracts the cloze ordinals from text (if any).
+     *
+     * `"{{c2::text}} {{c1::more}}"` => `[2, 1]`
+     */
+    @CheckResult
+    private fun getClozeOrdinals(text: String): List<Int> =
+        clozePattern
+            .findAll(text)
+            .mapNotNull { it.groups[2]?.value?.toIntOrNull() }
+            .toList()
+
+    /**
      * Retrieves all cloze text fields from the current editor note's note type.
      *
      * This method accesses the `editorNote` property to fetch its associated note type
@@ -206,6 +220,8 @@ class InstantEditorViewModel :
 
     fun setClozeFieldText(text: String?) {
         _actualClozeFieldText.value = text
+        intClozeList.replaceWith(getClozeOrdinals(text ?: ""))
+        _currentClozeNumber.value = (intClozeList.maxOrNull() ?: 0) + 1
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -213,6 +213,52 @@ class InstantEditorViewModelTest : RobolectricTest() {
             assertEquals(word, cleanWord)
         }
 
+    @Test
+    fun `cloze numbering continues from existing clozes`() =
+        runViewModelTest {
+            val text =
+                "This is the {{c1::first cloze}}. " +
+                    "This should be the {{c2::second cloze}}. " +
+                    "Similarly, this one as {{c3::third cloze}}."
+
+            setClozeFieldText(text)
+
+            val result = buildClozeText("fourth")
+
+            assertEquals("{{c4::fourth}}", result)
+        }
+
+    @Test
+    fun `removing a cloze does not reset numbering`() =
+        runViewModelTest {
+            val text = "{{c1::first}} {{c2::second}} {{c3::third}}"
+
+            setClozeFieldText(text)
+
+            val words = getWordsFromFieldText().toMutableList()
+
+            words[1] = buildClozeText(words[1]) // remove c2
+
+            val result = buildClozeText("fourth")
+
+            assertEquals("{{c4::fourth}}", result)
+        }
+
+    @Test
+    fun `toggling cloze mode does not reset numbering`() =
+        runViewModelTest {
+            val text = "{{c1::first}} {{c2::second}} {{c3::third}}"
+
+            setClozeFieldText(text)
+
+            toggleClozeMode() // switch to NO_INCREMENT mode
+            toggleClozeMode() // switch back to INCREMENT mode
+
+            val result = buildClozeText("fourth")
+
+            assertEquals("{{c4::fourth}}", result)
+        }
+
     private fun runViewModelTest(
         initViewModel: () -> InstantEditorViewModel = { InstantEditorViewModel() },
         testBody: suspend InstantEditorViewModel.() -> Unit,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_Instant Note was not displaying cloze number properly with cloze text._

## Fixes
* Fixes #20350 

## Approach

- Cloze counter and `intClozeList` is derived from actual text.

## How Has This Been Tested?
- Verified that existing unit tests pass (`InstantEditorViewModelTest.kt`).

- Added 3 unit test cases based on observations as mentioned in https://github.com/ankidroid/Anki-Android/issues/20350#issuecomment-3941428645

- Tested on my phone (Android 14, Xiaomi / HyperOS) using a debug build.

Used the following two texts for testing:

```
This is the {{c1::first cloze}}. This should be the second cloze.
```
```
This is the {{c1::first cloze}}. This should be the {{c2::second cloze}}. Similarly, this one as {{c3::third cloze}}.
```

Two screen recording attached as evidence.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->


https://github.com/user-attachments/assets/3355ef98-565e-4a0a-8001-38089b000ab6


https://github.com/user-attachments/assets/7cee9321-8b5c-42e5-bd35-952cb9da1502


