### PR TITLE
tests:add unit tests for TimeUtils

### DIFF
--- a/common/src/main/java/com/ichi2/anki/common/time/TimeUtils.kt
+++ b/common/src/main/java/com/ichi2/anki/common/time/TimeUtils.kt
@@ -16,7 +16,6 @@
 
 package com.ichi2.anki.common.time
 
-import com.ichi2.anki.common.annotations.NeedsTest
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -33,11 +32,9 @@ const val TIME_DAY = 24.0 * TIME_HOUR
 // private const val TIME_MONTH = 30.0 * TIME_DAY
 // private const val TIME_YEAR = 12.0 * TIME_MONTH
 
-@NeedsTest("untested")
 fun getTimestamp(time: Time): String = SimpleDateFormat("yyyyMMddHHmmss", Locale.US).format(time.currentDate)
 
 /** Formats the time as '00:00.00' (m:s:ms), OR 00:00:00.00 (h:m:s.ms) */
-@NeedsTest("untested")
 fun Duration.formatAsString(): String {
     val milliseconds = this.inWholeMilliseconds
     val ms = milliseconds % 1000
@@ -51,7 +48,6 @@ fun Duration.formatAsString(): String {
     }
 }
 
-@NeedsTest("untested")
 fun getDayStart(time: Time): Long {
     val cal = time.calendar()
     if (cal[Calendar.HOUR_OF_DAY] < 4) {

--- a/common/src/test/java/com/ichi2/anki/common/time/TimeUtilsTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/time/TimeUtilsTest.kt
@@ -19,8 +19,83 @@ import android.icu.util.Calendar
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.util.TimeZone
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class TimeUtilsTest {
+    @Test
+    fun getTimeStamp_returnsTimeStampAsUTC() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        try {
+            val time = MockTime(2020, 7, 7, 7, 0, 0, 0, 0)
+            assertEquals("20200807070000", getTimestamp(time))
+        } finally {
+            TimeZone.setDefault(null)
+        }
+    }
+
+    @Test
+    fun formatAsString_zeroDuration_returnsZeroString() {
+        val duration = 0.milliseconds
+        assertEquals("00:00.00", duration.formatAsString())
+    }
+
+    @Test
+    fun formatAsString_oneMinuteThirtySeconds_returnsOneMinuteThirtySecondsString() {
+        val duration = 1.minutes + 30.seconds + 500.milliseconds
+        assertEquals("01:30.50", duration.formatAsString())
+    }
+
+    @Test
+    fun formatAsString_oneHourDuration_returnsOneHourString() {
+        val duration = 1.hours
+        assertEquals("01:00:00.00", duration.formatAsString())
+    }
+
+    @Test
+    fun formatAsString_overOneHour_returnsHourMinuteSecondString() {
+        val duration = 1.hours + 3.minutes + 4.seconds + 500.milliseconds
+        assertEquals("01:03:04.50", duration.formatAsString())
+    }
+
+    @Test
+    fun getDayStart_BeforeFourAM_returnsDayStart() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        try {
+            val input = MockTime(2020, 7, 7, 3, 0, 0, 0, 0)
+            val expected = MockTime(2020, 7, 6, 4, 0, 0, 0, 0).calendar().timeInMillis
+            assertEquals(expected, getDayStart(input))
+        } finally {
+            TimeZone.setDefault(null)
+        }
+    }
+
+    @Test
+    fun getDayStart_AfterFourAM_returnsDayStart() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        try {
+            val input = MockTime(2020, 7, 7, 5, 0, 0, 0, 0)
+            val expected = MockTime(2020, 7, 7, 4, 0, 0, 0, 0).calendar().timeInMillis
+            assertEquals(expected, getDayStart(input))
+        } finally {
+            TimeZone.setDefault(null)
+        }
+    }
+
+    @Test
+    fun getDayStart_AtFourAM_returnsDayStart() {
+        TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
+        try {
+            val input = MockTime(2020, 7, 7, 4, 0, 0, 0, 0)
+            val expected = MockTime(2020, 7, 7, 4, 0, 0, 0, 0).calendar().timeInMillis
+            assertEquals(expected, getDayStart(input))
+        } finally {
+            TimeZone.setDefault(null)
+        }
+    }
+
     @Test
     fun getDayStart_AtJanuary1_returnsDayStart() {
         TimeZone.setDefault(TimeZone.getTimeZone("UTC"))


### PR DESCRIPTION

## Purpose / Description
Added unit test cases for TimeUtils, it was untested previously.

## Fixes
Fixes a part of #13283 

## Approach
`fun getTimestamp(time: Time): String ` 
added case for verifiying the correct UTC timestamp formatting


`fun Duration.formatAsString(): String 
`
added test cases for:

- zero duration
- under an hour
- exactly one hour
- over one hour

`fun getDayStart(time: Time): Long`
added test cases for:

- before 4am
- after 4 am
- at 4 am 
- at january 1: where there was a bug in the  calendar.roll function as the year was not  decrementing leading to incorrect day fixed the issue by replacing roll with add()


## How Has This Been Tested?
ran ./gradlew :common:testDebugUnitTest --tests "com.ichi2.anki.common.time.TimeUtilsTest"
All the  9 test cases passed successfully 

## Learning (optional, can help others)


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->