### PR TITLE
improvement(startup): split into methods and add timing

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -196,7 +196,7 @@ open class AnkiDroidApp :
         setup("setupContextMenus") { setupContextMenus() }
         setupNotificationChannels(applicationContext)
 
-        makeBackendUsable(this)
+        setup("makeBackendUsable") { makeBackendUsable(this) }
 
         // Probe WebView availability before any other init touches it (#5794).
         if (!checkWebViewAvailable()) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -207,7 +207,7 @@ open class AnkiDroidApp :
         CardBrowser.clearLastDeckId()
         LanguageUtil.setDefaultBackendLanguages()
 
-        initializeAnkiDroidDirectory()
+        setup("initializeAnkiDroidDirectory") { initializeAnkiDroidDirectory() }
 
         val context = this.withAppLocale()
         if (Prefs.newReviewRemindersEnabled) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -221,56 +221,8 @@ open class AnkiDroidApp :
 
         // listen for day rollover: time + timezone changes
         DayRolloverHandler.listenForRolloverEvents(this)
-
         restoreRecurringAlarms(this)
-
-        registerActivityLifecycleCallbacks(
-            object : ActivityLifecycleCallbacks {
-                override fun onActivityCreated(
-                    activity: Activity,
-                    savedInstanceState: Bundle?,
-                ) {
-                    Timber.i(
-                        "${activity::class.simpleName}::onCreate, savedInstanceState: %s",
-                        savedInstanceState?.let { "${it.keySet().size} keys" },
-                    )
-                    (activity as? FragmentActivity)
-                        ?.supportFragmentManager
-                        ?.registerFragmentLifecycleCallbacks(
-                            FragmentLifecycleLogger(activity),
-                            true,
-                        )
-                }
-
-                override fun onActivityStarted(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onStart")
-                }
-
-                override fun onActivityResumed(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onResume")
-                }
-
-                override fun onActivityPaused(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onPause")
-                }
-
-                override fun onActivityStopped(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onStop")
-                }
-
-                override fun onActivitySaveInstanceState(
-                    activity: Activity,
-                    outState: Bundle,
-                ) {
-                    Timber.i("${activity::class.simpleName}::onSaveInstanceState")
-                }
-
-                override fun onActivityDestroyed(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onDestroy")
-                }
-            },
-        )
-
+        setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
@@ -322,6 +274,55 @@ open class AnkiDroidApp :
         if (debugTraceSqlCalls) {
             Os.setenv("TRACESQL", "1", false)
         }
+    }
+
+    private fun setupLifecycleLogging() {
+        registerActivityLifecycleCallbacks(
+            object : ActivityLifecycleCallbacks {
+                override fun onActivityCreated(
+                    activity: Activity,
+                    savedInstanceState: Bundle?,
+                ) {
+                    Timber.i(
+                        "${activity::class.simpleName}::onCreate, savedInstanceState: %s",
+                        savedInstanceState?.let { "${it.keySet().size} keys" },
+                    )
+                    (activity as? FragmentActivity)
+                        ?.supportFragmentManager
+                        ?.registerFragmentLifecycleCallbacks(
+                            FragmentLifecycleLogger(activity),
+                            true,
+                        )
+                }
+
+                override fun onActivityStarted(activity: Activity) {
+                    Timber.i("${activity::class.simpleName}::onStart")
+                }
+
+                override fun onActivityResumed(activity: Activity) {
+                    Timber.i("${activity::class.simpleName}::onResume")
+                }
+
+                override fun onActivityPaused(activity: Activity) {
+                    Timber.i("${activity::class.simpleName}::onPause")
+                }
+
+                override fun onActivityStopped(activity: Activity) {
+                    Timber.i("${activity::class.simpleName}::onStop")
+                }
+
+                override fun onActivitySaveInstanceState(
+                    activity: Activity,
+                    outState: Bundle,
+                ) {
+                    Timber.i("${activity::class.simpleName}::onSaveInstanceState")
+                }
+
+                override fun onActivityDestroyed(activity: Activity) {
+                    Timber.i("${activity::class.simpleName}::onDestroy")
+                }
+            },
+        )
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -197,6 +197,10 @@ open class AnkiDroidApp :
         restoreRecurringAlarms(this)
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
+        setup("setupTextToSpeech") { setupTextToSpeech() }
+    }
+
+    private fun setupTextToSpeech() {
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -193,14 +193,19 @@ open class AnkiDroidApp :
         CardBrowser.clearLastDeckId()
         val anki = AnkiContext.apply { setup("setupBackend") { setupAnkiBackend() } }
         setup("initializeAnkiDroidDirectory") { dependency(anki) { initializeAnkiDroidDirectory() } }
-        // listen for day rollover: time + timezone changes
-        DayRolloverHandler.listenForRolloverEvents(this)
+        setup("setupDayRollover") { dependency(anki) { setupDayRollover() } }
         restoreRecurringAlarms(this)
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    /** listen for day rollover: time + timezone changes */
+    context(_: AnkiContext)
+    private fun setupDayRollover() {
+        DayRolloverHandler.listenForRolloverEvents(this)
     }
 
     private fun setupAnkiBackend() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -118,6 +118,7 @@ open class AnkiDroidApp :
         crossinline onFailure: ((Exception) -> Exception?) = { it },
         crossinline block: () -> T,
     ): T? {
+        // TODO: #20168 warn users of non-fatal component errors rather than crashing
         try {
             return measureTime(methodName = methodName) { block() }
         } catch (e: Exception) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -64,6 +64,7 @@ import com.ichi2.utils.ExceptionUtil
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.LanguageUtil.withAppLocale
 import com.ichi2.utils.Permissions
+import com.ichi2.utils.measureTime
 import com.ichi2.utils.setWebContentsDebuggingEnabled
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
@@ -96,23 +97,41 @@ open class AnkiDroidApp :
     var progressDialogShown = false
 
     /**
+     * Executes a setup method: [block], logging execution time. [onFailure] determines if a thrown
+     * exception is rethrown (default: rethrow)
+     *
+     * @param methodName Method name, used for logging.
+     * @param onFailure Processes an exception thrown by [block]. Return `null` to swallow
+     * @param block The method to execute and return
+     *
+     * @return The result of [block], or `null` if an exception is thrown and is not swallowed by
+     * [onFailure].
+     */
+    // 'inline fun' so logs use the correct context
+    inline fun <T> setup(
+        methodName: String,
+        crossinline onFailure: ((Exception) -> Exception?) = { it },
+        crossinline block: () -> T,
+    ): T? {
+        try {
+            return measureTime(methodName = methodName) { block() }
+        } catch (e: Exception) {
+            // NOTE: this can be called before Timber is initialized
+            Timber.w(e, "failed to execute $methodName")
+            onFailure.invoke(e)?.let { exceptionToThrow ->
+                throw exceptionToThrow
+            }
+
+            return null
+        }
+    }
+
+    /**
      * On application creation.
      */
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     override fun onCreate() {
-        try {
-            Os.setenv("PLATFORM", syncPlatform(), false)
-            // enable debug logging of sync actions
-            if (BuildConfig.DEBUG) {
-                Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
-            }
-        } catch (_: Exception) {
-        }
-        // Uncomment the following lines to see a log of all SQL statements
-        // executed by the backend. The log may be delayed by 100ms, so you should not
-        // assume than a given SQL statement has run after a Timber.* line just
-        // because the SQL statement appeared later.
-        //   Os.setenv("TRACESQL", "1", false);
+        setup("initAnkiBackend", onFailure = { null }) { initAnkiBackend(debugTraceSqlCalls = false) }
         super.onCreate()
         val appLifecycleObserver = AppLifecycleObserver(applicationContext)
 
@@ -269,6 +288,26 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    /**
+     * @param debugTraceSqlCalls Log all SQL statements executed by the backend.
+     * **Warning** The log may be delayed by 100ms, so you should not assume than a given SQL
+     * statement has run after a Timber.* line just because the SQL statement appeared later.
+     */
+    private fun initAnkiBackend(
+        @Suppress("SameParameterValue") debugTraceSqlCalls: Boolean = false,
+    ) {
+        // Note: This method runs before logs are enabled.
+        Os.setenv("PLATFORM", syncPlatform(), false)
+        // enable debug logging of sync actions
+        if (BuildConfig.DEBUG) {
+            Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
+        }
+
+        if (debugTraceSqlCalls) {
+            Os.setenv("TRACESQL", "1", false)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -178,8 +178,7 @@ open class AnkiDroidApp :
             showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
         }
 
-        setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
-
+        setup("setupWebView") { setupWebView() }
         setup("setupContextMenus") { setupContextMenus() }
         setup("makeBackendUsable") { makeBackendUsable(this) }
         setup("setupNotifications") { setupNotifications() }
@@ -202,6 +201,10 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    private fun setupWebView() {
+        setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
     }
 
     // crash reporting should be initialized before logging

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -194,9 +194,8 @@ open class AnkiDroidApp :
         setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
 
         setup("setupContextMenus") { setupContextMenus() }
-        setupNotificationChannels(applicationContext)
-
         setup("makeBackendUsable") { makeBackendUsable(this) }
+        setup("setupNotifications") { setupNotifications() }
 
         // Probe WebView availability before any other init touches it (#5794).
         if (!checkWebViewAvailable()) {
@@ -208,6 +207,18 @@ open class AnkiDroidApp :
         LanguageUtil.setDefaultBackendLanguages()
 
         setup("initializeAnkiDroidDirectory") { initializeAnkiDroidDirectory() }
+        // listen for day rollover: time + timezone changes
+        DayRolloverHandler.listenForRolloverEvents(this)
+        restoreRecurringAlarms(this)
+        setup("setupLifecycleLogging") { setupLifecycleLogging() }
+        activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
+        TtsVoices.launchBuildLocalesJob()
+        // enable {{tts-voices:}} field filter
+        TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    private fun setupNotifications() {
+        setupNotificationChannels(applicationContext)
 
         val context = this.withAppLocale()
         if (Prefs.newReviewRemindersEnabled) {
@@ -218,15 +229,6 @@ open class AnkiDroidApp :
             Timber.i("AnkiDroidApp: Starting Services")
             notifications.observeForever { NotificationService.triggerNotificationFor(context) }
         }
-
-        // listen for day rollover: time + timezone changes
-        DayRolloverHandler.listenForRolloverEvents(this)
-        restoreRecurringAlarms(this)
-        setup("setupLifecycleLogging") { setupLifecycleLogging() }
-        activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
-        TtsVoices.launchBuildLocalesJob()
-        // enable {{tts-voices:}} field filter
-        TtsVoicesFieldFilter.ensureApplied()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -156,8 +156,6 @@ open class AnkiDroidApp :
         }
         instance = this
 
-        // Ensures any change is propagated to widgets
-        ChangeManager.subscribe(this)
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
         setup("setupLogging") { dependency(acra) { setupLogging() } }
         setup("setupUsageAnalytics") { dependency(acra) { setupUsageAnalytics() } }
@@ -183,6 +181,7 @@ open class AnkiDroidApp :
         setup("setupContextMenus") { setupContextMenus() }
         setup("makeBackendUsable") { makeBackendUsable(this) }
         setup("setupNotifications") { setupNotifications() }
+        setup("setupBackendChangeManager") { setupBackendChangeManager() }
 
         // Probe WebView availability before any other init touches it (#5794).
         if (!checkWebViewAvailable()) {
@@ -198,6 +197,18 @@ open class AnkiDroidApp :
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setup("setupTextToSpeech") { setupTextToSpeech() }
+    }
+
+    /**
+     * Ensures any changes in the backend are propagated to:
+     *
+     * - widgets
+     *
+     * @see opExecuted
+     * @see ChangeManager
+     */
+    private fun setupBackendChangeManager() {
+        ChangeManager.subscribe(this)
     }
 
     private fun setupTextToSpeech() {
@@ -466,6 +477,7 @@ open class AnkiDroidApp :
      * Initialization for the Anki Backend has completed:
      * - [initAnkiBackend] - platform environment variables/logging
      * - [makeBackendUsable] - load rsdroid.so
+     * - [setupBackendChangeManager]
      * - [setupAnkiBackend] - i18n is set up
      */
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -34,6 +34,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ProcessLifecycleOwner
 import anki.collection.OpChanges
 import com.ichi2.anki.AnkiDroidApp.Companion.makeBackendUsable
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
@@ -141,12 +142,6 @@ open class AnkiDroidApp :
     override fun onCreate() {
         setup("initAnkiBackend", onFailure = { null }) { initAnkiBackend(debugTraceSqlCalls = false) }
         super.onCreate()
-        val appLifecycleObserver = AppLifecycleObserver(applicationContext)
-
-        androidx.lifecycle.ProcessLifecycleOwner
-            .get()
-            .lifecycle
-            .addObserver(appLifecycleObserver)
         if (isInitialized) {
             Timber.i("onCreate() called multiple times")
             // 5887 - fix crash.
@@ -174,6 +169,7 @@ open class AnkiDroidApp :
         setup("setupContextMenus") { setupContextMenus() }
         setup("makeBackendUsable") { makeBackendUsable(this) }
         setup("setupNotifications") { setupNotifications() }
+        setup("setupAppLifecycleObserver") { setupAppLifecycleObserver() }
         setup("setupBackendChangeManager") { setupBackendChangeManager() }
         // Probe WebView availability before any other init touches it (#5794).
         if ((setup("setupWebView") { setupWebView() }) != true) {
@@ -188,6 +184,15 @@ open class AnkiDroidApp :
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setup("setupTextToSpeech") { setupTextToSpeech() }
+    }
+
+    private fun setupAppLifecycleObserver() {
+        val appLifecycleObserver = AppLifecycleObserver(applicationContext)
+
+        ProcessLifecycleOwner
+            .get()
+            .lifecycle
+            .addObserver(appLifecycleObserver)
     }
 
     context(_: CrashReportingContext)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -158,21 +158,7 @@ open class AnkiDroidApp :
         // Ensures any change is propagated to widgets
         ChangeManager.subscribe(this)
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
-        val logType = LogType.value
-        when (logType) {
-            LogType.DEBUG -> Timber.plant(DebugTree())
-            LogType.ROBOLECTRIC -> Timber.plant(RobolectricDebugTree())
-            LogType.PRODUCTION -> Timber.plant(ProductionCrashReportingTree())
-        }
-        if (BuildConfig.ENABLE_LEAK_CANARY) {
-            LeakCanaryConfiguration.setInitialConfigFor(this)
-        } else {
-            LeakCanaryConfiguration.disable()
-        }
-        Timber.tag(TAG)
-        Timber.d("Startup - Application Start")
-        Timber.i("Timber config: $logType")
-
+        setup("setupLogging") { dependency(acra) { setupLogging() } }
         setup("setupUsageAnalytics") { dependency(acra) { setupUsageAnalytics() } }
 
         // Last in the UncaughtExceptionHandlers chain is our filter service
@@ -216,6 +202,25 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    // crash reporting should be initialized before logging
+    context(_: CrashReportingContext)
+    private fun setupLogging() {
+        val logType = LogType.value
+        when (logType) {
+            LogType.DEBUG -> Timber.plant(DebugTree())
+            LogType.ROBOLECTRIC -> Timber.plant(RobolectricDebugTree())
+            LogType.PRODUCTION -> Timber.plant(ProductionCrashReportingTree())
+        }
+        if (BuildConfig.ENABLE_LEAK_CANARY) {
+            LeakCanaryConfiguration.setInitialConfigFor(this)
+        } else {
+            LeakCanaryConfiguration.disable()
+        }
+        Timber.tag(TAG)
+        Timber.d("Startup - Application Start")
+        Timber.i("Timber config: $logType")
     }
 
     // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -102,33 +102,24 @@ open class AnkiDroidApp :
     var progressDialogShown = false
 
     /**
-     * Executes a setup method: [block], logging execution time. [onFailure] determines if a thrown
-     * exception is rethrown (default: rethrow)
+     * Executes a setup method: [block], logging execution time.
+     * Exceptions are logged and rethrown.
      *
      * @param methodName Method name, used for logging.
-     * @param onFailure Processes an exception thrown by [block]. Return `null` to swallow
      * @param block The method to execute and return
-     *
-     * @return The result of [block], or `null` if an exception is thrown and is not swallowed by
-     * [onFailure].
      */
     // 'inline fun' so logs use the correct context
     inline fun <T> setup(
         methodName: String,
-        crossinline onFailure: ((Exception) -> Exception?) = { it },
         crossinline block: () -> T,
-    ): T? {
-        // TODO: #20168 warn users of non-fatal component errors rather than crashing
+    ): T {
+        // TODO: #20168 warn users of non-fatal component errors rather than rethrowing
         try {
             return measureTime(methodName = methodName) { block() }
         } catch (e: Exception) {
             // NOTE: this can be called before Timber is initialized
             Timber.w(e, "failed to execute $methodName")
-            onFailure.invoke(e)?.let { exceptionToThrow ->
-                throw exceptionToThrow
-            }
-
-            return null
+            throw e
         }
     }
 
@@ -137,9 +128,9 @@ open class AnkiDroidApp :
      */
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     override fun onCreate() {
-        setup("initAnkiBackend", onFailure = { null }) { initAnkiBackend(debugTraceSqlCalls = false) }
+        runCatching { setup("initAnkiBackend") { initAnkiBackend(debugTraceSqlCalls = false) } }
         super.onCreate()
-        if ((setup("setupAnkiDroidApp") { setupAnkiDroidApp() }) != true) {
+        if (!setup("setupAnkiDroidApp") { setupAnkiDroidApp() }) {
             return // instance.resources is invalid
         }
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
@@ -162,7 +153,7 @@ open class AnkiDroidApp :
         setup("setupAppLifecycleObserver") { setupAppLifecycleObserver() }
         setup("setupBackendChangeManager") { setupBackendChangeManager() }
         // Probe WebView availability before any other init touches it (#5794).
-        if ((setup("setupWebView") { setupWebView() }) != true) {
+        if (!setup("setupWebView") { setupWebView() }) {
             return
         }
         // Forget the last deck that was used in the CardBrowser

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -164,20 +164,13 @@ open class AnkiDroidApp :
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
 
-        applicationScope.launch {
-            Timber.i("AnkiDroidApp: listing debug info")
-            Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
-        }
+        setup("performStartupLogging") { dependency(acra) { performStartupLogging() } }
 
         // Stop after analytics and logging are initialised.
         if (isAcraSenderProcess()) {
             Timber.d("Skipping AnkiDroidApp.onCreate from ACRA sender process")
             return
         }
-        if (AdaptionUtil.isUserATestClient) {
-            showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
-        }
-
         setup("setupContextMenus") { setupContextMenus() }
         setup("makeBackendUsable") { makeBackendUsable(this) }
         setup("setupNotifications") { setupNotifications() }
@@ -195,6 +188,21 @@ open class AnkiDroidApp :
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setup("setupTextToSpeech") { setupTextToSpeech() }
+    }
+
+    context(_: CrashReportingContext)
+    private fun performStartupLogging() {
+        applicationScope.launch {
+            Timber.i("AnkiDroidApp: listing debug info")
+            Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
+        }
+
+        // skip logging if we're under ACRA
+        if (CrashReportService.isProperServiceProcess()) return
+
+        if (AdaptionUtil.isUserATestClient) {
+            showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -34,6 +34,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
 import anki.collection.OpChanges
+import com.ichi2.anki.AnkiDroidApp.Companion.makeBackendUsable
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
@@ -190,9 +191,8 @@ open class AnkiDroidApp :
 
         // Forget the last deck that was used in the CardBrowser
         CardBrowser.clearLastDeckId()
-        LanguageUtil.setDefaultBackendLanguages()
-
-        setup("initializeAnkiDroidDirectory") { initializeAnkiDroidDirectory() }
+        val anki = AnkiContext.apply { setup("setupBackend") { setupAnkiBackend() } }
+        setup("initializeAnkiDroidDirectory") { dependency(anki) { initializeAnkiDroidDirectory() } }
         // listen for day rollover: time + timezone changes
         DayRolloverHandler.listenForRolloverEvents(this)
         restoreRecurringAlarms(this)
@@ -201,6 +201,10 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    private fun setupAnkiBackend() {
+        LanguageUtil.setDefaultBackendLanguages()
     }
 
     private fun setupWebView() {
@@ -354,6 +358,7 @@ open class AnkiDroidApp :
      * In most cases the Anki Backend now creates the collection and [initializeAnkiDroidDirectory]
      *  is called on startup of the activity.
      */
+    context(_: AnkiContext)
     private fun initializeAnkiDroidDirectory() {
         // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
         // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
@@ -447,6 +452,15 @@ open class AnkiDroidApp :
             Timber.d("No relevant changes to update the widget")
         }
     }
+
+    /**
+     * Initialization for the Anki Backend has completed:
+     * - [initAnkiBackend] - platform environment variables/logging
+     * - [makeBackendUsable] - load rsdroid.so
+     * - [setupAnkiBackend] - i18n is set up
+     */
+
+    object AnkiContext
 
     object CrashReportingContext
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -132,12 +132,6 @@ open class AnkiDroidApp :
         }
     }
 
-    /** ensures that [block] is called in the context of [receiver] */
-    inline fun <T, R> dependency(
-        receiver: T,
-        block: T.() -> R,
-    ): R = receiver.block()
-
     /**
      * On application creation.
      */
@@ -149,13 +143,13 @@ open class AnkiDroidApp :
             return // instance.resources is invalid
         }
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
-        setup("setupLogging") { dependency(acra) { setupLogging() } }
-        setup("setupUsageAnalytics") { dependency(acra) { setupUsageAnalytics() } }
+        setup("setupLogging") { with(acra) { setupLogging() } }
+        setup("setupUsageAnalytics") { with(acra) { setupUsageAnalytics() } }
 
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
 
-        setup("performStartupLogging") { dependency(acra) { performStartupLogging() } }
+        setup("performStartupLogging") { with(acra) { performStartupLogging() } }
 
         // Stop after analytics and logging are initialised.
         if (isAcraSenderProcess()) {
@@ -174,8 +168,8 @@ open class AnkiDroidApp :
         // Forget the last deck that was used in the CardBrowser
         CardBrowser.clearLastDeckId()
         val anki = AnkiContext.apply { setup("setupBackend") { setupAnkiBackend() } }
-        setup("initializeAnkiDroidDirectory") { dependency(anki) { initializeAnkiDroidDirectory() } }
-        setup("setupDayRollover") { dependency(anki) { setupDayRollover() } }
+        setup("initializeAnkiDroidDirectory") { with(anki) { initializeAnkiDroidDirectory() } }
+        setup("setupDayRollover") { with(anki) { setupDayRollover() } }
         restoreRecurringAlarms(this)
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -126,6 +126,12 @@ open class AnkiDroidApp :
         }
     }
 
+    /** ensures that [block] is called in the context of [receiver] */
+    inline fun <T, R> dependency(
+        receiver: T,
+        block: T.() -> R,
+    ): R = receiver.block()
+
     /**
      * On application creation.
      */
@@ -151,8 +157,7 @@ open class AnkiDroidApp :
 
         // Ensures any change is propagated to widgets
         ChangeManager.subscribe(this)
-
-        initializeAcraCrashReporter()
+        val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
         val logType = LogType.value
         when (logType) {
             LogType.DEBUG -> Timber.plant(DebugTree())
@@ -168,11 +173,7 @@ open class AnkiDroidApp :
         Timber.d("Startup - Application Start")
         Timber.i("Timber config: $logType")
 
-        // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
-        UsageAnalytics.initialize(this)
-        if (BuildConfig.DEBUG) {
-            UsageAnalytics.setDryRun(true)
-        }
+        setup("setupUsageAnalytics") { dependency(acra) { setupUsageAnalytics() } }
 
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
@@ -215,6 +216,15 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
+    context(_: CrashReportingContext)
+    private fun setupUsageAnalytics() {
+        UsageAnalytics.initialize(this)
+        if (BuildConfig.DEBUG) {
+            UsageAnalytics.setDryRun(true)
+        }
     }
 
     private fun setupNotifications() {
@@ -429,6 +439,8 @@ open class AnkiDroidApp :
             Timber.d("No relevant changes to update the widget")
         }
     }
+
+    object CrashReportingContext
 
     companion object {
         /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -36,6 +36,8 @@ import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
 import anki.collection.OpChanges
+import com.ichi2.anki.AnkiDroidApp.Companion.instance
+import com.ichi2.anki.AnkiDroidApp.Companion.isInitialized
 import com.ichi2.anki.AnkiDroidApp.Companion.makeBackendUsable
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
 import com.ichi2.anki.analytics.UsageAnalytics
@@ -142,16 +144,9 @@ open class AnkiDroidApp :
     override fun onCreate() {
         setup("initAnkiBackend", onFailure = { null }) { initAnkiBackend(debugTraceSqlCalls = false) }
         super.onCreate()
-        if (isInitialized) {
-            Timber.i("onCreate() called multiple times")
-            // 5887 - fix crash.
-            if (instance.resources == null) {
-                Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?")
-                return
-            }
+        if ((setup("setupAnkiDroidApp") { setupAnkiDroidApp() }) != true) {
+            return // instance.resources is invalid
         }
-        instance = this
-
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
         setup("setupLogging") { dependency(acra) { setupLogging() } }
         setup("setupUsageAnalytics") { dependency(acra) { setupUsageAnalytics() } }
@@ -184,6 +179,26 @@ open class AnkiDroidApp :
         setup("setupLifecycleLogging") { setupLifecycleLogging() }
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
         setup("setupTextToSpeech") { setupTextToSpeech() }
+    }
+
+    /**
+     * Sets [isInitialized] to `true` ([instance] != null)
+     *
+     * [onCreate] can be called multiple times due to ACRA using a separate sender process
+     *
+     * @return false if `instance.resources` is unusable
+     */
+    private fun setupAnkiDroidApp(): Boolean {
+        if (isInitialized) {
+            Timber.i("onCreate() called multiple times")
+            // 5887 - fix crash.
+            if (instance.resources == null) {
+                Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?")
+                return false
+            }
+        }
+        instance = this
+        return true
     }
 
     private fun setupAppLifecycleObserver() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -168,6 +168,30 @@ open class AnkiDroidApp :
     }
 
     /**
+     * @param debugTraceSqlCalls Log all SQL statements executed by the backend.
+     * **Warning** The log may be delayed by 100ms, so you should not assume than a given SQL
+     * statement has run after a Timber.* line just because the SQL statement appeared later.
+     */
+    private fun initAnkiBackend(
+        @Suppress("SameParameterValue") debugTraceSqlCalls: Boolean = false,
+    ) {
+        runCatching {
+            setup("initAnkiBackend") {
+                // Note: This method runs before logs are enabled.
+                Os.setenv("PLATFORM", syncPlatform(), false)
+                // enable debug logging of sync actions
+                if (BuildConfig.DEBUG) {
+                    Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
+                }
+
+                if (debugTraceSqlCalls) {
+                    Os.setenv("TRACESQL", "1", false)
+                }
+            }
+        }
+    }
+
+    /**
      * Sets [isInitialized] to `true` ([instance] != null)
      *
      * [onCreate] can be called multiple times due to ACRA using a separate sender process
@@ -187,82 +211,6 @@ open class AnkiDroidApp :
             instance = this
             true
         }
-    }
-
-    private fun setupAppLifecycleObserver() {
-        setup("setupAppLifecycleObserver") {
-            val appLifecycleObserver = AppLifecycleObserver(applicationContext)
-
-            ProcessLifecycleOwner
-                .get()
-                .lifecycle
-                .addObserver(appLifecycleObserver)
-        }
-    }
-
-    context(_: CrashReportingContext)
-    private fun performStartupLogging() {
-        setup("performStartupLogging") {
-            applicationScope.launch {
-                Timber.i("AnkiDroidApp: listing debug info")
-                Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
-            }
-
-            // skip logging if we're under ACRA
-            if (CrashReportService.isProperServiceProcess()) return@setup
-
-            if (AdaptionUtil.isUserATestClient) {
-                showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
-            }
-        }
-    }
-
-    /**
-     * Ensures any changes in the backend are propagated to:
-     *
-     * - widgets
-     *
-     * @see opExecuted
-     * @see ChangeManager
-     */
-    private fun setupBackendChangeManager() {
-        setup("setupBackendChangeManager") {
-            ChangeManager.subscribe(this)
-        }
-    }
-
-    private fun setupTextToSpeech() {
-        setup("setupTextToSpeech") {
-            TtsVoices.launchBuildLocalesJob()
-            // enable {{tts-voices:}} field filter
-            TtsVoicesFieldFilter.ensureApplied()
-        }
-    }
-
-    /** listen for day rollover: time + timezone changes */
-    context(_: AnkiContext)
-    private fun setupDayRollover() {
-        setup("setupDayRollover") {
-            DayRolloverHandler.listenForRolloverEvents(this)
-        }
-    }
-
-    private fun setupAnkiBackend() {
-        setup("setupAnkiBackend") {
-            LanguageUtil.setDefaultBackendLanguages()
-        }
-    }
-
-    /**
-     * @return whether [WebView] is usable
-     * [fatalInitializationError] is set otherwise
-     */
-    private fun setupWebView(): Boolean =
-        setup("setupWebView") {
-            // TODO: duplicated logging
-            setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
-
-        return@setup checkWebViewAvailable()
     }
 
     // crash reporting should be initialized before logging
@@ -297,18 +245,19 @@ open class AnkiDroidApp :
         }
     }
 
-    private fun setupNotifications() {
-        setup("setupNotifications") {
-            setupNotificationChannels(applicationContext)
+    context(_: CrashReportingContext)
+    private fun performStartupLogging() {
+        setup("performStartupLogging") {
+            applicationScope.launch {
+                Timber.i("AnkiDroidApp: listing debug info")
+                Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
+            }
 
-            val context = this.withAppLocale()
-            if (Prefs.newReviewRemindersEnabled) {
-                Timber.i("Setting review reminder notifications if they have not already been set")
-                AlarmManagerService.scheduleAllNotifications(context)
-            } else {
-                // Register for notifications
-                Timber.i("AnkiDroidApp: Starting Services")
-                notifications.observeForever { NotificationService.triggerNotificationFor(context) }
+            // skip logging if we're under ACRA
+            if (isAcraSenderProcess()) return@setup
+
+            if (AdaptionUtil.isUserATestClient) {
+                showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
             }
         }
     }
@@ -342,27 +291,118 @@ open class AnkiDroidApp :
         }
     }
 
+    private fun setupNotifications() {
+        setup("setupNotifications") {
+            setupNotificationChannels(applicationContext)
+
+            val context = this.withAppLocale()
+            if (Prefs.newReviewRemindersEnabled) {
+                Timber.i("Setting review reminder notifications if they have not already been set")
+                AlarmManagerService.scheduleAllNotifications(context)
+            } else {
+                // Register for notifications
+                Timber.i("AnkiDroidApp: Starting Services")
+                notifications.observeForever { NotificationService.triggerNotificationFor(context) }
+            }
+        }
+    }
+
+    private fun setupAppLifecycleObserver() {
+        setup("setupAppLifecycleObserver") {
+            val appLifecycleObserver = AppLifecycleObserver(applicationContext)
+
+            ProcessLifecycleOwner
+                .get()
+                .lifecycle
+                .addObserver(appLifecycleObserver)
+        }
+    }
+
     /**
-     * @param debugTraceSqlCalls Log all SQL statements executed by the backend.
-     * **Warning** The log may be delayed by 100ms, so you should not assume than a given SQL
-     * statement has run after a Timber.* line just because the SQL statement appeared later.
+     * Ensures any changes in the backend are propagated to:
+     *
+     * - widgets
+     *
+     * @see opExecuted
+     * @see ChangeManager
      */
-    private fun initAnkiBackend(
-        @Suppress("SameParameterValue") debugTraceSqlCalls: Boolean = false,
-    ) {
-        runCatching {
-            setup("initAnkiBackend") {
-                // Note: This method runs before logs are enabled.
-                Os.setenv("PLATFORM", syncPlatform(), false)
-                // enable debug logging of sync actions
-                if (BuildConfig.DEBUG) {
-                    Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
+    private fun setupBackendChangeManager() {
+        setup("setupBackendChangeManager") {
+            ChangeManager.subscribe(this)
+        }
+    }
+
+    /**
+     * @return whether [WebView] is usable
+     * [fatalInitializationError] is set otherwise
+     */
+    private fun setupWebView(): Boolean =
+        setup("setupWebView") {
+            // TODO: duplicated logging
+            setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
+
+            return@setup checkWebViewAvailable()
+        }
+
+    private fun setupAnkiBackend() {
+        setup("setupAnkiBackend") {
+            LanguageUtil.setDefaultBackendLanguages()
+        }
+    }
+
+    /**
+     * Manually initializes the collection directory and `.nomedia` if
+     * [Permissions.hasLegacyStorageAccessPermission] is set
+     *
+     * On failure, sets [fatalInitializationError] to [storageError][FatalInitializationError.StorageError]
+     *
+     * In most cases the Anki Backend now creates the collection and [initializeAnkiDroidDirectory]
+     *  is called on startup of the activity.
+     */
+    context(_: AnkiContext)
+    private fun initializeAnkiDroidDirectory() {
+        setup("initializeAnkiDroidDirectory") {
+            // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
+            // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
+            //  is not considered to be a fatal error, unless the directory itself is not writable.
+            val ankiDroidDir =
+                try {
+                    CollectionHelper.getCurrentAnkiDroidDirectory(this)
+                } catch (e: SystemStorageException) {
+                    fatalInitializationError = FatalInitializationError.StorageError(e)
+                    return@setup
                 }
 
-                if (debugTraceSqlCalls) {
-                    Os.setenv("TRACESQL", "1", false)
+            // TODO: This line is questionable, as it doesn't work on most post-scoped-storage
+            //  builds/Android versions, but we call initializeAnkiDroidDirectory later on startup
+            if (!Permissions.hasLegacyStorageAccessPermission(this)) return@setup
+
+            try {
+                CollectionHelper.initializeAnkiDroidDirectory(ankiDroidDir)
+                return@setup
+            } catch (e: StorageAccessException) {
+                Timber.e(e, "Could not initialize AnkiDroid directory")
+                try {
+                    val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
+                    if (isSdCardMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
+                        // Don't send report if the user is using a custom directory as SD cards trip up here a lot
+                        sendExceptionReport(e, "AnkiDroidApp.onCreate")
+                    }
+                } catch (e: SystemStorageException) {
+                    // The user can't write to the AnkiDroid directory (=> cant write to the collection)
+                    // AND getExternalFilesDir is null - file permissions are likely corrupted (Android 16 bug)
+                    // => show the 'fatal storage error' screen
+                    fatalInitializationError = FatalInitializationError.StorageError(e)
                 }
             }
+        }
+    }
+
+    /** listen for day rollover: time + timezone changes */
+    context(_: AnkiContext)
+    private fun setupDayRollover() {
+        setup("setupDayRollover") {
+            DayRolloverHandler.listenForRolloverEvents(this)
         }
     }
 
@@ -417,51 +457,11 @@ open class AnkiDroidApp :
         }
     }
 
-    /**
-     * Manually initializes the collection directory and `.nomedia` if
-     * [Permissions.hasLegacyStorageAccessPermission] is set
-     *
-     * On failure, sets [fatalInitializationError] to [storageError][FatalInitializationError.StorageError]
-     *
-     * In most cases the Anki Backend now creates the collection and [initializeAnkiDroidDirectory]
-     *  is called on startup of the activity.
-     */
-    context(_: AnkiContext)
-    private fun initializeAnkiDroidDirectory() {
-        setup("initializeAnkiDroidDirectory") {
-            // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
-            // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
-            //  is not considered to be a fatal error, unless the directory itself is not writable.
-            val ankiDroidDir =
-                try {
-                    CollectionHelper.getCurrentAnkiDroidDirectory(this)
-                } catch (e: SystemStorageException) {
-                    fatalInitializationError = FatalInitializationError.StorageError(e)
-                    return@setup
-                }
-
-            // TODO: This line is questionable, as it doesn't work on most post-scoped-storage
-            //  builds/Android versions, but we call initializeAnkiDroidDirectory later on startup
-            if (!Permissions.hasLegacyStorageAccessPermission(this)) return@setup
-
-            try {
-                CollectionHelper.initializeAnkiDroidDirectory(ankiDroidDir)
-                return@setup
-            } catch (e: StorageAccessException) {
-                Timber.e(e, "Could not initialize AnkiDroid directory")
-                try {
-                    val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
-                    if (isSdCardMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
-                        // Don't send report if the user is using a custom directory as SD cards trip up here a lot
-                        sendExceptionReport(e, "AnkiDroidApp.onCreate")
-                    }
-                } catch (e: SystemStorageException) {
-                    // The user can't write to the AnkiDroid directory (=> cant write to the collection)
-                    // AND getExternalFilesDir is null - file permissions are likely corrupted (Android 16 bug)
-                    // => show the 'fatal storage error' screen
-                    fatalInitializationError = FatalInitializationError.StorageError(e)
-                }
-            }
+    private fun setupTextToSpeech() {
+        setup("setupTextToSpeech") {
+            TtsVoices.launchBuildLocalesJob()
+            // enable {{tts-voices:}} field filter
+            TtsVoicesFieldFilter.ensureApplied()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -149,9 +149,6 @@ open class AnkiDroidApp :
         }
         instance = this
 
-        // Get preferences
-        val preferences = this.sharedPrefs()
-
         // Ensures any change is propagated to widgets
         ChangeManager.subscribe(this)
 
@@ -196,17 +193,7 @@ open class AnkiDroidApp :
 
         setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
 
-        CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
-            this,
-            preferences.getBoolean(
-                getString(R.string.card_browser_external_context_menu_key),
-                false,
-            ),
-        )
-        AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(
-            this,
-            preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true),
-        )
+        setup("setupContextMenus") { setupContextMenus() }
         setupNotificationChannels(applicationContext)
 
         makeBackendUsable(this)
@@ -288,6 +275,33 @@ open class AnkiDroidApp :
         TtsVoices.launchBuildLocalesJob()
         // enable {{tts-voices:}} field filter
         TtsVoicesFieldFilter.ensureApplied()
+    }
+
+    /**
+     * Sets up display of the context menus which appear when long pressing text on external apps,
+     * allowing it to be shared to this app.
+     *
+     * Example: 'Anki Card'
+     *
+     * @see Intent.ACTION_PROCESS_TEXT
+     */
+    private fun setupContextMenus() {
+        val preferences = this.sharedPrefs()
+
+        // setup 'Card Browser'
+        CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
+            this,
+            preferences.getBoolean(
+                getString(R.string.card_browser_external_context_menu_key),
+                false,
+            ),
+        )
+
+        // Setup 'Anki Card'
+        AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(
+            this,
+            preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true),
+        )
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -128,43 +128,43 @@ open class AnkiDroidApp :
      */
     @KotlinCleanup("analytics can be moved to attachBaseContext()")
     override fun onCreate() {
-        runCatching { setup("initAnkiBackend") { initAnkiBackend(debugTraceSqlCalls = false) } }
+        initAnkiBackend(debugTraceSqlCalls = false)
         super.onCreate()
-        if (!setup("setupAnkiDroidApp") { setupAnkiDroidApp() }) {
+        if (!setupAnkiDroidApp()) {
             return // instance.resources is invalid
         }
         val acra = CrashReportingContext.apply { initializeAcraCrashReporter() }
-        setup("setupLogging") { with(acra) { setupLogging() } }
-        setup("setupUsageAnalytics") { with(acra) { setupUsageAnalytics() } }
+        with(acra) { setupLogging() }
+        with(acra) { setupUsageAnalytics() }
 
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
 
-        setup("performStartupLogging") { with(acra) { performStartupLogging() } }
+        with(acra) { performStartupLogging() }
 
         // Stop after analytics and logging are initialised.
         if (isAcraSenderProcess()) {
             Timber.d("Skipping AnkiDroidApp.onCreate from ACRA sender process")
             return
         }
-        setup("setupContextMenus") { setupContextMenus() }
+        setupContextMenus()
         setup("makeBackendUsable") { makeBackendUsable(this) }
-        setup("setupNotifications") { setupNotifications() }
-        setup("setupAppLifecycleObserver") { setupAppLifecycleObserver() }
-        setup("setupBackendChangeManager") { setupBackendChangeManager() }
+        setupNotifications()
+        setupAppLifecycleObserver()
+        setupBackendChangeManager()
         // Probe WebView availability before any other init touches it (#5794).
-        if (!setup("setupWebView") { setupWebView() }) {
+        if (!setupWebView()) {
             return
         }
         // Forget the last deck that was used in the CardBrowser
         CardBrowser.clearLastDeckId()
-        val anki = AnkiContext.apply { setup("setupBackend") { setupAnkiBackend() } }
-        setup("initializeAnkiDroidDirectory") { with(anki) { initializeAnkiDroidDirectory() } }
-        setup("setupDayRollover") { with(anki) { setupDayRollover() } }
+        val anki = AnkiContext.apply { setupAnkiBackend() }
+        with(anki) { initializeAnkiDroidDirectory() }
+        with(anki) { setupDayRollover() }
         restoreRecurringAlarms(this)
-        setup("setupLifecycleLogging") { setupLifecycleLogging() }
+        setupLifecycleLogging()
         activityAgnosticDialogs = ActivityAgnosticDialogs.register(this)
-        setup("setupTextToSpeech") { setupTextToSpeech() }
+        setupTextToSpeech()
     }
 
     /**
@@ -175,39 +175,45 @@ open class AnkiDroidApp :
      * @return false if `instance.resources` is unusable
      */
     private fun setupAnkiDroidApp(): Boolean {
-        if (isInitialized) {
-            Timber.i("onCreate() called multiple times")
-            // 5887 - fix crash.
-            if (instance.resources == null) {
-                Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?")
-                return false
+        return setup("setupAnkiDroidApp") {
+            if (isInitialized) {
+                Timber.i("onCreate() called multiple times")
+                // 5887 - fix crash.
+                if (instance.resources == null) {
+                    Timber.w("Skipping re-initialisation - no resources. Maybe uninstalling app?")
+                    return@setup false
+                }
             }
+            instance = this
+            true
         }
-        instance = this
-        return true
     }
 
     private fun setupAppLifecycleObserver() {
-        val appLifecycleObserver = AppLifecycleObserver(applicationContext)
+        setup("setupAppLifecycleObserver") {
+            val appLifecycleObserver = AppLifecycleObserver(applicationContext)
 
-        ProcessLifecycleOwner
-            .get()
-            .lifecycle
-            .addObserver(appLifecycleObserver)
+            ProcessLifecycleOwner
+                .get()
+                .lifecycle
+                .addObserver(appLifecycleObserver)
+        }
     }
 
     context(_: CrashReportingContext)
     private fun performStartupLogging() {
-        applicationScope.launch {
-            Timber.i("AnkiDroidApp: listing debug info")
-            Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
-        }
+        setup("performStartupLogging") {
+            applicationScope.launch {
+                Timber.i("AnkiDroidApp: listing debug info")
+                Timber.i(DebugInfoService.getDebugInfo(this@AnkiDroidApp))
+            }
 
-        // skip logging if we're under ACRA
-        if (CrashReportService.isProperServiceProcess()) return
+            // skip logging if we're under ACRA
+            if (CrashReportService.isProperServiceProcess()) return@setup
 
-        if (AdaptionUtil.isUserATestClient) {
-            showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
+            if (AdaptionUtil.isUserATestClient) {
+                showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
+            }
         }
     }
 
@@ -220,75 +226,90 @@ open class AnkiDroidApp :
      * @see ChangeManager
      */
     private fun setupBackendChangeManager() {
-        ChangeManager.subscribe(this)
+        setup("setupBackendChangeManager") {
+            ChangeManager.subscribe(this)
+        }
     }
 
     private fun setupTextToSpeech() {
-        TtsVoices.launchBuildLocalesJob()
-        // enable {{tts-voices:}} field filter
-        TtsVoicesFieldFilter.ensureApplied()
+        setup("setupTextToSpeech") {
+            TtsVoices.launchBuildLocalesJob()
+            // enable {{tts-voices:}} field filter
+            TtsVoicesFieldFilter.ensureApplied()
+        }
     }
 
     /** listen for day rollover: time + timezone changes */
     context(_: AnkiContext)
     private fun setupDayRollover() {
-        DayRolloverHandler.listenForRolloverEvents(this)
+        setup("setupDayRollover") {
+            DayRolloverHandler.listenForRolloverEvents(this)
+        }
     }
 
     private fun setupAnkiBackend() {
-        LanguageUtil.setDefaultBackendLanguages()
+        setup("setupAnkiBackend") {
+            LanguageUtil.setDefaultBackendLanguages()
+        }
     }
 
     /**
      * @return whether [WebView] is usable
      * [fatalInitializationError] is set otherwise
      */
-    private fun setupWebView(): Boolean {
-        // TODO: duplicated logging
-        setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
+    private fun setupWebView(): Boolean =
+        setup("setupWebView") {
+            // TODO: duplicated logging
+            setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
 
-        return checkWebViewAvailable()
+        return@setup checkWebViewAvailable()
     }
 
     // crash reporting should be initialized before logging
     context(_: CrashReportingContext)
     private fun setupLogging() {
-        val logType = LogType.value
-        when (logType) {
-            LogType.DEBUG -> Timber.plant(DebugTree())
-            LogType.ROBOLECTRIC -> Timber.plant(RobolectricDebugTree())
-            LogType.PRODUCTION -> Timber.plant(ProductionCrashReportingTree())
+        setup("setupLogging") {
+            val logType = LogType.value
+            when (logType) {
+                LogType.DEBUG -> Timber.plant(DebugTree())
+                LogType.ROBOLECTRIC -> Timber.plant(RobolectricDebugTree())
+                LogType.PRODUCTION -> Timber.plant(ProductionCrashReportingTree())
+            }
+            if (BuildConfig.ENABLE_LEAK_CANARY) {
+                LeakCanaryConfiguration.setInitialConfigFor(this)
+            } else {
+                LeakCanaryConfiguration.disable()
+            }
+            Timber.tag(TAG)
+            Timber.d("Startup - Application Start")
+            Timber.i("Timber config: $logType")
         }
-        if (BuildConfig.ENABLE_LEAK_CANARY) {
-            LeakCanaryConfiguration.setInitialConfigFor(this)
-        } else {
-            LeakCanaryConfiguration.disable()
-        }
-        Timber.tag(TAG)
-        Timber.d("Startup - Application Start")
-        Timber.i("Timber config: $logType")
     }
 
     // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
     context(_: CrashReportingContext)
     private fun setupUsageAnalytics() {
-        UsageAnalytics.initialize(this)
-        if (BuildConfig.DEBUG) {
-            UsageAnalytics.setDryRun(true)
+        setup("setupUsageAnalytics") {
+            UsageAnalytics.initialize(this)
+            if (BuildConfig.DEBUG) {
+                UsageAnalytics.setDryRun(true)
+            }
         }
     }
 
     private fun setupNotifications() {
-        setupNotificationChannels(applicationContext)
+        setup("setupNotifications") {
+            setupNotificationChannels(applicationContext)
 
-        val context = this.withAppLocale()
-        if (Prefs.newReviewRemindersEnabled) {
-            Timber.i("Setting review reminder notifications if they have not already been set")
-            AlarmManagerService.scheduleAllNotifications(context)
-        } else {
-            // Register for notifications
-            Timber.i("AnkiDroidApp: Starting Services")
-            notifications.observeForever { NotificationService.triggerNotificationFor(context) }
+            val context = this.withAppLocale()
+            if (Prefs.newReviewRemindersEnabled) {
+                Timber.i("Setting review reminder notifications if they have not already been set")
+                AlarmManagerService.scheduleAllNotifications(context)
+            } else {
+                // Register for notifications
+                Timber.i("AnkiDroidApp: Starting Services")
+                notifications.observeForever { NotificationService.triggerNotificationFor(context) }
+            }
         }
     }
 
@@ -301,22 +322,24 @@ open class AnkiDroidApp :
      * @see Intent.ACTION_PROCESS_TEXT
      */
     private fun setupContextMenus() {
-        val preferences = this.sharedPrefs()
+        setup("setupContextMenus") {
+            val preferences = this.sharedPrefs()
 
-        // setup 'Card Browser'
-        CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
-            this,
-            preferences.getBoolean(
-                getString(R.string.card_browser_external_context_menu_key),
-                false,
-            ),
-        )
+            // setup 'Card Browser'
+            CardBrowserContextMenu.ensureConsistentStateWithPreferenceStatus(
+                this,
+                preferences.getBoolean(
+                    getString(R.string.card_browser_external_context_menu_key),
+                    false,
+                ),
+            )
 
-        // Setup 'Anki Card'
-        AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(
-            this,
-            preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true),
-        )
+            // Setup 'Anki Card'
+            AnkiCardContextMenu.ensureConsistentStateWithPreferenceStatus(
+                this,
+                preferences.getBoolean(getString(R.string.anki_card_external_context_menu_key), true),
+            )
+        }
     }
 
     /**
@@ -327,65 +350,71 @@ open class AnkiDroidApp :
     private fun initAnkiBackend(
         @Suppress("SameParameterValue") debugTraceSqlCalls: Boolean = false,
     ) {
-        // Note: This method runs before logs are enabled.
-        Os.setenv("PLATFORM", syncPlatform(), false)
-        // enable debug logging of sync actions
-        if (BuildConfig.DEBUG) {
-            Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
-        }
+        runCatching {
+            setup("initAnkiBackend") {
+                // Note: This method runs before logs are enabled.
+                Os.setenv("PLATFORM", syncPlatform(), false)
+                // enable debug logging of sync actions
+                if (BuildConfig.DEBUG) {
+                    Os.setenv("RUST_LOG", "info,anki::sync=debug,anki::media=debug,fsrs=error", false)
+                }
 
-        if (debugTraceSqlCalls) {
-            Os.setenv("TRACESQL", "1", false)
+                if (debugTraceSqlCalls) {
+                    Os.setenv("TRACESQL", "1", false)
+                }
+            }
         }
     }
 
     private fun setupLifecycleLogging() {
-        registerActivityLifecycleCallbacks(
-            object : ActivityLifecycleCallbacks {
-                override fun onActivityCreated(
-                    activity: Activity,
-                    savedInstanceState: Bundle?,
-                ) {
-                    Timber.i(
-                        "${activity::class.simpleName}::onCreate, savedInstanceState: %s",
-                        savedInstanceState?.let { "${it.keySet().size} keys" },
-                    )
-                    (activity as? FragmentActivity)
-                        ?.supportFragmentManager
-                        ?.registerFragmentLifecycleCallbacks(
-                            FragmentLifecycleLogger(activity),
-                            true,
+        setup("setupLifecycleLogging") {
+            registerActivityLifecycleCallbacks(
+                object : ActivityLifecycleCallbacks {
+                    override fun onActivityCreated(
+                        activity: Activity,
+                        savedInstanceState: Bundle?,
+                    ) {
+                        Timber.i(
+                            "${activity::class.simpleName}::onCreate, savedInstanceState: %s",
+                            savedInstanceState?.let { "${it.keySet().size} keys" },
                         )
-                }
+                        (activity as? FragmentActivity)
+                            ?.supportFragmentManager
+                            ?.registerFragmentLifecycleCallbacks(
+                                FragmentLifecycleLogger(activity),
+                                true,
+                            )
+                    }
 
-                override fun onActivityStarted(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onStart")
-                }
+                    override fun onActivityStarted(activity: Activity) {
+                        Timber.i("${activity::class.simpleName}::onStart")
+                    }
 
-                override fun onActivityResumed(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onResume")
-                }
+                    override fun onActivityResumed(activity: Activity) {
+                        Timber.i("${activity::class.simpleName}::onResume")
+                    }
 
-                override fun onActivityPaused(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onPause")
-                }
+                    override fun onActivityPaused(activity: Activity) {
+                        Timber.i("${activity::class.simpleName}::onPause")
+                    }
 
-                override fun onActivityStopped(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onStop")
-                }
+                    override fun onActivityStopped(activity: Activity) {
+                        Timber.i("${activity::class.simpleName}::onStop")
+                    }
 
-                override fun onActivitySaveInstanceState(
-                    activity: Activity,
-                    outState: Bundle,
-                ) {
-                    Timber.i("${activity::class.simpleName}::onSaveInstanceState")
-                }
+                    override fun onActivitySaveInstanceState(
+                        activity: Activity,
+                        outState: Bundle,
+                    ) {
+                        Timber.i("${activity::class.simpleName}::onSaveInstanceState")
+                    }
 
-                override fun onActivityDestroyed(activity: Activity) {
-                    Timber.i("${activity::class.simpleName}::onDestroy")
-                }
-            },
-        )
+                    override fun onActivityDestroyed(activity: Activity) {
+                        Timber.i("${activity::class.simpleName}::onDestroy")
+                    }
+                },
+            )
+        }
     }
 
     /**
@@ -399,37 +428,39 @@ open class AnkiDroidApp :
      */
     context(_: AnkiContext)
     private fun initializeAnkiDroidDirectory() {
-        // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
-        // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
-        //  is not considered to be a fatal error, unless the directory itself is not writable.
-        val ankiDroidDir =
-            try {
-                CollectionHelper.getCurrentAnkiDroidDirectory(this)
-            } catch (e: SystemStorageException) {
-                fatalInitializationError = FatalInitializationError.StorageError(e)
-                return
-            }
-
-        // TODO: This line is questionable, as it doesn't work on most post-scoped-storage
-        //  builds/Android versions, but we call initializeAnkiDroidDirectory later on startup
-        if (!Permissions.hasLegacyStorageAccessPermission(this)) return
-
-        try {
-            CollectionHelper.initializeAnkiDroidDirectory(ankiDroidDir)
-            return
-        } catch (e: StorageAccessException) {
-            Timber.e(e, "Could not initialize AnkiDroid directory")
-            try {
-                val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
-                if (isSdCardMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
-                    // Don't send report if the user is using a custom directory as SD cards trip up here a lot
-                    sendExceptionReport(e, "AnkiDroidApp.onCreate")
+        setup("initializeAnkiDroidDirectory") {
+            // #13207: `getCurrentAnkiDroidDirectory` failing is an unconditional be a fatal error
+            // TODO: For now, a null getExternalFilesDir, but a valid AnkiDroid Directory in prefs
+            //  is not considered to be a fatal error, unless the directory itself is not writable.
+            val ankiDroidDir =
+                try {
+                    CollectionHelper.getCurrentAnkiDroidDirectory(this)
+                } catch (e: SystemStorageException) {
+                    fatalInitializationError = FatalInitializationError.StorageError(e)
+                    return@setup
                 }
-            } catch (e: SystemStorageException) {
-                // The user can't write to the AnkiDroid directory (=> cant write to the collection)
-                // AND getExternalFilesDir is null - file permissions are likely corrupted (Android 16 bug)
-                // => show the 'fatal storage error' screen
-                fatalInitializationError = FatalInitializationError.StorageError(e)
+
+            // TODO: This line is questionable, as it doesn't work on most post-scoped-storage
+            //  builds/Android versions, but we call initializeAnkiDroidDirectory later on startup
+            if (!Permissions.hasLegacyStorageAccessPermission(this)) return@setup
+
+            try {
+                CollectionHelper.initializeAnkiDroidDirectory(ankiDroidDir)
+                return@setup
+            } catch (e: StorageAccessException) {
+                Timber.e(e, "Could not initialize AnkiDroid directory")
+                try {
+                    val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
+                    if (isSdCardMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
+                        // Don't send report if the user is using a custom directory as SD cards trip up here a lot
+                        sendExceptionReport(e, "AnkiDroidApp.onCreate")
+                    }
+                } catch (e: SystemStorageException) {
+                    // The user can't write to the AnkiDroid directory (=> cant write to the collection)
+                    // AND getExternalFilesDir is null - file permissions are likely corrupted (Android 16 bug)
+                    // => show the 'fatal storage error' screen
+                    fatalInitializationError = FatalInitializationError.StorageError(e)
+                }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -29,6 +29,7 @@ import android.os.Bundle
 import android.os.Environment
 import android.system.Os
 import android.webkit.CookieManager
+import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import androidx.core.net.toUri
 import androidx.fragment.app.FragmentActivity
@@ -177,17 +178,14 @@ open class AnkiDroidApp :
             showThemedToast(this.applicationContext, getString(R.string.user_is_a_robot), false)
         }
 
-        setup("setupWebView") { setupWebView() }
         setup("setupContextMenus") { setupContextMenus() }
         setup("makeBackendUsable") { makeBackendUsable(this) }
         setup("setupNotifications") { setupNotifications() }
         setup("setupBackendChangeManager") { setupBackendChangeManager() }
-
         // Probe WebView availability before any other init touches it (#5794).
-        if (!checkWebViewAvailable()) {
+        if ((setup("setupWebView") { setupWebView() }) != true) {
             return
         }
-
         // Forget the last deck that was used in the CardBrowser
         CardBrowser.clearLastDeckId()
         val anki = AnkiContext.apply { setup("setupBackend") { setupAnkiBackend() } }
@@ -227,8 +225,15 @@ open class AnkiDroidApp :
         LanguageUtil.setDefaultBackendLanguages()
     }
 
-    private fun setupWebView() {
+    /**
+     * @return whether [WebView] is usable
+     * [fatalInitializationError] is set otherwise
+     */
+    private fun setupWebView(): Boolean {
+        // TODO: duplicated logging
         setWebContentsDebuggingEnabled(Prefs.isWebDebugEnabled)
+
+        return checkWebViewAvailable()
     }
 
     // crash reporting should be initialized before logging


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6 - one commit:
> ```kotlin
> setup("setupX") { setupX() } // move the setup() call inside setupX
> ```


## Purpose / Description
I wanted a common method which would handle startup:

* So we could have one place where fatal and nonfatal initlilization errors occurred
* So we did not need to worry about methods throwing and hard-crashing on startup
* So we could profile startup times and be sure they're reasonable

## Fixes

* Part of #20168

## Approach

* introduce `setup`, which performs the logging & timing of methods
* Define dependencies using an object: `AnkiContext` or `CrashReportingContext`, and require their use via context providers

```kotlin
    context(_: AnkiContext)
    private fun initializeAnkiDroidDirectory() {}

    val anki = AnkiContext.apply { setupAnkiBackend() }
    with(anki) { initializeAnkiDroidDirectory() }
```

* Extract each setup operation into a method
* Combine and reorder methods where they make sense

## How Has This Been Tested?

```
executed setupLogging in 11.416833ms
executed setupUsageAnalytics in 94.884708ms
executed performStartupLogging in 3.251458ms
executed setupContextMenus in 1.153625ms
executed makeBackendUsable in 143us
executed setupNotifications in 5.957541ms
executed setupAppLifecycleObserver in 579.041us
executed setupBackendChangeManager in 10.660333ms
executed setupWebView in 992.291us
executed setupBackend in 774.709us
executed initializeAnkiDroidDirectory in 1.840709ms
executed setupDayRollover in 1.921333ms
executed setupLifecycleLogging in 181.791us
executed setupTextToSpeech in 2.633416ms
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)