### PR TITLE
fix: keep sync snackbar anchored correctly

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1124,6 +1124,7 @@ open class DeckPicker :
                     Timber.i("DeckPicker:: SearchItem opened")
                     // Hide the floating action button if it is visible
                     floatingActionMenu.hideFloatingActionButton()
+                    activeSnackBar?.anchorView = null
                     return true
                 }
 
@@ -1132,6 +1133,7 @@ open class DeckPicker :
                     Timber.i("DeckPicker:: SearchItem closed")
                     // Show the floating action button if it is hidden
                     floatingActionMenu.showFloatingActionButton()
+                    activeSnackBar?.anchorView = floatingActionButtonBinding.fabMain
                     return true
                 }
             },
@@ -1245,6 +1247,7 @@ open class DeckPicker :
             }
             R.id.action_sync -> {
                 Timber.i("DeckPicker:: Sync button pressed")
+                toolbarSearchItem?.collapseActionView()
                 val actionProvider = MenuItemCompat.getActionProvider(item) as? SyncActionProvider
                 if (actionProvider?.isProgressShown == true) {
                     launchCatchingTask {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
When the sync toolbar button is tapped while the search action view isexpanded, the keyboard is dismissed (focus leaves the search field) but the action view stays expanded, so the FAB remains hidden. The post-sync snackbar therefore shows unanchored, and the FAB is only restored when the user leaves and returns to the activity.

Also, when search is toggled while a snackbar is already showing, the snackbar's anchor becomes stale, either hovering above a hidden FAB (leaving a gap above the keyboard) or overlapping the FAB when it comes back.

## Fixes
* Fixes  #20765

## Approach
1. `onOptionsItemSelected(R.id.action_sync)` : collapse `toolbarSearchItem` before starting the sync. That fires
   `onMenuItemActionCollapse` -> `showFloatingActionButton()`, so the FAB is back by the time the sync result snackbar appears.
2. `onMenuItemActionExpand`:  after `hideFloatingActionButton()`, null out `activeSnackBar?.anchorView` so a live snackbar drops to sit above the keyboard instead of hovering where the FAB used to be.
3. `onMenuItemActionCollapse`: after `showFloatingActionButton()`, re-anchor `activeSnackBar?.anchorView` to `fabMain` so it sits above the FAB instead of being overlapped by it.

## How Has This Been Tested?
Pixel 10

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->