### PR TITLE
[BREAKING] deprecation/security: remove `setAcceptFileSchemeCookies`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -190,8 +190,8 @@ open class AnkiDroidApp :
 
         makeBackendUsable(this)
 
-        // Configure WebView to allow file scheme pages to access cookies.
-        if (!acceptFileSchemeCookies()) {
+        // Probe WebView availability before any other init touches it (#5794).
+        if (!checkWebViewAvailable()) {
             return
         }
 
@@ -331,18 +331,20 @@ open class AnkiDroidApp :
         notifications.postValue(null)
     }
 
-    @Suppress("deprecation") // 7109: setAcceptFileSchemeCookies
-    protected fun acceptFileSchemeCookies(): Boolean =
+    /**
+     * Checks that [android.webkit.WebView] is usable.
+     */
+    protected fun checkWebViewAvailable(): Boolean =
         try {
-            CookieManager.setAcceptFileSchemeCookies(true)
+            CookieManager.getInstance()
             true
         } catch (e: Throwable) {
             // 5794: Errors occur if the WebView fails to load
             // android.webkit.WebViewFactory.MissingWebViewPackageException.MissingWebViewPackageException
             // Error may be excessive, but I expect a UnsatisfiedLinkError to be possible here.
             fatalInitializationError = FatalInitializationError.WebViewError(e)
-            sendExceptionReport(e, "setAcceptFileSchemeCookies")
-            Timber.e(e, "setAcceptFileSchemeCookies")
+            sendExceptionReport(e, "checkWebViewAvailable")
+            Timber.e(e, "checkWebViewAvailable")
             false
         }
 


### PR DESCRIPTION
> [!CAUTION]
> **Breaking change (security)**. 
> Cards can no longer set or read `document.cookie` from `file://` origins.

> [!NOTE]
> Assisted-by: Claude Opus 4.6 - research


<!--- Please fill the necessary details below -->
## Purpose / Description
**Deprecation: `setAcceptFileSchemeCookies` API 30**
This setting is not secure, please use androidx.webkit.WebViewAssetLoader instead.

## Fixes
* Fixes #19863

## Approach
I replaced this with `CookieManager.getInstance()` to reduce code churn. `getWebViewPackage` is an alternative.

## How Has This Been Tested?

Cards display as normal

```
./adb uninstall com.google.android.webview
./adb shell pm uninstall -k --user 0 com.google.android.webview
```

<img width="343" height="362" alt="Screenshot 2026-04-06 at 08 24 10" src="https://github.com/user-attachments/assets/2035b92e-d832-4c69-a271-cc1f20593df1" />

## Learning (optional, can help others)

https://chromium.googlesource.com/chromium/src/+/refs/heads/main/android_webview/browser/cookie_manager.cc#867

https://chromium.googlesource.com/chromium/src/+/refs/heads/main/android_webview/glue/java/src/com/android/webview/chromium/CookieManagerAdapter.java

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->