### PR TITLE
Improve custom sync server and AnkiDroid directory dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
@@ -67,6 +67,7 @@ open class VersatileTextPreferenceDialogFragment : EditTextPreferenceDialogFragm
     override fun onBindDialogView(contentView: View) {
         editText = contentView.findViewById(android.R.id.edit)!!
         editText.inputType = versatileTextPreference.referenceEditText.inputType
+        editText.setBackgroundResource(com.ichi2.anki.R.drawable.edittext_border)
 
         super.onBindDialogView(contentView)
 
@@ -84,5 +85,10 @@ open class VersatileTextPreferenceDialogFragment : EditTextPreferenceDialogFragm
                     }
             })
         }
+    }
+
+    override fun onPrepareDialogBuilder(builder: AlertDialog.Builder) {
+        super.onPrepareDialogBuilder(builder)
+        builder.setPositiveButton(com.ichi2.anki.R.string.save, this)
     }
 }

--- a/AnkiDroid/src/main/res/drawable/edittext_border.xml
+++ b/AnkiDroid/src/main/res/drawable/edittext_border.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <stroke
+        android:width="1dp"
+        android:color="?attr/colorOutline" />
+    <corners android:radius="4dp" />
+    <padding
+        android:left="8dp"
+        android:top="8dp"
+        android:right="8dp"
+        android:bottom="8dp" />
+</shape>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -207,7 +207,7 @@
         If not set, the default AnkiWeb server will be used instead.
         <a href="%s">Learn more</a>
         ]]></string>
-    <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>
+    <string name="custom_sync_server_base_url_title" maxLength="41">Sync URL</string>
     <string name="custom_sync_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
     <!-- Key Bindings -->
     <string name="keyboard">Keyboard</string>


### PR DESCRIPTION
## Description
Improves the custom sync server and AnkiDroid directory dialogs as requested in #20487.

## Changes
- Capitalized 'url' to 'URL' in sync server dialog title
- Added border to input boxes (URL, PEM certificate, Directory) for better visual consistency
- Replaced 'OK' button with 'Save' button to match other dialogs

## Implementation Details
- Created `edittext_border.xml` drawable with 1dp stroke and 4dp corner radius
- Modified `VersatileTextPreference.kt` to apply border and change button text
- Updated string resource to use 'URL' instead of 'url'

## Testing
- Verified border appears on all EditText fields in preference dialogs
- Confirmed 'Save' button replaces 'OK' button
- Checked that URL capitalization is correct

Fixes #20487