### PR TITLE
fix: load video tags via relative src instead of file:// URI

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/SoundUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/SoundUtils.kt
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki.multimedia
 
+import android.net.Uri
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.common.utils.htmlEncode
 import com.ichi2.anki.compat.CompatHelper
@@ -31,12 +32,10 @@ import com.ichi2.anki.libanki.SoundOrVideoTag
 import com.ichi2.anki.libanki.SoundOrVideoTag.Type
 import com.ichi2.anki.libanki.TTSTag
 import com.ichi2.anki.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
-import com.ichi2.anki.libanki.getFileUri
 import com.ichi2.anki.utils.CollectionPreferences
 import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.VisibleForTesting
 import java.io.File
-import java.nio.file.Paths
 
 /**
  * Takes content with [AvRef]s and expands them to reference the media file
@@ -72,8 +71,7 @@ fun expandSounds(
 
     fun SoundOrVideoTag.asHtmlVideo(): String {
         val filename = this.filename
-        val path = Paths.get(mediaDir.absolutePath, filename).toString()
-        val uri = getFileUri(path)
+        val encodedFilename = Uri.encode(filename)
 
         val playsound = "${playTag.side}:${playTag.index}"
 
@@ -84,7 +82,7 @@ fun expandSounds(
         @Language("HTML")
         val result =
             """<video
-                    | src="$uri"
+                    | src="$encodedFilename"
                     | controls
                     | data-file="${filename.htmlEncode()}"
                     | onended='$onEnded'

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/SoundUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/SoundUtilsTest.kt
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Ayush Patel
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.multimedia
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.libanki.SoundOrVideoTag
+import com.ichi2.anki.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
+import org.hamcrest.CoreMatchers.containsString
+import org.hamcrest.CoreMatchers.not
+import org.hamcrest.MatcherAssert.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SoundUtilsTest : RobolectricTest() {
+    override fun getCollectionStorageMode() = CollectionStorageMode.IN_MEMORY_WITH_MEDIA
+
+    /** Regression test for https://github.com/ankidroid/Anki-Android/issues/20668 */
+    @Test
+    fun videoTagSrcIsRelativeNotFileUri() {
+        val renderOutput =
+            TemplateRenderOutput(
+                questionText = "",
+                answerText = "",
+                questionAvTags = listOf(SoundOrVideoTag("my#video.mov")),
+                answerAvTags = emptyList(),
+            )
+
+        val html =
+            expandSounds(
+                content = "[anki:play:q:0]",
+                renderOutput = renderOutput,
+                showAudioPlayButtons = true,
+                mediaDir = col.media.dir,
+            )
+
+        assertThat(html, not(containsString("file://")))
+        assertThat(html, containsString("src=\"my%23video.mov\""))
+    }
+}

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Sound.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Sound.kt
@@ -26,11 +26,7 @@
 package com.ichi2.anki.libanki
 
 import com.ichi2.anki.libanki.TemplateManager.TemplateRenderContext.TemplateRenderOutput
-import com.ichi2.anki.libanki.utils.NotInPyLib
 import org.intellij.lang.annotations.Language
-import org.jetbrains.annotations.VisibleForTesting
-import java.io.File
-import java.net.URI
 import java.util.regex.Pattern
 
 /**
@@ -147,15 +143,4 @@ data class AvRef(
 
         val REGEX = Regex("\\[anki:(play:(.):(\\d+))]")
     }
-}
-
-/** Similar to [File.toURI], but doesn't use the absolute file to simplify testing */
-@NotInPyLib
-@VisibleForTesting
-fun getFileUri(path: String): URI {
-    var p = path
-    if (File.separatorChar != '/') p = p.replace(File.separatorChar, '/')
-    if (!p.startsWith("/")) p = "/$p"
-    if (!p.startsWith("//")) p = "//$p"
-    return URI("file", p, null)
 }


### PR DESCRIPTION
## Purpose / Description

Regression introduced in v2.17 when card HTML switched to loading via `http://127.0.0.1` as the WebView base URL. Modern WebView blocks file:// resources from an http:// origin (cross-origin policy), causing video src attributes to silently fail. Worked in `v2.16.5` and earlier.

## Fixes
* Fixes #20668

## Approach
Use a relative filename as the video src instead of a file:// URI. `ViewerResourceHandler` intercepts the request and serves the file over HTTP, avoiding the cross-origin restriction.

## How Has This Been Tested?
Built locally. Tested on a flashcard with an embedded video file to verify that the inline `<video>` tag loads the player and successfully plays back with functioning playback/scrubbing controls.

Video:

https://github.com/user-attachments/assets/d44bbf5c-3bb9-4a9d-9080-4f318ad3dc3b



## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
