### PR TITLE
fix(export): use Bundle.putLongArray

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/export/ExportDialogFragment.kt
@@ -23,7 +23,6 @@ import android.widget.TextView
 import androidx.annotation.IdRes
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.BundleCompat
 import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
 import androidx.core.view.isVisible
@@ -328,18 +327,16 @@ class ExportDialogFragment : DialogFragment() {
         when (arguments?.getSerializableCompat<ExportType>(ARG_TYPE)) {
             ExportType.Notes -> {
                 val selectedNotesIds =
-                    arguments?.let {
-                        BundleCompat.getParcelableArrayList(it, ARG_EXPORTED_IDS, Long::class.java)
-                    } ?: error("Requested export for selected notes but no notes ids were passed in!")
+                    arguments?.getLongArray(ARG_EXPORTED_IDS)
+                        ?: error("Requested export for selected notes but no notes ids were passed in!")
                 exportLimit { noteIds = noteIds { this.noteIds.addAll(selectedNotesIds.toList()) } }
             }
 
             ExportType.Cards -> {
                 val selectedCardIds =
-                    arguments?.let {
-                        BundleCompat.getParcelableArrayList(it, ARG_EXPORTED_IDS, Long::class.java)
-                    } ?: error("Requested export for selected cards but no cards ids were passed in!")
-                exportLimit { cardIds = cardIds { this.cids.addAll(selectedCardIds) } }
+                    arguments?.getLongArray(ARG_EXPORTED_IDS)
+                        ?: error("Requested export for selected cards but no cards ids were passed in!")
+                exportLimit { cardIds = cardIds { this.cids.addAll(selectedCardIds.toList()) } }
             }
             // notes/cards weren't selected so export the chosen decks
             null -> {
@@ -446,10 +443,10 @@ class ExportDialogFragment : DialogFragment() {
             ids: List<Long>,
         ) = ExportDialogFragment().apply {
             arguments =
-                bundleOf(
-                    ARG_TYPE to type,
-                    ARG_EXPORTED_IDS to ids,
-                )
+                Bundle().apply {
+                    putSerializable(ARG_TYPE, type)
+                    putLongArray(ARG_EXPORTED_IDS, ids.toLongArray())
+                }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
The previous code worked incidentally. `List<Long>` is not always Parcelable. This was exposed when moving away from `bundleOf`

## Approach
Convert the list to a long array

## How Has This Been Tested?
API 33 emulator

<img width="773" height="93" src="https://github.com/user-attachments/assets/08601398-6422-4846-92f1-4d9f0d0ccda8" />

## Learning (optional, can help others)
bundleOf() is deprecated, exposing this issue: https://issuetracker.google.com/issues/434825212

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)