### PR TITLE
fix(whiteboard): draw smooth curves

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
@@ -29,6 +29,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import androidx.core.graphics.createBitmap
 import com.ichi2.anki.R
+import com.ichi2.anki.ui.windows.reviewer.whiteboard.SmoothPath.Companion.drawPath
 
 /**
  * A custom view for the whiteboard that handles drawing and touch events.
@@ -45,7 +46,7 @@ class WhiteboardView : View {
     var eraserMode: EraserMode = EraserMode.INK
     var isStylusOnlyMode: Boolean = false
 
-    private val currentPath = Path()
+    private val currentPath = SmoothPath()
     private val currentPaint =
         Paint().apply {
             isAntiAlias = true
@@ -148,7 +149,7 @@ class WhiteboardView : View {
                 if (!isDrawing) return false
 
                 hasMoved = true
-                currentPath.lineTo(touchX, touchY)
+                currentPath.drawAlong(event)
                 if (isPathEraser) {
                     onEraseGestureMove?.invoke(touchX, touchY)
                 }
@@ -165,7 +166,7 @@ class WhiteboardView : View {
                         // which makes it more robust for path operations.
                         currentPath.lineTo(touchX + 0.2f, touchY + 0.2f)
                     }
-                    onNewPath?.invoke(Path(currentPath))
+                    onNewPath?.invoke(currentPath.clone())
                 }
                 // Reset the path for the next gesture
                 currentPath.reset()
@@ -225,5 +226,78 @@ class WhiteboardView : View {
             bufferCanvas.drawPath(action.path, tempPaint)
         }
         invalidate()
+    }
+}
+
+/**
+ * A wrapper around a [Path] which supports smooth drawing & state tracking via [drawAlong]
+ */
+private class SmoothPath(
+    private val path: Path = Path(),
+) {
+    // for efficiency use two primitives rather than a 'point' class
+    private var lastX = 0f
+    private var lastY = 0f
+
+    /**
+     * Extracts and draws a smooth curve from the [MotionEvent]
+     */
+    fun drawAlong(event: MotionEvent) {
+        // use historySize for cases when the touchscreen samples faster than the screen
+        for (i in 0 until event.historySize) {
+            val hx = event.getHistoricalX(i)
+            val hy = event.getHistoricalY(i)
+            // draw Bézier curves between the midpoints, ensuring a continuous curve
+            path.quadTo(lastX, lastY, (lastX + hx) / 2f, (lastY + hy) / 2f)
+            lastX = hx
+            lastY = hy
+        }
+        // draw the current event
+        val x = event.x
+        val y = event.y
+        path.quadTo(lastX, lastY, (lastX + x) / 2f, (lastY + y) / 2f)
+        lastX = x
+        lastY = y
+    }
+
+    // Methods are reimplemented rather than using inheritance to ensure nothing is forgotten
+
+    /** @see Path.lineTo */
+    fun lineTo(
+        x: Float,
+        y: Float,
+    ) {
+        path.lineTo(x, y)
+        lastX = x
+        lastY = y
+    }
+
+    /** @see Path.moveTo */
+    fun moveTo(
+        x: Float,
+        y: Float,
+    ) {
+        path.moveTo(x, y)
+        lastX = x
+        lastY = y
+    }
+
+    /** @see Path.reset */
+    fun reset() {
+        path.reset()
+        lastX = 0f
+        lastY = 0f
+    }
+
+    fun clone() = Path(path)
+
+    companion object {
+        /** @see Canvas.drawPath */
+        fun Canvas.drawPath(
+            path: SmoothPath,
+            paint: Paint,
+        ) {
+            this.drawPath(path.path, paint)
+        }
     }
 }


### PR DESCRIPTION
## Purpose / Description
On the new whiteboard, we were not using Bezier curves, or handling the event history.

## Fixes
* Fixes #20529
* Related to #1862

## Approach
* Copy code from 1a3effd4829295821d890aa2620953d414af4992
* Move it into a class so the Whiteboard doesn't have the complexity of `lastX/Y` tracking

## How Has This Been Tested?

Tested on an API 33 emulator. To be frank, I'm not visually-minded and the difference isn't noticeable

⚠️ I encountered an existing bug where an eraser of size 10 wouldn't erase a line if the drawing was extremely quick.

## Learning (optional, can help others)
Code from 1a3effd4829295821d890aa2620953d414af4992

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)