### PR TITLE
Improve deck-naming dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -24,6 +24,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.libanki.Collection
@@ -78,6 +79,14 @@ class CreateDeckDialog(
         }
 
     fun showDialog(): AlertDialog {
+        val textInputHint =
+            when (deckDialogType) {
+                DeckDialogType.RENAME_DECK -> TR.actionsNewName().dropLastWhile { it == ':' }
+
+                DeckDialogType.DECK,
+                DeckDialogType.SUB_DECK,
+                -> TR.actionsName().dropLastWhile { it == ':' }
+            }
         val dialog =
             AlertDialog
                 .Builder(context)
@@ -98,28 +107,19 @@ class CreateDeckDialog(
                     }
                     negativeButton(R.string.dialog_cancel)
                     setView(R.layout.dialog_generic_text_input)
-                }.input(prefill = initialDeckName, displayKeyboard = true, waitForPositiveButton = false) { dialog, text ->
+                }.input(
+                    hint = textInputHint,
+                    prefill = initialDeckName,
+                    displayKeyboard = true,
+                    waitForPositiveButton = false,
+                ) { dialog, text ->
 
                     // defining the action of done button in ImeKeyBoard and enter button in physical keyBoard
                     val inputField = dialog.getInputField()
                     inputField.setOnEditorActionListener { _, actionId, event ->
                         if (actionId == EditorInfo.IME_ACTION_DONE || event?.keyCode == KeyEvent.KEYCODE_ENTER) {
-                            when {
-                                dialog.positiveButton.isEnabled -> {
-                                    onPositiveButtonClicked()
-                                }
-                                text.isBlank() -> {
-                                    dialog.getInputTextLayout().showSnackbar(
-                                        context.getString(R.string.empty_deck_name),
-                                        Snackbar.LENGTH_SHORT,
-                                    )
-                                }
-                                else -> {
-                                    dialog.getInputTextLayout().showSnackbar(
-                                        context.getString(R.string.deck_already_exists),
-                                        Snackbar.LENGTH_SHORT,
-                                    )
-                                }
+                            if (dialog.positiveButton.isEnabled) {
+                                onPositiveButtonClicked()
                             }
                             true
                         } else {
@@ -134,7 +134,7 @@ class CreateDeckDialog(
                         return@input
                     }
                     if (!maybeDeckName.equals(initialDeckName, ignoreCase = true) && deckExists(getColUnsafe, maybeDeckName)) {
-                        dialog.getInputTextLayout().error = context.getString(R.string.deck_already_exists)
+                        dialog.getInputTextLayout().error = context.getString(R.string.error_name_exists)
                         dialog.positiveButton.isEnabled = false
                         return@input
                     }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -221,9 +221,6 @@
     <string name="dismiss_backup_warning_new_user">Due to Android privacy changes, your data and automated backups will be deleted from your phone if the app is uninstalled</string>
     <string name="dismiss_backup_warning_upgrade">Due to Android privacy changes, your data and automated backups will be inaccessible if the app is uninstalled</string>
 
-    <string name="deck_already_exists">Deck already exists</string>
-    <string name="empty_deck_name">Deck name cannot be empty</string>
-
     <string name="create_deck_numeric_hint">If you have deck ordering issues (e.g. ‘10’ appears before ‘2’), replace ‘2’ with ‘02’</string>
 
     <!-- Set Due Date -->


### PR DESCRIPTION
## Purpose / Description
In this PR, I updated the "new deck" / "new subdeck" / "rename deck" dialogs as follows:
- Remove the snackbar that appeared within the dialog when the keyboard's checkmark button was clicked. It showed redundant warnings for empty and duplicate deck names (these are already shown as inline errors).
- Add hints to the input field, i.e. a label on the border: "Name" for deck/subdeck, and "New name" for renaming.
- Update the inline error for duplicate deck names to: "Name already exists".

<img width="4032" height="2244" alt="screenshots1" src="https://github.com/user-attachments/assets/06f4b50a-ad78-4c20-8b6a-19cfefac3e63" />

## Fixes
- Fixes #20475

## Approach
- For the redundant snackbar: I removed it from the calling site, i.e. the input field listener in `CreateDeckDialog.kt`. I then deleted the now-orphaned `empty_deck_name` resource from `03-dialogs.xml`.
- For the hints and warning: I added them all to `02-strings.xml`, since I saw that generic strings being favored in other PRs. Since the warning text changed significantly, I created a new key for it, and I removed the old entry from `03-dialogs.xml`.

## How Has This Been Tested?
I did some manual checks:
- Click the keyboard checkmark with an empty or duplicate input to verify that the redundant snackbar is gone.
- Create/rename new decks/subdecks, including trying to pick a duplicate name to trigger the updated inline error.
- Make sure that regular deck and subdeck creation still works as intended.

I ran these commands:
```
./gradlew jacocoUnitTestReport                      
./gradlew lintRelease ktlintCheck
```

## Learning
Lessons learned:
- Looking at maintainers' feedback on parent and sibling issues can give direction to your PR.
- Stick to a single commit (rebase/squash, as needed), to keep the `main` history clean.

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] ~~You have commented your code, particularly in hard-to-understand areas~~ NA
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)