### PR TITLE
Add isValidTextOrDataFile MIME type tests

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -103,7 +103,6 @@ object ImportUtils {
     fun isFileAValidDeck(fileName: String): Boolean =
         FileImporter.hasExtension(fileName, "apkg") || FileImporter.hasExtension(fileName, "colpkg")
 
-    @NeedsTest("Verify that only valid text or data file MIME types return true")
     fun isValidTextOrDataFile(
         context: Context,
         uri: Uri,

--- a/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/utils/ImportUtilsTest.kt
@@ -17,6 +17,7 @@ package com.ichi2.utils
 
 import android.content.ClipData
 import android.content.ClipDescription
+import android.content.ContentResolver
 import android.content.Context
 import android.content.Intent
 import android.net.Uri
@@ -35,6 +36,9 @@ import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 import java.io.File
 
 @RunWith(AndroidJUnit4::class)
@@ -114,6 +118,47 @@ class ImportUtilsTest : RobolectricTest() {
     @Test
     fun docxIsNotValidForImport() {
         assertFalse(ImportUtils.isValidPackageName("test.docx"))
+    }
+
+    @Test
+    fun onlyValidTextOrDataMimeTypesReturnTrue() {
+        val uri = "content://com.example".toUri()
+        val validMimeTypes =
+            listOf(
+                "text/plain",
+                "text/comma-separated-values",
+                "text/tab-separated-values",
+                "text/csv",
+                "text/tsv",
+            )
+        val invalidMimeTypes =
+            listOf(
+                null,
+                "text/html",
+                "application/pdf",
+                "image/jpeg",
+                "image/png",
+            )
+
+        for (mime in validMimeTypes) {
+            val context = mockContextWithMime(mime)
+            val isValid = ImportUtils.isValidTextOrDataFile(context, uri)
+            assertTrue("Expected MIME to be accepted: $mime", isValid)
+        }
+
+        for (mime in invalidMimeTypes) {
+            val context = mockContextWithMime(mime)
+            val isValid = ImportUtils.isValidTextOrDataFile(context, uri)
+            assertFalse("Expected MIME to be rejected: $mime", isValid)
+        }
+    }
+
+    private fun mockContextWithMime(mimeType: String?): Context {
+        val resolver = mock(ContentResolver::class.java)
+        whenever(resolver.getType(any())).thenReturn(mimeType)
+        val context = mock(Context::class.java)
+        whenever(context.contentResolver).thenReturn(resolver)
+        return context
     }
 
     @CheckResult


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This PR is part of ongoing efforts to address all `@NeedsTest` areas in the codebase. This test is specifically testing that the correct MIME type files are deemed valid in `ImportUtils.kt`.

## Fixes
* Fixes #13283

## Approach
In the test, we specify all currently valid MIME types, some sample invalid MIME types that are more likely to be accidentally added, or for users are more likely to accidentally try to import, and test that isValidTextOrDataFile returns the proper boolean for each type.

## How Has This Been Tested?

I've tested to make sure that this test fails if any valid MIME types are accidentally removed from isValidTextOrDataFile, and if any invalid MIME types are accidentally added to isValidTextOrDataFile!

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [X] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->