### PR TITLE
Fix hollow stripe in fullscreen mode with answer buttons at top (#14201)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -74,6 +74,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.net.toFile
 import androidx.core.net.toUri
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.children
@@ -1028,6 +1029,16 @@ abstract class AbstractFlashcardViewer :
         whiteboardContainer.layoutParams = whiteboardContainerParams
         cardFrame!!.layoutParams = flashcardContainerParams
         touchLayer!!.layoutParams = touchLayerContainerParams
+
+        // Fix for issue #14201: Apply inset handling for hollow stripe bug
+        // Only override padding when answer buttons are at top AND fullscreen mode is active
+        val answerOptionsLayout = findViewById<FrameLayout>(R.id.answer_options_layout)
+        ViewCompat.setOnApplyWindowInsetsListener(answerOptionsLayout) { view, insets ->
+            if (answerButtonsPosition == "top" && fullscreenMode.isFullScreenReview()) {
+                view.setPadding(0, 0, 0, 0)
+            }
+            insets
+        }
     }
 
     protected open fun createWebView(): WebView {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
A hollow stripe appears above the card content when "Fullscreen > Hide the system bars" and "Answer button position > Top" are both enabled.

## Fixes
* Fixes #14201 

## Approach
Initially, removing the `android:fitsSystemWindows="true"` attribute seemed like a simple fix. However, a maintainer noted that this broad approach would affect all button positions unnecessarily and could cause unintended side effects.

So, I implemented a targeted Kotlin solution using `WindowInsetsCompat`. The listener conditionally clears padding **only** when both specific conditions are met:
1. Answer buttons are positioned at the top
2. Fullscreen mode is active

This approach preserves the attribute's intended behavior for other button positions ("bottom", "none") and normal mode, while fixing the specific fullscreen + top-position issue. It's a more maintainable and safer solution than globally disabling `fitsSystemWindows`.

## How Has This Been Tested?
I Tested on emulator (API 33) and physical Android device (API 35):

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

