### PR TITLE
fix(reminders): catch BadParcelableException in NotificationService

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/AlarmManagerService.kt
@@ -271,7 +271,7 @@ class AlarmManagerService : AnkiBroadcastReceiver() {
          * notifications scheduled, this will NOT delete the old scheduled notifications. They must be
          * manually deleted via [unscheduleReviewReminderNotifications].
          */
-        private fun scheduleAllEnabledReviewReminderNotifications(context: Context) {
+        fun scheduleAllEnabledReviewReminderNotifications(context: Context) {
             Timber.d("scheduleAllEnabledReviewReminderNotifications")
             val allReviewRemindersAsMap =
                 ReviewRemindersDatabase.getAllAppWideReminders() + ReviewRemindersDatabase.getAllDeckSpecificReminders()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/NotificationService.kt
@@ -19,6 +19,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.graphics.Color
+import android.os.BadParcelableException
 import androidx.annotation.VisibleForTesting
 import androidx.core.app.NotificationCompat
 import androidx.core.app.PendingIntentCompat
@@ -458,11 +459,21 @@ class NotificationService : AnkiBroadcastReceiver() {
             val action = intent.action ?: return
             val extras = intent.extras ?: return
             val reviewReminder =
-                BundleCompat.getParcelable(
-                    extras,
-                    EXTRA_REVIEW_REMINDER,
-                    ReviewReminder::class.java,
-                ) ?: return
+                try {
+                    BundleCompat.getParcelable(
+                        extras,
+                        EXTRA_REVIEW_REMINDER,
+                        ReviewReminder::class.java,
+                    ) ?: return
+                } catch (e: BadParcelableException) {
+                    // #20782: If the extra's review reminder has an invalid schema, attempt a full re-schedule of all
+                    // review reminder notifications, as that will retrieve reminders from Shared Preferences
+                    // and handle any necessary schema updates. It will also trigger immediate notifications
+                    // (and thus this onReceiveBroadcast again for an uncorrupted version of this corrupted review reminder) as necessary.
+                    Timber.w(e, "Failed to get review reminder from intent extras, triggering full re-schedule")
+                    AlarmManagerService.scheduleAllEnabledReviewReminderNotifications(context)
+                    return
+                }
             Timber.d("onReceiveBroadcast: ${reviewReminder.id}")
 
             // We must run some suspending functions. Hence we mark this onReceiveBroadcast function as long-running


### PR DESCRIPTION
## Purpose / Description
If an old intent for a review reminder notification somehow sticks around after a schema migration update, the ReviewReminder stored in the intent will become out of date and cause a BadParcelableException.

## Fixes
* Fixes #20782

## Approach
While we could implement custom logic to migrate that reminder, that would duplicate the logic for schema migrations currently present in ReviewRemindersDatabase. It's simpler to just fallback on that already-existing logic by triggering a total review reminder schedule and returning early. Hence, this code change.

## How Has This Been Tested?
I cannot reproduce this bug personally, as whenever I trigger an update to the schema, the entire app uninstalls and re-installs, which throws out the old intents. I assume the original cause of the bug was some transient error. Nonetheless, this defensive try-catch should be a good addition to the codebase here.

## Learning (optional, can help others)
[Pertinent code in the AOSP](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/apex/jobscheduler/service/java/com/android/server/alarm/AlarmManagerService.java;l=4994)

Quoting from my initial response to this issue:
> I can think of two ways to solve this, both of which should work:

> 1. Try-catch, and when a BadParcelableException is thrown, simply trigger a AlarmManagerService.scheduleAllNotifications and return. Once https://github.com/ankidroid/Anki-Android/pull/20755 is merged, what scheduleAllNotifications does is fire any notifications that should have recently been fired and then schedule any future ones that need to happen. This is the simple solution.
> 2. Create a proper getParcelableReminder helper that successively attempts to de-parcelize using every schema from newest to oldest, and which only throws if all old schemas fail. Once a schema successfully parses the reminder, use .migrate() to bring it up to date. This is the most correct solution.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->