### PR TITLE
fix(note-editor): 'discard changes' incorrectly shown

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -1234,7 +1234,10 @@ class NoteEditorFragment :
         fun fieldsEdited(): Boolean {
             // Editing an existing note: Check to see if the fields are changed
             if (!addNote) {
-                fun normalizeNewlines(s: String) = convertToHtmlNewline(s, replaceNewlines = true)
+                fun normalizeNewlines(s: String) =
+                    convertToHtmlNewline(s, replaceNewlines = true)
+                        .replace("<br(\\s*/*)>".toRegex(), "<br>")
+
                 val currentStrings = editFields!!.map { it.text?.toString() ?: "" }
                 val originalStrings = editorNote!!.fields.toList()
                 return currentStrings.map(::normalizeNewlines) != originalStrings.map(::normalizeNewlines)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -657,6 +657,12 @@ class NoteEditorTest : RobolectricTest() {
             assertFalse(hasUnsavedChanges())
         }
 
+    @Test
+    fun `hasUnsavedChanges - note contained a legacy HTML newline`() =
+        withNoteEditorEditing(addBasicNote("hello<br />world")) {
+            assertFalse(hasUnsavedChanges())
+        }
+
     private suspend fun withNoteEditorAdding(
         from: FromScreen = FromScreen.DECK_LIST,
         block: suspend NoteEditorFragment.() -> Unit,


### PR DESCRIPTION
## Purpose / Description
The 'discard changes' dialog was incorrectly shown if a note contained `<br />`

`<br />` was converted to `\n`, back to `<br>`


## Approach
fix: use the normalization code in FieldEditText

## How Has This Been Tested?
API 33 emulator; Arthur's collection

The following caused the issue

`\(\frac{e^{\frac{(x-\mu)^2}{2\sigma^2} } }{\sigma\sqrt{2\pi} }=\frac{e^{\frac12\left(\frac{x-\mu}{\sigma}\right)^2 } }{\sigma\sqrt{2\pi} }\)<br /><img src="350px-Normal_Distribution_PDF.svg.png" />`

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)