### PR TITLE
Feat: Automate sync_translations workflow for 30 minute delays

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -3,6 +3,10 @@ name: 🌐 Sync Translations
 on:
   workflow_dispatch:
 
+concurrency:
+  group: sync-translations
+  cancel-in-progress: true
+
 # We use a machine account PAT from secrets so workflows are triggered
 # the default token is not needed and should be fully restricted
 permissions: {}
@@ -10,7 +14,7 @@ permissions: {}
 jobs:
   sync_translations:
     name: 'Sync Translations with Crowdin'
-    timeout-minutes: 20
+    timeout-minutes: 50
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -31,6 +35,28 @@ jobs:
           git checkout -b i18n_sync
           git reset --hard origin/main
         shell: bash
+
+      - name: Get second to latest run time
+        env:
+          GH_TOKEN: ${{ secrets.MACHINE_ACCOUNT_PAT }}
+        run: |
+          OUTPUT=$(gh run list --workflow sync_translations.yml --json updatedAt | jq -r '.[1].updatedAt')
+          echo "LATEST_RUN=$OUTPUT" >> $GITHUB_ENV
+
+      - name: Calculate seconds passed
+        id: calc_time
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const lastRun = new Date(process.env.LATEST_RUN);
+            const secondsPassed = Math.floor((Date.now() - lastRun.getTime()) / 1000);
+            const timeLeft = 1800 - secondsPassed > 0 ? 1800 - secondsPassed: 0;
+            console.log('Seconds to sleep for: ' + timeLeft);
+            core.setOutput('time_left', timeLeft);
+
+      - name: Await CrowdIn API Cooldown If Needed
+        if: steps.calc_time.outputs.time_left > 0
+        run: sleep ${{ steps.calc_time.outputs.time_left }}
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description
30 minute delays are necessary between every sync translation workflow run, requiring manual oversight

## Fixes
* Fixes #19994 

## Approach

1. Uses gh commands to get datetime of last workflow run
2. Uses javascript to calculate time to 30 minutes
3. Runs sleep on remaining time

## How Has This Been Tested?

The functionality of these commands have been tested exclusively on a repository explicitly created for this
Sleep Function has proven to work as intended 
<img width="1021" height="323" alt="image" src="https://github.com/user-attachments/assets/687d74ea-f49b-428d-b4c0-c1e043dd8d71" />


_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [ ] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->