### PR TITLE
fix(widget): standardize alarm interval to 10 minutes  and document updatePeriodMillis limitation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetAlarm.kt
@@ -101,8 +101,8 @@ fun setRecurringAlarm(
 
     alarmManager.setRepeating(
         AlarmManager.ELAPSED_REALTIME,
-        SystemClock.elapsedRealtime() + 1.minutes.inWholeMilliseconds,
-        1.minutes.inWholeMilliseconds,
+        SystemClock.elapsedRealtime() + 10.minutes.inWholeMilliseconds,
+        10.minutes.inWholeMilliseconds,
         newPendingIntent,
     )
 }

--- a/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
@@ -6,7 +6,8 @@
      * height between 56 and 800
      * width 84 and 800 -->
 
-<!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
+<!-- Note: It was suggested to use updatePeriodMillis but it has a minimum of 30 mins enforced by the android
+     which is too infrequent for due card count, and used a 10 minutes alarm as it was intended.-->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialKeyguardLayout="@layout/widget_card_analysis"

--- a/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
@@ -8,7 +8,8 @@
      * height between 50 and 800
      * width 120 and 800 -->
 
-<!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
+<!-- Note: It was suggested to use updatePeriodMillis but it has a minimum of 30 mins enforced by the android
+     which is too infrequent for due card count, and used a 10 minutes alarm as it was intended.-->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialKeyguardLayout="@layout/widget_deck_picker_large"


### PR DESCRIPTION
Problem: In widget_provider_deck_picker.xml line 11, a TODO comment suggests using updatePeriodMillis for simpler updates. However the actual implementation in WidgetAlarm.kt runs every 1 minute, contradicting the TODO's intended 10 minute interval.

Investigation: Research into updatePeriodMillis revealed a minimum enforced value of 30 minutes by Android. For a widget displaying due card counts, a 30-minute update interval is too infrequent — users glance at the home screen throughout the day and need accurate card counts. Additionally, the current 1-minute interval causes unnecessary battery drain. Standardizing to 10 minutes aligns with the original TODO intent while balancing accuracy and battery efficiency.

Fix: Updated WidgetAlarm.kt — changed interval from 1 minute to 10 minutes at 2 occurrences. Updated TODO comment in widget_provider_deck_picker.xml and widget_provider_card_analysis.xml with explanation of why updatePeriodMillis was not used.

Testing: The build was successfully running and there were no errors found after doing the change in the code

Addresses TODO comment in widget_provider_deck_picker.xml line 11