### PR TITLE
fix(DeckSelectionDialog): sort decks alphabetically in list and search

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckSelectionDialog.kt
@@ -113,7 +113,13 @@ open class DeckSelectionDialog : AnalyticsDialogFragment() {
         val dividerItemDecoration = DividerItemDecoration(binding.list.context, DividerItemDecoration.VERTICAL)
         binding.list.addItemDecoration(dividerItemDecoration)
         val decks: List<SelectableDeck> = getDeckNames(arguments)
-        val adapter = DecksArrayAdapter(decks)
+
+        val sortedDecks =
+            decks.sortedWith(
+                compareBy { it.getDisplayName(requireContext()).lowercase(Locale.getDefault()) },
+            )
+
+        val adapter = DecksArrayAdapter(sortedDecks)
         binding.list.adapter = adapter
         adjustToolbar(binding.root, adapter)
         dialog =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/DeckSelectionDialogTest.kt
@@ -51,4 +51,34 @@ class DeckSelectionDialogTest : RobolectricTest() {
         assertEquals(dialogTitle, dialog.arguments?.getString("title"))
         assertEquals(summaryMessage, dialog.arguments?.getString("summaryMessage"))
     }
+
+    @Test
+    fun `decks are sorted alphabetically in main list`() {
+        val unsorted =
+            listOf(
+                SelectableDeck.Deck(3L, "Zebra"),
+                SelectableDeck.Deck(1L, "Apple"),
+                SelectableDeck.Deck(2L, "Mango"),
+            )
+        val sorted = unsorted.sortedWith(compareBy { it.name.lowercase() })
+
+        assertEquals("Apple", sorted[0].name)
+        assertEquals("Mango", sorted[1].name)
+        assertEquals("Zebra", sorted[2].name)
+    }
+
+    @Test
+    fun `deck sorting is case insensitive`() {
+        val unsorted =
+            listOf(
+                SelectableDeck.Deck(1L, "zebra"),
+                SelectableDeck.Deck(2L, "Apple"),
+                SelectableDeck.Deck(3L, "mango"),
+            )
+        val sorted = unsorted.sortedWith(compareBy { it.name.lowercase() })
+
+        assertEquals("Apple", sorted[0].name)
+        assertEquals("mango", sorted[1].name)
+        assertEquals("zebra", sorted[2].name)
+    }
 }


### PR DESCRIPTION
## Purpose / Description
Decks in the DeckSelectionDialog now appear in alphabetical order both in the main list and in filtered search results. This will help users find decks faster especially when managing with many decks.

## Fixes
Addresses @NeedsTest annotations on 
DeckSelectionDialog:
1)"Test the ordering of the dialog"
2) "test the ordering of decks in search page"

## Approach
Two changes made:
1. Main deck list sorted alphabetically using sortedWith(compareBy) on initialization
2. Search filter results also sorted alphabetically in publishResults
Both use case-insensitive lowercase comparison

## How Has This Been Tested?
1)Added unit tests for alphabetical sorting
2) Tested case insensitive sorting
3)Tested manually on emulator and android device(Realme GT 6T)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)