### PR TITLE
Fix welcome page 'Remember more' text layout for large font sizes

### DIFF
--- a/AnkiDroid/src/main/res/layout/introduction_layout.xml
+++ b/AnkiDroid/src/main/res/layout/introduction_layout.xml
@@ -67,7 +67,7 @@
 
     <com.ichi2.ui.FixedTextView
         android:id="@+id/remember_more"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:paddingBottom="8dp"
         android:text="@string/intro_ankidroid_tagline_two"


### PR DESCRIPTION
Related to #17100

When the system font size is increased, the "Remember more" text on the welcome screen could overflow due to layout_width="wrap_content".

This change updates the width to 0dp so the TextView expands between constraints and allows proper text wrapping for larger font sizes.

<img width="1920" height="1200" alt="Screenshot (698)" src="https://github.com/user-attachments/assets/9151d0f3-d1fe-4f93-9249-2e40f424c29c" />

<img width="1920" height="1200" alt="Screenshot (699)" src="https://github.com/user-attachments/assets/c93157d9-07b4-48ce-8686-2b74b57b4254" />

