### PR TITLE
fix(study-options): fix overlapping text

### DIFF
--- a/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
+++ b/AnkiDroid/src/main/res/layout/studyoptions_fragment.xml
@@ -119,7 +119,7 @@
                         android:layout_marginStart="8dp"
                         android:textColor="?attr/newCountColor"
                         android:layout_height="wrap_content"
-                        tools:text="234"/>
+                        tools:text="88"/>
 
                     <TextView
                         android:id="@+id/studyoptions_new_bury"
@@ -131,7 +131,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
                         android:textColor="?attr/buryCountColor"
-                        tools:text="+4"/>
+                        tools:text="+4 buried"/>
 
                     <TextView
                         android:id="@+id/studyoptions_learning_count"
@@ -141,7 +141,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
                         android:textColor="?attr/learnCountColor"
-                        tools:text="3443"/>
+                        tools:text="3"/>
 
                     <TextView
                         android:id="@+id/studyoptions_learning_bury"
@@ -152,7 +152,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
                         android:textColor="?attr/buryCountColor"
-                        tools:text="+23"/>
+                        tools:text="+23 buried"/>
 
                     <TextView
                         android:id="@+id/studyoptions_review_count"
@@ -162,7 +162,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
                         android:textColor="?attr/reviewCountColor"
-                        tools:text="15"/>
+                        tools:text="104"/>
 
                     <TextView
                         android:id="@+id/studyoptions_review_bury"
@@ -173,7 +173,7 @@
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
                         android:textColor="?attr/buryCountColor"
-                        tools:text="+105"/>
+                        tools:text="+20 buried"/>
 
                     <TextView
                         android:id="@+id/studyoptions_total_new_label"
@@ -193,7 +193,7 @@
                         app:layout_constraintBottom_toBottomOf="@id/studyoptions_total_new_label"
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
-                        tools:text="2341"/>
+                        tools:text="16597"/>
 
                     <TextView
                         android:id="@+id/studyoptions_total_label"
@@ -213,7 +213,7 @@
                         app:layout_constraintBottom_toBottomOf="@id/studyoptions_total_label"
                         android:layout_marginStart="8dp"
                         android:layout_height="wrap_content"
-                        tools:text="781"/>
+                        tools:text="22177"/>
 
                     <androidx.constraintlayout.widget.Group
                         android:id="@+id/group_counts"


### PR DESCRIPTION
## Purpose / Description
If the width of the panel was too small, there was overlap between 'Total new cards' and the value

## Fixes
* Fixes #20422

## Approach
I believe a barrier was not updated in 9638e7c759e0210a6477c591a17cde2bc3b191f6
* https://github.com/ankidroid/Anki-Android/pull/17496

## How Has This Been Tested?
Before & after in the Android Studio designer

<img width="162" height="332" alt="Screenshot 2026-03-08 at 23 19 09" src="https://github.com/user-attachments/assets/2ac1ada0-5de6-4b1d-9105-d6ca7f20fbd1" />

<img width="158" height="332" alt="Screenshot 2026-03-08 at 23 19 20" src="https://github.com/user-attachments/assets/719468f4-5808-435c-9cc0-24308bc2a357" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
