### PR TITLE
fix: preserve tag segments when normalizing search for ignore-accents

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -77,7 +77,7 @@ import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
 import com.ichi2.anki.utils.ext.currentCardBrowse
-import com.ichi2.anki.utils.ext.normalizeForSearch
+import com.ichi2.anki.utils.ext.normalizeForSearchPreservingTags
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -1178,7 +1178,7 @@ class CardBrowserViewModel(
         }
         flowOfSearchTerms.value =
             if (shouldIgnoreAccents) {
-                searchQuery.normalizeForSearch()
+                searchQuery.normalizeForSearchPreservingTags()
             } else {
                 searchQuery
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/String.kt
@@ -22,6 +22,9 @@ import java.util.regex.Pattern
 
 private val DIACRITICAL_MARKS_PATTERN = Pattern.compile("\\p{InCombiningDiacriticalMarks}+")
 
+/** Matches `tag:` + quoted or unquoted value. Left verbatim so backend matches tags exactly. */
+private val TAG_SEGMENT_PATTERN = Pattern.compile("tag:(?:\"[^\"]*\"|[^\\s\\)]+)")
+
 /**
  * Normalizes the given string by removing diacritical marks (accents) to enable accent-insensitive searches.
  *
@@ -41,4 +44,24 @@ private val DIACRITICAL_MARKS_PATTERN = Pattern.compile("\\p{InCombiningDiacriti
 fun String.normalizeForSearch(): String {
     val normalized = Normalizer.normalize(this, Normalizer.Form.NFD)
     return DIACRITICAL_MARKS_PATTERN.matcher(normalized).replaceAll("")
+}
+
+/**
+ * Normalizes query for accent-insensitive search but keeps `tag:...` segments unchanged
+ * (backend matches tags literally). Uses [normalizeForSearch] only outside tag segments.
+ *
+ * @receiver Raw search query (e.g. `café ("tag:être")`).
+ * @return Query with accents removed except inside `tag:...`.
+ */
+fun String.normalizeForSearchPreservingTags(): String {
+    val matcher = TAG_SEGMENT_PATTERN.matcher(this)
+    val sb = StringBuilder(length)
+    var cursor = 0
+    while (matcher.find()) {
+        sb.append(substring(cursor, matcher.start()).normalizeForSearch())
+        sb.append(matcher.group())
+        cursor = matcher.end()
+    }
+    sb.append(substring(cursor).normalizeForSearch())
+    return sb.toString()
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -19,11 +19,13 @@ package com.ichi2.anki.browser
 import androidx.core.content.edit
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.config.ConfigKey
 import app.cash.turbine.TurbineTestContext
 import app.cash.turbine.test
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
 import com.ichi2.anki.NoteEditorActivity
 import com.ichi2.anki.NoteEditorFragment
@@ -70,6 +72,7 @@ import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.QueueType.ManuallyBuried
 import com.ichi2.anki.libanki.QueueType.New
 import com.ichi2.anki.libanki.testutils.AnkiTest
+import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.model.SortType
@@ -1357,6 +1360,21 @@ class CardBrowserViewModelTest : JvmTest() {
             )
             for (cardId in cardIds) {
                 assertNotNull(col.getCard(cardId))
+            }
+        }
+
+    @Test
+    fun `accented tags are searchable if ignoring accents - Issue 20409`() =
+        runTest {
+            addBasicNote().update { tags = mutableListOf("être") }
+            withCol { config.setBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH, true) }
+            runViewModelTest(notes = 0) {
+                flowOfSearchState.test {
+                    filterByTags(listOf("être"), CardStateFilter.ALL_CARDS)
+                    assertThat(awaitItem(), equalTo(CardBrowserViewModel.SearchState.Searching))
+                    assertThat(awaitItem(), equalTo(CardBrowserViewModel.SearchState.Completed))
+                    assertThat(rowCount, equalTo(1))
+                }
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/StringNormalizationTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/StringNormalizationTest.kt
@@ -18,6 +18,7 @@
 package com.ichi2.anki.browser
 
 import com.ichi2.anki.utils.ext.normalizeForSearch
+import com.ichi2.anki.utils.ext.normalizeForSearchPreservingTags
 import org.junit.Assert.assertEquals
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -36,5 +37,19 @@ class StringNormalizationTest {
         expected: String,
     ) {
         assertEquals(expected, input.normalizeForSearch())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "café tag:foo, cafe tag:foo",
+        "tag:être, tag:être",
+        "(\"tag:être\" or \"tag:foo\"), (\"tag:être\" or \"tag:foo\")",
+        "résumé tag:naïve, resume tag:naïve",
+    )
+    fun `test normalizeForSearchPreservingTags preserves tag segments`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.normalizeForSearchPreservingTags())
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
With Ignore accents in search on, the whole query was normalized, so `tag:être` became `tag:etre` and tag search failed. We now only normalize the parts of the query outside tag:... segments so tag search still works.

## Fixes
* Fixes #20409

## Approach
Added normalizeForSearchPreservingTags(): it finds every tag:... segment (quoted or not), leaves those unchanged, and runs normalizeForSearch() on the rest. The browser uses this instead of normalizeForSearch() when the option is on.

## How Has This Been Tested?
Unit tests for the new helper; integration test (note with tag "être", option on, filter by "être" → 1 row). 

Manually: same steps; note appears with the fix, no results without it.

## Screen Recording
[Screen_recording_20260307_020248.webm](https://github.com/user-attachments/assets/12c8d1cd-272e-4585-b59e-8d34f927c77f)




## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->