### PR TITLE
test(GradeNowDialog): add UI tests for the GradeNowDialog.kt

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/GradeNowDialog.kt
@@ -52,8 +52,6 @@ import timber.log.Timber
  * @see net.ankiweb.rsdroid.Backend.gradeNow
  */
 // TODO: handle rotation, via a DialogFragment with IdsFile handling or Fragment Result API
-@NeedsTest("UI test for this dialog")
-@NeedsTest("Menu only displayed if cards selected")
 @NeedsTest("Suspended card handling")
 object GradeNowDialog {
     fun showDialog(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/GradeNowDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/GradeNowDialogTest.kt
@@ -1,0 +1,112 @@
+/*
+ *  Copyright (c) 2026 Bhaskar Patel <patel.bhaskar09@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.dialogs
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.assertion.ViewAssertions.doesNotExist
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.RootMatchers.isDialog
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withText
+import com.ichi2.anki.CardBrowser
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.ui.internationalization.toSentenceCase
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/** Tests [GradeNowDialog] */
+@RunWith(RobolectricTestRunner::class)
+class GradeNowDialogTest : RobolectricTest() {
+    @Test
+    fun dialogLoads() {
+        val cardId = addBasicNote().firstCard().id
+        val cardBrowser = super.startRegularActivity<CardBrowser>()
+
+        val translatedTitle =
+            TR
+                .actionsGradeNow()
+                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+
+        GradeNowDialog.showDialog(cardBrowser, listOf(cardId))
+
+        onView(withText(translatedTitle))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun showsAllGradeOptions() {
+        val cardId = addBasicNote().firstCard().id
+        val cardBrowser = super.startRegularActivity<CardBrowser>()
+
+        GradeNowDialog.showDialog(cardBrowser, listOf(cardId))
+
+        onView(withText(TR.studyingAgain()))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withText(TR.studyingHard()))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withText(TR.studyingGood()))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+
+        onView(withText(TR.studyingEasy()))
+            .inRoot(isDialog())
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun clickingGradeDismissesDialog() {
+        val cardId = addBasicNote().firstCard().id
+        val cardBrowser = super.startRegularActivity<CardBrowser>()
+
+        val translatedTitle =
+            TR
+                .actionsGradeNow()
+                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+
+        GradeNowDialog.showDialog(cardBrowser, listOf(cardId))
+
+        onView(withText(TR.studyingGood()))
+            .inRoot(isDialog())
+            .perform(click())
+
+        onView(withText(translatedTitle))
+            .check(doesNotExist())
+    }
+
+    @Test
+    fun dialogNotShownIfNoCardsSelected() {
+        val cardBrowser = super.startRegularActivity<CardBrowser>()
+        val translatedTitle =
+            TR
+                .actionsGradeNow()
+                .toSentenceCase(cardBrowser, R.string.sentence_grade_now)
+
+        GradeNowDialog.showDialog(cardBrowser, emptyList())
+
+        onView(withText(translatedTitle))
+            .check(doesNotExist())
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
GradeNowDialog needed some unit tests to be implemented to check if UI handling and menu displaying with options work as intended.

## Fixes
@NeedsTest in the GradeNowDialog.kt file, a part of issue no. #13283 

## Approach
Adds Unit Tests for the following:
 - Dialog loads Properly
 - Dialog options (Easy, Good, Hard, Again) show up
 - Clicking an option correctly suspends the dialog
 - Dialog to not be shows if any card isn't selected
 Removed @NeedsTest from GradeNowDialog.kt

## How Has This Been Tested?
Emulator: Android Studio Pixel 9 Pro

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->