### PR TITLE
test(instant-card): Added a unit test for checking cloze counter numbering while toggling.

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -259,6 +259,21 @@ class InstantEditorViewModelTest : RobolectricTest() {
             assertEquals("{{c4::fourth}}", result)
         }
 
+    @Test
+    fun `toggle from increment to no_increment adjusts cloze counter`() =
+        runViewModelTest {
+            val text = "This is {{c1::first}} and {{c2::second}}"
+            setClozeFieldText(text)
+
+            assertEquals(3, currentClozeNumber)
+
+            toggleClozeMode() // switch to NO_INCREMENT mode
+            assertEquals(2, currentClozeNumber)
+
+            toggleClozeMode() // switch back to INCREMENT mode
+            assertEquals(3, currentClozeNumber)
+        }
+
     private fun runViewModelTest(
         initViewModel: () -> InstantEditorViewModel = { InstantEditorViewModel() },
         testBody: suspend InstantEditorViewModel.() -> Unit,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_While solving https://github.com/ankidroid/Anki-Android/issues/20350 issue and working with https://github.com/ankidroid/Anki-Android/pull/20398 PR, I noticed that **there is no unit test that checks if the cloze counter number is correct while toggling mode** (from `INCREMENT` to `NO_INCREMENT` and vice-versa)._

_It is the by-product of observations as mentioned in https://github.com/ankidroid/Anki-Android/issues/20350#issuecomment-3941428645_

_As a result of the absence of this unit test, even an incorrect implementation(intermediate code I used while testing) is passing all the unit tests._


## Fixes
* Related to #20350 

## Approach
It checks if the cloze counter number is assigned the correct value when we switch modes each time, by creating a unit test.

## How Has This Been Tested?

This test **fails on `main`** but **passes with fix made in https://github.com/ankidroid/Anki-Android/pull/20398 PR**.

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)