### PR TITLE
fix: potential skip in `repeatOnLifecycle`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Flow.kt
@@ -87,8 +87,8 @@ fun <T> StateFlow<T>.launchCollectionInLifecycleScope(block: suspend (T) -> Unit
         activity.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
             this@launchCollectionInLifecycleScope.collect {
                 // on re-resume, an unchanged value will be emitted for a StateFlow
-                if (lastValue == value) return@collect
-                lastValue = value
+                if (lastValue == it) return@collect
+                lastValue = it
                 if (isRobolectric) {
                     HandlerUtils.postOnNewHandler { runBlocking { block(it) } }
                 } else {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/StateFlowLifecycleCollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/StateFlowLifecycleCollectionTest.kt
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2026 HS0204(Hanseul Lee) <lhanseul0204@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.utils.ext
+
+import android.content.Intent
+import com.ichi2.anki.AnkiActivity
+import com.ichi2.anki.RobolectricTest
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+// test for the deduplication logic in StateFlow.launchCollectionInLifecycleScope
+@RunWith(RobolectricTestRunner::class)
+class StateFlowLifecycleCollectionTest : RobolectricTest() {
+    // scenario: background > value changes > resume triggers race
+    // to check StateFlow logic ensure that all updates are delivered and none are potentially skipped
+    @Test
+    fun `concurrent value change does not skip UI update`() {
+        val controller = Robolectric.buildActivity(AnkiActivity::class.java, Intent())
+        val flow = MutableStateFlow(0)
+        val concurrentFlow =
+            ConcurrentStateFlow(flow) { emitted ->
+                if (emitted == 1) flow.value = 2
+            }
+        val updates = mutableListOf<Int>()
+
+        controller.create().start().resume()
+        with(controller.get()) {
+            concurrentFlow.launchCollectionInLifecycleScope { updates.add(it) }
+        }
+        advanceRobolectricLooper()
+
+        assertEquals(listOf(0), updates)
+
+        controller.pause().stop()
+        advanceRobolectricLooper()
+        flow.value = 1
+        controller.start().resume()
+        advanceRobolectricLooper()
+
+        assertEquals(listOf(0, 1, 2), updates)
+    }
+
+    // simulates a concurrent value change between emission and the dedup check
+    @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
+    private class ConcurrentStateFlow(
+        private val delegate: MutableStateFlow<Int>,
+        private val onEmit: (Int) -> Unit,
+    ) : StateFlow<Int> by delegate {
+        override suspend fun collect(collector: FlowCollector<Int>): Nothing {
+            delegate.collect { emitted ->
+                onEmit(emitted)
+                collector.emit(emitted)
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
A potential issue was discussed in the review of #20192.
If the logic inside the collection block updates `lastValue` before the UI is actually updated, or if there is a mismatch between how `lastValue` is persisted and how the flow emits values, a critical UI update may be skipped because the check assumes the state has not changed since the last emission.
This PR reproduces the scenario discussed in the review with tests and adds a fix that ensures the corrected behaviour.

## Fixes
* Fixes #20394 

## Approach
1. Duplicated the existing logic with lifecycle transitions (STARTED -> CREATED -> STARTED) to reproduce the reviewer's concern like if the app is in background and value is updated.
2. Confirmed the potential issue occur. When `StateFlow.value` changes during collection, the update for that value was skipped.
3. Added a second test using the collected emission `it` instead of `StateFlow.value` under the same scenario.
4. Verified the fix ensures all updates are delivered.
5. Based on these testing process, I finally wrote an executable test directly using `launchCollectionInLifecycleScope`.

## How Has This Been Tested?
Test reproducing the potential scenario passed.

## Learning (optional, can help others)
This also helped me better understand the behaviour of `StateFlow.value`, especially how the current value can diverge from the collected emission when another updates the StateFlow during collection.
Before this PR, I assumed that `StateFlow.value` would always correspond to the value being collected. While looking into this issue, I gained a clearer understanding of the ["most recently emitted value" behaviour described in the official docs](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/kotlinx.coroutines.flow/-state-flow/).

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->