### PR TITLE
[Multiple-Profile]feat: fetch all profiles

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -105,12 +105,21 @@ class ProfileManager private constructor(
     }
 
     /**
+     * Returns all registered profiles and their metadata.
+     *
+     * @return A map of every [ProfileId] to its corresponding
+     *   [ProfileMetadata], including the default profile.
+     * @see ProfileRegistry.getAllProfiles
+     */
+    fun getAllProfiles(): Map<ProfileId, ProfileMetadata> = profileRegistry.getAllProfiles()
+
+    /**
      * Generates a unique [ProfileId] that does not collide with existing profiles.
      *
      * @return A unique [ProfileId] not present in the [profileRegistry].
      *
      * @throws IllegalStateException if a unique ID cannot be generated after
-     * [maxAttempts] attempts.
+     * [MAX_ATTEMPTS] attempts.
      */
     private fun generateUniqueProfileId(): ProfileId {
         var newId: ProfileId
@@ -286,6 +295,36 @@ class ProfileManager private constructor(
                 Timber.w(e, "Failed to parse profile metadata for ${id.value}")
                 null
             }
+        }
+
+        /**
+         * Retrieves all registered profiles from the global SharedPreferences.
+         *
+         * Iterates over all stored entries, skipping the
+         * [KEY_LAST_ACTIVE_PROFILE_ID] metadata key, and deserializes each
+         * value into a [ProfileMetadata] instance. Entries that fail to parse
+         * are logged and silently skipped.
+         *
+         * @return A map of [ProfileId] to [ProfileMetadata] for every
+         *   successfully parsed profile in the registry.
+         */
+        fun getAllProfiles(): Map<ProfileId, ProfileMetadata> {
+            val result = mutableMapOf<ProfileId, ProfileMetadata>()
+            val allEntries = globalPrefs.all
+            for ((key, value) in allEntries) {
+                // Skip internal bookkeeping keys; only profile entries remain
+                if (key == KEY_LAST_ACTIVE_PROFILE_ID) continue
+
+                val metadata =
+                    try {
+                        ProfileMetadata.fromJson(value as String)
+                    } catch (e: Exception) {
+                        Timber.w(e, "Skipping corrupt profile entry: $key")
+                        continue
+                    }
+                result[ProfileId(key)] = metadata
+            }
+            return result
         }
 
         fun contains(id: ProfileId): Boolean = globalPrefs.contains(id.value)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -172,4 +172,32 @@ class ProfileManagerTest {
 
         assertEquals("Serialization round-trip failed!", original, reconstructed)
     }
+
+    @Test
+    fun `getAllProfiles returns all registered profiles`() {
+        val manager = ProfileManager.create(context)
+
+        val profile1 = manager.createNewProfile("Work")
+        val profile2 = manager.createNewProfile("Personal")
+
+        val allProfiles = manager.getAllProfiles()
+
+        assertEquals(3, allProfiles.size)
+        assertTrue(allProfiles.containsKey(ProfileId.DEFAULT))
+        assertTrue(allProfiles.containsKey(profile1))
+        assertTrue(allProfiles.containsKey(profile2))
+        assertEquals("Default", allProfiles[ProfileId.DEFAULT]?.displayName)
+        assertEquals("Work", allProfiles[profile1]?.displayName)
+        assertEquals("Personal", allProfiles[profile2]?.displayName)
+    }
+
+    @Test
+    fun `getAllProfiles returns only default when no profiles created`() {
+        ProfileManager.create(context)
+
+        val allProfiles = ProfileManager.create(context).getAllProfiles()
+
+        assertEquals(1, allProfiles.size)
+        assertTrue(allProfiles.containsKey(ProfileId.DEFAULT))
+    }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Creating a method to fetch all stored profile (to be used in recycler view later)

## Fixes
* Fixes part of #18117

## Approach
NA

## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->