### PR TITLE
fix: potential storage leak in AudioRecorder

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/recorder/AudioRecorder.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/recorder/AudioRecorder.kt
@@ -41,6 +41,7 @@ class AudioRecorder(
     private val context: Context,
 ) : Closeable {
     private var recorder: MediaRecorder? = null
+    private var isTempFile = false
 
     /**
      * Indicates whether the recorder is currently capturing audio.
@@ -67,6 +68,7 @@ class AudioRecorder(
         Timber.i("AudioRecorder::startRecording (isRecording %b)", isRecording)
         if (isRecording) return
 
+        isTempFile = file == null
         val target = file ?: createTempFile() ?: return
         currentFile = target
 
@@ -125,18 +127,27 @@ class AudioRecorder(
 
     /**
      * Stops the recording and updates state.
+     * @param keepFile If false, deletes the file (only if it was a temp file).
      */
-    fun stop() {
+    fun stop(keepFile: Boolean = true) {
         if (!isRecording) return
 
         try {
             recorder?.stop()
         } catch (e: RuntimeException) {
             Timber.w(e, "Failed to stop recorder: likely called too soon after start")
-            currentFile?.delete()
-            currentFile = null
+            deleteCurrentFile()
         } finally {
             isRecording = false
+
+            if (!keepFile && isTempFile) {
+                deleteCurrentFile()
+            }
+
+            if (!keepFile) {
+                currentFile = null
+            }
+            isTempFile = false
         }
     }
 
@@ -181,8 +192,23 @@ class AudioRecorder(
      * Should be called in `onDestroy()` or when the class is no longer needed.
      */
     override fun close() {
-        stop()
-        recorder?.release()
-        recorder = null
+        try {
+            if (isRecording) {
+                // If closing while recording, we assume it's an abort
+                stop(keepFile = !isTempFile)
+            }
+        } finally {
+            recorder?.release()
+            recorder = null
+        }
+    }
+
+    private fun deleteCurrentFile() {
+        val file = currentFile ?: return
+        if (file.exists() && !file.delete()) {
+            Timber.w("Failed to delete temporary recording file: ${file.absolutePath}")
+        } else {
+            Timber.d("Deleted temporary recording file")
+        }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/recorder/AudioRecorderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/recorder/AudioRecorderTest.kt
@@ -36,6 +36,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
@@ -141,5 +143,50 @@ class AudioRecorderTest : RobolectricTest() {
 
         assertEquals(customFile.absolutePath, audioRecorder.currentFile?.absolutePath)
         verify { mockMediaRecorder.setOutputFile(customFile.absolutePath) }
+    }
+
+    @Test
+    fun `stop should delete temp file if not kept`() {
+        val audioRecorder = createRecorder()
+        audioRecorder.start()
+
+        val tempFile = audioRecorder.currentFile
+        assertTrue("Temp file should exist", tempFile?.exists() ?: false)
+
+        audioRecorder.stop(keepFile = false)
+        assertFalse(tempFile?.exists() ?: true)
+    }
+
+    @Test
+    fun `close() while recording temp file should delete the file`() {
+        val audioRecorder = createRecorder()
+        audioRecorder.start()
+        val tempFile = audioRecorder.currentFile
+
+        assertTrue("Temp file should exist", tempFile?.exists() ?: false)
+
+        audioRecorder.close()
+
+        assertFalse(tempFile?.exists() ?: true, "Temp file should be cleaned up on close")
+        verify { mockMediaRecorder.release() }
+    }
+
+    @Test
+    fun `recording after a failed stop should still work and clean up`() {
+        every { mockMediaRecorder.stop() } throws RuntimeException("stop failed")
+
+        val audioRecorder = createRecorder()
+        audioRecorder.start()
+        val firstFile = audioRecorder.currentFile
+
+        audioRecorder.stop()
+
+        assertFalse(firstFile?.exists() ?: true, "File should be deleted if recorder.stop() fails")
+        assertFalse(audioRecorder.isRecording)
+
+        // Ensure we can start again immediately
+        audioRecorder.start()
+        assertTrue(audioRecorder.isRecording)
+        assertNotNull(audioRecorder.currentFile)
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Here I want to addresses concerns regarding the lifecycle and cleanup of temporary recording files. Previously, files created in the cacheDir could persist indefinitely.

## Fixes
* Fixes #20381

## Approach
NA

## How Has This Been Tested?
Added Unit tests

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->