### PR TITLE
feat: enable explicit backing fields

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,13 +95,27 @@ subprojects {
         (see https://youtrack.jetbrains.com/issue/KT-28777/Using-experimental-coroutines-api-causes-unresolved-dependency)
          */
         tasks.withType(KotlinCompile::class.java).configureEach {
+            // We use `isInIdeaSync` to resolve a mismatch between Android Studio's code analyzer
+            // and the Kotlin 2.3 compiler regarding Explicit Backing Fields. The IDE requires
+            // the unsafe '-XXLanguage' flag to clear false syntax errors, but the actual compiler
+            // crashes if it receives this flag due to our strict 'warnings as errors'.
+            // This workaround safely feeds the unsafe flag *only* to the IDE during Gradle sync,
+            // while passing the standard, crash-free flag to the compiler during the actual build.
+            val isInIdeaSync = System.getProperty("idea.sync.active").toBoolean()
+
             compilerOptions {
                 allWarningsAsErrors = fatalWarnings
                 val compilerArgs = mutableListOf(
                     // https://youtrack.jetbrains.com/issue/KT-73255
                     // Apply @StringRes to both constructor params and generated properties
-                    "-Xannotation-default-target=param-property"
+                    "-Xannotation-default-target=param-property",
+                    "-Xexplicit-backing-fields"
                 )
+
+                if (isInIdeaSync) {
+                    compilerArgs += "-XXLanguage:+ExplicitBackingFields"
+                }
+
                 if (project.name != "api") {
                     compilerArgs += "-opt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
                     compilerArgs += "-Xcontext-parameters"


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
I want to Enable field backing for Kotlin (Kotlin automatically generates a backing field for properties that reference the field keyword in their custom accessors, though in experimental phase)

Here is what it will look like for VMs since most of the time we use this pattern in VMs

Before
```kotlin
private val _something = MutableStateFlow("")
val something: StateFlow<String> = _something
```

After
```kotlin
val something: StateFlow<String>
    field = MutableStateFlow("")
```

## Fixes
NA

## Approach
I simply added   "-Xexplicit-backing-fields" but there was warning in code for which I did a workaround to fix it, I have commented on the `val` to better explanation 

## How Has This Been Tested?
Compiled the code and tried adding `field` property to a class

## Learning (optional, can help others)
- https://kotlinlang.org/docs/whatsnew23.html#explicit-backing-fields

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->