### PR TITLE
build(compat): fix 'Unexpected reference to null'

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/compat/customtabs/CustomTabsHelper.kt
@@ -22,7 +22,7 @@ import androidx.core.net.toUri
 import com.ichi2.anki.compat.CompatHelper.Companion.queryIntentActivitiesCompat
 import com.ichi2.anki.compat.CompatHelper.Companion.resolveActivityCompat
 import com.ichi2.anki.compat.CompatHelper.Companion.resolveServiceCompat
-import com.ichi2.anki.compat.GET_RESOLVED_FILTER
+import com.ichi2.anki.compat.GET_RESOLVED_FILTER_L
 import com.ichi2.anki.compat.ResolveInfoFlagsCompat
 import com.ichi2.anki.runCatchingWithReport
 import timber.log.Timber
@@ -123,7 +123,7 @@ object CustomTabsHelper {
             val handlers =
                 pm.queryIntentActivitiesCompat(
                     intent,
-                    ResolveInfoFlagsCompat.of(GET_RESOLVED_FILTER.toLong()),
+                    ResolveInfoFlagsCompat.of(GET_RESOLVED_FILTER_L),
                 )
             if (handlers.isEmpty()) {
                 return false

--- a/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/AdaptionUtil.kt
@@ -30,7 +30,7 @@ import androidx.core.net.toUri
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.compat.CompatHelper.Companion.getPackageInfoCompat
 import com.ichi2.anki.compat.CompatHelper.Companion.queryIntentActivitiesCompat
-import com.ichi2.anki.compat.MATCH_DEFAULT_ONLY
+import com.ichi2.anki.compat.MATCH_DEFAULT_ONLY_L
 import com.ichi2.anki.compat.PackageInfoFlagsCompat
 import com.ichi2.anki.compat.ResolveInfoFlagsCompat
 import timber.log.Timber
@@ -80,7 +80,7 @@ object AdaptionUtil {
         }
         val intent = Intent(Intent.ACTION_VIEW, "http://www.google.com".toUri())
         val pm = context.packageManager
-        val list = pm.queryIntentActivitiesCompat(intent, ResolveInfoFlagsCompat.of(MATCH_DEFAULT_ONLY.toLong()))
+        val list = pm.queryIntentActivitiesCompat(intent, ResolveInfoFlagsCompat.of(MATCH_DEFAULT_ONLY_L))
         for (ri in list) {
             if (!isValidBrowser(ri)) {
                 continue

--- a/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/Permissions.kt
@@ -21,7 +21,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.pm.PackageManager.GET_PERMISSIONS
 import android.net.Uri
 import android.os.Build
 import android.os.Environment
@@ -38,6 +37,7 @@ import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.common.utils.android.isRobolectric
 import com.ichi2.anki.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.anki.compat.GET_PERMISSIONS_L
 import com.ichi2.anki.compat.PackageInfoFlagsCompat
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.showThemedToast
@@ -299,7 +299,7 @@ object Permissions {
     private fun Context.getPermissionsDefinedInManifest(packageName: String): Array<out String>? =
         try {
             // requestedPermissions => <uses-permission> in manifest
-            val flags = PackageInfoFlagsCompat.of(GET_PERMISSIONS.toLong())
+            val flags = PackageInfoFlagsCompat.of(GET_PERMISSIONS_L)
             getPackageInfoCompat(packageName, flags)!!.requestedPermissions
         } catch (e: Exception) {
             Timber.w(e)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ActivityStartupMetaTest.kt
@@ -15,9 +15,9 @@
  */
 package com.ichi2.anki
 
-import android.content.pm.PackageManager
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.compat.CompatHelper.Companion.getPackageInfoCompat
+import com.ichi2.anki.compat.GET_ACTIVITIES_L
 import com.ichi2.anki.compat.PackageInfoFlagsCompat
 import com.ichi2.testutils.ActivityList
 import org.hamcrest.MatcherAssert
@@ -32,7 +32,7 @@ class ActivityStartupMetaTest : RobolectricTest() {
         // if this fails, you may need to add the missing activity to ActivityList.allActivitiesAndIntents()
 
         // we can't access this in a static context
-        val flags = PackageInfoFlagsCompat.of(PackageManager.GET_ACTIVITIES.toLong())
+        val flags = PackageInfoFlagsCompat.of(GET_ACTIVITIES_L)
         val packageInfo =
             targetContext.getPackageInfoCompat(targetContext.packageName, flags)
                 ?: throw IllegalStateException("getPackageInfo failed")

--- a/compat/src/main/java/com/ichi2/anki/compat/PackageManagerCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/PackageManagerCompat.kt
@@ -92,6 +92,9 @@ class PackageInfoFlagsCompat private constructor(
  */
 const val MATCH_UNINSTALLED_PACKAGES = 0x00002000 // API 24
 
+/** @see MATCH_UNINSTALLED_PACKAGES */
+const val MATCH_UNINSTALLED_PACKAGES_L: Long = MATCH_UNINSTALLED_PACKAGES.toLong()
+
 /**
  * [PackageInfo] flag: return the signing certificates associated with
  * this package.  Each entry is a signing certificate that the package
@@ -100,10 +103,16 @@ const val MATCH_UNINSTALLED_PACKAGES = 0x00002000 // API 24
  */
 const val GET_SIGNING_CERTIFICATES = 0x08000000 // API 28
 
+/** @see GET_SIGNING_CERTIFICATES */
+const val GET_SIGNING_CERTIFICATES_L: Long = GET_SIGNING_CERTIFICATES.toLong()
+
 /**
  * [PackageInfo] flag: include disabled components in the returned info.
  */
 const val MATCH_DISABLED_COMPONENTS = 0x00000200 // API 24
+
+/** @see MATCH_DISABLED_COMPONENTS */
+const val MATCH_DISABLED_COMPONENTS_L: Long = MATCH_DISABLED_COMPONENTS.toLong()
 
 /**
  * [PackageInfo] flag: include disabled components which are in
@@ -113,11 +122,17 @@ const val MATCH_DISABLED_COMPONENTS = 0x00000200 // API 24
  */
 const val MATCH_DISABLED_UNTIL_USED_COMPONENTS = 0x00008000 // API 24
 
+/** @see MATCH_DISABLED_UNTIL_USED_COMPONENTS */
+const val MATCH_DISABLED_UNTIL_USED_COMPONENTS_L: Long = MATCH_DISABLED_UNTIL_USED_COMPONENTS.toLong()
+
 /**
  * Querying flag: include only components from applications that are marked
  * with [ApplicationInfo.FLAG_SYSTEM].
  */
 const val MATCH_SYSTEM_ONLY = 0x00100000 // API 24
+
+/** @see MATCH_SYSTEM_ONLY */
+const val MATCH_SYSTEM_ONLY_L: Long = MATCH_SYSTEM_ONLY.toLong()
 
 /**
  * [PackageInfo] flag: include APEX packages that are currently
@@ -128,33 +143,66 @@ const val MATCH_SYSTEM_ONLY = 0x00100000 // API 24
  */
 const val MATCH_APEX = 0x40000000 // API 29
 
+/** @see MATCH_APEX */
+const val MATCH_APEX_L: Long = MATCH_APEX.toLong()
+
+/** @see AndroidPackageManager.GET_ACTIVITIES */
+const val GET_ACTIVITIES_L: Long = AndroidPackageManager.GET_ACTIVITIES.toLong()
+
+/** @see AndroidPackageManager.GET_CONFIGURATIONS */
+const val GET_CONFIGURATIONS_L: Long = AndroidPackageManager.GET_CONFIGURATIONS.toLong()
+
+/** @see AndroidPackageManager.GET_GIDS */
+const val GET_GIDS_L: Long = AndroidPackageManager.GET_GIDS.toLong()
+
+/** @see AndroidPackageManager.GET_INSTRUMENTATION */
+const val GET_INSTRUMENTATION_L: Long = AndroidPackageManager.GET_INSTRUMENTATION.toLong()
+
+/** @see AndroidPackageManager.GET_PERMISSIONS */
+const val GET_PERMISSIONS_L: Long = AndroidPackageManager.GET_PERMISSIONS.toLong()
+
+/** @see AndroidPackageManager.GET_PROVIDERS */
+const val GET_PROVIDERS_L: Long = AndroidPackageManager.GET_PROVIDERS.toLong()
+
+/** @see AndroidPackageManager.GET_RECEIVERS */
+const val GET_RECEIVERS_L: Long = AndroidPackageManager.GET_RECEIVERS.toLong()
+
+/** @see AndroidPackageManager.GET_SERVICES */
+const val GET_SERVICES_L: Long = AndroidPackageManager.GET_SERVICES.toLong()
+
+/** @see AndroidPackageManager.GET_URI_PERMISSION_PATTERNS */
+const val GET_URI_PERMISSION_PATTERNS_L: Long = AndroidPackageManager.GET_URI_PERMISSION_PATTERNS.toLong()
+
 /**
  * [PackageInfo] flag: return all attributions declared in the package manifest
  */
 const val GET_ATTRIBUTIONS = -0x80000000 // API 31
 
+/** @see GET_ATTRIBUTIONS */
+const val GET_ATTRIBUTIONS_L: Long = GET_ATTRIBUTIONS.toLong()
+
 @LongDef(
     flag = true,
     // prefix = ["GET_", "MATCH_"],
     value = [
-        AndroidPackageManager.GET_ACTIVITIES.toLong(),
-        AndroidPackageManager.GET_CONFIGURATIONS.toLong(),
-        AndroidPackageManager.GET_GIDS.toLong(),
-        AndroidPackageManager.GET_INSTRUMENTATION.toLong(),
-        AndroidPackageManager.GET_META_DATA.toLong(),
-        AndroidPackageManager.GET_PERMISSIONS.toLong(),
-        AndroidPackageManager.GET_PROVIDERS.toLong(),
-        AndroidPackageManager.GET_RECEIVERS.toLong(),
-        AndroidPackageManager.GET_SERVICES.toLong(),
-        AndroidPackageManager.GET_SHARED_LIBRARY_FILES.toLong(),
-        GET_SIGNING_CERTIFICATES.toLong(),
-        AndroidPackageManager.GET_URI_PERMISSION_PATTERNS.toLong(),
-        MATCH_UNINSTALLED_PACKAGES.toLong(),
-        MATCH_DISABLED_COMPONENTS.toLong(),
-        MATCH_DISABLED_UNTIL_USED_COMPONENTS.toLong(),
-        MATCH_SYSTEM_ONLY.toLong(),
-        MATCH_APEX.toLong(),
-        GET_ATTRIBUTIONS.toLong(),
+        GET_ACTIVITIES_L,
+        GET_CONFIGURATIONS_L,
+        GET_GIDS_L,
+        GET_INSTRUMENTATION_L,
+        GET_META_DATA_L,
+        GET_PERMISSIONS_L,
+        GET_PROVIDERS_L,
+        GET_RECEIVERS_L,
+        GET_SERVICES_L,
+        GET_SHARED_LIBRARY_FILES_L,
+        GET_SIGNING_CERTIFICATES_L,
+        GET_URI_PERMISSION_PATTERNS_L,
+        MATCH_UNINSTALLED_PACKAGES_L,
+        MATCH_DISABLED_COMPONENTS_L,
+        MATCH_DISABLED_UNTIL_USED_COMPONENTS_L,
+        MATCH_SYSTEM_ONLY_L,
+        MATCH_APEX_L,
+        GET_ATTRIBUTIONS_L,
 
         // not handled: Deprecated & unused in our code
         // PackageManager.GET_INTENT_FILTERS.toLong(),

--- a/compat/src/main/java/com/ichi2/anki/compat/ResolveInfoCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/ResolveInfoCompat.kt
@@ -28,6 +28,9 @@
  *     limitations under the License.
  *
  *     https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/content/pm/PackageManager.java
+ *
+ * **Changes**
+ * * Added _L constants to fix 'Warning: Unexpected reference to null'
  */
 package com.ichi2.anki.compat
 
@@ -59,12 +62,18 @@ class ResolveInfoFlagsCompat private constructor(
  */
 const val GET_META_DATA = 0x00000080
 
+/** @see GET_META_DATA */
+const val GET_META_DATA_L: Long = GET_META_DATA.toLong()
+
 /**
  * [ResolveInfo] flag: return the IntentFilter that
  * was matched for a particular ResolveInfo in
  * [ResolveInfo.filter].
  */
 const val GET_RESOLVED_FILTER = 0x00000040
+
+/** @see GET_RESOLVED_FILTER */
+const val GET_RESOLVED_FILTER_L: Long = GET_RESOLVED_FILTER.toLong()
 
 /**
  * [ApplicationInfo] flag: return the
@@ -74,6 +83,9 @@ const val GET_RESOLVED_FILTER = 0x00000040
  * directly or nested inside of another.
  */
 const val GET_SHARED_LIBRARY_FILES = 0x00000400
+
+/** @see GET_SHARED_LIBRARY_FILES */
+const val GET_SHARED_LIBRARY_FILES_L: Long = GET_SHARED_LIBRARY_FILES.toLong()
 
 /**
  * Querying flag: if set and if the platform is doing any filtering of the
@@ -85,6 +97,9 @@ const val GET_SHARED_LIBRARY_FILES = 0x00000400
  */
 const val MATCH_ALL = 0x00020000
 
+/** @see MATCH_ALL */
+const val MATCH_ALL_L: Long = MATCH_ALL.toLong()
+
 /**
  * Resolution and querying flag: if set, only filters that support the
  * [android.content.Intent.CATEGORY_DEFAULT] will be considered for
@@ -92,6 +107,9 @@ const val MATCH_ALL = 0x00020000
  * supplied Intent.
  */
 const val MATCH_DEFAULT_ONLY = 0x00010000
+
+/** @see MATCH_DEFAULT_ONLY */
+const val MATCH_DEFAULT_ONLY_L: Long = MATCH_DEFAULT_ONLY.toLong()
 
 /**
  * Querying flag: automatically match components based on their Direct Boot
@@ -116,6 +134,9 @@ const val MATCH_DEFAULT_ONLY = 0x00010000
  */
 const val MATCH_DIRECT_BOOT_AUTO = 0x10000000
 
+/** @see MATCH_DIRECT_BOOT_AUTO */
+const val MATCH_DIRECT_BOOT_AUTO_L: Long = MATCH_DIRECT_BOOT_AUTO.toLong()
+
 /**
  * Querying flag: match components which are direct boot *aware* in
  * the returned info, regardless of the current user state.
@@ -133,6 +154,9 @@ const val MATCH_DIRECT_BOOT_AUTO = 0x10000000
  * @see UserManager.isUserUnlocked
  */
 const val MATCH_DIRECT_BOOT_AWARE = 0x00080000
+
+/** @see MATCH_DIRECT_BOOT_AWARE */
+const val MATCH_DIRECT_BOOT_AWARE_L: Long = MATCH_DIRECT_BOOT_AWARE.toLong()
 
 /**
  * Querying flag: match components which are direct boot *unaware* in
@@ -152,22 +176,25 @@ const val MATCH_DIRECT_BOOT_AWARE = 0x00080000
  */
 const val MATCH_DIRECT_BOOT_UNAWARE = 0x00040000
 
+/** @see MATCH_DIRECT_BOOT_UNAWARE */
+const val MATCH_DIRECT_BOOT_UNAWARE_L: Long = MATCH_DIRECT_BOOT_UNAWARE.toLong()
+
 @LongDef(
     flag = true,
     // prefix = ["GET_", "MATCH_"],
     value = [
-        GET_META_DATA.toLong(),
-        GET_RESOLVED_FILTER.toLong(),
-        GET_SHARED_LIBRARY_FILES.toLong(),
-        MATCH_ALL.toLong(),
-        MATCH_DISABLED_COMPONENTS.toLong(),
-        MATCH_DISABLED_UNTIL_USED_COMPONENTS.toLong(),
-        MATCH_DEFAULT_ONLY.toLong(),
-        MATCH_DIRECT_BOOT_AUTO.toLong(),
-        MATCH_DIRECT_BOOT_AWARE.toLong(),
-        MATCH_DIRECT_BOOT_UNAWARE.toLong(),
-        MATCH_SYSTEM_ONLY.toLong(),
-        MATCH_UNINSTALLED_PACKAGES.toLong(),
+        GET_META_DATA_L,
+        GET_RESOLVED_FILTER_L,
+        GET_SHARED_LIBRARY_FILES_L,
+        MATCH_ALL_L,
+        MATCH_DISABLED_COMPONENTS_L,
+        MATCH_DISABLED_UNTIL_USED_COMPONENTS_L,
+        MATCH_DEFAULT_ONLY_L,
+        MATCH_DIRECT_BOOT_AUTO_L,
+        MATCH_DIRECT_BOOT_AWARE_L,
+        MATCH_DIRECT_BOOT_UNAWARE_L,
+        MATCH_SYSTEM_ONLY_L,
+        MATCH_UNINSTALLED_PACKAGES_L,
         // PackageManager.MATCH_INSTANT, // @SystemApi
         // PackageManager.MATCH_DEBUG_TRIAGED_MISSING, // deprecated
         // PackageManager.GET_DISABLED_COMPONENTS, // deprecated


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 (Max effort) 
> I directed the fixes

## Purpose / Description
There was `Warning: Unexpected reference to null` spam in the build output

Cause: `GET_META_DATA.toLong()`

## Fixes
* Fixes #20785

## Approach
Fixed by adding specific `_L` constants: `GET_META_DATA_L`

Not ideal, but we couldn't directly use Long values as they would overflow the original Ints when a lower compat version is desired

## How Has This Been Tested?
`Warning: Unexpected reference to null'` no longer appears

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)