### PR TITLE
Fix: instant editor cloze bug

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/instantnoteeditor/InstantEditorViewModel.kt
@@ -214,7 +214,11 @@ class InstantEditorViewModel :
     fun setClozeFieldText(text: String?) {
         actualClozeFieldText.value = text
         intClozeList.replaceWith(getClozeOrdinals(text ?: ""))
-        currentClozeNumber.value = (intClozeList.maxOrNull() ?: 0) + 1
+        currentClozeNumber.value =
+            when (currentClozeMode.value) {
+                InstantNoteEditorActivity.ClozeMode.INCREMENT -> (intClozeList.maxOrNull() ?: 0) + 1
+                InstantNoteEditorActivity.ClozeMode.NO_INCREMENT -> intClozeList.maxOrNull() ?: 1
+            }
     }
 
     /**
@@ -391,11 +395,15 @@ class InstantEditorViewModel :
         val newMode =
             when (currentClozeMode.value) {
                 InstantNoteEditorActivity.ClozeMode.INCREMENT -> {
-                    decrementClozeNumber()
+                    if (intClozeList.isNotEmpty()) {
+                        decrementClozeNumber()
+                    }
                     InstantNoteEditorActivity.ClozeMode.NO_INCREMENT
                 }
                 InstantNoteEditorActivity.ClozeMode.NO_INCREMENT -> {
-                    incrementClozeNumber()
+                    if (intClozeList.isNotEmpty()) {
+                        incrementClozeNumber()
+                    }
                     InstantNoteEditorActivity.ClozeMode.INCREMENT
                 }
             }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/instanteditor/InstantEditorViewModelTest.kt
@@ -274,6 +274,47 @@ class InstantEditorViewModelTest : RobolectricTest() {
             assertEquals(3, currentClozeNumber.value)
         }
 
+    @Test
+    fun `setClozeFieldText does not increment in NO_INCREMENT mode`() =
+        runViewModelTest {
+            toggleClozeMode() // switch to NO_INCREMENT mode
+
+            val text = "{{c1::first}} {{c2::second}}"
+            setClozeFieldText(text)
+
+            assertEquals(2, currentClozeNumber.value)
+        }
+
+    @Test
+    fun `setClozeFieldText increments in INCREMENT mode`() =
+        runViewModelTest {
+            val text = "{{c1::first}} {{c2::second}}"
+            setClozeFieldText(text)
+
+            assertEquals(3, currentClozeNumber.value)
+        }
+
+    @Test
+    fun `toggling cloze mode with no clozes keeps cloze number at 1`() =
+        runViewModelTest {
+            assertEquals(1, currentClozeNumber.value)
+
+            toggleClozeMode() // INCREMENT -> NO_INCREMENT
+            assertEquals(1, currentClozeNumber.value)
+
+            toggleClozeMode() // NO_INCREMENT -> INCREMENT
+            assertEquals(1, currentClozeNumber.value)
+        }
+
+    @Test
+    fun `toggling cloze mode multiple times with no clozes keeps cloze number at 1`() =
+        runViewModelTest {
+            repeat(5) {
+                toggleClozeMode()
+            }
+            assertEquals(1, currentClozeNumber.value)
+        }
+
     private fun runViewModelTest(
         initViewModel: () -> InstantEditorViewModel = { InstantEditorViewModel() },
         testBody: suspend InstantEditorViewModel.() -> Unit,


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
- ~~Blocked by #20501~~

- When i was switching the increment or no increment, the no increment happens once but then again the cloze is incremented
  - `setClozeFieldText` always set `currentClozeNumber` to max + 1 regardless of the current cloze mode.
- There was bug if i tap the switch to increment button twice, and there are no clozes at all then it start with 2, i.e. -> Increment mode -> no increment mode -> increment mode, then starting cloze is 2
  - toggleClozeMode unconditionally called decrementClozeNumber() or incrementClozeNumber() when switching modes. 

## Fixes
- Fixes #16936

## Approach
Add fix and unit test to stop regression 

## How Has This Been Tested?
Pixel 10

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->