### PR TITLE
test(NoteEditorFragment): add unit test for saveToggleStickyMap

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -2279,8 +2279,8 @@ class NoteEditorFragment :
         }
     }
 
-    @NeedsTest("13719: moving from a note type with more fields to one with fewer fields")
-    private fun saveToggleStickyMap() {
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    fun saveToggleStickyMap() {
         for ((key) in toggleStickyText.toMap()) {
             // handle fields for different note type with different size
             if (key < editFields!!.size) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -723,6 +723,29 @@ class NoteEditorTest : RobolectricTest() {
             assertEquals(initialDeckId, col.getCard(cardIds[1]).did, "Sibling card should NOT move")
         }
 
+    @Test
+    fun `saveToggleStickyMap removes keys beyond current field count - 13719`() {
+        val editor = getNoteEditorAddingNote(DECK_LIST)
+        advanceRobolectricLooper()
+
+        val editFields = List(2) { index -> editor.getFieldForTest(index) }
+        editor.editFields!!.clear()
+        editor.editFields!!.addAll(editFields)
+        editor.toggleStickyText.putAll(
+            mapOf(
+                0 to "value0",
+                1 to "value1",
+                2 to "value2",
+            ),
+        )
+
+        editor.saveToggleStickyMap()
+
+        assertFalse(editor.toggleStickyText.containsKey(2), "key 2 should be removed when editFields has only 2 elements")
+        assertTrue(editor.toggleStickyText.containsKey(0), "key 0 should remain")
+        assertTrue(editor.toggleStickyText.containsKey(1), "key 1 should remain")
+    }
+
     private suspend fun withNoteEditorAdding(
         from: FromScreen = FromScreen.DECK_LIST,
         block: suspend NoteEditorFragment.() -> Unit,


### PR DESCRIPTION
## Purpose / Description
Add a unit test for NoteEditorFragment.saveToggleStickyMap() to cover the case where switching from a note type with more fields to one with fewer fields correctly removes stale keys from toggleStickyText.

## Fixes
* Fixes some of #13283

## Approach
The saveToggleStickyMap() method already contains the correct logic to remove stale keys when the number of fields changes. This PR adds a unit test using reflection to verify the behavior and removes the @NeedsTest annotation.

## How Has This Been Tested?
./gradlew :AnkiDroid:testPlayDebugUnitTest --tests "com.ichi2.anki.NoteEditorTest" 
./gradlew ktlintCheck 
./gradlew lintDebug 
./gradlew assembleDebug

## Learning (optional, can help others)
N/A

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)