### PR TITLE
test(widget): add unit tests for DeckWidgetData

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/widget/DeckPickerWidgetTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/widget/DeckPickerWidgetTest.kt
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2026 Mandeep Thakkar
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ */
+
+package com.ichi2.widget.deckpicker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/* This Tests are for [DeckWidgetData] to ensure deck data
+ * is correctly stored and retrieved for widget display.
+ *
+ * Here it Covers three different cases:
+ * 1)Standard deck with realistic card count values
+ * 2)Checking it can identify empty deck
+ * 3)Checking it can identify non empty deck
+ */
+
+class DeckPickerWidgetTest {
+    @Test
+    fun `deck widget data stores correct values`() {
+        val data =
+            DeckWidgetData(
+                deckId = 1L,
+                name = "Chemistry",
+                reviewCount = 10,
+                learnCount = 5,
+                newCount = 20,
+            )
+        assertEquals("Chemistry", data.name)
+        assertEquals(10, data.reviewCount)
+        assertEquals(5, data.learnCount)
+        assertEquals(20, data.newCount)
+        assertEquals(1L, data.deckId)
+    }
+
+    @Test
+    fun `empty deck is correctly identified`() {
+        val data =
+            DeckWidgetData(
+                deckId = 1L,
+                name = "Empty Deck",
+                reviewCount = 0,
+                learnCount = 0,
+                newCount = 0,
+            )
+        val isEmpty =
+            data.newCount == 0 &&
+                data.reviewCount == 0 &&
+                data.learnCount == 0
+        assertTrue(isEmpty)
+    }
+
+    @Test
+    fun `non empty deck is correctly identified`() {
+        val data =
+            DeckWidgetData(
+                deckId = 2L,
+                name = "Active Deck",
+                reviewCount = 5,
+                learnCount = 3,
+                newCount = 10,
+            )
+        val isEmpty =
+            data.newCount == 0 &&
+                data.reviewCount == 0 &&
+                data.learnCount == 0
+        assertFalse(isEmpty)
+    }
+}


### PR DESCRIPTION
## Purpose / Description
Adding unit tests for DeckWidgetData to improve the widget test coverage in widget package

## Fixes
Improves test coverage for widget package

## Approach
Here I have implemented three unit tests for DeckWidgetData:

1)Here it tests correct value storage for all the fields
2)It tests empty deck identification logic which was used in showDeck() in DeckPickerWidget.kt
3)Tests non-empty deck identification logic

Both the empty/non-empty deck logic is directly used in DeckPickerWidget.kt showDeck() function to determine click behavior per deck

## How Has This Been Tested?

All 3 tests pass locally and got BUILD SUCCESSFUL


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)