### PR TITLE
refactor: use field backing property in Instant Editor VM

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -56,10 +56,8 @@ class InstantEditorViewModel :
     /** Errors or Warnings related to the edit fields that might occur when trying to save note */
     val instantEditorError = MutableSharedFlow<String?>()
 
-    private val _currentClozeNumber = MutableStateFlow(1)
-
-    val currentClozeNumber: Int
-        get() = _currentClozeNumber.value
+    val currentClozeNumber: StateFlow<Int>
+        field = MutableStateFlow(1)
 
     // List to store the cloze integers
     private val intClozeList = mutableListOf<Int>()
@@ -68,17 +66,14 @@ class InstantEditorViewModel :
     @VisibleForTesting
     val clozeDeletionCount get() = intClozeList.size
 
-    private val _currentClozeMode = MutableStateFlow(InstantNoteEditorActivity.ClozeMode.INCREMENT)
+    val currentClozeMode: StateFlow<InstantNoteEditorActivity.ClozeMode>
+        field = MutableStateFlow(InstantNoteEditorActivity.ClozeMode.INCREMENT)
 
-    val currentClozeMode: StateFlow<InstantNoteEditorActivity.ClozeMode> = _currentClozeMode.asStateFlow()
+    val actualClozeFieldText: StateFlow<String?>
+        field = MutableStateFlow<String?>(null)
 
-    private val _actualClozeFieldText = MutableStateFlow<String?>(null)
-
-    val actualClozeFieldText: StateFlow<String?> = _actualClozeFieldText.asStateFlow()
-
-    private val _editorMode = MutableStateFlow(InstantNoteEditorActivity.EditMode.SINGLE_TAP)
-
-    val editorMode: StateFlow<InstantNoteEditorActivity.EditMode> = _editorMode.asStateFlow()
+    val editorMode: StateFlow<InstantNoteEditorActivity.EditMode>
+        field = MutableStateFlow(InstantNoteEditorActivity.EditMode.SINGLE_TAP)
 
     /**
      * Gets the current editor note.
@@ -86,22 +81,20 @@ class InstantEditorViewModel :
     @VisibleForTesting
     lateinit var editorNote: Note
 
-    private val _currentlySelectedNotetype = MutableLiveData<NotetypeJson>()
-
     /**
      * Representing the currently selected note type.
      *
      * @see NotetypeJson
      */
-    val currentlySelectedNotetype: LiveData<NotetypeJson> get() = _currentlySelectedNotetype
+    val currentlySelectedNotetype: LiveData<NotetypeJson>
+        field = MutableLiveData<NotetypeJson>()
 
     var deckId: DeckId? = null
 
-    private val _dialogType = MutableStateFlow<DialogType?>(null)
-
     /** Representing the type of dialog to be displayed.
      * @see DialogType*/
-    val dialogType: StateFlow<DialogType?> get() = _dialogType
+    val dialogType: StateFlow<DialogType?>
+        field = MutableStateFlow<DialogType?>(null)
 
     init {
         viewModelScope.launch {
@@ -113,18 +106,18 @@ class InstantEditorViewModel :
             // TODO: Use did here
             val noteType = withCol { notetypes.all().firstOrNull { it.isCloze } }
             if (noteType == null) {
-                _dialogType.emit(DialogType.NO_CLOZE_NOTE_TYPES_DIALOG)
+                dialogType.value = DialogType.NO_CLOZE_NOTE_TYPES_DIALOG
                 return@launch
             }
 
             @Suppress("RedundantRequireNotNullCall") // postValue lint requires this
             val clozeNoteType = requireNotNull(noteType) { "noteType" }
             Timber.d("Changing to cloze type note")
-            _currentlySelectedNotetype.postValue(clozeNoteType)
+            currentlySelectedNotetype.postValue(clozeNoteType)
             Timber.i("Using note type '%d", clozeNoteType.id)
             editorNote = withCol { Note.fromNotetypeId(this@withCol, clozeNoteType.id) }
 
-            _dialogType.emit(DialogType.SHOW_EDITOR_DIALOG)
+            dialogType.value = DialogType.SHOW_EDITOR_DIALOG
         }
     }
 
@@ -172,13 +165,13 @@ class InstantEditorViewModel :
     private fun shouldResetClozeNumber(number: Int) {
         intClozeList.remove(number)
 
-        _currentClozeNumber.value =
+        currentClozeNumber.value =
             when {
                 // Reset cloze number if the list is empty
                 intClozeList.isEmpty() -> 1
                 currentClozeMode.value == InstantNoteEditorActivity.ClozeMode.INCREMENT ->
                     (intClozeList.maxOrNull() ?: 0) + 1
-                else -> _currentClozeNumber.value
+                else -> currentClozeNumber.value
             }
     }
 
@@ -215,13 +208,13 @@ class InstantEditorViewModel :
 
     private fun incrementClozeNumber() {
         Timber.d("Incrementing cloze number: $currentClozeNumber")
-        _currentClozeNumber.value++
+        currentClozeNumber.value++
     }
 
     fun setClozeFieldText(text: String?) {
-        _actualClozeFieldText.value = text
+        actualClozeFieldText.value = text
         intClozeList.replaceWith(getClozeOrdinals(text ?: ""))
-        _currentClozeNumber.value = (intClozeList.maxOrNull() ?: 0) + 1
+        currentClozeNumber.value = (intClozeList.maxOrNull() ?: 0) + 1
     }
 
     /**
@@ -249,7 +242,7 @@ class InstantEditorViewModel :
 
         val clozeText: String?
 
-        val clozeNumber = currentClozeNumber
+        val clozeNumber = currentClozeNumber.value
         if (currentClozeMode.value == InstantNoteEditorActivity.ClozeMode.INCREMENT) {
             incrementClozeNumber()
         }
@@ -364,7 +357,7 @@ class InstantEditorViewModel :
     private fun processClozeUndo(text: String): String? {
         val matchResult = clozePattern.find(text)
         val capturedClozeNumber = matchResult?.groups?.get(2)?.value
-        if (capturedClozeNumber != null && currentClozeNumber - capturedClozeNumber.toInt() == 1) {
+        if (capturedClozeNumber != null && currentClozeNumber.value - capturedClozeNumber.toInt() == 1) {
             decrementClozeNumber()
         }
 
@@ -386,17 +379,17 @@ class InstantEditorViewModel :
     }
 
     fun setEditorMode(mode: InstantNoteEditorActivity.EditMode) {
-        _editorMode.value = mode
+        editorMode.value = mode
     }
 
     private fun decrementClozeNumber() {
-        val newValue = _currentClozeNumber.value - 1
-        _currentClozeNumber.value = max(1, newValue)
+        val newValue = currentClozeNumber.value - 1
+        currentClozeNumber.value = max(1, newValue)
     }
 
     fun toggleClozeMode() {
         val newMode =
-            when (_currentClozeMode.value) {
+            when (currentClozeMode.value) {
                 InstantNoteEditorActivity.ClozeMode.INCREMENT -> {
                     decrementClozeNumber()
                     InstantNoteEditorActivity.ClozeMode.NO_INCREMENT
@@ -406,7 +399,7 @@ class InstantEditorViewModel :
                     InstantNoteEditorActivity.ClozeMode.INCREMENT
                 }
             }
-        _currentClozeMode.value = newMode
+        currentClozeMode.value = newMode
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -574,7 +574,7 @@ class InstantNoteEditorActivity :
                     convertSelectedTextToCloze(
                         textBox,
                         selectedText,
-                        viewModel.currentClozeNumber,
+                        viewModel.currentClozeNumber.value,
                     )
 
                     mode.finish()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -69,7 +69,7 @@ class InstantEditorViewModelTest : RobolectricTest() {
             toggleAllClozeDeletions(sentenceArray)
 
             assertEquals("all cloze deletions are removed", clozeDeletionCount, 0)
-            assertEquals("cloze number is reset if there are no clozes", currentClozeNumber, 1)
+            assertEquals("cloze number is reset if there are no clozes", currentClozeNumber.value, 1)
         }
 
     @Test
@@ -83,11 +83,11 @@ class InstantEditorViewModelTest : RobolectricTest() {
             // disable cloze on the first 2, leaving "this" as {{c3::
             toggleClozeDeletions(sentenceArray, 0, 1)
 
-            assertEquals("cloze number is 'Current Cloze Number + 1'", currentClozeNumber, 4)
+            assertEquals("cloze number is 'Current Cloze Number + 1'", currentClozeNumber.value, 4)
 
             // remove the remaining cloze all clozes
             toggleClozeDeletion(sentenceArray, 2)
-            assertEquals("cloze number is reset if all clozes are removed", currentClozeNumber, 1)
+            assertEquals("cloze number is reset if all clozes are removed", currentClozeNumber.value, 1)
         }
 
     @Test
@@ -265,13 +265,13 @@ class InstantEditorViewModelTest : RobolectricTest() {
             val text = "This is {{c1::first}} and {{c2::second}}"
             setClozeFieldText(text)
 
-            assertEquals(3, currentClozeNumber)
+            assertEquals(3, currentClozeNumber.value)
 
             toggleClozeMode() // switch to NO_INCREMENT mode
-            assertEquals(2, currentClozeNumber)
+            assertEquals(2, currentClozeNumber.value)
 
             toggleClozeMode() // switch back to INCREMENT mode
-            assertEquals(3, currentClozeNumber)
+            assertEquals(3, currentClozeNumber.value)
         }
 
     private fun runViewModelTest(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Use the new field backing property in the ViewModels in our codebase

## Fixes
NA

## Approach
Replace the existing code `_something`with `field` and update the usage
The commits are clear as to what VM I touched and what I changed 

## How Has This Been Tested?
Local compile and tested the changes on my Pixel 

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->