### PR TITLE
fix(card-browser): 'change note type' option item

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -550,6 +550,10 @@ class CardBrowserFragment :
                         setIcon(R.drawable.ic_star_border_white)
                         isVisible = vm.hasSelectedAnyRows()
                     }
+                    menu.findItem(R.id.action_change_note_type).apply {
+                        title = TR.sentenceCase.changeNoteType
+                        isVisible = vm.hasSelectedAnyRows()
+                    }
                     menu.findItem(R.id.action_change_deck).isVisible = vm.hasSelectedAnyRows()
                     menu.findItem(R.id.action_reposition_cards).isVisible = vm.hasSelectedAnyRows()
                     menu.findItem(R.id.action_grade_now).isVisible = vm.hasSelectedAnyRows()

--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -51,7 +51,7 @@
 
     <item
         android:id="@+id/action_change_note_type"
-        android:title="@string/sentence_change_note_type"/>
+        tools:title="Change note type"/>
 
     <item
         android:id="@+id/action_change_deck"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1632,6 +1632,44 @@ class CardBrowserTest : RobolectricTest() {
         }
 
     @Test
+    fun `options menu test - mutliselect with no selection`() =
+        withOptionsMenu(
+            OptionsMenuType(
+                fragmented = false,
+                mutliselect = true,
+            ),
+        ) {
+            viewModel.selectNone()
+            advanceRobolectricLooper()
+            assertEquals(true, viewModel.isInMultiSelectMode, "still in multi-select mode")
+            assertEquals(0, viewModel.selectedRowCount(), "no rows selected")
+
+            val expectedMenuItems =
+                listOf(
+                    R.id.action_edit_note to false,
+                    R.id.action_delete_card to false,
+                    R.id.action_view_card_info to false,
+                    R.id.action_flag to false,
+                    R.id.action_mark_card to false,
+                    R.id.action_suspend_card to false,
+                    R.id.action_toggle_bury to false,
+                    R.id.action_change_note_type to false,
+                    R.id.action_change_deck to false,
+                    R.id.action_reposition_cards to false,
+                    R.id.action_reschedule_cards to false,
+                    R.id.action_edit_tags to false,
+                    R.id.action_grade_now to false,
+                    R.id.action_reset_cards_progress to false,
+                    R.id.action_preview_many to true,
+                    R.id.action_export_selected to false,
+                    R.id.action_undo to true,
+                    R.id.action_find_replace to false,
+                )
+
+            assertMenusEqual(expectedMenuItems, menu)
+        }
+
+    @Test
     fun `options menu test - fragmented`() =
         withOptionsMenu(
             OptionsMenuType(


### PR DESCRIPTION
## Purpose / Description
The title did not appear to be translated

I also fixed a bad rebase which reverted a98b72e37d529045c59cfc83da2c6234ddb0d3a7

So I added a unit test to catch this case in future

## How Has This Been Tested?
<img width="365" height="205" alt="Screenshot 2026-04-06 at 10 17 29" src="https://github.com/user-attachments/assets/1cf50a6d-70dc-4452-ada7-a027e7660655" />
<img width="361" height="258" alt="Screenshot 2026-04-06 at 10 17 18" src="https://github.com/user-attachments/assets/df4bdc07-c031-4016-aa0d-d199f7daa623" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)