### PR TITLE
use a local maven repo when local_backend is set

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -13,6 +13,7 @@ plugins {
 }
 
 repositories {
+    maven { url = uri("${rootDir}/../Anki-Android-Backend/build/localMaven") }
     google()
     mavenCentral()
     maven { url = "https://jitpack.io" }
@@ -417,7 +418,7 @@ dependencies {
         localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
     }
     if (localProperties['local_backend'] == "true") {
-        implementation(files(rootProject.file("../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")))
+        implementation("io.github.david-allison:rsdroid:1.0.0")
         testImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
     } else {
         implementation libs.ankiBackend.backend

--- a/libanki/build.gradle.kts
+++ b/libanki/build.gradle.kts
@@ -49,7 +49,7 @@ dependencies {
         localProperties.load(project.rootProject.file("local.properties").inputStream())
     }
     if (localProperties["local_backend"] == "true") {
-        implementation(files(rootProject.file("../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")))
+        implementation("io.github.david-allison:rsdroid:1.0.0")
         testImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
     } else {
         implementation(libs.ankiBackend.backend)

--- a/libanki/testutils/build.gradle.kts
+++ b/libanki/testutils/build.gradle.kts
@@ -65,8 +65,9 @@ dependencies {
         localProperties.load(project.rootProject.file("local.properties").inputStream())
     }
     if (localProperties["local_backend"] == "true") {
-        implementation(files(rootProject.file("../Anki-Android-Backend/rsdroid/build/outputs/aar/rsdroid-release.aar")))
-        testImplementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
+        implementation("io.github.david-allison:rsdroid:1.0.0")
+        implementation(files(rootProject.file("../Anki-Android-Backend/rsdroid-testing/build/libs/rsdroid-testing.jar")))
+        implementation(libs.protobuf.kotlin.lite)
     } else {
         implementation(libs.ankiBackend.backend)
         implementation(libs.ankiBackend.testing)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     //  which uses a local maven repository
     // repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        maven { url = uri("${rootDir}/../Anki-Android-Backend/build/localMaven") }
         google()
         mavenCentral()
         maven(url = "https://jitpack.io")


### PR DESCRIPTION
## Purpose / Description
it seems that directly referencing .aar files is no longer allowed.

anki android backend half: https://github.com/ankidroid/Anki-Android-Backend/pull/673

## Fixes
fixes https://github.com/ankidroid/Anki-Android-Backend/issues/671

## Approach
uses a local maven repo instead of referencing the .aar file directly

## How Has This Been Tested?
set `local_backend=true` in `local.properties` then `./gradlew assembleDebug`

## Learning (optional, can help others)
I have no idea what I am doing, but david did request that I put together some sort of pr when I got the whole thing working. Its entirely possible my approach to this whole thing is incorrect.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
