### PR TITLE
Allow deck names to wrap instead of truncating in deck picker (#17100)

### DIFF
--- a/AnkiDroid/src/main/res/layout/deck_item.xml
+++ b/AnkiDroid/src/main/res/layout/deck_item.xml
@@ -35,7 +35,7 @@
         android:background="@android:color/transparent" />
     <LinearLayout
         android:id="@+id/deck_name_linear_layout"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_toEndOf="@+id/indent_view"
         android:layout_toStartOf="@+id/counts_layout"
@@ -55,8 +55,7 @@
             android:minHeight="48dp"
             android:background="@color/transparent"
             android:gravity="start|center_vertical"
-            android:maxLines="2"
-            android:ellipsize="end"
+            android:ellipsize="none"
             android:textColor="?android:textColorPrimary"
             android:textSize="20sp"
             android:textStyle="bold"


### PR DESCRIPTION
Fixes #17100

### Problem
Deck names were truncated when they were long or when the font size was increased.

Example:
"Hello Everyone!!! Nice to meet you all"
was displayed as:
"Hello Everyone!!! ..."

### Solution
Removed the line limit and ellipsizing from the deck name TextView so the text can wrap into multiple lines.

### Before
Small font:
<img width="1920" height="1200" alt="Screenshot (714)" src="https://github.com/user-attachments/assets/57507578-5bec-46c9-a544-4f8677c6c1e0" />


Large font:
<img width="1920" height="1200" alt="Screenshot (713)" src="https://github.com/user-attachments/assets/69bcea94-0a6d-4311-9592-486caa76d44a" />



### After
Small font:
<img width="1920" height="1200" alt="Screenshot (719)" src="https://github.com/user-attachments/assets/f0690617-0b5e-4f98-a7f2-68e27bfab6dc" />


Large font:
<img width="1920" height="1200" alt="Screenshot (720)" src="https://github.com/user-attachments/assets/120b3342-2fe2-4102-be5a-dcf5f2601120" />
