### PR TITLE
build: reduce API minSdk to 16

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,6 +1,5 @@
 import com.android.build.api.dsl.LibraryExtension
 import com.android.build.gradle.internal.tasks.factory.dependsOn
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.library)
@@ -32,7 +31,7 @@ configure<LibraryExtension> {
 
     defaultConfig {
         minSdk =
-            libs.versions.minSdk
+            libs.versions.apiMinSdk
                 .get()
                 .toInt()
         buildConfigField(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,8 @@ compileSdk = "36"
 # to include the version codes of the last released version for the older
 # minSdk. It is critical to update those version codes when you change this.
 minSdk = "24"
+# The API should be as low as possible in order to enable dependencies to stay on a lower minSdk.
+apiMinSdk = "16"
 
 targetSdk = "35"  # affects which SDKs download in ../robolectricDownloader.gradle
 acra = '5.13.1'


### PR DESCRIPTION
## Purpose / Description
dcb10769b16c72f52c4191d35f36a494be46fc3a increased this, but I do not feel it was intentional

## Fixes
* Fixes #20777

## Approach
Add a new constant and use it.

## How Has This Been Tested?
No issues with:
`./gradlew :api:assembleDebug`
`./gradlew :api:lintDebug`

## Learning (optional, can help others)
`Cursor.use { }` needs API 16, very little point in going lower.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)