### PR TITLE
Fix note editor deck change

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -799,7 +799,7 @@ abstract class AbstractFlashcardViewer :
         }
         val animation = fromGesture.toAnimationTransition().invert()
         Timber.i("Launching 'edit card'")
-        val editCardIntent = NoteEditorLauncher.EditSelection(currentCard!!.id, animation).toIntent(this)
+        val editCardIntent = NoteEditorLauncher.EditSelection(listOf(currentCard!!.id), animation).toIntent(this)
         editCurrentCardLauncher.launch(editCardIntent)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -123,25 +123,23 @@ open class CardBrowser :
         get() = createAddNoteLauncher(viewModel)
 
     /**
-     * Provides an instance of NoteEditorLauncher for editing a note
+     * Provides an instance of NoteEditorLauncher for editing the current selection.
      */
-    private val editNoteLauncher: NoteEditorLauncher?
-        get() {
-            val cardId = viewModel.currentCardId
-            if (cardId == null) {
-                Timber.w("EditSelection skipped: no card selected")
-                return null
-            }
+    private suspend fun editNoteLauncher(): NoteEditorLauncher? {
+        val cardIds = viewModel.getCardIdsForNoteEditor()
 
-            return NoteEditorLauncher
-                .EditSelection(
-                    cardId,
-                    Direction.DEFAULT,
-                    fragmented,
-                ).also {
-                    Timber.i("editNoteLauncher: %s", it)
-                }
+        if (cardIds.isEmpty()) {
+            Timber.w("EditSelection skipped: card list is empty")
+            return null
         }
+
+        return NoteEditorLauncher
+            .EditSelection(
+                cardIds = cardIds,
+                animation = Direction.DEFAULT,
+                inCardBrowserActivity = fragmented,
+            )
+    }
 
     override fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let { deck -> launchCatchingTask { viewModel.setSelectedDeck(deck) } }
@@ -519,14 +517,14 @@ open class CardBrowser :
     /**
      * Loads the NoteEditor fragment in container if the view is x-large.
      */
-    fun loadNoteEditorFragmentIfFragmented() {
+    suspend fun loadNoteEditorFragmentIfFragmented() {
         if (!fragmented) {
             return
         }
         // Show note editor frame
         binding.noteEditorFrame!!.isVisible = true
 
-        val launcher = editNoteLauncher ?: return
+        val launcher = editNoteLauncher() ?: return
         // If there are unsaved changes in NoteEditor then show dialog for confirmation
         if (fragment?.hasUnsavedChanges() == true) {
             showSaveChangesDialog(launcher)
@@ -601,11 +599,13 @@ open class CardBrowser :
         }
 
         fun onSelectedCardUpdated(unit: Unit) {
-            if (fragmented) {
-                loadNoteEditorFragmentIfFragmented()
-            } else {
-                editNoteLauncher?.let {
-                    onEditCardActivityResult.launch(it.toIntent(this))
+            launchCatchingTask {
+                if (fragmented) {
+                    loadNoteEditorFragmentIfFragmented()
+                } else {
+                    editNoteLauncher()?.let {
+                        onEditCardActivityResult.launch(it.toIntent(this@CardBrowser))
+                    }
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -99,6 +99,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.CardOrdinal
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.Consts
@@ -300,6 +301,10 @@ class NoteEditorFragment :
 
     private val noteEditorActivity
         get() = requireAnkiActivity() as? NoteEditorActivity
+
+    // List of affected cards (siblings) when editing notes.
+    private val cardIdsFromArguments: LongArray?
+        get() = arguments?.getLongArray(EXTRA_CARD_IDS)
 
     /**
      * Whether this is displayed in a fragment view.
@@ -1374,7 +1379,10 @@ class NoteEditorFragment :
             // changed did? this has to be done first as remFromDyn() involves a direct write to the database
             if (currentEditedCard != null && currentEditedCard!!.currentDeckId() != deckId) {
                 reloadRequired = true
-                undoableOp { setDeck(listOf(currentEditedCard!!.id), deckId) }
+
+                val cardIdsToMove = getAffectedCards()
+                undoableOp { setDeck(cardIdsToMove, deckId) }
+
                 // refresh the card object to reflect the database changes from above
                 currentEditedCard!!.load(getColUnsafe)
                 // also reload the note object
@@ -1382,7 +1390,8 @@ class NoteEditorFragment :
                 // then set the card ID to the new deck
                 currentEditedCard!!.did = deckId
                 modified = true
-                Timber.d("deck ID updated to '%d'", deckId)
+
+                Timber.d("deck ID updated to '%d' for %d card(s) of note %d", deckId, cardIdsToMove.size, editorNote!!.id)
             }
             // now load any changes to the fields from the form
             for (f in editFields!!) {
@@ -1418,6 +1427,24 @@ class NoteEditorFragment :
             return
         }
         delegate?.onNoteSaved()
+    }
+
+    /**
+     * Returns the list of Card IDs that should be affected by bulk operations.
+     * For example deck changes.
+     *
+     * This list is determined by the caller (e.g., Card Browser) and passed
+     * via arguments.
+     *
+     * When the list is not provided, we use the current card.
+     */
+    private fun getAffectedCards(): List<CardId> {
+        val ids = cardIdsFromArguments
+        return if (ids != null && ids.isNotEmpty()) {
+            ids.toList()
+        } else {
+            listOf(currentEditedCard!!.id)
+        }
     }
 
     private fun closeNoteEditorAfterSave() {
@@ -2920,6 +2947,7 @@ class NoteEditorFragment :
         const val RELOAD_REQUIRED_EXTRA_KEY = "reloadRequired"
         const val EXTRA_IMG_OCCLUSION = "image_uri"
         const val IN_CARD_BROWSER_ACTIVITY = "inCardBrowserActivity"
+        const val EXTRA_CARD_IDS = "EXTRA_CARD_IDS"
 
         // calling activity
         enum class NoteEditorCaller(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -304,6 +304,28 @@ class CardBrowserViewModel(
 
     suspend fun queryAllSelectedNoteIds() = selectedRows.queryNoteIds(this.cardsOrNotes)
 
+    /**
+     * Returns the list of Card IDs that should be updated.
+     *
+     * In 'Notes' mode, this includes all cards of the current note (sibling cards).
+     * In 'Cards' mode, this returns only the selected cards.
+     */
+    suspend fun getCardIdsForNoteEditor(): List<CardId> {
+        val cardId = currentCardId ?: return emptyList()
+
+        return if (cardsOrNotes == NOTES) {
+            withCol {
+                getCard(cardId).note(this).cardIds(this)
+            }
+        } else {
+            if (isInMultiSelectMode) {
+                queryAllSelectedCardIds()
+            } else {
+                listOf(cardId)
+            }
+        }
+    }
+
     fun requestChangeNoteType() =
         viewModelScope.launch {
             val noteIds = queryAllSelectedNoteIds()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorLauncher.kt
@@ -165,18 +165,22 @@ sealed interface NoteEditorLauncher : Destination {
 
     /**
      * Opens the NoteEditor for the current selection (card or note).
-     * @property cardId The selected card ID, or null when editing a note.
+     * @property cardIds The selected card ID when editing a card, or the IDs of cards of the same note when editing a note.
      * @property animation The animation direction.
+     * @property inCardBrowserActivity True if opened within Card Browser Activity.
      */
     data class EditSelection(
-        val cardId: CardId?,
+        val cardIds: List<CardId>,
         val animation: ActivityTransitionAnimation.Direction,
         val inCardBrowserActivity: Boolean = false,
     ) : NoteEditorLauncher {
         override fun toBundle(): Bundle =
             bundleOf(
                 NoteEditorFragment.EXTRA_CALLER to NoteEditorCaller.EDIT.value,
-                NoteEditorFragment.EXTRA_CARD_ID to cardId,
+                // To handle single card selection
+                NoteEditorFragment.EXTRA_CARD_ID to cardIds.first(),
+                // To handle multi select and note edit
+                NoteEditorFragment.EXTRA_CARD_IDS to cardIds.toLongArray(),
                 AnkiActivity.FINISH_ANIMATION_EXTRA to animation as Parcelable,
                 NoteEditorFragment.IN_CARD_BROWSER_ACTIVITY to inCardBrowserActivity,
             )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -663,6 +663,66 @@ class NoteEditorTest : RobolectricTest() {
             assertFalse(hasUnsavedChanges())
         }
 
+    @Test
+    fun `changing deck with multiple card ids moves all sibling cards`() =
+        runTest {
+            // Create a note with 2 cards (Basic and Reversed)
+            val note = addBasicAndReversedNote()
+
+            val cardIds: List<Long> = note.cardIds(col)
+            val testDeckId: Long = addDeck("Test Deck")
+
+            // Launch Editor using the Launcher bundle (mimic launch from browser)
+            val bundle =
+                NoteEditorLauncher
+                    .EditSelection(
+                        cardIds = cardIds,
+                        animation = DEFAULT,
+                    ).toBundle()
+
+            val editor = openNoteEditorWithArgs(bundle)
+
+            // Change the note's deck to test deck and save
+            editor.onDeckSelected(SelectableDeck.Deck(testDeckId, "Test Deck"))
+            editor.saveNote()
+
+            advanceRobolectricLooper()
+
+            // Check if both cards belonging to the note have moved to the test deck
+            assertEquals(testDeckId, col.getCard(cardIds[0]).did, "First card should be in the test deck")
+            assertEquals(testDeckId, col.getCard(cardIds[1]).did, "Second card should also be in the test deck")
+        }
+
+    @Test
+    fun `changing deck with single card id moves only that card`() =
+        runTest {
+            // Create a note with 2 cards (Basic and Reversed)
+            val note = addBasicAndReversedNote()
+
+            val cardIds: List<Long> = note.cardIds(col)
+            val initialDeckId = col.getCard(cardIds[1]).did
+            val newDeckId: Long = addDeck("Test Deck")
+
+            // Launch Editor using the Launcher bundle with a single card id
+            val bundle =
+                NoteEditorLauncher
+                    .EditSelection(
+                        cardIds = listOf(cardIds[0]),
+                        animation = DEFAULT,
+                    ).toBundle()
+
+            val editor = openNoteEditorWithArgs(bundle)
+
+            // Change the card's deck to test deck and save
+            editor.onDeckSelected(SelectableDeck.Deck(newDeckId, "Test Deck"))
+            editor.saveNote()
+            advanceRobolectricLooper()
+
+            // Check whether sibling cards are unaffected and only the target card has moved to the test deck
+            assertEquals(newDeckId, col.getCard(cardIds[0]).did, "Selected card should move")
+            assertEquals(initialDeckId, col.getCard(cardIds[1]).did, "Sibling card should NOT move")
+        }
+
     private suspend fun withNoteEditorAdding(
         from: FromScreen = FromScreen.DECK_LIST,
         block: suspend NoteEditorFragment.() -> Unit,
@@ -758,7 +818,7 @@ class NoteEditorTest : RobolectricTest() {
     ): NoteEditorFragment {
         val bundle =
             when (from) {
-                REVIEWER -> NoteEditorLauncher.EditSelection(n.firstCard().id, DEFAULT).toBundle()
+                REVIEWER -> NoteEditorLauncher.EditSelection(listOf(n.firstCard().id), DEFAULT).toBundle()
                 DECK_LIST -> NoteEditorLauncher.AddNote().toBundle()
             }
         return openNoteEditorWithArgs(bundle)


### PR DESCRIPTION
## Purpose / Description
When the user modifies a note's deck from the Note Editor, only the chosen card is transferred to the selected deck. The sibling cards remain in the same deck. This PR fixes this issue so that changing the deck updates all the sibling cards as well.

## Fixes
* Fixes #17415

## Approach
The deck-change logic in `NoteEditorFragment.saveNote()` used to pass a single-item list with just the ID of the active card: `setDeck(listOf(currentEditedCard!!.id), deckId)`. 

I modified this to use `editorNote!!.cardIds(this@undoableOp)` to retrieve card IDs of the sibling cards, then pass the complete list to `setDeck()`, making sure that all sibling cards are moved together.

## How Has This Been Tested?

**1. Automated Regression Test (Robolectric):**
Added `moveNoteToDifferentDeckMovesAllCards` in the Note Editor tests.
- Creates a "Basic (and reversed card)" note in Deck 1.
- Opens the editor in edit mode and selects Deck 2.
- Saves the note and asserts that both `cards[0].did` and `cards[1].did` equal Deck 2's ID.

**2. Manual Testing:**
- Device: Samsung Galaxy A54
- Created a basic and reversed type note.
- Opened the reviewer and selected the edit note option.
- Changed the deck from Test to Test 2.
- Verified in the browser that all associated cards moved to the Test 2 deck.


https://github.com/user-attachments/assets/be270ad3-ab9d-458d-bea0-2dad35dd72b0



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (N/A - Backend logic only)
-[ ] UI Changes: You have tested your change using the Google Accessibility Scanner (N/A)