### PR TITLE
feat(progress-dialog): display sync progress in MB

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -539,17 +539,28 @@ data class ProgressContext(
     var progress: Progress,
     var text: String = "",
     /** If set, shows a progress bar with `current` of `max` complete. */
-    var amount: Pair<Int, Int>? = null,
+    var amount: Amount? = null,
 ) {
     @Suppress("Deprecation") // ProgressDialog deprecation
     fun updateDialog(dialog: android.app.ProgressDialog) {
         val message =
             listOfNotNull(
                 text,
-                amount?.let { "${it.first}/$${it.second}" },
+                amount?.let { "${it.current}/$${it.max}" },
             ).joinToString(" ")
         dialog.setMessage(message)
     }
+
+    /**
+     * Represents a progress value and a maximum limit.
+     *
+     * @see ProgressContext
+     */
+    // values are 'Long' as this can represent bytes.
+    data class Amount(
+        val current: Long,
+        val max: Long,
+    )
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -538,7 +538,7 @@ private suspend fun ProgressContext.monitorProgress(
  */
 data class ProgressContext(
     var progress: Progress = Progress.getDefaultInstance(),
-    var text: String = "",
+    var text: String? = null,
     /** If set, shows a progress bar with `current` of `max` complete. */
     var amount: Amount? = null,
     val formatAmount: (Amount) -> String = { (current, max) -> "$current/$max" },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -333,6 +333,7 @@ suspend fun HelpAction.execute(context: Context): Boolean {
  * progress UI.
  */
 suspend fun <T> Backend.withProgress(
+    progressContext: ProgressContext,
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
     block: suspend CoroutineScope.() -> T,
@@ -340,7 +341,7 @@ suspend fun <T> Backend.withProgress(
     coroutineScope {
         val monitor =
             launch {
-                monitorProgress(this@withProgress, extractProgress, updateUi)
+                progressContext.monitorProgress(this@withProgress, extractProgress, updateUi)
             }
         try {
             block()
@@ -357,6 +358,7 @@ suspend fun <T> Backend.withProgress(
  * flashes of a dialog.
  */
 suspend fun <T> FragmentActivity.withProgress(
+    progressContext: ProgressContext = ProgressContext(Progress.getDefaultInstance()),
     extractProgress: ProgressContext.() -> Unit,
     onCancel: ((Backend) -> Unit)? = { it.setWantsAbort() },
     @StringRes manualCancelButton: Int? = null,
@@ -376,6 +378,7 @@ suspend fun <T> FragmentActivity.withProgress(
         manualCancelButton = manualCancelButton,
     ) { dialog ->
         backend.withProgress(
+            progressContext = progressContext,
             extractProgress = extractProgress,
             updateUi = { updateDialog(dialog) },
         ) {
@@ -508,12 +511,12 @@ private fun dismissDialogIfShowing(dialog: Dialog) {
  * [ProgressContext]. Calls updateUi() to update the UI with the extracted
  * progress.
  */
-private suspend fun monitorProgress(
+private suspend fun ProgressContext.monitorProgress(
     backend: Backend,
     extractProgress: ProgressContext.() -> Unit,
     updateUi: ProgressContext.() -> Unit,
 ) {
-    val state = ProgressContext(Progress.getDefaultInstance())
+    val state = this
     while (true) {
         state.progress =
             withContext(Dispatchers.IO) {
@@ -528,28 +531,25 @@ private suspend fun monitorProgress(
     }
 }
 
-/** Holds the current backend progress, and text/amount properties
+/**
+ * Holds the current backend progress, and text/amount properties
  * that can be written to in order to update the UI.
  */
 data class ProgressContext(
     var progress: Progress,
     var text: String = "",
-    /** If set, shows progress bar with a of b complete. */
+    /** If set, shows a progress bar with `current` of `max` complete. */
     var amount: Pair<Int, Int>? = null,
-)
-
-@Suppress("Deprecation") // ProgressDialog deprecation
-private fun ProgressContext.updateDialog(dialog: android.app.ProgressDialog) {
-    // ideally this would show a progress bar, but MaterialDialog does not support
-    // setting progress after starting with indeterminate progress, so we just use
-    // this for now
-    // this code has since been updated to ProgressDialog, and the above not rechecked
-    val progressText =
-        amount?.let {
-            " ${it.first}/${it.second}"
-        } ?: ""
+) {
     @Suppress("Deprecation") // ProgressDialog deprecation
-    dialog.setMessage(text + progressText)
+    fun updateDialog(dialog: android.app.ProgressDialog) {
+        val message =
+            listOfNotNull(
+                text,
+                amount?.let { "${it.first}/$${it.second}" },
+            ).joinToString(" ")
+        dialog.setMessage(message)
+    }
 }
 
 /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -542,6 +542,8 @@ data class ProgressContext(
     /** If set, shows a progress bar with `current` of `max` complete. */
     var amount: Amount? = null,
     val formatAmount: (Amount) -> String = { (current, max) -> "$current/$max" },
+    /** Separator between [text] and [amount] */
+    val separator: String = " ",
 ) {
     @Suppress("Deprecation") // ProgressDialog deprecation
     fun updateDialog(dialog: android.app.ProgressDialog) {
@@ -549,7 +551,7 @@ data class ProgressContext(
             listOfNotNull(
                 text,
                 amount?.let { formatAmount(it) },
-            ).joinToString(" ")
+            ).joinToString(separator)
         dialog.setMessage(message)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -565,7 +565,7 @@ data class ProgressContext(
                     // replace spaces with NBSP so newlines are handled better
                     val curStr = Formatter.formatShortFileSize(context, current).replace(' ', '\u00A0')
                     val maxStr = Formatter.formatShortFileSize(context, max).replace(' ', '\u00A0')
-                    "$curStr/$maxStr"
+                    context.getString(R.string.progress_amount_bytes, curStr, maxStr)
                 },
             )
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -22,6 +22,7 @@ import android.content.Context
 import android.content.DialogInterface
 import android.database.sqlite.SQLiteDatabaseCorruptException
 import android.net.Uri
+import android.text.format.Formatter
 import android.view.WindowManager
 import android.view.WindowManager.BadTokenException
 import androidx.annotation.StringRes
@@ -358,7 +359,7 @@ suspend fun <T> Backend.withProgress(
  * flashes of a dialog.
  */
 suspend fun <T> FragmentActivity.withProgress(
-    progressContext: ProgressContext = ProgressContext(Progress.getDefaultInstance()),
+    progressContext: ProgressContext = ProgressContext(),
     extractProgress: ProgressContext.() -> Unit,
     onCancel: ((Backend) -> Unit)? = { it.setWantsAbort() },
     @StringRes manualCancelButton: Int? = null,
@@ -536,19 +537,37 @@ private suspend fun ProgressContext.monitorProgress(
  * that can be written to in order to update the UI.
  */
 data class ProgressContext(
-    var progress: Progress,
+    var progress: Progress = Progress.getDefaultInstance(),
     var text: String = "",
     /** If set, shows a progress bar with `current` of `max` complete. */
     var amount: Amount? = null,
+    val formatAmount: (Amount) -> String = { (current, max) -> "$current/$max" },
 ) {
     @Suppress("Deprecation") // ProgressDialog deprecation
     fun updateDialog(dialog: android.app.ProgressDialog) {
         val message =
             listOfNotNull(
                 text,
-                amount?.let { "${it.current}/$${it.max}" },
+                amount?.let { formatAmount(it) },
             ).joinToString(" ")
         dialog.setMessage(message)
+    }
+
+    companion object {
+        /**
+         * A [com.ichi2.anki.ProgressContext] which formats progress as bytes:
+         *
+         * `28 MB/141 MB`
+         */
+        fun ofBytes(context: Context) =
+            ProgressContext(
+                formatAmount = { (current, max) ->
+                    // replace spaces with NBSP so newlines are handled better
+                    val curStr = Formatter.formatShortFileSize(context, current).replace(' ', '\u00A0')
+                    val maxStr = Formatter.formatShortFileSize(context, max).replace(' ', '\u00A0')
+                    "$curStr/$maxStr"
+                },
+            )
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DatabaseCheck.kt
@@ -16,10 +16,18 @@
 
 package com.ichi2.anki
 
+import anki.collection.Progress
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 
 fun DeckPicker.handleDatabaseCheck() {
+    fun Progress.DatabaseCheck.toAmount() =
+        if (stageTotal > 0) {
+            ProgressContext.Amount(stageCurrent.toLong(), stageTotal.toLong())
+        } else {
+            null
+        }
+
     launchCatchingTask {
         val problems =
             withProgress(
@@ -27,12 +35,7 @@ fun DeckPicker.handleDatabaseCheck() {
                     if (progress.hasDatabaseCheck()) {
                         progress.databaseCheck.let {
                             text = it.stage
-                            amount =
-                                if (it.stageTotal > 0) {
-                                    Pair(it.stageCurrent, it.stageTotal)
-                                } else {
-                                    null
-                                }
+                            amount = it.toAmount()
                         }
                     }
                 },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -232,7 +232,7 @@ private suspend fun handleDownload(
 ) {
     Timber.i("Sync: Full collection download requested")
     deckPicker.withProgress(
-        progressContext = ProgressContext.ofBytes(context = deckPicker),
+        progressContext = ProgressContext.ofBytes(context = deckPicker).copy(separator = "\n"),
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
         onCancel = ::cancelSync,
         manualCancelButton = R.string.dialog_cancel,
@@ -267,7 +267,7 @@ private suspend fun handleUpload(
 ) {
     Timber.i("Sync: Full collection upload requested")
     deckPicker.withProgress(
-        progressContext = ProgressContext.ofBytes(context = deckPicker),
+        progressContext = ProgressContext.ofBytes(context = deckPicker).copy(separator = "\n"),
         extractProgress = fullDownloadProgress(TR.syncUploadingToAnkiweb()),
         onCancel = ::cancelSync,
         manualCancelButton = R.string.dialog_cancel,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -232,6 +232,7 @@ private suspend fun handleDownload(
 ) {
     Timber.i("Sync: Full collection download requested")
     deckPicker.withProgress(
+        progressContext = ProgressContext.ofBytes(context = deckPicker),
         extractProgress = fullDownloadProgress(TR.syncDownloadingFromAnkiweb()),
         onCancel = ::cancelSync,
         manualCancelButton = R.string.dialog_cancel,
@@ -266,6 +267,7 @@ private suspend fun handleUpload(
 ) {
     Timber.i("Sync: Full collection upload requested")
     deckPicker.withProgress(
+        progressContext = ProgressContext.ofBytes(context = deckPicker),
         extractProgress = fullDownloadProgress(TR.syncUploadingToAnkiweb()),
         onCancel = ::cancelSync,
         manualCancelButton = R.string.dialog_cancel,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -216,8 +216,8 @@ private suspend fun handleNormalSync(
 
 private fun fullDownloadProgress(title: String): ProgressContext.() -> Unit =
     {
-        if (progress.hasFullSync()) {
-            text = title
+        text = title
+        if (progress.hasFullSync() && progress.fullSync.total > 0) {
             amount = progress.fullSync.run { Pair(transferred, total) }
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/Sync.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import androidx.annotation.StringRes
 import androidx.appcompat.app.AlertDialog
+import anki.collection.Progress
 import anki.sync.SyncAuth
 import anki.sync.SyncCollectionResponse
 import anki.sync.syncAuth
@@ -216,9 +217,11 @@ private suspend fun handleNormalSync(
 
 private fun fullDownloadProgress(title: String): ProgressContext.() -> Unit =
     {
+        fun Progress.FullSync.toAmount() = ProgressContext.Amount(transferred.toLong(), total.toLong())
+
         text = title
         if (progress.hasFullSync() && progress.fullSync.total > 0) {
-            amount = progress.fullSync.run { Pair(transferred, total) }
+            amount = progress.fullSync.toAmount()
         }
     }
 

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -216,6 +216,8 @@
     <string name="white_board_eraser_enabled">Eraser mode activated</string>
     <string name="white_board_eraser_disabled">Eraser mode deactivated</string>
 
+    <string comment="Progress amount e.g. '28 MB/141 MB'. %1$s is the current amount, %2$s is the max." name="progress_amount_bytes">%1$s/%2$s</string>
+
     <string name="media_file_size_warning_title">Media too large</string>
     <string name="media_file_size_warning_message" comment="1$s: File name, 2$s: File size, 3$s: The size limit (e.g. 100MB)">The file \"%1$s\" (%2$s) exceeds the AnkiWeb limit of %3$s and cannot be synced. Add anyway?</string>
     <string name="media_file_size_add_anyway">Add anyway</string>


### PR DESCRIPTION
## Purpose / Description

Before this change, full sync progress was shown as a long numeric value. Now it is shown as XMB/YMB

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/pull/18341
* Related to #19084

## Approach

This was difficult to reason through. It turned out that `ProgressContext` was being constructed deep in the call chain, and we needed to allow a caller to modify this initial value

Once a default value was threaded through, this became simple:

* Define `formatAmount`
* Define `ofBytes` to create a `ProgressContext` which handles bytes
* Some refactorings: creation of the `Amount` class

## How Has This Been Tested?
<img width="355" height="177" alt="Screenshot 2026-04-06 at 11 13 08" src="https://github.com/user-attachments/assets/b04b1803-e718-4d9d-b76c-5b51134c2486" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)