### PR TITLE
Fix controls: prevent duplicate bindings

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/preferences/ReviewerControlPreference.kt
@@ -84,10 +84,12 @@ open class ReviewerControlPreference : ControlPreference {
         val cardSide = side ?: return super.getPreferenceAssignedTo(binding)
         val reviewerBinding = ReviewerBinding(binding, cardSide)
         // Bindings only conflict when the card sides overlap
-        return getRelatedPreferences().firstOrNull { preference ->
-            reviewerBinding in preference.getMappableBindings()
-        }
+        return getPreferencesAssignedTo(reviewerBinding).firstOrNull()
     }
+
+    @NeedsTest("Ensure correct preferences are returned for side-specific binding")
+    private fun getPreferencesAssignedTo(binding: ReviewerBinding): List<ReviewerControlPreference> =
+        getRelatedPreferences().filter { preference -> binding in preference.getMappableBindings() }
 
     fun interface OnBindingSelectedListener {
         /**
@@ -125,9 +127,19 @@ open class ReviewerControlPreference : ControlPreference {
         side: CardSide,
     ) {
         val newBinding = ReviewerBinding(binding, side)
-        getPreferenceAssignedTo(binding)?.removeMappableBinding(newBinding)
+        // Before adding new binding, remove all conflicting bindings
+        getPreferencesAssignedTo(newBinding).forEach { preference ->
+            preference.removeDuplicateBindings(newBinding)
+        }
         val bindings = ReviewerBinding.fromPreferenceString(value).toMutableList()
         bindings.add(newBinding)
+        value = bindings.toPreferenceString()
+    }
+
+    @NeedsTest("Check dup removal, including partial side overlap: e.g. QUESTION & BOTH")
+    private fun removeDuplicateBindings(binding: ReviewerBinding) {
+        val bindings = ReviewerBinding.fromPreferenceString(value).toMutableList()
+        bindings.removeAll { it == binding } // Uses overridden .equals() to detect overlaps
         value = bindings.toPreferenceString()
     }
 


### PR DESCRIPTION
## Purpose / Description
This PR fixes the following bug: In Controls, it is currently possible to end up with conflicting bindings.

For instance, if you

1. assign "swipe down" to both "Toggle red -> Q" and "Toggle orange -> A"
2. assign "swipe down" to "Toggle green -> BOTH"

you end up with "swipe down" assigned to both "Toggle orange -> A" and "Toggle green -> BOTH", i.e. duplicate bindings. This happens because we're only removing a single conflicting binding.

## Fixes
* Third bug in #20504

## Approach
When we add a new binding, instead of removing a single conflicting binding, we now retrieve for and remove all conflicting bindings. I did this by introducing a couple of helpers: `getPreferencesAssignedTo()` and `removeDuplicateBindings()`.

After the fix, the steps above don't produce duplicates anymore:

https://github.com/user-attachments/assets/74c05d93-48f6-4a28-8d90-d049a511bac0

<TODO>

## How Has This Been Tested?
I manually tried various combinations of gesture/key assignments on my physical device.

I ran:
```
./gradlew jacocoUnitTestReport                      
./gradlew lintRelease ktlintCheck
```

## Checklist
- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] ~~UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)~~ NA