### PR TITLE
tests: fix EmptyApplication tests

### DIFF
--- a/.github/workflows/tests_unit.yml
+++ b/.github/workflows/tests_unit.yml
@@ -159,6 +159,16 @@ jobs:
       - name: Run Unit Tests
         run: ./gradlew jacocoUnitTestReport --daemon
 
+
+      # Only runs:
+      # - on a scheduled run
+      # - on a manually dispatched run
+      # This is not run on the 'happy' CI path as it's a rare de-flake, and would unnecessarily slow
+      #  down CI
+      - name: De-flake EmptyApplication Tests (schedule/manual run only)
+        if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && matrix.iteration == 1 && matrix.os == 'ubuntu-latest'
+        run: ./gradlew testFullDebugUnitTest -PemptyApplication --daemon
+
       - name: Store Logcat as Artifact
         # cancelled() handles test timeouts
         # remove when test timeouts cause a failure()

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -252,6 +252,13 @@ android {
                     } else {
                         excludeTags "com.ichi2.anki.ScreenshotTestCategory"
                     }
+                    // TODO: run this in our de-flake test run
+                    // Ensures that no EmptyApplication test relies on AnkiDroidApp
+                    //  by only running EmptyApplication tests
+                    // ./gradlew testFullDebugUnitTest -PemptyApplication
+                    if (project.hasProperty("emptyApplication")) {
+                        includeTags "com.ichi2.anki.EmptyApplicationCategory"
+                    }
                 }
             }
         }

--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -252,7 +252,6 @@ android {
                     } else {
                         excludeTags "com.ichi2.anki.ScreenshotTestCategory"
                     }
-                    // TODO: run this in our de-flake test run
                     // Ensures that no EmptyApplication test relies on AnkiDroidApp
                     //  by only running EmptyApplication tests
                     // ./gradlew testFullDebugUnitTest -PemptyApplication

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -21,7 +21,6 @@ import com.ichi2.anki.instantnoteeditor.InstantNoteEditorActivity
 import com.ichi2.anki.preferences.PreferencesActivity
 import com.ichi2.testutils.ActivityList
 import com.ichi2.testutils.ActivityList.ActivityLaunchParam
-import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.ExceptionUtil.getFullStackTrace
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -29,17 +28,13 @@ import org.junit.Assert
 import org.junit.Assume.assumeThat
 import org.junit.Before
 import org.junit.Test
-import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
 import org.robolectric.android.controller.ActivityController
-import org.robolectric.annotation.Config
 import java.util.stream.Collectors
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(application = EmptyApplication::class)
-@Category(EmptyApplicationCategory::class) // no point in Application init if we don't use it
 class ActivityStartupUnderBackupTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
     @JvmField // required for Parameter

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupUnderBackupTest.kt
@@ -29,6 +29,7 @@ import org.junit.Assert
 import org.junit.Assume.assumeThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
@@ -37,7 +38,8 @@ import org.robolectric.annotation.Config
 import java.util.stream.Collectors
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
-@Config(application = EmptyApplication::class) // no point in Application init if we don't use it
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class) // no point in Application init if we don't use it
 class ActivityStartupUnderBackupTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter
     @JvmField // required for Parameter

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerFloatingActionMenuTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki
 
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.testutils.EmptyApplication
+import org.junit.experimental.categories.Category
 import org.robolectric.annotation.Config
 
 /**
@@ -25,5 +26,6 @@ import org.robolectric.annotation.Config
  */
 // @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 @NeedsTest("reimplement: doubleTapAddsNote; singleTapTogglesFab")
 class DeckPickerFloatingActionMenuTest

--- a/AnkiDroid/src/test/java/com/ichi2/anki/EmptyApplicationCategory.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/EmptyApplicationCategory.kt
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020 David Allison <davidallisongithub@gmail.com>
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
  *
  *  This program is free software; you can redistribute it and/or modify it under
  *  the terms of the GNU General Public License as published by the Free Software
@@ -13,18 +13,17 @@
  *  You should have received a copy of the GNU General Public License along with
  *  this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package com.ichi2.testutils
 
-import android.app.Application
-import com.ichi2.anki.AnkiDroidApp
+package com.ichi2.anki
+
+import com.ichi2.testutils.EmptyApplication
 
 /**
- * A performance improvement to be used to avoid the startup cost of [AnkiDroidApp].
+ * Support de-flaking [EmptyApplication] usages which have an AnkiDroidApp dependency
  *
  * usage:
  *
  * ```kt
- * @Config(application = EmptyApplication::class)
  * @Category(EmptyApplicationCategory::class)
  * ```
  *
@@ -34,11 +33,4 @@ import com.ichi2.anki.AnkiDroidApp
  * ./gradlew testFullDebugUnitTest -PemptyApplication
  * ```
  */
-class EmptyApplication : Application() {
-    override fun onCreate() {
-        super.onCreate()
-
-        // reset the static state of the app
-        AnkiDroidApp.simulateRestoreFromBackup()
-    }
-}
+interface EmptyApplicationCategory

--- a/AnkiDroid/src/test/java/com/ichi2/anki/FlagTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/FlagTest.kt
@@ -25,12 +25,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.hasSize
 import org.junit.Assert.assertEquals
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /** Tests for [Flag] */
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class FlagTest : JvmTest() {
     @Test
     fun `search node conversion integration test`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/HandlerUtilsTest.kt
@@ -24,12 +24,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.closeTo
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTasks
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class HandlerUtilsTest {
     @Test
     fun checkHandlerFunctionExecution() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/InitialActivityTest.kt
@@ -34,6 +34,7 @@ import org.hamcrest.Matchers.contains
 import org.hamcrest.core.IsInstanceOf.instanceOf
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.times
@@ -42,7 +43,8 @@ import org.robolectric.annotation.Config
 import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
-@Config(application = EmptyApplication::class) // no point in Application init if we don't use it
+@Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class) // no point in Application init if we don't use it
 class InitialActivityTest : RobolectricTest() {
     private lateinit var sharedPreferences: SharedPreferences
     private val appContext: Context

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -16,6 +16,7 @@
 package com.ichi2.anki.analytics
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.preferences.PreferenceTestUtils
@@ -24,12 +25,14 @@ import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class PreferencesAnalyticsTest : RobolectricTest() {
     private val developerOptionsKeys = PreferenceTestUtils.getDeveloperOptionsKeys(targetContext)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardStateTest.kt
@@ -16,10 +16,12 @@
 
 package com.ichi2.anki.browser.search
 
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.libanki.testutils.AnkiTest
 import com.ichi2.testutils.EmptyApplication
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -28,6 +30,7 @@ import kotlin.test.assertEquals
 /** Test for [CardState] */
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class CardStateTest : RobolectricTest() {
     @ParameterizedRobolectricTestRunner.Parameter(0)
     @JvmField

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/SearchRequestTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/SearchRequestTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.browser.search
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.Flag
 import com.ichi2.anki.browser.SearchHistory.SearchHistoryEntry
 import com.ichi2.anki.libanki.DeckNameId
@@ -28,6 +29,7 @@ import com.ichi2.testutils.JvmTest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.assertFailsWith
@@ -35,6 +37,7 @@ import kotlin.test.assertFailsWith
 /** Tests for [SearchRequest] */
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class SearchRequestTest : JvmTest() {
     @Test
     fun `search string generation - empty`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MediaErrorHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/cardviewer/MediaErrorHandlerTest.kt
@@ -20,12 +20,14 @@ import android.net.Uri
 import android.webkit.WebResourceRequest
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.EmptyApplication
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
@@ -36,6 +38,7 @@ import java.io.File
 // and URLUtil.guessFileName (static - likely harder)
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class MediaErrorHandlerTest {
     private lateinit var sut: MediaErrorHandler
     private var timesCalled = 0

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/InsertFieldDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/InsertFieldDialogTest.kt
@@ -17,6 +17,7 @@
 package com.ichi2.anki.dialogs
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.cardviewer.SingleCardSide
 import com.ichi2.anki.model.SpecialField
@@ -28,12 +29,14 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.emptyString
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 /** Tests for [InsertFieldDialog] */
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class InsertFieldDialogTest : RobolectricTest() {
     val metadata =
         InsertFieldMetadata(

--- a/AnkiDroid/src/test/java/com/ichi2/anki/libanki/FieldTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/libanki/FieldTest.kt
@@ -17,11 +17,13 @@
 package com.ichi2.anki.libanki
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.EmptyApplication
 import org.intellij.lang.annotations.Language
 import org.json.JSONObject
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
@@ -29,6 +31,7 @@ import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class) // required due to differing JSON implementation
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class FieldTest : AndroidTest {
     @Test
     fun `'tag' - null handling`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/pages/viewmodel/ImageOcclusionViewModelTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.pages.viewmodel
 import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.NoteId
@@ -34,6 +35,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertInstanceOf
 import org.junit.jupiter.api.assertNull
@@ -48,6 +50,7 @@ import kotlin.test.assertNotNull
 // TODO: make this run with no Android dependencies
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class ImageOcclusionViewModelTest : JvmTest() {
     private var deckIdToSwitchTo by notNull<DeckId>()
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/recorder/AudioRecorderTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/recorder/AudioRecorderTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.recorder
 
 import android.media.MediaRecorder
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.testutils.EmptyApplication
@@ -33,6 +34,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.File
@@ -42,6 +44,7 @@ import kotlin.test.junit5.JUnit5Asserter.assertNotNull
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class AudioRecorderTest : RobolectricTest() {
     private val mockMediaRecorder = mockk<MediaRecorder>(relaxed = true)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AnswerTimerTest.kt
@@ -21,6 +21,7 @@ import android.view.View
 import android.widget.Chronometer
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.testutils.EmptyApplication
@@ -30,6 +31,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Rule
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.mockito.Mockito
 import org.mockito.kotlin.any
@@ -46,6 +48,7 @@ import timber.log.Timber
 // This is difficult to test as Chronometer.mStarted isn't visible
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class AnswerTimerTest : JvmTest() {
     private val chronometer = spy(Chronometer(ApplicationProvider.getApplicationContext()))
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/reviewer/AutomaticAnswerTest.kt
@@ -17,12 +17,14 @@
 package com.ichi2.anki.reviewer
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.reviewer.AutomaticAnswer.AutomaticallyAnswered
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.JvmTest
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.mockito.kotlin.mock
 import org.robolectric.annotation.Config
@@ -30,6 +32,7 @@ import org.robolectric.shadows.ShadowLooper.runUiThreadTasksIncludingDelayedTask
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class AutomaticAnswerTest : JvmTest() {
     @Test
     fun disableWorks() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/settings/PrefsRobolectricTest.kt
@@ -18,6 +18,7 @@ package com.ichi2.anki.settings
 import android.content.res.Resources
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.libanki.utils.append
 import com.ichi2.anki.preferences.PreferenceTestUtils
@@ -30,6 +31,7 @@ import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
@@ -47,6 +49,7 @@ import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class PrefsRobolectricTest : RobolectricTest() {
     private fun getKeysAndDefaultValues(): MutableMap<String, Any?> {
         val sharedPrefsSpy = spy(SPMockBuilder().createSharedPreferences())

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/internationalization/SentenceCaseTest.kt
@@ -20,6 +20,7 @@ import androidx.fragment.app.Fragment
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.CollectionManager.TR
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.testutils.EmptyAnkiActivity
@@ -28,11 +29,13 @@ import com.ichi2.testutils.launchFragmentInContainer
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class SentenceCaseTest : RobolectricTest() {
     @Test
     fun `English is converted to sentence case`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenRepositoryCollectionTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenRepositoryCollectionTest.kt
@@ -19,6 +19,7 @@ import android.content.res.Resources
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.ivanshafran.sharedpreferencesmock.SPMockBuilder
 import com.ichi2.anki.CollectionManager
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.settings.PrefsRepository
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.anki.utils.ext.cardStateCustomizer
@@ -27,12 +28,14 @@ import com.ichi2.testutils.JvmTest
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class StudyScreenRepositoryCollectionTest : JvmTest() {
     private val repository: StudyScreenRepository
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/JSONObjectTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.utils.ext
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.common.utils.ext.getStringOrNull
 import com.ichi2.anki.common.utils.ext.jsonObjectIterable
 import com.ichi2.testutils.AndroidTest
@@ -28,6 +29,7 @@ import org.intellij.lang.annotations.Language
 import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.assertFailsWith
@@ -36,6 +38,7 @@ import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class) // This is necessary, android and JVM differ on JSONObject.NULL
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class JSONObjectTest : AndroidTest {
     @Test
     fun `test getStringOrNull`() {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ParcelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/utils/ext/ParcelTest.kt
@@ -19,6 +19,7 @@ package com.ichi2.anki.utils.ext
 import android.os.Parcel
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest
 import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest.Companion.write
 import com.ichi2.anki.utils.ext.ParcelableUtilsTest.UnderTest.User
@@ -28,12 +29,14 @@ import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.nullValue
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import java.io.Serializable
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class ParcelableUtilsTest {
     @Test
     fun `serializableList - valid`() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ContentResolverUtilTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ContentResolverUtilTest.kt
@@ -21,11 +21,13 @@ import android.database.sqlite.SQLiteException
 import android.net.Uri
 import androidx.core.net.toUri
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.ContentResolverUtil.getFileName
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
@@ -34,6 +36,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class) // needs a URI instance
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class ContentResolverUtilTest {
     @Test
     fun testViaQueryWorking() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/EditTextUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/EditTextUtilsTest.kt
@@ -19,17 +19,20 @@ package com.ichi2.utils
 import android.widget.EditText
 import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.AndroidTest
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.testutils.targetContext
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.nullValue
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class EditTextUtilsTest : AndroidTest {
     @Test
     fun `textAsIntOrNull test`() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/JSONObjectTest.kt
@@ -17,6 +17,7 @@ package com.ichi2.utils
 
 import android.annotation.SuppressLint
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.anki.common.utils.ext.deepClone
 import com.ichi2.anki.common.utils.ext.deepClonedInto
 import com.ichi2.anki.common.utils.ext.fromMap
@@ -26,6 +27,7 @@ import org.json.JSONObject
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
@@ -34,6 +36,7 @@ import org.robolectric.annotation.Config
  */
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 // TODO: move to common test
 @SuppressLint("CheckResult") // many usages: checking exceptions
 class JSONObjectTest {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/KeyUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/KeyUtilsTest.kt
@@ -23,6 +23,7 @@ import android.view.KeyEvent.KEYCODE_9
 import android.view.KeyEvent.KEYCODE_ENDCALL
 import android.view.KeyEvent.KEYCODE_STAR
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.KeyUtils.getDigit
 import com.ichi2.utils.KeyUtils.isDigit
@@ -30,11 +31,13 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class KeyUtilsTest {
     @Test
     fun testIsDigit() {

--- a/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/LanguageUtilsTest.kt
@@ -17,6 +17,7 @@ package com.ichi2.utils
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.collect.Sets
+import com.ichi2.anki.EmptyApplicationCategory
 import com.ichi2.testutils.EmptyApplication
 import com.ichi2.utils.LanguageUtilsTest.Companion.CURRENT_LANGUAGES
 import com.ichi2.utils.LanguageUtilsTest.Companion.PREVIOUS_LANGUAGES
@@ -24,11 +25,13 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.junit.Ignore
 import org.junit.Test
+import org.junit.experimental.categories.Category
 import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(application = EmptyApplication::class)
+@Category(EmptyApplicationCategory::class)
 class LanguageUtilsTest {
     @Test
     @Ignore("temp ignore - languages were removed for 18980")


### PR DESCRIPTION
## Purpose / Description
Mike was having David-inflicted test issues, I suspected one of these was a rare flake where 'EmptyApplication' was incorrectly applied.

I was correct. Fix `ActivityStartupUnderBackupTest`, then add a de-flake on our scheduled run.

## Approach
* add `@Category(EmptyApplicationCategory::class)` and `./gradlew testFullDebugUnitTest -PemptyApplication`
* fix the broken test
* add `./gradlew testFullDebugUnitTest -PemptyApplication` to CI
  * for performance reasons: only performed on our scheduled de-flake run, or on a manual run

## How Has This Been Tested?
Test-only

* A standard test run does not execute the step
  * ✅ https://github.com/david-allison/Anki-Android/actions/runs/24421500451/job/71344743448
* Using `workflow_dispatch` on my branch where the test runs and passes
  * ✅ https://github.com/david-allison/Anki-Android/actions/runs/24422780269/job/71349183877
* ⚠️ I didn't test the scheduled run 

## Learning (optional, can help others)
Our tests need tests 🤯 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->