### PR TITLE
fix(card-browser): strip Qt accelerator from menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -414,7 +414,8 @@ class CardBrowserFragment :
                 override fun onPrepareMenu(menu: Menu) {
                     if (vm.isInMultiSelectMode) return
 
-                    menu.findItem(R.id.action_create_filtered_deck).title = TR.qtMiscCreateFilteredDeck()
+                    // qtMiscCreateFilteredDeck() contains QT Accelerators ('&') in Belarusian
+                    menu.findItem(R.id.action_create_filtered_deck).title = getString(R.string.new_dynamic_deck)
 
                     saveSearchItem?.isVisible = legacySearchView?.query?.isNotEmpty() != false
 


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description


"Create filtered deck..."

In Belarusian contains an '&', we use the AnkiDroid string to fix this:

```diff
- Стварыць &фільтраваную калоду...
+ Стварыць фільтраваную калоду
```

Thanks to `bigtalkerbox` on Crowdin

## Approach
Use the AnkiDroid string, as Anki Desktop doesn't have an equivalent string

## How Has This Been Tested?
<img width="260" height="44" alt="Screenshot 2026-03-21 at 23 36 21" src="https://github.com/user-attachments/assets/072f8af7-a3cc-4905-b3b4-fdcc76fc9844" />


## Learning (optional, can help others)
`TR.qtMiscCreateFilteredDeck()` can contain '&' as an accelerator for some translations

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)