### PR TITLE
Add 'Create backup' menu option to DeckPicker

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/BackendBackups.kt
@@ -21,11 +21,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-suspend fun performBackupInBackground() {
+suspend fun performBackupInBackground(force: Boolean = false) {
     // Wait a second to allow the deck list to finish loading first, or it
     // will hang until the first stage of the backup completes.
     delay(1000)
-    createBackup(force = false)
+    createBackup(force = force)
 }
 
 fun <Activity> Activity.importColpkg(colpkgPath: String) where Activity : AnkiActivity, Activity : ImportColpkgListener {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1392,7 +1392,21 @@ open class DeckPicker :
                 ExportDialogFragment.newInstance().show(supportFragmentManager, "exportDialog")
                 return true
             }
+            R.id.action_create_backup -> {
+                Timber.i("DeckPicker::Create backup")
+                createBackup()
+                return true
+            }
             else -> return super.onOptionsItemSelected(item)
+        }
+    }
+
+    private fun createBackup() {
+        launchCatchingTask {
+            withProgress(message = TR.profilesCreatingBackup()) {
+                performBackupInBackground(true)
+            }
+            showThemedToast(this@DeckPicker, TR.profilesBackupCreated(), false)
         }
     }
 
@@ -1564,7 +1578,11 @@ open class DeckPicker :
                 return true
             }
             KeyEvent.KEYCODE_B -> {
-                if (event.isCtrlPressed) {
+                if (event.isShiftPressed && event.isCtrlPressed) {
+                    // shortcut SHIFT + CTRL + B
+                    Timber.i("Create backup from keypress")
+                    createBackup()
+                } else if (event.isCtrlPressed) {
                     // Shortcut: CTRL + B
                     Timber.i("show restore backup dialog from keypress")
                     showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_CONFIRM_RESTORE_BACKUP)

--- a/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu-xlarge/deck_picker.xml
@@ -49,6 +49,12 @@
                 android:title="@string/empty_cards"/>
         </menu>
     </item>
+    <!-- Backend string TR.qtAccelCreateBackup() has an & in it -->
+    <item
+        android:id="@+id/action_create_backup"
+        android:menuCategory="secondary"
+        android:title="@string/menu_create_backup"
+        />
     <item
         android:id="@+id/action_restore_backup"
         android:menuCategory="secondary"

--- a/AnkiDroid/src/main/res/menu/deck_picker.xml
+++ b/AnkiDroid/src/main/res/menu/deck_picker.xml
@@ -39,6 +39,12 @@
                 android:title="@string/empty_cards"/>
         </menu>
     </item>
+    <!-- Backend string TR.qtAccelCreateBackup() has an & in it -->
+    <item
+        android:id="@+id/action_create_backup"
+        android:menuCategory="secondary"
+        android:title="@string/menu_create_backup"
+        />
     <item
         android:id="@+id/action_restore_backup"
         android:menuCategory="secondary"

--- a/AnkiDroid/src/main/res/values/01-core.xml
+++ b/AnkiDroid/src/main/res/values/01-core.xml
@@ -99,6 +99,7 @@
     <string name="menu_unmark_note">Unmark note</string>
     <string name="menu_enable_voice_playback" maxLength="28">Enable voice playback</string>
     <string name="menu_disable_voice_playback">Disable voice playback</string>
+    <string name="menu_create_backup" maxLength="28">Create backup</string>
     <string name="new_deck">Create deck</string>
     <string name="new_dynamic_deck">Create filtered deck</string>
     <string name="directory_inaccessible">AnkiDroid directory is inaccessible</string>


### PR DESCRIPTION
## Purpose / Description

This allows the user to create a backup manually from the menu like desktop does. Uses the current code that we use to create backups.

<img width="338" height="394" alt="Screenshot from 2026-04-01 11-18-25" src="https://github.com/user-attachments/assets/05cc2bba-ed98-41bf-b7f2-cc249dae56d6" />


## How Has This Been Tested?

Tried to create a backup, backup was created.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
