### PR TITLE
fix: Flasky-tests #20413

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -97,7 +97,12 @@ class DeckPickerTest : RobolectricTest() {
         // but Android lifecycle callback (onCreate) have not yet executed.
         DeckPicker()
 
-        assertDoesNotThrow { ChangeManager.notifySubscribers(opChanges { studyQueues = true }, null) }
+        assertDoesNotThrow {
+            ChangeManager.notifySubscribers(
+                opChanges { studyQueues = true },
+                null,
+            )
+        }
     }
 
     @Test
@@ -143,7 +148,8 @@ class DeckPickerTest : RobolectricTest() {
         whenever(editor.remove(DeckPickerViewModel.UPGRADE_VERSION_KEY)).thenReturn(updated)
         ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
             scenario.onActivity { deckPicker: DeckPicker ->
-                val previousVersion = deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
+                val previousVersion =
+                    deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
                 assertEquals(40, previousVersion)
             }
         }
@@ -167,7 +173,8 @@ class DeckPickerTest : RobolectricTest() {
         whenever(editor.remove(DeckPickerViewModel.UPGRADE_VERSION_KEY)).thenReturn(updated)
         ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
             scenario.onActivity { deckPicker: DeckPicker ->
-                val previousVersion = deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
+                val previousVersion =
+                    deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
                 assertEquals(prevVersion.toLong(), previousVersion)
             }
         }
@@ -186,7 +193,8 @@ class DeckPickerTest : RobolectricTest() {
         whenever(preferences.edit()).thenReturn(editor)
         ActivityScenario.launch(DeckPicker::class.java).use { scenario ->
             scenario.onActivity { deckPicker: DeckPicker ->
-                val previousVersion = deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
+                val previousVersion =
+                    deckPicker.viewModel.getPreviousVersion(preferences, newVersion)
                 assertEquals(prevVersion, previousVersion)
             }
         }
@@ -377,15 +385,24 @@ class DeckPickerTest : RobolectricTest() {
         deckPicker {
             val didA = addDeck("Deck 1")
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.RENAME_DECK, didA)
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.RENAME_DECK,
+                didA,
+            )
             assertDialogTitleEquals("Rename deck")
             dismissAllDialogFragments()
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CREATE_SUBDECK, didA)
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.CREATE_SUBDECK,
+                didA,
+            )
             assertDialogTitleEquals("Create subdeck")
             dismissAllDialogFragments()
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY, didA)
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.CUSTOM_STUDY,
+                didA,
+            )
             assertDialogTitleEquals("Custom study")
             dismissAllDialogFragments()
 
@@ -432,27 +449,47 @@ class DeckPickerTest : RobolectricTest() {
             val didA = addDeck("Deck 1")
             val didDynamicA = addDynamicDeck("Deck Dynamic 1")
 
-            val noteEditor = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.ADD_CARD, didA)
+            val noteEditor =
+                selectContextMenuOptionForActivity(DeckPickerContextMenuOption.ADD_CARD, didA)
             assertEquals("com.ichi2.anki.NoteEditorActivity", noteEditor.component!!.className)
             onBackPressedDispatcher.onBackPressed()
 
-            val browser = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.BROWSE_CARDS, didA)
+            val browser =
+                selectContextMenuOptionForActivity(DeckPickerContextMenuOption.BROWSE_CARDS, didA)
             assertEquals("com.ichi2.anki.CardBrowser", browser.component!!.className)
             onBackPressedDispatcher.onBackPressed()
 
             // select deck options for a normal deck
-            val deckOptionsNormal = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.DECK_OPTIONS, didA)
-            assertEquals("com.ichi2.anki.SingleFragmentActivity", deckOptionsNormal.component!!.className)
+            val deckOptionsNormal =
+                selectContextMenuOptionForActivity(DeckPickerContextMenuOption.DECK_OPTIONS, didA)
+            assertEquals(
+                "com.ichi2.anki.SingleFragmentActivity",
+                deckOptionsNormal.component!!.className,
+            )
             onBackPressedDispatcher.onBackPressed()
 
             // select deck options for a dynamic deck
-            val deckOptionsDynamic = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.DECK_OPTIONS, didDynamicA)
-            assertEquals("com.ichi2.anki.FilteredDeckOptions", deckOptionsDynamic.component!!.className)
+            val deckOptionsDynamic =
+                selectContextMenuOptionForActivity(
+                    DeckPickerContextMenuOption.DECK_OPTIONS,
+                    didDynamicA,
+                )
+            assertEquals(
+                "com.ichi2.anki.FilteredDeckOptions",
+                deckOptionsDynamic.component!!.className,
+            )
             onBackPressedDispatcher.onBackPressed()
 
             Prefs.newReviewRemindersEnabled = true
-            val scheduleReminders = selectContextMenuOptionForActivity(DeckPickerContextMenuOption.SCHEDULE_REMINDERS, didA)
-            assertEquals("com.ichi2.anki.SingleFragmentActivity", scheduleReminders.component!!.className)
+            val scheduleReminders =
+                selectContextMenuOptionForActivity(
+                    DeckPickerContextMenuOption.SCHEDULE_REMINDERS,
+                    didA,
+                )
+            assertEquals(
+                "com.ichi2.anki.SingleFragmentActivity",
+                scheduleReminders.component!!.className,
+            )
             onBackPressedDispatcher.onBackPressed()
         }
 
@@ -460,20 +497,32 @@ class DeckPickerTest : RobolectricTest() {
     fun `ContextMenu deletes deck when selecting DELETE_DECK`() =
         deckPicker {
             val didA = addDeck("Deck 1")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.DELETE_DECK, didA)
-            assertThat(getColUnsafe.decks.allNamesAndIds().map { it.id }, not(containsInAnyOrder(didA)))
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.DELETE_DECK,
+                didA,
+            )
+            assertThat(
+                getColUnsafe.decks.allNamesAndIds().map { it.id },
+                not(containsInAnyOrder(didA)),
+            )
         }
 
     @Test
     fun `ContextMenu creates deck shortcut when selecting CREATE_SHORTCUT`() =
         deckPicker {
             val didA = addDeck("Deck 1")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CREATE_SHORTCUT, didA)
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.CREATE_SHORTCUT,
+                didA,
+            )
             // Wait for the shortcut creation to complete
             ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
             assertEquals(
                 "Deck 1",
-                ShortcutManagerCompat.getShortcuts(this, ShortcutManagerCompat.FLAG_MATCH_PINNED).first().shortLabel,
+                ShortcutManagerCompat
+                    .getShortcuts(this, ShortcutManagerCompat.FLAG_MATCH_PINNED)
+                    .first()
+                    .shortLabel,
             )
         }
 
@@ -493,7 +542,10 @@ class DeckPickerTest : RobolectricTest() {
             advanceRobolectricLooper()
             assertEquals(1, visibleDeckCount)
             assertTrue(getColUnsafe.sched.haveBuried(), "Deck should have buried cards")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.UNBURY, deckId)
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.UNBURY,
+                deckId,
+            )
             kotlin.test.assertFalse(getColUnsafe.sched.haveBuried())
         }
 
@@ -508,14 +560,21 @@ class DeckPickerTest : RobolectricTest() {
             getColUnsafe.sched.rebuildFilteredDeck(deckId)
             assertTrue(allCardsInSameDeck(cardIds, deckId))
             updateDeckList()
+            advanceRobolectricLooper()
             assertEquals(1, visibleDeckCount)
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY_EMPTY, deckId) // Empty
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.CUSTOM_STUDY_EMPTY,
+                deckId,
+            ) // Empty
 
             assertTrue(allCardsInSameDeck(cardIds, 1))
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY_REBUILD, deckId) // Rebuild
-
+            supportFragmentManager.selectContextMenuOption(
+                DeckPickerContextMenuOption.CUSTOM_STUDY_REBUILD,
+                deckId,
+            ) // Rebuild
+            advanceRobolectricLooper()
             assertTrue(allCardsInSameDeck(cardIds, deckId))
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ReviewerTest.kt
@@ -68,6 +68,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks
 import timber.log.Timber
 import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
@@ -246,31 +247,27 @@ class ReviewerTest : RobolectricTest() {
                     addBasicNote("2", "bar").firstCard(),
                     addBasicNote("3", "bar").firstCard(),
                 )
-            advanceRobolectricLooper()
-
             val reviewer = startReviewer()
-
-            advanceRobolectricLooper()
 
             equalFirstField(cards[0], reviewer.currentCard!!)
             reviewer.answerCard(Rating.AGAIN)
-            advanceRobolectricLooper()
+            runUiThreadTasksIncludingDelayedTasks()
 
             equalFirstField(cards[1], reviewer.currentCard!!)
             reviewer.answerCard(Rating.AGAIN)
-            advanceRobolectricLooper()
+            runUiThreadTasksIncludingDelayedTasks()
 
             undo(reviewer)
-            advanceRobolectricLooper()
 
             equalFirstField(cards[1], reviewer.currentCard!!)
             reviewer.answerCard(Rating.GOOD)
-            advanceRobolectricLooper()
+            runUiThreadTasksIncludingDelayedTasks()
 
             equalFirstField(cards[2], reviewer.currentCard!!)
             time.addM(2)
             reviewer.answerCard(Rating.GOOD)
-            advanceRobolectricLooper()
+            runUiThreadTasksIncludingDelayedTasks()
+
             equalFirstField(
                 cards[0],
                 reviewer.currentCard!!,
@@ -359,14 +356,17 @@ class ReviewerTest : RobolectricTest() {
             val nonDefaultDeck = addDeck("Hello")
             assertThat("first card is shown", this.cardContent, containsString("One"))
             flipOrAnswerCard(Rating.GOOD)
+            advanceRobolectricLooper()
             // answer good, 'Rating.GOOD' should now be < 10m
             assertThat("initial time is 10m", this.getCardDataForJsApi().nextTime3, equalTo("<\u206810\u2069m"))
             flipOrAnswerCard(Rating.GOOD)
+            advanceRobolectricLooper()
             assertThat("next card is shown", this.cardContent, containsString("Two"))
 
             undoableOp { col.setDeck(listOf(currentCard!!.id), nonDefaultDeck) }
-
+            advanceRobolectricLooper()
             flipOrAnswerCard(Rating.GOOD)
+            advanceRobolectricLooper()
             assertThat("buttons should be updated", this.getCardDataForJsApi().nextTime3, equalTo("\u20681\u2069d"))
             assertThat("content should be updated", this.cardContent, containsString("One"))
         }
@@ -403,6 +403,7 @@ class ReviewerTest : RobolectricTest() {
 
     private fun undo(reviewer: Reviewer) {
         reviewer.undo()
+        runUiThreadTasksIncludingDelayedTasks()
     }
 
     @Suppress("SameParameterValue")
@@ -439,14 +440,14 @@ class ReviewerTest : RobolectricTest() {
 
         r.answerCard(Rating.GOOD)
 
-        advanceRobolectricLooper()
+        runUiThreadTasksIncludingDelayedTasks()
     }
 
     private fun assertCurrentOrdIs(
         r: Reviewer,
         i: Int,
     ) {
-        advanceRobolectricLooper()
+        runUiThreadTasksIncludingDelayedTasks()
         val ord = r.currentCard!!.ord
 
         assertThat("Unexpected card ord", ord + 1, equalTo(i))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/PrefsSearchBarTest.kt
@@ -59,10 +59,10 @@ class PrefsSearchBarTest : RobolectricTest() {
 
         // Join both lists
         val allResIds =
-            filesResIds
-                .plus(prefItemsResIds)
-                .distinct() as List<Int>
-
+            (filesResIds + prefItemsResIds)
+                .filterIsInstance<Int>()
+                .filter { it != 0 }
+                .distinct()
         // Check if all indexed XML resIDs lead to the correct fragments on getFragmentFromXmlRes
         for (resId in allResIds) {
             val fragment = getFragmentFromXmlRes(resId)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -44,6 +44,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.util.Calendar
+import java.util.TimeZone
 import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
@@ -60,6 +61,7 @@ class AlarmManagerServiceTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
         context = mockk(relaxed = true)
         alarmManager = mockk(relaxed = true)
         notificationManager = mockk(relaxed = true)

--- a/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/MockTime.kt
@@ -102,9 +102,11 @@ open class MockTime(
             milliseconds: Int = 0,
         ): Long {
             val timeZone = TimeZone.getTimeZone("GMT")
-            val gregorianCalendar: Calendar = GregorianCalendar(year, month, date, hourOfDay, minute, second)
-            gregorianCalendar.timeZone = timeZone
-            gregorianCalendar[Calendar.MILLISECOND] = milliseconds
+            val gregorianCalendar: Calendar =
+                GregorianCalendar(timeZone).apply {
+                    set(year, month, date, hourOfDay, minute, second)
+                    set(Calendar.MILLISECOND, milliseconds)
+                }
             return gregorianCalendar.timeInMillis
         }
     }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
While working on my PR #20412, I faced failure in JUnitTests (macos run 1) and on reviewing it, I observed that no changes I had made during any of my commits affected the files in which errors were faced and on further reviewing, I realized that these were triggered due to the specific development environment (Linux/Windows dual-boot and non-UTC TimeZone. Hence, I raised the issue #20413. This PR aims to resolve the issue.

## Fixes
Fixes #20413 

## Approach
This change addresses the following three categories of instabilities (all of those reported in the issue #20413):
- ResourceID #0x0: Added a filter in the file `PrefsSearchBarTest.kt` in the directory `AnkiDroid/src/test/java/com/ichi2/anki/preferences` to ignore non-XML indexed items (IDs of 0), which were causing `Resources$NotFoundException.`
- TimeZone Determinism: Modified `MockTime.timestamp` in the `MockTime.kt` inside directory `common/src/main/java/com/ichi2/anki/common/time` to use a forced GMT calendar and updated `AlarmManagerServiceTest.kt` inside the directory `AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt` to set a UTC default during execution which prevents assertions from failing in a non-UTC TimeZone.
- Race Conditions: Replaced `advanceRobolectricLooper()` with `ShadowLooper.runUiThreadTasksIncludingDelayedTasks()` in `ReviewerTest.kt` wherever required and added `advanceRobolectricLooper()` where required in `DeckPickerTest.kt`, both of the files present in the directory `AnkiDroid/src/test/java/com/ichi2/anki`. This ensures the full asynchronous chain (Collection -> Scheduler -> WebView) completes before assertions run.
## How Has This Been Tested?

- Used OpenJDK version 24 to run `./gradlew testPlayDebugUnitTest` which ran successfully on implementing the following changes allowing me to conclude that the changes were made successfully.

## Learning (optional, can help others)
- AI Disclosure: I used AI as a debugging consultant to help interpret the stack traces and understand Robolectric looper function. It helped me fix the issues in Race Conditions.  I implemented and reviewed the changes manually ensuring there are no unnecessary changes in the code.
- Insights: I learned about how virtual time works with Robolectric, as well as the need for proper looper flushes, especially with WebView-based activities like the Reviewer. I also learned more about how JNI binaries are handled by the build system, depending on the host OS architecture.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->