### PR TITLE
fix: prevent state loss crash in showDialogFragment (#20715)

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
@@ -25,7 +25,7 @@ import com.ichi2.anki.utils.ext.DIALOG_FRAGMENT_TAG
  * Global method to show dialog fragment including adding it to back stack
  * If you need to show a dialog from an async task, use [AnkiActivity.showAsyncDialogFragment]
  *
- * @param manager The[FragmentManager] of the activity/fragment
+ * @param manager The [FragmentManager] of the activity/fragment
  * @param newFragment the [DialogFragment] you want to show
  */
 fun showDialogFragmentImpl(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Dialog.kt
@@ -25,13 +25,17 @@ import com.ichi2.anki.utils.ext.DIALOG_FRAGMENT_TAG
  * Global method to show dialog fragment including adding it to back stack
  * If you need to show a dialog from an async task, use [AnkiActivity.showAsyncDialogFragment]
  *
- * @param manager The [FragmentManager] of the activity/fragment
+ * @param manager The[FragmentManager] of the activity/fragment
  * @param newFragment the [DialogFragment] you want to show
  */
 fun showDialogFragmentImpl(
     manager: FragmentManager,
     newFragment: DialogFragment,
 ) {
+    if (manager.isStateSaved) {
+        return
+    }
+
     // DialogFragment.show() will take care of adding the fragment
     // in a transaction. We also want to remove any currently showing
     // dialog, so make our own transaction and take care of that here.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
@@ -35,12 +35,15 @@ const val DIALOG_FRAGMENT_TAG = "dialog"
 
 /**
  * Global method to show dialog fragment including adding it to back stack
- * If you need to show a dialog from an async task, use [AnkiActivity.showAsyncDialogFragment]
+ * If you need to show a dialog from an async task, use[AnkiActivity.showAsyncDialogFragment]
  *
  * @param newFragment the [DialogFragment] you want to show
  */
 fun FragmentActivity.showDialogFragment(newFragment: DialogFragment) {
     runOnUiThread {
+        if (this.isFinishing || this.supportFragmentManager.isStateSaved) {
+            return@runOnUiThread
+        }
         showDialogFragmentImpl(this.supportFragmentManager, newFragment)
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/ext/FragmentActivity.kt
@@ -35,13 +35,13 @@ const val DIALOG_FRAGMENT_TAG = "dialog"
 
 /**
  * Global method to show dialog fragment including adding it to back stack
- * If you need to show a dialog from an async task, use[AnkiActivity.showAsyncDialogFragment]
+ * If you need to show a dialog from an async task, use [AnkiActivity.showAsyncDialogFragment]
  *
  * @param newFragment the [DialogFragment] you want to show
  */
 fun FragmentActivity.showDialogFragment(newFragment: DialogFragment) {
     runOnUiThread {
-        if (this.isFinishing || this.supportFragmentManager.isStateSaved) {
+        if (this.isFinishing) {
             return@runOnUiThread
         }
         showDialogFragmentImpl(this.supportFragmentManager, newFragment)


### PR DESCRIPTION
**Fixes #20715**

**Description**
Added lifecycle guards (`isStateSaved` and `isFinishing`) inside `FragmentActivity.showDialogFragment` and `Dialog.showDialogFragmentImpl`. 

**Root Cause**
A coroutine in `DeckPicker.kt` (`showDeckPickerContextMenu`) attempts to show a `DialogFragment` using the `showDialogFragment` extension function after waiting on a suspend call (`viewModel.selectDeck(deckId).join()`). If the user backgrounds the app while the coroutine is suspended, `onSaveInstanceState()` gets called. When the coroutine resumes and forces the dialog onto the main thread, the `FragmentManager` throws a fatal `IllegalStateException`.

By fixing this at the utility level, we protect not just the DeckPicker, but all asynchronous dialog invocations across the app.