### PR TITLE
feat: improve Study by card state or tag dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyDialog.kt
@@ -47,6 +47,7 @@ import anki.scheduler.CustomStudyRequest.Cram.CramKind
 import anki.scheduler.copy
 import anki.scheduler.customStudyRequest
 import anki.search.SearchNode
+import anki.search.searchNode
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.R
@@ -147,13 +148,173 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         parentFragmentManager.setFragmentResultListener(ON_SELECTED_TAGS_KEY, this) { _, bundle ->
             val tagsToInclude = bundle.getStringArrayList(ON_SELECTED_TAGS__SELECTED_TAGS) ?: emptyList<String>()
             val option = selectedSubDialog ?: return@setFragmentResultListener
-            val selectedCardStateIndex = viewModel.selectedCardStateIndex
-            if (selectedCardStateIndex == AdapterView.INVALID_POSITION) return@setFragmentResultListener
-            val kind = CustomStudyCardState.entries[selectedCardStateIndex].kind
-            val cardsAmount = userInputValue ?: 100 // the default value
-            launchCustomStudy(option, cardsAmount, kind, tagsToInclude, emptyList())
+            if (option == ContextMenuOption.STUDY_TAGS) {
+                viewModel.selectedTags = tagsToInclude
+                updateTags()
+                (dialog as? AlertDialog)?.let { validateSelection(it) }
+            }
         }
     }
+
+    /**
+     * Populates the chip group with the currently selected tags.
+     * Manages the dummy text field to ensure the outline box expands properly when tags are present.
+     */
+    private fun updateTags() {
+        if (!::binding.isInitialized) return
+        val tags = viewModel.selectedTags
+
+        binding.tagsDummyEdittext.setText(if (tags.isEmpty()) null else " ")
+
+        binding.tagsChipGroup.removeAllViews()
+        tags.forEach { tag ->
+            val chip =
+                com.google.android.material.chip
+                    .Chip(
+                        requireContext(),
+                        null,
+                        com.google.android.material.R.style.Widget_Material3_Chip_Suggestion_Elevated,
+                    ).apply {
+                        text = tag
+                        shapeAppearanceModel =
+                            shapeAppearanceModel
+                                .toBuilder()
+                                .setAllCornerSizes(
+                                    com.google.android.material.shape
+                                        .RelativeCornerSize(0.5f),
+                                ).build()
+                    }
+            binding.tagsChipGroup.addView(chip)
+        }
+    }
+
+    /**
+     * Fetches notes from the current deck and launches the [TagsDialog] for tag selection.
+     * The dialog is only shown if there are notes with tags available to filter.
+     */
+    private fun showTagSelectionDialog() {
+        launchCatchingTask {
+            val selectedState = CustomStudyCardState.entries[viewModel.selectedCardStateIndex]
+            val currentDeckName = withCol { decks.name(viewModel.deckId) }
+
+            // Find all notes in the deck that have at least one tag
+            val nids =
+                withCol {
+                    val searchNodes =
+                        buildList {
+                            add(SearchNode.newBuilder().setDeck(currentDeckName).build())
+                            add(SearchNode.newBuilder().setNegated(SearchNode.newBuilder().setTag("none").build()).build())
+                        }
+                    findNotes(buildSearchString(searchNodes))
+                }
+
+            if (isAdded && nids.isNotEmpty()) {
+                val stateQuery =
+                    withCol {
+                        buildSearchString(
+                            listOf(
+                                SearchNode.newBuilder().setDeck(currentDeckName).build(),
+                                selectedState.toSearchNode(),
+                            ),
+                        )
+                    }
+                TagsDialog()
+                    .withArguments(
+                        requireContext(),
+                        TagsDialog.DialogType.CUSTOM_STUDY,
+                        nids,
+                        stateQuery,
+                        ArrayList(viewModel.selectedTags),
+                    ).show(parentFragmentManager, "TagsDialog")
+            }
+        }
+    }
+
+    /**
+     * Validates the current card state selection and updates the dialog UI.
+     * Called when the card state dropdown changes or tags are updated.
+     */
+    private fun validateSelection(dialog: AlertDialog) {
+        val option = selectedSubDialog ?: return
+        if (option != STUDY_TAGS) return
+        launchCatchingTask {
+            val stateQuery = buildStateQuery()
+            if (withCol { findNotes(stateQuery).isEmpty() }) {
+                onNoCardsMatchState(dialog)
+            } else {
+                onValidCardState(dialog, stateQuery)
+            }
+        }
+    }
+
+    /** Builds the search query for the currently selected card state and deck. */
+    private suspend fun buildStateQuery(): String {
+        val selectedState = CustomStudyCardState.entries[viewModel.selectedCardStateIndex]
+        return withCol {
+            buildSearchString(
+                listOf(
+                    SearchNode.newBuilder().setDeck(decks.name(viewModel.deckId)).build(),
+                    selectedState.toSearchNode(),
+                ),
+            )
+        }
+    }
+
+    /** Updates UI to reflect that no cards match the selected state. Clears any selected tags. */
+    private fun onNoCardsMatchState(dialog: AlertDialog) {
+        binding.cardsStateSelectorLayout.error = TR.customStudyNoCardsMatchedTheCriteriaYou()
+        dialog.positiveButton.isEnabled = false
+        binding.tagsSelectionLayout.isEnabled = false
+        viewModel.selectedTags = emptyList()
+        updateTags()
+    }
+
+    /** Updates UI when the selected card state has matching cards. Filters stale tags and refreshes the chip group. */
+    private suspend fun onValidCardState(
+        dialog: AlertDialog,
+        stateQuery: String,
+    ) {
+        binding.cardsStateSelectorLayout.error = null
+        dialog.positiveButton.isEnabled = userInputValue != null && userInputValue != 0
+        viewModel.selectedTags = filterValidTags(stateQuery)
+        binding.tagsSelectionLayout.isEnabled = hasTagsForState(stateQuery)
+        updateTags()
+    }
+
+    /** Returns only the tags from [viewModel.selectedTags] that have matching notes in [stateQuery]. */
+    private suspend fun filterValidTags(stateQuery: String): List<String> {
+        val tags = viewModel.selectedTags
+        if (tags.isEmpty()) return emptyList()
+        return withCol {
+            tags.filter { tag ->
+                findNotes(
+                    buildSearchString(
+                        listOf(
+                            SearchNode.newBuilder().setParsableText(stateQuery).build(),
+                            SearchNode.newBuilder().setTag(tag).build(),
+                        ),
+                    ),
+                ).isNotEmpty()
+            }
+        }
+    }
+
+    /** Returns true if there are any tagged notes matching [stateQuery]. */
+    private suspend fun hasTagsForState(stateQuery: String): Boolean =
+        withCol {
+            findNotes(
+                buildSearchString(
+                    listOf(
+                        SearchNode.newBuilder().setParsableText(stateQuery).build(),
+                        SearchNode
+                            .newBuilder()
+                            .setNegated(
+                                SearchNode.newBuilder().setTag("none").build(),
+                            ).build(),
+                    ),
+                ),
+            ).isNotEmpty()
+        }
 
     /** @see customStudy */
     private fun launchCustomStudy(
@@ -297,9 +458,37 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         binding = FragmentCustomStudyBinding.inflate(requireActivity().layoutInflater)
 
         binding.detailsText1.text = text1
+        binding.detailsText1.isVisible = text1.isNotEmpty()
         binding.detailsText2.text = text2
+        binding.detailsText2.isVisible = text2.isNotEmpty()
 
+        binding.detailsEditText2Layout.hint =
+            when (contextMenuOption) {
+                STUDY_TAGS -> getString(R.string.custom_study_card_limit_hint)
+                STUDY_FORGOT, STUDY_AHEAD, STUDY_PREVIEW -> getString(R.string.custom_study_day_limit_hint)
+                EXTEND_NEW, EXTEND_REV -> ""
+            }
+        val tagsContainer = binding.tagsSelectionLayout.parent as? android.view.View
+        tagsContainer?.isVisible = contextMenuOption == STUDY_TAGS
         binding.cardsStateSelectorLayout.isVisible = contextMenuOption == STUDY_TAGS
+        if (contextMenuOption == STUDY_TAGS) {
+            updateTags()
+            // Open the tag selection dialog which is pre-filtered by the current card state
+            binding.tagsDummyEdittext.setOnClickListener { showTagSelectionDialog() }
+            binding.tagsChipGroup.setOnClickListener { showTagSelectionDialog() }
+
+            // Ensures the outline dynamically resizes to wrap the chips during layout reflows like rotation or split-screen
+            binding.tagsChipGroup.addOnLayoutChangeListener { _, _, top, _, bottom, _, oldTop, _, oldBottom ->
+                val newHeight = bottom - top
+                val oldHeight = oldBottom - oldTop
+
+                // Only request layout if the height actually changed to prevent infinite loops
+                if (newHeight != oldHeight) {
+                    binding.tagsDummyEdittext.minHeight = newHeight
+                    binding.tagsDummyEdittext.requestLayout()
+                }
+            }
+        }
         binding.cardsStateSelector.apply {
             fun setAdapterAndSelection(
                 entries: List<String>,
@@ -319,6 +508,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 AdapterView.OnItemClickListener { _, _, position, _ ->
                     viewModel.selectedCardStateIndex = position
                     setAdapterAndSelection(cardStates, viewModel.selectedCardStateIndex)
+                    validateSelection(dialog as AlertDialog)
                 }
             // set the first item as automatically selected if we don't already have a valid
             // position stored in the ViewModel
@@ -332,6 +522,11 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
             // Give EditText focus and show keyboard
             setSelectAllOnFocus(true)
             requestFocus()
+            // Ensure the text is highlighted once the dialog and keyboard are ready
+            post {
+                selectAll()
+            }
+            filters = arrayOf(android.text.InputFilter.LengthFilter(5))
             // a user may enter a negative value when extending limits
             if (contextMenuOption == EXTEND_NEW || contextMenuOption == EXTEND_REV) {
                 inputType = EditorInfo.TYPE_CLASS_NUMBER or EditorInfo.TYPE_NUMBER_FLAG_SIGNED
@@ -339,7 +534,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         }
         val positiveBtnLabel =
             if (contextMenuOption == STUDY_TAGS) {
-                TR.customStudyChooseTags().toSentenceCase(R.string.sentence_choose_tags)
+                getString(R.string.dialog_positive_create)
             } else {
                 getString(R.string.dialog_ok)
             }
@@ -351,6 +546,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         val dialog =
             AlertDialog
                 .Builder(requireActivity())
+                .title(text = contextMenuOption.getTitle(resources))
                 .customView(
                     view = binding.root,
                     paddingStart = horizontalPadding,
@@ -385,45 +581,37 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                     // we come back we wouldn't be able to trigger again TagLimitFragment
                     allowSubmit = true
                     launchCatchingTask {
-                        val nids =
-                            withCol {
-                                val currentDeckName = decks.name(viewModel.deckId)
-                                // this allows us to skip the tag selection dialog entirely
-                                // if there are no tags available to choose from in this deck
-                                val searchNodes =
-                                    buildList {
-                                        add(SearchNode.newBuilder().setDeck(currentDeckName).build())
-                                        add(
-                                            SearchNode
-                                                .newBuilder()
-                                                .setNegated(SearchNode.newBuilder().setTag("none").build())
-                                                .build(),
-                                        )
-                                    }
-                                findNotes(buildSearchString(searchNodes))
-                            }
-                        // skip tag selection if there's no tags to select
-                        if (nids.isEmpty()) {
-                            launchCustomStudy(contextMenuOption, n)
-                            return@launchCatchingTask
-                        }
-                        if (isAdded) {
-                            TagsDialog()
-                                .withArguments(
-                                    requireContext(),
-                                    TagsDialog.DialogType.CUSTOM_STUDY,
-                                    nids,
-                                ).show(parentFragmentManager, "TagsDialog")
+                        val selectedCardStateIndex = viewModel.selectedCardStateIndex
+                        if (selectedCardStateIndex != AdapterView.INVALID_POSITION) {
+                            val kind = CustomStudyCardState.entries[selectedCardStateIndex].kind
+                            launchCustomStudy(
+                                contextMenuOption,
+                                n,
+                                kind,
+                                viewModel.selectedTags,
+                                emptyList(),
+                            )
                         }
                     }
-                    return@setOnClickListener
+                } else {
+                    launchCustomStudy(contextMenuOption, n)
                 }
-                launchCustomStudy(contextMenuOption, n)
             }
+            validateSelection(dialog)
         }
 
-        binding.detailsEditText2.doAfterTextChanged {
-            dialog.positiveButton.isEnabled = userInputValue != null && userInputValue != 0
+        binding.detailsEditText2.doAfterTextChanged { text ->
+            val input = text?.toString().orEmpty()
+            if (contextMenuOption in LEADING_ZERO_OPTIONS && input.length > 1 && input[0] == '0') {
+                val sanitized = input.trimStart('0').ifEmpty { "0" }
+                binding.detailsEditText2.setText(sanitized)
+                binding.detailsEditText2.setSelection(sanitized.length)
+                return@doAfterTextChanged
+            }
+            dialog.positiveButton.isEnabled =
+                binding.cardsStateSelectorLayout.error == null &&
+                userInputValue != null &&
+                userInputValue != 0
         }
 
         // Show soft keyboard
@@ -527,7 +715,7 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
                 STUDY_FORGOT -> res.getString(R.string.custom_study_forgotten)
                 STUDY_AHEAD -> res.getString(R.string.custom_study_ahead)
                 STUDY_PREVIEW -> res.getString(R.string.custom_study_preview)
-                STUDY_TAGS -> res.getString(R.string.custom_study_tags)
+                STUDY_TAGS -> ""
                 null -> ""
             }
         }
@@ -620,6 +808,18 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
         DueCardsOnly({ TR.customStudyDueCardsOnly() }, CramKind.CRAM_KIND_DUE),
         ReviewCardsRandom({ TR.customStudyAllReviewCardsInRandomOrder() }, CramKind.CRAM_KIND_REVIEW),
         AllCardsRandom({ TR.customStudyAllCardsInRandomOrderDont() }, CramKind.CRAM_KIND_ALL),
+        ;
+
+        /**
+         * Converts the [CustomStudyCardState] into a [SearchNode] used for card filtering.
+         */
+        fun toSearchNode(): SearchNode =
+            when (this) {
+                NewCardsOnly -> searchNode { cardState = SearchNode.CardState.CARD_STATE_NEW }
+                DueCardsOnly -> searchNode { cardState = SearchNode.CardState.CARD_STATE_DUE }
+                ReviewCardsRandom -> searchNode { cardState = SearchNode.CardState.CARD_STATE_REVIEW }
+                AllCardsRandom -> searchNode { parsableText = "" }
+            }
     }
 
     /**
@@ -744,6 +944,8 @@ class CustomStudyDialog : AnalyticsDialogFragment() {
          */
         // This exists as `isInitialized` can't be checked in an instance of CustomStudyDialog
         private fun defaultsAreInitialized(): Boolean = ::deferredDefaults.isInitialized
+
+        private val LEADING_ZERO_OPTIONS = setOf(STUDY_TAGS, STUDY_FORGOT, STUDY_AHEAD, STUDY_PREVIEW)
 
         /**
          * Creates an instance of the Custom Study Dialog: a user can select a custom study type

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/customstudy/CustomStudyViewModel.kt
@@ -42,11 +42,19 @@ class CustomStudyViewModel(
     val deckId: DeckId
         get() = savedStateHandle.get<DeckId>(KEY_DID) ?: error("Deck id was not provided!")
 
+    /** The list of tags selected by the user for the custom study session. */
+    var selectedTags: List<String>
+        get() = savedStateHandle.get<List<String>>(KEY_SELECTED_TAGS) ?: emptyList()
+        set(value) {
+            savedStateHandle[KEY_SELECTED_TAGS] = value
+        }
+
     companion object {
         /**
          * Required key for a [DeckId] which [CustomStudyDialog] expects to receive as an argument.
          */
         const val KEY_DID = "key_did"
         private const val KEY_CARDS_SELECTION_INDEX = "key_cards_selection_index"
+        private const val KEY_SELECTED_TAGS = "key_selected_tags"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialog.kt
@@ -105,12 +105,14 @@ class TagsDialog : AnalyticsDialogFragment {
             }
         val type = BundleCompat.getParcelable(requireArguments(), ARG_DIALOG_TYPE, DialogType::class.java)
         val isCustomStudying = type != null && type == DialogType.CUSTOM_STUDY
+        val filterQuery = requireArguments().getString(ARG_FILTER_QUERY)
         viewModelFactory {
             initializer {
                 TagsDialogViewModel(
                     noteIds = noteIds,
                     checkedTags = checkedTags,
                     isCustomStudying = isCustomStudying,
+                    filterQuery = filterQuery,
                 )
             }
         }
@@ -142,6 +144,7 @@ class TagsDialog : AnalyticsDialogFragment {
         context: Context,
         type: DialogType,
         noteIds: List<NoteId> = emptyList(),
+        filterQuery: String? = null,
         checkedTags: ArrayList<String> = arrayListOf(),
     ): TagsDialog {
         // TODO: checkedTags is unbounded and could exceed the bundle size
@@ -150,6 +153,7 @@ class TagsDialog : AnalyticsDialogFragment {
             ARG_TAGS_FILE to file,
             ARG_DIALOG_TYPE to type,
             ARG_CHECKED_TAGS to checkedTags,
+            ARG_FILTER_QUERY to filterQuery,
         )
         return this
     }
@@ -180,10 +184,11 @@ class TagsDialog : AnalyticsDialogFragment {
         binding = DialogTagsBinding.inflate(layoutInflater)
 
         val positiveText =
-            if (type == DialogType.EDIT_TAGS) {
-                getString(R.string.dialog_confirm)
-            } else {
-                getString(R.string.select)
+            when (type) {
+                DialogType.EDIT_TAGS,
+                DialogType.CUSTOM_STUDY,
+                -> getString(R.string.dialog_confirm)
+                else -> getString(R.string.select)
             }
 
         val tagsListLayout: RecyclerView.LayoutManager = LinearLayoutManager(requireContext())
@@ -478,6 +483,7 @@ class TagsDialog : AnalyticsDialogFragment {
         const val ARG_TAGS_FILE = "tagsFile"
         private const val ARG_DIALOG_TYPE = "dialogType"
         private const val ARG_CHECKED_TAGS = "checkedTags"
+        private const val ARG_FILTER_QUERY = "filterQuery"
 
         /**
          * The filter that constrains the inputted tag.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModel.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.flow.StateFlow
  * @param isCustomStudying true if all inputs are to be handled as unchecked tags, false otherwise(
  * this is a temporary parameter until custom study by tags is modified)
  *  They are joined with the tags retrieved from noteIds
+ * @param filterQuery an optional search query to pre-filter the tags shown in the dialog.
  *
  *  @see <a href="https://github.com/ankidroid/Anki-Android/pull/19499#discussion_r2532184695">Extra checked tags</>
  */
@@ -37,6 +38,7 @@ class TagsDialogViewModel(
     noteIds: Collection<NoteId> = emptyList(),
     checkedTags: Collection<String> = emptyList(),
     isCustomStudying: Boolean = false,
+    private val filterQuery: String? = null,
 ) : ViewModel() {
     val tags: Deferred<TagsList>
 
@@ -46,33 +48,52 @@ class TagsDialogViewModel(
     init {
         tags =
             asyncIO {
-                val allTags = withCol { tags.all() }
-                val allCheckedTags = mutableSetOf<String>()
-                val uncheckedTags = mutableSetOf<String>()
-                // For each note, put the checked tag in checked list and unchecked tags in unchecked list.
-                // This will result in few tags being present in both lists, checked and
-                // unchecked as they might be present in one note but absent in any other.
-                // Such tags are referred as `indeterminateTags` in [TagsList]
-                noteIds.forEachIndexed { index, nid ->
-                    // TODO: Lift up withCol{ } call out of loop. Performs `N` expensive db queries.
-                    val noteTags = withCol { getNote(nid) }.tags
-                    initProgress.emit(InitProgress.FetchingNoteTags(index + 1, noteIds.size))
-                    val (checked, unchecked) = allTags.partition { noteTags.contains(it) }
-                    allCheckedTags.addAll(checked)
-                    uncheckedTags.addAll(unchecked)
-                }
-                // add the extra checked tags, these are to be shown as `checked` and cannot be indeterminate
-                val extraCheckedTags = checkedTags.toSet()
-                allCheckedTags.addAll(extraCheckedTags)
-                uncheckedTags.removeAll(extraCheckedTags)
-                initProgress.emit(InitProgress.Processing)
-                if (isCustomStudying) {
+                if (isCustomStudying && filterQuery != null) {
+                    // Pre-filter the list of tags based on the selected card state so that
+                    // the user only sees tags that will actually return cards.
+                    val filteredTags =
+                        withCol {
+                            val nids = findNotes(filterQuery)
+                            nids
+                                .asSequence()
+                                .map { getNote(it).tags }
+                                .flatten()
+                                .distinct()
+                                .sorted()
+                                .toList()
+                        }
+
+                    initProgress.emit(InitProgress.Finished)
+
+                    val currentChecked = checkedTags.filter { it in filteredTags }
+
                     TagsList(
-                        allTags = allCheckedTags,
-                        checkedTags = emptyList(),
-                        uncheckedTags = allCheckedTags,
+                        allTags = filteredTags,
+                        checkedTags = currentChecked,
+                        uncheckedTags = filteredTags.filter { it !in currentChecked },
                     )
                 } else {
+                    val allTags = withCol { tags.all() }
+                    val allCheckedTags = mutableSetOf<String>()
+                    val uncheckedTags = mutableSetOf<String>()
+                    // For each note, put the checked tag in checked list and unchecked tags in unchecked list.
+                    // This will result in few tags being present in both lists, checked and
+                    // unchecked as they might be present in one note but absent in any other.
+                    // Such tags are referred as `indeterminateTags` in [TagsList]
+                    noteIds.forEachIndexed { index, nid ->
+                        // TODO: Lift up withCol{ } call out of loop. Performs `N` expensive db queries.
+                        val noteTags = withCol { getNote(nid) }.tags
+                        initProgress.emit(InitProgress.FetchingNoteTags(index + 1, noteIds.size))
+                        val (checked, unchecked) = allTags.partition { noteTags.contains(it) }
+                        allCheckedTags.addAll(checked)
+                        uncheckedTags.addAll(unchecked)
+                    }
+                    // add the extra checked tags, these are to be shown as `checked` and cannot be indeterminate
+                    val extraCheckedTags = checkedTags.toSet()
+                    allCheckedTags.addAll(extraCheckedTags)
+                    uncheckedTags.removeAll(extraCheckedTags)
+                    initProgress.emit(InitProgress.Processing)
+
                     TagsList(
                         allTags = allTags,
                         checkedTags = allCheckedTags,

--- a/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_custom_study.xml
@@ -18,74 +18,113 @@
 */
 -->
 
-<LinearLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:gravity="start"
-    android:orientation="vertical" >
+    android:fadeScrollbars="false">
 
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/details_text_1"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_marginLeft="4dip"
-        android:layout_marginRight="4dip"
         android:gravity="start"
-        android:text=""
-        android:textSize="16sp" />
+        android:orientation="vertical" >
 
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/details_text_2"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="start"
-        android:layout_marginBottom="16dip"
-        android:layout_marginStart="4dip"
-        android:layout_weight="4"
-        android:gravity="start|center"
-        android:lines="2"
-        android:text=""
-        android:textSize="16sp" />
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/details_text_1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_marginLeft="4dip"
+            android:layout_marginRight="4dip"
+            android:gravity="start"
+            android:text=""
+            android:textSize="16sp" />
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/details_edit_text_2_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        <com.ichi2.ui.FixedTextView
+            android:id="@+id/details_text_2"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start"
+            android:layout_marginBottom="16dip"
+            android:layout_marginStart="4dip"
+            android:layout_weight="4"
+            android:gravity="start|center"
+            android:lines="2"
+            android:text=""
+            android:textSize="16sp" />
 
-        <com.google.android.material.textfield.TextInputEditText
-            android:id="@+id/details_edit_text_2"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/details_edit_text_2_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="16dp"
-            android:inputType="number|numberSigned"
-            tools:text="1"
-            />
-    </com.google.android.material.textfield.TextInputLayout>
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/cards_state_selector_layout"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
-        android:visibility="gone"
-        tools:visibility="visible">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/details_edit_text_2"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="22dp"
+                android:inputType="number|numberSigned"
+                android:textColorHighlight="?attr/colorControlHighlight"
+                tools:text="1" />
+        </com.google.android.material.textfield.TextInputLayout>
 
-        <!--
-        Material3Fix we shouldn't have to tint the dropdown background(otherwise it's transparent),
-        also the color of the selected entry needs to be updated in the theme
-         -->
-        <com.google.android.material.textfield.MaterialAutoCompleteTextView
-            android:id="@+id/cards_state_selector"
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/cards_state_selector_layout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:inputType="textFilter|textMultiLine"
-            app:dropDownBackgroundTint="?android:attr/colorBackground"
-            tools:text="New cards only"
-            />
-    </com.google.android.material.textfield.TextInputLayout>
-</LinearLayout>
+            style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+            app:errorEnabled="true"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <!--
+            Material3Fix we shouldn't have to tint the dropdown background(otherwise it's transparent),
+            also the color of the selected entry needs to be updated in the theme
+             -->
+            <com.google.android.material.textfield.MaterialAutoCompleteTextView
+                android:id="@+id/cards_state_selector"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textFilter|textMultiLine"
+                app:dropDownBackgroundTint="?android:attr/colorBackground"
+                tools:text="New cards only"
+                />
+        </com.google.android.material.textfield.TextInputLayout>
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tags_selection_layout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/card_details_tags">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/tags_dummy_edittext"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:cursorVisible="false"
+                    android:inputType="none"
+                    android:focusable="false"/>
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.chip.ChipGroup
+                android:id="@+id/tags_chip_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:paddingTop="8dp"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                app:chipSpacingVertical="-4dp"
+                app:chipSpacingHorizontal="8dp" />
+        </FrameLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AnkiDroid/src/main/res/values/03-dialogs.xml
+++ b/AnkiDroid/src/main/res/values/03-dialogs.xml
@@ -48,7 +48,8 @@
     <string name="custom_study_forgotten">Review cards forgotten in last x days:</string>
     <string name="custom_study_ahead">Review ahead by x days:</string>
     <string name="custom_study_preview">Preview new cards added in the last x days:</string>
-    <string name="custom_study_tags">Select x cards from the deck:</string>
+    <string name="custom_study_card_limit_hint">Number of cards</string>
+    <string name="custom_study_day_limit_hint">Number of days</string>
 
     <string name="storage_full_title">Storage full</string>
     <string name="storage_almost_full_title">Storage almost full</string>

--- a/AnkiDroid/src/main/res/values/sentence-case.xml
+++ b/AnkiDroid/src/main/res/values/sentence-case.xml
@@ -46,7 +46,6 @@ undoActionUndone()
     <string name="sentence_find_and_replace">Find and replace</string>
     <string name="sentence_all_fields">All fields</string>
     <string name="sentence_check_media_delete_unused">Delete unused</string>
-    <string name="sentence_choose_tags">Choose tags</string>
     <string name="sentence_selective_study">Selective study</string>
     <string name="sentence_sync_media_log">Media sync log</string>
     <string name="sentence_empty_trash">Empty trash</string>

--- a/AnkiDroid/src/main/res/values/theme_dark.xml
+++ b/AnkiDroid/src/main/res/values/theme_dark.xml
@@ -14,7 +14,6 @@
         <item name="colorPrimary">@color/material_blue_400</item>
         <item name="colorOnPrimary">@color/white</item>
         <item name="colorPrimaryDark">@color/theme_dark_primary_dark</item>
-        <item name="colorSurface">?android:colorBackground</item>
         <item name="colorAccent">@color/material_blue_400</item>
         <item name="colorOnSurface">@color/white</item>
         <item name="colorPrimaryContainer">@color/white</item> <!-- Switch thumb color when disabled and being pressed -->

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/CustomStudyDialogTest.kt
@@ -232,6 +232,7 @@ class CustomStudyDialogTest : RobolectricTest() {
                     ON_SELECTED_TAGS_KEY,
                     bundleOf(ON_SELECTED_TAGS__SELECTED_TAGS to selectedTags),
                 )
+                studyDialog.submitSubscreenData()
                 val customStudyDeck = col.decks.customStudySession
                 assertNotNull(customStudyDeck)
                 assertThat(col.decks.cardCount(customStudyDeck.id), equalTo(1))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/dialogs/tags/TagsDialogViewModelTest.kt
@@ -140,25 +140,24 @@ class TagsDialogViewModelTest : RobolectricTest() {
         }
 
     @Test
-    fun `custom study mode makes all tags unchecked`() =
+    fun `custom study mode pre-checks previously selected tags`() =
         runTest(testDispatcher) {
             val vm =
                 TagsDialogViewModel(
                     noteIds = listOf(note1, note2),
                     checkedTags = listOf("a"),
                     isCustomStudying = true,
+                    filterQuery = "nid:$note1,$note2",
                 )
             val tags = vm.tags.await()
             // tags from both notes = {a,b,c,d}
             val all = tags.copyOfAllTagList().sorted()
             assertEquals(listOf("a", "b", "c", "d"), all)
-            // custom study: checked = empty
-            assertTrue(tags.copyOfCheckedTagList().isEmpty())
+            // "a" was previously selected, so it should be pre-checked on re-open
+            assertEquals(listOf("a"), tags.copyOfCheckedTagList())
             // custom study: indeterminate = empty
             assertTrue(tags.copyOfIndeterminateTagList().isEmpty())
-            // custom study:
-            // checked - empty, unchecked - empty, all - not empty
-            // implies unchecked = allTags
+            // all tags are still present in the list
             assertTrue(tags.copyOfAllTagList().isNotEmpty())
         }
 }


### PR DESCRIPTION
> [!NOTE]  
> Logic and documentation assisted by Gemini 3 Flash.

<!--- Please fill the necessary details below -->
## Purpose / Description
Improves the "Study by card state or tag" dialog and implements filtering of tags.

## Fixes
* Fixes #20601

## Approach
* Added a title to the input dialog using `AlertDialog.Builder.title()`, affecting all custom study sub-dialogs
* Removed the "Select x cards from the deck" label 
* Implemented dynamic hints in `TextInputLayout` that switch between "Number of days" and "Number of cards" based on the `ContextMenuOption`
* Called `selectAll()` in a `post {}` block within the input dialog to improve text selection behavior
* Changed positive button labels to "Create" in `CustomStudyDialog` and "Confirm" in `TagsDialog`
* Integrated a red error state in `TextInputLayout` and dynamic `isEnabled` updates for the positive button when `findNotes` returns zero results
* Added a tag selection button that mimics the Note Editor's tag box
* Updated `TagsDialogViewModel` to accept a `filterQuery`, ensuring the `TagsDialog` only displays tags available for the selected `CustomStudyCardState`
* Implemented an intersection check during card state changes to retain valid tags in `viewModel.selectedTags` while removing unavailable ones
* Added logic in the `doAfterTextChanged` listener to sanitize numeric input and prevent leading zeros

## How Has This Been Tested?

https://github.com/user-attachments/assets/ca6b0f1b-00ea-426e-90b5-0867135a8537

Screenshots of affected dialogs
| | | |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/3d7baea4-913a-4d87-bfe3-2a2c14771524" width="300" /> | <img src="https://github.com/user-attachments/assets/bff991c8-8e88-4b73-8faf-f1ebc7812886" width="300" /> | <img src="https://github.com/user-attachments/assets/dcd16e97-d947-4edb-8af6-0eda48992261" width="300" /> |
| <img src="https://github.com/user-attachments/assets/b120688a-5147-435f-ac75-5761a468b9a2" width="300" /> | <img src="https://github.com/user-attachments/assets/bbcf2480-b994-4abe-8e7c-3a764fdbcd39" width="300" /> | <img src="https://github.com/user-attachments/assets/c3f2ead2-dc07-4082-aafe-95a7d1fcae59" width="300" /> | 
| <img src="https://github.com/user-attachments/assets/453006f5-3d22-4766-aa7b-ab35e1ab87db" width="300" /> | | |


## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->