### PR TITLE
Fix FAB visibility after SearchView dismissal on deck deletion

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -610,6 +610,7 @@ open class DeckPicker :
     @Suppress("UNUSED_PARAMETER")
     private fun setupFlows() {
         fun onDeckDeleted(result: DeckDeletionResult) {
+            floatingActionButtonBinding.fabMain.isVisible = true
             showSnackbar(result.toHumanReadableString(), Snackbar.LENGTH_SHORT) {
                 setAction(R.string.undo) { undo() }
             }


### PR DESCRIPTION
## Purpose / Description

A small fix for the following bug in DeckPicker:

_Open toolbar SearchView -> FAB is hidden -> long click deck -> delete deck -> Info SnackBar appears, SearchView is closed, at this point FAB is still missing(and remains missing until search is used)_

Note: similar issue with SearchView opened and trying to undo something, fab goes missing. This is more difficult(we undo, show a snackbar while the undo also triggers an opExecuted call and a menu refresh again) to fix and also less likely to happen vs the deck deletion situation above.


## How Has This Been Tested?

Ran tests, checked the bug behavior.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
