### PR TITLE
build: rm proguard jsoup -dontwarn declarations

### DIFF
--- a/AnkiDroid/proguard-rules.pro
+++ b/AnkiDroid/proguard-rules.pro
@@ -34,9 +34,3 @@
 # Ignore unused packages
 -dontwarn javax.naming.**
 -dontwarn org.ietf.jgss.**
-
-# Ignore intended-to-be-optional re2j classes - only needed if using re2j for jsoup regex
-# jsoup safely falls back to JDK regex if re2j not on classpath, but has concrete re2j refs
-# See https://github.com/jhy/jsoup/issues/2459 - may be resolved in future, then this may be removed
-# See https://github.com/ankidroid/Anki-Android/pull/19985
--dontwarn com.google.re2j.**


### PR DESCRIPTION
no longer necessary in jsoup 1.22.2

* https://github.com/jhy/jsoup/issues/2459
* I missed this in https://github.com/ankidroid/Anki-Android/pull/20795

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)