### PR TITLE
Specify type of `arrayOf` explicitly to fix compilation error (LayoutValidationTest)

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/LayoutValidationTest.kt
@@ -116,7 +116,7 @@ class LayoutValidationTest : InstrumentedTest() {
                     }
 
             return layout::class.java.fields
-                .map { arrayOf(it.getInt(layout), it.name) }
+                .map { arrayOf<Any>(it.getInt(layout), it.name) }
                 .filterNot { (id, name) -> name in nonAnkiFieldNames || id in ignoredLayoutIds }
         }
 


### PR DESCRIPTION
## Purpose / Description

Fix `TYPE_INTERSECTION_AS_REIFIED` error caused by a bugfix in kotlin compiler.

## Fixes

Compilation on newer versions of Kotlin compiler (see 
https://youtrack.jetbrains.com/issue/KT-74516/False-negative-TYPEPARAMETERASREIFIED-for-DNN-type and https://youtrack.jetbrains.com/issue/KTLC-399/Report-missing-reification-errors-in-DNNs-and-flexible-types)

## Approach

Specifying type of `arrayOf` call explicitly.

## How Has This Been Tested?

No extra testing is needed.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have performed a self-review of your own code