### PR TITLE
Fix(Whiteboard): Fixed onSizeChanged and implemented testcase

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardView.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.PorterDuff
@@ -46,6 +47,7 @@ class WhiteboardView : View {
     var isStylusOnlyMode: Boolean = false
 
     private val currentPath = Path()
+    private val currentMatrix = Matrix()
     private val currentPaint =
         Paint().apply {
             isAntiAlias = true
@@ -89,6 +91,10 @@ class WhiteboardView : View {
     ) {
         super.onSizeChanged(w, h, oldw, oldh)
         if (::bufferBitmap.isInitialized) bufferBitmap.recycle()
+        currentMatrix.setScale(w.toFloat() / oldw, h.toFloat() / oldh)
+        history.forEach {
+            it.path.transform(currentMatrix)
+        }
         bufferBitmap = createBitmap(w, h)
         bufferCanvas = Canvas(bufferBitmap)
         redrawHistory()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 LUwUcifer <luwucifwer@proton.me>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.ui.windows.reviewer.whiteboard
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.Path
+import android.graphics.RectF
+import android.view.View.MeasureSpec
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class WhiteboardViewTest {
+    private lateinit var context: Context
+    private lateinit var view: WhiteboardView
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        view = WhiteboardView(context)
+    }
+
+    private fun sizeView(
+        width: Int,
+        height: Int,
+    ) {
+        view.measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+        )
+        view.layout(0, 0, width, height)
+    }
+
+    /**
+     * Creates a view of 1080x1920
+     * Creates a Path in the shape of a rectangle along the boundaries of the view
+     * Rotates the view to 1920x1080
+     * If Path Matrix isn't transformed, the bottom or right edges will go out of bounds, failing the test
+     */
+    @Test
+    fun `full-rect path bounds do not exceed screen bounds after resize`() {
+        val initialWidth = 1080
+        val initialHeight = 1920
+
+        sizeView(initialWidth, initialHeight)
+
+        val path =
+            Path().apply {
+                addRect(0f, 0f, initialWidth.toFloat(), initialHeight.toFloat(), Path.Direction.CW)
+            }
+        view.setHistory(
+            listOf(DrawingAction(path, Color.BLACK, 4f, isEraser = false)),
+        )
+
+        val newWidth = 1920
+        val newHeight = 1080
+
+        sizeView(newWidth, newHeight)
+
+        val bounds = RectF()
+        path.computeBounds(bounds, true)
+
+        assertTrue("right bound must not exceed new width ($newWidth)", bounds.right <= newWidth.toFloat())
+        assertTrue("bottom bound must not exceed new height ($newHeight)", bounds.bottom <= newHeight.toFloat())
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Issue as described in #20616 

## Fixes
* Fixes #20616 

## Approach
Utilises matrix transform to correct the bitmap
https://developer.android.com/reference/android/graphics/Path#transform(android.graphics.Matrix)

## How Has This Been Tested?

Tested on local device as well as emulator, testcase fails for old implementation

## Learning (optional, can help others)
Requesting a thorough review of the test file as it has been implemented through a vague understanding of implementation from other repositories
AI Disclaimer: Github Copilot in github was used to search for other repositories testcases for research

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->