### PR TITLE
fix(browser): SearchView fragment state transitions [dev only]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -249,6 +249,11 @@ class CardBrowserFragment :
             view.findViewById<SearchView>(R.id.search_view)?.apply {
                 editText.doAfterTextChanged { searchViewModel.onSearchTextChanged(it.toString()) }
                 addTransitionListener { _, _, state ->
+                    if (state == SearchView.TransitionState.SHOWING) {
+                        getOrCreateSearchFragment(StandardSearchFragment.TAG, ::StandardSearchFragment)
+                        return@addTransitionListener
+                    }
+
                     if (state != SearchView.TransitionState.HIDDEN) return@addTransitionListener
                     // clear state on hide
                     childFragmentManager

--- a/AnkiDroid/src/main/res/layout/card_browser_searchview_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser_searchview_fragment.xml
@@ -140,7 +140,6 @@
                 android:id="@+id/search_view_content_container"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:name="com.ichi2.anki.browser.search.StandardSearchFragment"
                 />
 
         </LinearLayout>


### PR DESCRIPTION
## Purpose / Description
Previously if opening the 'advanced' search, the content of the 'standard' search overlapped with it

This ensures that a tag is used when attaching the 'standard' search so it can be hidden properly

## Fixes
* split out of my large change for #18709

## Approach
Always use the tag to create/restore the fragment

## How Has This Been Tested?
Personal `browser-advanced-more` branch 

Content no longer overlaps between the two fragments

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)