### PR TITLE
Test: Remember value used when increasing reviews

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -33,7 +33,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.ContextMenuOption
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyDefaults.Companion.toDomainModel
@@ -126,7 +125,6 @@ class CustomStudyDialogTest : RobolectricTest() {
         }
 
     @Test
-    @NeedsTest("previous value for 'increase review card limit' is suggested")
     fun `previous value for 'increase new card limit' is suggested`() {
         // add cards to be sure we can extend successfully. Needs to be > 20
         repeat(23) {
@@ -160,6 +158,40 @@ class CustomStudyDialogTest : RobolectricTest() {
         ) {
             onSubscreenEditText()
                 .check(matches(withText(newExtendByValue.toString())))
+        }
+    }
+
+    @Test
+    fun `previous value for 'increase review card limit' is suggested`() {
+        // Reduce review limit to 0, so we can successfully extend with just 1 review card.
+        updateDeckConfig(Consts.DEFAULT_DECK_ID) { rev.perDay = 0 }
+        addRevBasicNoteDueToday("Review", "Today")
+
+        val reviewExtendByValue = 1
+        assertThat("'review' default value", defaultsOfDefaultDeck.extendReview.initialValue, equalTo(0))
+
+        // Extend reviews by 'reviewExtendByValue'.
+        withCustomStudyFragment(
+            args = argumentsDisplayingSubscreen(ContextMenuOption.EXTEND_REV),
+        ) { dialogFragment: CustomStudyDialog ->
+            onSubscreenEditText()
+                .perform(replaceText(reviewExtendByValue.toString()))
+            dialogFragment.submitSubscreenData()
+        }
+
+        // Ensure backend is updated.
+        assertThat(
+            "'review' updated value",
+            defaultsOfDefaultDeck.extendReview.initialValue,
+            equalTo(reviewExtendByValue),
+        )
+
+        // Ensure 'reviewExtendByValue' is used in our UI.
+        withCustomStudyFragment(
+            args = argumentsDisplayingSubscreen(ContextMenuOption.EXTEND_REV),
+        ) {
+            onSubscreenEditText()
+                .check(matches(withText(reviewExtendByValue.toString())))
         }
     }
 

--- a/libanki/src/main/java/com/ichi2/anki/libanki/DeckConfig.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/DeckConfig.kt
@@ -129,6 +129,9 @@ data class DeckConfig(
         override val jsonObject: JSONObject,
     ) : JSONObjectHolder {
         @VisibleForTesting
+        var perDay by jsonInt("perDay")
+
+        @VisibleForTesting
         var delays by jsonArray("delays")
 
         @VisibleForTesting


### PR DESCRIPTION
## Purpose / Description
When you start a custom study session and increase your "review limit" by a certain value, that value is remembered and becomes the default for your next review limit increase. This PR adds a test to preserve that behavior.

## Fixes
* Related to #13283.

## Approach
There was already a test for a very similar behavior: remembering "new cards limit" increases. That test is relatively recent, so I used it as reference for the new test, simply adapting it to check the "review limit" instead of "new cards limit". I placed the new test right underneath its "sibling".

## How Has This Been Tested?
```
./gradlew jacocoUnitTestReport
./gradlew lintRelease
./gradlew ktlintCheck
```

## Learning
Lesson learned:
- `@NeedsTest` may also be found in existing test files; so far, I'd only searched for them in prod files.
- Consider the performance cost of your tests.
- Prefer properties over raw JSON access when possible.

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] ~~UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)~~ NA
- [X] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~ NA