### PR TITLE
fix: limit due date input length in SetDueDateDialog (part of #18553)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.scheduling
 import android.app.Dialog
 import android.content.res.Configuration
 import android.os.Bundle
+import android.text.InputFilter
 import android.view.KeyEvent
 import android.view.View
 import android.view.ViewGroup
@@ -290,6 +291,8 @@ class SetDueDateDialog : DialogFragment() {
             super.onViewCreated(view, savedInstanceState)
             binding.setDueDateSingleDayInputLayout.apply {
                 editText!!.apply {
+                    filters = arrayOf(InputFilter.LengthFilter(5))
+
                     viewModel.nextSingleDayDueDate?.let { value -> setText(value.toString()) }
                     doOnTextChanged { text, _, _, _ ->
                         val currentValue = text?.toString()?.toIntOrNull()
@@ -354,6 +357,8 @@ class SetDueDateDialog : DialogFragment() {
             super.onViewCreated(view, savedInstanceState)
             binding.dateRangeStartLayout.apply {
                 editText!!.apply {
+                    filters = arrayOf(InputFilter.LengthFilter(5))
+
                     viewModel.dateRange.start?.let { start -> setText(start.toString()) }
                     doOnTextChanged { text, _, _, _ ->
                         val value = text.toString().toIntOrNull()
@@ -370,6 +375,7 @@ class SetDueDateDialog : DialogFragment() {
             }
             binding.dateRangeEndLayout.apply {
                 editText!!.apply {
+                    filters = arrayOf(InputFilter.LengthFilter(5))
                     doOnTextChanged { text, _, _, _ ->
                         val value = text.toString().toIntOrNull()
                         viewModel.setNextDateRangeEnd(value)


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Part of issue #18553 highlights that the "Set due date" dialog in the
Browser allows extremely large values (e.g. 1000000000 days).

This PR addresses the checklist item:

Browser → Set due date → Limit the number

An `InputFilter` is added to restrict the number of digits that can
be entered in the due date input fields.
## Fixes
Addresses part of #18553

Specifically fixes the following item:

Browser → Set due date:
- Limit the number

## Approach
Added `InputFilter.LengthFilter` to the EditText fields in
`SetDueDateDialog.kt`.

Applied to:
- Single day input
- Range start input
- Range end input

This prevents extremely large values while maintaining
support for large but reasonable intervals.

## How Has This Been Tested?

Tested using the debug build on an Android emulator.

Steps:
1. Open a deck.
2. Go to Browser → select a card → Set due date.
3. Enter very large values (e.g. 1000000000).
4. Confirm the input stops accepting digits after the limit.
5. Verify normal values (10, 365, 2000) still work.
6. Confirm due dates update correctly after pressing OK.

Test environment:
- Android Emulator
- Android SDK 34

## Learning
Reviewed the dialog implementation in `SetDueDateDialog.kt`
and how input changes are handled using `doOnTextChanged`.


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

## Screenshots

<img src="https://github.com/user-attachments/assets/abc1775c-4373-408a-8eb6-84aeed95b2f7" width="300"/>

<img src="https://github.com/user-attachments/assets/62a31272-8b7e-401b-b0a2-b5f9177f154d" width="300"/>

<img src="https://github.com/user-attachments/assets/0af32a37-ff1f-494d-99b1-2673a48c4f83" width="300"/>

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->