### PR TITLE
Promote find replace dialog to production

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -416,6 +416,8 @@ class CardBrowserFragment :
                     Timber.d("onCreateMenu()")
                     menuInflater.inflate(R.menu.card_browser, menu)
                     menu.findItem(R.id.action_search_by_flag).subMenu?.setupFlags()
+                    // note: this menu item is available with and without a selection of items
+                    menu.findItem(R.id.action_find_replace)?.title = TR.sentenceCase.findAndReplace
 
                     if (!useSearchView) {
                         searchItem = menu.findItem(R.id.action_search)
@@ -562,6 +564,10 @@ class CardBrowserFragment :
                             showFilteredDeckScreen()
                             return true
                         }
+                        R.id.action_find_replace -> {
+                            showFindAndReplaceDialog()
+                            return true
+                        }
                     }
 
                     return false
@@ -594,11 +600,8 @@ class CardBrowserFragment :
                     menu.findItem(R.id.action_reschedule_cards).title = TR.sentenceCase.setDueDate
                     menu.findItem(R.id.action_grade_now).title = TR.sentenceCase.gradeNow
 
-                    val isFindReplaceEnabled = sharedPrefs().getBoolean(getString(R.string.pref_browser_find_replace), false)
-                    menu.findItem(R.id.action_find_replace).apply {
-                        isVisible = isFindReplaceEnabled
-                        title = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
-                    }
+                    // note: this menu item is available with and without a selection of items
+                    menu.findItem(R.id.action_find_replace)?.title = TR.sentenceCase.findAndReplace
 
                     menu.findItem(R.id.action_undo).setupUndo()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/FindAndReplaceDialogFragment.kt
@@ -99,6 +99,8 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
             }
     }
 
+    // TODO maybe get rid of the html tags that come with the backend strings and handle the
+    //  sentence case for TR.browsingReplaceWith()
     private fun setupLabels() {
         binding.labelFind.text =
             HtmlCompat.fromHtml(TR.browsingFind(), HtmlCompat.FROM_HTML_MODE_LEGACY)
@@ -218,7 +220,10 @@ class FindAndReplaceDialogFragment : AnalyticsDialogFragment() {
         ): FindAndReplaceDialogFragment {
             val file = IdsFile(context.cacheDir, noteIds, "find-replace")
             return FindAndReplaceDialogFragment().apply {
-                arguments = bundleOf(ARG_IDS to file)
+                arguments =
+                    Bundle().apply {
+                        putParcelable(ARG_IDS, file)
+                    }
             }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/servicelayer/PreferenceUpgradeService.kt
@@ -137,6 +137,7 @@ object PreferenceUpgradeService {
                     yield(UpgradeToggleBacksideOnlyControl())
                     yield(UpgradeThemes())
                     yield(UpgradeAnswerControls())
+                    yield(RemoveDeveloperFindReplace())
                 }
 
             /** Returns a list of preference upgrade classes which have not been applied */
@@ -897,6 +898,14 @@ object PreferenceUpgradeService {
                 }
                 preferences.edit {
                     putString("binding_SHOW_ANSWER", showAnswerBindings.toPreferenceString())
+                }
+            }
+        }
+
+        internal class RemoveDeveloperFindReplace : PreferenceUpgrade(28) {
+            override fun upgrade(preferences: SharedPreferences) {
+                preferences.edit {
+                    remove("browserFindReplace")
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -127,6 +127,9 @@ object SentenceCase {
 
     context(_: Fragment)
     val toggleSuspend get() = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
+
+    context(_: Fragment)
+    val findAndReplace get() = TR.browsingFindAndReplace().toSentenceCase(R.string.sentence_find_and_replace)
 }
 
 /**

--- a/AnkiDroid/src/main/res/layout/fragment_find_replace.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_find_replace.xml
@@ -22,14 +22,29 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="16dp">
+
+        <TextView
+            android:id="@+id/label_warning"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:drawableStart="@drawable/ic_warning"
+            android:drawablePadding="4dp"
+            android:layout_marginHorizontal="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            android:text="@string/warning_find_and_replace"
+            android:textStyle="italic"
+            />
+
         <TextView
             android:id="@+id/label_find"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/label_warning"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             android:layout_marginHorizontal="8dp"
+            android:layout_marginTop="8dp"
             tools:text="Find:"/>
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/input_search_layout"

--- a/AnkiDroid/src/main/res/menu/card_browser.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser.xml
@@ -76,6 +76,7 @@
 
     <item
         android:id="@+id/action_find_replace"
-        android:visible="false"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        tools:title="Find and replace"
+        />
 </menu>

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -86,8 +86,9 @@
 
     <item
         android:id="@+id/action_find_replace"
-        android:visible="false"
-        app:showAsAction="never"/>
+        app:showAsAction="never"
+        tools:title="Find and replace"
+        />
 
     <!-- Delete should be last, if undo is not visible -->
     <item

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -192,6 +192,7 @@
     <string name="tag_editor_add_feedback">Touch “%2$s” to confirm adding “%1$s”</string>
     <string name="tag_editor_add_feedback_existing">Existing tag “%1$s” selected</string>
     <string name="tag_already_exists">Tag already exists</string>
+    <string name="warning_find_and_replace">Consider backing up your collection from DeckPicker before using this option!</string>
     <!-- Time spans -->
 
     <!-- Currently only used if exporting APKG fails -->

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -230,7 +230,6 @@
     <string name="pref_corrupt_fsrs_params">debug_corrupt_fsrs_params</string>
     <string name="new_congrats_screen_pref_key">new_congrats_screen</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
-    <string name="pref_browser_find_replace">browserFindReplace</string>
     <string name="pref_new_review_reminders">newReviewReminders</string>
     <string name="developer_options_enabled_by_user_key">devOptionsEnabledByUser</string>
     <string name="pref_cat_wip_key">workInProgressDevOptions</string>

--- a/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_developer_options.xml
@@ -112,11 +112,6 @@
             android:key="@string/dev_card_browser_search_view"
             android:defaultValue="false"/>
         <SwitchPreferenceCompat
-            android:title="Find and replace in browser"
-            android:summary="Caution, this can be very destructive for your collection!"
-            android:key="@string/pref_browser_find_replace"
-            android:defaultValue="false"/>
-        <SwitchPreferenceCompat
             android:title="Enable new notifications"
             android:key="@string/pref_new_review_reminders"
             android:defaultValue="false"/>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1594,7 +1594,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_select_all to true,
                     R.id.action_open_options to true,
                     R.id.action_create_filtered_deck to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                 )
 
             assertMenusEqual(expectedMenuItems, menu)
@@ -1626,7 +1626,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_select_all to true,
                     R.id.action_open_options to true,
                     R.id.action_create_filtered_deck to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                 )
 
             assertMenusEqual(expectedMenuItems, menu)
@@ -1657,7 +1657,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to true,
                     R.id.action_preview_many to true,
                     R.id.action_export_selected to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                     R.id.action_delete_card to true,
                     R.id.action_undo to true,
                 )
@@ -1695,7 +1695,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to false,
                     R.id.action_preview_many to true,
                     R.id.action_export_selected to false,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                     R.id.action_delete_card to false,
                     R.id.action_undo to true,
                 )
@@ -1729,7 +1729,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_select_all to true,
                     R.id.action_open_options to true,
                     R.id.action_create_filtered_deck to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                     // Note Editor
                     R.id.action_save to true,
                     R.id.action_preview to true,
@@ -1770,7 +1770,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to true,
                     R.id.action_preview_many to false,
                     R.id.action_export_selected to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                     R.id.action_delete_card to true,
                     R.id.action_undo to true,
                     // Note Editor
@@ -1832,7 +1832,7 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_select_all to false,
                     R.id.action_open_options to true,
                     R.id.action_create_filtered_deck to true,
-                    R.id.action_find_replace to false,
+                    R.id.action_find_replace to true,
                 )
 
             assertMenusEqual(expectedMenuItems, menu)


### PR DESCRIPTION
## Purpose / Description

This was discussed and I think we should do it.

From the linked issue:

- left a TODO for the ui improvements
-  the ViewModel can and will come at a later point

Later edit: wondering if we should add to the dialog a warning about the (potential) destructive effects of using the dialog.

## Fixes
* Fixes #19929

## How Has This Been Tested?

The dialog appears without having to enable the dev setting.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
