### PR TITLE
feat(manage-tags): introduce ViewModel [DEV-only]

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/observability/OpChangesNotifier.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/observability/OpChangesNotifier.kt
@@ -22,8 +22,15 @@ import com.ichi2.anki.libanki.Collection
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-/** Wrap a routine that returns OpChanges* or similar undo info with this
- * to notify change subscribers of the changes. */
+/**
+ * Wraps a routine that returns OpChanges* or similar undo info,
+ * notifying [ChangeManager] subscribers of the changes.
+ *
+ * **[block] must return an OpChanges subtype as its last expression.**
+ * [T] is inferred from [block]'s return type. If the last expression returns `Unit`
+ * (e.g. a `Timber` call), [ChangeManager.notifySubscribers] throws
+ * "unhandled change type of class 'class kotlin.Unit'" at runtime.
+ */
 suspend fun <T : Any> undoableOp(
     handler: Any? = null,
     block: Collection.() -> T,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/tags/ManageTagsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/tags/ManageTagsViewModel.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.tags
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.libanki.Tags
+import com.ichi2.anki.observability.undoableOp
+import com.ichi2.anki.tags.ManageTagsEvent.DisplayMessage
+import com.ichi2.anki.tags.ManageTagsState.Error
+import com.ichi2.anki.tags.UserMessage.ClearedUnusedTags
+import com.ichi2.anki.tags.UserMessage.TagRemoved
+import com.ichi2.anki.tags.UserMessage.TagRenamed
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import anki.tags.TagTreeNode as BackendTagTreeNode
+
+/**
+ * ViewModel for the Manage Tags screen.
+ *
+ * Handles display of hierarchical tags with expand/collapse and a search filter.
+ * Tag operations (rename, delete) are applied to individual tags.
+ *
+ * This must handle a huge amount of tags, AnKing v11 contains ~17k tags.
+ *
+ * @see Tags for backend functions.
+ * @see TagListItem for display.
+ * @see ManageTagsState for UI state.
+ * @see ManageTagsEvent for one-shot events.
+ */
+class ManageTagsViewModel : ViewModel() {
+    val state: StateFlow<ManageTagsState>
+        field = MutableStateFlow<ManageTagsState>(ManageTagsState.Loading)
+
+    private val _events = Channel<ManageTagsEvent>(Channel.BUFFERED)
+    val events = _events.receiveAsFlow()
+
+    /** Cached flat list of all tags, rebuilt when the backend tree changes */
+    private var tagList: List<TagListItem> = emptyList()
+
+    init {
+        refreshTags()
+    }
+
+    /** Reloads the tag tree from the backend. Preserves the current search query if any */
+    fun refreshTags() =
+        launchTagOperation {
+            Timber.i("Refreshing tags")
+        }
+
+    /**
+     * Filters visible tags by [query]. Ancestors of matches are shown to preserve hierarchy.
+     *
+     * WARN: Mutliselect was not implemented on this screen due to the confusing combination
+     * of having a filtered tag selected.
+     */
+    fun filter(query: String) {
+        if (tagList.isEmpty()) return
+        updateState { loaded ->
+            loaded.copy(
+                searchQuery = query,
+                visibleNodes = computeVisibleNodes(query),
+            )
+        }
+    }
+
+    /** Returns the visible node for [tag], or null with a warning if not found or not loaded */
+    private fun findVisibleNode(tag: TagName): TagListItem? {
+        val loaded = state.value as? ManageTagsState.Loaded
+        if (loaded == null) {
+            Timber.w("findVisibleNode called while not loaded")
+            return null
+        }
+        return loaded.visibleNodes.firstOrNull { it.fullTag == tag }.also {
+            if (it == null) {
+                Timber.w("Tag not found in visible nodes")
+                Timber.d("Tag: %s", tag)
+            }
+        }
+    }
+
+    /**
+     * Expands or collapses [tag] in the tree. Persists the state to the backend.
+     *
+     * PERF: ~55ms to process 10k+ tags on my M1; ~350ms to process 10k+ tags in CI
+     *
+     * @see Tags.setCollapsed
+     */
+    fun toggleCollapsed(tag: TagName) =
+        viewModelScope.launch {
+            try {
+                val node =
+                    findVisibleNode(tag) ?: run {
+                        _events.send(DisplayMessage(UserMessage.UnexpectedError))
+                        return@launch
+                    }
+                val newCollapsed = !node.collapsed
+                withCol { tags.setCollapsed(tag, newCollapsed) }
+                // re-fetch tree to get updated collapsed state
+                tagList = flattenTree(withCol { tags.tree() })
+                updateState { it.copy(visibleNodes = computeVisibleNodes(it.searchQuery)) }
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to toggle collapsed state")
+            }
+        }
+
+    /**
+     * Deletes [tag] and its children from all notes.
+     * @see Tags.remove
+     */
+    fun removeTag(tag: TagName) =
+        launchTagOperation {
+            val result = undoableOp { tags.remove(tag) }
+            _events.send(DisplayMessage(TagRemoved(result.count)))
+        }
+
+    /**
+     * Renames [oldName] to [newName], updating all notes and child tags.
+     * @see Tags.rename
+     */
+    fun renameTag(
+        oldName: TagName,
+        newName: TagName,
+    ) = launchTagOperation {
+        val result = undoableOp { tags.rename(oldName, newName) }
+        _events.send(DisplayMessage(TagRenamed(result.count)))
+    }
+
+    /**
+     * Removes tags not present on any note. Emits a [ClearedUnusedTags] event with the count.
+     * @see Tags.clearUnusedTags
+     */
+    fun clearUnusedTags() =
+        launchTagOperation {
+            val result = undoableOp { tags.clearUnusedTags() }
+            Timber.i("Deleted %d unused tags", result.count)
+            _events.send(DisplayMessage(ClearedUnusedTags(result.count)))
+        }
+
+    private suspend fun loadTags(searchQuery: String) {
+        Timber.i("Loading tags from collection")
+        tagList = flattenTree(withCol { tags.tree() })
+        state.value =
+            ManageTagsState.Loaded(
+                visibleNodes = computeVisibleNodes(searchQuery),
+                searchQuery = searchQuery,
+            )
+    }
+
+    /**
+     * Sets [ManageTagsState.Loading], runs [block], then [reloads][loadTags].
+     * On failure, transitions to [Error]
+     */
+    private fun launchTagOperation(block: suspend () -> Unit): Job {
+        val previousLoaded = state.value as? ManageTagsState.Loaded
+        state.value = ManageTagsState.Loading
+        return viewModelScope.launch {
+            try {
+                block()
+                loadTags(searchQuery = previousLoaded?.searchQuery ?: "")
+            } catch (e: Exception) {
+                Timber.w(e, "launchTagOperation failed")
+                state.value = Error(e)
+            }
+        }
+    }
+
+    private fun computeVisibleNodes(searchQuery: String): List<TagListItem> =
+        if (searchQuery.isBlank()) {
+            // filter out the collapsed nodes from the results
+            applyCollapsedVisibility(tagList)
+        } else {
+            // collapsed nodes can be re-expanded if searchQuery matches the leaf nodes
+            applySearchFilter(tagList, searchQuery)
+        }
+
+    /** Applies [transform] only if the current state is [ManageTagsState.Loaded]; no-ops otherwise */
+    private inline fun updateState(transform: (ManageTagsState.Loaded) -> ManageTagsState.Loaded) {
+        state.update { current ->
+            when (current) {
+                is ManageTagsState.Loaded -> transform(current)
+                else -> {
+                    Timber.w("updateState called while in %s; ignoring", current::class.simpleName)
+                    current
+                }
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Converts the backend's recursive [BackendTagTreeNode] into a flat list of all
+         * [TagListItem]s in pre-order. Always recurses into all children regardless of
+         * collapsed state; the `collapsed` flag is preserved on each item for later filtering.
+         */
+        @VisibleForTesting
+        fun flattenTree(root: BackendTagTreeNode): List<TagListItem> {
+            val result = mutableListOf<TagListItem>()
+
+            fun traverse(
+                node: BackendTagTreeNode,
+                parentFullTag: String,
+            ) {
+                for (child in node.childrenList) {
+                    val fullTag = if (parentFullTag.isEmpty()) child.name else "$parentFullTag::${child.name}"
+                    result.add(
+                        TagListItem(
+                            fullTag = TagName(fullTag),
+                            displayName = child.name,
+                            level = child.level - 1,
+                            hasChildren = child.childrenList.isNotEmpty(),
+                            collapsed = child.collapsed,
+                        ),
+                    )
+                    if (child.childrenList.isNotEmpty()) {
+                        traverse(child, fullTag)
+                    }
+                }
+            }
+
+            traverse(root, "")
+            return result
+        }
+
+        /**
+         * Filters a flat tag list to hide children of collapsed nodes.
+         * Expects [allNodes] in pre-order (parent before children).
+         */
+        @VisibleForTesting
+        fun applyCollapsedVisibility(allNodes: List<TagListItem>): List<TagListItem> =
+            buildList {
+                var skipBelowLevel: Int? = null
+                for (item in allNodes) {
+                    if (skipBelowLevel != null && item.level > skipBelowLevel) {
+                        continue
+                    }
+                    skipBelowLevel = if (item.collapsed && item.hasChildren) item.level else null
+                    add(item)
+                }
+            }
+
+        /**
+         * Filters a flat tag list to items matching [searchQuery] (case-insensitive substring),
+         * plus their ancestors to preserve hierarchy.
+         * Collapsed nodes are expanded if their children match, ensuring leaf matches are visible.
+         *
+         * O(n*d) where n = number of tags and d = maximum tag depth.
+         */
+        @VisibleForTesting
+        fun applySearchFilter(
+            allNodes: List<TagListItem>,
+            searchQuery: String,
+        ): List<TagListItem> {
+            val queryLowercase = searchQuery.lowercase()
+            val visibleTags = mutableSetOf<String>()
+            val parentsWithVisibleChildren = mutableSetOf<String>()
+            for (item in allNodes) {
+                if (item.containsLowercase(queryLowercase)) {
+                    visibleTags.add(item.fullTag.value)
+                    for (ancestor in item.fullTag.ancestors) {
+                        visibleTags.add(ancestor)
+                        parentsWithVisibleChildren.add(ancestor)
+                    }
+                }
+            }
+            return allNodes
+                .filter { it.fullTag.value in visibleTags }
+                .map {
+                    // expand a collapsed parent if a child matches the search
+                    if (it.collapsed && it.fullTag.value in parentsWithVisibleChildren) {
+                        it.copy(collapsed = false)
+                    } else {
+                        it
+                    }
+                }
+        }
+    }
+}
+
+/**
+ * A flattened representation of a tag for display in a RecyclerView.
+ *
+ * @param fullTag full hierarchical tag path, e.g. "science::biology"
+ * @param displayName leaf name only, e.g. "biology"
+ * @param level tree depth (0 = top-level)
+ */
+data class TagListItem(
+    val fullTag: TagName,
+    val displayName: String,
+    val level: Int,
+    val hasChildren: Boolean,
+    val collapsed: Boolean,
+) {
+    // cache the tag name to support fast case-insensitive searches
+    private val fullTagLower: String = fullTag.value.lowercase()
+
+    /** Case-insensitive check against the full tag path. [query] must be pre-lowercased. */
+    fun containsLowercase(query: String): Boolean = fullTagLower.contains(query)
+}
+
+sealed class ManageTagsState {
+    data object Loading : ManageTagsState()
+
+    data class Loaded(
+        val visibleNodes: List<TagListItem>,
+        val searchQuery: String = "",
+    ) : ManageTagsState()
+
+    data class Error(
+        val error: Throwable,
+    ) : ManageTagsState()
+}
+
+sealed interface ManageTagsEvent {
+    data class DisplayMessage(
+        val message: UserMessage,
+    ) : ManageTagsEvent
+}
+
+sealed interface UserMessage {
+    /** @param notesAffected number of notes the tag was removed from */
+    data class TagRemoved(
+        val notesAffected: Int,
+    ) : UserMessage
+
+    /** @param notesAffected number of notes whose tags were updated */
+    data class TagRenamed(
+        val notesAffected: Int,
+    ) : UserMessage
+
+    /** @param count number of unused tags removed from the collection */
+    data class ClearedUnusedTags(
+        val count: Int,
+    ) : UserMessage
+
+    /** A generic error message for unexpected failures */
+    data object UnexpectedError : UserMessage
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/tags/TagName.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/tags/TagName.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.tags
+
+import anki.collection.OpChanges
+import anki.collection.OpChangesWithCount
+import com.ichi2.anki.libanki.Tags
+import timber.log.Timber
+
+/**
+ * A tag name, e.g. "science::biology".
+ *
+ * Tag names should not be logged using `Timber.i` or above to avoid leaking PII to crash reports.
+ */
+@JvmInline
+value class TagName(
+    val value: String,
+) {
+    /** Ancestor tags, e.g. `TagName("a::b::c").ancestors` returns `["a", "a::b"]` */
+    val ancestors: List<String>
+        get() {
+            val parts = value.split("::")
+            if (parts.size <= 1) return emptyList()
+            return buildList {
+                // prefer StringBuilder over joinToString for performance
+                val sb = StringBuilder()
+                for (i in 0 until parts.size - 1) {
+                    if (i > 0) sb.append("::")
+                    sb.append(parts[i])
+                    add(sb.toString())
+                }
+            }
+        }
+
+    override fun toString(): String = value
+}
+
+// Extension methods serve two purposes: removing `.value` from the call site
+// and ensuring that collection operation lambdas return `OpChanges`
+// Having Timber.d as a final call means the Lambda returns `Unit`, which is converted to `Any`
+// which causes opChanges { } to crash, as it expects an `OpChanges` return type
+
+/** @see Tags.setCollapsed */
+fun Tags.setCollapsed(
+    tag: TagName,
+    collapsed: Boolean,
+): OpChanges {
+    Timber.i("Setting tag collapsed=%b", collapsed)
+    return setCollapsed(tag.value, collapsed).also {
+        Timber.d("Set tag collapsed=%b: %s", collapsed, tag)
+    }
+}
+
+/** @see Tags.remove */
+fun Tags.remove(tag: TagName): OpChangesWithCount {
+    Timber.i("Deleting tag")
+    return remove(tag.value).also {
+        Timber.d("Deleted tag: %s", tag)
+    }
+}
+
+/** @see Tags.rename */
+fun Tags.rename(
+    old: TagName,
+    new: TagName,
+): OpChangesWithCount {
+    Timber.i("Renaming tag")
+    return rename(old.value, new.value).also {
+        Timber.d("Renamed tag: %s to %s", old, new)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/tags/FlattenTreeTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/tags/FlattenTreeTest.kt
@@ -1,0 +1,417 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.tags
+
+import anki.tags.tagTreeNode
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.Test
+
+/** Unit tests for [ManageTagsViewModel.flattenTree] (no collection needed) */
+class FlattenTreeTest {
+    /** Composes flatten + filter to match the old two-arg flattenTree behavior */
+    private fun flattenAndFilter(
+        root: anki.tags.TagTreeNode,
+        searchQuery: String,
+    ): List<TagListItem> {
+        val all = ManageTagsViewModel.flattenTree(root)
+        return if (searchQuery.isBlank()) {
+            ManageTagsViewModel.applyCollapsedVisibility(all)
+        } else {
+            ManageTagsViewModel.applySearchFilter(all, searchQuery)
+        }
+    }
+
+    @Test
+    fun `flattenTree with flat tags`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "biology"
+                        level = 1
+                    },
+                )
+                children.add(
+                    tagTreeNode {
+                        name = "chemistry"
+                        level = 1
+                    },
+                )
+                children.add(
+                    tagTreeNode {
+                        name = "physics"
+                        level = 1
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(3))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("biology"))
+        MatcherAssert.assertThat(result[0].level, Matchers.equalTo(0))
+        MatcherAssert.assertThat(result[0].hasChildren, Matchers.equalTo(false))
+    }
+
+    @Test
+    fun `flattenTree with nested tags - collapsed`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "science"
+                        level = 1
+                        collapsed = true
+                        children.add(
+                            tagTreeNode {
+                                name = "biology"
+                                level = 2
+                            },
+                        )
+                        children.add(
+                            tagTreeNode {
+                                name = "chemistry"
+                                level = 2
+                            },
+                        )
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "")
+        // only "science" visible since it's collapsed
+        MatcherAssert.assertThat(result, Matchers.hasSize(1))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("science"))
+        MatcherAssert.assertThat(result[0].hasChildren, Matchers.equalTo(true))
+        MatcherAssert.assertThat(result[0].collapsed, Matchers.equalTo(true))
+    }
+
+    @Test
+    fun `flattenTree with nested tags - expanded`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "science"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "biology"
+                                level = 2
+                            },
+                        )
+                        children.add(
+                            tagTreeNode {
+                                name = "chemistry"
+                                level = 2
+                            },
+                        )
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(3))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("science"))
+        MatcherAssert.assertThat(result[0].collapsed, Matchers.equalTo(false))
+        MatcherAssert.assertThat(result[1].fullTagName, Matchers.equalTo("science::biology"))
+        MatcherAssert.assertThat(result[1].level, Matchers.equalTo(1))
+        MatcherAssert.assertThat(result[2].fullTagName, Matchers.equalTo("science::chemistry"))
+    }
+
+    @Test
+    fun `flattenTree with search query filters and shows ancestors`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "science"
+                        level = 1
+                        collapsed = true
+                        children.add(
+                            tagTreeNode {
+                                name = "biology"
+                                level = 2
+                            },
+                        )
+                        children.add(
+                            tagTreeNode {
+                                name = "chemistry"
+                                level = 2
+                            },
+                        )
+                    },
+                )
+                children.add(
+                    tagTreeNode {
+                        name = "history"
+                        level = 1
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "bio")
+        // should show "science" (ancestor) and "science::biology" (match)
+        MatcherAssert.assertThat(result, Matchers.hasSize(2))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("science"))
+        MatcherAssert.assertThat(result[1].fullTagName, Matchers.equalTo("science::biology"))
+    }
+
+    @Test
+    fun `flattenTree deeply nested - partial expansion`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "a"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "b"
+                                level = 2
+                                collapsed = true
+                                children.add(
+                                    tagTreeNode {
+                                        name = "c"
+                                        level = 3
+                                        children.add(
+                                            tagTreeNode {
+                                                name = "d"
+                                                level = 4
+                                            },
+                                        )
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+            }
+        // "a" expanded, "a::b" collapsed
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(2))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("a"))
+        MatcherAssert.assertThat(result[1].fullTagName, Matchers.equalTo("a::b"))
+        MatcherAssert.assertThat(result[1].hasChildren, Matchers.equalTo(true))
+        MatcherAssert.assertThat(result[1].collapsed, Matchers.equalTo(true))
+    }
+
+    @Test
+    fun `flattenTree deeply nested - fully expanded`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "a"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "b"
+                                level = 2
+                                collapsed = false
+                                children.add(
+                                    tagTreeNode {
+                                        name = "c"
+                                        level = 3
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(3))
+        MatcherAssert.assertThat(result[2].fullTagName, Matchers.equalTo("a::b::c"))
+        MatcherAssert.assertThat(result[2].level, Matchers.equalTo(2))
+        MatcherAssert.assertThat(result[2].hasChildren, Matchers.equalTo(false))
+    }
+
+    @Test
+    fun `flattenTree empty root`() {
+        val root = tagTreeNode { level = 0 }
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(0))
+    }
+
+    @Test
+    fun `flattenTree search with no matches`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "science"
+                        level = 1
+                    },
+                )
+                children.add(
+                    tagTreeNode {
+                        name = "history"
+                        level = 1
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "zzz")
+        MatcherAssert.assertThat(result, Matchers.hasSize(0))
+    }
+
+    @Test
+    fun `flattenTree multiple root tags with children - expanded`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "math"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "algebra"
+                                level = 2
+                            },
+                        )
+                    },
+                )
+                children.add(
+                    tagTreeNode {
+                        name = "science"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "biology"
+                                level = 2
+                            },
+                        )
+                    },
+                )
+            }
+        val result = flattenAndFilter(root, "")
+        MatcherAssert.assertThat(result, Matchers.hasSize(4))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("math"))
+        MatcherAssert.assertThat(result[1].fullTagName, Matchers.equalTo("math::algebra"))
+        MatcherAssert.assertThat(result[2].fullTagName, Matchers.equalTo("science"))
+        MatcherAssert.assertThat(result[3].fullTagName, Matchers.equalTo("science::biology"))
+    }
+
+    @Test
+    fun `flattenTree produces all nodes regardless of collapsed state`() {
+        val root =
+            tagTreeNode {
+                level = 0
+                children.add(
+                    tagTreeNode {
+                        name = "a"
+                        level = 1
+                        collapsed = false
+                        children.add(
+                            tagTreeNode {
+                                name = "b"
+                                level = 2
+                                collapsed = true
+                                children.add(
+                                    tagTreeNode {
+                                        name = "c"
+                                        level = 3
+                                        children.add(
+                                            tagTreeNode {
+                                                name = "d"
+                                                level = 4
+                                            },
+                                        )
+                                    },
+                                )
+                            },
+                        )
+                    },
+                )
+            }
+        val result = ManageTagsViewModel.flattenTree(root)
+        MatcherAssert.assertThat(result, Matchers.hasSize(4))
+        MatcherAssert.assertThat(result[0].fullTagName, Matchers.equalTo("a"))
+        MatcherAssert.assertThat(result[1].fullTagName, Matchers.equalTo("a::b"))
+        MatcherAssert.assertThat(result[1].collapsed, Matchers.equalTo(true))
+        MatcherAssert.assertThat(result[2].fullTagName, Matchers.equalTo("a::b::c"))
+        MatcherAssert.assertThat(result[3].fullTagName, Matchers.equalTo("a::b::c::d"))
+    }
+
+    @Test
+    fun `applyCollapsedVisibility skips children of collapsed nodes`() {
+        val items =
+            listOf(
+                tagListItem("a", "a", level = 0, hasChildren = true, collapsed = true),
+                tagListItem("a::b", "b", level = 1, hasChildren = true, collapsed = false),
+                tagListItem("a::b::c", "c", level = 2, hasChildren = false, collapsed = false),
+                tagListItem("d", "d", level = 0, hasChildren = false, collapsed = false),
+            )
+        val result = ManageTagsViewModel.applyCollapsedVisibility(items)
+        MatcherAssert.assertThat(result, Matchers.hasSize(2))
+        MatcherAssert.assertThat(result[0].fullTag.value, Matchers.equalTo("a"))
+        MatcherAssert.assertThat(result[1].fullTag.value, Matchers.equalTo("d"))
+    }
+
+    @Test
+    fun `applySearchFilter includes ancestors`() {
+        val items =
+            listOf(
+                tagListItem("science", "science", level = 0, hasChildren = true, collapsed = true),
+                tagListItem("science::biology", "biology", level = 1, hasChildren = false, collapsed = false),
+                tagListItem("science::chemistry", "chemistry", level = 1, hasChildren = false, collapsed = false),
+                tagListItem("history", "history", level = 0, hasChildren = false, collapsed = false),
+            )
+        val result = ManageTagsViewModel.applySearchFilter(items, "bio")
+        MatcherAssert.assertThat(result, Matchers.hasSize(2))
+        MatcherAssert.assertThat(result[0].fullTag.value, Matchers.equalTo("science"))
+        MatcherAssert.assertThat(result[0].collapsed, Matchers.equalTo(false))
+        MatcherAssert.assertThat(result[1].fullTag.value, Matchers.equalTo("science::biology"))
+    }
+
+    @Test
+    fun `applyCollapsedVisibility - collapsed parent hides children`() {
+        val items =
+            listOf(
+                tagListItem("aa", "aa", level = 0, hasChildren = true, collapsed = true),
+                tagListItem("aa::bb", "bb", level = 1, hasChildren = false, collapsed = false),
+                tagListItem("aa::cc", "cc", level = 1, hasChildren = false, collapsed = false),
+            )
+        val result = ManageTagsViewModel.applyCollapsedVisibility(items)
+        MatcherAssert.assertThat(result, Matchers.hasSize(1))
+        MatcherAssert.assertThat(result[0].fullTag.value, Matchers.equalTo("aa"))
+        MatcherAssert.assertThat(result[0].collapsed, Matchers.equalTo(true))
+    }
+
+    @Test
+    fun `applySearchFilter - expands collapsed node when children are visible`() {
+        val items =
+            listOf(
+                tagListItem("bb", "bb", level = 0, hasChildren = true, collapsed = true),
+                tagListItem("bb::aa", "aa", level = 1, hasChildren = false, collapsed = false),
+            )
+        val result = ManageTagsViewModel.applySearchFilter(items, "aa")
+        MatcherAssert.assertThat(result, Matchers.hasSize(2))
+        MatcherAssert.assertThat(result[0].fullTag.value, Matchers.equalTo("bb"))
+        MatcherAssert.assertThat(result[0].collapsed, Matchers.equalTo(false))
+        MatcherAssert.assertThat(result[1].fullTag.value, Matchers.equalTo("bb::aa"))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/tags/ManageTagsTestUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/tags/ManageTagsTestUtils.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.tags
+
+/** Unwraps [TagListItem.fullTag] to a plain [String] for test assertions */
+internal val TagListItem.fullTagName: String get() = fullTag.value
+
+internal val ManageTagsState.Loaded.visibleTagNames: List<String>
+    get() = visibleNodes.map { it.fullTagName }
+
+internal fun ManageTagsViewModel.toggleCollapsed(tag: String) = toggleCollapsed(TagName(tag))
+
+internal fun ManageTagsViewModel.removeTag(tag: String) = removeTag(TagName(tag))
+
+internal fun ManageTagsViewModel.renameTag(
+    oldName: String,
+    newName: String,
+) = renameTag(TagName(oldName), TagName(newName))
+
+/** Creates a [TagListItem] from a plain [String] tag */
+internal fun tagListItem(
+    fullTag: String,
+    displayName: String,
+    level: Int,
+    hasChildren: Boolean,
+    collapsed: Boolean,
+) = TagListItem(
+    fullTag = TagName(fullTag),
+    displayName = displayName,
+    level = level,
+    hasChildren = hasChildren,
+    collapsed = collapsed,
+)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/tags/ManageTagsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/tags/ManageTagsViewModelTest.kt
@@ -1,0 +1,387 @@
+/*
+ * Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.tags
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.dialogs.utils.AnKingTags
+import com.ichi2.testutils.ensureOpsExecuted
+import kotlinx.coroutines.flow.first
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItem
+import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.not
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.system.measureTimeMillis
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/** Integration tests for [ManageTagsViewModel] with a real collection */
+@RunWith(AndroidJUnit4::class)
+class ManageTagsViewModelTest : RobolectricTest() {
+    @Test
+    fun `refreshTags loads empty collection`() =
+        runTest {
+            withViewModel {
+                assertIs<ManageTagsState.Loaded>(state.value)
+                assertThat(loadedState.visibleNodes, hasSize(0))
+            }
+        }
+
+    @Test
+    fun `refreshTags loads tags from notes`() =
+        runTest {
+            addTags("science")
+            withViewModel {
+                assertThat(loadedState.visibleTagNames, equalTo(listOf("science")))
+            }
+        }
+
+    @Test
+    fun `refreshTags loads hierarchical tags`() =
+        runTest {
+            addTags("science::biology", "science::chemistry")
+            withViewModel {
+                // "science" parent is collapsed by default, so only it should be visible
+                assertThat(loadedState.visibleNodes, hasSize(1))
+                assertThat(loadedState.visibleNodes[0].fullTagName, equalTo("science"))
+                assertThat(loadedState.visibleNodes[0].hasChildren, equalTo(true))
+            }
+        }
+
+    @Test
+    fun `refreshTags loads multiple tags from multiple notes`() =
+        runTest {
+            addTags("math")
+            addTags("history")
+            withViewModel {
+                assertThat(loadedState.visibleNodes, hasSize(2))
+                assertThat(
+                    loadedState.visibleTagNames,
+                    containsInAnyOrder("history", "math"),
+                )
+            }
+        }
+
+    @Test
+    fun `refreshTags preserves search query`() =
+        runTest {
+            addTags("science", "history")
+            withViewModel {
+                filter("sci")
+                refreshTags()
+                assertThat(loadedState.searchQuery, equalTo("sci"))
+                assertThat(loadedState.visibleTagNames, equalTo(listOf("science")))
+            }
+        }
+
+    @Test
+    fun `initial state is Loaded after construction`() =
+        runTest {
+            withViewModel {
+                assertIs<ManageTagsState.Loaded>(state.value)
+            }
+        }
+
+    @Test
+    fun `filter narrows visible tags`() =
+        runTest {
+            addTags("science", "history", "math")
+            withViewModel {
+                filter("sci")
+                assertThat(loadedState.visibleTagNames, equalTo(listOf("science")))
+                assertThat(loadedState.searchQuery, equalTo("sci"))
+            }
+        }
+
+    @Test
+    fun `filter with empty query shows all tags`() =
+        runTest {
+            addTags("science", "history")
+            withViewModel {
+                filter("sci")
+                assertThat(loadedState.visibleNodes, hasSize(1))
+
+                filter("")
+                assertThat(loadedState.visibleNodes, hasSize(2))
+            }
+        }
+
+    @Test
+    fun `filter shows ancestors of matching nested tags`() =
+        runTest {
+            addTags("science::biology", "history")
+            withViewModel {
+                filter("bio")
+                // "science" (ancestor) + "science::biology" (match)
+                assertThat(loadedState.visibleNodes, hasSize(2))
+                assertThat(loadedState.visibleNodes[0].fullTagName, equalTo("science"))
+                assertThat(loadedState.visibleNodes[1].fullTagName, equalTo("science::biology"))
+            }
+        }
+
+    @Test
+    fun `filter with no matches returns empty`() =
+        runTest {
+            addTags("science")
+            withViewModel {
+                filter("zzz")
+                assertThat(loadedState.visibleNodes, hasSize(0))
+            }
+        }
+
+    @Test
+    fun `toggleCollapsed expands a collapsed tag`() =
+        runTest {
+            addTags("science::biology", "science::chemistry")
+            withViewModel {
+                assertThat(loadedState.visibleNodes, hasSize(1))
+
+                toggleCollapsed("science")
+
+                assertThat(loadedState.visibleNodes, hasSize(3))
+                assertThat(loadedState.visibleNodes[0].fullTagName, equalTo("science"))
+                assertThat(loadedState.visibleNodes[0].collapsed, equalTo(false))
+                assertThat(loadedState.visibleNodes[1].fullTagName, equalTo("science::biology"))
+                assertThat(loadedState.visibleNodes[2].fullTagName, equalTo("science::chemistry"))
+            }
+        }
+
+    @Test
+    fun `toggleCollapsed collapses an expanded tag`() =
+        runTest {
+            addTags("science::biology")
+            withViewModel {
+                toggleCollapsed("science")
+                assertThat(loadedState.visibleNodes, hasSize(2))
+
+                toggleCollapsed("science")
+                assertThat(loadedState.visibleTagNames, equalTo(listOf("science")))
+                assertThat(loadedState.visibleNodes[0].collapsed, equalTo(true))
+            }
+        }
+
+    @Test
+    fun `toggleCollapsed on unknown tag sends UnexpectedError`() =
+        runTest {
+            addTags("science")
+            withViewModel {
+                toggleCollapsed("nonexistent")
+                val event = events.first() as ManageTagsEvent.DisplayMessage
+                assertIs<UserMessage.UnexpectedError>(event.message)
+            }
+        }
+
+    @Test
+    fun `removeTag removes a single tag`() =
+        runTest {
+            addTags("science", "history")
+            withViewModel {
+                removeTag("science")
+            }
+            checkCollectionTags { tags ->
+                assertThat(tags, not(hasItem("science")))
+                assertThat(tags, hasItem("history"))
+            }
+        }
+
+    @Test
+    fun `removeTag removes tag and children`() =
+        runTest {
+            addTags("science::biology", "science::chemistry", "history")
+            withViewModel {
+                removeTag("science")
+            }
+            checkCollectionTags { tags ->
+                assertThat(tags, not(hasItem("science::biology")))
+                assertThat(tags, not(hasItem("science::chemistry")))
+                assertThat(tags, hasItem("history"))
+            }
+        }
+
+    @Test
+    fun `renameTag updates tag name`() =
+        runTest {
+            addTags("science")
+            withViewModel {
+                renameTag("science", "physics")
+            }
+            checkCollectionTags { tags ->
+                assertThat(tags, hasItem("physics"))
+                assertThat(tags, not(hasItem("science")))
+            }
+        }
+
+    @Test
+    fun `renameTag updates hierarchical tags`() =
+        runTest {
+            addTags("science::biology")
+            withViewModel {
+                renameTag("science", "studies")
+            }
+            checkCollectionTags { tags ->
+                assertThat(tags, hasItem("studies::biology"))
+                assertThat(tags, not(hasItem("science::biology")))
+            }
+        }
+
+    @Test
+    fun `clearUnusedTags removes tags not on any note`() =
+        runTest {
+            addTags("used")
+            addUnusedTag("unused")
+            withViewModel {
+                assertThat(loadedState.visibleTagNames, hasItem("unused"))
+
+                clearUnusedTags()
+
+                assertThat(loadedState.visibleTagNames, equalTo(listOf("used")))
+            }
+        }
+
+    @Test
+    fun `clearUnusedTags sends event with count`() =
+        runTest {
+            addTags("used")
+            addUnusedTag("unused")
+            withViewModel {
+                clearUnusedTags()
+                val event = events.first() as ManageTagsEvent.DisplayMessage
+                val message = assertIs<UserMessage.ClearedUnusedTags>(event.message)
+                assertThat(message.count, equalTo(1))
+            }
+        }
+
+    @Test
+    fun `removeTag sends event with affected note count`() =
+        runTest {
+            // add 'science to 2 notes - ensure that the return value is the notes affected
+            addTags("science")
+            addTags("science")
+            withViewModel {
+                removeTag("science")
+                val event = events.first() as ManageTagsEvent.DisplayMessage
+                val message = assertIs<UserMessage.TagRemoved>(event.message)
+                assertThat(message.notesAffected, equalTo(2))
+            }
+        }
+
+    @Test
+    fun `renameTag sends event with affected note count`() =
+        runTest {
+            // add 'science to 2 notes - ensure that the return value is the notes affected
+            addTags("science")
+            addTags("science")
+            withViewModel {
+                renameTag("science", "physics")
+                val event = events.first() as ManageTagsEvent.DisplayMessage
+                val message = assertIs<UserMessage.TagRenamed>(event.message)
+                assertThat(message.notesAffected, equalTo(2))
+            }
+        }
+
+    @Test
+    fun `removeTag fires opChanges`() =
+        runTest {
+            addTags("science")
+            ensureOpsExecuted(1) {
+                withViewModel { removeTag("science") }
+            }
+        }
+
+    @Test
+    fun `renameTag fires opChanges`() =
+        runTest {
+            addTags("science")
+            ensureOpsExecuted(1) {
+                withViewModel { renameTag("science", "physics") }
+            }
+        }
+
+    @Test
+    fun `clearUnusedTags fires opChanges`() =
+        runTest {
+            addTags("used")
+            addUnusedTag("unused")
+            ensureOpsExecuted(1) {
+                withViewModel { clearUnusedTags() }
+            }
+        }
+
+    @Test
+    @MediumTest
+    fun `toggleCollapsed performance with AnKing tags`() =
+        runTest {
+            val expected = 1.seconds
+
+            fun ManageTagsViewModel.toggleOnOff(tag: String) {
+                toggleCollapsed(tag)
+                toggleCollapsed(tag)
+            }
+
+            val tags = setupAnKing()
+
+            withViewModel {
+                val hugeTag = "#AK_Step1_v11" // 10k+ child tags
+
+                // warm up
+                toggleOnOff(hugeTag)
+
+                val iterations = 1
+                val elapsed =
+                    measureTimeMillis {
+                        repeat(iterations) {
+                            toggleOnOff(hugeTag)
+                        }
+                    }
+
+                // ~55ms on my M1
+                // ~342ms on a Ubuntu CI runner
+                val avgMs = (elapsed.toDouble() / (iterations * 2)).milliseconds
+                println("toggleCollapsed: ${tags.size} tags, avg ${avgMs}ms over ${iterations * 2} toggles")
+                assertTrue(avgMs < expected, "toggleCollapsed took ${avgMs}ms on average, expected < $expected")
+            }
+        }
+
+    private suspend fun withViewModel(block: suspend ManageTagsViewModel.() -> Unit) = ManageTagsViewModel().block()
+
+    /** Helper abstracting [com.ichi2.anki.libanki.Tags.all] */
+    private fun checkCollectionTags(block: (List<String>) -> Unit) = block(col.tags.all())
+
+    /** Adds 17k tags to a note */
+    private fun setupAnKing(): List<String> =
+        AnKingTags.value.also { tags ->
+            addBasicNote().update { tags.forEach { addTag(it) } }
+        }
+
+    private fun addTags(vararg tags: String) = addBasicNote().update { tags.forEach { addTag(it) } }
+
+    /** Adds a tag to the collection cache without it being on any note */
+    private fun addUnusedTag(
+        @Suppress("SameParameterValue") tag: String,
+    ) {
+        addTags(tag).update { removeTag(tag) }
+    }
+}
+
+private val ManageTagsViewModel.loadedState: ManageTagsState.Loaded
+    get() = state.value as ManageTagsState.Loaded

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Tags.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Tags.kt
@@ -85,13 +85,21 @@ class Tags(
      * ***********************************************************
      */
 
-    /** Rename provided tag and its children, returning number of changed notes. */
+    /**
+     * Rename a given tag and its children on all notes that reference it.
+     *
+     * @return [OpChangesWithCount] containing the number of affected notes.
+     */
     fun rename(
         old: String,
         new: String,
     ): OpChangesWithCount = col.backend.renameTags(currentPrefix = old, newPrefix = new)
 
-    /** Remove the provided tag(s) and their children from notes and the tag list. */
+    /**
+     * Remove the provided tag(s) and their children from notes and the tag list.
+     *
+     * @return [OpChangesWithCount] containing the number of affected notes.
+     */
     fun remove(spaceSeparatedTags: String): OpChangesWithCount = col.backend.removeTags(`val` = spaceSeparatedTags)
 
     /**


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6
> Almost entirely written by Claude, with hours of back-and-forth over design and refactorings
> I drove the ideas, Claude wrote the code. Read it heavily

> [!NOTE]
> Please request I break this up into commits if appropriate. 400LOC of well-commented non-test code is borderline to me.

## Purpose / Description

Even though the UI of the tags dialog is subject to design, the ViewModel and basic operations which we will support are unlikely to change

* Based on `tags.tree()`
* Delete/clear unused/rename are supported
* Collapsed/expanded state is synced with the collection
* A `TagName` abstraction acts as a guardrail against logging tag names
* Introduces a Compose-style 'Channel' for UI state notifications

## Fixes
* Part of issue #10397

## Approach
* Build a ViewModel
* Add basic logic: delete, rename, clear unused & collapsed. Claude added multiselect & deletion
* Refactored ManageTagsState to use a union of Loading/Loaded/Error
* Refactored to use `tag.tree()`
* Lots of refactoring of both the code and the tests
* Lots of high-level docs
* Added a TagName abstraction to handle bad logging decisions
* Added in indeterminate states to fix bugs in multi-selection & delete
* Removed mutlti-select after further UX issues combining it with filtering

## How Has This Been Tested?
Heavily unit tested

## Learning

* I've been using Compose more, and I like the `Channel<Event>` pattern to consolidate all events in 1 flow
* Indeterminate selection states in a treeview is nasty
  * Happy I skipped it 
* We need to look into `OpChanges` classes at a later date and add a common marker interface, the lambda return bug has hit too many times
* Performance could likely be optimized, but it's a lot of complexity for an op which takes ~50ms on my emulator.
* filtering + selection just feels dangerous


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)