### PR TITLE
Improve custom server sync dialogs

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextPreference.kt
@@ -15,15 +15,20 @@
 package com.ichi2.preferences
 
 import android.content.Context
-import android.content.DialogInterface
 import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.View
 import android.widget.EditText
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.widget.AppCompatEditText
+import androidx.core.content.res.use
 import androidx.core.widget.addTextChangedListener
 import androidx.preference.EditTextPreference
 import androidx.preference.EditTextPreferenceDialogFragmentCompat
+import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.R
+import com.ichi2.anki.databinding.DialogVersatileTextPreferenceBinding
+import com.ichi2.utils.positiveButton
 import kotlin.jvm.Throws
 
 /**
@@ -35,7 +40,7 @@ import kotlin.jvm.Throws
  *
  *   * If [continuousValidator] is set, the dialog uses it to prevent user
  *     from entering invalid data. On each text change, the validator is run;
- *     if it throws, the Ok button gets disabled.
+ *     if it throws, the positive button gets disabled.
  */
 open class VersatileTextPreference(
     context: Context,
@@ -46,6 +51,12 @@ open class VersatileTextPreference(
         @Throws(Exception::class)
         fun validate(value: String)
     }
+
+    // Floating label shown on the dialog text field
+    val dialogHint: CharSequence? =
+        context.obtainStyledAttributes(attrs, R.styleable.CustomPreference).use {
+            it.getText(R.styleable.CustomPreference_dialogHint)
+        }
 
     val referenceEditText = AppCompatEditText(context, attrs)
 
@@ -59,30 +70,48 @@ open class VersatileTextPreferenceDialogFragment : EditTextPreferenceDialogFragm
 
     protected lateinit var editText: EditText
 
+    override fun onCreateDialogView(context: Context): View =
+        DialogVersatileTextPreferenceBinding.inflate(LayoutInflater.from(context)).root
+
     // This changes input type first, as it resets the cursor,
     // And only then calls super, which sets up text and moves the cursor to end.
     //
     // Positive button isn't present in a dialog until it is shown, which happens around onStart;
     // for simplicity, obtain it in the listener itself.
     override fun onBindDialogView(contentView: View) {
-        editText = contentView.findViewById(android.R.id.edit)!!
+        val binding = DialogVersatileTextPreferenceBinding.bind(contentView)
+
+        editText = binding.textInputLayout.editText!!
         editText.inputType = versatileTextPreference.referenceEditText.inputType
 
         super.onBindDialogView(contentView)
 
-        versatileTextPreference.continuousValidator?.let { validator ->
-            editText.addTextChangedListener(afterTextChanged = {
-                val alertDialog = dialog as AlertDialog
-                val positiveButton = alertDialog.getButton(DialogInterface.BUTTON_POSITIVE)
+        binding.textInputLayout.hint =
+            versatileTextPreference.dialogHint ?: preference.dialogTitle ?: preference.title
 
-                positiveButton?.isEnabled =
-                    try {
-                        validator.validate(editText.text.toString())
-                        true
-                    } catch (e: Exception) {
-                        false
-                    }
-            })
+        versatileTextPreference.continuousValidator?.let {
+            editText.addTextChangedListener(afterTextChanged = { updatePositiveButtonState() })
         }
+    }
+
+    override fun onStart() {
+        super.onStart()
+
+        (dialog as? AlertDialog)?.positiveButton?.text = TR.actionsSave()
+
+        updatePositiveButtonState()
+    }
+
+    private fun updatePositiveButtonState() {
+        val validator = versatileTextPreference.continuousValidator ?: return
+        val positiveButton = (dialog as? AlertDialog)?.positiveButton ?: return
+
+        positiveButton.isEnabled =
+            try {
+                validator.validate(editText.text.toString())
+                true
+            } catch (_: Exception) {
+                false
+            }
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/VersatileTextWithASwitchPreference.kt
@@ -35,8 +35,8 @@ import com.ichi2.anki.R
  *   * If text is present, tapping on the switch toggles it.
  *   * If text is empty, tapping on the switch will open the dialog, as if the title was tapped.
  *   * If the dialog is closed with Cancel, no changes happen.
- *   * If the dialog is closed with Ok, and text is present, the switch will be set to on.
- *   * If the dialog is closed with Ok, and text is empty, the switch will be set to off.
+ *   * If the dialog is closed with the positive button, and text is present, the switch will be set to on.
+ *   * If the dialog is closed with the positive button, and text is empty, the switch will be set to off.
  *
  * The preference inherits from [VersatileTextPreference] and supports any attributes it does,
  * including the regular [EditTextPreference] attributes.
@@ -86,7 +86,7 @@ class VersatileTextWithASwitchPreference(
 
 class VersatileTextWithASwitchPreferenceDialogFragment : VersatileTextPreferenceDialogFragment() {
     // This replicates what the overridden method does, which is needed as we want to catch
-    // the event when the Ok button was pressed and the change listener approved the new value.
+    // the event when the positive button was pressed and the change listener approved the new value.
     override fun onDialogClosed(positiveResult: Boolean) {
         if (positiveResult) {
             val preference = preference as VersatileTextWithASwitchPreference

--- a/AnkiDroid/src/main/res/layout/dialog_versatile_text_preference.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_versatile_text_preference.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingBottom="8dp"
+    android:paddingHorizontal="24dp"
+    android:paddingTop="16dp">
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/text_input_layout"
+        style="@style/TextInputSelectionColorFixStyle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@android:id/edit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="56dp"
+            android:padding="12dp" />
+
+    </com.google.android.material.textfield.TextInputLayout>
+</FrameLayout>

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -284,6 +284,9 @@
     <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled" maxLength="28">Capitalize sentences</string>
     <string name="menu_scroll_toolbar" comment="Checkbox stating whether note editor toolbar is scrollable or stacked. Checked: Scroll" maxLength="28">Scroll toolbar</string>
 
+    <!-- Dialog hints -->
+    <string name="dialog_hint_url">URL</string>
+    <string name="dialog_hint_certificate">Certificate</string>
 
     <!-- IncrementNumberRangePreference -->
     <string name="plus_sign" comment="Label for increment button in IncrementerNumberRangePreference">+</string>

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -207,7 +207,7 @@
         If not set, the default AnkiWeb server will be used instead.
         <a href="%s">Learn more</a>
         ]]></string>
-    <string name="custom_sync_server_base_url_title" maxLength="41">Sync url</string>
+    <string name="custom_sync_server_base_url_title" maxLength="41">Sync URL</string>
     <string name="custom_sync_certificate_title" maxLength="41">Custom root certificate (PEM)</string>
     <!-- Key Bindings -->
     <string name="keyboard">Keyboard</string>

--- a/AnkiDroid/src/main/res/values/attrs.xml
+++ b/AnkiDroid/src/main/res/values/attrs.xml
@@ -36,6 +36,8 @@
              The placeholder is replaced by the preference value, and it must be only one placeholder.
              If the preference value is updated, the summary is automatically updated as well. -->
         <attr name="summaryFormat" format="string"/>
+        <!-- Floating label displayed on the dialog text field border. -->
+        <attr name="dialogHint" format="string|reference"/>
     </declare-styleable>
 
     <declare-styleable name="NumberRangePreference">

--- a/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_custom_sync_server.xml
@@ -16,9 +16,11 @@
         android:key="@string/custom_sync_server_collection_url_key"
         android:title="@string/custom_sync_server_base_url_title"
         android:inputType="textUri"
+        app:dialogHint="@string/dialog_hint_url"
         app:useSimpleSummaryProvider="true" />
     <com.ichi2.preferences.VersatileTextPreference
         android:key="@string/custom_sync_certificate_key"
         android:title="@string/custom_sync_certificate_title"
-        android:inputType="textMultiLine" />
+        android:inputType="textMultiLine"
+        app:dialogHint="@string/dialog_hint_certificate" />
 </PreferenceScreen>


### PR DESCRIPTION
## Purpose / Description
In this PR, I updated the "Sync URL" and "Custom root certificate"~~, and "AnkiDroid directory"~~ [[scope update 1](https://github.com/ankidroid/Anki-Android/pull/20619#issuecomment-4190976919)] dialogs to:

- Style them consistently ~~most notably, make their titles the same size~~ [[scope update 2](https://github.com/ankidroid/Anki-Android/pull/20619#discussion_r3046827280)].
- Add a dialog hint: i.e. a floating label on the input border.
- Rename the positive button from "OK" to "Save".

Additionally, I capitalized "url" in "Sync URL".

<img width="3056" height="2260" alt="custom-stylings-removed" src="https://github.com/user-attachments/assets/507b94a4-e796-4e84-bf2f-9810ec9324e9" />

## Fixes
* Fixes #20487.

## Approach

To enforce consistency across dialogs, I identified the shared classes: "Sync URL" and "Custom root certificate" use `VersatileTextPreference`/`VersatileTextPreferenceDialogFragment`~~; I updated "AnkiDroid directory" to use it too~~.

Then, I wired a `dialogHint` attribute, and I made shared layout display the hint and have a "Save" button. The dialog styling update follows the same approach as the already-merged #20520.

## How Has This Been Tested?

I did some manual tests across the two dialogs on my physical device:

- Checked hint, title size, and "Save" button.
- Tried valid and invalid inputs.

I ran the following commands:
```
./gradlew jacocoUnitTestReport                      
./gradlew lintRelease ktlintCheck
```

## Learning

Lessons learned:
- Understanding the preference/dialog class hierarchy helped identify the right shared implementation point.
- Reviewing sibling PRs under the same parent issue helped confirm the preferred dialog pattern to use.
- Favor view binding over `findViewById` ([ref](https://github.com/ankidroid/Anki-Android/pull/20619#discussion_r3041898026)) and use extensions ([ref](https://github.com/ankidroid/Anki-Android/pull/20619#discussion_r3041903850)) when possible.
- Favor default styles over custom ([ref](https://github.com/ankidroid/Anki-Android/pull/20619#discussion_r3046827280)), unless there's a strong reason not to.

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)