### PR TITLE
[Multiple-Profile]feat: allow renaming profiles

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -224,6 +224,44 @@ class ProfileManager private constructor(
         return ProfileRestrictedDirectory(directoryFile)
     }
 
+    /**
+     * Renames an existing profile by updating its display name in
+     * the registry.
+     *
+     * All other metadata fields (version, creation timestamp) are
+     * preserved. The change is persisted immediately.
+     *
+     * @param profileId      The [ProfileId] of the profile to rename.
+     * @param newDisplayName  The new user-facing name.
+     *
+     * @throws IllegalArgumentException if [profileId] does not
+     *   exist in the registry.
+     */
+    fun renameProfile(
+        profileId: ProfileId,
+        newDisplayName: String,
+    ) {
+        Timber.d("ProfileManager::renameProfile called for $profileId")
+
+        require(newDisplayName.isNotBlank()) {
+            "Profile display name must not be blank"
+        }
+
+        val existing =
+            profileRegistry.getProfileMetadata(profileId)
+                ?: throw IllegalArgumentException("Profile $profileId not found")
+
+        if (existing.displayName == newDisplayName) {
+            Timber.d("Rename skipped: New name matches existing name for $profileId")
+            return
+        }
+
+        val updated = existing.copy(displayName = newDisplayName)
+        profileRegistry.saveProfile(profileId, updated)
+
+        Timber.d("Renamed profile $profileId to '$newDisplayName'")
+    }
+
     private fun triggerAppRestart() {
         Timber.w("Restarting app to apply profile switch")
         // TODO: Implement process restart logic (e.g. ProcessPhoenix)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -39,6 +39,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
@@ -199,5 +200,66 @@ class ProfileManagerTest {
 
         assertEquals(1, allProfiles.size)
         assertTrue(allProfiles.containsKey(ProfileId.DEFAULT))
+    }
+
+    fun `renameProfile updates displayName in registry`() {
+        val manager = ProfileManager.create(context)
+        val profileId = manager.createNewProfile("Original Name")
+        val newName = "Updated Name"
+
+        manager.renameProfile(profileId, newName)
+
+        val json = prefs.getString(profileId.value, null)
+        val metadata = ProfileManager.ProfileMetadata.fromJson(json!!)
+
+        assertEquals(newName, metadata.displayName)
+    }
+
+    @Test
+    fun `renameProfile preserves version and createdTimestamp`() {
+        val manager = ProfileManager.create(context)
+        val profileId = manager.createNewProfile("Original Name")
+
+        val originalJson = prefs.getString(profileId.value, null)
+        val originalMetadata = ProfileManager.ProfileMetadata.fromJson(originalJson!!)
+
+        manager.renameProfile(profileId, "New Name")
+
+        val updatedJson = prefs.getString(profileId.value, null)
+        val updatedMetadata = ProfileManager.ProfileMetadata.fromJson(updatedJson!!)
+
+        assertEquals("Version must be preserved", originalMetadata.version, updatedMetadata.version)
+        assertEquals(
+            "Timestamp must be preserved",
+            originalMetadata.createdTimestamp,
+            updatedMetadata.createdTimestamp,
+        )
+    }
+
+    @Test
+    fun `renameProfile does not write to disk if name is identical`() {
+        val manager = ProfileManager.create(context)
+        val name = "No Change"
+        val profileId = manager.createNewProfile(name)
+
+        val originalJson = prefs.getString(profileId.value, null)
+
+        manager.renameProfile(profileId, name)
+
+        val currentJson = prefs.getString(profileId.value, null)
+        assertEquals("No disk write should occur for identical names", originalJson, currentJson)
+    }
+
+    @Test
+    fun `renameProfile throws IllegalArgumentException for missing profile`() {
+        val manager = ProfileManager.create(context)
+        val fakeId = ProfileId("p_ghost")
+
+        val exception =
+            assertThrows(IllegalArgumentException::class.java) {
+                manager.renameProfile(fakeId, "New Name")
+            }
+
+        assertTrue(exception.message!!.contains("not found"))
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Allow renaming profile for that I am adding a method in Profile Manager and unit test to test this change

## Fixes
* Fixes part of #18117

## Approach
NA

## How Has This Been Tested?
Unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->