### PR TITLE
Improve instant note saving error dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantNoteEditorActivity.kt
@@ -510,10 +510,12 @@ class InstantNoteEditorActivity :
     private fun savingErrorDialog(message: String) {
         AlertDialog.Builder(this).show {
             message(text = message)
-            positiveButton(R.string.dialog_cancel) {
+            positiveButton(R.string.try_again) {
+                checkAndSave()
+            }
+            negativeButton(R.string.dialog_cancel) {
                 instantAlertDialog.dismiss()
             }
-            negativeButton(R.string.try_again)
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

Previously, the "Try Again" button was on the left, and the "Cancel" button was on the right. As well, clicking "Try Again" did not actually automatically reattempt to save the card.

## Fixes
* Fixes #20638

## Approach
This change swaps the order of the buttons and also triggers another save after clicking "Try Again"

## How Has This Been Tested?

1. Add some code to trigger the savingErrorDialog each time there is an attempt to save an instant note

I added the following code:
```
// a flag
private var forceSaveFailureDialogForUiTest = true

// under handleSaveNoteResult()
if (forceSaveFailureDialogForUiTest) {
        // toggle the flag to false so you can test Try Again's new behaviour
        forceSaveFailureDialogForUiTest = false
        savingErrorDialog("Forced failure dialog for UI testing")
        return
    }
```

2. Attempt to save an Instant Note
3. Observe that 'Try Again' is on the right side, and 'Cancel' is on the left side.
4. Observe that clicking "Try Again" tries saving the card again immediately, rather than exiting out of the dialog back to the "Add" [dialog.]

https://github.com/user-attachments/assets/030d3bf8-5282-4df9-8b3a-ba1c167e3994

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->