### PR TITLE
fix(study-screen): copying to clipboard 

### DIFF
--- a/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
@@ -36,6 +36,16 @@ globalThis.ankidroid.onTypeAnswerKeyDown = function (event) {
 // ============================================================================
 
 (() => {
+    function localRequest(endpoint, payload = {}) {
+        fetch(`ankidroid/${endpoint}`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(payload),
+        }).catch(err => console.log("Failed to reach local server:", err));
+    }
+
     /**
      * Checks if the target element is a text input field.
      * @param {Event} event
@@ -46,16 +56,15 @@ globalThis.ankidroid.onTypeAnswerKeyDown = function (event) {
         return target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA");
     }
 
-    // Communicate whether a text input is focused to avoid triggering controls if necessary
     document.addEventListener("focusin", event => {
         if (isTextInput(event)) {
-            window.location.href = `ankidroid://focusin`;
+            localRequest("focusin");
         }
     });
 
     document.addEventListener("focusout", event => {
         if (isTextInput(event)) {
-            window.location.href = `ankidroid://focusout`;
+            localRequest("focusout");
         }
     });
 })();

--- a/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
+++ b/AnkiDroid/src/main/assets/scripts/ankidroid-reviewer.js
@@ -31,13 +31,38 @@ globalThis.ankidroid.onTypeAnswerKeyDown = function (event) {
     }
 };
 
-document.addEventListener("focusin", event => {
-    window.location.href = `ankidroid://focusin`;
-});
+// ============================================================================
+// Input focus listeners
+// ============================================================================
 
-document.addEventListener("focusout", event => {
-    window.location.href = `ankidroid://focusout`;
-});
+(() => {
+    /**
+     * Checks if the target element is a text input field.
+     * @param {Event} event
+     * @returns {boolean}
+     */
+    function isTextInput(event) {
+        const target = event.target;
+        return target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA");
+    }
+
+    // Communicate whether a text input is focused to avoid triggering controls if necessary
+    document.addEventListener("focusin", event => {
+        if (isTextInput(event)) {
+            window.location.href = `ankidroid://focusin`;
+        }
+    });
+
+    document.addEventListener("focusout", event => {
+        if (isTextInput(event)) {
+            window.location.href = `ankidroid://focusout`;
+        }
+    });
+})();
+
+// ============================================================================
+// Gesture detection
+// ============================================================================
 
 (() => {
     const SCHEME = "gesture";

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/AnkiServer.kt
@@ -73,6 +73,7 @@ open class AnkiServer(
 
         /** Common prefix used on Anki requests */
         const val ANKI_PREFIX = "/_anki/"
+        const val ANKIDROID_PREFIX = "/ankidroid/"
         const val ANKIDROID_JS_PREFIX = "/jsapi/"
 
         fun getSessionBytes(session: IHTTPSession): ByteArray {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/PostRequestHandler.kt
@@ -63,6 +63,14 @@ interface PostRequestHandler {
 value class PostRequestUri(
     val uri: String,
 ) {
+    val ankidroidMethodName: String?
+        get() =
+            if (uri.startsWith(AnkiServer.ANKIDROID_PREFIX)) {
+                uri.substring(AnkiServer.ANKIDROID_PREFIX.length)
+            } else {
+                null
+            }
+
     val backendMethodName: String?
         get() =
             if (uri.startsWith(AnkiServer.ANKI_PREFIX)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -116,7 +116,6 @@ class ReviewerFragment :
     private val sensorManager get() = ContextCompat.getSystemService(requireContext(), SensorManager::class.java)
     private val whiteboardFragment get() = childFragmentManager.findFragmentByTag(WhiteboardFragment::class.jvmName) as? WhiteboardFragment
     private val isBigScreen: Boolean get() = resources.configuration.smallestScreenWidthDp >= 720
-    private var webviewHasFocus = false
 
     override val baseSnackbarBuilder: SnackbarBuilder = {
         anchorView =
@@ -320,7 +319,7 @@ class ReviewerFragment :
 
     @NeedsTest("Whiteboard takes priority on key events")
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
-        if (webviewHasFocus ||
+        if (
             event.action != KeyEvent.ACTION_DOWN ||
             view?.let { binding.typeAnswerEditText }?.isFocused == true
         ) {
@@ -671,8 +670,6 @@ class ReviewerFragment :
                 }
                 "ankidroid" -> {
                     when (url.host) {
-                        "focusin" -> webviewHasFocus = true
-                        "focusout" -> webviewHasFocus = false
                         "show-answer" -> viewModel.onShowAnswer()
                     }
                     true

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -99,6 +99,7 @@ class ReviewerViewModel(
                 ?: Card(anki.cards.Card.getDefaultInstance())
         }
     private val repository = StudyScreenRepository()
+    private var isInputFocused = false
     val finishResultFlow = MutableSharedFlow<Int>()
     val isMarkedFlow = MutableStateFlow(false)
     val flagFlow = MutableStateFlow(Flag.NONE)
@@ -439,12 +440,23 @@ class ReviewerViewModel(
     override suspend fun handlePostRequest(
         uri: PostRequestUri,
         bytes: ByteArray,
-    ): ByteArray =
-        when (uri.backendMethodName) {
+    ): ByteArray {
+        when (uri.ankidroidMethodName) {
+            "focusin" -> {
+                isInputFocused = true
+                return byteArrayOf()
+            }
+            "focusout" -> {
+                isInputFocused = false
+                return byteArrayOf()
+            }
+        }
+        return when (uri.backendMethodName) {
             "getSchedulingStatesWithContext" -> getSchedulingStatesWithContext()
             "setSchedulingStates" -> setSchedulingStates(bytes)
             else -> super.handlePostRequest(uri, bytes)
         }
+    }
 
     override suspend fun showQuestion() {
         Timber.v("ReviewerViewModel::showQuestion")
@@ -750,7 +762,11 @@ class ReviewerViewModel(
         binding: ReviewerBinding,
     ): Boolean {
         Timber.v("ReviewerViewModel::processAction")
-        if (binding.side != CardSide.BOTH && CardSide.fromAnswer(showingAnswer.value) != binding.side) return false
+        if ((binding.side != CardSide.BOTH && CardSide.fromAnswer(showingAnswer.value) != binding.side) ||
+            (binding.isKey && isInputFocused)
+        ) {
+            return false
+        }
         executeAction(action)
         return true
     }


### PR DESCRIPTION
## Purpose / Description

fixes an issue in a (too) hacky notetype that creates an invisible text area and uses a deprecated HTML method to copy stuff to the clipboard

https://forums.ankiweb.net/t/new-study-screen-is-blocking-some-of-the-javascript-features/67530

Instead of using a `window.location.href`, which stops the event propagation, I used POST requests

Now, communicating from the JS code to the Kotlin code is mixed between `window.location.href` GET requests and POST requests, so it should be discussed whether the old requests should be migrated to POST requests as well

## Fixes
* Fixes #20719

## How Has This Been Tested?

Emulator 37

[Screen_recording_20260422_071636.webm](https://github.com/user-attachments/assets/87491c65-8f83-497b-bc3b-3867817bb997)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->