### PR TITLE
refactor: layout name conventions: 'widget_'

### DIFF
--- a/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LayoutPrefixDetector.kt
+++ b/lint-rules/src/main/java/com/ichi2/anki/lint/rules/LayoutPrefixDetector.kt
@@ -41,10 +41,6 @@ class LayoutPrefixDetector : LayoutDetector() {
         // undecided(?): "include_" prefix for layouts that will be included in other layouts => include_toolbar.xml
         if (layoutFileName.startsWith("include_")) return
 
-        // TODO: decide on this to enforce or fix
-        // undecided(?): "widget_" prefix for layouts that will be used by widgets => widget_card_analysis.xml
-        if (layoutFileName.startsWith("widget_")) return
-
         // TODO: fix these and remove this check
         if (layoutFileName in TEMPORARILY_IGNORED) return
 
@@ -91,6 +87,8 @@ class LayoutPrefixDetector : LayoutDetector() {
                 "view_",
                 // layouts used by items in an adapter => item_locale.xml
                 "item_",
+                // layouts used by widgets
+                "widget_",
             )
 
         /**


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Layouts that will be included in other layouts should have the `widget_` prefix

## Fixes
* Part of #20516

## Approach

I searched in the com.ichi2.widget directory and everything looked good

## How Has This Been Tested?
⚠️ Trusting CI

## Learning
@xenonnn4w is AWESOME [not really learning, but praise when there's a reason for it 😄]

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)