### PR TITLE
fix: suppress dotenv runtime log using quiet option

### DIFF
--- a/tools/localization/src/constants.ts
+++ b/tools/localization/src/constants.ts
@@ -12,7 +12,7 @@ import { Credentials } from "@crowdin/crowdin-api-client";
 import { createDirIfNotExisting } from "./update";
 
 import dotenv from "dotenv";
-dotenv.config({ path: path.join(__dirname, "../.env") });
+dotenv.config({ path: path.join(__dirname, "../.env"), quiet: true });
 
 const CROWDIN_APIv2_PAT = process.env.CROWDIN_APIv2_PAT ?? "";
 


### PR DESCRIPTION
## Purpose / Description
Suppress the runtime log message printed by dotenv when loading environment variables in the localization tool.

## Fixes
* Fixes #20563

## Approach
Updated the dotenv configuration in `tools/localization/src/constants.ts` by adding the `quiet: true` option. This suppresses the runtime log message without affecting existing functionality.

## How Has This Been Tested?

- Ran the localization tool using:
  npm start
- Verified that before the change, the following message was printed:
  [dotenv@17.3.1] injecting env (0) from .env -- tip: suppress all logs with { quiet: true }

- After the change, the message is no longer displayed.

Test Environment:
- Node.js: v20.x
- OS: Windows

## Learning (optional, can help others)
- Learned about dotenv configuration options, specifically the `quiet` flag to suppress logs.
- Understood how the localization tool initializes environment variables in AnkiDroid.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (not applicable)
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner (not applicable)

The fix was verified by running the localization tool (`npm start`), which imports `constants.ts` and triggers dotenv initialization.

<img width="1920" height="1080" alt="Screenshot (98)" src="https://github.com/user-attachments/assets/9dcef4dc-8319-49d4-a9a7-6e0ca96f0128" />
