### PR TITLE
fix: minor Android Studio warnings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/Utils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/Utils.kt
@@ -13,6 +13,7 @@
  * You should have received a copy of the GNU General Public License along with
  * this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+package com.ichi2.anki.dialogs
 
 import android.text.method.LinkMovementMethod
 import android.widget.TextView

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1232,7 +1232,7 @@ class CardBrowserTest : RobolectricTest() {
     @Test
     @Ignore(
         "issues with launchCollectionInLifecycleScope - provided value is not current" +
-            "use an integration test",
+            " use an integration test",
     )
     fun `column text is updated - cardsOrNotes and column change`() {
         addBasicAndReversedNote("Hello", "World")

--- a/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/compat/Test21And26.kt
@@ -89,7 +89,7 @@ abstract class Test21And26 {
      * Represents structure and compat required to simulate https://github.com/ankidroid/Anki-Android/issues/10358
      * This is a bug that occurred in a smartphone, where listFiles returned `null` on an existing directory.
      */
-    inner class PermissionDenied(
+    class PermissionDenied(
         val directory: Directory,
         val compat: Compat,
     ) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
As a new contributor, I wanted to get familiar with the codebase and wanted to have my first pull request merged. Fixes #13282 seemed to be a good starting point and hence, I decided to fix some Android Studio warnings.

## Fixes
- Fixed a problem/error in 1 file (`AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt`)
- Fixed simple warnings in 2 other files
## Approach
Ran `Code/Inspect Code` in Android Studio and reviewed the warnings/problems in the code and made the following changes:
- In `CardBrowserTest.kt` in the directory `AnkiDroid/src/test/java/com/ichi2/anki`, added a space between 'current' and 'use' since it was a problem in the file
- In `Utils.kt` in the directory `AnkiDroid/src/main/java/com/ichi2/anki/dialogs`, added the `package com.ichi2.anki ...` line to resolve the warning "Package directive does not match the file location"
- In `Test21And26.kt` in the directory `AnkiDroid/src/test/java/com/ichi2/compat`, removed the redundant `inner`  call on the class `PermissionDenied`. 

## How Has This Been Tested?
- Performed Github Actions' workflows on the changes in the branch which ran successfully helping me conclude changes were made successfully
- Checked by deploying the `:AnkiDroid` module to an emulator which ran successfully
## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code'
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->