### PR TITLE
Fix: The last selected deck is correctly restored instead of default deck 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -449,6 +449,7 @@ class NoteEditorFragment :
         }
         require(deck is SelectableDeck.Deck)
         deckId = deck.deckId
+        saveLastSelectedDeck(deckId)
         view?.findViewById<TextView>(R.id.note_deck_name)?.text = deck.name
     }
 
@@ -518,7 +519,7 @@ class NoteEditorFragment :
         if (savedInstanceState != null) {
             caller = fromValue(savedInstanceState.getInt(CALLER_KEY))
             addNote = savedInstanceState.getBoolean("addNote")
-            deckId = savedInstanceState.getLong("did")
+            deckId = savedInstanceState.getLong("did", loadLastSelectedDeck())
             selectedTags = savedInstanceState.getStringArrayList("tags")
             reloadRequired = savedInstanceState.getBoolean(RELOAD_REQUIRED_EXTRA_KEY)
             pastedImageCache =
@@ -533,6 +534,9 @@ class NoteEditorFragment :
                 if (ACTION_CREATE_FLASHCARD == action || ACTION_CREATE_FLASHCARD_SEND == action || Intent.ACTION_PROCESS_TEXT == action) {
                     caller = NoteEditorCaller.NOTEEDITOR_INTENT_ADD
                 }
+            }
+            if (caller == NoteEditorCaller.NOTEEDITOR_INTENT_ADD) {
+                deckId = loadLastSelectedDeck()
             }
         }
     }
@@ -2953,6 +2957,7 @@ class NoteEditorFragment :
         private const val PREF_NOTE_EDITOR_CAPITALIZE = "note_editor_capitalize"
         private const val PREF_NOTE_EDITOR_FONT_SIZE = "note_editor_font_size"
         private const val PREF_NOTE_EDITOR_CUSTOM_BUTTONS = "note_editor_custom_buttons"
+        private const val PREF_LAST_DECK_ID = "last_deck_id"
 
         fun newInstance(launcher: NoteEditorLauncher): NoteEditorFragment =
             NoteEditorFragment().apply {
@@ -2976,5 +2981,16 @@ class NoteEditorFragment :
             !AnkiDroidApp.instance
                 .sharedPrefs()
                 .getBoolean(PREF_NOTE_EDITOR_SHOW_TOOLBAR, true)
+
+        @SuppressLint("UseKtx")
+        fun saveLastSelectedDeck(deckId: Long) {
+            val prefs = AnkiDroidApp.instance.sharedPrefs()
+            prefs.edit { putLong(PREF_LAST_DECK_ID, deckId) }
+        }
+
+        fun loadLastSelectedDeck(defaultDeckId: Long = 0): Long {
+            val prefs = AnkiDroidApp.instance.sharedPrefs()
+            return prefs.getLong(PREF_LAST_DECK_ID, defaultDeckId)
+        }
     }
 }


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description

When sharing text into the app, the selected deck was not preserved correctly. Instead, the default deck was used, even if the user had previously selected a different deck.

This leads to inconsistent behavior and a poor user experience, as users expect the last selected deck to be reused during the share flow.

## Fixes
Fix : #20497


## Approach

While the exact root cause is not explicitly isolated, the behavior suggests that the last selected deck is no longer reliably preserved during the share flow.

To address this, I explicitly store the last selected deck and restore it when handling incoming shared text, ensuring that the correct deck is used instead of falling back to the default deck.


## How Has This Been Tested?

Tested manually using the following steps:

		Open the app and select a non-default deck
		Share text from another app (e.g., browser or notes)
		Observe the selected deck in the add note screen

Before fix: The default deck is always selected

After fix: The last selected deck is correctly restored

Demo: https://drive.google.com/file/d/1vSJJV8fAvFwLIHCB4O37kfI-lRqZrL2e/view?usp=sharing

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->