### PR TITLE
fix: flaky tests in PreviewerViewModelTest

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -63,7 +63,8 @@ class PreviewerViewModelTest : JvmTest() {
     }
 
     @Before
-    fun setup() {
+    override fun setUp() {
+        super.setUp()
         val cardIds =
             (0..3).flatMap {
                 val note = addBasicNote()

--- a/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/previewer/PreviewerViewModelTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.previewer
 
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.Flag
 import com.ichi2.anki.browser.IdsFile
@@ -26,9 +27,11 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
@@ -82,6 +85,12 @@ class PreviewerViewModelTest : JvmTest() {
         // the default implementation requires the Collection media directory,
         // which needs Robolectric with CollectionStorageMode.IN_MEMORY_WITH_MEDIA or ON_DISK
         coEvery { viewModel.prepareCardTextForDisplay(any()) } answers { firstArg() }
+    }
+
+    @After
+    override fun tearDown() {
+        viewModel.viewModelScope.cancel()
+        super.tearDown()
     }
 
     @Test


### PR DESCRIPTION
## Fixes
* Fixes #20704

## Approach
* Coroutines started in `init { }` appear to have not been cancelled
* Write a fix, then check over 15*3 test runs

## How Has This Been Tested?
Test only

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)