### PR TITLE
feat: analytics interface in `:common`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AcraCrashReporter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AcraCrashReporter.kt
@@ -13,7 +13,7 @@ import androidx.core.content.pm.PackageInfoCompat
 import androidx.webkit.WebViewCompat
 import com.ichi2.anki.analytics.AnkiDroidCrashReportDialog
 import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics.sendAnalyticsException
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.crashreporting.CrashReporter
 import com.ichi2.anki.common.crashreporting.CrashReporter.Companion.FEEDBACK_REPORT_ALWAYS
@@ -267,7 +267,7 @@ private object AcraCrashReporter : CrashReporter {
         onlyIfSilent: Boolean,
         context: Context,
     ) {
-        sendAnalyticsException(e, false)
+        Analytics.sendAnalyticsException(e, false)
         AnkiDroidApp.sentExceptionReportHack = true
         val reportMode =
             context

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiActivity.kt
@@ -55,10 +55,10 @@ import androidx.viewbinding.ViewBinding
 import com.google.android.material.color.MaterialColors
 import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anim.ActivityTransitionAnimation
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
 import com.ichi2.anki.android.input.ShortcutGroup
 import com.ichi2.anki.android.input.ShortcutGroupProvider
 import com.ichi2.anki.android.input.shortcut
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.common.android.AdaptionUtil
 import com.ichi2.anki.common.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.android.animationDisabled
@@ -201,7 +201,7 @@ open class AnkiActivity(
 
     override fun onResume() {
         super.onResume()
-        AnkiDroidUsageAnalytics.sendAnalyticsScreenView(this)
+        Analytics.sendAnalyticsScreenView(this)
         (getSystemService(NOTIFICATION_SERVICE) as NotificationManager).cancel(
             SIMPLE_NOTIFICATION_ID,
         )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -23,7 +23,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ProcessLifecycleOwner
 import anki.collection.OpChanges
 import com.ichi2.anki.AnkiDroidApp.Companion.sharedPreferencesTestingOverride
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.analytics.initializeAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.common.android.AdaptionUtil
 import com.ichi2.anki.common.android.Animations
@@ -149,7 +149,7 @@ open class AnkiDroidApp :
         Timber.i("Timber config: $logType")
 
         // analytics after ACRA, they both install UncaughtExceptionHandlers but Analytics chains while ACRA does not
-        AnkiDroidUsageAnalytics.initialize(this)
+        initializeAnalytics()
         // Last in the UncaughtExceptionHandlers chain is our filter service
         ThrowableFilterService.initialize()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/MoreFragment.kt
@@ -10,7 +10,7 @@ import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import com.ichi2.anki.analytics.AnalyticsConstants.Actions
 import com.ichi2.anki.analytics.AnalyticsConstants.Category
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.common.destinations.PreferencesDestination
 import com.ichi2.anki.common.destinations.navigate
 import com.ichi2.anki.databinding.FragmentMoreBinding
@@ -46,47 +46,47 @@ class MoreFragment : Fragment(R.layout.fragment_more) {
 
         // Help section: each opens HelpDialog with the relevant sub-items
         binding.moreHelpManual.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_USING_ANKIDROID)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_USING_ANKIDROID)
             openHelpSection(R.string.help_title_using_ankidroid)
         }
         binding.moreHelpGetHelp.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_GET_HELP)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_GET_HELP)
             openHelpSection(R.string.help_title_get_help)
         }
         binding.moreHelpCommunity.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_COMMUNITY)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_COMMUNITY)
             openHelpSection(R.string.help_title_community)
         }
         binding.moreHelpPrivacy.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
             openHelpSection(R.string.help_title_privacy)
         }
 
         // Support section: direct URL actions
         binding.moreSupportDonate.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DONATE)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DONATE)
             openUrl(getString(R.string.link_opencollective_donate))
         }
         binding.moreSupportTranslate.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_TRANSLATE)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_TRANSLATE)
             openUrl(getString(R.string.link_translation))
         }
         binding.moreSupportDevelop.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DEVELOP)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_DEVELOP)
             openUrl(getString(R.string.link_ankidroid_development_guide))
         }
         binding.moreSupportRate.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_RATE)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_RATE)
             if (IntentUtil.canOpenIntent(requireContext(), marketIntent)) {
                 startActivity(marketIntent)
             }
         }
         binding.moreSupportOther.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_OTHER)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_OTHER)
             openUrl(getString(R.string.link_contribution))
         }
         binding.moreSupportFeedback.setOnClickListener {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_SEND_FEEDBACK)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_SEND_FEEDBACK)
             openUrl(AnkiDroidApp.feedbackUrl)
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AcraAnalyticsInteraction.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AcraAnalyticsInteraction.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.analytics
 
 import android.content.Context
 import com.google.auto.service.AutoService
+import com.ichi2.anki.common.analytics.Analytics
 import org.acra.config.CoreConfiguration
 import org.acra.interaction.ReportInteraction
 import org.acra.util.Installation
@@ -39,7 +40,7 @@ class AcraAnalyticsInteraction : ReportInteraction {
     ): Boolean {
         // Send an analytics exception hit with a UUID to match
         Timber.e("ACRA handling crash, sending analytics exception report")
-        AnkiDroidUsageAnalytics.sendAnalyticsEvent("ACRA Crash Handler", "UUID " + Installation.id(context))
+        Analytics.sendAnalyticsEvent("ACRA Crash Handler", "UUID " + Installation.id(context))
         return true
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsDialogFragment.kt
@@ -18,12 +18,13 @@ package com.ichi2.anki.analytics
 
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.DialogFragment
+import com.ichi2.anki.common.analytics.Analytics
 
 abstract class AnalyticsDialogFragment(
     @LayoutRes contentLayoutId: Int = 0,
 ) : DialogFragment(contentLayoutId) {
     override fun onResume() {
         super.onResume()
-        AnkiDroidUsageAnalytics.sendAnalyticsScreenView(this)
+        Analytics.sendAnalyticsScreenView(this)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
@@ -33,7 +33,7 @@ import java.util.UUID
  * model, and answers to common reviewer questions.
  */
 @NeedsTest("Add coverage for opt-in handling, client id persistence and event/exception sending")
-object AnkiDroidUsageAnalytics : UsageAnalytics {
+internal object AnkiDroidUsageAnalytics : UsageAnalytics {
     const val ANALYTICS_OPTIN_KEY = UsageAnalytics.ANALYTICS_OPTIN_KEY
     private const val ANALYTICS_CLIENT_ID = "googleAnalyticsClientId"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnkiDroidUsageAnalytics.kt
@@ -11,6 +11,8 @@ import androidx.core.content.edit
 import com.criticalay.GoogleAnalytics
 import com.ichi2.anki.BuildConfig
 import com.ichi2.anki.R
+import com.ichi2.anki.common.analytics.Analytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.preferences.sharedPrefs
@@ -31,8 +33,8 @@ import java.util.UUID
  * model, and answers to common reviewer questions.
  */
 @NeedsTest("Add coverage for opt-in handling, client id persistence and event/exception sending")
-object AnkiDroidUsageAnalytics {
-    const val ANALYTICS_OPTIN_KEY = "analytics_opt_in_v2"
+object AnkiDroidUsageAnalytics : UsageAnalytics {
+    const val ANALYTICS_OPTIN_KEY = UsageAnalytics.ANALYTICS_OPTIN_KEY
     private const val ANALYTICS_CLIENT_ID = "googleAnalyticsClientId"
 
     /**
@@ -175,19 +177,19 @@ object AnkiDroidUsageAnalytics {
      * name (e.g. `DeckPicker`, not `com.ichi2.anki.DeckPicker`). Pass an
      * activity/fragment/`this` from the screen you want to record.
      */
-    fun sendAnalyticsScreenView(screen: Any) = sendAnalyticsScreenView(screen.javaClass.simpleName)
+    override fun sendAnalyticsScreenView(screen: Any) = sendAnalyticsScreenView(screen.javaClass.simpleName)
 
-    fun sendAnalyticsScreenView(screenName: String) {
+    override fun sendAnalyticsScreenView(screenName: String) {
         Timber.d("AnkiDroidUsageAnalytics: screenView($screenName)")
         if (!optIn) return
         analytics?.screenView(clientId)?.screenName(screenName)?.sendAsync()
     }
 
-    fun sendAnalyticsEvent(
+    override fun sendAnalyticsEvent(
         category: String,
         action: String,
-        value: Int? = null,
-        label: String? = null,
+        value: Int?,
+        label: String?,
     ) {
         Timber.d("AnkiDroidUsageAnalytics: event(category=$category action=$action)")
         if (!optIn) return
@@ -202,7 +204,7 @@ object AnkiDroidUsageAnalytics {
         event.sendAsync()
     }
 
-    fun sendAnalyticsException(
+    override fun sendAnalyticsException(
         t: Throwable,
         fatal: Boolean,
     ) {
@@ -281,4 +283,13 @@ object AnkiDroidUsageAnalytics {
         samplePercentage = AnalyticsSamplePercentage.Full
         reinitialize(context)
     }
+}
+
+/**
+ * Initializes GA4 analytics and wires it up as the global [Analytics] implementation.
+ */
+context(application: Application)
+fun initializeAnalytics() {
+    AnkiDroidUsageAnalytics.initialize(application)
+    Analytics.setAnalytics(AnkiDroidUsageAnalytics)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/DialogHandler.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.CrashReportData.Companion.toCrashReportData
 import com.ichi2.anki.DeckPicker
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.common.utils.android.HandlerUtils.getDefaultLooper
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
 import com.ichi2.anki.showError
@@ -46,7 +46,7 @@ class DialogHandler(
 
     override fun handleMessage(message: Message) {
         val msg = DialogHandlerMessage.fromMessage(message)
-        AnkiDroidUsageAnalytics.sendAnalyticsScreenView(msg.analyticName)
+        Analytics.sendAnalyticsScreenView(msg.analyticName)
         Timber.i("Handling Message: %s", msg.analyticName)
         msg.handleAsyncMessage(activity.get() as AnkiActivity)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ImportFileSelectionFragment.kt
@@ -17,7 +17,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsConstants
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.MimeTypeUtils
@@ -35,7 +35,7 @@ class ImportFileSelectionFragment : DialogFragment() {
                 entries.map { requireActivity().getString(it.titleRes) }.toTypedArray(),
             ) { _, position ->
                 val entry = entries[position]
-                AnkiDroidUsageAnalytics.sendAnalyticsEvent(
+                Analytics.sendAnalyticsEvent(
                     AnalyticsConstants.Category.LINK_CLICKED,
                     entry.analyticsId,
                 )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/help/HelpDialog.kt
@@ -29,8 +29,8 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.AnalyticsConstants.Actions
 import com.ichi2.anki.analytics.AnalyticsConstants.Category
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
 import com.ichi2.anki.ankiActivity
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.databinding.DialogHelpBinding
 import com.ichi2.anki.databinding.FragmentHelpPageBinding
 import com.ichi2.anki.databinding.ItemHelpEntryBinding
@@ -123,7 +123,7 @@ class HelpDialog : DialogFragment() {
         private const val PAGE_TAG = "HelpMenuPage"
 
         fun newHelpInstance(): HelpDialog {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_HELP_DIALOG)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_HELP_DIALOG)
             return HelpDialog().apply {
                 arguments =
                     Bundle().apply {
@@ -134,7 +134,7 @@ class HelpDialog : DialogFragment() {
         }
 
         fun newPrivacyPolicyInstance(): HelpDialog {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
+            Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, Actions.OPENED_PRIVACY)
             val privacyId = mainHelpMenuItems.single { it.analyticsId == Actions.OPENED_PRIVACY }.id
             val privacyItems = childHelpMenuItems.filter { it.parentId == privacyId }
             return HelpDialog().apply {
@@ -150,7 +150,7 @@ class HelpDialog : DialogFragment() {
          * @param canRateApp a boolean that indicates if the system has an app to open to rate AnkiDroid
          */
         fun newSupportInstance(canRateApp: Boolean): HelpDialog {
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(
+            Analytics.sendAnalyticsEvent(
                 Category.LINK_CLICKED,
                 Actions.OPENED_SUPPORT_ANKIDROID,
             )
@@ -200,7 +200,7 @@ class HelpPageFragment : Fragment(R.layout.fragment_help_page) {
                 setCompoundDrawablesRelativeWithIntrinsicBoundsKt(start = menuItem.iconResId)
                 compoundDrawablePadding = 16.dp.toPx(requireContext())
                 setOnClickListener {
-                    AnkiDroidUsageAnalytics.sendAnalyticsEvent(Category.LINK_CLICKED, menuItem.analyticsId)
+                    Analytics.sendAnalyticsEvent(Category.LINK_CLICKED, menuItem.analyticsId)
                     parentFragmentManager.setFragmentResult(
                         REQUEST_HELP_PAGE,
                         Bundle().apply { putParcelable(ARG_SELECTED_MENU_ITEM, menuItem) },

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/SettingsFragment.kt
@@ -28,6 +28,7 @@ import androidx.preference.PreferenceManager
 import androidx.preference.PreferenceManager.OnPreferenceTreeClickListener
 import com.ichi2.anki.analytics.AnalyticsConstants
 import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
 import com.ichi2.anki.databinding.FragmentSettingsBinding
 import com.ichi2.preferences.DialogFragmentProvider
 import dev.androidbroadcast.vbpd.viewBinding
@@ -48,7 +49,7 @@ abstract class SettingsFragment :
     abstract fun initSubscreen()
 
     override fun onPreferenceTreeClick(preference: Preference): Boolean {
-        AnkiDroidUsageAnalytics.sendAnalyticsEvent(
+        Analytics.sendAnalyticsEvent(
             category = AnalyticsConstants.Category.SETTING,
             action = AnalyticsConstants.Actions.TAPPED_SETTING,
             label = preference.key,
@@ -65,7 +66,7 @@ abstract class SettingsFragment :
         }
         if (key != null) {
             val valueToReport = getPreferenceReportableValue(sharedPreferences.get(key))
-            AnkiDroidUsageAnalytics.sendAnalyticsEvent(
+            Analytics.sendAnalyticsEvent(
                 category = AnalyticsConstants.Category.SETTING,
                 action = AnalyticsConstants.Actions.CHANGED_SETTING,
                 value = valueToReport,
@@ -101,7 +102,7 @@ abstract class SettingsFragment :
         savedInstanceState: Bundle?,
         rootKey: String?,
     ) {
-        AnkiDroidUsageAnalytics.sendAnalyticsScreenView(analyticsScreenNameConstant)
+        Analytics.sendAnalyticsScreenView(analyticsScreenNameConstant)
         addPreferencesFromResource(preferenceResource)
         initSubscreen()
     }
@@ -142,7 +143,7 @@ abstract class SettingsFragment :
         /**
          * Converts a preference value to a numeric number that
          * can be reported to analytics, since analytics events only accept
-         * [Int] as value ([AnkiDroidUsageAnalytics.sendAnalyticsEvent]),
+         * [Int] as value ([Analytics.sendAnalyticsEvent]),
          * or null if it can't be converted.
          *
          * Boolean preferences will return 1 if true and 0 if false

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AddNoteWidget.kt
@@ -19,7 +19,7 @@ import android.content.Context
 import android.widget.RemoteViews
 import androidx.core.app.PendingIntentCompat
 import com.ichi2.anki.R
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 
 class AddNoteWidget : AnalyticsWidgetProvider() {
@@ -27,7 +27,7 @@ class AddNoteWidget : AnalyticsWidgetProvider() {
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: AppWidgetIds,
-        ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+        usageAnalytics: UsageAnalytics,
     ) {
         updateWidgets(context, appWidgetManager, appWidgetIds)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
@@ -23,11 +23,12 @@ import android.content.Intent
 import androidx.annotation.CallSuper
 import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
 import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
 import timber.log.Timber
 
 /**
  * AnalyticsWidgetProvider is an abstract base class for App Widgets that integrates
- * with AnkiDroidUsageAnalytics to send analytics events when the widget is enabled, disabled,
+ * with [Analytics] to send analytics events when the widget is enabled, disabled,
  * or updated.
  *
  * This class should always be used as the base class for App Widgets in this application.
@@ -49,7 +50,7 @@ abstract class AnalyticsWidgetProvider : AppWidgetProvider() {
     override fun onEnabled(context: Context) {
         super.onEnabled(context)
         Timber.d("${this.javaClass.name}: Widget enabled")
-        AnkiDroidUsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "enabled")
+        Analytics.sendAnalyticsEvent(this.javaClass.simpleName, "enabled")
     }
 
     /**
@@ -61,7 +62,7 @@ abstract class AnalyticsWidgetProvider : AppWidgetProvider() {
     override fun onDisabled(context: Context) {
         super.onDisabled(context)
         Timber.d("${this.javaClass.name}: Widget disabled")
-        AnkiDroidUsageAnalytics.sendAnalyticsEvent(this.javaClass.simpleName, "disabled")
+        Analytics.sendAnalyticsEvent(this.javaClass.simpleName, "disabled")
     }
 
     @CallSuper

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnalyticsWidgetProvider.kt
@@ -22,8 +22,8 @@ import android.content.Context
 import android.content.Intent
 import androidx.annotation.CallSuper
 import com.ichi2.anki.IntentHandler.Companion.grantedStoragePermissions
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
 import com.ichi2.anki.common.analytics.Analytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import timber.log.Timber
 
 /**
@@ -93,7 +93,7 @@ abstract class AnalyticsWidgetProvider : AppWidgetProvider() {
         }
         // Pass usageAnalytics to performUpdate
         Timber.d("${this.javaClass.name}: performUpdate")
-        performUpdate(context, appWidgetManager, AppWidgetIds(appWidgetIds), AnkiDroidUsageAnalytics)
+        performUpdate(context, appWidgetManager, AppWidgetIds(appWidgetIds), Analytics.instance)
     }
 
     /**
@@ -106,13 +106,13 @@ abstract class AnalyticsWidgetProvider : AppWidgetProvider() {
      * @param context The context in which the receiver is running.
      * @param appWidgetManager The AppWidgetManager instance to use for updating widgets.
      * @param appWidgetIds The app widget IDs to update.
-     * @param ankiDroidUsageAnalytics The AnkiDroidUsageAnalytics instance for logging analytics events.
+     * @param usageAnalytics used to report widget events.
      */
 
     abstract fun performUpdate(
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: AppWidgetIds,
-        ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+        usageAnalytics: UsageAnalytics,
     )
 }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -34,7 +34,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.android.appContext
 import com.ichi2.anki.common.preferences.sharedPrefs
 import com.ichi2.anki.common.utils.android.SdCard
@@ -53,7 +53,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: AppWidgetIds,
-        ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+        usageAnalytics: UsageAnalytics,
     ) {
         WidgetStatus.updateInBackground(context)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -13,7 +13,7 @@ import android.view.View
 import android.widget.RemoteViews
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
@@ -229,7 +229,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: AppWidgetIds,
-        ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+        usageAnalytics: UsageAnalytics,
     ) {
         Timber.d("Performing widget update for appWidgetIds: %s", appWidgetIds)
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -14,7 +14,7 @@ import android.widget.RemoteViews
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.destinations.DeckOptionsDestination
@@ -239,7 +239,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
         context: Context,
         appWidgetManager: AppWidgetManager,
         appWidgetIds: AppWidgetIds,
-        ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+        usageAnalytics: UsageAnalytics,
     ) {
         Timber.d("Performing widget update for appWidgetIds: %s", appWidgetIds)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/widget/AnalyticalWidgetProviderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/widget/AnalyticalWidgetProviderTest.kt
@@ -18,7 +18,8 @@
 import android.appwidget.AppWidgetManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.anki.analytics.AnkiDroidUsageAnalytics
+import com.ichi2.anki.common.analytics.Analytics
+import com.ichi2.anki.common.analytics.UsageAnalytics
 import com.ichi2.widget.AnalyticsWidgetProvider
 import com.ichi2.widget.AppWidgetIds
 import io.mockk.every
@@ -35,14 +36,14 @@ class AnalyticalWidgetProviderTest : RobolectricTest() {
     @Before
     override fun setUp() {
         super.setUp()
-        mockkObject(AnkiDroidUsageAnalytics)
-        every { AnkiDroidUsageAnalytics.sendAnalyticsEvent(any(), any()) } answers { }
+        mockkObject(Analytics)
+        every { Analytics.sendAnalyticsEvent(any(), any()) } answers { }
     }
 
     @After
     override fun tearDown() {
         super.tearDown()
-        unmockkObject(AnkiDroidUsageAnalytics)
+        unmockkObject(Analytics)
     }
 
     @Test
@@ -51,7 +52,7 @@ class AnalyticalWidgetProviderTest : RobolectricTest() {
 
         widgetProvider.onEnabled(targetContext)
 
-        verify { AnkiDroidUsageAnalytics.sendAnalyticsEvent("TestWidgetProvider", "enabled") }
+        verify { Analytics.sendAnalyticsEvent("TestWidgetProvider", "enabled") }
     }
 
     private class TestWidgetProvider : AnalyticsWidgetProvider() {
@@ -59,7 +60,7 @@ class AnalyticalWidgetProviderTest : RobolectricTest() {
             context: android.content.Context,
             appWidgetManager: AppWidgetManager,
             appWidgetIds: AppWidgetIds,
-            ankiDroidUsageAnalytics: AnkiDroidUsageAnalytics,
+            usageAnalytics: UsageAnalytics,
         ) {
             // Do nothing
         }

--- a/common/src/main/java/com/ichi2/anki/common/analytics/Analytics.kt
+++ b/common/src/main/java/com/ichi2/anki/common/analytics/Analytics.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.common.analytics
+
+import androidx.annotation.VisibleForTesting
+
+/**
+ * Interface for analytics tracking.
+ *
+ * Implemented in the app module (e.g. by `AnkiDroidUsageAnalytics`).
+ * Feature modules should use [Analytics] object to send events.
+ */
+interface UsageAnalytics {
+    /**
+     * Send a detailed arbitrary analytics event, with noun/verb pairs and extra data if needed.
+     *
+     * @param category the category of event, make your own but use a constant so reporting is good
+     * @param action   the action the user performed
+     * @param value    a value for the event
+     * @param label    a label for the event
+     */
+    fun sendAnalyticsEvent(
+        category: String,
+        action: String,
+        value: Int? = null,
+        label: String? = null,
+    )
+
+    /**
+     * Submit a screen for aggregation / analysis.
+     * Intended for use to determine if / how features are being used.
+     *
+     * @param screen the result of [Class.getSimpleName] will be used as the screen tag
+     */
+    fun sendAnalyticsScreenView(screen: Any) {
+        sendAnalyticsScreenView(screen.javaClass.simpleName)
+    }
+
+    /**
+     * Submit a screen display with a synthetic name for aggregation / analysis.
+     * Intended for use if your class handles multiple screens you want to track separately.
+     *
+     * @param screenName the name to show in analysis reports
+     */
+    fun sendAnalyticsScreenView(screenName: String)
+}
+
+/**
+ * Global accessor for analytics. Delegates to the [UsageAnalytics] implementation
+ * set during app initialization.
+ *
+ * Usage:
+ * ```
+ * Analytics.sendAnalyticsEvent("Widget", "enabled")
+ * Analytics.sendAnalyticsScreenView("DeckPicker")
+ * ```
+ */
+object Analytics {
+    lateinit var instance: UsageAnalytics
+        private set
+
+    fun setAnalytics(analytics: UsageAnalytics) {
+        instance = analytics
+    }
+
+    @VisibleForTesting
+    fun getAnalytics(): UsageAnalytics = instance
+
+    fun sendAnalyticsEvent(
+        category: String,
+        action: String,
+        value: Int? = null,
+        label: String? = null,
+    ) = instance.sendAnalyticsEvent(category, action, value, label)
+
+    fun sendAnalyticsScreenView(screen: Any) = instance.sendAnalyticsScreenView(screen)
+
+    fun sendAnalyticsScreenView(screenName: String) = instance.sendAnalyticsScreenView(screenName)
+}

--- a/common/src/main/java/com/ichi2/anki/common/analytics/Analytics.kt
+++ b/common/src/main/java/com/ichi2/anki/common/analytics/Analytics.kt
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.analytics
+
+/**
+ * Opt-in usage analytics, implemented in the app module by `AnkiDroidUsageAnalytics`.
+ *
+ * Takes no Android types, so it can live in `:common`. Setup that needs a `Context`
+ * stays on the implementation.
+ *
+ * Send events through [Analytics]; this is the contract it delegates to.
+ *
+ * @see Analytics
+ */
+interface UsageAnalytics {
+    /**
+     * @param category groups related events; use a constant so reporting stays consistent
+     * @param action what the user did
+     */
+    fun sendAnalyticsEvent(
+        category: String,
+        action: String,
+        value: Int? = null,
+        label: String? = null,
+    )
+
+    /** Records a screen view named after [screen]'s class. */
+    fun sendAnalyticsScreenView(screen: Any) {
+        sendAnalyticsScreenView(screen.javaClass.simpleName)
+    }
+
+    /** Records a screen view under [screenName], for classes serving several screens. */
+    fun sendAnalyticsScreenView(screenName: String)
+
+    /** Reports the root cause of [t]. */
+    fun sendAnalyticsException(
+        t: Throwable,
+        fatal: Boolean,
+    )
+
+    companion object {
+        /** Bumped to `_v2` for GA4 so consent given for the old backend isn't reused. */
+        const val ANALYTICS_OPTIN_KEY = "analytics_opt_in_v2"
+    }
+}
+
+/**
+ * Sends analytics through whichever [UsageAnalytics] was registered at startup.
+ *
+ * ```
+ * Analytics.sendAnalyticsEvent("Widget", "enabled")
+ * ```
+ */
+object Analytics {
+    /**
+     * Used until [setAnalytics] runs. Crashes are reported through here, and that can
+     * happen before startup registers an implementation, so dropping the hit has to be
+     * safe: throwing would hide the crash we were reporting.
+     */
+    private object Unregistered : UsageAnalytics {
+        override fun sendAnalyticsEvent(
+            category: String,
+            action: String,
+            value: Int?,
+            label: String?,
+        ) = Unit
+
+        override fun sendAnalyticsScreenView(screenName: String) = Unit
+
+        override fun sendAnalyticsException(
+            t: Throwable,
+            fatal: Boolean,
+        ) = Unit
+    }
+
+    var instance: UsageAnalytics = Unregistered
+        private set
+
+    fun setAnalytics(analytics: UsageAnalytics) {
+        instance = analytics
+    }
+
+    fun sendAnalyticsEvent(
+        category: String,
+        action: String,
+        value: Int? = null,
+        label: String? = null,
+    ) = instance.sendAnalyticsEvent(category, action, value, label)
+
+    fun sendAnalyticsScreenView(screen: Any) = instance.sendAnalyticsScreenView(screen)
+
+    fun sendAnalyticsScreenView(screenName: String) = instance.sendAnalyticsScreenView(screenName)
+
+    fun sendAnalyticsException(
+        t: Throwable,
+        fatal: Boolean,
+    ) = instance.sendAnalyticsException(t, fatal)
+}

--- a/common/src/test/java/com/ichi2/anki/common/analytics/AnalyticsTest.kt
+++ b/common/src/test/java/com/ichi2/anki/common/analytics/AnalyticsTest.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.common.analytics
+
+import org.junit.Test
+
+/**
+ * Analytics is reported from the crash path, which can run before startup has
+ * registered an implementation. Nothing here may throw, or it would mask the
+ * crash being reported.
+ *
+ * This class must never call [Analytics.setAnalytics]: the accessor is a singleton
+ * and registering would leak into the other cases.
+ */
+class AnalyticsTest {
+    @Test
+    fun `sending an event without an implementation does nothing`() {
+        Analytics.sendAnalyticsEvent("category", "action")
+    }
+
+    @Test
+    fun `sending a screen view without an implementation does nothing`() {
+        Analytics.sendAnalyticsScreenView("Screen")
+        Analytics.sendAnalyticsScreenView(this)
+    }
+
+    @Test
+    fun `reporting an exception without an implementation does nothing`() {
+        Analytics.sendAnalyticsException(RuntimeException("boom"), fatal = true)
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 5

<!--- Please fill the necessary details below -->
## Purpose / Description
Create interface in :common for analytics, I want to use this i.e. actual implementation after GA4 PR is merged 
after everything is in modules this will look something like this
```
// In :widgets — just use it
AnalyticsProvider.instance.sendAnalyticsEvent("CardAnalysisWidget", "enabled")
```

## Fixes
NA

## Approach
see commit

## How Has This Been Tested?
NA

## Learning (optional, can help others)
Things are very coupled to move in one go

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->