### PR TITLE
fix(api): correct joinTags space replacement

### DIFF
--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -45,10 +45,7 @@ internal object Utils {
         if (tags.isNullOrEmpty()) {
             return ""
         }
-        for (t in tags) {
-            t!!.replace(" ".toRegex(), "_")
-        }
-        return tags.joinToString(" ")
+        return tags.joinToString(" ") { it!!.replace(" ", "_") }
     }
 
     fun splitTags(tags: String): Array<String> = tags.trim().split("\\s+".toRegex()).toTypedArray()

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -57,6 +57,12 @@ internal class ApiUtilsTest {
     }
 
     @Test
+    fun joinTagsShouldReplaceSpacesWithUnderscores() {
+        val tags = linkedSetOf("hello world", "foo bar")
+        assertEquals("hello_world foo_bar", Utils.joinTags(tags))
+    }
+
+    @Test
     fun splitTagsShouldReturnNullWhenStringIsValid() {
         val tags = "A B C"
         val output = Utils.splitTags(tags)


### PR DESCRIPTION
## Purpose / Description

Fix `Utils.joinTags()` so spaces inside a tag are replaced with underscores
before joining.

## Fixes
* Fixes #20628

## Approach

Use the result of `replace()` when joining tags, and add a regression test
for tags containing spaces.

## How Has This Been Tested?

- Added a regression test for tags containing spaces
- `:api:testDebugUnitTest`

## Learning (optional, can help others)

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner