### PR TITLE
fix(deck-picker): metered 'full sync' retry logic

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -161,6 +161,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.BaseSnackbarBuilderProvider
 import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.sync.MeteredSyncPolicy
 import com.ichi2.anki.sync.launchCatchingRequiringOneWaySyncDiscardUndo
 import com.ichi2.anki.ui.ResizablePaneManager
 import com.ichi2.anki.ui.animations.fadeIn
@@ -187,7 +188,6 @@ import com.ichi2.utils.ClipboardUtil.IMPORT_MIME_TYPES
 import com.ichi2.utils.ImportResult
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.NetworkUtils
-import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils
 import com.ichi2.utils.checkBoxPrompt
@@ -1535,11 +1535,9 @@ open class DeckPicker :
             return TimeManager.time.intTimeMS() - Prefs.lastSyncTime > automaticSyncIntervalInMS
         }
 
-        val isBlockedByMeteredConnection = !Prefs.allowSyncOnMeteredConnections && isActiveNetworkMetered()
-
         when {
             !Prefs.isAutoSyncEnabled -> Timber.d("autoSync: not enabled")
-            isBlockedByMeteredConnection -> Timber.d("autoSync: blocked by metered connection")
+            MeteredSyncPolicy.shouldBlock() -> Timber.d("autoSync: blocked by metered connection")
             !NetworkUtils.isOnline -> Timber.d("autoSync: offline")
             !runInBackground && !syncIntervalPassed() -> Timber.d("autoSync: interval not passed")
             !isLoggedIn() -> Timber.d("autoSync: not logged in")
@@ -1965,13 +1963,13 @@ open class DeckPicker :
             handleNewSync(conflict, shouldFetchMedia())
         }
         // Warn the user in case the connection is metered
-        if (!Prefs.allowSyncOnMeteredConnections && isActiveNetworkMetered()) {
+        if (MeteredSyncPolicy.shouldBlock()) {
             AlertDialog.Builder(this).show {
                 message(R.string.metered_sync_data_warning)
                 positiveButton(R.string.dialog_continue) { doSync() }
                 negativeButton(R.string.dialog_cancel)
                 checkBoxPrompt(R.string.button_do_not_show_again) { isCheckboxChecked ->
-                    Prefs.allowSyncOnMeteredConnections = isCheckboxChecked
+                    MeteredSyncPolicy.setAlwaysAllow(isCheckboxChecked)
                 }
             }
             refreshState()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1956,7 +1956,12 @@ open class DeckPicker :
             return
         }
 
-        MeteredSyncPolicy.confirmThen(onDialogShown = { refreshState() }) {
+        MeteredSyncPolicy.confirmThen(
+            // After selecting 'upload/download', the user has already accepted the metered warning.
+            skipPrompt = conflict != null,
+            // TODO: why is this needed? 1f91b2868d
+            onDialogShown = ::refreshState,
+        ) {
             handleNewSync(conflict, shouldFetchMedia())
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -190,7 +190,6 @@ import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.NetworkUtils
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.VersionUtils
-import com.ichi2.utils.checkBoxPrompt
 import com.ichi2.utils.checkWebviewVersion
 import com.ichi2.utils.configureView
 import com.ichi2.utils.customView
@@ -1957,24 +1956,8 @@ open class DeckPicker :
             return
         }
 
-        /** Nested function that makes the connection to
-         * the sync server and starts syncing the data */
-        fun doSync() {
+        MeteredSyncPolicy.confirmThen(onDialogShown = { refreshState() }) {
             handleNewSync(conflict, shouldFetchMedia())
-        }
-        // Warn the user in case the connection is metered
-        if (MeteredSyncPolicy.shouldBlock()) {
-            AlertDialog.Builder(this).show {
-                message(R.string.metered_sync_data_warning)
-                positiveButton(R.string.dialog_continue) { doSync() }
-                negativeButton(R.string.dialog_cancel)
-                checkBoxPrompt(R.string.button_do_not_show_again) { isCheckboxChecked ->
-                    MeteredSyncPolicy.setAlwaysAllow(isCheckboxChecked)
-                }
-            }
-            refreshState()
-        } else {
-            doSync()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
@@ -16,8 +16,16 @@
 
 package com.ichi2.anki.sync
 
+import android.content.Context
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.R
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
+import com.ichi2.utils.checkBoxPrompt
+import com.ichi2.utils.message
+import com.ichi2.utils.negativeButton
+import com.ichi2.utils.positiveButton
+import com.ichi2.utils.show
 
 /**
  * Single source of truth for the "warn the user before syncing on a metered connection"
@@ -31,5 +39,31 @@ object MeteredSyncPolicy {
     /** Persist the user's "don't ask again" choice from the warning dialog. */
     fun setAlwaysAllow(allow: Boolean) {
         Prefs.allowSyncOnMeteredConnections = allow
+    }
+
+    /**
+     * Run [onConfirm] immediately if the network is unmetered, or metered-network sync is
+     * allowed, otherwise shows a warning dialog and runs [onConfirm] when 'Continue' is pressed.
+     *
+     * @param onDialogShown invoked only if the warning dialog is displayed
+     */
+    context(context: Context)
+    fun confirmThen(
+        onDialogShown: () -> Unit,
+        onConfirm: () -> Unit,
+    ) {
+        if (!shouldBlock()) {
+            onConfirm()
+            return
+        }
+        AlertDialog.Builder(context).show {
+            message(R.string.metered_sync_data_warning)
+            positiveButton(R.string.dialog_continue) { onConfirm() }
+            negativeButton(R.string.dialog_cancel)
+            checkBoxPrompt(R.string.button_do_not_show_again) { checked ->
+                setAlwaysAllow(checked)
+            }
+        }
+        onDialogShown()
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.sync
+
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.utils.NetworkUtils.isActiveNetworkMetered
+
+/**
+ * Single source of truth for the "warn the user before syncing on a metered connection"
+ * preference. All reads of [Prefs.allowSyncOnMeteredConnections] should go through here
+ * so that the gating policy lives in one place.
+ */
+object MeteredSyncPolicy {
+    /** True when sync should be blocked/prompted because the network is metered. */
+    fun shouldBlock(): Boolean = !Prefs.allowSyncOnMeteredConnections && isActiveNetworkMetered()
+
+    /** Persist the user's "don't ask again" choice from the warning dialog. */
+    fun setAlwaysAllow(allow: Boolean) {
+        Prefs.allowSyncOnMeteredConnections = allow
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/sync/MeteredSyncPolicy.kt
@@ -42,17 +42,21 @@ object MeteredSyncPolicy {
     }
 
     /**
-     * Run [onConfirm] immediately if the network is unmetered, or metered-network sync is
-     * allowed, otherwise shows a warning dialog and runs [onConfirm] when 'Continue' is pressed.
+     * Run [onConfirm] immediately if the network is unmetered, metered-network sync is
+     * allowed, or [skipPrompt] is set; otherwise show a warning dialog and run [onConfirm] when
+     * 'Continue' is pressed.
      *
+     * @param skipPrompt `true` if the user has already accepted a metered sync earlier in this
+     *   attempt (e.g. retry after conflict resolution); skips the warning.
      * @param onDialogShown invoked only if the warning dialog is displayed
      */
     context(context: Context)
     fun confirmThen(
+        skipPrompt: Boolean = false,
         onDialogShown: () -> Unit,
         onConfirm: () -> Unit,
     ) {
-        if (!shouldBlock()) {
+        if (skipPrompt || !shouldBlock()) {
             onConfirm()
             return
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/sync/MeteredSyncPolicyTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/sync/MeteredSyncPolicyTest.kt
@@ -27,6 +27,7 @@ import io.mockk.unmockkObject
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.notNullValue
+import org.hamcrest.Matchers.nullValue
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -58,7 +59,7 @@ class MeteredSyncPolicyTest : RobolectricTest() {
 
         assertThat("onDialogShown not called", result.dialogShown, equalTo(false))
         assertThat("onConfirm ran", result.onConfirmCalled, equalTo(true))
-        assertThat("no dialog shown", result.dialog, org.hamcrest.Matchers.nullValue())
+        assertThat("no dialog shown", result.dialog, nullValue())
     }
 
     @Test
@@ -97,6 +98,28 @@ class MeteredSyncPolicyTest : RobolectricTest() {
     }
 
     @Test
+    fun `skipPrompt skips prompt even when metered`() {
+        // Issue 20674
+        every { MeteredSyncPolicy.shouldBlock() } returns true
+
+        val result = attemptMeteredSync(skipPrompt = true)
+
+        assertThat("onConfirm ran immediately", result.onConfirmCalled, equalTo(true))
+        assertThat("no dialog shown", result.dialog, nullValue())
+        assertThat("onDialogShown not called", result.dialogShown, equalTo(false))
+    }
+
+    @Test
+    fun `skipPrompt on unmetered network runs directly`() {
+        every { MeteredSyncPolicy.shouldBlock() } returns false
+
+        val result = attemptMeteredSync(skipPrompt = true)
+
+        assertThat("onConfirm ran immediately", result.onConfirmCalled, equalTo(true))
+        assertThat("no dialog shown", result.dialog, nullValue())
+    }
+
+    @Test
     fun `setAlwaysAllow persists choice`() {
         unmockkObject(MeteredSyncPolicy)
         Prefs.allowSyncOnMeteredConnections = false
@@ -105,11 +128,12 @@ class MeteredSyncPolicyTest : RobolectricTest() {
     }
 
     /** Invokes [MeteredSyncPolicy.confirmThen] from a freshly-built activity. */
-    private fun attemptMeteredSync(): MeteredSyncAttemptResult {
+    private fun attemptMeteredSync(skipPrompt: Boolean = false): MeteredSyncAttemptResult {
         var dialogShown = false
         var confirmed = false
         with(startRegularActivity<EmptyAnkiActivity>()) {
             MeteredSyncPolicy.confirmThen(
+                skipPrompt = skipPrompt,
                 onDialogShown = { dialogShown = true },
             ) { confirmed = true }
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/sync/MeteredSyncPolicyTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/sync/MeteredSyncPolicyTest.kt
@@ -1,0 +1,146 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.sync
+
+import android.content.DialogInterface
+import androidx.appcompat.app.AlertDialog
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.settings.Prefs
+import com.ichi2.testutils.EmptyAnkiActivity
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.shadows.ShadowDialog
+import org.robolectric.shadows.ShadowLooper
+
+/** Tests for [MeteredSyncPolicy] */
+@RunWith(RobolectricTestRunner::class)
+class MeteredSyncPolicyTest : RobolectricTest() {
+    @Before
+    override fun setUp() {
+        super.setUp()
+        mockkObject(MeteredSyncPolicy)
+    }
+
+    @After
+    override fun tearDown() {
+        unmockkObject(MeteredSyncPolicy)
+        super.tearDown()
+    }
+
+    @Test
+    fun `runs onConfirm immediately when not blocked`() {
+        every { MeteredSyncPolicy.shouldBlock() } returns false
+
+        val result = attemptMeteredSync()
+
+        assertThat("onDialogShown not called", result.dialogShown, equalTo(false))
+        assertThat("onConfirm ran", result.onConfirmCalled, equalTo(true))
+        assertThat("no dialog shown", result.dialog, org.hamcrest.Matchers.nullValue())
+    }
+
+    @Test
+    fun `shows dialog and notifies onDialogShown when blocked`() {
+        every { MeteredSyncPolicy.shouldBlock() } returns true
+
+        val result = attemptMeteredSync()
+
+        assertThat("onDialogShown invoked", result.dialogShown, equalTo(true))
+        assertThat("onConfirm not yet run", result.onConfirmCalled, equalTo(false))
+        assertThat("dialog shown", result.dialog, notNullValue())
+    }
+
+    @Test
+    fun `Continue runs onConfirm`() {
+        every { MeteredSyncPolicy.shouldBlock() } returns true
+
+        val result = attemptMeteredSync()
+        assertThat("onConfirm not called initially", result.onConfirmCalled, equalTo(false))
+
+        result.clickContinue()
+
+        assertThat("onConfirm ran after Continue", result.onConfirmCalled, equalTo(true))
+    }
+
+    @Test
+    fun `Cancel does not run onConfirm`() {
+        every { MeteredSyncPolicy.shouldBlock() } returns true
+
+        val result = attemptMeteredSync()
+        assertThat("onConfirm not called initially", result.onConfirmCalled, equalTo(false))
+
+        result.clickCancel()
+
+        assertThat("onConfirm not run after Cancel", result.onConfirmCalled, equalTo(false))
+    }
+
+    @Test
+    fun `setAlwaysAllow persists choice`() {
+        unmockkObject(MeteredSyncPolicy)
+        Prefs.allowSyncOnMeteredConnections = false
+        MeteredSyncPolicy.setAlwaysAllow(true)
+        assertThat(Prefs.allowSyncOnMeteredConnections, equalTo(true))
+    }
+
+    /** Invokes [MeteredSyncPolicy.confirmThen] from a freshly-built activity. */
+    private fun attemptMeteredSync(): MeteredSyncAttemptResult {
+        var dialogShown = false
+        var confirmed = false
+        with(startRegularActivity<EmptyAnkiActivity>()) {
+            MeteredSyncPolicy.confirmThen(
+                onDialogShown = { dialogShown = true },
+            ) { confirmed = true }
+        }
+        return MeteredSyncAttemptResult(
+            dialogShown = dialogShown,
+            isConfirmed = { confirmed },
+            dialog = ShadowDialog.getLatestDialog() as? AlertDialog,
+        )
+    }
+
+    /**
+     * Tracks the side effects of a single call to [MeteredSyncPolicy.confirmThen].
+     *
+     * @property dialogShown whether the warning dialog's `onDialogShown` callback fired
+     * @property onConfirmCalled whether `onConfirm` has been invoked
+     * @property dialog the most recently displayed [AlertDialog], or `null` if none was shown
+     */
+    private class MeteredSyncAttemptResult(
+        val dialogShown: Boolean,
+        private val isConfirmed: () -> Boolean,
+        val dialog: AlertDialog?,
+    ) {
+        val onConfirmCalled: Boolean get() = isConfirmed()
+
+        fun clickContinue() = clickDialogButton(DialogInterface.BUTTON_POSITIVE)
+
+        fun clickCancel() = clickDialogButton(DialogInterface.BUTTON_NEGATIVE)
+
+        private fun clickDialogButton(button: Int) {
+            dialog!!.getButton(button).performClick()
+            ShadowLooper.runUiThreadTasks()
+        }
+    }
+}


### PR DESCRIPTION
## Purpose / Description
There was a bug where the metered connection warning was shown twice on a full sync: once before and once after the confirmation.

## Fixes
* Fixes #20674

## Approach
* Extract the logic to a testable class
* Add a `skipPrompt` parameter

The refactorings were designed to remove logic from `DeckPicker` and make it testable.

## How Has This Been Tested?
Unit tested

https://github.com/user-attachments/assets/0df2f3ce-bc1e-4a15-82a4-acdb585373d6

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)