### PR TITLE
fix: remove app from recents if in an invalid state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/AppLoadedFromBackupWorkaround.kt
@@ -48,6 +48,7 @@ object AppLoadedFromBackupWorkaround {
         if (AnkiDroidApp.isInitialized) {
             return false
         }
+        // TODO: Timber likely does not work on this path - maybe add a check in IntentHandler
 
         // #7630: Can be triggered with `adb shell bmgr restore com.ichi2.anki` after AnkiDroid settings are changed.
         // Application.onCreate() is not called if:


### PR DESCRIPTION
## Purpose / Description
I suspect this fixes the app being in an invalid state, causing "android backup in progress, please try again" to appear until the device is restarted.

`Process.killProcess()` is a hard kill.

I suspect some Android internals keep a reference to the process (users are reporting AnkiDroid being broken in the task list when the backup toast shows)

If the app is in an invalid state within Android, it is feasible that `Application.onCreate()` is skipped, perpetually causing the "android backup in progress, please try again" toast.

## Fixes
* Fixes #19050

## Approach
Use `finishAndRemoveTask`: https://developer.android.com/reference/android/app/Activity#finishAndRemoveTask()

## How Has This Been Tested?
After manual testing, the app no longer appears in Recents.

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt	(revision 0d08afc531cfaba74f76b6e2c44eefbc5edfd31d)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt	(date 1772881617915)
@@ -126,7 +126,8 @@
                 return
             }
         }
-        instance = this
+        // instance = this
+        return
 
         // Get preferences
         val preferences = this.sharedPrefs()
```


## Learning (optional, can help others)
* https://developer.android.com/reference/android/app/Activity#finishAndRemoveTask()
* We are now over API 21

Seen on many devices, including a Samsung A35


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)