### PR TITLE
Bug fix - Gesture navigation overriding Slider

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerFragment.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.previewer
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.Rect
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.Menu
@@ -24,6 +25,8 @@ import android.view.MenuItem
 import android.view.View
 import androidx.appcompat.widget.Toolbar
 import androidx.core.os.bundleOf
+import androidx.core.view.ViewCompat
+import androidx.core.view.doOnLayout
 import androidx.core.view.isVisible
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.flowWithLifecycle
@@ -133,9 +136,15 @@ class PreviewerFragment :
 
         binding.slider.apply {
             valueTo = cardsCount.toFloat()
+            doOnLayout {
+                updateSliderGestureExclusion(this)
+            }
+            addOnLayoutChangeListener { _, _, _, _, _, _, _, _, _ ->
+                updateSliderGestureExclusion(this)
+            }
             addOnSliderTouchListener(
                 object : Slider.OnSliderTouchListener {
-                    override fun onStartTrackingTouch(slider: Slider) {}
+                    override fun onStartTrackingTouch(slider: Slider) = Unit
 
                     override fun onStopTrackingTouch(slider: Slider) {
                         viewModel.onSliderChange(slider.value.toInt())
@@ -182,6 +191,13 @@ class PreviewerFragment :
         binding.webviewContainer.setFrameStyle()
 
         bindingMap = BindingMap(sharedPrefs(), PreviewerAction.entries, this)
+    }
+
+    private fun updateSliderGestureExclusion(slider: Slider) {
+        ViewCompat.setSystemGestureExclusionRects(
+            slider,
+            listOf(Rect(0, 0, slider.width, slider.height)),
+        )
     }
 
     private fun setupFlagMenu(menu: Menu) {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
 Dragging the Previewer slider from the screen edges can trigger Android’s back gesture instead of moving the slide .

## Fixes
* Fixes #20397

## Approach
I initially tried [requestDisallowInterceptTouchEvent()](https://developer.android.com/reference/android/view/ViewGroup#requestDisallowInterceptTouchEvent(boolean))  while dragging the slider, but that did not fully solve the issue because the system back gesture could still win before the slider started  tracking the touch.

The final fix uses `ViewCompat.setSystemGestureExclusionRects()` on the slider bounds, and refreshes that rect after layout changes. That prevents edge back gestures from taking over when the user starts dragging from either end of the slider.

## How Has This Been Tested?


Tested the changes manually -



| After | Before |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/75b71b7e-f775-489e-85fc-7bffa7a4004f"> | <video src="https://github.com/user-attachments/assets/4a6bc42f-32fa-41f2-b3e8-84d8eba5d5bd"> |


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->