### PR TITLE
chore(api): add copyright headers and fix BasicModel inconsistencies

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Basic2Model.kt
@@ -1,4 +1,18 @@
-//noinspection MissingCopyrightHeader #8659
+/*
+ * Copyright (c) 2022 Sanjaykumar Sargam <sargamsanjaykumar@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.ichi2.anki.api
 
 /**
@@ -20,15 +34,15 @@ internal object Basic2Model {
     internal val AFMT =
         arrayOf(
             """{{FrontSide}}
-    
+
     |<hr id="answer">
-    
+
     |{{Back}}
             """.trimMargin(),
             """{{FrontSide}}
-    
+
     |<hr id="answer">
-    
+
     |{{Front}}
             """.trimMargin(),
         )

--- a/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
+++ b/api/src/main/java/com/ichi2/anki/api/BasicModel.kt
@@ -1,32 +1,44 @@
-//noinspection MissingCopyrightHeader #8659
+/*
+ * Copyright (c) 2022 Sanjaykumar Sargam <sargamsanjaykumar@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.ichi2.anki.api
 
 /**
  * Definitions of the basic model
  */
-internal class BasicModel {
-    companion object {
-        @JvmField // required for API
-        @Suppress("ktlint:standard:property-naming")
-        var FIELDS = arrayOf("Front", "Back")
+internal object BasicModel {
+    @JvmField // required for API
+    @Suppress("ktlint:standard:property-naming")
+    val FIELDS = arrayOf("Front", "Back")
 
-        // List of card names that will be used in AnkiDroid (one for each direction of learning)
-        @JvmField // required for API
-        val CARD_NAMES = arrayOf("Card 1")
+    // List of card names that will be used in AnkiDroid (one for each direction of learning)
+    @JvmField // required for API
+    val CARD_NAMES = arrayOf("Card 1")
 
-        // Template for the question of each card
-        @JvmField // required for API
-        val QFMT = arrayOf("{{Front}}")
+    // Template for the question of each card
+    @JvmField // required for API
+    val QFMT = arrayOf("{{Front}}")
 
-        @JvmField // required for API
-        val AFMT =
-            arrayOf(
-                """{{FrontSide}}
-        
+    @JvmField // required for API
+    val AFMT =
+        arrayOf(
+            """{{FrontSide}}
+
         |<hr id="answer">
-        
+
         |{{Back}}
-                """.trimMargin(),
-            )
-    }
+            """.trimMargin(),
+        )
 }

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -1,5 +1,18 @@
-//noinspection MissingCopyrightHeader #8659
-
+/*
+ * Copyright (c) 2017 Rodrigo Bresan <rcbresan@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 package com.ichi2.anki.api
 
 import org.junit.Test


### PR DESCRIPTION
## Purpose / Description

Three small cleanup items in the `api/` module:

1. **Copyright headers** (tracked in #8659): `BasicModel.kt`, `Basic2Model.kt`, and `ApiUtilsTest.kt` had `//noinspection MissingCopyrightHeader #8659` suppressions. This adds the LGPL header to all three.

2. **`BasicModel` converted from `class` to `object`**: `Basic2Model` is already an `object`. `BasicModel` was a `class` with a `companion object`, but it has no instance state and is used identically. Converted for consistency.

3. **`BasicModel.FIELDS` changed from `var` to `val`**: The field was declared as `var`, allowing external code to reassign `BasicModel.FIELDS = ...`. `Basic2Model.FIELDS` is already `val`. Changed to match.

## Fixes

* Addresses #8659 (copyright headers for `BasicModel.kt`, `Basic2Model.kt`, `ApiUtilsTest.kt`)

## How Has This Been Tested?

- All `:api:test` unit tests pass

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code