### PR TITLE
improvement(card-browser): improve 'ignore accents in search' & tag filters

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -50,6 +50,7 @@ import com.ichi2.anki.browser.FindAndReplaceDialogFragment.Companion.TAGS_AS_FIE
 import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.browser.search.SavedSearch
 import com.ichi2.anki.browser.search.SavedSearches
+import com.ichi2.anki.browser.search.SearchFilters
 import com.ichi2.anki.browser.search.SearchRequest
 import com.ichi2.anki.browser.search.SearchString
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -1119,13 +1120,15 @@ class CardBrowserViewModel(
         selectedTags: List<String>,
         cardState: CardStateFilter,
     ) {
-        val sb = StringBuilder(cardState.toSearch)
-        // join selectedTags as "tag:$tag" with " or " between them
-        val tagsConcat = selectedTags.joinToString(" or ") { tag -> "\"tag:$tag\"" }
-        if (selectedTags.isNotEmpty()) {
-            sb.append("($tagsConcat)") // Only if we added anything to the tag list
-        }
-        setFilterQuery(sb.toString())
+        val searchString =
+            withCol {
+                SearchRequest(
+                    query = cardState.toSearch,
+                    filters = SearchFilters.EMPTY.copy(tags = selectedTags),
+                ).toSearchString()
+            }.getOrThrow()
+
+        setFilterQuery(searchString.value)
     }
 
     /** Previewing */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -31,7 +31,6 @@ import androidx.lifecycle.viewmodel.initializer
 import androidx.lifecycle.viewmodel.viewModelFactory
 import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
-import anki.config.ConfigKey
 import anki.search.BrowserColumns
 import anki.search.BrowserRow
 import com.ichi2.anki.ALL_DECKS_ID
@@ -80,6 +79,7 @@ import com.ichi2.anki.preferences.SharedPreferencesProvider
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.PrefsRepository
 import com.ichi2.anki.utils.ext.currentCardBrowse
+import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
@@ -482,7 +482,7 @@ class CardBrowserViewModel(
             }.launchIn(viewModelScope)
 
         viewModelScope.launch {
-            shouldIgnoreAccents = withCol { config.getBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH) }
+            shouldIgnoreAccents = withCol { config.ignoreAccentsInSearch }
 
             val initialDeckId = if (selectAllDecks) SelectableDeck.AllDecks else getInitialDeck()
             // PERF: slightly inefficient if the source was lastDeckId
@@ -699,7 +699,7 @@ class CardBrowserViewModel(
         Timber.d("Setting ignore accent in search to: $value")
         viewModelScope.launch {
             shouldIgnoreAccents = value
-            withCol { config.setBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH, value) }
+            withCol { config.ignoreAccentsInSearch = value }
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Config.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/Config.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import anki.config.ConfigKey
+import com.ichi2.anki.libanki.Config
+
+// Extensions for com.ichi2.anki.libanki.Config
+
+/**
+ * When enabled, simple text searches automatically ignore accents.
+ *
+ * When enabled, both 'uber' and 'über' match `["uber", "über", "Über"]`.
+ *
+ * [Manual: Searching - Ignoring accents/combining characters](https://docs.ankiweb.net/searching.html#ignoring-accentscombining-characters)
+ *
+ * [Added in Anki#1667](https://github.com/ankitects/anki/pull/1667)
+ */
+var Config.ignoreAccentsInSearch
+    get() = getBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH)
+    set(value) = setBool(ConfigKey.Bool.IGNORE_ACCENTS_IN_SEARCH, value)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -70,6 +70,7 @@ import com.ichi2.anki.libanki.QueueType
 import com.ichi2.anki.libanki.QueueType.ManuallyBuried
 import com.ichi2.anki.libanki.QueueType.New
 import com.ichi2.anki.libanki.testutils.AnkiTest
+import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.CardsOrNotes
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.model.SortType
@@ -79,6 +80,7 @@ import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.setFlagFilterSync
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.ifNotZero
+import com.ichi2.anki.utils.ext.ignoreAccentsInSearch
 import com.ichi2.testutils.IntentAssert
 import com.ichi2.testutils.JvmTest
 import com.ichi2.testutils.createTransientDirectory
@@ -1408,6 +1410,49 @@ class CardBrowserViewModelTest : JvmTest() {
                 assertNotNull(col.getCard(cardId))
             }
         }
+
+    @Test
+    fun `accented tags are searchable if ignoring accents`() {
+        addBasicNote().update { tags = mutableListOf("être") }
+        addBasicNote("hello").update { tags = mutableListOf("être") }
+        addBasicNote("hêllo").update { tags = mutableListOf("être") }
+
+        col.config.ignoreAccentsInSearch = true
+
+        runViewModelTest {
+            filterByTags(listOf("être"), CardStateFilter.ALL_CARDS)
+
+            assertThat(searchTerms, equalTo("tag:être"))
+            assertThat("all tagged cards are returned", rowCount, equalTo(3))
+
+            updateQueryText("tag:être hêllo")
+            launchSearchForCards(tempSearchQuery!!)
+            assertThat("input is unchanged", searchTerms, equalTo("tag:être hêllo"))
+        }
+    }
+
+    @Test
+    fun `ignoring accents behavior`() {
+        // when ignoring accents, either 'hello' or 'hêllo' match.
+        addBasicNote("hello")
+        addBasicNote("hêllo")
+
+        col.config.ignoreAccentsInSearch = true
+
+        runViewModelTest {
+            updateQueryText("hêllo")
+            launchSearchForCards(tempSearchQuery!!)
+
+            assertThat("hello and hêllo are matched", rowCount, equalTo(2))
+            assertThat("input is unchanged", searchTerms, equalTo("hêllo"))
+
+            updateQueryText("hello")
+            launchSearchForCards(tempSearchQuery!!)
+
+            assertThat("hello and hêllo are matched", rowCount, equalTo(2))
+            assertThat("input is unchanged", searchTerms, equalTo("hello"))
+        }
+    }
 
     private fun assertDate(str: String?) {
         // 2025-01-09 @ 18:06

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ConfigTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ConfigTest.kt
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+/**
+ * Tests for extensions to [com.ichi2.anki.libanki.Config]
+ */
+@RunWith(AndroidJUnit4::class)
+class ConfigTest : RobolectricTest() {
+    @Test
+    fun `test non-diacritic input`() {
+        addBasicNote("uber")
+        addBasicNote("über")
+        addBasicNote("Über")
+
+        assertEquals(1, col.findCards("uber").size)
+
+        col.config.ignoreAccentsInSearch = true
+
+        assertEquals(3, col.findCards("uber").size)
+    }
+
+    @Test
+    fun `test diacritic input`() {
+        addBasicNote("uber")
+        addBasicNote("über")
+        addBasicNote("Über")
+
+        assertEquals(1, col.findCards("über").size)
+
+        col.config.ignoreAccentsInSearch = true
+
+        assertEquals(3, col.findCards("über").size)
+    }
+
+    @Test
+    fun `test Japanese input`() {
+        addBasicNote("は")
+        addBasicNote("ば")
+        addBasicNote("ぱ")
+
+        assertEquals(1, col.findCards("は").size)
+
+        col.config.ignoreAccentsInSearch = true
+
+        assertEquals(3, col.findCards("は").size)
+    }
+}


### PR DESCRIPTION
## Purpose / Description
This adds regression cover and documentation for the below issue

## Fixes
* Regression cover for #20409

## Approach
* Firstly, I wrote code to fix the bug
* Then I researched and documented `Config.ignoreAccentsInSearch`, as I didn't understand it fully
* It turned out that my code was not necessary
* I split out a small improvement to `filterByTags` and kept the regression tests I used

## How Has This Been Tested?
Unit tests

## Learning
We should have better docs for Anki Desktop config flags

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)