### PR TITLE
fix: Add validation for empty note type name

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -78,7 +78,11 @@ class AddNewNotesType(
                 .apply {
                     customView(binding.root, paddingStart = 32, paddingEnd = 32, paddingTop = 64, paddingBottom = 64)
                     positiveButton(R.string.dialog_ok) { _ ->
-                        val newName = binding.notetypeNewName.text.toString()
+                        val newName =
+                            binding.notetypeNewName.text
+                                .toString()
+                                .trim()
+                        if (newName.isEmpty()) return@positiveButton
                         val selectedPosition = binding.notetypeNewType.selectedItemPosition
                         if (selectedPosition == AdapterView.INVALID_POSITION) return@positiveButton
                         val selectedOption = allOptions[selectedPosition]
@@ -100,7 +104,7 @@ class AddNewNotesType(
         val addPrefixStr = context.resources.getString(R.string.model_browser_add_add)
         val clonePrefixStr = context.resources.getString(R.string.model_browser_add_clone)
         binding.notetypeNewName.addTextChangedListener { editableText ->
-            val currentName = editableText?.toString() ?: ""
+            val currentName = editableText?.toString()?.trim() ?: ""
             positiveButton.isEnabled =
                 currentName.isNotEmpty() &&
                 !currentNames.contains(currentName)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
@@ -25,6 +25,7 @@ import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.annotation.StringRes
+import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.SearchView
 import androidx.appcompat.widget.Toolbar
@@ -217,7 +218,8 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
         return true
     }
 
-    private fun renameNotetype(state: NoteTypeItemState) {
+    @VisibleForTesting
+    internal fun renameNotetype(state: NoteTypeItemState) {
         launchCatchingTask {
             val allNotetypes = viewModel.state.value.noteTypes
             val dialog =
@@ -226,7 +228,13 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
                     .show {
                         title(R.string.rename_model)
                         positiveButton(R.string.rename) {
-                            val userInput = (it as AlertDialog).getInputField().text.toString()
+                            val userInput =
+                                (it as AlertDialog)
+                                    .getInputField()
+                                    .text
+                                    .toString()
+                                    .trim()
+                            if (userInput.isEmpty()) return@positiveButton
                             viewModel.rename(state.id, userInput)
                         }
                         negativeButton(R.string.dialog_cancel)
@@ -236,9 +244,10 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
                         waitForPositiveButton = false,
                         displayKeyboard = true,
                         callback = { dialog, text ->
+                            val currentName = text.toString().trim()
                             val isNotADuplicate =
-                                !allNotetypes.map { it.name }.contains(text.toString())
-                            dialog.positiveButton.isEnabled = text.isNotEmpty() && isNotADuplicate
+                                !allNotetypes.map { it.name }.contains(currentName)
+                            dialog.positiveButton.isEnabled = currentName.isNotEmpty() && isNotADuplicate
                         },
                     )
             // start with the button disabled as dialog shows the initial name
@@ -246,7 +255,8 @@ class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
         }
     }
 
-    private fun deleteNotetype(state: NoteTypeItemState) {
+    @VisibleForTesting
+    internal fun deleteNotetype(state: NoteTypeItemState) {
         launchCatchingTask {
             @StringRes val messageResourceId: Int? =
                 if (userAcceptsSchemaChange()) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/notetype/AddNewNotesTypeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/notetype/AddNewNotesTypeTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Chaitanya Medidar <2023.chaitanya.medidar@ves.ac.in>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.notetype
+
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.lifecycle.lifecycleScope
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import kotlinx.coroutines.launch
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowDialog
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(AndroidJUnit4::class)
+class AddNewNotesTypeTest : RobolectricTest() {
+    @Test
+    fun `add note type - whitespace only name keeps OK button disabled`() =
+        runTest {
+            val activity = startRegularActivity<ManageNotetypes>()
+            val addNewNotesType = AddNewNotesType(activity)
+            activity.lifecycleScope.launch {
+                addNewNotesType.showAddNewNotetypeDialog()
+            }
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+            val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+            val nameInput = dialog.findViewById<EditText>(R.id.notetype_new_name)!!
+            val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+
+            // whitespace-only should disable the OK button
+            nameInput.setText("   ")
+            assertThat("OK button disabled for whitespace-only name", positiveButton.isEnabled, equalTo(false))
+
+            // valid name should enable the button
+            nameInput.setText("My New Note Type")
+            assertThat("OK button enabled for a valid name", positiveButton.isEnabled, equalTo(true))
+
+            // empty string should disable it again
+            nameInput.setText("")
+            assertThat("OK button disabled for empty name", positiveButton.isEnabled, equalTo(false))
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNotetypesTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/notetype/ManageNotetypesTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Chaitanya Medidar <2023.chaitanya.medidar@ves.ac.in>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.notetype
+
+import android.widget.EditText
+import androidx.appcompat.app.AlertDialog
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowDialog
+import org.robolectric.shadows.ShadowLooper
+
+@RunWith(AndroidJUnit4::class)
+class ManageNotetypesTest : RobolectricTest() {
+    @Test
+    fun `rename note type - whitespace only name keeps Rename button disabled`() =
+        runTest {
+            ensureCollectionLoadIsSynchronous()
+            addStandardNoteType(TEST_NOTE_TYPE_NAME, arrayOf("front", "back"), "", "")
+
+            val activity = startRegularActivity<ManageNotetypes>()
+            val firstNoteType =
+                activity.viewModel.state.value.noteTypes
+                    .first { it.name == TEST_NOTE_TYPE_NAME }
+            activity.renameNotetype(firstNoteType)
+
+            ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
+
+            val dialog = ShadowDialog.getLatestDialog() as AlertDialog
+            val nameInput = dialog.findViewById<EditText>(R.id.dialog_text_input)!!
+            val positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+
+            // whitespace-only should disable the Rename button
+            nameInput.setText("   ")
+            assertThat("Rename button disabled for whitespace-only name", positiveButton.isEnabled, equalTo(false))
+
+            // a valid new name should enable the button
+            nameInput.setText("Renamed Note Type")
+            assertThat("Rename button enabled for a valid name", positiveButton.isEnabled, equalTo(true))
+
+            // empty string should disable it again
+            nameInput.setText("")
+            assertThat("Rename button disabled for empty name", positiveButton.isEnabled, equalTo(false))
+        }
+
+    companion object {
+        private const val TEST_NOTE_TYPE_NAME = "BasicTestNoteType1"
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Added a validation in creating new note type, that disables OK button, if the input is empty.

## Fixes
Fixes #20476 

## Approach
1. Disabling the OK button for whitespace-only names : Previously, the `addTextChangedListener` only checked if the input was not empty. Since a string of spaces (like "   ") is technically not empty, the app would enable the OK button. By adding `.trim()` inside the listener, we strip away all leading and trailing spaces. If the user only types spaces, `trim()` reduces it to an empty string (""), which fails the `isNotEmpty()` check and keeps the OK button correctly disabled.

2. Guarding the Note Type creation : When the OK button is actually clicked, we fetch the text and apply `.trim()` again

## How Has This Been Tested?

Built the app on my physical device:
1. Go to Manage Note Type
2. Click on '+' to add a new note
3. Try adding a note with whitespace-only name

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code


<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->