### PR TITLE
docs: document onWebViewRecreated and onWebViewRecreatedListener

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -146,6 +146,12 @@ abstract class CardViewerFragment(
 
     protected open fun onCreateWebChromeClient() = CardViewerWebChromeClient()
 
+    /**
+     * Reconfigures the [WebView] after a render process crash by calling [setupWebView].
+     *
+     * Subclasses that override this method must call `super.onWebViewRecreated(webView)`,
+     * as the base implementation reapplies all clients, settings, and content.
+     */
     override fun onWebViewRecreated(webView: WebView) {
         setupWebView(null)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/workarounds/SafeWebViewLayout.kt
@@ -217,6 +217,26 @@ open class SafeWebViewLayout :
     }
 }
 
+/**
+ * Listener for [SafeWebViewLayout.onRenderProcessGone], called after the internal [WebView] is
+ * replaced due to a render process crash or the system killing it to free memory.
+ *
+ * Any [Fragment] containing a [SafeWebViewLayout] **must** implement this interface. In debug builds,
+ * a missing implementation will throw at [SafeWebViewLayout.onAttachedToWindow()]
+ *
+ * @see SafeWebViewLayout.onRenderProcessGone
+ */
 fun interface OnWebViewRecreatedListener {
+    /**
+     * Reconfigures a [WebView] after [SafeWebViewLayout.onRenderProcessGone] has replaced
+     * the old instance. Implementations must reapply all clients, settings and content
+     * that were configured on the original [WebView], as [SafeWebViewLayout] only handles
+     * the structural replacement and cannot reapply app level configuration.
+     *
+     * To manually trigger this path, call `webViewLayout.loadUrl("chrome://crash")`.
+     * Automated testing requires an instrumented test; a unit test is not sufficient.
+     *
+     * @param webView the new [WebView], already attached to [SafeWebViewLayout]
+     */
     fun onWebViewRecreated(webView: WebView)
 }


### PR DESCRIPTION

## Purpose / Description
The pr adds documentation for OnWebViewRecreated and onWebViewRecreatedListener in order to clarify their usage 
when webview is recreated after a render process crash.


## Fixes
* Fixes #19585

## Approach
The kdoc comments address the following questions:
When it is called
How it should be implemented, and why
How to test it
Whether it can be tested automatically
Whether @CallSuper is needed in CardViewerFragment::onWebViewRecreated

## Checklist

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)