### PR TITLE
fix(api): joinTags now correctly replaces spaces with underscores

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -45,10 +45,7 @@ internal object Utils {
         if (tags.isNullOrEmpty()) {
             return ""
         }
-        for (t in tags) {
-            t!!.replace(" ".toRegex(), "_")
-        }
-        return tags.joinToString(" ")
+        return tags.joinToString(" ") { it!!.replace(" ", "_") }
     }
 
     fun splitTags(tags: String): Array<String> = tags.trim().split("\\s+".toRegex()).toTypedArray()

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 /**
  * Created by rodrigobresan on 19/10/17.
@@ -57,6 +58,28 @@ internal class ApiUtilsTest {
     }
 
     @Test
+    fun joinTagsShouldReplaceSpacesWithUnderscores() {
+        assertEquals("multi_word", Utils.joinTags(setOf("multi word")))
+    }
+
+    @Test
+    fun joinTagsShouldReplaceSpacesInAllTags() {
+        // Tags containing spaces must have spaces replaced by underscores because
+        // Anki uses spaces as the tag separator in the joined string.
+        val result = Utils.joinTags(setOf("hello world", "foo bar"))
+        val resultTags = result.split(" ")
+        assertEquals(2, resultTags.size)
+        assert(resultTags.all { "_" in it || " " !in it }) {
+            "Tags with spaces were not underscore-escaped: $result"
+        }
+    }
+
+    @Test
+    fun joinTagsShouldReturnSingleTagWithoutTrailingSpace() {
+        assertEquals("only_one", Utils.joinTags(setOf("only one")))
+    }
+
+    @Test
     fun splitTagsShouldReturnNullWhenStringIsValid() {
         val tags = "A B C"
         val output = Utils.splitTags(tags)
@@ -68,6 +91,61 @@ internal class ApiUtilsTest {
     @Test
     fun shouldGenerateProperCheckSum() {
         assertEquals(3533307532L, Utils.fieldChecksum("AnkiDroid"))
+    }
+
+    @Test
+    fun fieldChecksumShouldHandleEmptyString() {
+        // Should not throw and should be deterministic
+        val checksum = Utils.fieldChecksum("")
+        assertTrue(checksum >= 0, "Checksum of empty string should be non-negative")
+        assertEquals(checksum, Utils.fieldChecksum(""), "Checksum should be deterministic")
+    }
+
+    @Test
+    fun fieldChecksumShouldStripHtmlTags() {
+        // Checksum is computed on stripped text, so "<b>AnkiDroid</b>" strips to "AnkiDroid"
+        assertEquals(Utils.fieldChecksum("AnkiDroid"), Utils.fieldChecksum("<b>AnkiDroid</b>"))
+    }
+
+    @Test
+    fun fieldChecksumShouldDecodeHtmlEntities() {
+        // "&amp;" decodes to "&", so checksum of "&amp;amp" strips to "&amp" after entity decode
+        // The key property: two strings that differ only in HTML encoding must produce the same checksum
+        assertEquals(Utils.fieldChecksum("A&B"), Utils.fieldChecksum("A&amp;B"))
+    }
+
+    @Test
+    fun splitTagsShouldHandleMultipleConsecutiveSpaces() {
+        val tags = "A  B   C"
+        val output = Utils.splitTags(tags)
+        assertEquals(3, output.size)
+        assertEquals("A", output[0])
+        assertEquals("B", output[1])
+        assertEquals("C", output[2])
+    }
+
+    @Test
+    fun splitTagsShouldTrimLeadingAndTrailingWhitespace() {
+        val tags = "  A B C  "
+        val output = Utils.splitTags(tags)
+        assertEquals(3, output.size)
+        assertEquals("A", output[0])
+    }
+
+    @Test
+    fun splitFieldsShouldHandleSingleField() {
+        val output = Utils.splitFields("OnlyField")
+        assertEquals(1, output.size)
+        assertEquals("OnlyField", output[0])
+    }
+
+    @Test
+    fun splitFieldsShouldPreserveEmptyFieldBetweenDelimiters() {
+        val output = Utils.splitFields("A" + DELIMITER + "" + DELIMITER + "C")
+        // dropLastWhile removes trailing empty strings but not middle ones
+        assertEquals("A", output[0])
+        assertEquals("", output[1])
+        assertEquals("C", output[2])
     }
 
     companion object {


### PR DESCRIPTION
## Purpose / Description

`Utils.joinTags()` in the API module is supposed to replace spaces within individual tags with underscores before joining them with a space separator. This is necessary because Anki uses spaces as tag separators — a tag like `"multi word"` would otherwise be interpreted as two separate tags.

The bug: `String.replace()` was called but its return value was discarded. Kotlin strings are immutable, so the original string is unchanged and the loop was a no-op.

```kotlin
// Before (buggy)
for (t in tags) {
    t!!.replace(" ".toRegex(), "_")  // result discarded
}
return tags.joinToString(" ")

// After
return tags.joinToString(" ") { it!!.replace(" ", "_") }
```

## Fixes

* Fixes #20628

## Approach

- Fix `joinTags` to use the result of `replace()` via a `joinToString` transform lambda
- Remove the unnecessary `.toRegex()` call since the pattern is a literal string
- Expand `ApiUtilsTest` from 8 to 18 tests, adding coverage for:
  - `joinTags` space-to-underscore replacement (regression test for this bug)
  - `fieldChecksum` with empty string, HTML content, and HTML entities
  - `splitTags` with consecutive spaces and leading/trailing whitespace
  - `splitFields` with single field and empty field between delimiters

## How Has This Been Tested?

- All 18 unit tests in `:api:testDebugUnitTest` pass
- Regression test `joinTagsShouldReplaceSpacesWithUnderscores` would have caught this bug

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code