### PR TITLE
fix(study-screen): keep timer stopped

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimer.kt
@@ -44,7 +44,8 @@ class AnswerTimer : DefaultLifecycleObserver {
     fun stop() {
         when (val currentState = _state.value) {
             is AnswerTimerState.Running -> {
-                val elapsed = SystemClock.elapsedRealtime() - currentState.baseTime
+                val elapsed = (SystemClock.elapsedRealtime() - currentState.baseTime).coerceAtMost(currentState.limitMs.toLong())
+
                 _state.value =
                     AnswerTimerState.Stopped(
                         elapsedTimeMs = elapsed,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/AnswerTimerTest.kt
@@ -184,4 +184,19 @@ class AnswerTimerTest {
         assertTrue(state is AnswerTimerState.Stopped)
         assertEquals(2000L, (state).elapsedTimeMs)
     }
+
+    @Test
+    fun `stop clamps elapsed time to limit if exceeded`() {
+        currentTime = 1000L
+        val limit = 5000
+        answerTimer.configureForCard(shouldShow = true, limitMs = limit)
+
+        currentTime = 7000L
+        answerTimer.stop()
+
+        val state = answerTimer.state.value
+        assertTrue(state is AnswerTimerState.Stopped)
+
+        assertEquals(5000L, (state).elapsedTimeMs)
+    }
 }


### PR DESCRIPTION
if the timer was stopped and `Show answer` got pressed, the elapsed time increased past the timer limit

Auto-advance isn't necessary to reproduce that

## Fixes
* Fixes #20771

## How Has This Been Tested?

Emulator 37

[Screen_recording_20260422_140959.webm](https://github.com/user-attachments/assets/0720f070-16a4-4cf2-8c02-6384220b4f10)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->