### PR TITLE
build(ci): fix CodeQL OOM

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -102,6 +102,8 @@ jobs:
       shell: bash
       run: |
         ./gradlew assemblePlayRelease -x lintVitalPlayRelease
+        # Free the Gradle daemon's heap before CodeQL analysis runs, or we OOM the runner (#20768)
+        ./gradlew --stop
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 (investigation)

## Purpose / Description
Since the configuration cache was enabled in 6a87b7dd1c8947ab20df470868ac54bac43e193c, the CodeQL job has regularly OOMed.

CodeQL appears to run its own JVM, stopping the Gradle daemon should free ~3 GB for CodeQL with no downside.

## Fixes
* Fixes #20768

## Approach
`./gradlew --stop`

## How Has This Been Tested?
⚠️ CI Only

## Learning
CodeQL recommends 16GB+ RAM for a codebase of 100kLOC+, we have 7GB with `ubuntu-latest`

https://docs.github.com/en/code-security/reference/code-scanning/codeql/recommended-hardware-resources-for-running-codeql

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)