### PR TITLE
fix: convert toolbar format strings to sentence case

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -248,13 +248,13 @@
 
     <string name="menu_show_toolbar" comment="Checkable item stating whether the note editor toolbar should be shown" maxLength="28">Show toolbar</string>
 
-    <string name="format_insert_bold">Format as Bold</string>
-    <string name="format_insert_italic">Format as Italic</string>
-    <string name="format_insert_underline">Format as Underline</string>
-    <string name="insert_horizontal_line">Insert Horizontal Line</string>
-    <string name="insert_heading">Insert Heading</string>
-    <string name="format_font_size">Change Font Size</string>
-    <string name="insert_mathjax">Insert MathJax Equation</string>
+    <string name="format_insert_bold">Format as bold</string>
+    <string name="format_insert_italic">Format as italic</string>
+    <string name="format_insert_underline">Format as underline</string>
+    <string name="insert_horizontal_line">Insert horizontal line</string>
+    <string name="insert_heading">Insert heading</string>
+    <string name="format_font_size">Change font size</string>
+    <string name="insert_mathjax">Insert MathJax equation</string>
 
     <string name="note_editor_toolbar_icon">Button text</string>
     <string name="before_text">HTML Before Selection</string>


### PR DESCRIPTION
## Purpose / Description
Convert toolbar format strings to sentence case to follow Material Design 3 guidelines and maintain consistency with other strings in the app.

Strings changed:
- Format as Bold → Format as bold
- Format as Italic → Format as italic
- Format as Underline → Format as underline
- Insert Horizontal Line → Insert horizontal line
- Insert Heading → Insert heading
- Change Font Size → Change font size
- Insert MathJax Equation → Insert MathJax equation

## Fixes
Fixes #15760