### PR TITLE
feat(logs): improve measureTime logging

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/TimeUtil.kt
@@ -19,28 +19,52 @@ package com.ichi2.utils
 import androidx.annotation.CheckResult
 import com.ichi2.anki.common.time.TimeManager
 import timber.log.Timber
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.InvocationKind
+import kotlin.contracts.contract
+import kotlin.time.TimeSource
 
 /**
+ * Measures the time it takes to execute [block] and logs the result as `Timber.d` on success
+ * or `Timber.w` on failure.
+ *
+ * Exceptions are rethrown.
+ *
  * Usage:
  *
  * ```kotlin
  * val result = measureTime("operation") { operation() }
  * ```
- * -> `D/TimeUtilKt executed mHtmlGenerator in 23ms`
+ * -> `D/TimeUtilKt executed htmlGenerator in 447.458us`
  */
-fun <T> measureTime(
-    functionName: String? = "",
-    function: () -> T,
+@OptIn(ExperimentalContracts::class)
+// 'inline fun' so logs use the correct context
+inline fun <T> measureTime(
+    methodName: String? = "",
+    block: () -> T,
 ): T {
-    val startTime = TimeManager.time.intTimeMS()
-    val result = function()
-    val endTime = TimeManager.time.intTimeMS()
-    Timber.d(
-        "executed %sin %dms",
-        if (functionName.isNullOrEmpty()) "" else "$functionName ",
-        endTime - startTime,
-    )
-    return result
+    contract {
+        callsInPlace(block, InvocationKind.EXACTLY_ONCE)
+    }
+    val mark = TimeSource.Monotonic.markNow()
+    var returnSuccess = true
+    try {
+        return block()
+    } catch (e: Throwable) {
+        returnSuccess = false
+        throw e
+    } finally {
+        // elapsedNow can throw IllegalArgumentException; almost impossible practically
+        runCatching { mark.elapsedNow() }.getOrNull()?.let { elapsed ->
+            val functionName = if (methodName.isNullOrEmpty()) "" else "$methodName "
+
+            if (returnSuccess) {
+                Timber.d("executed %sin %s", functionName, elapsed)
+            } else {
+                Timber.w("executed %sin %s [FAILED]", functionName, elapsed)
+            }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
## Purpose / Description
I want to use `measureTime` for #20168, but there were various issues:

* Failures were not logged
* it did not handle microseconds

## Fixes
* Part of #20168

## Approach
`TimeSource.Monotonic.measureTime` is more accurate and returns a duration, but does not allow returning the `T`

So write a wrapper, using the implementation: of the method: `markNow()`

* Log a Duration
* Timber.w on failure

## How Has This Been Tested?
Tested locally in `AnkiDroidApp`

```
executed setupLogging in 11.416833ms
executed setupUsageAnalytics in 94.884708ms
executed performStartupLogging in 3.251458ms
executed setupContextMenus in 1.153625ms
executed makeBackendUsable in 143us
executed setupNotifications in 5.957541ms
executed setupAppLifecycleObserver in 579.041us
executed setupBackendChangeManager in 10.660333ms
executed setupWebView in 992.291us
executed setupBackend in 774.709us
executed initializeAnkiDroidDirectory in 1.840709ms
executed setupDayRollover in 1.921333ms
executed setupLifecycleLogging in 181.791us
executed setupTextToSpeech in 2.633416ms
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)