### PR TITLE
Revert "chore(deps): bump kotlin from 2.3.10 to 2.3.20"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -90,7 +90,7 @@ androidTestJunit = "1.3.0"
 # https://github.com/junit-team/junit5/releases/
 junit = "6.0.3"
 # https://github.com/JetBrains/kotlin/releases/
-kotlin = '2.3.20'
+kotlin = '2.3.10'
 # https://github.com/Kotlin/kotlinx.serialization/releases
 kotlinxSerializationJson = "1.11.0"
 ktlintGradlePlugin = "14.2.0"


### PR DESCRIPTION
This reverts commit d2cce60a3ce127ce7e5cf4190dfe5cd2eb4a0f95.

Breaks CodeQL
* See #20742

> A failure occurred while executing org.jetbrains.kotlin.compilerRunner.btapi.BuildToolsApiCompilationWork
   > Kotlin version 2.3.20 is too recent. CodeQL currently supports versions below 2.3.20

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)