### PR TITLE
fix: handle nonfatal review reminder deserialization errors on startup

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.reviewreminders.ReviewReminder
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
 import com.ichi2.anki.showThemedToast
+import kotlinx.serialization.SerializationException
 import timber.log.Timber
 import java.util.Calendar
 import kotlin.time.Duration
@@ -223,7 +224,25 @@ class AlarmManagerService : BroadcastReceiver() {
         private fun scheduleAllEnabledReviewReminderNotifications(context: Context) {
             Timber.d("scheduleAllEnabledReviewReminderNotifications")
             val allReviewRemindersAsMap =
-                ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()
+                try {
+                    ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()
+                } catch (e: SerializationException) {
+                    Timber.w(e, "Failed to read review reminders from storage")
+                    try {
+                        showThemedToast(context, context.getString(R.string.boot_service_review_reminders_corrupt), false)
+                    } catch (toastException: Exception) {
+                        Timber.w(toastException, "Failed to show review reminders corrupt toast")
+                    }
+                    return
+                } catch (e: IllegalArgumentException) {
+                    Timber.w(e, "Failed to read review reminders from storage")
+                    try {
+                        showThemedToast(context, context.getString(R.string.boot_service_review_reminders_corrupt), false)
+                    } catch (toastException: Exception) {
+                        Timber.w(toastException, "Failed to show review reminders corrupt toast")
+                    }
+                    return
+                }
             val enabledReviewReminders = allReviewRemindersAsMap.values.filter { it.enabled }
             for (reviewReminder in enabledReviewReminders) {
                 scheduleReviewReminderNotification(context, reviewReminder)

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -152,6 +152,7 @@
     <!-- Boot Service -->
     <string name="boot_service_failed_to_schedule_notifications">Failed to schedule reminders</string>
     <string name="boot_service_too_many_notifications">Too many reminders scheduled. Some will not appear</string>
+    <string name="boot_service_review_reminders_corrupt">Review reminder data could not be read. Some reminders may not appear</string>
 
     <!-- Locale Selection Dialog -->
     <string name="locale_selection_dialog_title_new">Set Language</string>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/services/AlarmManagerServiceTest.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.reviewreminders.ReviewReminder
 import com.ichi2.anki.reviewreminders.ReviewReminderId
 import com.ichi2.anki.reviewreminders.ReviewReminderTime
 import com.ichi2.anki.reviewreminders.ReviewRemindersDatabase
+import com.ichi2.anki.showThemedToast
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -158,6 +159,21 @@ class AlarmManagerServiceTest : RobolectricTest() {
             AlarmManagerService.scheduleAllNotifications(context)
             verify(exactly = 3) { alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), 10.minutes.inWholeMilliseconds, any()) }
         }
+
+    @Test
+    fun `scheduleAllNotifications does not crash and shows toast when review reminder data is corrupt`() {
+        mockkStatic("com.ichi2.anki.UIUtilsKt")
+        every { showThemedToast(any(), any<String>(), any()) } returns Unit
+
+        ReviewRemindersDatabase.remindersSharedPrefs.edit {
+            putString(ReviewRemindersDatabase.APP_WIDE_KEY, "not valid json at all")
+        }
+
+        AlarmManagerService.scheduleAllNotifications(context)
+
+        verify(exactly = 0) { alarmManager.setWindow(any(), any(), any(), any()) }
+        verify(exactly = 1) { showThemedToast(any(), any<String>(), false) }
+    }
 
     @Test
     fun `onReceive schedules snoozed notification and cancels clicked notification`() {


### PR DESCRIPTION
fix handle nonfatal review reminder deserialization errors on startup.                                                                                                                                                                                                                           
Currently, if review reminder data in SharedPreferences can't be deserialized, the app crashes on startup. This catches the exception in `scheduleAllEnabledReviewReminderNotifications` and shows a toast instead, so the app can continue starting up normally.

  Changes:
  - `AlarmManagerService.kt`: catch `SerializationException` and
    `IllegalArgumentException` when reading from `ReviewRemindersDatabase`,
    show toast on failure
  - `03-dialogs.xml`: add `boot_service_review_reminders_corrupt` string
  - `AlarmManagerServiceTest.kt`: test that corrupt data doesn't crash and
    shows toast
