### PR TITLE
fix: NoSuchFileException in card template fragment

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardTemplateNotetype.kt
@@ -542,8 +542,20 @@ class NotetypeFile(
                 NotetypeJson(target.toString())
             }
         } catch (e: IOException) {
-            Timber.e(e, "Unable to read+parse tempNoteType from file %s", absolutePath)
+            Timber.w(e, "Unable to read+parse tempNoteType from file %s", absolutePath)
             throw e
+        }
+
+    /**
+     * Returns the notetype, or `null` if the backing file can't be read (e.g. the temp
+     * file was cleaned up by the OS after process death, or the user cleared app data).
+     */
+    fun getNotetypeOrNull(): NotetypeJson? =
+        try {
+            getNotetype()
+        } catch (e: IOException) {
+            Timber.d(e, "Failed to read notetype")
+            null
         }
 
     override fun describeContents(): Int = 0

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/CardViewerFragment.kt
@@ -74,11 +74,18 @@ abstract class CardViewerFragment(
 
     override fun onStart() {
         super.onStart()
+        // A subclass may call requireActivity().finish() to abort setup so skip viewModel access here
+        if (activity?.isFinishing == true) return
         viewModel.setSoundPlayerEnabled(true)
     }
 
     override fun onStop() {
         super.onStop()
+        // If the activity is finishing, the ViewModel will be cleared shortly,
+        // releasing the CardMediaPlayer via its addCloseable hook
+        // (see CardViewerViewModel.cardMediaPlayer). We can skip the explicit
+        // shutdown here.
+        if (activity?.isFinishing == true) return
         if (!requireActivity().isChangingConfigurations) {
             viewModel.setSoundPlayerEnabled(false)
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerFragment.kt
@@ -28,6 +28,7 @@ import com.ichi2.anki.snackbar.SnackbarBuilder
 import com.ichi2.anki.workarounds.SafeWebViewLayout
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import timber.log.Timber
 
 class TemplatePreviewerFragment :
     CardViewerFragment(R.layout.fragment_template_previewer),
@@ -48,6 +49,15 @@ class TemplatePreviewerFragment :
         // binding must be set before super.onViewCreated
         // as super.onViewCreated depends on webViewLayout, which depends on the binding
         binding = FragmentTemplatePreviewerBinding.bind(view)
+
+        // The backing NotetypeFile may be missing after process death if the OS cleared
+        // its cache dir. Bail out before the ViewModel is constructed; the constructor
+        // would otherwise throw on `getNotetype()`.
+        if (!TemplatePreviewerArguments.isUsable(requireArguments())) {
+            Timber.w("Notetype file missing on previewer open; finishing")
+            requireActivity().finish()
+            return
+        }
 
         super.onViewCreated(view, savedInstanceState)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/previewer/TemplatePreviewerViewModel.kt
@@ -15,8 +15,10 @@
  */
 package com.ichi2.anki.previewer
 
+import android.os.Bundle
 import android.os.Parcelable
 import androidx.annotation.CheckResult
+import androidx.core.os.BundleCompat
 import androidx.lifecycle.SavedStateHandle
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.withCol
@@ -289,4 +291,19 @@ data class TemplatePreviewerArguments(
     val deckId: DeckId = DEFAULT_DECK_ID,
 ) : Parcelable {
     val notetype: NotetypeJson get() = notetypeFile.getNotetype()
+
+    companion object {
+        /**
+         * Returns `true` if [bundle] holds a [TemplatePreviewerArguments]
+         * whose backing [NotetypeFile] is still readable. Use this before
+         * constructing [TemplatePreviewerViewModel] to detect when the
+         * temp file was cleaned up by the OS (e.g. after process death) so
+         * the previewer can abort instead of throwing from the constructor.
+         */
+        fun isUsable(bundle: Bundle): Boolean =
+            BundleCompat
+                .getParcelable(bundle, TemplatePreviewerFragment.ARGS_KEY, TemplatePreviewerArguments::class.java)
+                ?.notetypeFile
+                ?.getNotetypeOrNull() != null
+    }
 }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
> [!NOTE]
> Assisted-by: Claude Opus 4.6 - Reproduction of the issue
> Turn on Don't keep activitiy -> open template editor -> press home -> clear AnkiDroid cache -> open AnkiDroid -> crash -> report
> (I tried in Tablet)
## Purpose / Description
The previewer was crashing after process death. Android restores the activity, the ViewModel tries to rebuild by reading a temp file we'd stashed earlier, and the file is gone so the constructor throws and the app dies. so bug: SavedStateHandle promised durability, the file didn't deliver it.

## Fixes
* Fixes #20781

## Approach
- I switched  out of the cache directory i.e. Temp notetype files used to live in cacheDir, which Android is allowed to wipe whenever it wants - low storage, OEM cleaners, user tapping "Clear cache." [this is what i did]  Now they live in noBackupFilesDir.
- Since the OS no longer evicts the files for us, the ViewModel now deletes its temp file in onCleared() 
- the fragment detects this at the start of onViewCreated and just finishes the activity instead of letting the ViewModel blow up  

## How Has This Been Tested?
Emulator API 31 tablet

## Learning (optional, can help others)
I am open to any other suggestion but this is what i can think of even note editor is finished when we do that same or dont keep activity is turned on

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging