### PR TITLE
[API] Added fields to cards endpoints ( Part - 3 )

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -23,6 +23,7 @@ import android.content.ContentValues
 import android.database.Cursor
 import android.database.CursorWindow
 import android.net.Uri
+import anki.cards.FsrsMemoryState
 import anki.notetypes.StockNotetype
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.FlashCardsContract
@@ -541,6 +542,314 @@ class ContentProviderTest : InstrumentedTest() {
             assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.REPS))
             assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.LAPSES))
             assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.ORIGINAL_DECK_ID))
+        }
+    }
+
+    @Test
+    fun testQueryCardOriginalPosition() {
+        val expectedOriginalPosition = 37
+        val card =
+            getFirstCardFromScheduler(col)!!.update {
+                originalPosition = expectedOriginalPosition
+            }
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.ORIGINAL_POSITION) {
+            assertEquals(
+                expectedOriginalPosition,
+                it.getInt(it.getColumnIndex(FlashCardsContract.Card.ORIGINAL_POSITION)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardOriginalPosition_defaultsToNull() {
+        val card = getFirstCardFromScheduler(col)!!
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.ORIGINAL_POSITION) {
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.ORIGINAL_POSITION)))
+        }
+    }
+
+    @Test
+    fun testQueryCardRawCustomData() {
+        val expectedRawCustomData = """{"part3":true}"""
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setCustomData(expectedRawCustomData)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.RAW_CUSTOM_DATA) {
+            assertEquals(
+                expectedRawCustomData,
+                it.getString(it.getColumnIndex(FlashCardsContract.Card.RAW_CUSTOM_DATA)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardRawCustomData_defaultsToEmptyString() {
+        val card = getFirstCardFromScheduler(col)!!
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.RAW_CUSTOM_DATA) {
+            assertEquals(
+                "",
+                it.getString(it.getColumnIndex(FlashCardsContract.Card.RAW_CUSTOM_DATA)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardFsrsStability() {
+        val expectedFsrsStability = 12.5f
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setMemoryState(
+                        FsrsMemoryState
+                            .newBuilder()
+                            .setStability(expectedFsrsStability)
+                            .setDifficulty(4.25f),
+                    ).build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.FSRS_STABILITY) {
+            assertEquals(
+                expectedFsrsStability,
+                it.getFloat(it.getColumnIndex(FlashCardsContract.Card.FSRS_STABILITY)),
+                0.0f,
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardFsrsDifficulty() {
+        val expectedFsrsDifficulty = 4.25f
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setMemoryState(
+                        FsrsMemoryState
+                            .newBuilder()
+                            .setStability(12.5f)
+                            .setDifficulty(expectedFsrsDifficulty),
+                    ).build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.FSRS_DIFFICULTY) {
+            assertEquals(
+                expectedFsrsDifficulty,
+                it.getFloat(it.getColumnIndex(FlashCardsContract.Card.FSRS_DIFFICULTY)),
+                0.0f,
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardFsrsDesiredRetention() {
+        val expectedFsrsDesiredRetention = 0.86f
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setDesiredRetention(expectedFsrsDesiredRetention)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.FSRS_DESIRED_RETENTION) {
+            assertEquals(
+                expectedFsrsDesiredRetention,
+                it.getFloat(it.getColumnIndex(FlashCardsContract.Card.FSRS_DESIRED_RETENTION)),
+                0.0f,
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardFsrsDecay() {
+        val expectedFsrsDecay = -0.52f
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setDecay(expectedFsrsDecay)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.FSRS_DECAY) {
+            assertEquals(
+                expectedFsrsDecay,
+                it.getFloat(it.getColumnIndex(FlashCardsContract.Card.FSRS_DECAY)),
+                0.0f,
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardLastReviewTimeSeconds() {
+        val expectedLastReviewTimeSeconds = 1_700_000_123L
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setLastReviewTimeSecs(expectedLastReviewTimeSeconds)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleCardColumn(card, FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS) {
+            assertEquals(
+                expectedLastReviewTimeSeconds,
+                it.getLong(it.getColumnIndex(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardFsrsFields_defaultToNull() {
+        val card = getFirstCardFromScheduler(col)!!
+        val projection =
+            arrayOf(
+                FlashCardsContract.Card.FSRS_STABILITY,
+                FlashCardsContract.Card.FSRS_DIFFICULTY,
+                FlashCardsContract.Card.FSRS_DESIRED_RETENTION,
+                FlashCardsContract.Card.FSRS_DECAY,
+                FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS,
+            )
+
+        assertSingleCardProjection(card, projection, projection.toList()) {
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.FSRS_STABILITY)))
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.FSRS_DIFFICULTY)))
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.FSRS_DESIRED_RETENTION)))
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.FSRS_DECAY)))
+            assertTrue(it.isNull(it.getColumnIndex(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS)))
+        }
+    }
+
+    @Test
+    fun testSearchCards_withPart3Projection() {
+        val expectedRawCustomData = """{"part3":"search"}"""
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setCustomData(expectedRawCustomData)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleRowProjection(
+            FlashCardsContract.Card.CONTENT_URI,
+            arrayOf(FlashCardsContract.Card.RAW_CUSTOM_DATA),
+            listOf(FlashCardsContract.Card.RAW_CUSTOM_DATA),
+            selection = "cid:${card.id}",
+        ) {
+            assertEquals(
+                expectedRawCustomData,
+                it.getString(it.getColumnIndex(FlashCardsContract.Card.RAW_CUSTOM_DATA)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryNoteCardByOrd_withPart3Projection() {
+        val expectedLastReviewTimeSeconds = 1_700_000_456L
+        val card = getFirstCardFromScheduler(col)!!
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setLastReviewTimeSecs(expectedLastReviewTimeSeconds)
+                    .build(),
+            ),
+            true,
+        )
+        val noteCardsUri =
+            Uri.withAppendedPath(
+                Uri.withAppendedPath(
+                    FlashCardsContract.Note.CONTENT_URI,
+                    card.nid.toString(),
+                ),
+                "cards",
+            )
+        val specificCardUri = Uri.withAppendedPath(noteCardsUri, card.ord.toString())
+
+        assertSingleRowProjection(
+            specificCardUri,
+            arrayOf(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS),
+            listOf(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS),
+        ) {
+            assertEquals(
+                expectedLastReviewTimeSeconds,
+                it.getLong(it.getColumnIndex(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS)),
+            )
+        }
+    }
+
+    @Test
+    fun testQueryCardById_defaultProjectionOmitsPart3Fields() {
+        val card =
+            getFirstCardFromScheduler(col)!!.update {
+                originalPosition = 37
+            }
+        col.backend.updateCards(
+            listOf(
+                card
+                    .toBackendCard()
+                    .toBuilder()
+                    .setCustomData("""{"part3":true}""")
+                    .setMemoryState(
+                        FsrsMemoryState
+                            .newBuilder()
+                            .setStability(12.5f)
+                            .setDifficulty(4.25f),
+                    ).setDesiredRetention(0.86f)
+                    .setDecay(-0.52f)
+                    .setLastReviewTimeSecs(1_700_000_123L)
+                    .build(),
+            ),
+            true,
+        )
+
+        assertSingleCardProjection(card, null, FlashCardsContract.Card.DEFAULT_PROJECTION.toList()) {
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.ORIGINAL_POSITION))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.RAW_CUSTOM_DATA))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.FSRS_STABILITY))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.FSRS_DIFFICULTY))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.FSRS_DESIRED_RETENTION))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.FSRS_DECAY))
+            assertEquals(-1, it.getColumnIndex(FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS))
         }
     }
 
@@ -1978,6 +2287,53 @@ class ContentProviderTest : InstrumentedTest() {
                 .build()
         val exception = assertThrows<IllegalArgumentException> { contentResolver.delete(emptyCardsUri, null, null) }
         assertThat(exception.message, containsString("must be either numeric or"))
+    }
+
+    private fun assertSingleCardColumn(
+        card: Card,
+        column: String,
+        assertions: (Cursor) -> Unit,
+    ) {
+        assertSingleCardProjection(card, arrayOf(column), listOf(column), assertions)
+    }
+
+    private fun assertSingleCardProjection(
+        card: Card,
+        projection: Array<String>?,
+        expectedColumns: List<String>,
+        assertions: (Cursor) -> Unit,
+    ) {
+        val cardUri =
+            Uri.withAppendedPath(
+                FlashCardsContract.Card.CONTENT_URI,
+                card.id.toString(),
+            )
+
+        assertSingleRowProjection(cardUri, projection, expectedColumns, assertions = assertions)
+    }
+
+    private fun assertSingleRowProjection(
+        uri: Uri,
+        projection: Array<String>?,
+        expectedColumns: List<String>,
+        selection: String? = null,
+        assertions: (Cursor) -> Unit,
+    ) {
+        val cursor =
+            contentResolver.query(
+                uri,
+                projection,
+                selection,
+                null,
+                null,
+            )
+
+        assertNotNull(cursor)
+        cursor.use {
+            assertEquals(expectedColumns, it.columnNames.toList())
+            assertTrue(it.moveToFirst())
+            assertions(it)
+        }
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1193,6 +1193,13 @@ class CardContentProvider : ContentProvider() {
                 FlashCardsContract.Card.INTERVAL -> rb.add(currentCard.ivl)
                 FlashCardsContract.Card.RAW_SM2_FACTOR -> rb.add(currentCard.factor)
                 FlashCardsContract.Card.RAW_LEFT -> rb.add(currentCard.left)
+                FlashCardsContract.Card.ORIGINAL_POSITION -> rb.add(currentCard.originalPosition)
+                FlashCardsContract.Card.RAW_CUSTOM_DATA -> rb.add(currentCard.customData)
+                FlashCardsContract.Card.FSRS_STABILITY -> rb.add(currentCard.memoryStateStability)
+                FlashCardsContract.Card.FSRS_DIFFICULTY -> rb.add(currentCard.memoryStateDifficulty)
+                FlashCardsContract.Card.FSRS_DESIRED_RETENTION -> rb.add(currentCard.fsrsDesiredRetention)
+                FlashCardsContract.Card.FSRS_DECAY -> rb.add(currentCard.decay)
+                FlashCardsContract.Card.LAST_REVIEW_TIME_SECONDS -> rb.add(currentCard.lastReviewTimeSecs)
                 else -> throw UnsupportedOperationException("Queue \"$column\" is unknown")
             }
         }
@@ -1463,3 +1470,12 @@ private fun NotetypeJson.getEmptyCardIds(col: Collection): List<CardId> {
         .filter { noteIdsOfType.contains(it.noteId) }
         .flatMap { it.cardIdsList }
 }
+
+private val Card.memoryStateStability: Float?
+    get() = memoryState?.stability
+
+private val Card.memoryStateDifficulty: Float?
+    get() = memoryState?.difficulty
+
+private val Card.fsrsDesiredRetention: Float?
+    get() = desiredRetention

--- a/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
+++ b/api/src/main/java/com/ichi2/anki/FlashCardsContract.kt
@@ -787,6 +787,110 @@ public object FlashCardsContract {
         public const val RAW_LEFT: String = "left"
 
         /**
+         * The stored original position for this card, if the backend has one.
+         *
+         * This is raw card metadata from the backend. It is not the same as the card's current
+         * due/order value, and it is not related to filtered-deck original due handling.
+         *
+         * See [Anki's studying documentation](https://docs.ankiweb.net/studying.html#editing-and-more)
+         * for the user-facing "Restore original position" behavior, and
+         * [Anki's card info documentation](https://docs.ankiweb.net/stats.html#card-info) for the
+         * card position shown in card info.
+         *
+         * When present, Anki uses this to retain a card's original position independently from
+         * later user changes such as repositioning. Cards that do not have this metadata return
+         * `null`.
+         */
+        public const val ORIGINAL_POSITION: String = "original_position"
+
+        /**
+         * The raw custom data string stored on this card.
+         *
+         * This value is used by custom scheduling hooks. The provider exposes the backend value
+         * as-is: it does not parse, validate, normalize, or promise a schema for the string.
+         *
+         * See [Anki's custom-data search documentation](https://docs.ankiweb.net/searching.html#custom-data)
+         * for examples of how Anki treats this as custom scheduler data.
+         *
+         * Consumers should treat this as opaque text owned by the scheduler/custom scheduling
+         * code that wrote it. Cards with no custom data return an empty string.
+         */
+        public const val RAW_CUSTOM_DATA: String = "custom_data"
+
+        /**
+         * The FSRS stability value stored in the card's memory state, if present.
+         *
+         * This is raw FSRS scheduler state. Stability represents the estimated number of days it
+         * takes for recall probability to drop from 100% to 90% for this card's memory.
+         *
+         * See [Anki's card stability documentation](https://docs.ankiweb.net/stats.html#card-stability).
+         *
+         * Cards without stored FSRS memory state return `null`. Consumers should not expect this
+         * value to be present for cards scheduled without FSRS, new cards without memory state, or
+         * cards whose scheduler state has not stored FSRS memory data.
+         *
+         * @see FSRS_DIFFICULTY
+         */
+        public const val FSRS_STABILITY: String = "fsrs_stability"
+
+        /**
+         * The FSRS difficulty value stored in the card's memory state, if present.
+         *
+         * This is raw FSRS scheduler state. Difficulty represents the estimated inherent
+         * difficulty of recalling this card's memory.
+         *
+         * See [Anki's card difficulty documentation](https://docs.ankiweb.net/stats.html#card-difficulty).
+         *
+         * Cards without stored FSRS memory state return `null`. Consumers should not expect this
+         * value to be present for cards scheduled without FSRS, new cards without memory state, or
+         * cards whose scheduler state has not stored FSRS memory data.
+         *
+         * @see FSRS_STABILITY
+         */
+        public const val FSRS_DIFFICULTY: String = "fsrs_difficulty"
+
+        /**
+         * The desired retention value stored on this card, if present.
+         *
+         * This is raw FSRS scheduler metadata, expressed as a fraction such as `0.9` for 90%.
+         * It is exposed as stored by the backend and is not derived from deck options at query
+         * time.
+         *
+         * See [Anki's desired retention documentation](https://docs.ankiweb.net/deck-options.html#desired-retention).
+         *
+         * Cards without a stored desired-retention value return `null`.
+         */
+        public const val FSRS_DESIRED_RETENTION: String = "fsrs_desired_retention"
+
+        /**
+         * The FSRS decay value stored on this card, if present.
+         *
+         * This is raw FSRS scheduler metadata used by the FSRS forgetting curve. The provider
+         * exposes the backend value as-is and does not reinterpret it.
+         *
+         * See the [FSRS algorithm documentation](https://github.com/open-spaced-repetition/fsrs4anki/wiki/The-Algorithm#fsrs-6)
+         * for the forgetting-curve context.
+         *
+         * Cards without a stored decay value return `null`.
+         */
+        public const val FSRS_DECAY: String = "fsrs_decay"
+
+        /**
+         * The last review time stored on this card, if present.
+         *
+         * This is raw backend card metadata in Unix epoch seconds. It is not a formatted date and
+         * it is not synthesized from the revlog by this provider.
+         *
+         * See [Anki's revlog documentation](https://docs.ankiweb.net/stats.html#manual-analysis)
+         * for the related Unix epoch convention used in review history, and the upstream
+         * [last review time change](https://github.com/ankitects/anki/pull/4124) for why this
+         * card-level value exists.
+         *
+         * Cards without a stored last-review time return `null`.
+         */
+        public const val LAST_REVIEW_TIME_SECONDS: String = "last_review_time_secs"
+
+        /**
          * The content:// style URI for cards. Can be used to search for cards or access specific cards.
          * For examples on how to use the URI for queries see the overview in [FlashCardsContract].
          */

--- a/libanki/src/main/java/com/ichi2/anki/libanki/Card.kt
+++ b/libanki/src/main/java/com/ichi2/anki/libanki/Card.kt
@@ -108,11 +108,15 @@ open class Card : Cloneable {
 
     @VisibleForTesting
     var flags = 0
-    private var memoryState: FSRSMemoryState? = null
-    private var desiredRetention: Float? = null
-    private var decay: Float? = null
+    var memoryState: FSRSMemoryState? = null
+        private set
+    var desiredRetention: Float? = null
+        private set
+    var decay: Float? = null
+        private set
 
-    private var lastReviewTimeSecs: Long? = null
+    var lastReviewTimeSecs: Long? = null
+        private set
 
     var renderOutput: TemplateRenderOutput? = null
     var note: Note? = null


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: GPT 5.4  - with investigation + documentation

<!--- Please fill the necessary details below -->
<!--- Please fill the necessary details below -->
## Purpose / Description
Expose the remaining agreed raw card fields through the cards content-provider API for issue #20458.

Parts [1](https://github.com/ankidroid/Anki-Android/pull/20589) and [2](https://github.com/ankidroid/Anki-Android/pull/20675) added the earlier card scheduling/stat fields in small reviewable groups. This PR continues that approach for the remaining fields that can be represented cleanly as opt-in content-provider columns:

- `original_position`
- `custom_data`
- `fsrs_stability`
- `fsrs_difficulty`
- `fsrs_desired_retention`
- `fsrs_decay`
- `last_review_time_secs`

The fields are intentionally opt-in only. `DEFAULT_PROJECTION` is unchanged.

## Fixes
* Fixes #20458

## Approach
- Added the remaining card columns to `FlashCardsContract.Card` with KDoc for the raw/default behavior.
- Wired them into `addCardToCursor()` so they work anywhere card rows are built.
- Kept them opt-in only; `DEFAULT_PROJECTION` is unchanged.
- Added small read-only getters on `Card` for the private values the provider needs.
- Exposed `memoryState` as `fsrs_stability` and `fsrs_difficulty` instead of returning the whole object.


## How Has This Been Tested?

- added/updated ContentProviderTest coverage for the new fields
-  manually queried the debug provider at content://com.ichi2.anki.debug.flashcards/cards

<img width="1185" height="383" alt="Screenshot 2026-04-19 at 2 40 21 AM" src="https://github.com/user-attachments/assets/59c5b977-d10d-44bf-aa50-760b56be6cbc" />
- manually queried with explicit projection

<img width="1158" height="195" alt="Screenshot 2026-04-19 at 2 41 29 AM" src="https://github.com/user-attachments/assets/afccee2e-2187-4d7b-ab39-0198cfebfed4" />

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->