### PR TITLE
fix(study-screen): regex crash on typed answers

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TypeAnswer.kt
@@ -55,7 +55,7 @@ class TypeAnswer private constructor(
 
         @Language("HTML")
         val repl = """<div style="font-family: '$font'; font-size: ${fontSize}px">$answerComparison</div>"""
-        return typeAnsRe.replace(text, repl)
+        return typeAnsRe.replace(text, Regex.escapeReplacement(repl))
     }
 
     companion object {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/TypeAnswerTest.kt
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.previewer
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.libanki.Card
+import com.ichi2.testutils.JvmTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TypeAnswerTest : JvmTest() {
+    /** [Issue #20575](https://github.com/ankidroid/Anki-Android/issues/20575) */
+    @Test
+    fun `answerFilter escapes Regex`() =
+        runTest {
+            val card = addBasicWithTypingNote("List directory contents.", "$ ls").firstCard()
+
+            val typeAnswer = TypeAnswer.createInstance(card)
+
+            val result = assertDoesNotThrow { typeAnswer.answerFilter("") }
+            assertThat(result, containsString("$ ls"))
+            assertThat(result, not(containsString("[[type:Back]]")))
+        }
+
+    companion object {
+        suspend fun TypeAnswer.Companion.createInstance(card: Card) = requireNotNull(TypeAnswer.getInstance(card, VALID_CARD_TEXT))
+
+        const val VALID_CARD_TEXT = """<style>.card {
+    font-family: arial;
+    font-size: 20px;
+    line-height: 1.5;
+    text-align: center;
+    color: black;
+    background-color: white;
+}
+</style>List directory contents.
+
+<hr id=answer>
+
+[[type:Back]]"""
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6; Very minor: created the base test file

## Purpose / Description
* New study screen
* Enable setting: "Type answer into card"
* A 'type' card with the back containing: "$"

caused:

"java.lang.IllegalArgumentException: Illegal group reference"

## Fixes
* Fixes #20575

## Approach
Fixed by using `Regex.escapeReplacement` as recommended in the docs

## How Has This Been Tested?
Unit test

<img width="201" height="162" alt="Screenshot 2026-03-24 at 22 25 19" src="https://github.com/user-attachments/assets/2b7a9a5b-5265-46c3-b5cc-d8e279b69f55" />

## Learning (optional, can help others)

https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/-regex/replace.html.

> . [Regex.escapeReplacement](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/-regex/-companion/escape-replacement.html) can be used if [replacement](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin.text/-regex/replace.html) have to be treated as a literal string.

The lambda `.replace()` overload was also an option, but I wanted to be explicit about the intent


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->