### PR TITLE
Test getFileCachedCopy returns absolute path

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -161,7 +161,6 @@ object ImportUtils {
             }
         }
 
-        @NeedsTest("Check file name is absolute")
         fun getFileCachedCopy(
             context: Context,
             uri: Uri,

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -30,10 +30,12 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.endsWith
 import org.hamcrest.Matchers.lessThanOrEqualTo
 import org.hamcrest.Matchers.not
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.io.File
 
 @RunWith(AndroidJUnit4::class)
 class ImportUtilsTest : RobolectricTest() {
@@ -74,6 +76,14 @@ class ImportUtilsTest : RobolectricTest() {
 
         // COULD_BE_BETTER: Strip off the file path
         return testFileImporter.cacheFileName
+    }
+
+    @Test
+    fun getFileCachedCopyReturnsAbsolutePath() {
+        val filename = "spaced filename.apkg"
+        val expectedFilepath = File(targetContext.cacheDir, filename).absolutePath
+        val actualFilepath = TestFileImporter(filename).getFileCachedCopy(targetContext, "dummy".toUri())
+        assertEquals(expectedFilepath, actualFilepath)
     }
 
     @Test


### PR DESCRIPTION
## Purpose / Description
Regression test that ensures that `getFileCachedCopy` in `ImportUtils.kt` returns a regular absolute path, as per the `@NeedsTest`.

## Fixes
Relates to #13283.

## Approach
I looked at the older `getFileCachedCopy`. It used to return a URI-encoded path. It was updated to return a regular absolute filepath. That's when `@NeedsTest` was added.

To discriminate between old/new behavior, I used a filename with a space, since they have a particular URI-encoding. If `getFileCachedCopy` were to return a URI-encoded path again, the test would catch the regression.

I used the already-implemented `TestFileImporter` to handle method dependencies and isolate the behavior under test.

## How Has This Been Tested?
```
./gradlew jacocoUnitTestReport
./gradlew lintRelease
./gradlew ktlintCheck
./gradlew assembleDebug
```

## Learning
A couple of things I did that helped:
- Contrasting the old/new method helped clarify the motivation behind the `@NeedsTest`.
- Checking for helpers (`TestFileImporter`) helped save time and keep the commit short.

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] ~~You have commented your code, particularly in hard-to-understand areas~~ NA
- [X] You have performed a self-review of your own code
- [X] ~~UI changes: include screenshots of all affected screens~~ NA
- [X] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~ NA