### PR TITLE
fix(previewer): showingAnswer race condition

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/PreviewerViewModel.kt
@@ -38,7 +38,6 @@ import com.ichi2.anki.utils.ext.require
 import com.ichi2.anki.utils.ext.setUserFlagForCards
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import timber.log.Timber
@@ -88,8 +87,8 @@ class PreviewerViewModel(
     @NeedsTest("16302 - a sound-only card on the back/flipped with 'don't keep activities'")
     @NeedsTest("16302 - on config changes, sound continues to play")
     override fun onPageFinished(isAfterRecreation: Boolean) {
-        if (isAfterRecreation) {
-            launchCatchingIO {
+        launchCatchingIO {
+            if (isAfterRecreation) {
                 showCard(showAnswerOnReload)
                 // isAfterRecreation can either mean:
                 // * after config change (ViewModel exists)
@@ -97,13 +96,9 @@ class PreviewerViewModel(
                 // if the ViewModel existed, we want to continue playing audio
                 // if not, we want to setup the sound player
                 cardMediaPlayer.ensureAvTagsLoaded(currentCard.await())
-            }
-            return
-        }
-        launchCatchingIO {
-            currentIndex.collectLatest {
-                showCard(showAnswer = backSideOnly.value)
-                loadAndPlaySounds()
+            } else {
+                // re-render the current card
+                updateCurrentIndex { it }
             }
         }
     }
@@ -159,7 +154,7 @@ class PreviewerViewModel(
                 showAnswer()
                 cardMediaPlayer.autoplayAllForSide(CardSide.ANSWER)
             } else {
-                currentIndex.update { it + 1 }
+                updateCurrentIndex { it + 1 }
             }
         }
     }
@@ -171,7 +166,7 @@ class PreviewerViewModel(
     fun onPreviousButtonClick() {
         launchCatchingIO {
             if (currentIndex.value > 0) {
-                currentIndex.update { it - 1 }
+                updateCurrentIndex { it - 1 }
             } else if (showingAnswer.value && !backSideOnly.value) {
                 showQuestion()
             }
@@ -196,13 +191,20 @@ class PreviewerViewModel(
         val index = sliderPosition - 1
         if (index !in selectedCardIds.indices) return
         launchCatchingIO {
-            currentIndex.emit(index)
+            updateCurrentIndex { index }
         }
     }
 
     /* *********************************************************************************************
      *************************************** Internal methods ***************************************
      ********************************************************************************************* */
+
+    /** Applies [update] to [currentIndex] and re-renders the resulting card. */
+    private suspend fun updateCurrentIndex(update: (Int) -> Int) {
+        currentIndex.update(update)
+        showCard(showAnswer = backSideOnly.value)
+        loadAndPlaySounds()
+    }
 
     private suspend fun showCard(showAnswer: Boolean) {
         currentCard =

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -22,8 +22,6 @@ import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.servicelayer.NoteService
 import com.ichi2.anki.utils.ext.flag
 import com.ichi2.testutils.JvmTest
-import com.ichi2.testutils.common.Flaky
-import com.ichi2.testutils.common.OS
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -103,7 +101,6 @@ class PreviewerViewModelTest : JvmTest() {
         }
 
     @Test
-    @Flaky(OS.ALL)
     fun `previous button`() =
         runTest {
             // Start at Index 1
@@ -122,7 +119,6 @@ class PreviewerViewModelTest : JvmTest() {
         }
 
     @Test
-    @Flaky(OS.ALL)
     fun `toggle back side only`() =
         runTest {
             assertFalse(viewModel.backSideOnly.value) // initial state should be false


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6 - diagnostics

## Purpose / Description

There was a race condition on `showingAnswer` mutation:
* update via `currentIndex.collectLatest` => `showCard`
* update via `onNextButtonClick` -> `launchCatchingIO` -> `showAnswer`

`collectLatest` could fire AFTER a second user action, which overwrites the value of the later user action.

## Fixes
* Fixes #20665

## Approach
Remove 'collectLatest'

## How Has This Been Tested?
Unit tested, tested on an API 33 emulator and screen still works

## Learning (optional, can help others)
We need to be more careful of using `collectLatest` within a ViewModel than I expected

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)