### PR TITLE
Remove unused import from AnswerFeedbackView

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerFeedbackView.kt
@@ -23,7 +23,6 @@ import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.appcompat.widget.AppCompatImageView
 import com.ichi2.anki.R
-import com.ichi2.utils.HandlerUtils
 
 class AnswerFeedbackView : AppCompatImageView {
     constructor(context: Context) : this(context, null)


### PR DESCRIPTION
## Purpose / Description
Fix warning caused by unused import.

## Fixes
NA

## Approach
Removed the unused import from `AnswerFeedbackView.kt`.

## How Has This Been Tested?
No impact on tests:`./gradlew jacocoUnitTestReport` ran as normal.

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] ~~You have commented your code, particularly in hard-to-understand areas~~ NA
- [X] You have performed a self-review of your own code
- [X] ~~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~~ NA
- [X] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~ NA