### PR TITLE
Fix controls bug: missing dialog after tab switch

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -124,6 +124,7 @@ class ControlsSettingsFragment :
         setControlPreferencesDefaultValues(screen)
         setDynamicTitle()
         setupNewStudyScreenSettings()
+        setupAnswerCommands()
     }
 
     @NeedsTest("Only the tab elements are removed")


### PR DESCRIPTION
## Purpose / Description
This PR fixes the following bug: In the controls settings, after picking a gesture/key for one of the main actions (again, hard, good, easy), a dialog is supposed to pop up. But if we first switch tabs, that dialog fails to appear.

## Fixes
- First bug in #20504.

## Approach
The dialog behavior is first set up in `initSubscreen()` by calling `setupAnswerCommands()`. But when we switch tabs, the tab content is recreated, so we have to set it up again by also calling the method in `onTabSelected()`.

After the fix, the dialog appears even after switching tabs:

https://github.com/user-attachments/assets/c51a0a12-7519-499b-a0ca-daa2734b281d

## How Has This Been Tested?
Manually, on my physical device, by trying various combinations of opening controls, setting gesture/key, switching tabs.

I also ran:
```
./gradlew jacocoUnitTestReport                      
./gradlew lintRelease ktlintCheck
```
## Learning

Lesson learned: When there are multiple valid options, look for clues in the surrounding code to decide which one fits best. For instance, [here](https://github.com/ankidroid/Anki-Android/pull/20659#issuecomment-4189207438), I dropped an optional guard to match the surrounding method calls.

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] ~~You have commented your code, particularly in hard-to-understand areas~~NA
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)