### PR TITLE
fix: SettingsFragment memory leak

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -30,6 +30,7 @@ import androidx.preference.PreferenceManager.OnPreferenceTreeClickListener
 import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.databinding.FragmentSettingsBinding
 import com.ichi2.preferences.DialogFragmentProvider
+import dev.androidbroadcast.vbpd.viewBinding
 import timber.log.Timber
 
 abstract class SettingsFragment :
@@ -42,7 +43,7 @@ abstract class SettingsFragment :
     @get:XmlRes
     abstract override val preferenceResource: Int
 
-    protected lateinit var binding: FragmentSettingsBinding
+    protected val binding by viewBinding(FragmentSettingsBinding::bind)
 
     abstract fun initSubscreen()
 
@@ -81,7 +82,6 @@ abstract class SettingsFragment :
         FragmentSettingsBinding
             .inflate(inflater, container, false)
             .apply {
-                binding = this
                 listContainer.addView(super.onCreateView(inflater, container, savedInstanceState))
             }.root
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
SettingsFragment had a lateinit var binding that was assigned in onCreateView() but never cleared when the view was destroyed.

The leak chain was:
```
HeaderFragment (alive, CREATED state)
  → binding (never cleared)
    → FragmentSettingsBinding
      → CoordinatorLayout (detached, should be GC'd — LEAKED)
```

<details>
<summary>leak trace details</summary>

```
┬───
│ GC Root: Global variable in native code
│
├─ android.window.WindowOnBackInvokedDispatcher$OnBackInvokedCallbackWrapper
│  instance
│    Leaking: NO (PreferencesActivity↓ is not leaking)
│    ↓ WindowOnBackInvokedDispatcher$OnBackInvokedCallbackWrapper.this$0
├─ android.window.WindowOnBackInvokedDispatcher instance
│    Leaking: NO (PreferencesActivity↓ is not leaking)
│    ↓ WindowOnBackInvokedDispatcher.mAllCallbacks
├─ java.util.HashMap instance
│    Leaking: NO (PreferencesActivity↓ is not leaking)
│    ↓ HashMap[key()]
├─ android.app.Activity$$ExternalSyntheticLambda0 instance
│    Leaking: NO (PreferencesActivity↓ is not leaking)
│    f$0 instance of com.ichi2.anki.preferences.PreferencesActivity with
│    mDestroyed = false
│    ↓ Activity$$ExternalSyntheticLambda0.f$0
├─ com.ichi2.anki.preferences.PreferencesActivity instance
│    Leaking: NO (HeaderFragment↓ is not leaking and Activity#mDestroyed is
│    false)
│    ankiActivity instance of com.ichi2.anki.preferences.PreferencesActivity
│    with mDestroyed = false
│    mApplication instance of com.ichi2.anki.AnkiDroidApp
│    mBase instance of androidx.appcompat.view.ContextThemeWrapper
│    ↓ ComponentActivity.onConfigurationChangedListeners
├─ java.util.concurrent.CopyOnWriteArrayList instance
│    Leaking: NO (HeaderFragment↓ is not leaking)
│    ↓ CopyOnWriteArrayList[3]
├─ androidx.fragment.app.FragmentManager$$ExternalSyntheticLambda0 instance
│    Leaking: NO (HeaderFragment↓ is not leaking)
│    ↓ FragmentManager$$ExternalSyntheticLambda0.f$0
├─ androidx.fragment.app.FragmentManagerImpl instance
│    Leaking: NO (HeaderFragment↓ is not leaking)
│    ↓ FragmentManager.mParent
├─ com.ichi2.anki.preferences.HeaderFragment instance
│    Leaking: NO (Fragment.mLifecycleRegistry.state is CREATED)
│    Fragment.mTag = com.ichi2.anki.preferences.HeaderFragment
│    ↓ SettingsFragment.binding
│                       ~~~~~~~
├─ com.ichi2.anki.databinding.FragmentSettingsBinding instance
│    Leaking: UNKNOWN
│    Retaining 73.2 kB in 1257 objects
│    ↓ FragmentSettingsBinding.rootView
│                              ~~~~~~~~
╰→ androidx.coordinatorlayout.widget.CoordinatorLayout instance
​     Leaking: YES (ObjectWatcher was watching this because com.ichi2.anki.
​     preferences.HeaderFragment received Fragment#onDestroyView() callback
​     (references to its views should be cleared to prevent leaks))
​     Retaining 5.2 kB in 105 objects
​     key = 22c09e54-affd-48ca-8ed4-bbebc6ee745c
​     watchDurationMillis = 10566
​     retainedDurationMillis = 5565
​     View not part of a window view hierarchy
​     View.mAttachInfo is null (view detached)
​     View.mWindowAttachCount = 1
​     mContext instance of com.ichi2.anki.preferences.PreferencesActivity with
​     mDestroyed = false

METADATA

Build.VERSION.SDK_INT: 36
Build.MANUFACTURER: Google
LeakCanary version: 2.14
App process name: com.ichi2.anki.debug
Class count: 38718
Instance count: 328192
Primitive array count: 208649
Object array count: 41264
Thread count: 55
Heap total bytes: 37522736
Bitmap count: 2
Bitmap total bytes: 2495806
Large bitmap count: 0
Large bitmap total bytes: 0
Db 1: open /data/user/0/com.ichi2.anki.debug/no_backup/androidx.work.workdb
Stats: LruCache[maxSize=3000,hits=169856,misses=308215,hitRate=35%]
RandomAccess[bytes=15303213,reads=308215,travel=243305203891,range=47333876,size
=57943842]
Analysis duration: 221491 ms
```
</details>


## Fixes
NA

## Approach
Use `viewBinding(FragmentSettingsBinding::bind)` it calls FragmentSettingsBinding.bind(requireView()) on first access (in onViewCreated), so it doesn't need to be assigned in onCreateView()

## How Has This Been Tested?
I didn't see leak report after dump in LeakCanary

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->