### PR TITLE
Fix color picker dialog crash on lower Android versions

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/ColorPickerDialog.kt
@@ -17,8 +17,12 @@
 package com.ichi2.anki.ui.windows.reviewer.whiteboard
 
 import android.content.Context
+import android.os.Build
 import android.view.Choreographer
+import android.widget.FrameLayout
 import androidx.annotation.ColorInt
+import androidx.core.view.updateLayoutParams
+import androidx.core.view.updatePadding
 import com.ichi2.anki.R
 import com.ichi2.utils.Dp
 import com.ichi2.utils.dp
@@ -59,7 +63,24 @@ fun Context.showColorPickerDialog(
             // default position, resulting in an incorrect displayed color.
             colorPickerView.post { colorPickerView.setInitialColor(initialColor) }
             // Bubble showing the selected color
-            colorPickerView.flagView = BubbleFlag(this@showColorPickerDialog)
+            val bubbleFlag = BubbleFlag(this@showColorPickerDialog)
+            colorPickerView.flagView = bubbleFlag
+            // TODO on these lower Android versions the view clipping fails and we end up with a
+            //  square(standard view shape) instead of the expected circle so we update the
+            //  positioning values so the square sis smaller and is centered in the background pin
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.R) {
+                bubbleFlag
+                    .findViewById<FrameLayout>(R.id.flag_color_layout_wrapper)
+                    .updatePadding(
+                        10.dp.toPx(this@showColorPickerDialog),
+                        7.dp.toPx(this@showColorPickerDialog),
+                        10.dp.toPx(this@showColorPickerDialog),
+                    )
+                bubbleFlag.alphaTileView.updateLayoutParams {
+                    this.width = 12.dp.toPx(this@showColorPickerDialog)
+                    this.height = 12.dp.toPx(this@showColorPickerDialog)
+                }
+            }
             setTitle(R.string.choose_color)
             setPositiveButton(R.string.dialog_ok, onPositiveCallback)
             negativeButton(R.string.dialog_cancel)

--- a/AnkiDroid/src/main/res/drawable/color_picker_circle_indicator.xml
+++ b/AnkiDroid/src/main/res/drawable/color_picker_circle_indicator.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <!-- color doesn't really matter -->
+    <solid android:color="@color/material_blue_500" />
+</shape>

--- a/AnkiDroid/src/main/res/layout/colorpicker_flag_bubble.xml
+++ b/AnkiDroid/src/main/res/layout/colorpicker_flag_bubble.xml
@@ -15,17 +15,18 @@
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/flag_color_layout_wrapper"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:paddingHorizontal="8dp"
     android:paddingTop="5dp"
     android:paddingBottom="11dp"
     android:background="@drawable/pin_shape">
-
+    <!-- TODO we already have a circle_background.xml but that one is used in widget theming? -->
     <com.skydoves.colorpickerview.AlphaTileView
         android:id="@+id/flag_color_layout"
         android:layout_width="16dp"
         android:layout_height="16dp"
-        android:background="@drawable/circle_background"
+        android:background="@drawable/color_picker_circle_indicator"
         android:clipToOutline="true" />
 </FrameLayout>


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

The dialog was using a drawable for the color indicator from the color picker dialog that was only defined for Android 31 and above. The fix looked simple, just declare a new circle drawable(the old drawable could be moved to the drawable folder but it is used by widgets and I didn't want to potentially introduce other issues there/test it). However, when testing on older Android versions the clipping to a circle didn't worked and it looked ugly. So I introduced extra code to fix this by updating the size/positioning on the indicator view. See images below:

How it looked on older Android versions without positioning update/with positioning update:

<img width="400" height="800" alt="Screenshot_20260326_130842" src="https://github.com/user-attachments/assets/90bf563d-29b5-4035-914f-b8b33794e191" /><img width="400" height="800" alt="Screenshot_20260326_125332" src="https://github.com/user-attachments/assets/1305d318-f4d2-472e-afab-747254e0b133" />

How it looks with the old and new code on newer Android versions:

<img width="400" height="900" alt="Screenshot_20260326_125516" src="https://github.com/user-attachments/assets/2b6bf386-c269-4dbc-abbf-23a1691048c5" />


## Fixes
* Fixes #20577

## How Has This Been Tested?

Used the dialog.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
