### PR TITLE
fix(whiteboard): prevent eraser skipping on fast swipe

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -89,7 +89,7 @@ class WhiteboardFragment :
 
         binding.whiteboardView.onNewPath = viewModel::addPath
         binding.whiteboardView.onEraseGestureStart = viewModel::startPathEraseGesture
-        binding.whiteboardView.onEraseGestureMove = viewModel::erasePathsAtPoint
+        binding.whiteboardView.onEraseGestureMove = viewModel::erasePathsToPoint
         binding.whiteboardView.onEraseGestureEnd = viewModel::endPathEraseGesture
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
@@ -38,7 +38,7 @@ class WhiteboardView : View {
     constructor(context: Context) : this(context, null)
 
     var onNewPath: ((Path) -> Unit)? = null
-    var onEraseGestureStart: (() -> Unit)? = null
+    var onEraseGestureStart: ((Float, Float) -> Unit)? = null
     var onEraseGestureMove: ((Float, Float) -> Unit)? = null
     var onEraseGestureEnd: (() -> Unit)? = null
     var isEraserActive: Boolean = false
@@ -139,8 +139,7 @@ class WhiteboardView : View {
                 hasMoved = false
                 currentPath.moveTo(touchX, touchY)
                 if (isPathEraser) {
-                    onEraseGestureStart?.invoke()
-                    onEraseGestureMove?.invoke(touchX, touchY)
+                    onEraseGestureStart?.invoke(touchX, touchY)
                 }
                 invalidate()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModel.kt
@@ -110,6 +110,8 @@ class WhiteboardViewModel(
             if (mode == EraserMode.INK) inkWidth else strokeWidth
         }.stateIn(viewModelScope, SharingStarted.Eagerly, WhiteboardRepository.DEFAULT_ERASER_WIDTH)
 
+    private var eraserLastX = 0.0f
+    private var eraserLastY = 0.0f
     private val pathsErasedInCurrentGesture = mutableListOf<DrawingAction>()
     private var pathsBeforeGesture: List<DrawingAction> = emptyList()
     private var isDarkMode = false
@@ -152,17 +154,24 @@ class WhiteboardViewModel(
     }
 
     /**
-     * Clears the list of paths erased in the current gesture.
+     * Clears the list of paths erased in the current gesture and initializes previous
+     * eraser position.
      */
-    fun startPathEraseGesture() {
+    fun startPathEraseGesture(
+        x: Float,
+        y: Float,
+    ) {
         pathsBeforeGesture = paths.value
         pathsErasedInCurrentGesture.clear()
+        eraserLastX = x
+        eraserLastY = y
+        erasePathsToPoint(x, y)
     }
 
     /**
-     * Finds and removes paths that intersect with the given point.
+     * Finds and removes paths that intersect with the previous eraser line segment.
      */
-    fun erasePathsAtPoint(
+    fun erasePathsToPoint(
         x: Float,
         y: Float,
     ) {
@@ -174,7 +183,7 @@ class WhiteboardViewModel(
         val pathsToEvaluate = remainingPaths.filter { it !in pathsErasedInCurrentGesture && !it.isEraser }
 
         for (action in pathsToEvaluate) {
-            if (isPathIntersectingWithCircle(action, x, y, activeStrokeWidth.value / 2)) {
+            if (isPathIntersectingWithSegment(action, x, y, eraserLastX, eraserLastY, activeStrokeWidth.value / 2)) {
                 remainingPaths.remove(action)
                 pathsErasedInCurrentGesture.add(action)
                 pathWasErased = true
@@ -184,15 +193,20 @@ class WhiteboardViewModel(
         if (pathWasErased) {
             paths.value = remainingPaths
         }
+
+        eraserLastX = x
+        eraserLastY = y
     }
 
     /**
-     * Checks if a path intersects with a circular area.
+     * Checks if a path intersects with a line segment.
      */
-    private fun isPathIntersectingWithCircle(
+    private fun isPathIntersectingWithSegment(
         action: DrawingAction,
-        cx: Float,
-        cy: Float,
+        currentX: Float,
+        currentY: Float,
+        prevX: Float,
+        prevY: Float,
         eraserRadius: Float,
     ): Boolean {
         val path = action.path
@@ -206,18 +220,32 @@ class WhiteboardViewModel(
         val totalRadius = eraserRadius + pathRadius
         val totalRadiusSquared = totalRadius * totalRadius
 
-        if (length == 0f) {
-            pathMeasure.getPosTan(0f, pos, null)
-            val dx = pos[0] - cx
-            val dy = pos[1] - cy
-            return dx * dx + dy * dy <= totalRadiusSquared
-        }
+        val segmentX = currentX - prevX
+        val segmentY = currentY - prevY
+        val segmentLengthSq = segmentX * segmentX + segmentY * segmentY
 
         var distance = 0f
-        while (distance < length) {
+        while (distance <= length) {
             pathMeasure.getPosTan(distance, pos, null)
-            val dx = pos[0] - cx
-            val dy = pos[1] - cy
+
+            val prevToPathX = pos[0] - prevX
+            val prevToPathY = pos[1] - prevY
+
+            val dx: Float
+            val dy: Float
+
+            if (segmentLengthSq == 0f) {
+                dx = prevToPathX
+                dy = prevToPathY
+            } else {
+                // Project path point onto segment to find the closest point on the segment
+                val dot = prevToPathX * segmentX + prevToPathY * segmentY
+                val t = (dot / segmentLengthSq).coerceIn(0f, 1f)
+
+                dx = pos[0] - (prevX + t * segmentX)
+                dy = pos[1] - (prevY + t * segmentY)
+            }
+
             if (dx * dx + dy * dy <= totalRadiusSquared) {
                 return true
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The new study screen whiteboard eraser occasionally skips parts of a drawn path when the user swipes quickly across the screen.

## Fixes
* Fixes #20555

## Approach
- Added `eraserLastX` and `eraserLastY` in `WhiteboardViewModel` to remember the previous eraser coordinates during an erase gesture
- Replaced the check if the current eraser location is close enough to a drawn path with a check if any drawn path is close enough to the last line segment of the eraser stroke

## How Has This Been Tested?

Tested on a physical device - drew a line with width 10 on the new whiteboard and tested a quick swipe with eraser width 10 to ensure the line is erased. Also checked that existing eraser functionality works as expected.

Before:

https://github.com/user-attachments/assets/a1580c3f-02c7-4ddb-b044-bccaba7ed8ea

After:

https://github.com/user-attachments/assets/b2bc22c4-b3c9-417b-a48d-e8249e862370

## Learning (optional, can help others)
Android MotionEvent touch coordinates can have large gaps between ACTION_MOVE events during fast gestures. These events can [batch together coordinates](https://developer.android.com/reference/android/view/MotionEvent#batching), but even processing the batched coordinates for the eraser, it was still possible for lines to be missed during very fast swipes.

Interpolating between eraser positions by sampling many points along the eraser segment and checking each one against every path was too slow. Instead, projecting each point on the drawn paths onto the eraser line segment to find the shortest distance was much faster.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->