### PR TITLE
Fix FAB accessibility issue with TalkBack

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -18,10 +18,14 @@ package com.ichi2.anki
 import android.animation.Animator
 import android.content.Context
 import android.content.res.ColorStateList
+import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MotionEvent
 import android.view.View
 import android.widget.LinearLayout
+import androidx.core.view.AccessibilityDelegateCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
 import com.google.android.material.color.MaterialColors
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.FloatingAddButtonBinding
@@ -346,6 +350,28 @@ class DeckPickerFloatingActionMenu(
         }
 
     init {
+        ViewCompat.setAccessibilityDelegate(
+            binding.fabMain,
+            object : AccessibilityDelegateCompat() {
+                override fun performAccessibilityAction(
+                    host: View,
+                    action: Int,
+                    args: Bundle?,
+                ): Boolean {
+                    if (action == AccessibilityNodeInfoCompat.ACTION_CLICK) {
+                        Timber.d("FAB main button: TalkBack CLICK action performed")
+                        if (!isFABOpen) {
+                            showFloatingActionMenu()
+                        } else {
+                            addNote()
+                        }
+                        return true
+                    }
+                    return super.performAccessibilityAction(host, action, args)
+                }
+            },
+        )
+
         binding.fabMain.setOnTouchListener(
             object : DoubleTapListener(context) {
                 override fun onDoubleTap(e: MotionEvent?) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPickerFloatingActionMenu.kt
@@ -63,9 +63,11 @@ class DeckPickerFloatingActionMenu(
     val isFragmented: Boolean
         get() = studyOptionsFrame != null
 
+    @Suppress("DEPRECATION")
     private fun showFloatingActionMenu() {
         toggleListener?.onBeginToggle(isOpening = true)
         deckPicker.activeSnackBar?.dismiss()
+        binding.fabMain.announceForAccessibility(context.getString(R.string.fab_menu_opened))
         linearLayout.alpha = 0.5f
         studyOptionsFrame?.let { it.alpha = 0.5f }
         isFABOpen = true
@@ -147,8 +149,10 @@ class DeckPickerFloatingActionMenu(
      * Case 2: When the user opens the side navigation drawer (without touching the FAB). In that case we don't
      * want to show any type of rise and shrink animation for the FAB so we put the value `false` for the parameter.
      */
+    @Suppress("DEPRECATION")
     fun closeFloatingActionMenu(applyRiseAndShrinkAnimation: Boolean) {
         toggleListener?.onBeginToggle(isOpening = false)
+        binding.fabMain.announceForAccessibility(context.getString(R.string.fab_menu_closed))
         if (applyRiseAndShrinkAnimation) {
             linearLayout.alpha = 1f
             studyOptionsFrame?.let { it.alpha = 1f }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -450,5 +450,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
 
     <!-- Whitespace is OK -->
     <string name="list_separator" comment="The character and spacing to display between elements of a list, for example ', ' in 'Apple, Banana, Cherry" tools:ignore="TranslationTypo">, </string>
+    <!-- Accessibility -->
+    <string name="fab_menu_opened">Menu opened</string>
+    <string name="fab_menu_closed">Menu closed</string>
 </resources>
-


### PR DESCRIPTION
### Purpose / Description
Fixed an accessibility bug where the "Add FAB" functionality does not work when TalkBack is enabled. The FloatingActionButton was receiving focus but not handling the `ACTION_CLICK` event properly for TalkBack users, and it was also failing to announce its state changes (menu opened/menu closed) to visually impaired users.

### Fixes
 [Accessibility] Add FAB doesn't work when talkback is enabled #20379

### Approach
- Added `AccessibilityDelegateCompat` to [DeckPickerFloatingActionMenu](cci:2://file:///d:/Anki-Android/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt:26:0-28:38) to explicitly handle TalkBack `ACTION_CLICK` events on the `fabMain` button.
- Added `announceForAccessibility` calls (using explicit localized string resources `fab_menu_opened` and `fab_menu_closed` in `02-strings.xml`) to explicitly tell TalkBack users when the FAB menu opens and closes.
- Cleaned up the PR commit history to only include the relevant fixed changes. 

### How Has This Been Tested?
Tested manually with TalkBack enabled.
1. Verified the FAB now reads its label properly.
2. Verified that double-tapping (the standard TalkBack click gesture) activates the menu or adds a note depending on whether the FAB is open.
3. Verified the app accurately announces "Menu opened" and "Menu closed" when toggling the FAB states.
Ran `testPlayDebugUnitTest` locally without regressions.

### Learning (optional, can help others)
- TalkBack intercepting touch events requires `AccessibilityDelegateCompat` to pass an explicit `ACTION_CLICK` when relying on custom touch handlers.
- Dynamic visual state changes to Floating Action Buttons (such as unrolling a menu) should announce their state via `announceForAccessibility` to ensure screen-reader users understand what visual changes just took place on-screen.

### Checklist
Please, go through these checks before submitting the PR.

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner
