### PR TITLE
fix(card-browser): 'all columns' selected

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnWithSample.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/ColumnWithSample.kt
@@ -62,34 +62,22 @@ class ColumnWithSample(
         ): BrowserRow? {
             if (id == null) return null
 
-            // save the current columns
-            val originalColumns =
+            val originalKeys =
                 BrowserColumnCollection
-                    .replace(
-                        AnkiDroidApp.sharedPrefs(),
-                        cardsOrNotes,
-                        CardBrowserColumn.entries,
-                    ).let { result ->
-                        CollectionManager.withCol { backend.setActiveBrowserColumns(result.newColumns.backendKeys) }
-                        result.originalColumns
-                    }
+                    .load(AnkiDroidApp.sharedPrefs(), cardsOrNotes)
+                    .backendKeys
+                    .toList()
 
-            // obtain a sample row
-            val sampleRow: BrowserRow =
-                CollectionManager.withCol { browserRowForId(id.cardOrNoteId) }
-            Timber.d("got sample row")
-
-            // restore the past values
-            BrowserColumnCollection
-                .replace(
-                    AnkiDroidApp.sharedPrefs(),
-                    cardsOrNotes,
-                    originalColumns,
-                ).also { result ->
-                    CollectionManager.withCol { backend.setActiveBrowserColumns(result.newColumns.backendKeys) }
-                }
-
-            return sampleRow
+            return try {
+                val allKeys = CardBrowserColumn.entries.map { it.ankiColumnKey }
+                CollectionManager
+                    .withCol {
+                        backend.setActiveBrowserColumns(allKeys)
+                        browserRowForId(id.cardOrNoteId)
+                    }.also { Timber.d("got sample row") }
+            } finally {
+                CollectionManager.withCol { backend.setActiveBrowserColumns(originalKeys) }
+            }
         }
     }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -62,6 +62,7 @@ import com.ichi2.anki.browser.RepositionCardsRequest.RepositionData
 import com.ichi2.anki.browser.search.SavedSearch
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.flagCardForNote
+import com.ichi2.anki.libanki.BrowserConfig
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.CardType
@@ -1243,6 +1244,21 @@ class CardBrowserViewModelTest : JvmTest() {
             }
         }
     }
+
+    @Test
+    fun `preview does not write to SharedPreferences - issue 19885`() =
+        runViewModelTest(notes = 1) {
+            // A crash/close here caused all columns to be visible.
+            sharedPrefs().edit { remove(BrowserConfig.ACTIVE_CARD_COLUMNS_KEY) }
+
+            previewColumnHeadings(CardsOrNotes.CARDS)
+
+            assertThat(
+                "activeCols must not be written during preview",
+                sharedPrefs().contains(BrowserConfig.ACTIVE_CARD_COLUMNS_KEY),
+                equalTo(false),
+            )
+        }
 
     @Suppress("SpellCheckingInspection") // German
     @Test


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - diagnostics & code
> I fixed up some verbose comments

## Purpose / Description
If 'loadSampleRow' crashed, preferences were written using the sample row, which was all columns

## Fixes
* Fixes #19885

## Approach
No longer write preferences

## How Has This Been Tested?
Unit tested, tested manually

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)