### PR TITLE
feat(card-browser): move 'delete notes' to bottom of options menu

### DIFF
--- a/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
+++ b/AnkiDroid/src/main/res/menu/card_browser_multiselect.xml
@@ -11,11 +11,6 @@
         android:icon="@drawable/ic_mode_edit_white"/>
 
     <item
-        android:id="@+id/action_delete_card"
-        android:icon="@drawable/ic_delete_white"
-        tools:title="Delete card" />
-
-    <item
         android:id="@+id/action_view_card_info"
         android:icon="@drawable/ic_dialog_info"
         android:title="@string/card_info_title" />
@@ -88,15 +83,22 @@
         android:id="@+id/action_export_selected"
         tools:title="Export cards"/>
 
+
+    <item
+        android:id="@+id/action_find_replace"
+        android:visible="false"
+        app:showAsAction="never"/>
+
+    <!-- Delete should be last, if undo is not visible -->
+    <item
+        android:id="@+id/action_delete_card"
+        android:icon="@drawable/ic_delete_white"
+        tools:title="Delete card" />
+
     <item
         ankidroid:showAsAction="ifRoom"
         android:id="@+id/action_undo"
         android:title="@string/undo"
         ankidroid:actionProviderClass="com.ichi2.ui.RtlCompliantActionProvider"
         android:icon="@drawable/ic_undo_white"/>
-
-    <item
-        android:id="@+id/action_find_replace"
-        android:visible="false"
-        app:showAsAction="never"/>
 </menu>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -1609,7 +1609,6 @@ class CardBrowserTest : RobolectricTest() {
             val expectedMenuItems =
                 listOf(
                     R.id.action_edit_note to true,
-                    R.id.action_delete_card to true,
                     R.id.action_view_card_info to true,
                     R.id.action_flag to true,
                     R.id.action_mark_card to true,
@@ -1624,8 +1623,9 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to true,
                     R.id.action_preview_many to true,
                     R.id.action_export_selected to true,
-                    R.id.action_undo to true,
                     R.id.action_find_replace to false,
+                    R.id.action_delete_card to true,
+                    R.id.action_undo to true,
                 )
 
             assertMenusEqual(expectedMenuItems, menu)
@@ -1647,7 +1647,6 @@ class CardBrowserTest : RobolectricTest() {
             val expectedMenuItems =
                 listOf(
                     R.id.action_edit_note to false,
-                    R.id.action_delete_card to false,
                     R.id.action_view_card_info to false,
                     R.id.action_flag to false,
                     R.id.action_mark_card to false,
@@ -1662,8 +1661,9 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to false,
                     R.id.action_preview_many to true,
                     R.id.action_export_selected to false,
-                    R.id.action_undo to true,
                     R.id.action_find_replace to false,
+                    R.id.action_delete_card to false,
+                    R.id.action_undo to true,
                 )
 
             assertMenusEqual(expectedMenuItems, menu)
@@ -1722,7 +1722,6 @@ class CardBrowserTest : RobolectricTest() {
                 listOf(
                     // should never be enabled, the fragment handles the editing
                     R.id.action_edit_note to false,
-                    R.id.action_delete_card to true,
                     R.id.action_view_card_info to true,
                     R.id.action_flag to true,
                     R.id.action_mark_card to true,
@@ -1737,8 +1736,9 @@ class CardBrowserTest : RobolectricTest() {
                     R.id.action_reset_cards_progress to true,
                     R.id.action_preview_many to false,
                     R.id.action_export_selected to true,
-                    R.id.action_undo to true,
                     R.id.action_find_replace to false,
+                    R.id.action_delete_card to true,
+                    R.id.action_undo to true,
                     // Note Editor
                     R.id.action_save to true,
                     R.id.action_preview to true,


### PR DESCRIPTION
User request - delete is normally on the bottom. I preferred it being above 'undo'

<img width="366" height="625" alt="Screenshot 2026-04-10 at 21 28 32" src="https://github.com/user-attachments/assets/38b42dd8-9ff5-4d6c-9e82-2f7fcae0f309" />

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)