### PR TITLE
fix(browser): Use correct label for queue bottom

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/RepositionCardFragment.kt
@@ -47,7 +47,7 @@ class RepositionCardFragment : DialogFragment() {
         binding.queueLimitsLabel.text =
             """
             ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_TOP))}
-            ${TR.browsingQueueTop(requireArguments().getInt(ARG_QUEUE_BOTTOM))} 
+            ${TR.browsingQueueBottom(requireArguments().getInt(ARG_QUEUE_BOTTOM))}
             """.trimIndent()
         binding.startInputLayout.hint =
             TR.browsingStartPosition().removeSuffix(":")


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Card Reposition Window showed "queue top" twice, one of which should have been "queue bottom"

Edit: Fixed the trailing whitespace too

## Fixes
* Fixes part of #18553

## Screenshots
### Before
<img width="320" height="2856" alt="Screenshot_20260308_091105" src="https://github.com/user-attachments/assets/e1934ead-1b80-4b9a-a453-a4ecf24c67cc" />

### After
<img width="320" height="2856" alt="Screenshot_20260308_091153" src="https://github.com/user-attachments/assets/936608ce-f79c-450f-b661-790951c6bff3" />

## Approach
Replaced using browsingQueueTop to browsingQueueBottom text for the bottom label

## How Has This Been Tested?
Tested on Pixel 9 Pro Emulator Device

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->