### PR TITLE
refactor(deck-picker): context menus

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -97,7 +97,6 @@ import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.anki.contextmenu.DeckPickerMenuContentProvider
-import com.ichi2.anki.contextmenu.MouseContextMenuHandler
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeDeckPickerBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
@@ -267,9 +266,6 @@ open class DeckPicker :
     private lateinit var decksLayoutManager: LinearLayoutManager
     private lateinit var deckListAdapter: DeckAdapter
     private lateinit var pullToSyncWrapper: SwipeRefreshLayout
-
-    // Right-click context menu handler using decoupled menu system
-    private lateinit var mouseContextMenuHandler: MouseContextMenuHandler
 
     private lateinit var floatingActionMenu: DeckPickerFloatingActionMenu
 
@@ -457,10 +453,13 @@ open class DeckPicker :
         y: Float,
     ) = launchCatchingTask {
         withCol { decks.select(deckId) }
-        val menuContentProvider = DeckPickerMenuContentProvider.newInstance(deckId, this@DeckPicker)
         updateDeckList()
-        mouseContextMenuHandler = MouseContextMenuHandler(deckPickerBinding.deckPickerContent, menuContentProvider)
-        mouseContextMenuHandler.showContextMenu(deckPickerBinding.decks, x, y)
+        DeckPickerMenuContentProvider.show(
+            deckPicker = this@DeckPicker,
+            deckId = deckId,
+            x = x,
+            y = y,
+        )
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -440,10 +440,9 @@ open class DeckPicker :
 
     private fun showDeckPickerContextMenu(deckId: DeckId) =
         launchCatchingTask {
-            withCol { decks.select(deckId) }
+            viewModel.selectDeck(deckId).join()
             val menu = DeckPickerContextMenu.newInstance(deckId)
             CardBrowser.clearLastDeckId()
-            updateDeckList()
             showDialogFragment(menu)
         }
 
@@ -452,8 +451,7 @@ open class DeckPicker :
         x: Float,
         y: Float,
     ) = launchCatchingTask {
-        withCol { decks.select(deckId) }
-        updateDeckList()
+        viewModel.selectDeck(deckId).join()
         DeckPickerMenuContentProvider.show(
             deckPicker = this@DeckPicker,
             deckId = deckId,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -442,49 +442,25 @@ open class DeckPicker :
         }
     }
 
-    private fun showDeckPickerContextMenu(deckId: DeckId) {
+    private fun showDeckPickerContextMenu(deckId: DeckId) =
         launchCatchingTask {
-            val (deckName, isDynamic, hasBuriedInDeck) =
-                withCol {
-                    decks.select(deckId)
-                    Triple(
-                        decks.name(deckId),
-                        decks.isFiltered(deckId),
-                        sched.haveBuried(),
-                    )
-                }
+            withCol { decks.select(deckId) }
+            val menu = DeckPickerContextMenu.newInstance(deckId)
             CardBrowser.clearLastDeckId()
             updateDeckList()
-            showDialogFragment(
-                DeckPickerContextMenu.newInstance(
-                    id = deckId,
-                    name = deckName,
-                    isDynamic = isDynamic,
-                    hasBuriedInDeck = hasBuriedInDeck,
-                ),
-            )
+            showDialogFragment(menu)
         }
-    }
 
     private fun showDeckPickerRightClickContextMenu(
         deckId: DeckId,
         x: Float,
         y: Float,
-    ) {
-        launchCatchingTask {
-            val (isDynamic, hasBuriedInDeck) =
-                withCol {
-                    decks.select(deckId)
-                    Pair(
-                        decks.isFiltered(deckId),
-                        sched.haveBuried(),
-                    )
-                }
-            updateDeckList()
-            val menuContentProvider = DeckPickerMenuContentProvider(deckId, isDynamic, hasBuriedInDeck, this@DeckPicker)
-            mouseContextMenuHandler = MouseContextMenuHandler(deckPickerBinding.deckPickerContent, menuContentProvider)
-            mouseContextMenuHandler.showContextMenu(deckPickerBinding.decks, x, y)
-        }
+    ) = launchCatchingTask {
+        withCol { decks.select(deckId) }
+        val menuContentProvider = DeckPickerMenuContentProvider.newInstance(deckId, this@DeckPicker)
+        updateDeckList()
+        mouseContextMenuHandler = MouseContextMenuHandler(deckPickerBinding.deckPickerContent, menuContentProvider)
+        mouseContextMenuHandler.showContextMenu(deckPickerBinding.decks, x, y)
     }
 
     // ----------------------------------------------------------------------------

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -136,6 +136,7 @@ import com.ichi2.anki.dialogs.SyncErrorDialog.SyncErrorDialogListener
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction
 import com.ichi2.anki.dialogs.customstudy.CustomStudyDialog.CustomStudyAction.Companion.REQUEST_KEY
+import com.ichi2.anki.dialogs.setDeckPickerContextMenuResultListener
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.filtered.FilteredDeckOptionsFragment
 import com.ichi2.anki.introduction.CollectionPermissionScreenLauncher
@@ -602,20 +603,8 @@ open class DeckPicker :
             }
         }
 
-        setFragmentResultListener(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU) { _, bundle ->
-            handleContextMenuSelection(
-                bundle.getSerializableCompat<DeckPickerContextMenuOption>(DeckPickerContextMenu.CONTEXT_MENU_DECK_OPTION)
-                    ?: error("Unable to retrieve selected context menu option"),
-                bundle.getLong(DeckPickerContextMenu.CONTEXT_MENU_DECK_ID, -1),
-            )
-        }
-
-        setFragmentResultListener(DeckPickerMenuContentProvider.REQUEST_KEY_CONTEXT_MENU) { _, bundle ->
-            handleContextMenuSelection(
-                bundle.getSerializableCompat<DeckPickerContextMenuOption>(DeckPickerMenuContentProvider.CONTEXT_MENU_DECK_OPTION)
-                    ?: error("Unable to retrieve selected context menu option"),
-                bundle.getLong(DeckPickerMenuContentProvider.CONTEXT_MENU_DECK_ID, -1),
-            )
+        setDeckPickerContextMenuResultListener { result ->
+            handleContextMenuSelection(result.option, result.deckId)
         }
 
         setFragmentResultListener(StudyOptionsFragment.REQUEST_STUDY_OPTIONS_STUDY) { _, _ ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
@@ -63,21 +63,30 @@ class DeckPickerMenuContentProvider(
 
     companion object {
         /**
-         * Builds a [DeckPickerMenuContentProvider] for [deckId], reading the dynamic /
-         * has-buried flags from the collection.
+         * Builds a [DeckPickerMenuContentProvider] for [deckId] (reading the dynamic /
+         * has-buried flags from the collection) and shows it as a popup anchored at
+         * ([x], [y]) on the deck picker's recycler view.
          */
-        suspend fun newInstance(
-            deckId: DeckId,
+        suspend fun show(
             deckPicker: DeckPicker,
-        ): DeckPickerMenuContentProvider =
-            withCol {
-                DeckPickerMenuContentProvider(
-                    id = deckId,
-                    isDynamic = decks.isFiltered(deckId),
-                    hasBuriedInDeck = sched.haveBuried(),
-                    deckPicker = deckPicker,
-                )
-            }
+            deckId: DeckId,
+            x: Float,
+            y: Float,
+        ) {
+            val provider =
+                withCol {
+                    DeckPickerMenuContentProvider(
+                        id = deckId,
+                        isDynamic = decks.isFiltered(deckId),
+                        hasBuriedInDeck = sched.haveBuried(),
+                        deckPicker = deckPicker,
+                    )
+                }
+            val anchorParent = deckPicker.deckPickerBinding.deckPickerContent
+            val target = deckPicker.deckPickerBinding.decks
+            MouseContextMenuHandler(viewGroup = anchorParent, menuContentProvider = provider)
+                .showContextMenu(view = target, x = x, y = y)
+        }
 
         fun createOptionsList(
             isDynamic: Boolean,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
@@ -18,9 +18,10 @@ package com.ichi2.anki.contextmenu
 
 import android.view.Menu
 import android.view.MenuItem
-import androidx.core.os.bundleOf
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.dialogs.DeckPickerContextMenu
+import com.ichi2.anki.dialogs.DeckPickerContextMenuResult
+import com.ichi2.anki.dialogs.setDeckPickerContextMenuResult
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.settings.Prefs
 
@@ -44,12 +45,8 @@ class DeckPickerMenuContentProvider(
         val options = createOptionsList()
         val selectedOption = options.getOrNull(item.itemId) ?: return false
 
-        deckPicker.supportFragmentManager.setFragmentResult(
-            REQUEST_KEY_CONTEXT_MENU,
-            bundleOf(
-                CONTEXT_MENU_DECK_ID to id,
-                CONTEXT_MENU_DECK_OPTION to selectedOption,
-            ),
+        deckPicker.supportFragmentManager.setDeckPickerContextMenuResult(
+            DeckPickerContextMenuResult(deckId = id, option = selectedOption),
         )
         return true
     }
@@ -96,9 +93,5 @@ class DeckPickerMenuContentProvider(
                 }
                 add(DeckPickerContextMenu.DeckPickerContextMenuOption.DELETE_DECK)
             }
-
-        const val REQUEST_KEY_CONTEXT_MENU = "request_key_deck_context_menu_provider"
-        const val CONTEXT_MENU_DECK_OPTION = "context_menu_deck_option"
-        const val CONTEXT_MENU_DECK_ID = "context_menu_deck_id"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/contextmenu/DeckPickerMenuContentProvider.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.contextmenu
 
 import android.view.Menu
 import android.view.MenuItem
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.dialogs.DeckPickerContextMenu
 import com.ichi2.anki.dialogs.DeckPickerContextMenuResult
@@ -61,6 +62,23 @@ class DeckPickerMenuContentProvider(
     private fun createOptionsList(): List<DeckPickerContextMenu.DeckPickerContextMenuOption> = createOptionsList(isDynamic, hasBuriedInDeck)
 
     companion object {
+        /**
+         * Builds a [DeckPickerMenuContentProvider] for [deckId], reading the dynamic /
+         * has-buried flags from the collection.
+         */
+        suspend fun newInstance(
+            deckId: DeckId,
+            deckPicker: DeckPicker,
+        ): DeckPickerMenuContentProvider =
+            withCol {
+                DeckPickerMenuContentProvider(
+                    id = deckId,
+                    isDynamic = decks.isFiltered(deckId),
+                    hasBuriedInDeck = sched.haveBuried(),
+                    deckPicker = deckPicker,
+                )
+            }
+
         fun createOptionsList(
             isDynamic: Boolean,
             hasBuriedInDeck: Boolean,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/DeckPickerViewModel.kt
@@ -277,6 +277,17 @@ class DeckPickerViewModel :
             flowOfDeckCountsChanged.emit(Unit)
         }
 
+    /**
+     * Marks [deckId] as the currently selected deck and updates the selection in the deck list.
+     */
+    fun selectDeck(deckId: DeckId) =
+        viewModelScope.launch {
+            // TODO: should we always reset the Card Browser default deck here?
+            withCol { decks.select(deckId) }
+            focusedDeck = deckId
+            flowOfRefreshDeckList.emit(Unit)
+        }
+
     fun browseCards(deckId: DeckId) =
         launchCatchingIO {
             withCol { decks.select(deckId) }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -21,10 +21,16 @@ import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
+import com.ichi2.anki.compat.requireSerializableCompat
 import com.ichi2.anki.contextmenu.DeckPickerMenuContentProvider
+import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
 import com.ichi2.anki.libanki.DeckId
+import com.ichi2.anki.utils.ext.requireLong
+import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.utils.title
 
 class DeckPickerContextMenu : AnalyticsDialogFragment() {
@@ -41,11 +47,10 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
             .setItems(
                 options.map { resources.getString(it.optionName) }.toTypedArray(),
             ) { _, index: Int ->
-                parentFragmentManager.setFragmentResult(
-                    REQUEST_KEY_CONTEXT_MENU,
-                    bundleOf(
-                        CONTEXT_MENU_DECK_ID to requireArguments().getLong(ARG_DECK_ID),
-                        CONTEXT_MENU_DECK_OPTION to options[index],
+                parentFragmentManager.setDeckPickerContextMenuResult(
+                    DeckPickerContextMenuResult(
+                        deckId = requireArguments().getLong(ARG_DECK_ID),
+                        option = options[index],
                     ),
                 )
             }.create()
@@ -77,10 +82,6 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
     }
 
     companion object {
-        const val REQUEST_KEY_CONTEXT_MENU = "request_key_context_menu"
-        const val CONTEXT_MENU_DECK_OPTION = "context_menu_deck_option"
-        const val CONTEXT_MENU_DECK_ID = "context_menu_deck_id"
-
         @VisibleForTesting
         const val ARG_DECK_ID = "arg_deck_id"
 
@@ -108,5 +109,45 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
                         ARG_DECK_HAS_BURIED_IN_DECK to hasBuriedInDeck,
                     )
             }
+    }
+}
+
+/**
+ * Result delivered by the deck-picker context menus
+ *
+ * @see DeckPickerContextMenuOption
+ * @see DeckPickerContextMenu
+ * @see DeckPickerMenuContentProvider
+ */
+data class DeckPickerContextMenuResult(
+    val deckId: DeckId,
+    val option: DeckPickerContextMenuOption,
+) {
+    fun toBundle(): Bundle =
+        Bundle().apply {
+            putLong(ARG_DECK_ID, deckId)
+            putSerializable(ARG_OPTION, option)
+        }
+
+    companion object {
+        const val REQUEST_KEY = "request_key_deck_picker_context_menu"
+        private const val ARG_DECK_ID = "deck_id"
+        private const val ARG_OPTION = "option"
+
+        fun fromBundle(bundle: Bundle) =
+            DeckPickerContextMenuResult(
+                deckId = bundle.requireLong(ARG_DECK_ID),
+                option = bundle.requireSerializableCompat<DeckPickerContextMenuOption>(ARG_OPTION),
+            )
+    }
+}
+
+fun FragmentManager.setDeckPickerContextMenuResult(result: DeckPickerContextMenuResult) {
+    setFragmentResult(DeckPickerContextMenuResult.REQUEST_KEY, result.toBundle())
+}
+
+fun FragmentActivity.setDeckPickerContextMenuResultListener(listener: (DeckPickerContextMenuResult) -> Unit) {
+    setFragmentResultListener(DeckPickerContextMenuResult.REQUEST_KEY) { _, bundle ->
+        listener(DeckPickerContextMenuResult.fromBundle(bundle))
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DeckPickerContextMenu.kt
@@ -20,9 +20,9 @@ import android.os.Bundle
 import androidx.annotation.StringRes
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.app.AlertDialog
-import androidx.core.os.bundleOf
 import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
+import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsDialogFragment
 import com.ichi2.anki.compat.requireSerializableCompat
@@ -82,6 +82,23 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
     }
 
     companion object {
+        /**
+         * Builds a [DeckPickerContextMenu] for [deckId], reading the deck's name and
+         * the dynamic / has-buried flags from the collection.
+         */
+        suspend fun newInstance(deckId: DeckId): DeckPickerContextMenu =
+            withCol {
+                DeckPickerContextMenu().apply {
+                    arguments =
+                        Bundle().apply {
+                            putLong(ARG_DECK_ID, deckId)
+                            putString(ARG_DECK_NAME, decks.name(deckId))
+                            putBoolean(ARG_DECK_IS_DYN, decks.isFiltered(deckId))
+                            putBoolean(ARG_DECK_HAS_BURIED_IN_DECK, sched.haveBuried())
+                        }
+                }
+            }
+
         @VisibleForTesting
         const val ARG_DECK_ID = "arg_deck_id"
 
@@ -93,22 +110,6 @@ class DeckPickerContextMenu : AnalyticsDialogFragment() {
 
         @VisibleForTesting
         const val ARG_DECK_HAS_BURIED_IN_DECK = "arg_deck_has_buried_in_deck"
-
-        fun newInstance(
-            id: DeckId,
-            name: String,
-            isDynamic: Boolean,
-            hasBuriedInDeck: Boolean,
-        ): DeckPickerContextMenu =
-            DeckPickerContextMenu().apply {
-                arguments =
-                    bundleOf(
-                        ARG_DECK_ID to id,
-                        ARG_DECK_NAME to name,
-                        ARG_DECK_IS_DYN to isDynamic,
-                        ARG_DECK_HAS_BURIED_IN_DECK to hasBuriedInDeck,
-                    )
-            }
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerTest.kt
@@ -7,7 +7,6 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.database.sqlite.SQLiteDatabaseCorruptException
-import android.os.Bundle
 import android.view.Menu
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
@@ -15,7 +14,6 @@ import androidx.core.content.IntentCompat
 import androidx.core.content.edit
 import androidx.core.content.pm.ShortcutManagerCompat
 import androidx.core.view.children
-import androidx.fragment.app.FragmentManager
 import androidx.test.core.app.ActivityScenario
 import anki.collection.opChanges
 import anki.scheduler.CardAnswer.Rating
@@ -25,8 +23,9 @@ import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
-import com.ichi2.anki.dialogs.DeckPickerContextMenu
 import com.ichi2.anki.dialogs.DeckPickerContextMenu.DeckPickerContextMenuOption
+import com.ichi2.anki.dialogs.DeckPickerContextMenuResult
+import com.ichi2.anki.dialogs.setDeckPickerContextMenuResult
 import com.ichi2.anki.dialogs.utils.title
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.observability.ChangeManager
@@ -78,6 +77,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
+
+typealias ContextMenuOption = DeckPickerContextMenuOption
 
 @KotlinCleanup("SPMockBuilder")
 @RunWith(ParameterizedRobolectricTestRunner::class)
@@ -384,15 +385,15 @@ class DeckPickerTest : RobolectricTest() {
         deckPicker {
             val didA = addDeck("Deck 1")
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.RENAME_DECK, didA)
+            selectContextMenuOption(ContextMenuOption.RENAME_DECK, didA)
             assertDialogTitleEquals("Rename deck")
             dismissAllDialogFragments()
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CREATE_SUBDECK, didA)
+            selectContextMenuOption(ContextMenuOption.CREATE_SUBDECK, didA)
             assertDialogTitleEquals("Create subdeck")
             dismissAllDialogFragments()
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY, didA)
+            selectContextMenuOption(ContextMenuOption.CUSTOM_STUDY, didA)
             assertDialogTitleEquals("Custom study")
             dismissAllDialogFragments()
 
@@ -403,17 +404,12 @@ class DeckPickerTest : RobolectricTest() {
         }
 
     /** Simulates a selection in the context menu by setting the specific result in FragmentManager */
-    private fun FragmentManager.selectContextMenuOption(
+    private fun DeckPicker.selectContextMenuOption(
         option: DeckPickerContextMenuOption,
         deckId: DeckId,
-    ) {
-        val arguments =
-            Bundle().apply {
-                putLong(DeckPickerContextMenu.CONTEXT_MENU_DECK_ID, deckId)
-                putSerializable(DeckPickerContextMenu.CONTEXT_MENU_DECK_OPTION, option)
-            }
-        setFragmentResult(DeckPickerContextMenu.REQUEST_KEY_CONTEXT_MENU, arguments)
-    }
+    ) = supportFragmentManager.setDeckPickerContextMenuResult(
+        DeckPickerContextMenuResult(deckId = deckId, option = option),
+    )
 
     private fun assertDialogTitleEquals(expectedTitle: String) {
         val actualTitle = (ShadowDialog.getLatestDialog() as AlertDialog).title
@@ -425,12 +421,12 @@ class DeckPickerTest : RobolectricTest() {
     fun `ContextMenu starts expected activities when specific options are selected`() =
         deckPicker {
             suspend fun DeckPicker.selectContextMenuOptionForActivity(
-                option: DeckPickerContextMenuOption,
+                option: ContextMenuOption,
                 deckId: DeckId,
             ): Intent {
                 var result: Destination? = null
                 viewModel.flowOfDestination.test(1.seconds) {
-                    supportFragmentManager.selectContextMenuOption(option, deckId)
+                    selectContextMenuOption(option, deckId)
                     result = awaitItem()
                 }
                 return result!!.toIntent(this)
@@ -467,7 +463,7 @@ class DeckPickerTest : RobolectricTest() {
     fun `ContextMenu deletes deck when selecting DELETE_DECK`() =
         deckPicker {
             val didA = addDeck("Deck 1")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.DELETE_DECK, didA)
+            selectContextMenuOption(ContextMenuOption.DELETE_DECK, didA)
             assertThat(getColUnsafe.decks.allNamesAndIds().map { it.id }, not(containsInAnyOrder(didA)))
         }
 
@@ -475,7 +471,7 @@ class DeckPickerTest : RobolectricTest() {
     fun `ContextMenu creates deck shortcut when selecting CREATE_SHORTCUT`() =
         deckPicker {
             val didA = addDeck("Deck 1")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CREATE_SHORTCUT, didA)
+            selectContextMenuOption(ContextMenuOption.CREATE_SHORTCUT, didA)
             // Wait for the shortcut creation to complete
             ShadowLooper.runUiThreadTasksIncludingDelayedTasks()
             assertEquals(
@@ -500,7 +496,7 @@ class DeckPickerTest : RobolectricTest() {
             advanceRobolectricLooper()
             assertEquals(1, visibleDeckCount)
             assertTrue(getColUnsafe.sched.haveBuried(), "Deck should have buried cards")
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.UNBURY, deckId)
+            selectContextMenuOption(ContextMenuOption.UNBURY, deckId)
             kotlin.test.assertFalse(getColUnsafe.sched.haveBuried())
         }
 
@@ -517,11 +513,11 @@ class DeckPickerTest : RobolectricTest() {
             updateDeckList()
             assertEquals(1, visibleDeckCount)
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY_EMPTY, deckId) // Empty
+            selectContextMenuOption(ContextMenuOption.CUSTOM_STUDY_EMPTY, deckId)
 
             assertTrue(allCardsInSameDeck(cardIds, 1))
 
-            supportFragmentManager.selectContextMenuOption(DeckPickerContextMenuOption.CUSTOM_STUDY_REBUILD, deckId) // Rebuild
+            selectContextMenuOption(ContextMenuOption.CUSTOM_STUDY_REBUILD, deckId)
 
             assertTrue(allCardsInSameDeck(cardIds, deckId))
         }

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatHelper.kt
@@ -217,3 +217,8 @@ class CompatHelper private constructor() {
  * @param tooltipText the tooltip text
  */
 fun View.setTooltipTextCompat(tooltipText: CharSequence?) = TooltipCompat.setTooltipText(this, tooltipText)
+
+inline fun <reified T : Serializable> Bundle.requireSerializableCompat(key: String): T =
+    requireNotNull(compat.getSerializable(this, key, T::class.java)) {
+        "key: '$key' not found or null"
+    }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6 - wrote the code, with a lot of refactoring from myself

## Purpose / Description
Just cutting down the code in the Deck Picker & a partial ViewModel move

## Approach
See the commits:

* Common pattern of `FragmentActivity.setDeckPickerContextMenuResultListener`
  * But the two menus used the same result type, so I could combine them
* moved instantiation logic to `newInstance`
* moved `MouseContextMenuHandler` inside the Right click context menu
* moved deck selection to the View Model, now the rationale is clear.

## How Has This Been Tested?
API 35 emulator: I long pressed a deck and the focus still changes

Trusting CI for the rest.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)