### PR TITLE
fix(ci): APK Size Comparison

### DIFF
--- a/.github/workflows/compare_apk_size.yml
+++ b/.github/workflows/compare_apk_size.yml
@@ -42,6 +42,12 @@ jobs:
           echo y | keytool -genkeypair -dname "cn=AnkiDroid, ou=ankidroid, o=AnkiDroid, c=US" -alias $KEYALIAS -keypass $KEYPWD -keystore $KEYSTOREPATH -storepass $KEYSTOREPWD -keyalg RSA -validity 20000
         shell: bash
 
+      - name: Checkout PR
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: 'refs/pull/${{ github.event.inputs.prNumber }}/head'
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
         timeout-minutes: 5
@@ -49,12 +55,6 @@ jobs:
           # Use open source provider: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#basic-caching
           cache-provider: basic
           cache-read-only: true
-
-      - name: Checkout PR
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          ref: 'refs/pull/${{ github.event.inputs.prNumber }}/head'
 
       - name: Assemble PR APK
         # This makes sure we fetch gradle network resources with a retry


### PR DESCRIPTION
## Purpose / Description
`setup-gradle@v6` now hard-errors when it can't find files to build a hash key.

Previously it had nothing to hash, now it hashes the selected PR

## Fixes
* Fixes #20779

## Approach
Change the ordering to match other workflow files.

## How Has This Been Tested?
* pushed this commit to 'main' on my fork
* made a change which should cause a minor APK size increase
* Check: https://github.com/david-allison/Anki-Android/actions/runs/24627441561
  * https://github.com/david-allison/Anki-Android/pull/51
  * Comment works now ✅
  * A size difference can be seen ✅
    * https://github.com/david-allison/Anki-Android/pull/51#issuecomment-4275851211 
 

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)