### PR TITLE
Remove redundant constructs in Kotlin files

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -249,7 +249,7 @@ internal fun selectAnkiDroidFolder(
     return if (canManageExternalStorage) {
         AnkiDroidFolder.PublicFolder(PermissionSet.EXTERNAL_MANAGER)
     } else {
-        return AnkiDroidFolder.AppPrivateFolder
+        AnkiDroidFolder.AppPrivateFolder
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DisplayDeckNode.kt
@@ -153,10 +153,9 @@ fun DeckNode.addVisibleToList(list: MutableList<DeckNode>) {
 }
 
 @SuppressLint("LocaleRootUsage")
-private fun DeckNode.nameMatchesFilter(filter: CharSequence?): Boolean {
-    return if (filter == null) {
+private fun DeckNode.nameMatchesFilter(filter: CharSequence?): Boolean =
+    if (filter == null) {
         true
     } else {
-        return node.name.lowercase(Locale.getDefault()).contains(filter) || node.name.lowercase(Locale.ROOT).contains(filter)
+        node.name.lowercase(Locale.getDefault()).contains(filter) || node.name.lowercase(Locale.ROOT).contains(filter)
     }
-}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/SavedBrowserSearchesDialogFragment.kt
@@ -168,7 +168,7 @@ fun CardBrowser.registerSavedSearchActionHandler(action: (Int, String?) -> Unit)
         this,
     ) { _, bundle ->
         val type = bundle.getInt(SavedBrowserSearchesDialogFragment.ARG_TYPE)
-        val searchName = bundle.getString(SavedBrowserSearchesDialogFragment.ARG_SAVED_SEARCH)
+        val searchName = bundle.getString(ARG_SAVED_SEARCH)
         Timber.d("On user saved search selection named: %s", searchName)
         action(type, searchName)
     }


### PR DESCRIPTION
## Purpose / Description
Removed some redundant constructs found during Android Studio code inspection.

## Fixes
No linked issue — code cleanup only

## Approach
Removed redundant return keywords in DisplayDeckNode.kt and InitialActivity.kt and removed redundant qualifier name in SavedBrowserSearchesDialogFragment.kt

## How Has This Been Tested?
Built the project locally and inspection warnings are gone.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code