### PR TITLE
refactor: change pref key for analytics dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 
 @NeedsTest("Add coverage for opt-in handling, client id persistence and event/exception sending")
 object AnkiDroidUsageAnalytics {
-    private const val ANALYTICS_OPTIN_KEY = "analytics_opt_in"
+    private const val ANALYTICS_OPTIN_KEY = "analytics_opt_in_v2"
     private const val ANALYTICS_CLIENT_ID = "googleAnalyticsClientId"
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -22,6 +22,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.core.content.edit
 import androidx.core.os.LocaleListCompat
+import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.BrowserColumnCollection
 import com.ichi2.anki.browser.CardBrowserColumn.ANSWER
@@ -138,6 +139,7 @@ object PreferenceUpgradeService {
                     yield(UpgradeThemes())
                     yield(UpgradeAnswerControls())
                     yield(RemoveDeveloperFindReplace())
+                    yield(ResetAnalyticsOptIn2())
                 }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -908,6 +910,15 @@ object PreferenceUpgradeService {
                     remove("browserFindReplace")
                 }
             }
+        }
+
+        /**
+         * Removes the legacy "analytics_opt_in" key so all users are re-prompted
+         * to opt in under the new GA4-backed analytics implementation, which
+         * stores the opt-in under [AnkiDroidUsageAnalytics.ANALYTICS_OPTIN_KEY].
+         */
+        internal class ResetAnalyticsOptIn2 : PreferenceUpgrade(29) {
+            override fun upgrade(preferences: SharedPreferences) = preferences.edit { remove("analytics_opt_in") }
         }
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- On top of #20584

Change the pref key for dialog to reset it for all users
Set the state to unchecked by default 

## Fixes
NA

## Approach
NA

## How Has This Been Tested?
I don't think we need test here since its pref key change and the dialog state is set to false

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->