### PR TITLE
feat: improve learn ahead and timebox dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -81,7 +81,7 @@ class IncrementerNumberRangePreferenceCompat :
         override fun onStart() {
             super.onStart()
             positiveButton = (dialog as? androidx.appcompat.app.AlertDialog)?.positiveButton
-
+            positiveButton?.setText(R.string.save)
             // Rerun validation now that we have the OK button reference
             updateButtonState()
         }

--- a/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewing.xml
@@ -35,16 +35,16 @@
             android:title="@string/day_offset_with_description"
             app:persistent="false"
             app:summaryFormat="@plurals/day_offset_summ"/>
-        <com.ichi2.preferences.NumberRangePreferenceCompat
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/learn_cutoff_preference"
             android:title="@string/learn_cutoff"
             app:max="999"
             app:min="0"
             app:summaryFormat="@plurals/pref_summ_minutes"/>
-        <com.ichi2.preferences.NumberRangePreferenceCompat
+        <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
             android:key="@string/time_limit_preference"
             android:title="@string/time_limit"
-            app:max="9999"
+            app:max="999"
             app:min="0"
             app:summaryFormat="@plurals/pref_summ_minutes"/>
     </PreferenceCategory>


### PR DESCRIPTION
## Purpose / Description
The "Learn ahead limit" and "Timebox time limit" dialogs use a plain text input. This PR improves them by adding stepper buttons and changing "OK" to "Save".

## Fixes
* Part of #20478

## Approach
Switched both preferences in `preferences_reviewing.xml` from `NumberRangePreferenceCompat` to `IncrementerNumberRangePreferenceCompat` which already has +/- stepper buttons and input validation built in. Added `dialog_save` string to `03-dialogs.xml` and updated the positive button text in `IncrementerNumberRangePreferenceCompat` to use it.

This addresses the required changes from the issue. The optional changes (unit label and description text) are not included in this PR and can be done separately.

## How Has This Been Tested?
Built with `assembleDebug` and tested both dialogs on emulator (API 36).