### PR TITLE
fix: handle Kotlin 2.3.10 compile errors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/TagLimitFragment.kt
@@ -132,8 +132,8 @@ class TagLimitFragment : DialogFragment() {
     override fun onStart() {
         super.onStart()
         lifecycleScope.launch {
-            binding.loadingViews?.isVisible = true
-            binding.contentViews?.isVisible = false
+            binding.loadingViews.isVisible = true
+            binding.contentViews.isVisible = false
             val customStudyDefaults = withCol { sched.customStudyDefaults(deckId) }
             binding.requireOneOrMoreCheckBox.isChecked =
                 customStudyDefaults.tagsList.any { tag -> tag.include }
@@ -143,8 +143,8 @@ class TagLimitFragment : DialogFragment() {
                 }
             tagsIncludedAdapter.tags = tags.toMutableList() // make a copy
             tagsExcludedAdapter.tags = tags.toMutableList() // make a copy
-            binding.loadingViews?.isVisible = false
-            binding.contentViews?.isVisible = true
+            binding.loadingViews.isVisible = false
+            binding.contentViews.isVisible = true
         }
     }
 


### PR DESCRIPTION
```
TagLimitFragment.kt:135:33 Unnecessary safe call on a non-null receiver of type 'Group'.
TagLimitFragment.kt:136:33 Unnecessary safe call on a non-null receiver of type 'LinearLayout'.
TagLimitFragment.kt:146:33 Unnecessary safe call on a non-null receiver of type 'Group'.
TagLimitFragment.kt:147:33 Unnecessary safe call on a non-null receiver of type 'LinearLayout'.
```

* Unblocks: #20299

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)