### PR TITLE
fix: refresh NoteEditor fields after restoring templates to default

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -404,6 +404,11 @@ open class CardBrowser :
         setupMenuProvider()
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        ChangeManager.unsubscribe(this)
+    }
+
     fun setupMenuProvider() {
         // the drawerToggle has priority over other menu items
         addMenuProvider(
@@ -1093,7 +1098,8 @@ open class CardBrowser :
             return
         }
 
-        if (changes.browserSidebar ||
+        if (changes.notetype ||
+            changes.browserSidebar ||
             changes.browserTable ||
             changes.noteText ||
             changes.card

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -1057,12 +1057,16 @@ open class CardTemplateEditor :
         private suspend fun restoreNotetypeToStock(kind: StockNotetype.Kind? = null) {
             val nid = notetypeId { ntid = tempModel.noteTypeId }
             undoableOp { notetypes.restoreNotetypeToStock(nid, kind) }
-            onModelSaved()
+            requireActivity().setResult(
+                RESULT_OK,
+                Intent().putExtra(EXTRA_NOTETYPE_FIELDS_CHANGED, true),
+            )
             showThemedToast(
                 requireContext(),
                 TR.cardTemplatesRestoredToDefault(),
                 shortLength = false,
             )
+            onModelSaved()
         }
 
         /**
@@ -1587,6 +1591,9 @@ open class CardTemplateEditor :
 
         @Suppress("unused")
         private const val REQUEST_CARD_BROWSER_APPEARANCE = 1
+
+        // True if the notetype's fields were changed
+        const val EXTRA_NOTETYPE_FIELDS_CHANGED = "noteTypeFieldsChanged"
 
         @CheckResult
         fun getIntent(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -76,6 +76,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import anki.collection.OpChanges
 import anki.config.ConfigKey
 import anki.notes.NoteFieldsCheckResponse
 import com.google.android.material.color.MaterialColors
@@ -140,6 +141,7 @@ import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.noteeditor.Toolbar
 import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
+import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.ImageOcclusion
 import com.ichi2.anki.pages.viewmodel.ImageOcclusionArgs
@@ -219,7 +221,8 @@ class NoteEditorFragment :
     BaseSnackbarBuilderProvider,
     DispatchKeyEventListener,
     MenuProvider,
-    ShortcutGroupProvider {
+    ShortcutGroupProvider,
+    ChangeManager.Subscriber {
     /** Whether any change are saved. E.g. multimedia, new card added, field changed and saved. */
     private var changed = false
     private var isTagsEdited = false
@@ -591,6 +594,9 @@ class NoteEditorFragment :
             viewLifecycleOwner,
             Lifecycle.State.RESUMED,
         )
+
+        // Subscribe to note type changes
+        ChangeManager.subscribe(this)
     }
 
     /**
@@ -2915,6 +2921,26 @@ class NoteEditorFragment :
             )
             populateEditFields(FieldChangeType.changeFieldCount(shouldReplaceNewlines()))
         }
+        updateToolbar()
+    }
+
+    override fun opExecuted(
+        changes: OpChanges,
+        handler: Any?,
+    ) {
+        if (addNote) return
+        if (handler === this) return
+        if (!changes.notetype) return
+
+        Timber.d("Note type changed externally, reloading notetype")
+        val editorNote = this.editorNote ?: return
+        val noteTypeId = editorNote.noteTypeId
+        val currentNotetype = getColUnsafe.notetypes.get(noteTypeId) ?: return
+
+        // Always update notetype and repopulate fields when notetype changes externally
+        // This ensures field order changes are also handled correctly
+        editorNote.notetype = currentNotetype
+        populateEditFields(FieldChangeType.changeFieldCount(shouldReplaceNewlines()))
         updateToolbar()
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -341,6 +341,7 @@ class NoteEditorFragment :
             NoteEditorActivityResultCallback {
                 // Note type can change regardless of exit type - update ourselves and CardBrowser
                 reloadRequired = true
+                val previousFieldNames = editorNote!!.notetype.fieldsNames.toList()
                 editorNote!!.notetype = getColUnsafe.notetypes.get(editorNote!!.noteTypeId)!!
                 if (currentEditedCard == null ||
                     !editorNote!!
@@ -355,6 +356,7 @@ class NoteEditorFragment :
                         Timber.d("onActivityResult() template edit return - current card is gone, close note editor")
                         showSnackbar(getString(R.string.template_for_current_card_deleted))
                         closeNoteEditor()
+                        return@NoteEditorActivityResultCallback
                     } else {
                         Timber.d("onActivityResult() template edit return, in add mode, just re-display")
                         updateCards(editorNote!!.notetype)
@@ -369,6 +371,7 @@ class NoteEditorFragment :
                     editorNote = currentEditedCard!!.note // update the NoteEditor's working note reference
                     updateCards(editorNote!!.notetype)
                 }
+                repopulateFieldsIfChanged(previousFieldNames)
             },
         )
 
@@ -2855,6 +2858,14 @@ class NoteEditorFragment :
         noteTypeSpinner!!.setSelection(position)
     }
 
+    @VisibleForTesting(otherwise = VisibleForTesting.NONE)
+    fun reloadEditorNote(
+        note: Note,
+        changeType: FieldChangeType = FieldChangeType.changeFieldCount(shouldReplaceNewlines()),
+    ) {
+        setNote(note, changeType)
+    }
+
     /**
      * Whether sticky fields are currently being loaded. In this card, don't consider the text changed.
      */
@@ -2891,6 +2902,20 @@ class NoteEditorFragment :
         ) {
             // do nothing
         }
+    }
+
+    @VisibleForTesting
+    fun repopulateFieldsIfChanged(previousFieldNames: List<String>) {
+        val newFieldNames = editorNote!!.notetype.fieldsNames.toList()
+        if (newFieldNames != previousFieldNames) {
+            Timber.d(
+                "Note type fields changed from %s to %s, repopulating edit fields",
+                previousFieldNames,
+                newFieldNames,
+            )
+            populateEditFields(FieldChangeType.changeFieldCount(shouldReplaceNewlines()))
+        }
+        updateToolbar()
     }
 
     companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -599,6 +599,11 @@ class NoteEditorFragment :
         ChangeManager.subscribe(this)
     }
 
+    override fun onDestroyView() {
+        super.onDestroyView()
+        ChangeManager.unsubscribe(this)
+    }
+
     /**
      * Handles an intent containing an image from the user's gallery or the internet by opening
      * MultimediaActivity specifically for creating a new card.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -696,6 +696,9 @@ class CardBrowserFragment :
 
     override fun onDestroyView() {
         super.onDestroyView()
+
+        ChangeManager.unsubscribe(this)
+
         if (::cardsListView.isInitialized) {
             cardsListView.adapter = null
         }
@@ -873,11 +876,13 @@ class CardBrowserFragment :
             return
         }
 
-        if (changes.browserSidebar ||
+        if (changes.notetype ||
+            changes.browserSidebar ||
             changes.browserTable ||
             changes.noteText ||
             changes.card
         ) {
+            Timber.d("CardBrowserFragment: refreshing adapter due to external change (notetype=%b)", changes.notetype)
             cardsAdapter.notifyDataSetChanged()
         }
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -663,6 +663,75 @@ class NoteEditorTest : RobolectricTest() {
             assertFalse(hasUnsavedChanges())
         }
 
+    @Test
+    fun `restoring notetype to stock updates field count in editor`() =
+        runTest {
+            val notetype = col.notetypes.byName("Basic")!!
+            col.notetypes.addFieldModChanged(notetype, col.notetypes.newField("Extra"))
+            col.notetypes.update(notetype)
+            col.notetypes.clearCache()
+
+            val note = col.newNote(notetype)
+            note.setField(0, "Front")
+            note.setField(1, "Back")
+            note.setField(2, "Extra")
+            col.addNote(note, col.decks.id("Default"))
+
+            val editor = getNoteEditorEditingExistingBasicNote(note, REVIEWER)
+            advanceRobolectricLooper()
+            assertThat(editor.editFields!!.size, equalTo(3))
+
+            // simulate restoreNotetypeToStock: backend drops back to 2 fields
+            col.notetypes.remFieldLegacy(notetype, notetype.fields.last())
+            col.notetypes.update(notetype)
+            col.notetypes.clearCache()
+
+            val previousFieldNames =
+                editor.editorNote!!
+                    .notetype.fieldsNames
+                    .toList()
+
+            val reloadedNote = col.getNote(note.id)
+            reloadedNote.fields = reloadedNote.fields.take(reloadedNote.notetype.fields.size).toMutableList()
+            val newNote =
+                com.ichi2.anki.libanki
+                    .Note(col, reloadedNote.id)
+
+            editor.reloadEditorNote(newNote)
+            editor.repopulateFieldsIfChanged(previousFieldNames)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "Field count should match restored notetype",
+                editor.editFields!!.size,
+                equalTo(2),
+            )
+        }
+
+    @Test
+    fun `returning from template editor without field changes does not repopulate fields`() =
+        runTest {
+            val note = addBasicNote("Front", "Back")
+            val editor = getNoteEditorEditingExistingBasicNote(note, REVIEWER)
+            advanceRobolectricLooper()
+
+            val originalRef = editor.editFields
+            val previousFieldNames =
+                editor.editorNote!!
+                    .notetype.fieldsNames
+                    .toList()
+
+            editor.repopulateFieldsIfChanged(previousFieldNames)
+            advanceRobolectricLooper()
+
+            assertThat(editor.editFields!!.size, equalTo(2))
+            assertThat(
+                "editFields reference must not change when fields are unchanged",
+                editor.editFields,
+                equalTo(originalRef),
+            )
+        }
+
     private suspend fun withNoteEditorAdding(
         from: FromScreen = FromScreen.DECK_LIST,
         block: suspend NoteEditorFragment.() -> Unit,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -31,6 +31,7 @@ import androidx.test.espresso.matcher.RootMatchers.isDialog
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import anki.collection.OpChanges
 import anki.config.ConfigKey
 import com.ichi2.anim.ActivityTransitionAnimation.Direction.DEFAULT
 import com.ichi2.anki.NoteEditorTest.FromScreen.DECK_LIST
@@ -730,6 +731,85 @@ class NoteEditorTest : RobolectricTest() {
                 editor.editFields,
                 equalTo(originalRef),
             )
+        }
+
+    @Test
+    fun `opExecuted with notetype change triggers field repopulation`() =
+        runTest {
+            var notetype = col.notetypes.byName("Basic")!!
+            col.notetypes.addFieldModChanged(notetype, col.notetypes.newField("Extra"))
+            col.notetypes.update(notetype)
+            col.notetypes.clearCache()
+
+            val note = col.newNote(notetype)
+            note.setField(0, "Front")
+            note.setField(1, "Back")
+            note.setField(2, "Extra")
+            col.addNote(note, col.decks.id("Default"))
+
+            val editor = getNoteEditorEditingExistingBasicNote(note, REVIEWER)
+            advanceRobolectricLooper()
+            assertThat(editor.editFields!!.size, equalTo(3))
+
+            // Simulate external notetype change: backend removes the extra field
+            col.notetypes.remFieldLegacy(notetype, notetype.fields.last())
+            col.notetypes.update(notetype)
+            col.notetypes.clearCache()
+
+            val originalRef = editor.editFields
+            val previousFieldNames =
+                editor.editorNote!!
+                    .notetype.fieldsNames
+                    .toList()
+
+            // Simulate a notetype change notification from ChangeManager
+            val opChanges = OpChanges.newBuilder().setNotetype(true).build()
+            editor.opExecuted(opChanges, handler = null)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "editFields reference must change when notetype is changed externally",
+                editor.editFields,
+                not(equalTo(originalRef)),
+            )
+            assertThat(
+                "Field count should match the updated notetype",
+                editor.editFields!!.size,
+                equalTo(2),
+            )
+        }
+
+    @Test
+    fun `opExecuted ignores changes from self`() =
+        runTest {
+            val note = addBasicNote("Front", "Back")
+            val editor = getNoteEditorEditingExistingBasicNote(note, REVIEWER)
+            advanceRobolectricLooper()
+
+            val originalRef = editor.editFields
+
+            // Simulate a notetype change from the editor itself (handler = editor)
+            val opChanges = OpChanges.newBuilder().setNotetype(true).build()
+            editor.opExecuted(opChanges, handler = editor)
+            advanceRobolectricLooper()
+
+            assertThat(
+                "editFields reference must not change when change is from self",
+                editor.editFields,
+                equalTo(originalRef),
+            )
+        }
+
+    @Test
+    fun `opExecuted ignores add note mode`() =
+        runTest {
+            val editor = getNoteEditorAddingNote(REVIEWER)
+            advanceRobolectricLooper()
+
+            // Simulate a notetype change via ChangeManager
+            val opChanges = OpChanges.newBuilder().setNotetype(true).build()
+            editor.opExecuted(opChanges, handler = null)
+            advanceRobolectricLooper()
         }
 
     private suspend fun withNoteEditorAdding(

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Note.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Note.kt
@@ -45,6 +45,7 @@ class Note : Cloneable {
         get() = _notetype!!
         set(value) {
             _notetype = value
+            fMap = Notetypes.fieldMap(value)
         }
 
     val noteTypeId: NoteTypeId

--- a/libanki/src/test/java/com/ichi2/anki/libanki/NotetypesTest.kt
+++ b/libanki/src/test/java/com/ichi2/anki/libanki/NotetypesTest.kt
@@ -21,8 +21,10 @@ import net.ankiweb.rsdroid.exceptions.BackendInvalidInputException
 import net.ankiweb.rsdroid.exceptions.BackendNotFoundException
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasItems
 import org.junit.Test
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class NotetypesTest : InMemoryAnkiTest() {
     @Test
@@ -72,5 +74,38 @@ class NotetypesTest : InMemoryAnkiTest() {
         val result =
             assertFailsWith<BackendInvalidInputException> { col.notetypes.getSingleNotetypeOfNotes(listOf(basicNote.id, clozeNote.id)) }
         assertThat(result.message, equalTo("Please select notes from only one note type."))
+    }
+
+    @Test
+    fun `updating note notetype updates fMap`() {
+        val notetype = col.notetypes.byName("Basic")!!
+        val note = col.newNote(notetype)
+
+        col.notetypes.addFieldModChanged(notetype, col.notetypes.newField("Extra"))
+        col.notetypes.update(notetype)
+        col.notetypes.clearCache()
+
+        note.notetype = col.notetypes.get(notetype.id)!!
+
+        val fieldNames = note.notetype.fieldsNames
+        assertThat(fieldNames, hasItems("Front", "Back", "Extra"))
+    }
+
+    @Test
+    fun `note items reflects updated notetype`() {
+        val notetype = col.notetypes.byName("Basic")!!
+
+        col.notetypes.addFieldModChanged(notetype, col.notetypes.newField("Extra"))
+        col.notetypes.update(notetype)
+        col.notetypes.clearCache()
+
+        val note = col.newNote(notetype)
+        note.setField(0, "Front")
+        note.setField(1, "Back")
+        note.setField(2, "Extra")
+
+        val items = note.items()
+        val itemFieldNames = items.map { it[0] }
+        assertThat(itemFieldNames, hasItems("Front", "Back", "Extra"))
     }
 }


### PR DESCRIPTION
## Purpose / Description
Fixes IndexOutOfBoundsException by refreshing NoteEditor fields after a template reset.When restores a notetype to its default templates, the backend field count can change,but the NoteEditor UI was not notified. So the field count in the UI did not match the backend.

Why opChanges didn't trigger a refresh is that NoteEditorFragment never subscribes to ChangeManager.

## Fixes
* Fixes #20510

## Approach
- Capture the field name list before overwriting the notetype
- Reload the notetype from the backend
- Compare field names before and after; if they differ, trigger populateEditFields to redraw the UI with the correct field count

## How Has This Been Tested?
Manually tested the dialog in the app on a physical device:
Device: realme RMX1991
reproduce actions of #20510
before
![81eaf083f3888d9ebe02151b4788c243](https://github.com/user-attachments/assets/fb3becff-1837-4256-804c-ba3a110b1b60)
after
![7d4790e85951f923dae769f0656e6d18](https://github.com/user-attachments/assets/0d305840-d685-4fd5-84f4-56c6c377afda)

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)