### PR TITLE
fix(sync-dialogue): prevent cancellation via outside touch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -436,6 +436,7 @@ suspend fun <T> withProgressDialog(
                 setCancelable(onCancel != null)
                 if (manualCancelButton != null) {
                     setCancelable(false)
+                    setCanceledOnTouchOutside(false)
                     setButton(DialogInterface.BUTTON_NEGATIVE, context.getString(manualCancelButton)) { _, _ ->
                         Timber.i("Progress dialog cancelled via cancel button")
                         onCancel?.let { it() }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -231,6 +231,7 @@ private suspend fun handleDownload(
     deckPicker.withProgress(
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
         onCancel = ::cancelSync,
+        manualCancelButton = R.string.dialog_cancel,
     ) {
         withCol {
             try {
@@ -264,6 +265,7 @@ private suspend fun handleUpload(
     deckPicker.withProgress(
         extractProgress = fullDownloadProgress(TR.syncUploadingToAnkiweb()),
         onCancel = ::cancelSync,
+        manualCancelButton = R.string.dialog_cancel,
     ) {
         withCol {
             close(downgrade = false, forFullSync = true)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_During a forced one-way / full sync, the progress dialog can currently be dismissed by tapping on the dimmed background (i.e. Outside the box)._

## Fixes
* Fixes #20073

## Approach

- Added `Cancel` button to manually abort the full sync.
- Canellation logic now handles disabling of outside touch.

## How Has This Been Tested?

Tested on my phone (Android 14, Xiaomi / HyperOS) using a debug build.

Outside touch no longer cancels syncing.

Videos attached as evidence.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings) (N/A – no visual UI changes)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner] (N/A – no UI changes)(https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->

---
**Before this change**:

https://github.com/user-attachments/assets/f94913e2-ba16-4fdd-90ab-a6f89219b8a0

**After this change**:

https://github.com/user-attachments/assets/86fadff8-fa48-4811-ab85-c2b37f0ce6cd

