### PR TITLE
deleted annotations for onMenuItemSelected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -432,8 +432,6 @@ class CardBrowserFragment :
                     menu.findItem(R.id.action_undo).setupUndo()
                 }
 
-                @NeedsTest("filter-marked query needs testing")
-                @NeedsTest("filter-suspended query needs testing")
                 override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
                     if (vm.isInMultiSelectMode) return false
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
It is no longer necessary to write test for onMenuItemSelected since the method is going to be recoded.
https://github.com/ankidroid/Anki-Android/issues/13283#issuecomment-4230797625

## Fixes
* #13283 

## Approach

## How Has This Been Tested?

## Learning (optional, can help others)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->