### PR TITLE
Improve the "Rename note type" dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -236,8 +236,16 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
                         waitForPositiveButton = false,
                         displayKeyboard = true,
                         callback = { dialog, text ->
+                            val textInputLayout = dialog.findViewById<com.google.android.material.textfield.TextInputLayout>(R.id.dialog_text_input_layout)
                             val isNotADuplicate =
                                 !allNotetypes.map { it.name }.contains(text.toString())
+                            
+                            if (!isNotADuplicate && text.isNotEmpty()) {
+                                textInputLayout?.error = getString(R.string.note_type_already_exists)
+                            } else {
+                                textInputLayout?.error = null
+                            }
+                            
                             dialog.positiveButton.isEnabled = text.isNotEmpty() && isNotADuplicate
                         },
                     )

--- a/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_text_input.xml
@@ -26,7 +26,8 @@
     android:paddingEnd="32dp"
     android:paddingBottom="4dp"
     app:errorEnabled="true"
-    android:paddingTop="16dp">
+    android:paddingTop="16dp"
+    android:hint="@string/name">
 
     <com.google.android.material.textfield.TextInputEditText
         android:id="@+id/dialog_text_input"

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -62,6 +62,8 @@
 
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
+    <string name="name">Name</string>
+    <string name="note_type_already_exists">Note type already exists</string>
     <string name="dialog_confirm" tools:ignore="UnusedResources">Confirm</string>
     <string name="dialog_no">No</string>
     <string name="dialog_yes">Yes</string>


### PR DESCRIPTION
Fixes #20467

## Changes
- ✅ Add "Name" hint to the text input field border
- ✅ Show red error text when note type already exists
- ✅ Error message: "Note type already exists"
- ✅ Clear error when input becomes valid

## Implementation Details
- Added `android:hint="@string/name"` to `TextInputLayout`
- Added new string resources: `name` and `note_type_already_exists`
- Modified callback to set/clear error on `TextInputLayout`
- Error only shows when duplicate name is entered

## Testing
- Entering an existing note type name shows red error text
- Changing to a unique name clears the error
- Button remains disabled when duplicate name is present