### PR TITLE
[Multiple-Profile]fix: external directory not created for profile

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CollectionHelper.kt
@@ -174,18 +174,24 @@ object CollectionHelper {
      * like Samsung may refer to external emulated storage as internal storage, even though for developers, they mean
      * very different things as explained above.
      *
+     * @param directoryName  The leaf folder name to use at the end of the returned path.
+     *                       Defaults to `"AnkiDroid"` (the historical default-profile folder name).
+     *                       Callers wanting a profile-specific layout can pass e.g. the profile id.
      * @return Absolute Path to the default location starting location for the AnkiDroid directory
      *
      * @throws SystemStorageException if `getExternalFilesDir` returns null
      */
     // TODO Tracked in https://github.com/ankidroid/Anki-Android/issues/5304
     @CheckResult
-    fun getDefaultAnkiDroidDirectory(context: Context): File {
+    fun getDefaultAnkiDroidDirectory(
+        context: Context,
+        directoryName: String = "AnkiDroid",
+    ): File {
         val legacyStorage = selectAnkiDroidFolder(context) != AppPrivateFolder
-        return if (!legacyStorage) {
-            File(getAppSpecificExternalAnkiDroidDirectory(context), "AnkiDroid")
+        return if (legacyStorage) {
+            legacyAnkiDroidDirectory(directoryName)
         } else {
-            legacyAnkiDroidDirectory
+            File(getAppSpecificExternalAnkiDroidDirectory(context), directoryName)
         }
     }
 
@@ -193,13 +199,13 @@ object CollectionHelper {
      * Returns the absolute path to the AnkiDroid directory under the primary/shared external storage directory.
      * This directory may be in emulated external storage, or can be an SD Card directory.
      *
-     *
-     * The path returned will no longer be accessible to AnkiDroid once targetSdk > 29
-     *
+     * @param directoryName  The folder name to use at the end of the returned path. Defaults to
+     *                       `"AnkiDroid"`. Non-default profiles can pass `ProfileId` here to get a
+     *                       profile-specific layout.
      * @return Absolute path to the AnkiDroid directory in primary shared/external storage
      */
-    private val legacyAnkiDroidDirectory: File
-        get() = File(Environment.getExternalStorageDirectory(), "AnkiDroid")
+    private fun legacyAnkiDroidDirectory(directoryName: String = "AnkiDroid"): File =
+        File(Environment.getExternalStorageDirectory(), directoryName)
 
     /**
      * Returns the absolute path to the AnkiDroid directory under the app-specific, primary/shared external storage

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -26,15 +26,15 @@ import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
+import com.ichi2.anki.CollectionHelper.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
-import org.acra.ACRA
+import com.ichi2.anki.preferences.sharedPrefs
 import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
-import java.util.UUID
 
 /**
  * Manages the creation, loading, and switching of user profiles.
@@ -169,18 +169,51 @@ class ProfileManager private constructor(
         val profileBaseDir = resolveProfileDirectory(profileId)
 
         try {
-            activeProfileContext =
+            val wrapper =
                 ProfileContextWrapper.create(
                     context = appContext,
                     profileId = profileId,
                     profileBaseDir = profileBaseDir.file,
                 )
+            activeProfileContext = wrapper
+            ensureProfileCollectionPath(wrapper, profileId)
         } catch (e: Exception) {
             Timber.w(e, "Failed to load profile context for $profileId")
             throw RuntimeException("Failed to load profile environment", e)
         }
 
         Timber.d("Profile loaded: $profileId at ${profileBaseDir.file.absolutePath}")
+    }
+
+    /**
+     * Ensures that a valid collection path is initialized and stored in the profile's shared preferences.
+     *
+     * For non-default profiles, this method mirrors the standard AnkiDroid directory structure
+     * by creating a profile-specific subdirectory within the external files directory.
+     *
+     * @param wrapper  The [ProfileContextWrapper] providing access to the profile-namespaced SharedPreferences.
+     * @param profileId  The unique identifier of the profile being initialized.
+     *
+     * @throws com.ichi2.anki.exception.SystemStorageException
+     *   if the app's external storage is unavailable (surfaced by
+     *   [getDefaultAnkiDroidDirectory]). The profile cannot be loaded without writable
+     *   external storage.
+     *
+     * @see PREF_COLLECTION_PATH
+     */
+    private fun ensureProfileCollectionPath(
+        wrapper: ProfileContextWrapper,
+        profileId: ProfileId,
+    ) {
+        if (profileId.isDefault()) return
+
+        val prefs = wrapper.sharedPrefs()
+        if (prefs.getString(PREF_COLLECTION_PATH, null) != null) return
+
+        val profileCollectionDir =
+            getDefaultAnkiDroidDirectory(appContext, directoryName = profileId.value).apply { mkdirs() }
+
+        prefs.edit { putString(PREF_COLLECTION_PATH, profileCollectionDir.absolutePath) }
     }
 
     private fun configureWebView(profileId: ProfileId) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multiprofile/ProfileManager.kt
@@ -26,15 +26,15 @@ import android.webkit.WebView
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.content.edit
-import com.ichi2.anki.IntentHandler
+import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
+import com.ichi2.anki.CollectionHelper.getDefaultAnkiDroidDirectory
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
-import org.acra.ACRA
+import com.ichi2.anki.preferences.sharedPrefs
 import org.json.JSONObject
 import timber.log.Timber
 import java.io.File
-import java.util.UUID
 
 /**
  * Manages the creation, loading, and switching of user profiles.
@@ -169,18 +169,48 @@ class ProfileManager private constructor(
         val profileBaseDir = resolveProfileDirectory(profileId)
 
         try {
-            activeProfileContext =
+            val wrapper =
                 ProfileContextWrapper.create(
                     context = appContext,
                     profileId = profileId,
                     profileBaseDir = profileBaseDir.file,
                 )
+            activeProfileContext = wrapper
+            ensureProfileCollectionPath(wrapper)
         } catch (e: Exception) {
             Timber.w(e, "Failed to load profile context for $profileId")
             throw RuntimeException("Failed to load profile environment", e)
         }
 
         Timber.d("Profile loaded: $profileId at ${profileBaseDir.file.absolutePath}")
+    }
+
+    /**
+     * Ensures that a valid collection path is initialized and stored in the profile's shared preferences.
+     *
+     * For non-default profiles, this method mirrors the standard AnkiDroid directory structure
+     * by creating a profile-specific subdirectory within the external files directory.
+     *
+     * @param wrapper  The [ProfileContextWrapper] providing access to the profile-namespace SharedPreferences.
+     *
+     * @throws com.ichi2.anki.exception.SystemStorageException
+     *   if the app's external storage is unavailable (surfaced by
+     *   [getDefaultAnkiDroidDirectory]). The profile cannot be loaded without writable
+     *   external storage.
+     *
+     * @see PREF_COLLECTION_PATH
+     */
+    private fun ensureProfileCollectionPath(wrapper: ProfileContextWrapper) {
+        val profileId = wrapper.profileId
+        if (profileId.isDefault()) return
+
+        val prefs = wrapper.sharedPrefs()
+        if (prefs.getString(PREF_COLLECTION_PATH, null) != null) return
+
+        val profileCollectionDir =
+            getDefaultAnkiDroidDirectory(appContext, directoryName = profileId.value).apply { mkdirs() }
+
+        prefs.edit { putString(PREF_COLLECTION_PATH, profileCollectionDir.absolutePath) }
     }
 
     private fun configureWebView(profileId: ProfileId) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileContextWrapperTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileContextWrapperTest.kt
@@ -219,4 +219,44 @@ class ProfileContextWrapperTest {
         assertEquals(baseContext.filesDir.absolutePath, result.absolutePath)
         assertNotEquals(File(profileBaseDir, "files").absolutePath, result.absolutePath)
     }
+
+    @Test
+    fun `all profile internal directories sit under profileBaseDir`() {
+        val wrapper = ProfileContextWrapper.create(baseContext, profileId, profileBaseDir)
+        val rootPrefix = profileBaseDir.absolutePath + File.separator
+
+        assertTrue("filesDir", wrapper.filesDir.absolutePath.startsWith(rootPrefix))
+        assertTrue("cacheDir", wrapper.cacheDir.absolutePath.startsWith(rootPrefix))
+        assertTrue("codeCacheDir", wrapper.codeCacheDir.absolutePath.startsWith(rootPrefix))
+        assertTrue("noBackupFilesDir", wrapper.noBackupFilesDir.absolutePath.startsWith(rootPrefix))
+        assertTrue(
+            "databasePath",
+            wrapper.getDatabasePath("collection.anki2").absolutePath.startsWith(rootPrefix),
+        )
+        assertTrue(
+            "getDir",
+            wrapper.getDir("acra", Context.MODE_PRIVATE).absolutePath.startsWith(rootPrefix),
+        )
+    }
+
+    @Test
+    fun `two non-default profiles have disjoint internal directory trees`() {
+        val appDataRoot = baseContext.filesDir.parentFile!!
+        val profileA = ProfileId("p_alpha")
+        val profileB = ProfileId("p_bravo")
+        val baseA = File(appDataRoot, profileA.value).apply { deleteRecursively() }
+        val baseB = File(appDataRoot, profileB.value).apply { deleteRecursively() }
+
+        val wrapperA = ProfileContextWrapper.create(baseContext, profileA, baseA)
+        val wrapperB = ProfileContextWrapper.create(baseContext, profileB, baseB)
+
+        assertNotEquals(wrapperA.filesDir.absolutePath, wrapperB.filesDir.absolutePath)
+        assertNotEquals(wrapperA.cacheDir.absolutePath, wrapperB.cacheDir.absolutePath)
+        assertNotEquals(wrapperA.codeCacheDir.absolutePath, wrapperB.codeCacheDir.absolutePath)
+        assertNotEquals(wrapperA.noBackupFilesDir.absolutePath, wrapperB.noBackupFilesDir.absolutePath)
+        assertNotEquals(
+            wrapperA.getDatabasePath("collection.anki2").absolutePath,
+            wrapperB.getDatabasePath("collection.anki2").absolutePath,
+        )
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multiprofile/ProfileManagerTest.kt
@@ -25,8 +25,10 @@ import android.webkit.WebView
 import androidx.core.content.edit
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.CollectionHelper.PREF_COLLECTION_PATH
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.KEY_LAST_ACTIVE_PROFILE_ID
 import com.ichi2.anki.multiprofile.ProfileManager.Companion.PROFILE_REGISTRY_FILENAME
+import com.ichi2.anki.preferences.sharedPrefs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -238,6 +240,31 @@ class ProfileManagerTest {
     }
 
     @Test
+    fun `loading a non-default profile sets deckPath to the profile-specific external dir`() {
+        val manager = ProfileManager.create(context)
+        val ashishId = manager.createNewProfile(ProfileName.fromTrustedSource("Ashish"))
+        with(ProfileManager.ProfileSwitchContext) { manager.switchActiveProfile(ashishId) }
+
+        val reloaded = ProfileManager.create(context)
+        val deckPath = reloaded.activeProfileContext.sharedPrefs().getString(PREF_COLLECTION_PATH, null)
+
+        val expected = File(context.getExternalFilesDir(null), ashishId.value).absolutePath
+        assertEquals(expected, deckPath)
+    }
+
+    @Test
+    fun `loading a non-default profile creates the deckPath directory on disk`() {
+        val manager = ProfileManager.create(context)
+        val ashishId = manager.createNewProfile(ProfileName.fromTrustedSource("Ashish"))
+        with(ProfileManager.ProfileSwitchContext) { manager.switchActiveProfile(ashishId) }
+
+        val reloaded = ProfileManager.create(context)
+        val deckPath = reloaded.activeProfileContext.sharedPrefs().getString(PREF_COLLECTION_PATH, null)!!
+
+        assertTrue("deckPath directory must exist after profile load", File(deckPath).isDirectory)
+    }
+
+    @Test
     fun `renameProfile does not write to disk if name is identical`() {
         val manager = ProfileManager.create(context)
         val name = ProfileName.fromTrustedSource("No Change")
@@ -262,5 +289,25 @@ class ProfileManagerTest {
             }
 
         assertTrue(exception.message!!.contains("not found"))
+    }
+
+    @Test
+    fun `reloading an existing profile does not overwrite a pre-existing deckPath`() {
+        val manager = ProfileManager.create(context)
+        val newId = manager.createNewProfile(ProfileName.fromTrustedSource("Work"))
+        with(ProfileManager.ProfileSwitchContext) { manager.switchActiveProfile(newId) }
+
+        // First load materializes deckPath. Then the user "relocates" their collection.
+        val firstLoad = ProfileManager.create(context)
+        val userChosenPath = File(context.filesDir, "user_relocated").apply { mkdirs() }.absolutePath
+        firstLoad.activeProfileContext.sharedPrefs().edit(commit = true) {
+            putString(PREF_COLLECTION_PATH, userChosenPath)
+        }
+
+        // Simulate app restart - ProfileManager.create runs again.
+        val reloaded = ProfileManager.create(context)
+        val deckPath = reloaded.activeProfileContext.sharedPrefs().getString(PREF_COLLECTION_PATH, null)
+
+        assertEquals("User-relocated deckPath must not be overwritten on reload", userChosenPath, deckPath)
     }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Fixes a VERY BIG BLUNDER that I did earlier, I overlooked external dir. but thanks to @david-allison I figured this one, apart from deletion the addition logic was also missing 

## Fixes
* Fixes part of #18117

## Approach
See commit

## How Has This Been Tested?
Unit test to verify that directory was created 

## Learning (optional, can help others)
Always doc first

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->