### PR TITLE
fix(deck-options): crash on API 30 and below

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreference.kt
@@ -21,6 +21,7 @@ import android.text.InputType
 import android.util.AttributeSet
 import android.view.View
 import com.ichi2.anki.R
+import com.ichi2.anki.utils.ext.usingStyledAttributes
 import timber.log.Timber
 
 @Suppress(
@@ -115,8 +116,8 @@ open class NumberRangePreference :
      * This method should only be called once from the constructor.
      */
     private fun getMinFromAttributes(attrs: AttributeSet?): Int =
-        context.obtainStyledAttributes(attrs, R.styleable.NumberRangePreference).use {
-            it.getInt(R.styleable.NumberRangePreference_min, 0)
+        context.usingStyledAttributes(attrs, R.styleable.NumberRangePreference) {
+            getInt(R.styleable.NumberRangePreference_min, 0)
         }
 
     /**
@@ -126,8 +127,8 @@ open class NumberRangePreference :
      * This method should only be called once from the constructor.
      */
     private fun getMaxFromAttributes(attrs: AttributeSet?): Int =
-        context.obtainStyledAttributes(attrs, R.styleable.NumberRangePreference).use {
-            it.getInt(R.styleable.NumberRangePreference_max, Int.MAX_VALUE)
+        context.usingStyledAttributes(attrs, R.styleable.NumberRangePreference) {
+            getInt(R.styleable.NumberRangePreference_max, Int.MAX_VALUE)
         }
 
     /**


### PR DESCRIPTION
## Purpose / Description
`TypedArray` crashes when cast to `AutoCloseable` on API 30 or below

## Fixes
* Fixes #20456

## Approach
Replace `.use` with `usingStyledAttributes`

## How Has This Been Tested?
No longer crashes on an API 29 emulator

## Learning (optional, can help others)
Introduced by f157e172f2158c69f71f070fa9c9e0651072d8b0

TypedArray crashes when cast to AutoCloseable on API 30 or below

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)