### PR TITLE
[API] Added fields to cards endpoints ( Part - 2 )

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.FlashCardsContract
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.common.utils.emptyStringArray
 import com.ichi2.anki.libanki.Card
+import com.ichi2.anki.libanki.CardType
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.Decks
 import com.ichi2.anki.libanki.Note
@@ -599,6 +600,182 @@ class ContentProviderTest : InstrumentedTest() {
             exception.message,
             containsString("Invalid Anki search query"),
         )
+    }
+
+    @Test
+    fun testQueryCardById_withRawQueueProjection() {
+        val expectedRawQueue = 2
+        val card = updateCardForRawFieldQuery(rawQueue = expectedRawQueue)
+
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.RAW_QUEUE, expectedRawQueue)
+    }
+
+    @Test
+    fun testQueryCardById_withRawDueProjection() {
+        val expectedRawQueue = 1
+        val expectedRawDue = 123456789
+        val card =
+            updateCardForRawFieldQuery(
+                rawQueue = expectedRawQueue,
+                rawDue = expectedRawDue,
+            )
+
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.RAW_DUE, expectedRawDue)
+    }
+
+    @Test
+    fun testQueryCardById_withRawOriginalDueProjection() {
+        val expectedRawDue = 654321
+        val expectedRawOriginalDue = 765432
+        val card =
+            updateCardForRawFieldQuery(
+                rawDue = expectedRawDue,
+                rawOriginalDue = expectedRawOriginalDue,
+            )
+
+        assertProjectedCardInt(
+            card.id,
+            FlashCardsContract.Card.RAW_ORIGINAL_DUE,
+            expectedRawOriginalDue,
+        )
+    }
+
+    @Test
+    fun testQueryCardById_withFilteredDeckRawDueProjection() {
+        val originalDue = col.sched.today + 25
+        val card =
+            updateCardForRawFieldQuery(
+                rawQueue = 2,
+                rawDue = originalDue,
+                rawInterval = 50,
+            )
+
+        // Move the card into a filtered deck so due is replaced and the original due is kept in oDue.
+        val filteredDeckId = col.decks.newFiltered("Raw due filtered deck")
+        testDeckIds.add(filteredDeckId)
+        val filteredDeck = checkNotNull(col.decks.getLegacy(filteredDeckId))
+        filteredDeck.getJSONArray("terms").getJSONArray(0).put(0, "cid:${card.id}")
+        col.decks.save(filteredDeck)
+        col.sched.rebuildFilteredDeck(filteredDeckId)
+        card.load(col)
+
+        assertNotEquals(originalDue, card.due)
+        assertEquals(originalDue, card.oDue)
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.RAW_DUE, card.due)
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.RAW_ORIGINAL_DUE, card.oDue)
+    }
+
+    @Test
+    fun testQueryCardById_withRawIntervalProjection() {
+        val expectedRawInterval = 37
+        val card = updateCardForRawFieldQuery(rawInterval = expectedRawInterval)
+
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.INTERVAL, expectedRawInterval)
+    }
+
+    @Test
+    fun testQueryCardById_withRawSm2FactorProjection() {
+        val expectedRawSm2Factor = 2870
+        val card = updateCardForRawFieldQuery(rawSm2Factor = expectedRawSm2Factor)
+
+        assertProjectedCardInt(
+            card.id,
+            FlashCardsContract.Card.RAW_SM2_FACTOR,
+            expectedRawSm2Factor,
+        )
+    }
+
+    @Test
+    fun testQueryCardById_withRawLeftProjection() {
+        val expectedRawLeft = 2003
+        val card = updateCardForRawFieldQuery(rawLeft = expectedRawLeft)
+
+        assertProjectedCardInt(card.id, FlashCardsContract.Card.RAW_LEFT, expectedRawLeft)
+    }
+
+    @Test
+    fun testQueryCardById_defaultProjectionDoesNotIncludeRawFields() {
+        val card =
+            updateCardForRawFieldQuery(
+                rawQueue = 2,
+                rawDue = 99,
+                rawOriginalDue = 88,
+                rawInterval = 77,
+                rawSm2Factor = 2500,
+                rawLeft = 66,
+            )
+
+        val cardUri =
+            Uri.withAppendedPath(
+                FlashCardsContract.Card.CONTENT_URI,
+                card.id.toString(),
+            )
+
+        val cursor = contentResolver.cursorFor(cardUri)
+
+        cursor.use {
+            assertEquals(FlashCardsContract.Card.DEFAULT_PROJECTION.toList(), it.columnNames.toList())
+            assertTrue("default projection cursor should contain a row", it.moveToFirst())
+
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_QUEUE))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_DUE))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_ORIGINAL_DUE))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.INTERVAL))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_SM2_FACTOR))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_LEFT))
+        }
+    }
+
+    @Test
+    fun testSearchCards_withRawQueueProjection() {
+        val expectedRawQueue = 2
+        val card = updateCardForRawFieldQuery(rawQueue = expectedRawQueue)
+
+        val cursor =
+            contentResolver.cursorFor(
+                FlashCardsContract.Card.CONTENT_URI,
+                projection = arrayOf(FlashCardsContract.Card.RAW_QUEUE),
+                selection = "cid:${card.id}",
+            )
+
+        cursor.use {
+            assertEquals(listOf(FlashCardsContract.Card.RAW_QUEUE), it.columnNames.toList())
+            assertTrue("search cursor should contain a row", it.moveToFirst())
+            assertEquals(expectedRawQueue, it.getInt(it.getColumnIndex(FlashCardsContract.Card.RAW_QUEUE)))
+        }
+    }
+
+    @Test
+    fun testQueryNoteCardByOrd_withRawDueProjection() {
+        val expectedRawQueue = 1
+        val expectedRawDue = 24680
+        val card =
+            updateCardForRawFieldQuery(
+                rawQueue = expectedRawQueue,
+                rawDue = expectedRawDue,
+            )
+
+        val noteCardsUri =
+            Uri.withAppendedPath(
+                Uri.withAppendedPath(
+                    FlashCardsContract.Note.CONTENT_URI,
+                    card.nid.toString(),
+                ),
+                "cards",
+            )
+        val specificCardUri = Uri.withAppendedPath(noteCardsUri, card.ord.toString())
+
+        val cursor =
+            contentResolver.cursorFor(
+                specificCardUri,
+                projection = arrayOf(FlashCardsContract.Card.RAW_DUE),
+            )
+
+        cursor.use {
+            assertEquals(listOf(FlashCardsContract.Card.RAW_DUE), it.columnNames.toList())
+            assertTrue("note card cursor should contain a row", it.moveToFirst())
+            assertEquals(expectedRawDue, it.getInt(it.getColumnIndex(FlashCardsContract.Card.RAW_DUE)))
+        }
     }
 
     /**
@@ -1821,6 +1998,53 @@ class ContentProviderTest : InstrumentedTest() {
         return contentResolver.delete(emptyCardsUri, null, null)
     }
 
+    private fun updateCardForRawFieldQuery(
+        rawQueue: Int = 0,
+        rawDue: Int = 0,
+        rawOriginalDue: Int = 0,
+        rawInterval: Int = 0,
+        rawSm2Factor: Int = 0,
+        rawLeft: Int = 0,
+    ): Card {
+        val card = getFirstCardFromScheduler(col) ?: error("No card available for raw field test")
+        card.queue = QueueType.fromCode(rawQueue)
+        card.type =
+            when (rawQueue) {
+                0 -> CardType.New
+                1 -> CardType.Lrn
+                2 -> CardType.Rev
+                3 -> CardType.Relearning
+                else -> card.type
+            }
+        card.due = rawDue
+        card.oDue = rawOriginalDue
+        card.ivl = rawInterval
+        card.factor = rawSm2Factor
+        card.left = rawLeft
+        col.updateCard(card, skipUndoEntry = true)
+        return card
+    }
+
+    private fun assertProjectedCardInt(
+        cardId: Long,
+        columnName: String,
+        expectedValue: Int,
+    ) {
+        val cardUri =
+            Uri.withAppendedPath(
+                FlashCardsContract.Card.CONTENT_URI,
+                cardId.toString(),
+            )
+
+        val cursor = contentResolver.cursorFor(cardUri, projection = arrayOf(columnName))
+
+        cursor.use {
+            assertEquals(listOf(columnName), it.columnNames.toList())
+            assertTrue("card cursor should contain a row", it.moveToFirst())
+            assertEquals(expectedValue, it.getInt(it.getColumnIndex(columnName)))
+        }
+    }
+
     /** Adds a note which will be removed by [tearDown] */
     private fun addTempClozeNote(text: String): Note =
         addClozeNote(text).update {
@@ -1910,6 +2134,17 @@ class ContentProviderTest : InstrumentedTest() {
         return name
     }
 }
+
+private fun ContentResolver.cursorFor(
+    uri: Uri,
+    projection: Array<String>? = null,
+    selection: String? = null,
+    selectionArgs: Array<String>? = null,
+    sortOrder: String? = null,
+): Cursor =
+    checkNotNull(query(uri, projection, selection, selectionArgs, sortOrder)) {
+        "null cursor from $uri"
+    }
 
 /**
  * Unbury all buried cards in all decks. Only used for tests.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1187,6 +1187,12 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.QUESTION_SIMPLE -> rb.add(currentCard.renderOutput(col).questionText)
                 FlashCardsContract.Card.ANSWER_SIMPLE -> rb.add(currentCard.renderOutput(col, false).answerText)
                 FlashCardsContract.Card.ANSWER_PURE -> rb.add(currentCard.pureAnswer(col))
+                FlashCardsContract.Card.RAW_QUEUE -> rb.add(currentCard.queue.code)
+                FlashCardsContract.Card.RAW_DUE -> rb.add(currentCard.due)
+                FlashCardsContract.Card.RAW_ORIGINAL_DUE -> rb.add(currentCard.oDue)
+                FlashCardsContract.Card.INTERVAL -> rb.add(currentCard.ivl)
+                FlashCardsContract.Card.RAW_SM2_FACTOR -> rb.add(currentCard.factor)
+                FlashCardsContract.Card.RAW_LEFT -> rb.add(currentCard.left)
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -689,6 +689,104 @@ public object FlashCardsContract {
         public const val ANSWER_PURE: String = "answer_pure"
 
         /**
+         * The stored Anki queue code for this card: how Anki decides whether the card can be shown.
+         *
+         * See [AnkiDroid's cards table docs](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure/#cards).
+         *
+         * Unlike [TYPE], queue also includes temporary display states such as buried, suspended,
+         * and preview.
+         *
+         * * `-3` = manually buried
+         * * `-2` = sibling buried
+         * * `-1` = suspended
+         * * `0` = new
+         * * `1` = learning
+         * * `2` = review
+         * * `3` = day-learning / relearning; next review is at least one day after the previous
+         *   review
+         * * `4` = preview
+         *
+         * Negative values indicate cards that are not currently schedulable. Non-negative values
+         * indicate active scheduler queues.
+         *
+         * Other values should be treated as unknown.
+         */
+        public const val RAW_QUEUE: String = "queue"
+
+        /**
+         * The stored Anki due value for this card.
+         *
+         * This is raw scheduler state, not a single normalized timestamp or day number.
+         *
+         * See [AnkiDroid's cards table docs](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure/#cards).
+         *
+         * This value is state-dependent:
+         *
+         * * new queue: the order in which cards are to be studied; starts from 1
+         * * learning / relearning queue: Unix timestamp in seconds
+         * * review queue: the collection scheduler day number when the card is due for review.
+         *   This is not a calendar date; converting it to one requires collection
+         *   creation/day-cutoff metadata not currently exposed by this API.
+         * * filtered deck: the position of the card inside the filtered deck
+         *
+         * Consumers must read this together with [RAW_QUEUE], and with [RAW_ORIGINAL_DUE] when
+         * filtered-deck behavior matters.
+         */
+        public const val RAW_DUE: String = "due"
+
+        /**
+         * The stored original due value for this card.
+         *
+         * For cards in filtered decks, this stores the due value from before the card entered the
+         * filtered deck. If the card is not currently in a filtered deck, this value is `0`.
+         *
+         * @see RAW_DUE for the state-dependent meaning of the current due value
+         */
+        public const val RAW_ORIGINAL_DUE: String = "original_due"
+
+        /**
+         * The stored Anki interval (`ivl`) for this card, in days.
+         *
+         * See [AnkiDroid's cards table docs](https://github.com/ankidroid/Anki-Android/wiki/Database-Structure/#cards).
+         *
+         * For review cards, this is the scheduled number of days between reviews. For relearning
+         * cards, this retains the review interval that will apply when the card returns to the
+         * review queue.
+         *
+         * Learning cards store `0`; their active learning due value is stored in [RAW_DUE].
+         */
+        public const val INTERVAL: String = "interval"
+
+        /**
+         * The stored SM-2 ease factor for this card.
+         *
+         * This factor helps determine the next review interval for cards using SM-2 scheduling.
+         * It is not used by FSRS.
+         *
+         * This is an integer scaled by 10, so `2500` means `250%`.
+         * New SM-2 cards typically start at `2500`.
+         */
+        public const val RAW_SM2_FACTOR: String = "sm2_factor"
+
+        /**
+         * The stored Anki `left` value for this card.
+         *
+         * This is relevant for learning and relearning cards.
+         *
+         * Anki uses this as an internal scheduler counter. The stored value is encoded as:
+         *
+         * * `left % 1000`: learning or relearning reps left before graduation
+         * * `left / 1000`: reps that can still be completed before the day cutoff
+         *
+         * For example, `left = 2003` means 3 reps left before graduation, with 2 of
+         * them still completable before the day cutoff.
+         *
+         * This provider exposes the backend value as-is, so consumers should not depend on a
+         * normalized encoding.
+         */
+        public const val RAW_LEFT: String = "left"
+
+        /**
          * The content:// style URI for cards. Can be used to search for cards or access specific cards.
          * For examples on how to use the URI for queries see the overview in [FlashCardsContract].
          */


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT 5.4  - with investigation + documentation


<!--- Please fill the necessary details below -->
## Purpose / Description
- Expose the next set of card scheduling properties from the content provider.
- This PR adds the agreed PR 2 raw fields:
  - `raw_queue`
  - `raw_due`
  - `raw_original_due`
  - `interval`
  - `raw_sm2_factor`
  - `raw_left`

## Fixes
* Fixes #20458 ( Part - 2 )

## Approach
- Added the new public columns in `FlashCardsContract.Card`
- Populated them in `CardContentProvider.addCardToCursor()`
- Kept them opt-in, so `DEFAULT_PROJECTION` did not change
- Kept all card endpoints aligned by using the shared card row-building path
- Added focused KDoc for the raw/state-dependent fields, following the PR 1 review direction


## How Has This Been Tested?

- added/updated `ContentProviderTest` coverage for the new fields
- verified explicit projection behavior
- verified that querying without an explicit projection still omits the new fields
Regarding below testing I tweaked the debug build to allow com.android.shell for manual provider queries; not part of the PR
- manually queried with explicit projection
<img width="1177" height="116" alt="Screenshot 2026-04-08 at 12 16 29 AM" src="https://github.com/user-attachments/assets/bf226a10-fdf4-418a-9cdb-b2d19ea29b4e" />
- manually queried the debug provider at content://com.ichi2.anki.debug.flashcards/cards
<img width="1154" height="259" alt="Screenshot 2026-04-08 at 12 16 57 AM" src="https://github.com/user-attachments/assets/b2c0af8b-a72e-47e7-83fb-19dd66203624" />


## Learning (optional, can help others)
Have shared the modelling discussion for this follow-up pass in these issue comments:
- https://github.com/ankidroid/Anki-Android/issues/20458#issuecomment-4165266675


## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->