### PR TITLE
Enhance Add Note Type dialog styling and validation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -24,6 +24,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.addTextChangedListener
 import anki.notetypes.StockNotetype
 import anki.notetypes.copy
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.common.time.TimeManager
@@ -36,8 +37,10 @@ import com.ichi2.anki.libanki.backend.BackendUtils
 import com.ichi2.anki.libanki.getNotetype
 import com.ichi2.anki.libanki.getNotetypeNames
 import com.ichi2.anki.libanki.getStockNotetype
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.customView
+import com.ichi2.utils.dp
 import com.ichi2.utils.moveCursorToEnd
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -76,8 +79,15 @@ class AddNewNotesType(
             AlertDialog
                 .Builder(activity)
                 .apply {
-                    customView(binding.root, paddingStart = 32, paddingEnd = 32, paddingTop = 64, paddingBottom = 64)
-                    positiveButton(R.string.dialog_ok) { _ ->
+                    setTitle(TR.notetypesAddNoteType().toSentenceCase(activity, R.string.sentence_add_note_type))
+                    customView(
+                        binding.root,
+                        paddingStart = 24.dp.toPx(activity),
+                        paddingEnd = 24.dp.toPx(activity),
+                        paddingTop = 24.dp.toPx(activity),
+                        paddingBottom = 0,
+                    )
+                    positiveButton(R.string.dialog_add) { _ ->
                         val newName =
                             binding.notetypeNewName.text
                                 .toString()
@@ -103,11 +113,22 @@ class AddNewNotesType(
     ) {
         val addPrefixStr = context.resources.getString(R.string.model_browser_add_add)
         val clonePrefixStr = context.resources.getString(R.string.model_browser_add_clone)
+
+        binding.notetypeTypeLabel.text = TR.notetypesType()
+        binding.notetypeNewNameLayout.hint = TR.deckConfigNamePrompt()
+
         binding.notetypeNewName.addTextChangedListener { editableText ->
             val currentName = editableText?.toString()?.trim() ?: ""
-            positiveButton.isEnabled =
-                currentName.isNotEmpty() &&
-                !currentNames.contains(currentName)
+            val alreadyExists = currentNames.any { it.equals(currentName, true) }
+
+            binding.notetypeNewNameLayout.error =
+                if (alreadyExists) {
+                    context.getString(R.string.error_name_exists)
+                } else {
+                    null
+                }
+
+            positiveButton.isEnabled = currentName.isNotEmpty() && !alreadyExists
         }
         binding.notetypeNewType.apply {
             onItemSelectedListener =

--- a/AnkiDroid/src/main/res/layout/dialog_new_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_new_note_type.xml
@@ -1,30 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:orientation="vertical">
 
     <TextView
-        android:text="Type"
+        android:id="@+id/notetype_type_label"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:ignore="HardcodedText" />
+        android:textAppearance="@style/TextAppearance.Material3.LabelLarge"
+        android:layout_marginBottom="12dp"
+        tools:text="Type"
+        />
 
     <Spinner
         android:id="@+id/notetype_new_type"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content" />
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp" />
 
-    <TextView
-        android:text="Name"
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/notetype_new_name_layout"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        tools:ignore="HardcodedText" />
+        app:errorEnabled="true"
+        tools:hint="Name">
 
-    <EditText
-        android:id="@+id/notetype_new_name"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:inputType="text" />
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/notetype_new_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            />
+
+    </com.google.android.material.textfield.TextInputLayout>
 </LinearLayout>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -455,5 +455,9 @@ opening the system text to speech settings fails">Failed to open text to speech 
 
     <!-- Whitespace is OK -->
     <string name="list_separator" comment="The character and spacing to display between elements of a list, for example ', ' in 'Apple, Banana, Cherry" tools:ignore="TranslationTypo">, </string>
+
+    <!-- Other errors -->
+    <!-- Similar to TR.qtMiscNameExists(): "Name exists." -->
+    <string name="error_name_exists">Name already exists</string>
 </resources>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -62,6 +62,7 @@
 
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
+    <string name="dialog_add" comment="Positive dialog action button label to add 'something'">Add</string>
     <string name="dialog_confirm" tools:ignore="UnusedResources">Confirm</string>
     <string name="dialog_no">No</string>
     <string name="dialog_yes">Yes</string>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -57,4 +57,5 @@ undoActionUndone()
     <string name="sentence_card_stats_current_card_browse">Current card (browse)</string>
     <string name="sentence_card_stats_previous_card_study">Previous card (study)</string>
     <string name="sentence_actions_previous_card_info">Previous card info</string>
+    <string name="sentence_add_note_type">Add note type</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -44,6 +44,7 @@ class SentenceCaseTest : RobolectricTest() {
             assertThat(TR.mediaCheckRestoreTrash().toSentenceCase(this, R.string.sentence_restore_deleted), equalTo("Restore deleted"))
             assertThat(TR.browsingChangeNotetype().toSentenceCase(this, R.string.sentence_change_note_type), equalTo("Change note type"))
             assertThat(TR.actionsGradeNow().toSentenceCase(this, R.string.sentence_grade_now), equalTo("Grade now"))
+            assertThat(TR.notetypesAddNoteType().toSentenceCase(this, R.string.sentence_add_note_type), equalTo("Add note type"))
 
             assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
             assertThat(


### PR DESCRIPTION
## Purpose / Description
This PR modernizes the Add Note Type dialog by replacing outdated UI components with Material Design elements and introducing real-time validation. These changes provide immediate feedback to the user and align the dialog with modern Android design standards.

## Fixes
* Fixes #20466


## Approach
Changes
1. UI Modernization
(i) Material Components: Replaced the standard EditText with TextInputLayout using the OutlinedBox style. This adds a professional border and a floating "Name" label.

(ii) Copy Updates:  Changed dialog title from "Type" to "Add note type".
     · Updated confirmation button from "OK" to "Add" for better intent clarity.

2. Validation Logic & Feedback
 (i)Real-time Detection: Implemented an addTextChangedListener to compare user input against existing note type names.

 (ii)Error Handling: Utilized TextInputLayout.setError() to trigger a red border and a "This note name already exists" message when a duplicate is detected.
 
 (iii)State Management: The "Add" button is now dynamically disabled while a validation error is present.


## How Has This Been Tested?

Device: Techno spark 30

Test Steps:
1. Navigate to the Manage Note Types screen.

2. Tap the + button to open the new dialog.

3. Verification: Confirmed the title displays "Add note type".

4. Duplicate Test: Entered an existing name (e.g., "Basic").
    · Result: Border turned red; error message appeared; "Add" button disabled.

5. Unique Test: Entered a new, unique name.
   · Result: Error cleared; "Add" button enabled.

![1000644839](https://github.com/user-attachments/assets/96c04d68-3d05-4c6e-a308-7477be7254d5)
![1000644838](https://github.com/user-attachments/assets/c9ecf2f7-3011-4da2-a115-3dd97dc1e622)
