### PR TITLE
Fix controls: warn only on true binding conflict

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ControlPreference.kt
@@ -215,7 +215,7 @@ open class ControlPreference :
      *
      * @see getRelatedPreferences
      */
-    protected fun getPreferenceAssignedTo(binding: Binding): ControlPreference? {
+    protected open fun getPreferenceAssignedTo(binding: Binding): ControlPreference? {
         for (pref in getRelatedPreferences()) {
             val bindings = pref.getMappableBindings().map { it.binding }
             if (binding in bindings) {

--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -19,6 +19,7 @@ import android.content.Context
 import android.util.AttributeSet
 import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.GestureProcessor
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.dialogs.CardSideSelectionDialog
 import com.ichi2.anki.preferences.allPreferences
 import com.ichi2.anki.reviewer.Binding
@@ -77,6 +78,16 @@ open class ReviewerControlPreference : ControlPreference {
             .filter {
                 it::class == ReviewerControlPreference::class
             } as List<ReviewerControlPreference>
+
+    @NeedsTest("Ensure correct preference is returned for side-specific binding")
+    override fun getPreferenceAssignedTo(binding: Binding): ControlPreference? {
+        val cardSide = side ?: return super.getPreferenceAssignedTo(binding)
+        val reviewerBinding = ReviewerBinding(binding, cardSide)
+        // Bindings only conflict when the card sides overlap
+        return getRelatedPreferences().firstOrNull { preference ->
+            reviewerBinding in preference.getMappableBindings()
+        }
+    }
 
     fun interface OnBindingSelectedListener {
         /**


### PR DESCRIPTION
## Purpose / Description
This PR fixes the following bug: In Controls, when we assign the same gesture/key to "Show answer" and an answer action (again, hard, good, easy), there's a warning. This shouldn't happen, because these actions happen on different "sides" of the card, so they can't conflict.

For instance, assigning "swipe down" to "Show answer" and "Answer easy" shouldn't show a warning. (But assigning it to "Answer easy" and "Answer hard" should continue to show one.)

## Fixes
* Second bug in #20504.

## Approach
In `ControlPreference`, conflicts are assessed by comparing raw bindings: i.e. is this gesture/key already used? If so, warn. 

I overrode `getPreferenceAssignedTo()` in `ReviewerControlPreference` to instead compare "side-aware" bindings: i.e. is this gesture/key already used on the same side? If so, warn.

https://github.com/user-attachments/assets/aaf89e03-61a6-4de9-86d6-50eb66889cf8

## How Has This Been Tested?
Manually, on my physical device by trying various sequences of gesture/key assignments.

And I ran:
```
./gradlew jacocoUnitTestReport                      
./gradlew lintRelease ktlintCheck
```

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] ~~You have commented your code, particularly in hard-to-understand areas.~~ NA
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~ NA