### PR TITLE
fix: replace dialog_ok with dialog_move in field reposition dialog (#…

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteTypeFieldEditor.kt
@@ -379,7 +379,7 @@ class NoteTypeFieldEditor : AnkiActivity(R.layout.activity_note_type_field_edito
             AlertDialog
                 .Builder(this)
                 .show {
-                    positiveButton(R.string.dialog_ok) {
+                    positiveButton(R.string.dialog_move) {
                         val input = (it as AlertDialog).getInputField()
                         result(input.text.toString().toInt())
                     }

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -62,6 +62,7 @@
 
     <string name="dialog_cancel">Cancel</string>
     <string name="dialog_ok">OK</string>
+    <string name="dialog_move">Move</string>
     <string name="dialog_add" comment="Positive dialog action button label to add 'something'">Add</string>
     <string name="restore">Restore</string>
     <string name="dialog_confirm" tools:ignore="UnusedResources">Confirm</string>


### PR DESCRIPTION
## Purpose / Description
In the field reposition dialog (`NoteTypeFieldEditor`), the positive 
button was using the generic `dialog_ok` ("OK") string. As per 
Material Design guidelines, buttons should use action-specific labels.
Added a new `dialog_move` string and replaced `dialog_ok` with it.

## Fixes
* Fixes #20508

## Approach
- Added `<string name="dialog_move">Move</string>` in `03-dialogs.xml`
- Replaced `R.string.dialog_ok` with `R.string.dialog_move` in 
  `NoteTypeFieldEditor.kt` inside `repositionFieldDialog()`

## How Has This Been Tested?
- Manually tested on physical device Android 14
- Steps: Manage note types → Basic → Front field → Reposition
- Before: Button showed "OK"
- After: Button shows "Move"

## Checklist
- [x] You have a descriptive commit message with a short title
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens

## Before/After
<img width="556" height="550" alt="Screenshot 2026-03-29 at 2 30 16 PM" src="https://github.com/user-attachments/assets/216b2a88-2138-4764-846d-a98f5c4dff3b" />
