### PR TITLE
Improve some dialogs Appearance, Note editor and Template editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -25,9 +25,11 @@ import androidx.activity.OnBackPressedCallback
 import androidx.annotation.CheckResult
 import androidx.appcompat.app.AlertDialog
 import androidx.core.widget.doAfterTextChanged
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.databinding.CardBrowserAppearanceBinding
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.CardTemplate
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -115,7 +117,8 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity(R.layout.card_browser_a
 
     private fun showRestoreDefaultDialog() {
         AlertDialog.Builder(this).show {
-            positiveButton(R.string.dialog_ok) {
+            setTitle(TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default))
+            positiveButton(R.string.restore) {
                 restoreDefaultAndClose()
             }
             negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -98,6 +98,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerPage
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
+import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -1125,9 +1126,9 @@ open class CardTemplateEditor :
 
                     fun askUser(kind: StockNotetype.Kind? = null) {
                         AlertDialog.Builder(requireContext()).show {
-                            setTitle(TR.cardTemplatesRestoreToDefault())
+                            setTitle(TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default))
                             setMessage(TR.cardTemplatesRestoreToDefaultConfirmation())
-                            setPositiveButton(R.string.dialog_ok) { _, _ ->
+                            setPositiveButton(R.string.restore) { _, _ ->
                                 launchCatchingTask {
                                     restoreNotetypeToStock(kind)
                                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -181,7 +181,7 @@ class TagsDialog : AnalyticsDialogFragment {
 
         val positiveText =
             if (type == DialogType.EDIT_TAGS) {
-                getString(R.string.dialog_ok)
+                getString(R.string.dialog_confirm)
             } else {
                 getString(R.string.select)
             }
@@ -381,11 +381,11 @@ class TagsDialog : AnalyticsDialogFragment {
                 .Builder(requireActivity())
                 .show {
                     title(text = getString(R.string.add_tag))
-                    positiveButton(R.string.dialog_ok)
+                    positiveButton(R.string.menu_add)
                     negativeButton(R.string.dialog_cancel)
                     setView(R.layout.dialog_generic_text_input)
                 }.input(
-                    hint = getString(R.string.tag_name),
+                    hint = TR.actionsName().dropLastWhile { it == ':' },
                     inputType = InputType.TYPE_CLASS_TEXT,
                     displayKeyboard = true,
                 ) { d: AlertDialog?, input: CharSequence ->

--- a/AnkiDroid/src/main/res/layout/card_browser_appearance.xml
+++ b/AnkiDroid/src/main/res/layout/card_browser_appearance.xml
@@ -39,6 +39,7 @@
                 />
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/question_format_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/card_template_browser_appearance_question_format"
@@ -54,6 +55,7 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/answer_format_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/card_template_browser_appearance_answer_format"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -34,7 +34,6 @@
     <string name="edit_occlusions">Edit occlusions</string>
     <string name="paste_from_clipboard" maxLength="28">Paste from clipboard</string>
 
-    <string name="tag_name">Tag name</string>
     <string name="add_new_filter_tags">Add/filter tags</string>
     <string name="add_tag" maxLength="28">Add tag</string>
     <string name="check_all_tags" maxLength="28">Check/uncheck all tags</string>
@@ -209,7 +208,7 @@
     <string name="background_image_title" maxLength="41">Background</string>
     <string name="choose_an_image" maxLength="41">Select image</string>
     <string name="remove_wallpaper_image" maxLength="41">Remove background</string>
-    <string name="remove_background_image">Remove background?</string>
+    <string name="remove_background_image">Are you sure you wish to remove the background?</string>
     <!-- Card Template Browser Appearance -->
     <string name="restore_default" maxLength="28">Restore default</string>
 

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -63,6 +63,7 @@
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
     <string name="dialog_add" comment="Positive dialog action button label to add 'something'">Add</string>
+    <string name="restore">Restore</string>
     <string name="dialog_confirm" tools:ignore="UnusedResources">Confirm</string>
     <string name="dialog_no">No</string>
     <string name="dialog_yes">Yes</string>

--- a/AnkiDroid/src/main/res/values/17-model-manager.xml
+++ b/AnkiDroid/src/main/res/values/17-model-manager.xml
@@ -66,9 +66,9 @@
 
     <!--Browser Appearance-->
     <string name="card_template_browser_appearance_summary">Enter the template that the card browser will use to display your cards. Use this to display a more concise answer.\n\nA front template of\n“The capital of {{Country}} is:”\ncould be compressed in the card browser to\n“Capital: {{Country}}”</string>
-    <string name="card_template_browser_appearance_question_format">Question Format</string>
-    <string name="card_template_browser_appearance_answer_format">Answer Format</string>
-    <string name="card_template_browser_appearance_restore_default_dialog">Restore Default Values?</string>
+    <string name="card_template_browser_appearance_question_format">Question format</string>
+    <string name="card_template_browser_appearance_answer_format">Answer format</string>
+    <string name="card_template_browser_appearance_restore_default_dialog">Are you sure you want to restore the browser appearance to default?</string>
     <string name="card_template_browser_appearance_saving_note">These changes are applied when the card template is saved</string>
 
     <!-- Deck Override -->

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -58,4 +58,5 @@ undoActionUndone()
     <string name="sentence_card_stats_previous_card_study">Previous card (study)</string>
     <string name="sentence_actions_previous_card_info">Previous card info</string>
     <string name="sentence_add_note_type">Add note type</string>
+    <string name="sentence_restore_to_default">Restore to default</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -45,6 +45,10 @@ class SentenceCaseTest : RobolectricTest() {
             assertThat(TR.browsingChangeNotetype().toSentenceCase(this, R.string.sentence_change_note_type), equalTo("Change note type"))
             assertThat(TR.actionsGradeNow().toSentenceCase(this, R.string.sentence_grade_now), equalTo("Grade now"))
             assertThat(TR.notetypesAddNoteType().toSentenceCase(this, R.string.sentence_add_note_type), equalTo("Add note type"))
+            assertThat(
+                TR.cardTemplatesRestoreToDefault().toSentenceCase(this, R.string.sentence_restore_to_default),
+                equalTo("Restore to default"),
+            )
 
             assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
             assertThat(


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Improve some dialogs and UI text to make labels, and buttons more consistent and readable.  
Changes include updating button texts, making certain titles sentence case, and improving the Browser Appearance dialogs.


## Fixes
Fixes ##20508

## Approach
* Settings -> Appearance: added informative text message.  
* Note editor:  
  - Replaced generic "OK" button with "Select" in Tags dialog.  
  - Replaced "OK" with "Add" in Add Tag dialog.  
  - Updated tag input box label from "Tag name" to "Name".  
* Template editor / Restore to Default dialog:  
  - Replaced "(OK)" button with "(Restore)".  
  - Title changed to sentence case "Restore to default".  
* Browser appearance (CardTemplateBrowserAppearanceEditor):  
  - Changed the border titles above EditTexts: "Question Format" and "Answer Format" to lowercase.  
  - "Loop" icon dialog:  
    - Button "(OK)" replaced with "(Restore)".  
    - Added dialog title: "Restore to default".  
    - Message updated to: "Are you sure you want to restore the browser appearance to default?".  


## How Has This Been Tested?

* Manually verified dialogs in the app:  
  - Tags dialog in Note editor shows "Select" button and "Name" label.  
  - Add Tag dialog shows "Add" button and updated input label.  
  - Template editor Restore to Default shows "Restore" button and sentence-case title.  
  - Browser appearance: Question/Answer format labels are lowercase; loop icon dialog shows updated title, message, and button.  