### PR TITLE
fix(notifications): reduce sync notification importance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NotificationChannels.kt
@@ -17,6 +17,7 @@
 
 package com.ichi2.anki
 
+import android.app.NotificationChannel
 import android.content.Context
 import android.content.Intent
 import android.content.res.Resources
@@ -51,14 +52,13 @@ fun setupNotificationChannels(context: Context) {
     for (channel in Channel.entries) {
         val id = channel.id
         val name = channel.getName(res)
-        val importance = NotificationManagerCompat.IMPORTANCE_DEFAULT
         Timber.i("Creating notification channel with id/name: %s/%s", id, name)
 
         // Vibration is enabled by default, but the user can turn it off from the system settings
         // Vibration will also not occur if the phone has been set to silent
         val notificationChannel =
             NotificationChannelCompat
-                .Builder(id, importance)
+                .Builder(id, channel.importance)
                 .setName(name)
                 .setShowBadge(true)
                 .setVibrationPattern(longArrayOf(0, 500))
@@ -74,14 +74,16 @@ fun setupNotificationChannels(context: Context) {
  *
  * @property id The unique identifier for the notification channel.
  * @property nameId The string resource ID for the localized channel name.
+ * @property importance The [importance][NotificationChannel.getImportance] of the channel.
  */
 enum class Channel(
     val id: String,
     @StringRes val nameId: Int,
+    val importance: Int,
 ) {
-    GENERAL("General Notifications", R.string.app_name),
-    SYNC("Synchronization", R.string.sync_title),
-    REVIEW_REMINDERS("Review Reminders", R.string.review_reminders_do_not_translate),
+    GENERAL("General Notifications", R.string.app_name, NotificationManagerCompat.IMPORTANCE_DEFAULT),
+    SYNC("Synchronization", R.string.sync_title, NotificationManagerCompat.IMPORTANCE_LOW),
+    REVIEW_REMINDERS("Review Reminders", R.string.review_reminders_do_not_translate, NotificationManagerCompat.IMPORTANCE_DEFAULT),
     ;
 
     fun getName(res: Resources) = res.getString(nameId)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 (max effort): investigation and implementation, some fixups by myself

## Purpose / Description
A user requested that 'sync completed' should be silent. This seems reasonable, this is a common notification, and is often only informative .

Note: This does not affect current channels, only newly created channels

## Fixes
* Fixes #20789

## Approach
Assign `IMPORTANCE_LOW` to the channel

## How Has This Been Tested?
⚠️ Untested

## Learning (optional, can help others)
https://developer.android.com/reference/android/app/NotificationManager#IMPORTANCE_LOW

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
