### PR TITLE
fix: convert 'Deck Search' to sentence case

### DIFF
--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -112,7 +112,7 @@
     <string name="empty_cram_label" maxLength="28">Empty</string>
     <string name="create_subdeck">Create subdeck</string>
     <string name="empty_filtered_deck">Emptying filtered deck…</string>
-    <string name="search_deck" comment="Deck search for selecting it">Deck Search</string>
+    <string name="search_deck" comment="Deck search for selecting it">Deck search</string>
     <string name="empty_deck">This deck is empty</string>
     <string name="invalid_deck_name">Invalid deck name</string>
     <string name="studyoptions_congrats_finished">Congratulations! You have finished for today.</string>


### PR DESCRIPTION
## Purpose / Description
Convert 'Deck Search' string to sentence case to follow Material Design 3 guidelines and maintain consistency with other strings in the app.

## Fixes
* Fixes some of  #15760