### PR TITLE
fix(reminders): only set alarm if enabled

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/reviewreminders/ScheduleReminders.kt
@@ -295,10 +295,12 @@ class ScheduleReminders :
             )
         }
         newOrModifiedReminder?.let {
-            AlarmManagerService.scheduleReviewReminderNotification(
-                requireContext(),
-                it,
-            )
+            if (it.enabled) {
+                AlarmManagerService.scheduleReviewReminderNotification(
+                    requireContext(),
+                    it,
+                )
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose / Description
Fixes a bit of an embarrassing bug. 😅

## Fixes
* Previously, if you edited a reminder that was disabled, it would set an alarm for that reminder. This change fixes that.

## Approach
...just check if it's enabled.

## How Has This Been Tested?
* Physical Samsung S23, API 34. Disabled reminders no longer create notifications.

## Learning (optional, can help others)
Noticed this while working on a separate bug fix, whoops.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->