### PR TITLE
Fix UI text for study by card state screen

### DIFF
--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -18,6 +18,8 @@
 ~ You should have received a copy of the GNU General Public License along with
 ~ this program.  If not, see <http://www.gnu.org/licenses/>.
 --><resources xmlns:tools="http://schemas.android.com/tools">
+    <string name="study_by_state_title">Study by card state or tag</string>
+    <string name="cards_unit">cards</string>
     <string name="check_db_title">Check database?</string>
     <string name="check_db_warning">This may take a long time</string>
     <string name="contextmenu_deckpicker_delete_deck" maxLength="28">Delete deck</string>
@@ -49,7 +51,7 @@
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead">Review ahead by x days:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
-    <string name="custom_study_tags">Select x cards from the deck:</string>
+    <string name="custom_study_tags">Number of cards</string>
 
     <string name="storage_full_title">Storage full</string>
     <string name="storage_almost_full_title">Storage almost full</string>


### PR DESCRIPTION
This PR partially addresses the issue by updating UI text:

- Replaced "Select x cards from the deck" with "Number of cards"
- Added title "Study by card state or tag"
- Added "cards" unit text

Further improvements like validation logic and button state handling can be implemented next.