### PR TITLE
Tests: Ensure a toast is shown on a successful action

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/CreateDeckDialog.kt
@@ -26,7 +26,6 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
-import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
@@ -49,7 +48,6 @@ import timber.log.Timber
  *
  * required property: [onNewDeckCreated]. Called on successful creation of a deck
  */
-@NeedsTest("Ensure a toast is shown on a successful action")
 class CreateDeckDialog(
     private val context: Context,
     private val title: Int,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CreateDeckDialogTest.kt
@@ -17,6 +17,10 @@
 
 package com.ichi2.anki.dialogs
 
+import android.app.Activity
+import android.content.ContextWrapper
+import android.os.Looper
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
@@ -39,6 +43,8 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows
+import org.robolectric.shadows.ShadowToast
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.resume
@@ -287,6 +293,141 @@ class CreateDeckDialogTest : RobolectricTest() {
         }
     }
 
+    /*
+     * The next 8 testcases test every permutation of
+     * {createDeck, renameDeck}, {validName, invalidName}, [activityContext, nonActivityContext]
+     * Shadows.shadowOf(Looper.getMainLooper()).idle()
+     * is used to flush the queue and get the latest snackbar, since asking for it immediately fails the test
+     * as the display time is LENGTH_LONG
+     */
+    @Test
+    fun `createDeck with activity context shows snackbar for valid name`() {
+        ensureExecutionOfScenario(DeckDialogType.DECK) { dialog, assertionCalled ->
+            dialog.onNewDeckCreated = { _: DeckId -> assertionCalled() }
+            dialog.createDeck("Create Deck")
+
+            activityScenario.onActivity { activity ->
+                assertThat(
+                    "Snackbar should confirm deck creation for valid name",
+                    activity.latestSnackbarText(),
+                    equalTo(getResourceString(R.string.deck_created)),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `createDeck with activity context shows snackbar for invalid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.DECK, null)
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.createDeck("   ")
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+            assertThat(
+                "Snackbar should show invalid name error for blank name",
+                activity.latestSnackbarText(),
+                equalTo(getResourceString(R.string.invalid_deck_name)),
+            )
+        }
+    }
+
+    @Test
+    fun `createDeck with non-activity context shows toast for valid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(ContextWrapper(activity), R.string.new_deck, DeckDialogType.DECK, null)
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.createDeck("Create Deck")
+
+            assertThat(
+                "Toast should confirm deck creation for valid name",
+                ShadowToast.getTextOfLatestToast(),
+                equalTo(getResourceString(R.string.deck_created)),
+            )
+        }
+    }
+
+    @Test
+    fun `createDeck with non-activity context shows toast for invalid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(ContextWrapper(activity), R.string.new_deck, DeckDialogType.DECK, null)
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.createDeck("   ")
+
+            assertThat(
+                "Toast should show invalid name error for blank name",
+                ShadowToast.getTextOfLatestToast(),
+                equalTo(getResourceString(R.string.invalid_deck_name)),
+            )
+        }
+    }
+
+    @Test
+    fun `renameDeck with activity context shows snackbar for valid name`() {
+        ensureExecutionOfScenario(DeckDialogType.RENAME_DECK) { dialog, assertionCalled ->
+            dialog.deckName = "Old Deck"
+            dialog.onNewDeckCreated = { _: DeckId -> assertionCalled() }
+            dialog.renameDeck("Rename Deck")
+
+            activityScenario.onActivity { activity ->
+                assertThat(
+                    "Snackbar should confirm rename for valid name",
+                    activity.latestSnackbarText(),
+                    equalTo(getResourceString(R.string.deck_renamed)),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `renameDeck with activity context shows snackbar for invalid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(activity, R.string.new_deck, DeckDialogType.RENAME_DECK, null)
+            dialog.deckName = "Old Deck"
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.renameDeck("   ")
+            Shadows.shadowOf(Looper.getMainLooper()).idle()
+
+            assertThat(
+                "Snackbar should show invalid name error for blank name",
+                activity.latestSnackbarText(),
+                equalTo(getResourceString(R.string.invalid_deck_name)),
+            )
+        }
+    }
+
+    @Test
+    fun `renameDeck with non-activity context shows toast for valid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(ContextWrapper(activity), R.string.new_deck, DeckDialogType.RENAME_DECK, null)
+            dialog.deckName = "Old Deck"
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.renameDeck("Rename Deck")
+
+            assertThat(
+                "Toast should confirm rename for valid name",
+                ShadowToast.getTextOfLatestToast(),
+                equalTo(getResourceString(R.string.deck_renamed)),
+            )
+        }
+    }
+
+    @Test
+    fun `renameDeck with non-activity context shows toast for invalid name`() {
+        activityScenario.onActivity { activity ->
+            val dialog = CreateDeckDialog(ContextWrapper(activity), R.string.new_deck, DeckDialogType.RENAME_DECK, null)
+            dialog.deckName = "Old Deck"
+            dialog.onNewDeckCreated = { _: DeckId -> }
+            dialog.renameDeck("   ")
+
+            assertThat(
+                "Toast should show invalid name error for blank name",
+                ShadowToast.getTextOfLatestToast(),
+                equalTo(getResourceString(R.string.invalid_deck_name)),
+            )
+        }
+    }
+
     /**
      * Tests a scenario with a [DeckPicker] hosting a [CreateDeckDialog].
      * The second parameter of the callback ('assertionCalled') must be called for this to pass
@@ -336,3 +477,7 @@ class CreateDeckDialogNonAndroidTest {
         assertLargerThanNine("suffix", "Deck 34", true)
     }
 }
+
+// Returns latest snackbar text
+private fun Activity.latestSnackbarText(): String? =
+    findViewById<TextView>(com.google.android.material.R.id.snackbar_text)?.text?.toString()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Upon Creation/Renaming of Decks, a Toast/Snackbar appears stating the validity, unit testcases confirm the message is displayed 

## Fixes
* Fixes part of #13283 

## Approach
Calls createDeck and renameDeck when context is activity is true or false where the inputted name might be valid/invalid
Uses roboelectric to get latest toast and a custom helper function to get latest snackbar

## How Has This Been Tested?
Unit tests have been confirmed to be passing on local machine
Tests fail when snackbar or toast is removed from function displayFeedback

## Learning (optional, can help others)
1. https://robolectric.org/javadoc/4.16/org/robolectric/shadows/ShadowToast.html#
2. https://gist.github.com/brunodles/badaa6de2ad3a84138d517795f15efc7
3. https://stackoverflow.com/questions/33421913/android-snackbar-how-to-test-with-roboelectric
4. https://medium.com/@jotaemepereira/android-tests-with-roboelectric-snackbarshadow-update-71681bc59e0f
5. https://stackoverflow.com/questions/28051396/test-toast-with-robolectric
6. https://www.slf4j.org/codes.html#multiple_bindings

AI Disclaimer: Claude AI was used to debug the need for Shadows.shadowOf(Looper.getMainLooper()).idle(), use is mentioned in comments

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->