### PR TITLE
feat(preferences): improve timeout/backup number dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/NonLeadingZeroInputFilter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/NonLeadingZeroInputFilter.kt
@@ -1,0 +1,36 @@
+/*
+*  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+*
+*  This program is free software; you can redistribute it and/or modify it under
+*  the terms of the GNU General Public License as published by the Free Software
+*  Foundation; either version 3 of the License, or (at your option) any later
+*  version.
+*
+*  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+*  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+*  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+*  You should have received a copy of the GNU General Public License along with
+*  this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+package com.ichi2.anki.ui
+
+import android.text.InputFilter
+import android.text.Spanned
+
+object NonLeadingZeroInputFilter : InputFilter {
+    override fun filter(
+        source: CharSequence,
+        start: Int,
+        end: Int,
+        dest: Spanned,
+        dstart: Int,
+        dend: Int,
+    ): CharSequence? {
+        val result =
+            StringBuilder(dest)
+                .replace(dstart, dend, source.subSequence(start, end).toString())
+        return if (result.length > 1 && result.startsWith("0")) "" else null
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/IncrementerNumberRangePreferenceCompat.kt
@@ -23,8 +23,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.Button
 import androidx.core.widget.doAfterTextChanged
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.DialogIncrementerPreferenceBinding
+import com.ichi2.anki.ui.NonLeadingZeroInputFilter
 import com.ichi2.utils.moveCursorToEnd
 import com.ichi2.utils.positiveButton
 
@@ -70,7 +72,7 @@ class IncrementerNumberRangePreferenceCompat :
                     // This should not be possible but just in case, recover with a valid minimum from superclass
                     numberRangePreference.min
                 }
-
+            editText.filters += NonLeadingZeroInputFilter
             // Validate the final value, not individual character changes
             editText.doAfterTextChanged { updateButtonState() }
 
@@ -81,7 +83,8 @@ class IncrementerNumberRangePreferenceCompat :
         override fun onStart() {
             super.onStart()
             positiveButton = (dialog as? androidx.appcompat.app.AlertDialog)?.positiveButton
-            positiveButton?.setText(R.string.save)
+            positiveButton?.text = TR.actionsSave()
+
             // Rerun validation now that we have the OK button reference
             updateButtonState()
         }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/NumberRangePreferenceCompat.kt
@@ -21,14 +21,20 @@ import android.content.Context
 import android.text.InputFilter
 import android.text.InputType
 import android.util.AttributeSet
+import android.util.TypedValue
 import android.view.View
 import android.widget.EditText
 import androidx.core.content.withStyledAttributes
+import androidx.core.widget.TextViewCompat
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import com.google.android.material.textview.MaterialTextView
 import com.ichi2.anki.R
 import com.ichi2.anki.utils.getFormattedStringOrPlurals
+import com.ichi2.utils.dp
+import com.ichi2.utils.setPaddingRelative
 import timber.log.Timber
+import com.google.android.material.R as MaterialR
 
 open class NumberRangePreferenceCompat
     @JvmOverloads // fixes: Error inflating class com.ichi2.preferences.NumberRangePreferenceCompat
@@ -169,6 +175,35 @@ open class NumberRangePreferenceCompat
             val numberRangePreference: NumberRangePreferenceCompat get() = preference as NumberRangePreferenceCompat
 
             lateinit var editText: EditText
+
+            override fun onPrepareDialogBuilder(builder: androidx.appcompat.app.AlertDialog.Builder) {
+                super.onPrepareDialogBuilder(builder)
+
+                val titleText = preference.dialogTitle ?: preference.title
+                if (titleText.isNullOrEmpty()) {
+                    return
+                }
+                // Use a custom MaterialTextView to match the title text appearance and padding,
+                // as seen in other dialogs (e.g. "Create deck"). The default TextView renders
+                // the title too small and inconsistent with Material dialog standards.
+                val tv =
+                    MaterialTextView(requireContext()).apply {
+                        text = titleText
+                        setPaddingRelative(start = 24.dp, top = 20.dp, end = 24.dp, bottom = 8.dp)
+
+                        val outValue = TypedValue()
+                        val hasStyle =
+                            context.theme.resolveAttribute(MaterialR.attr.materialAlertDialogTitleTextStyle, outValue, true)
+                        val styleRes = if (hasStyle) outValue.resourceId else 0
+                        if (styleRes != 0) {
+                            TextViewCompat.setTextAppearance(this, styleRes)
+                        } else {
+                            TextViewCompat.setTextAppearance(this, MaterialR.style.TextAppearance_Material3_HeadlineSmall)
+                        }
+                    }
+
+                builder.setCustomTitle(tv)
+            }
 
             /**
              * Update settings to only allow integer input and set the maximum number of digits allowed in the text field based

--- a/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_backup_limits.xml
@@ -14,23 +14,31 @@
         android:key="@string/pref_minutes_between_automatic_backups_key"
         android:title="@string/pref__minutes_between_automatic_backups__title"
         android:persistent="false"
-        app:min="5"/>
+        app:min="5"
+        app:max="99999"
+        />
 
     <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
         android:key="@string/pref_daily_backups_to_keep_key"
         android:title="@string/pref__daily_backups_to_keep__title"
         android:persistent="false"
-        app:min="0"/>
+        app:min="0"
+        app:max="99999"
+        />
 
     <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
         android:key="@string/pref_weekly_backups_to_keep_key"
         android:title="@string/pref__weekly_backups_to_keep__title"
         android:persistent="false"
-        app:min="0"/>
+        app:min="0"
+        app:max="99999"
+        />
 
     <com.ichi2.preferences.IncrementerNumberRangePreferenceCompat
         android:key="@string/pref_monthly_backups_to_keep_key"
         android:title="@string/pref__monthly_backups_to_keep__title"
         android:persistent="false"
-        app:min="0"/>
+        app:min="0"
+        app:max="99999"
+        />
 </PreferenceScreen>

--- a/AnkiDroid/src/main/res/xml/preferences_sync.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_sync.xml
@@ -16,8 +16,7 @@
   -->
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
-    xmlns:app="http://arbitrary.app.namespace/com.ichi2.anki"
-    xmlns:app1="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:title="@string/pref_cat_sync"
     android:key="@string/pref_sync_screen_key"
     xmlns:tools="http://schemas.android.com/tools">
@@ -33,7 +32,7 @@
         android:entryValues="@array/sync_media_values"
         android:key="@string/sync_fetch_media_key"
         android:title="@string/sync_fetch_missing_media"
-        app1:useSimpleSummaryProvider="true"/>
+        app:useSimpleSummaryProvider="true"/>
     <SwitchPreferenceCompat
         android:defaultValue="false"
         android:key="@string/automatic_sync_choice_key"


### PR DESCRIPTION
## Purpose / Description
Improves the backup and timeout dialogs problems as described in #20477.

## Fixes
* Fixes #20477

## Approach
- NumberRangePreferenceCompat: Larger dialog title, input capped at 5 digits
- IncrementerNumberRangePreferenceCompat: OK → Save button by TR; unit plural suffix  aligned to input baseline
- SyncSettingsFragment: Added dialogTitle for network timeout
- sync and backup limits: Added unitPlural and max=99999; fixed namespace "app1" to "app"
- Added that sec/secs, min/mins, day/days, week/weeks, month/months to add unit

Note: Large diff in NumberRangePreferenceCompat.kt is just ktlint indent formatting

## How Has This Been Tested?
Manually tested the dialog in the app on a physical device:
- Device: realme RMX1991
- type  5 digits then find forbid typing
![814f51a512a84be9083e27462b028ded](https://github.com/user-attachments/assets/f9bbaaa0-3e17-46a8-91f0-14aa84189b0e)
- Display a title "Network timeout" to the network timeout dialog
- Display a red warning when try to enter values below the lower limit and disable the Save button
![8d71cc18a63bb7698ad21284327a2a62](https://github.com/user-attachments/assets/b16ab75a-73fa-4149-a423-1c073831aff2)
![f36f6532b78b00b123435527ad567155](https://github.com/user-attachments/assets/9f87aecd-88e8-41f0-8666-bb2dcf833292)
-  Titles change to bigger
- type 1 to test singular unit,type other to test plural unit
![ea66ed43b2a9811a3798c7f3d8558acd](https://github.com/user-attachments/assets/701db29c-34aa-4c57-a9af-d6c9dd13a380)
![1500ebe4aca9bd0571e6125223c63ca5](https://github.com/user-attachments/assets/c4ba3300-1af2-4cc5-b383-45868da1af13)
![855821cadd0d5d807b9e4942a2134104](https://github.com/user-attachments/assets/b70053a6-c1ad-4d97-ba2f-0a2fbb24ffe4)

## Checklist
- [✓] You have a descriptive commit message with a short title (first line, max 50 chars).
- [✓] You have commented your code, particularly in hard-to-understand areas
- [✓] You have performed a self-review of your own code
- [✓] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)