### PR TITLE
test: test timeout is unchanged

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/MetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/MetaTest.kt
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import com.ichi2.anki.libanki.testutils.DEFAULT_TEST_TIMEOUT
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for our testing framework
+ */
+class MetaTest {
+    @Test
+    fun `test timeout is unchanged`() {
+        // a number of users are changing the default timeout on tests to try to fix a timeout,
+        // rather than debug the cause of the timeout.
+
+        // This is normally a hung thread (often due to Robolectric), so increasing the timeout
+        // just makes the problem worse
+        assertEquals(
+            60.seconds,
+            DEFAULT_TEST_TIMEOUT,
+            "Default test timeout should be unchanged",
+        )
+    }
+}

--- a/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
+++ b/libanki/testutils/src/main/java/com/ichi2/anki/libanki/testutils/AnkiTest.kt
@@ -46,7 +46,8 @@ import net.ankiweb.rsdroid.exceptions.BackendDeckIsFilteredException
 import timber.log.Timber
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
-import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * marker interface for classes which contain tests and access the Anki collection
@@ -348,10 +349,13 @@ interface AnkiTest {
      * A fix for this might require either wrapping all tests in runTest(),
      * or finding some other way to isolate the coroutine and non-coroutine tests
      * on separate threads/processes.
+     *
+     * @param dispatchTimeout The test fails with an AssertionError if not completed within this
+     * time
      * */
     fun runTest(
         context: CoroutineContext = EmptyCoroutineContext,
-        dispatchTimeoutMs: Long = 60_000L,
+        dispatchTimeout: Duration = DEFAULT_TEST_TIMEOUT,
         times: Int = 1,
         testBody: suspend TestScope.() -> Unit,
     ) {
@@ -360,7 +364,7 @@ interface AnkiTest {
         setupTestDispatcher(dispatcher)
         repeat(times) {
             if (times != 1) Timber.d("------ Executing test $it/$times ------")
-            kotlinx.coroutines.test.runTest(context, dispatchTimeoutMs.milliseconds) {
+            kotlinx.coroutines.test.runTest(context, dispatchTimeout) {
                 runTestInner(testBody)
             }
         }
@@ -385,3 +389,11 @@ interface AnkiTest {
      */
     fun NotetypeJson.proto(): Notetype = col.getNotetype(this.id)
 }
+
+/**
+ * The default timeout for tests. An [AssertionError] is thrown if execution takes longer than this
+ * time.
+ *
+ * Do not change this, instead determine why a test is taking longer than a minute.
+ */
+val DEFAULT_TEST_TIMEOUT: Duration = 60.seconds


### PR DESCRIPTION
A number of users are changing the default timeout on tests to try to fix a timeout, rather than debug the cause of the timeout.

This is normally a hung thread (often due to Robolectric), so increasing the timeout just makes the problem worse

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)