### PR TITLE
style: round the edges of the deck picker FAB

### DIFF
--- a/AnkiDroid/src/main/res/layout/include_floating_add_button.xml
+++ b/AnkiDroid/src/main/res/layout/include_floating_add_button.xml
@@ -39,7 +39,7 @@
                 >
                 <TextView
                     android:layout_width="wrap_content"
-                    android:background="@color/material_grey_600"
+                    android:background="@drawable/fab_label_background"
                     android:id="@+id/add_shared_label"
                     android:paddingBottom="5dp"
                     android:paddingTop="5dp"
@@ -80,7 +80,7 @@
                 >
                 <TextView
                     android:layout_width="wrap_content"
-                    android:background="@color/material_grey_600"
+                    android:background="@drawable/fab_label_background"
                     android:id="@+id/add_filtered_deck_label"
                     android:paddingBottom="5dp"
                     android:paddingTop="5dp"
@@ -121,7 +121,7 @@
                 >
                 <TextView
                     android:layout_width="wrap_content"
-                    android:background="@color/material_grey_600"
+                    android:background="@drawable/fab_label_background"
                     android:id="@+id/add_deck_label"
                     android:paddingBottom="5dp"
                     android:paddingTop="5dp"
@@ -157,7 +157,7 @@
                 >
                 <TextView
                     android:layout_width="wrap_content"
-                    android:background="@color/material_grey_600"
+                    android:background="@drawable/fab_label_background"
                     android:id="@+id/add_note_label"
                     android:paddingBottom="5dp"
                     android:paddingTop="5dp"

--- a/AnkiDroid/src/main/res/values/colors.xml
+++ b/AnkiDroid/src/main/res/values/colors.xml
@@ -130,7 +130,7 @@
     <color name="badge_error">#f45000</color>
     <color name="badge_warning">#ff5e13</color>
 
-    <color name="fab_background">#777</color>
+    <color name="fab_background">#ff757575</color>
 
     <color name="theme_light_drawer_row_current">#E8E8E8</color>
     <color name="popup_background_theme_dark">#434343</color>


### PR DESCRIPTION
## Purpose / Description
This PR rounds off the edges of the deck picker FAB labels to be more consistent with material design and the apps own design style.

## Approach
I replaced the `@color/material_grey_600` background with `@drawable/fab_label_background` for the floating add button labels. This drawable already existed and contained the rounded edges needed, but I needed to change the background color to the same hexcode of material_grey_600 to keep the same text contrast.

## How Has This Been Tested?
I tested on a Pixel 9 Pro XL and verified there were no unintended UI regressions like improper contrast on light, dark, and night themes.

## Learning
Material Design 3 generally uses rounded shapes for labels or clickable items.

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<img width="1344" height="2992" alt="Screenshot_20260406-190326" src="https://github.com/user-attachments/assets/f0f150ea-d09a-4172-867e-d088dcc54e27" />
<img width="1344" height="2992" alt="Screenshot_20260406-190340" src="https://github.com/user-attachments/assets/27c371ab-b2b6-4961-9a06-ea994785e6ec" />
<img width="1344" height="2992" alt="Screenshot_20260406-190358" src="https://github.com/user-attachments/assets/d6476f9e-49b8-41d2-8887-97521d027736" />
