### PR TITLE
refactor(deck-picker): background image

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -31,7 +31,6 @@ import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.database.SQLException
 import android.graphics.PixelFormat
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.text.util.Linkify
 import android.view.KeyEvent
@@ -103,7 +102,6 @@ import com.ichi2.anki.contextmenu.MouseContextMenuHandler
 import com.ichi2.anki.databinding.ActivityHomescreenBinding
 import com.ichi2.anki.databinding.IncludeDeckPickerBinding
 import com.ichi2.anki.databinding.IncludeFloatingAddButtonBinding
-import com.ichi2.anki.deckpicker.BITMAP_BYTES_PER_PIXEL
 import com.ichi2.anki.deckpicker.BackgroundImage
 import com.ichi2.anki.deckpicker.DeckDeletionResult
 import com.ichi2.anki.deckpicker.DeckPickerViewModel
@@ -170,12 +168,11 @@ import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
 import com.ichi2.anki.utils.Destination
 import com.ichi2.anki.utils.ShortcutUtils
 import com.ichi2.anki.utils.ext.dismissAllDialogFragments
-import com.ichi2.anki.utils.ext.getSizeOfBitmapFromCollection
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.positionIsVisible
 import com.ichi2.anki.utils.ext.setFragmentResultListener
+import com.ichi2.anki.utils.ext.setImageDrawableSafe
 import com.ichi2.anki.utils.ext.showDialogFragment
-import com.ichi2.anki.utils.runWithOOMCheck
 import com.ichi2.anki.widgets.DeckAdapter
 import com.ichi2.anki.worker.SyncMediaWorker
 import com.ichi2.anki.worker.SyncWorker
@@ -200,7 +197,6 @@ import com.ichi2.utils.negativeButton
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
@@ -1045,82 +1041,23 @@ open class DeckPicker :
         showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DISK_FULL)
     }
 
-    // Note: when changing this method consider OutOfMemoryErrors
     private suspend fun applyDeckPickerBackground() {
-        // Allow the user to clear data and get back to a good state if they provide an invalid background.
-        if (!Prefs.isBackgroundEnabled) {
-            Timber.d("No DeckPicker background preference")
-            deckPickerBinding.background.setBackgroundResource(0)
-            deckListAdapter.activityHasBackground = false
-            return
+        val result = BackgroundImage.resolve(this)
+        if (result is BackgroundImage.ResolveResult.Failure) {
+            showThemedToast(this, result.message(this), shortLength = false)
         }
-        val currentAnkiDroidDirectory = CollectionHelper.getCurrentAnkiDroidDirectory(this)
-        val imgFile = File(currentAnkiDroidDirectory, BackgroundImage.FILENAME)
-        if (!imgFile.exists()) {
-            Timber.d("No DeckPicker background image")
-            deckPickerBinding.background.setBackgroundResource(0)
-            deckListAdapter.activityHasBackground = false
-            return
-        }
+        val drawable = (result as? BackgroundImage.ResolveResult.Ready)?.drawable
 
-        // TODO: Temporary fix to stop a crash on startup [15450], it can be removed either:
-        // * by moving this check to an upgrade path
-        // * once enough time has passed
-        // null shouldn't happen as we check for the file being present above this call
-        val (bitmapWidth, bitmapHeight) = getSizeOfBitmapFromCollection(BackgroundImage.FILENAME) ?: return
-        if (bitmapWidth <= 0 || bitmapHeight <= 0) {
-            Timber.w("Decoding background image for dimensions info failed")
-            deckPickerBinding.background.setBackgroundResource(0)
-            deckListAdapter.activityHasBackground = false
-            return
-        }
-        if (bitmapWidth * bitmapHeight * BITMAP_BYTES_PER_PIXEL > BackgroundImage.MAX_BITMAP_SIZE) {
-            Timber.w("DeckPicker background image dimensions too large")
-            deckPickerBinding.background.setBackgroundResource(0)
-            deckListAdapter.activityHasBackground = false
-            return
-        }
-
-        fun onOOMError(error: OutOfMemoryError) {
-            Timber.w(error, "Failed to apply background - OOM")
-            showThemedToast(
-                this@DeckPicker,
-                getString(R.string.background_image_too_large),
-                false,
-            )
-            deckListAdapter.activityHasBackground = false
-        }
-
-        try {
-            Timber.i("Applying background image selected by user")
-            val drawable =
-                withContext(Dispatchers.IO) {
-                    // 6608 - OOM should be catchable here.
-                    runWithOOMCheck(
-                        { Drawable.createFromPath(imgFile.absolutePath) },
-                        ::onOOMError,
-                    )
-                }
-            runWithOOMCheck(
-                {
-                    deckPickerBinding.background.setImageDrawable(drawable)
-                    deckListAdapter.activityHasBackground = drawable != null
-                },
-                onError = ::onOOMError,
-            )
-        } catch (e: Exception) {
-            if (e is CancellationException) {
-                throw e
-            } else {
-                Timber.w(e, "Failed to apply background")
-                showThemedToast(
-                    this,
-                    getString(R.string.failed_to_apply_background_image, e.localizedMessage),
-                    false,
-                )
-                deckListAdapter.activityHasBackground = false
+        var hasBackground = drawable != null
+        if (drawable != null) {
+            deckPickerBinding.background.setImageDrawableSafe(drawable) {
+                showThemedToast(this, getString(R.string.background_image_too_large), shortLength = false)
+                hasBackground = false
             }
+        } else {
+            deckPickerBinding.background.setBackgroundResource(0)
         }
+        deckListAdapter.activityHasBackground = hasBackground
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1047,17 +1047,12 @@ open class DeckPicker :
             showThemedToast(this, result.message(this), shortLength = false)
         }
         val drawable = (result as? BackgroundImage.ResolveResult.Ready)?.drawable
-
-        var hasBackground = drawable != null
-        if (drawable != null) {
+        val applied =
             deckPickerBinding.background.setImageDrawableSafe(drawable) {
                 showThemedToast(this, getString(R.string.background_image_too_large), shortLength = false)
-                hasBackground = false
             }
-        } else {
-            deckPickerBinding.background.setBackgroundResource(0)
-        }
-        deckListAdapter.activityHasBackground = hasBackground
+        // activityHasBackground calls notifyDataSetChanged, ensure only 1 call
+        deckListAdapter.activityHasBackground = applied && drawable != null
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/deckpicker/BackgroundImage.kt
@@ -17,15 +17,22 @@
 package com.ichi2.anki.deckpicker
 
 import android.content.Context
+import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.MediaStore
+import androidx.annotation.CheckResult
 import com.ichi2.anki.CollectionHelper
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.R
 import com.ichi2.anki.preferences.AppearanceSettingsFragment
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.utils.ext.getSizeOfBitmapFromCollection
 import com.ichi2.utils.openInputStreamSafe
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -49,6 +56,83 @@ object BackgroundImage {
     const val FILENAME = "DeckPickerBackground.png"
 
     fun shouldBeShown(context: Context) = Prefs.isBackgroundEnabled && getImageFile(context) != null
+
+    /** Outcome of resolving the user's [DeckPicker] background. */
+    sealed interface ResolveResult {
+        /** Either disabled, or no usable image file is present. */
+        data object None : ResolveResult
+
+        /** A drawable ready to assign to a view. */
+        data class Ready(
+            val drawable: Drawable,
+        ) : ResolveResult
+
+        /** Resolving failed in a way the user should be told about. */
+        sealed interface Failure : ResolveResult {
+            fun message(context: Context): String
+        }
+
+        /** The bitmap is too large to draw safely. */
+        data object TooLarge : Failure {
+            override fun message(context: Context): String = context.getString(R.string.background_image_too_large)
+        }
+
+        /** Decoding failed for some other reason. */
+        data class Failed(
+            val cause: String?,
+        ) : Failure {
+            override fun message(context: Context): String = context.getString(R.string.failed_to_apply_background_image, cause)
+        }
+    }
+
+    /**
+     * Resolves the configured [DeckPicker] background, applying all OOM/size guards.
+     *
+     * Performs disk I/O and bitmap decoding.
+     *
+     * This method does not throw.
+     */
+    @CheckResult
+    suspend fun resolve(context: Context): ResolveResult {
+        if (!Prefs.isBackgroundEnabled) {
+            Timber.d("No DeckPicker background preference")
+            return ResolveResult.None
+        }
+        val imgFile =
+            getImageFile(context) ?: run {
+                Timber.d("No DeckPicker background image")
+                return ResolveResult.None
+            }
+
+        // 15450 - guard against decoded dimensions that would crash Canvas.
+        val size = context.getSizeOfBitmapFromCollection(FILENAME) ?: return ResolveResult.None
+        if (size.width <= 0 || size.height <= 0) {
+            Timber.w("Decoding background image for dimensions info failed")
+            return ResolveResult.None
+        }
+        if (size.width.toLong() * size.height * BITMAP_BYTES_PER_PIXEL > MAX_BITMAP_SIZE) {
+            Timber.w("DeckPicker background image dimensions too large")
+            return ResolveResult.TooLarge
+        }
+
+        return try {
+            Timber.i("Loading background image selected by user")
+            val drawable =
+                withContext(Dispatchers.IO) {
+                    // 6608 - OOM should be catchable here.
+                    Drawable.createFromPath(imgFile.absolutePath)
+                }
+            if (drawable != null) ResolveResult.Ready(drawable) else ResolveResult.None
+        } catch (e: OutOfMemoryError) {
+            Timber.w(e, "Failed to load background - OOM")
+            ResolveResult.TooLarge
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to load background")
+            ResolveResult.Failed(cause = e.localizedMessage)
+        }
+    }
 
     sealed interface FileSizeResult {
         data object OK : FileSizeResult

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ImageView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ImageView.kt
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.utils.ext
+
+import android.graphics.drawable.Drawable
+import android.widget.ImageView
+import com.ichi2.anki.utils.runWithOOMCheck
+
+/**
+ * [ImageView.setImageDrawable] guarded against [OutOfMemoryError] (#6608).
+ */
+fun ImageView.setImageDrawableSafe(
+    drawable: Drawable?,
+    onError: (OutOfMemoryError) -> Unit = {},
+) = runWithOOMCheck(
+    action = { setImageDrawable(drawable) },
+    onError = onError,
+)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ImageView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/ImageView.kt
@@ -22,11 +22,17 @@ import com.ichi2.anki.utils.runWithOOMCheck
 
 /**
  * [ImageView.setImageDrawable] guarded against [OutOfMemoryError] (#6608).
+ *
+ * @return `true` if the drawable was applied, `false` if an [OutOfMemoryError] occurred
  */
 fun ImageView.setImageDrawableSafe(
     drawable: Drawable?,
     onError: (OutOfMemoryError) -> Unit = {},
-) = runWithOOMCheck(
-    action = { setImageDrawable(drawable) },
-    onError = onError,
-)
+): Boolean =
+    runWithOOMCheck(
+        action = {
+            setImageDrawable(drawable)
+            true
+        },
+        onError = onError,
+    ) ?: false


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.6 (first commit)

## Approach
* extract the bulk of the logic
* fix a bug [no issue], allowing `setBackgroundResource(0)` to be replaced with `setImageDrawable[Safe](null)`

## How Has This Been Tested?
API 33 emulator - added and removed a background

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)