### PR TITLE
fix(reviewer): flags sometimes have no colors

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -225,8 +225,6 @@ open class Reviewer :
             FlashCardViewerResultCallback(),
         )
 
-    private val flagItemIds = mutableSetOf<Int>()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
@@ -1032,7 +1030,6 @@ open class Reviewer :
         lifecycleScope.launch {
             for ((flag, displayName) in Flag.queryDisplayNames()) {
                 subMenu.findItem(flag.id).title = displayName
-                flagItemIds.add(flag.id)
             }
         }
     }
@@ -1816,6 +1813,8 @@ open class Reviewer :
 
         /** Default (500ms) time for action snackbars, such as undo, bury and suspend */
         const val ACTION_SNACKBAR_TIME = 500
+
+        private val flagItemIds: Set<Int> = Flag.entries.map { it.id }.toSet()
 
         fun getIntent(context: Context): Intent =
             if (Prefs.isNewStudyScreenEnabled) {


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6 - Diagnostics only

## Purpose / Description
* `flagItemIds` had a race condition

## Fixes
* Fixes #20464

## Approach
The ids were in the enum, use them and move them to the `companion object` as it's static data.

## How Has This Been Tested?
API 33 emulator - flags still appear

<img width="183" height="346" alt="Screenshot 2026-03-23 at 20 11 04" src="https://github.com/user-attachments/assets/03176d33-177b-45fb-a146-8f0284fc4b0b" />

**Reproduction data**

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt	(revision 829f6c6510cd50199d7b44656a572a9f4b04b791)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt	(date 1774296308046)
@@ -141,10 +141,12 @@
 import com.ichi2.utils.show
 import com.ichi2.utils.tintOverflowMenuIcons
 import com.ichi2.utils.title
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import timber.log.Timber
 import kotlin.coroutines.resume
+import kotlin.time.Duration.Companion.seconds
 
 @Suppress("LeakingThis")
 @NeedsTest("#14709: Timebox shouldn't appear instantly when the Reviewer is opened")
@@ -1030,6 +1032,7 @@
 
     private fun setupFlags(subMenu: SubMenu) {
         lifecycleScope.launch {
+            delay(1.seconds)
             for ((flag, displayName) in Flag.queryDisplayNames()) {
                 subMenu.findItem(flag.id).title = displayName
                 flagItemIds.add(flag.id)
```


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)