### PR TITLE
refactor: type multimedia results with a sealed contract

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -124,11 +124,11 @@ import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.multimedia.AudioRecordingFragment
 import com.ichi2.anki.multimedia.AudioVideoFragment
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT_FIELD_INDEX
 import com.ichi2.anki.multimedia.MultimediaActivityExtra
 import com.ichi2.anki.multimedia.MultimediaBottomSheet
 import com.ichi2.anki.multimedia.MultimediaImageFragment
+import com.ichi2.anki.multimedia.MultimediaResult
+import com.ichi2.anki.multimedia.MultimediaResultContract
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
 import com.ichi2.anki.multimedia.MultimediaViewModel
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
@@ -330,21 +330,19 @@ class NoteEditorFragment :
         )
 
     private val multimediaFragmentLauncher =
-        registerForActivityResult(
-            ActivityResultContracts.StartActivityForResult(),
-            NoteEditorActivityResultCallback { result ->
-                if (result.resultCode == RESULT_CANCELED) {
+        registerForActivityResult(MultimediaResultContract()) { result ->
+            when (result) {
+                is MultimediaResult.Cancelled -> {
                     Timber.d("Multimedia result canceled")
-                    val index = result.data?.extras?.getInt(MULTIMEDIA_RESULT_FIELD_INDEX) ?: return@NoteEditorActivityResultCallback
-                    handleMultimediaActions(index)
-                    return@NoteEditorActivityResultCallback
+                    handleMultimediaActions(result.fieldIndex)
                 }
-
-                Timber.d("Getting multimedia result")
-                val extras = result.data?.extras ?: return@NoteEditorActivityResultCallback
-                handleMultimediaResult(extras)
-            },
-        )
+                is MultimediaResult.Success -> {
+                    Timber.d("Getting multimedia result")
+                    handleMultimediaResult(result)
+                }
+                null -> Timber.d("Multimedia launcher returned no result")
+            }
+        }
 
     private val requestTemplateEditLauncher =
         registerForActivityResult(
@@ -2134,15 +2132,11 @@ class NoteEditorFragment :
         multimediaFragmentLauncher.launch(imageIntent)
     }
 
-    private fun handleMultimediaResult(extras: Bundle) {
-        val index = extras.getInt(MULTIMEDIA_RESULT_FIELD_INDEX)
-        val field =
-            extras.getSerializableCompat<IField>(MULTIMEDIA_RESULT)
-                ?: return
-
+    private fun handleMultimediaResult(result: MultimediaResult.Success) {
+        val field = result.field
         // Process successful result only if field has data
         if (field.type != EFieldType.TEXT || field.mediaFile != null) {
-            performAddMedia(index, field, skipSizeCheck = false)
+            performAddMedia(result.fieldIndex, field, skipSizeCheck = false)
         } else {
             Timber.i("field imagePath and audioPath are both null")
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
@@ -23,14 +23,11 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.databinding.FragmentAudioRecordingBinding
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT_FIELD_INDEX
 import com.ichi2.anki.multimedia.audio.AudioRecordingController
 import com.ichi2.utils.FileUtil
 import com.ichi2.utils.Permissions
@@ -109,14 +106,7 @@ class AudioRecordingFragment : MultimediaFragment(R.layout.fragment_audio_record
 
             field.mediaFile = viewModel.currentMultimediaPath.value
             field.hasTemporaryMedia = true
-
-            val resultData =
-                Intent().apply {
-                    putExtra(MULTIMEDIA_RESULT, field)
-                    putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                }
-            requireActivity().setResult(AppCompatActivity.RESULT_OK, resultData)
-            requireActivity().finish()
+            setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
@@ -27,7 +27,6 @@ import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.OptIn
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
@@ -43,8 +42,6 @@ import com.ichi2.anki.databinding.FragmentAudioVideoBinding
 import com.ichi2.anki.multimedia.AudioVideoFragment.MediaOption.AUDIO_CLIP
 import com.ichi2.anki.multimedia.AudioVideoFragment.MediaOption.VIDEO_CLIP
 import com.ichi2.anki.multimedia.MultimediaActivity.Companion.EXTRA_MEDIA_OPTIONS
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT_FIELD_INDEX
 import com.ichi2.anki.multimedia.MultimediaUtils.createCachedFile
 import com.ichi2.anki.utils.ext.sharedPrefs
 import com.ichi2.utils.ExceptionUtil.executeSafe
@@ -71,12 +68,7 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
                 result.resultCode != Activity.RESULT_OK || result.data == null -> {
                     Timber.d("Uri is empty or Result not OK")
                     if (viewModel.currentMultimediaUri.value == null) {
-                        val resultData =
-                            Intent().apply {
-                                putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                            }
-                        requireActivity().setResult(AppCompatActivity.RESULT_CANCELED, resultData)
-                        requireActivity().finish()
+                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
                     }
                 }
                 else -> {
@@ -201,16 +193,8 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
                 return@setOnClickListener
             }
             field.mediaFile = viewModel.currentMultimediaPath.value
-
             field.hasTemporaryMedia = true
-
-            val resultData =
-                Intent().apply {
-                    putExtra(MULTIMEDIA_RESULT, field)
-                    putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                }
-            requireActivity().setResult(AppCompatActivity.RESULT_OK, resultData)
-            requireActivity().finish()
+            setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActivity.kt
@@ -123,9 +123,6 @@ class MultimediaActivity :
         const val MULTIMEDIA_ARGS_EXTRA = "fragmentArgs"
         const val MULTIMEDIA_FRAGMENT_NAME_EXTRA = "fragmentName"
 
-        const val MULTIMEDIA_RESULT = "multimedia_result"
-        const val MULTIMEDIA_RESULT_FIELD_INDEX = "multimedia_result_index"
-
         /** used in case a fragment supports more than media operations **/
         const val EXTRA_MEDIA_OPTIONS = "extra_media_options"
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -32,7 +32,6 @@ import android.webkit.WebView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.DrawableRes
 import androidx.appcompat.app.AlertDialog
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
@@ -46,8 +45,6 @@ import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.anki.databinding.FragmentMultimediaImageBinding
 import com.ichi2.anki.multimedia.MultimediaActivity.Companion.EXTRA_MEDIA_OPTIONS
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT
-import com.ichi2.anki.multimedia.MultimediaActivity.Companion.MULTIMEDIA_RESULT_FIELD_INDEX
 import com.ichi2.anki.multimedia.MultimediaUtils.IMAGE_LIMIT
 import com.ichi2.anki.multimedia.MultimediaUtils.IMAGE_SAVE_MAX_WIDTH
 import com.ichi2.anki.multimedia.MultimediaUtils.createCachedFile
@@ -100,12 +97,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             when (result.resultCode) {
                 Activity.RESULT_CANCELED -> {
                     if (viewModel.currentMultimediaUri.value == null) {
-                        val resultData =
-                            Intent().apply {
-                                putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                            }
-                        requireActivity().setResult(AppCompatActivity.RESULT_CANCELED, resultData)
-                        requireActivity().finish()
+                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
                     }
                 }
 
@@ -132,12 +124,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
                 Activity.RESULT_CANCELED -> {
                     // If user didn't draw, return the indexValue as a result and finish the activity
                     if (viewModel.currentMultimediaUri.value == null) {
-                        val resultData =
-                            Intent().apply {
-                                putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                            }
-                        requireActivity().setResult(AppCompatActivity.RESULT_CANCELED, resultData)
-                        requireActivity().finish()
+                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
                     }
                 }
 
@@ -159,12 +146,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             hasStartedImageSelection = false
             when {
                 !isPictureTaken && viewModel.currentMultimediaUri.value == null -> {
-                    val resultData =
-                        Intent().apply {
-                            putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-                        }
-                    requireActivity().setResult(AppCompatActivity.RESULT_CANCELED, resultData)
-                    requireActivity().finish()
+                    setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
                 }
 
                 isPictureTaken -> {
@@ -345,14 +327,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     private fun finishAddingImage() {
         field.mediaFile = viewModel.currentMultimediaPath.value
         field.hasTemporaryMedia = true
-
-        val resultData =
-            Intent().apply {
-                putExtra(MULTIMEDIA_RESULT, field)
-                putExtra(MULTIMEDIA_RESULT_FIELD_INDEX, indexValue)
-            }
-        requireActivity().setResult(AppCompatActivity.RESULT_OK, resultData)
-        requireActivity().finish()
+        setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
     }
 
     private fun openGallery() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaResult.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaResult.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.multimedia
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.fragment.app.Fragment
+import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.anki.multimediacard.fields.IField
+
+/**
+ * Typed result returned by a [MultimediaActivity] launched from the note editor.
+ */
+sealed interface MultimediaResult {
+    /** Index of the field in the note editor that requested the capture. */
+    val fieldIndex: Int
+
+    /** Media was captured/selected and is attached to [field]. */
+    data class Success(
+        override val fieldIndex: Int,
+        val field: IField,
+    ) : MultimediaResult
+
+    /** User dismissed the capture/selection without producing media. */
+    data class Cancelled(
+        override val fieldIndex: Int,
+    ) : MultimediaResult
+}
+
+/**
+ * [ActivityResultContract] for launching a [MultimediaActivity] and parsing the
+ * returned [MultimediaResult].
+ */
+class MultimediaResultContract : ActivityResultContract<Intent, MultimediaResult?>() {
+    override fun createIntent(
+        context: Context,
+        input: Intent,
+    ): Intent = input
+
+    override fun parseResult(
+        resultCode: Int,
+        intent: Intent?,
+    ): MultimediaResult? {
+        val extras = intent?.extras ?: return null
+        val index = extras.getInt(EXTRA_FIELD_INDEX, -1).takeIf { it >= 0 } ?: return null
+        return when (resultCode) {
+            Activity.RESULT_OK -> {
+                val field = extras.getSerializableCompat<IField>(EXTRA_FIELD) ?: return null
+                MultimediaResult.Success(index, field)
+            }
+            Activity.RESULT_CANCELED -> MultimediaResult.Cancelled(index)
+            else -> null
+        }
+    }
+
+    companion object {
+        internal const val EXTRA_FIELD = "multimedia_result"
+        internal const val EXTRA_FIELD_INDEX = "multimedia_result_index"
+    }
+}
+
+/**
+ * Sets the activity result of the [Fragment]'s host to the given [MultimediaResult]
+ * and finishes the activity.
+ */
+fun Fragment.setMultimediaResultAndFinish(result: MultimediaResult) {
+    val data =
+        Intent().apply {
+            putExtra(MultimediaResultContract.EXTRA_FIELD_INDEX, result.fieldIndex)
+            if (result is MultimediaResult.Success) {
+                putExtra(MultimediaResultContract.EXTRA_FIELD, result.field)
+            }
+        }
+    val resultCode =
+        when (result) {
+            is MultimediaResult.Success -> Activity.RESULT_OK
+            is MultimediaResult.Cancelled -> Activity.RESULT_CANCELED
+        }
+    requireActivity().setResult(resultCode, data)
+    requireActivity().finish()
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This replaces Bundle-based extras + Serializable passing between the note editor and multimedia fragments with a typed MultimediaResult / MultimediaResultContract. No behavior change;

## Fixes
NA

## Approach
see commits

## How Has This Been Tested?
Pixel 10

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->