### PR TITLE
fix(widget): standardize alarm interval to 10 minutes and document updatePeriodMillis limitation

### DIFF
--- a/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_card_analysis.xml
@@ -6,8 +6,6 @@
      * height between 56 and 800
      * width 84 and 800 -->
 
-<!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
-
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialKeyguardLayout="@layout/widget_card_analysis"
     android:initialLayout="@layout/widget_card_analysis"

--- a/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
+++ b/AnkiDroid/src/main/res/xml/widget_provider_deck_picker.xml
@@ -8,7 +8,6 @@
      * height between 50 and 800
      * width 120 and 800 -->
 
-<!-- TODO: Use updatePeriodMillis instead of the 10-minute alarm for simpler widget updates.-->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
     android:initialKeyguardLayout="@layout/widget_deck_picker_large"


### PR DESCRIPTION
 Purpose / Description: 
There was a difference between a comment and the real code and also proposed a new approach

## Fixes
There is no issue number since this was TODO and it is located inside the widget_provider_deck_picker.xml at line 11

## Approach
So it was mentioned to use updatePeriodMillis and by research i found out it's minimum time is for 30 mins and that time is slower/delayed when the widget is added because it can create inconsistency and confusion for the user and the code was not following the 10 mins thing mentioned in the TODO so updated it to 10 minutes instead of being set at 1 minute.

## How Has This Been Tested?

The tests were performed on the emulator device and it was running successfully without any error or crash

##Learning (optional, can help others)
Referred topic for this problem was updatePeriodMillis, source for learning were developer.android.com

## Checklist

- [✓] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✓] You have commented your code, particularly in hard-to-understand areas
- [✓] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)