### PR TITLE
Fix inconsistent string casing in 02-strings.xml (#15760)

### DIFF
--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -31,7 +31,7 @@
     <string name="CardEditorModel">Type:</string>
     <string name="CardEditorTags">Tags: %1$s</string>
     <string name="CardEditorCards">Cards: %1$s</string>
-    <string name="edit_occlusions">Edit Occlusions</string>
+    <string name="edit_occlusions">Edit occlusions</string>
     <string name="paste_from_clipboard" maxLength="28">Paste from clipboard</string>
 
     <string name="tag_name">Tag name</string>
@@ -206,7 +206,7 @@
     <string name="remove_wallpaper_image" maxLength="41">Remove background</string>
     <string name="remove_background_image">Remove background?</string>
     <!-- Card Template Browser Appearance -->
-    <string name="restore_default" maxLength="28">Restore Default</string>
+    <string name="restore_default" maxLength="28">Restore default</string>
 
     <string name="reviewer_tts_cloze_spoken_replacement">Blank</string>
 
@@ -361,7 +361,7 @@
     <!-- Browser Options Dialog -->
     <string name="show_cards" comment="Label for toggle cards button in BrowserOptionsDialog">Cards</string>
     <string name="show_notes" comment="Label for toggle notes button in BrowserOptionsDialog">Notes</string>
-    <string name="toggle_cards_notes">Toggle Cards/Notes</string>
+    <string name="toggle_cards_notes">Toggle cards/notes</string>
     <string name="truncate_content_help">Truncate the height of each row of the Browser to show only first 3&#160;lines of content</string>
     <string name="browser_options_dialog_heading">Browser options</string>
 
@@ -401,7 +401,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
 
     <string name="deck_description_field_hint">Description</string>
     <string name="deck_description_saved">Description updated</string>
-    <string name="format_deck_description_as_markdown">Format as Markdown</string>
+    <string name="format_deck_description_as_markdown">Format as markdown</string>
     <string name="help_button_content_description">Open help for ‘%s’</string>
 
     <string name="failed_to_copy">Failed to copy</string>
@@ -421,7 +421,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <string name="next_recording" comment="Description of a button to go to the next recording">Next</string>
 
     <!--  AlertDialog in the deleteCardTemplate  -->
-    <string name="orphan_note_title">Cannot Delete Card Type</string>
+    <string name="orphan_note_title">Cannot delete card type</string>
     <string name="orphan_note_message">Deleting this card type will leave some notes without any cards.</string>
 
     <string name="voice_not_supported">Voice not supported. Try another or install a voice engine.</string>


### PR DESCRIPTION
## Fixes

Fixes some of #15760

Fixed 5 strings in 02-strings.xml from Title Case to sentence case.

## Examples

- Edit Occlusions → Edit occlusions
- Restore Default → Restore default
- Toggle Cards/Notes → Toggle cards/notes
- Format as Markdown → Format as markdown
- Cannot Delete Card Type → Cannot delete card type