### PR TITLE
fix: prevent deck overlap by skipping redundant scroll for visible items

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -174,6 +174,7 @@ import com.ichi2.anki.utils.ShortcutUtils
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.getSizeOfBitmapFromCollection
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
+import com.ichi2.anki.utils.ext.positionIsVisible
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.anki.utils.runWithOOMCheck
@@ -784,6 +785,12 @@ open class DeckPicker :
 
         fun onFocusedDeckChanged(deckId: DeckId?) {
             val position = deckId?.let { viewModel.findDeckPosition(it) } ?: 0
+
+            // Skip centering if the deck is already on screen.
+            // Scrolling during a tap animation causes deck labels to overlap on older devices.
+            if (decksLayoutManager.positionIsVisible(position)) {
+                return
+            }
             // HACK: a small delay is required before scrolling works
             deckPickerBinding.decks.postDelayed({
                 decksLayoutManager.scrollToPositionWithOffset(position, deckPickerBinding.decks.height / 2)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/LinearLayoutManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/LinearLayoutManager.kt
@@ -35,3 +35,8 @@ val LinearLayoutManager.visibleItemPositions: IntRange
         }
         return first..last
     }
+
+/**
+ * Returns true if the position is currently visible.
+ */
+fun LinearLayoutManager.positionIsVisible(position: Int): Boolean = position in visibleItemPositions


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes visual overlapping of deck names/counts when a deck is tapped.

## Fixes
* Fixes #19193

## Approach
Skips the programmatic centering scroll if the deck is already visible to the user. This avoids a layout conflict between the scroll and the adapter's repaint.

## How Has This Been Tested?
Verified on Android 11 (API 30) emulator. Taps on visible decks are now smooth without glitches, and secondary focus (returning from reviewer) still centers correctly.

https://github.com/user-attachments/assets/e3e7a056-bd60-4bcf-997c-45d3cdf817fa


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
