### PR TITLE
refactor(i18n): use 'TR.sentenceCase'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateBrowserAppearanceEditor.kt
@@ -29,7 +29,7 @@ import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.databinding.ActivityCardBrowserAppearanceBinding
 import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.CardTemplate
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
@@ -117,7 +117,7 @@ class CardTemplateBrowserAppearanceEditor : AnkiActivity(R.layout.activity_card_
 
     private fun showRestoreDefaultDialog() {
         AlertDialog.Builder(this).show {
-            setTitle(TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default))
+            setTitle(TR.sentenceCase.restoreToDefault)
             positiveButton(R.string.restore) {
                 restoreDefaultAndClose()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateEditor.kt
@@ -98,7 +98,7 @@ import com.ichi2.anki.previewer.TemplatePreviewerPage
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.ResizablePaneManager
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
 import com.ichi2.anki.utils.ext.doOnTabSelected
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -1126,7 +1126,7 @@ open class CardTemplateEditor :
 
                     fun askUser(kind: StockNotetype.Kind? = null) {
                         AlertDialog.Builder(requireContext()).show {
-                            setTitle(TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default))
+                            setTitle(TR.sentenceCase.restoreToDefault)
                             setMessage(TR.cardTemplatesRestoreToDefaultConfirmation())
                             setPositiveButton(R.string.restore) { _, _ ->
                                 launchCatchingTask {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Reviewer.kt
@@ -115,7 +115,7 @@ import com.ichi2.anki.servicelayer.NoteService.toggleMark
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.DayTheme
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.windows.reviewer.ReviewerFragment
 import com.ichi2.anki.utils.ext.cardStatsNoCardClean
 import com.ichi2.anki.utils.ext.currentCardStudy
@@ -858,8 +858,7 @@ open class Reviewer :
         }
 
         // Anki Desktop Translations
-        menu.findItem(R.id.action_reschedule_card).title =
-            CollectionManager.TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+        menu.findItem(R.id.action_reschedule_card).title = TR.sentenceCase.setDueDate
 
         // Undo button
         @DrawableRes val undoIconId: Int

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -51,7 +51,7 @@ import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.ext.showDialogFragment
 import com.ichi2.ui.CollectionMediaImageGetter
 import kotlinx.coroutines.Job
@@ -432,7 +432,7 @@ class StudyOptionsFragment :
             if (!isDynamic) {
                 deckInfoLayout.visibility = View.GONE
                 buttonStart.visibility = View.VISIBLE
-                buttonStart.text = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study)
+                buttonStart.text = TR.sentenceCase.customStudy
             } else {
                 buttonStart.visibility = View.GONE
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -30,7 +30,7 @@ import com.ichi2.anki.observability.ChangeManager.notifySubscribersAllValuesChan
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.settings.enums.ShouldFetchMedia
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.preferences.VersatileTextWithASwitchPreference
 import com.ichi2.utils.NetworkUtils
@@ -310,7 +310,7 @@ suspend fun monitorMediaSync(deckPicker: DeckPicker) {
         withContext(Dispatchers.Main) {
             AlertDialog
                 .Builder(deckPicker)
-                .setTitle(TR.syncMediaLogTitle().toSentenceCase(deckPicker, R.string.sentence_sync_media_log))
+                .setTitle(with(deckPicker) { TR.sentenceCase.mediaSyncLog })
                 .setMessage("")
                 .setPositiveButton(R.string.dialog_continue) { _, _ ->
                     scope.cancel()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -111,6 +111,7 @@ import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.ui.attachFastScroller
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.undoAndShowSnackbar
 import com.ichi2.anki.utils.ext.getCurrentDialogFragment
@@ -522,11 +523,8 @@ class CardBrowserFragment :
                 override fun onPrepareMenu(menu: Menu) {
                     if (!vm.isInMultiSelectMode) return
 
-                    menu.findItem(R.id.action_reschedule_cards).title =
-                        TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
-
-                    menu.findItem(R.id.action_grade_now).title =
-                        TR.actionsGradeNow().toSentenceCase(R.string.sentence_grade_now)
+                    menu.findItem(R.id.action_reschedule_cards).title = TR.sentenceCase.setDueDate
+                    menu.findItem(R.id.action_grade_now).title = TR.sentenceCase.gradeNow
 
                     val isFindReplaceEnabled = sharedPrefs().getBoolean(getString(R.string.pref_browser_find_replace), false)
                     menu.findItem(R.id.action_find_replace).apply {
@@ -538,13 +536,13 @@ class CardBrowserFragment :
 
                     menu.findItem(R.id.action_flag).isVisible = vm.hasSelectedAnyRows()
                     menu.findItem(R.id.action_suspend_card).apply {
-                        title = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
+                        title = TR.sentenceCase.toggleSuspend
                         // TODO: I don't think this icon is necessary
                         setIcon(R.drawable.ic_suspend)
                         isVisible = vm.hasSelectedAnyRows()
                     }
                     menu.findItem(R.id.action_toggle_bury).apply {
-                        title = TR.browsingToggleBury().toSentenceCase(R.string.sentence_toggle_bury)
+                        title = TR.sentenceCase.toggleBury
                         isVisible = vm.hasSelectedAnyRows()
                     }
                     menu.findItem(R.id.action_mark_card).apply {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -70,7 +70,7 @@ import com.ichi2.anki.showError
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.sync.launchCatchingRequiringOneWaySync
 import com.ichi2.anki.ui.BasicItemSelectedListener
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.InitStatus
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.LanguageUtil
@@ -114,9 +114,7 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
 
         return MaterialAlertDialogBuilder(requireContext())
             .create {
-                title(
-                    text = TR.browsingChangeNotetype().toSentenceCase(R.string.sentence_change_note_type),
-                )
+                title(text = TR.sentenceCase.changeNoteType)
                 positiveButton(R.string.dialog_ok)
                 negativeButton(R.string.dialog_cancel)
                 setView(binding.root)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/EmptyCardsDialogFragment.kt
@@ -57,7 +57,7 @@ import com.ichi2.anki.dialogs.EmptyCardsUiState.SearchingForEmptyCards
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.NoteId
 import com.ichi2.anki.libanki.emptyCids
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
@@ -86,7 +86,7 @@ class EmptyCardsDialogFragment : DialogFragment() {
         return AlertDialog
             .Builder(requireContext())
             .show {
-                setTitle(TR.emptyCardsWindowTitle().toSentenceCase(R.string.sentence_empty_cards))
+                setTitle(TR.sentenceCase.emptyCards)
                 setPositiveButton(R.string.dialog_ok) { _, _ ->
                     val state = viewModel.uiState.value
                     if (state is EmptyCardsSearchResult) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -71,6 +71,7 @@ import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.bundleOfNotNull
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
@@ -273,7 +274,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
 
         return AlertDialog
             .Builder(requireActivity())
-            .title(text = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study))
+            .title(text = TR.sentenceCase.customStudy)
             .cancelable(true)
             .customView(customMenuView)
             .create()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/mediacheck/MediaCheckFragment.kt
@@ -106,7 +106,7 @@ class MediaCheckFragment : Fragment(R.layout.fragment_media_check) {
                     menuInflater.inflate(R.menu.media_check_menu, menu)
                     menu.findItem(R.id.action_restore_trash).apply {
                         isVisible = true
-                        title = TR.mediaCheckRestoreTrash().toSentenceCase(R.string.sentence_restore_deleted)
+                        title = TR.sentenceCase.restoreDeleted
                     }
                     menu.findItem(R.id.action_empty_trash).apply {
                         isVisible = true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/AddNewNotesType.kt
@@ -37,7 +37,7 @@ import com.ichi2.anki.libanki.backend.BackendUtils
 import com.ichi2.anki.libanki.getNotetype
 import com.ichi2.anki.libanki.getNotetypeNames
 import com.ichi2.anki.libanki.getStockNotetype
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.customView
 import com.ichi2.utils.dp
@@ -79,7 +79,7 @@ class AddNewNotesType(
             AlertDialog
                 .Builder(activity)
                 .apply {
-                    setTitle(TR.notetypesAddNoteType().toSentenceCase(activity, R.string.sentence_add_note_type))
+                    setTitle(with(activity) { TR.sentenceCase.addNoteType })
                     customView(
                         binding.root,
                         paddingStart = 24.dp.toPx(activity),

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.MappableBinding.Companion.toPreferenceString
 import com.ichi2.anki.settings.Prefs
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.preferences.ControlPreference
@@ -140,7 +141,7 @@ class ControlsSettingsFragment :
 
     private fun setDynamicTitle() {
         findPreference<ControlPreference>(getString(R.string.reschedule_command_key))?.let {
-            val preferenceTitle = TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+            val preferenceTitle = TR.sentenceCase.setDueDate
             it.title = preferenceTitle
             it.dialogTitle = preferenceTitle
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/HeaderFragment.kt
@@ -31,7 +31,7 @@ import com.ichi2.anki.preferences.reviewer.ReviewerMenuSettingsFragment
 import com.ichi2.anki.reviewreminders.ReviewReminderScope
 import com.ichi2.anki.reviewreminders.ScheduleReminders
 import com.ichi2.anki.settings.Prefs
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.compat.CompatHelper
 import com.ichi2.preferences.HeaderPreference
 import com.ichi2.utils.AdaptionUtil
@@ -100,7 +100,7 @@ class HeaderFragment : SettingsFragment() {
             activity: AppCompatActivity,
             searchConfiguration: SearchConfiguration,
         ) {
-            val setDuePreferenceTitle = TR.actionsSetDueDate().toSentenceCase(activity, R.string.sentence_set_due_date)
+            val setDuePreferenceTitle = with(activity) { TR.sentenceCase.setDueDate }
             with(searchConfiguration) {
                 setActivity(activity)
                 setBreadcrumbsEnabled(true)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ViewerAction.kt
@@ -35,6 +35,7 @@ import com.ichi2.anki.reviewer.Binding.ModifierKeys.Companion.shift
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableAction
 import com.ichi2.anki.reviewer.ReviewerBinding
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.ui.internationalization.toSentenceCase
 
 /**
@@ -259,7 +260,7 @@ enum class ViewerAction(
         when (this) {
             BROWSE -> TR.qtMiscBrowse()
             STATISTICS -> TR.statisticsTitle()
-            RESCHEDULE_NOTE -> TR.actionsSetDueDate().toSentenceCase(context, R.string.sentence_set_due_date)
+            RESCHEDULE_NOTE -> with(context) { TR.sentenceCase.setDueDate }
             PREVIOUS_CARD_INFO -> TR.actionsPreviousCardInfo().toSentenceCase(context, R.string.sentence_actions_previous_card_info)
             else -> context.getString(titleRes)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/scheduling/SetDueDateDialog.kt
@@ -57,7 +57,7 @@ import com.ichi2.anki.scheduling.SetDueDateViewModel.Tab
 import com.ichi2.anki.servicelayer.getFSRSStatus
 import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.snackbar.showSnackbar
-import com.ichi2.anki.ui.internationalization.toSentenceCase
+import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.utils.doOnImeHidden
 import com.ichi2.anki.utils.ext.requireBoolean
 import com.ichi2.anki.utils.openUrl
@@ -140,12 +140,7 @@ class SetDueDateDialog : DialogFragment() {
         binding = DialogSetDueDateBinding.inflate(layoutInflater)
         return MaterialAlertDialogBuilder(requireContext())
             .create {
-                title(
-                    text =
-                        TR
-                            .actionsSetDueDate()
-                            .toSentenceCase(R.string.sentence_set_due_date),
-                )
+                title(text = TR.sentenceCase.setDueDate)
                 positiveButton(R.string.dialog_ok) { launchUpdateDueDate() }
                 negativeButton(R.string.dialog_cancel)
                 neutralButton(R.string.help)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/internationalization/SentenceCase.kt
@@ -72,6 +72,12 @@ fun String.toSentenceCase(
 // TODO: Expand for all past properties
 object SentenceCase {
     context(_: Context)
+    val addNoteType get() = TR.notetypesAddNoteType().toSentenceCase(R.string.sentence_add_note_type)
+
+    context(_: Fragment)
+    val changeNoteType get() = TR.browsingChangeNotetype().toSentenceCase(R.string.sentence_change_note_type)
+
+    context(_: Context)
     val checkDatabase get() = TR.databaseCheckTitle().toSentenceCase(R.string.sentence_check_db)
 
     context(_: Fragment)
@@ -87,6 +93,40 @@ object SentenceCase {
     val checkMediaAction get() = TR.mediaCheckCheckMediaAction().toSentenceCase(R.string.sentence_check_media)
     context(_: Fragment)
     val checkMediaAction get() = TR.mediaCheckCheckMediaAction().toSentenceCase(R.string.sentence_check_media)
+
+    context(_: Fragment)
+    val customStudy get() = TR.actionsCustomStudy().toSentenceCase(R.string.sentence_custom_study)
+
+    context(_: Fragment)
+    val emptyCards get() = TR.emptyCardsWindowTitle().toSentenceCase(R.string.sentence_empty_cards)
+    context(_: Fragment)
+    val emptyTrash get() = TR.mediaCheckEmptyTrash().toSentenceCase(R.string.sentence_empty_trash)
+
+    context(_: Fragment)
+    val gradeNow get() = TR.actionsGradeNow().toSentenceCase(R.string.sentence_grade_now)
+
+    context(_: Context)
+    val mediaSyncLog get() = TR.syncMediaLogTitle().toSentenceCase(R.string.sentence_sync_media_log)
+
+    context(_: Fragment)
+    val restoreDeleted get() = TR.mediaCheckRestoreTrash().toSentenceCase(R.string.sentence_restore_deleted)
+
+    context(_: Fragment)
+    val restoreToDefault get() = TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default)
+    context(_: Context)
+    val restoreToDefault get() = TR.cardTemplatesRestoreToDefault().toSentenceCase(R.string.sentence_restore_to_default)
+
+    context(_: Context)
+    val setDueDate get() = TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+
+    context(_: Fragment)
+    val setDueDate get() = TR.actionsSetDueDate().toSentenceCase(R.string.sentence_set_due_date)
+
+    context(_: Fragment)
+    val toggleBury get() = TR.browsingToggleBury().toSentenceCase(R.string.sentence_toggle_bury)
+
+    context(_: Fragment)
+    val toggleSuspend get() = TR.browsingToggleSuspend().toSentenceCase(R.string.sentence_toggle_suspend)
 }
 
 /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -16,12 +16,15 @@
 
 package com.ichi2.anki.ui.internationalization
 
+import androidx.fragment.app.Fragment
+import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.TR
-import com.ichi2.anki.IntroductionActivity
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
+import com.ichi2.testutils.EmptyAnkiActivity
 import com.ichi2.testutils.EmptyApplication
+import com.ichi2.testutils.launchFragmentInContainer
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -34,34 +37,35 @@ class SentenceCaseTest : RobolectricTest() {
     @Test
     fun `English is converted to sentence case`() {
         ensureCollectionLoadIsSynchronous()
-        with(super.startRegularActivity<IntroductionActivity>()) {
-            assertThat(TR.browsingToggleSuspend().toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
-            assertThat(TR.browsingToggleBury().toSentenceCase(this, R.string.sentence_toggle_bury), equalTo("Toggle bury"))
-            assertThat(TR.actionsSetDueDate().toSentenceCase(this, R.string.sentence_set_due_date), equalTo("Set due date"))
-            assertThat(TR.actionsCustomStudy().toSentenceCase(this, R.string.sentence_custom_study), equalTo("Custom study"))
-            assertThat(TR.emptyCardsWindowTitle().toSentenceCase(this, R.string.sentence_empty_cards), equalTo("Empty cards"))
-            assertThat(TR.mediaCheckEmptyTrash().toSentenceCase(this, R.string.sentence_empty_trash), equalTo("Empty trash"))
-            assertThat(TR.mediaCheckRestoreTrash().toSentenceCase(this, R.string.sentence_restore_deleted), equalTo("Restore deleted"))
-            assertThat(TR.browsingChangeNotetype().toSentenceCase(this, R.string.sentence_change_note_type), equalTo("Change note type"))
-            assertThat(TR.actionsGradeNow().toSentenceCase(this, R.string.sentence_grade_now), equalTo("Grade now"))
-            assertThat(TR.notetypesAddNoteType().toSentenceCase(this, R.string.sentence_add_note_type), equalTo("Add note type"))
-            assertThat(
-                TR.cardTemplatesRestoreToDefault().toSentenceCase(this, R.string.sentence_restore_to_default),
-                equalTo("Restore to default"),
-            )
-            assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
-            assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
-            assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
 
-            assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
-            assertThat(
-                "sentence_sync_media_log",
-                TR.syncMediaLogTitle().toSentenceCase(this, R.string.sentence_sync_media_log),
-                equalTo("Media sync log"),
-            )
+        launchFragmentInContainer<Fragment>().onFragment { fragment ->
+            with(fragment) {
+                assertThat(TR.sentenceCase.toggleSuspend, equalTo("Toggle suspend"))
+                assertThat(TR.sentenceCase.toggleBury, equalTo("Toggle bury"))
+                assertThat(TR.sentenceCase.customStudy, equalTo("Custom study"))
+                assertThat(TR.sentenceCase.emptyCards, equalTo("Empty cards"))
+                assertThat(TR.sentenceCase.emptyTrash, equalTo("Empty trash"))
+                assertThat(TR.sentenceCase.restoreDeleted, equalTo("Restore deleted"))
+                assertThat(TR.sentenceCase.changeNoteType, equalTo("Change note type"))
+                assertThat(TR.sentenceCase.gradeNow, equalTo("Grade now"))
+            }
+        }
 
-            assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
-            assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
+        ActivityScenario.launch(EmptyAnkiActivity::class.java).onActivity { activity ->
+            with(activity) {
+                assertThat(TR.sentenceCase.setDueDate, equalTo("Set due date"))
+                assertThat(TR.sentenceCase.addNoteType, equalTo("Add note type"))
+                assertThat(TR.sentenceCase.restoreToDefault, equalTo("Restore to default"))
+                assertThat(TR.sentenceCase.checkDatabase, equalTo("Check database"))
+                assertThat(TR.sentenceCase.checkMediaTitle, equalTo("Check media"))
+                assertThat(TR.sentenceCase.checkMediaAction, equalTo("Check media"))
+
+                assertThat("syncMediaLogTitle", TR.syncMediaLogTitle(), equalTo("Media Sync Log"))
+                assertThat(TR.sentenceCase.mediaSyncLog, equalTo("Media sync log"))
+
+                assertThat("Toggle Suspend".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Toggle suspend"))
+                assertThat("Ook? Ook?".toSentenceCase(this, R.string.sentence_toggle_suspend), equalTo("Ook? Ook?"))
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description
I introduced `sentenceCase` for cleanup in 478ae51d419f443332ae0e2db9655ef9f3c8629f

This applies the pattern throughout the codebase

## How Has This Been Tested?
Mechanical refactoring, unit tests still pass

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)