### PR TITLE
Fix: Implements go back twice to exit in the whiteboard for gesture navigation

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/back/ExitViaDoubleTapBackBackPressCallback.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/back/ExitViaDoubleTapBackBackPressCallback.kt
@@ -23,11 +23,41 @@ import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
-import com.ichi2.anki.libanki.Consts
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.utils.HandlerUtils
 import timber.log.Timber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Creates an [OnBackPressedCallback] that requires two back presses to exit.
+ *
+ * On first back press, [onFirstBack] is called and the callback disables itself
+ * for [timeout]. While disabled, a second back press is not intercepted and falls
+ * through to the default behavior (finishing the activity). If no second press occurs
+ * within the timeout, the callback re-enables itself only if [shouldReEnable] returns true.
+ *
+ * @param enabled initial enabled state
+ * @param timeout how long the callback stays disabled after the first back press
+ * @param onFirstBack action on first back press (typically show a snackbar)
+ * @param shouldReEnable condition checked after timeout to decide whether to re-enable
+ */
+fun doubleBackPressCallback(
+    enabled: Boolean,
+    timeout: Duration = 2.seconds,
+    onFirstBack: () -> Unit,
+    shouldReEnable: () -> Boolean = { true },
+): OnBackPressedCallback =
+    object : OnBackPressedCallback(enabled) {
+        override fun handleOnBackPressed() {
+            onFirstBack()
+            isEnabled = false
+            HandlerUtils.executeFunctionWithDelay(timeout.inWholeMilliseconds) {
+                isEnabled = shouldReEnable()
+            }
+        }
+    }
 
 /**
  * Note: this uses sharedPreferences via AnkiDroidApp, so must be called after
@@ -43,7 +73,7 @@ fun AnkiActivity.exitViaDoubleTapBackCallback(): OnBackPressedCallback =
         override fun handleOnBackPressed() {
             showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT)
             this.isEnabled = false
-            HandlerUtils.executeFunctionWithDelay(Consts.SHORT_TOAST_DURATION) {
+            HandlerUtils.executeFunctionWithDelay(2.seconds.inWholeMilliseconds) {
                 this.isEnabled = true
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -49,13 +49,16 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import anki.scheduler.CardAnswer.Rating
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
+import com.ichi2.anki.android.back.doubleBackPressCallback
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
+import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.anki.databinding.FragmentReviewerBinding
 import com.ichi2.anki.dialogs.showDeckOptionsSelectionDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
@@ -164,7 +167,7 @@ class ReviewerFragment :
         super.onViewCreated(view, savedInstanceState)
 
         binding.backButton.setOnClickListener {
-            requireActivity().finish()
+            requireActivity().onBackPressedDispatcher.onBackPressed()
         }
 
         setupBindings()
@@ -527,8 +530,20 @@ class ReviewerFragment :
             },
             false,
         )
+        val doubleBackCallback =
+            doubleBackPressCallback(
+                enabled = false,
+                onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
+                shouldReEnable = {
+                    viewModel.whiteboardEnabledFlow.value &&
+                        compat.isUsingSystemGestureNavigation(requireContext())
+                },
+            )
+        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, doubleBackCallback)
         viewModel.whiteboardEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
             binding.whiteboardContainer.isVisible = isEnabled
+            doubleBackCallback.isEnabled =
+                isEnabled && compat.isUsingSystemGestureNavigation(requireContext())
             if (whiteboardFragment == null && isEnabled) {
                 childFragmentManager.commit {
                     add(R.id.whiteboard_container, WhiteboardFragment::class.java, null, WhiteboardFragment::class.jvmName)

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -301,7 +301,7 @@
     <string name="invalid_email">Enter a valid email</string>
     <string name="password_empty">Password is required</string>
 
-    <string name="back_pressed_once">Press back again to exit</string>
+    <string name="back_pressed_once">Go back again to exit</string>
 
     <!-- %% is required to display % symbol. Reference: https://stackoverflow.com/a/16834358 -->
     <string name="percentage">%s%%</string>

--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -285,6 +285,12 @@ open class BaseCompat : Compat {
         context: Context,
         fallback: String,
     ): String = fallback
+
+    // Until API 29, gesture navigation does not exist
+    override fun isUsingSystemGestureNavigation(
+        context: Context,
+        defaultValue: Boolean,
+    ): Boolean = false
 }
 
 typealias CompatV24 = BaseCompat

--- a/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/Compat.kt
@@ -273,4 +273,19 @@ interface Compat {
         context: Context,
         fallback: String,
     ): String
+
+    /**
+     * Returns `true` if the device is using gesture navigation (swipe from edges).
+     * Gesture navigation was introduced in Android 10 (API 29).
+     * On older versions, this always returns `false`.
+     *
+     * Note: this reads a `Settings.Secure` key that is not part of the public API.
+     * It will not throw, but the result is manufacturer dependent.
+     *
+     * @param defaultValue value returned when the `navigation_mode` key is unset
+     */
+    fun isUsingSystemGestureNavigation(
+        context: Context,
+        defaultValue: Boolean = false,
+    ): Boolean
 }

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV29.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV29.kt
@@ -22,6 +22,7 @@ import android.media.ThumbnailUtils
 import android.net.Uri
 import android.os.Environment
 import android.provider.MediaStore
+import android.provider.Settings
 import android.util.Size
 import androidx.annotation.RequiresApi
 import com.ichi2.anki.common.time.TimeManager
@@ -82,6 +83,14 @@ open class CompatV29 : CompatV26() {
         newImage.put(MediaStore.Images.Media.IS_PENDING, 0)
         context.contentResolver.update(newImageUri, newImage, null, null)
         return newImageUri
+    }
+
+    override fun isUsingSystemGestureNavigation(
+        context: Context,
+        defaultValue: Boolean,
+    ): Boolean {
+        val defaultMode = if (defaultValue) 2 else 0
+        return Settings.Secure.getInt(context.contentResolver, "navigation_mode", defaultMode) == 2
     }
 
     companion object {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
> [!NOTE]
> Tested out Opus 4.6 with code generation, still wrote all the code manually and tested everything physically

## Purpose / Description
Currently, the double tap/swipe to back option doesn't work properly in the whiteboard and a single gesture/back press exits. This was a pain point for users who were using the whiteboard for language like Japanese.
Currently, this doesn't detect gestures since it involved an external API and I wasn't very sure of how that worked so didn't want to include it here.

## Fixes
* Fixes #20322 

## Approach
Implements a new doubleBackPressCallback function which intercepts back presses when the whiteboard is enabled. If the user presses back once, a snackbar is shown. If they press back again within 2 seconds, the activity finishes. If they don't, shouldReEnable checks whether the whiteboard is still active.

## How Has This Been Tested?

[Screen_recording_20260420_121417.webm](https://github.com/user-attachments/assets/34e2bb23-1cff-47f2-8663-181f60c50f60)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->