### PR TITLE
fix(widgets): refresh after day cutoff

### DIFF
--- a/AnkiDroid/src/main/AndroidManifest.xml
+++ b/AnkiDroid/src/main/AndroidManifest.xml
@@ -612,6 +612,16 @@
             </intent-filter>
         </receiver>
 
+        <!-- #14372: Handles updates after the day rollover (04:00). -->
+        <receiver android:name="com.ichi2.widget.DayRolloverAlarm"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.ichi2.widget.ACTION_ROLLOVER" />
+                <action android:name="android.intent.action.TIMEZONE_CHANGED" />
+                <action android:name="android.intent.action.TIME_SET" />
+            </intent-filter>
+        </receiver>
+
         <receiver
             android:name="com.ichi2.anki.receiver.SdCardReceiver"
             android:enabled="true"

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -65,6 +65,7 @@ import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.LanguageUtil.withAppLocale
 import com.ichi2.utils.Permissions
 import com.ichi2.utils.setWebContentsDebuggingEnabled
+import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import com.ichi2.widget.restoreRecurringAlarms
@@ -215,6 +216,7 @@ open class AnkiDroidApp :
 
         // listen for day rollover: time + timezone changes
         DayRolloverHandler.listenForRolloverEvents(this)
+        DayRolloverAlarm.scheduleNext(this)
 
         restoreRecurringAlarms(this)
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -40,6 +40,7 @@ import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.libanki.EpochSeconds
 import com.ichi2.anki.libanki.sched.Scheduler
 import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.WidgetStatus
 import kotlinx.coroutines.Dispatchers
 import timber.log.Timber
@@ -50,7 +51,12 @@ import timber.log.Timber
  * If so, notifies [ChangeManager] that [studyQueues][OpChanges.getStudyQueues] have changed
  *
  * HACK: This exists due to Android's complexities of scheduling an event at a given time.
- * It would be preferred to receive an event at the instant of rollover
+ * It would be preferred to receive an event at the instant of rollover.
+ *
+ * NOTE: this may not be registered in the manifest as it listens for [ACTION_TIME_TICK].
+ *
+ * @see DayRolloverAlarm for a Manifest-registered alternative (using AlarmManager.setWindow - less
+ * precise).
  */
 object DayRolloverHandler : AnkiBroadcastReceiver() {
     /** @see Scheduler.dayCutoff */
@@ -102,6 +108,8 @@ object DayRolloverHandler : AnkiBroadcastReceiver() {
         if (lastCutoff == currentCutoff) return
 
         Timber.i("day cutoff changed %d -> %d", lastCutoff, currentCutoff)
+        // Re-arm the wall-clock alarm whenever the cutoff changes
+        DayRolloverAlarm.scheduleNext(AnkiDroidApp.instance)
         // we do not want to send a "study queues changes" message initially
         if (lastCutoff != null) {
             handleDayRollover()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewingSettingsFragment.kt
@@ -29,6 +29,7 @@ import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.CollectionPreferences
 import com.ichi2.preferences.NumberRangePreferenceCompat
 import com.ichi2.preferences.SliderPreference
+import com.ichi2.widget.DayRolloverAlarm
 import timber.log.Timber
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -87,5 +88,6 @@ suspend fun setDayOffset(
         setPreferences(newPrefs)
     }
     if (!Prefs.newReviewRemindersEnabled) scheduleNotification(TimeManager.time, context)
+    DayRolloverAlarm.scheduleNext(context)
     Timber.i("set day offset: '%d'", hours)
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/services/BootService.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.preferences.PENDING_NOTIFICATIONS_ONLY
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.showThemedToast
+import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.restoreRecurringAlarms
 import timber.log.Timber
 import java.util.Calendar
@@ -82,6 +83,7 @@ class BootService : AnkiBroadcastReceiver() {
         }
 
         restoreRecurringAlarms(context)
+        DayRolloverAlarm.scheduleNext(context)
         wasRun = true
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -61,6 +61,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
         super.onEnabled(context)
         val preferences = context.sharedPrefs()
         preferences.edit(commit = true) { putBoolean("widgetSmallEnabled", true) }
+        DayRolloverAlarm.scheduleNext(context)
     }
 
     override fun onDisabled(context: Context) {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
@@ -1,0 +1,163 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_TIMEZONE_CHANGED
+import android.content.Intent.ACTION_TIME_CHANGED
+import androidx.annotation.VisibleForTesting
+import androidx.core.app.PendingIntentCompat
+import androidx.core.content.getSystemService
+import anki.collection.opChanges
+import com.ichi2.anki.AnkiDroidApp.Companion.applicationScope
+import com.ichi2.anki.CollectionManager.withOpenColOrNull
+import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.time.TimeManager
+import com.ichi2.anki.exception.ManuallyReportedException
+import com.ichi2.anki.launchCatching
+import com.ichi2.anki.libanki.EpochMilliseconds
+import com.ichi2.anki.libanki.sched.Scheduler
+import com.ichi2.anki.observability.ChangeManager
+import com.ichi2.anki.services.AlarmManagerService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import timber.log.Timber
+import java.util.Date
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Schedules a wake-up alarm at the collection's next [dayCutoff][Scheduler.dayCutoff] and refreshes
+ * widgets when it fires.
+ *
+ * Manifest-declared so it survives normal process death.
+ * Does not handle `FLAG_STOPPED` (force-stop or aggressive OEM swipe-to-kill/battery optimizations)
+ */
+class DayRolloverAlarm : AnkiBroadcastReceiver() {
+    override fun onReceiveBroadcast(
+        context: Context,
+        intent: Intent,
+    ) {
+        applicationScope.launchCatchingIoWithReport("DayRolloverAlarm::onReceive") {
+            Timber.i("DayRolloverAlarm received %s", intent.action)
+            when (intent.action) {
+                ACTION_ROLLOVER -> {
+                    Timber.i("ACTION_ROLLOVER: Updating widgets")
+                    ChangeManager.notifySubscribers(opChanges { studyQueues = true }, initiator = null)
+                    runCatching { WidgetStatus.updateInBackground(context) }.onFailure { Timber.w(it) }
+                    scheduleNextInternal(context)
+                }
+                ACTION_TIMEZONE_CHANGED, ACTION_TIME_CHANGED -> scheduleNextInternal(context)
+            }
+        }
+    }
+
+    companion object {
+        /** Custom action used for when [dayCutoff][Scheduler.dayCutoff] is reached. */
+        const val ACTION_ROLLOVER = "com.ichi2.widget.ACTION_ROLLOVER"
+
+        /**
+         * Set an alarm at the next `dayCutoff`.
+         * Idempotent (repeated calls update the existing pending intent).
+         */
+        fun scheduleNext(context: Context) {
+            applicationScope.launchCatchingIoWithReport("DayRolloverAlarm::scheduleNext") {
+                scheduleNextInternal(context)
+            }
+        }
+
+        @VisibleForTesting
+        internal suspend fun scheduleNextInternal(context: Context) {
+            val cutoffMs = nextFutureCutoffMs() ?: return
+            val pendingIntent = context.buildPendingIntent(ACTION_ROLLOVER) ?: return
+            val alarmManager = context.getSystemService<AlarmManager>() ?: return
+            // TODO: This uses setWindow with a 10 minute window, so likely fires at 04:10, rather than 04:00
+            // Consider requesting SCHEDULE_EXACT_ALARM,
+            alarmManager.setWindowSafe(
+                type = AlarmManager.RTC_WAKEUP,
+                windowStartMillis = cutoffMs,
+                windowLengthMillis = AlarmManagerService.WINDOW_LENGTH_MS,
+                operation = pendingIntent,
+            )
+        }
+
+        /**
+         * The next `[Scheduler.dayCutoff]`, or `null` if the alarm should not be set.
+         */
+        private suspend fun nextFutureCutoffMs(): EpochMilliseconds? {
+            val cutoffMs = (withOpenColOrNull { sched.dayCutoff } ?: return null) * 1000L
+            if (cutoffMs <= TimeManager.time.intTimeMS()) {
+                Timber.w("dayCutoff %d is not in the future; skipping", cutoffMs)
+                return null
+            }
+            return cutoffMs
+        }
+
+        private fun Context.buildPendingIntent(
+            @Suppress("SameParameterValue") action: String,
+        ): PendingIntent? =
+            PendingIntentCompat.getBroadcast(
+                this,
+                0,
+                Intent(this, DayRolloverAlarm::class.java).apply { this.action = action },
+                PendingIntent.FLAG_UPDATE_CURRENT,
+                false,
+            )
+    }
+}
+
+/**
+ * [AlarmManager.setWindow] implementation which catches exceptions.
+ */
+private fun AlarmManager.setWindowSafe(
+    type: Int,
+    windowStartMillis: EpochMilliseconds,
+    windowLengthMillis: Long,
+    operation: PendingIntent,
+) = try {
+    setWindow(type, windowStartMillis, windowLengthMillis, operation)
+    val delta = (windowStartMillis - TimeManager.time.intTimeMS()).milliseconds
+    Timber.i("scheduled day rollover alarm at %s (in %s)", Date(windowStartMillis), delta)
+} catch (e: SecurityException) {
+    // #6332 - Too Many Alarms on Samsung Devices
+    Timber.w(e, "too many alarms — could not schedule alarm")
+} catch (e: Exception) {
+    Timber.w(e, "failed to schedule alarm")
+}
+
+/**
+ * Launches [block] on [Dispatchers.IO], reporting exceptions to ACRA.
+ *
+ * @param origin origin in the crash report
+ */
+private fun CoroutineScope.launchCatchingIoWithReport(
+    origin: String,
+    block: suspend () -> Unit,
+) {
+    launchCatching(Dispatchers.IO, errorMessageHandler = { msg ->
+        CrashReportService.sendExceptionReport(
+            e = ManuallyReportedException(msg),
+            origin = origin,
+            onlyIfSilent = true,
+        )
+    }) {
+        block()
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -39,6 +39,7 @@ import com.ichi2.widget.AppWidgetId
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId
 import com.ichi2.widget.AppWidgetIds
+import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cancelRecurringAlarm
 import com.ichi2.widget.deckpicker.DeckWidgetData
 import com.ichi2.widget.deckpicker.getDeckNameAndStats
@@ -227,6 +228,11 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
                 updateWidget(context, appWidgetManager, appWidgetId)
             }
         }
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        DayRolloverAlarm.scheduleNext(context)
     }
 
     override fun performUpdate(

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -39,6 +39,7 @@ import com.ichi2.widget.AppWidgetId
 import com.ichi2.widget.AppWidgetId.Companion.INVALID_APPWIDGET_ID
 import com.ichi2.widget.AppWidgetId.Companion.getAppWidgetId
 import com.ichi2.widget.AppWidgetIds
+import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cancelRecurringAlarm
 import com.ichi2.widget.getAppWidgetIdsEx
 import com.ichi2.widget.setRecurringAlarm
@@ -237,6 +238,11 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
                 updateWidget(context, appWidgetManager, appWidgetId, deckIds)
             }
         }
+    }
+
+    override fun onEnabled(context: Context) {
+        super.onEnabled(context)
+        DayRolloverAlarm.scheduleNext(context)
     }
 
     override fun performUpdate(

--- a/AnkiDroid/src/test/java/com/ichi2/widget/DayRolloverAlarmTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/widget/DayRolloverAlarmTest.kt
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.widget
+
+import android.app.AlarmManager
+import android.content.Context
+import androidx.core.content.getSystemService
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.services.AlarmManagerService
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.greaterThan
+import org.junit.After
+import org.junit.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class DayRolloverAlarmTest : RobolectricTest() {
+    private val mockContext: Context = mockk(relaxed = true)
+    private val alarmManager: AlarmManager = mockk(relaxed = true)
+
+    init {
+        every { mockContext.getSystemService<AlarmManager>() } returns alarmManager
+    }
+
+    @After
+    override fun tearDown() {
+        super.tearDown()
+        unmockkAll()
+    }
+
+    @Test
+    fun `doScheduleNext calls setWindow with dayCutoff`() =
+        runTest {
+            val expectedCutoffMs = col.sched.dayCutoff * 1000L
+
+            DayRolloverAlarm.scheduleNextInternal(mockContext)
+
+            verify {
+                alarmManager.setWindow(
+                    AlarmManager.RTC_WAKEUP,
+                    expectedCutoffMs,
+                    AlarmManagerService.WINDOW_LENGTH_MS,
+                    any(),
+                )
+            }
+
+            assertThat("alarm is in the future", expectedCutoffMs, greaterThan(collectionTime.intTimeMS()))
+        }
+
+    @Test
+    fun `doScheduleNext does not crash`() =
+        runTest {
+            every {
+                alarmManager.setWindow(AlarmManager.RTC_WAKEUP, any(), any(), any<android.app.PendingIntent>())
+            } throws SecurityException("too many alarms")
+
+            assertDoesNotThrow { DayRolloverAlarm.scheduleNextInternal(mockContext) }
+        }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - initial implementation, was heavily refactored

## Purpose / Description
Before this change, widgets depended on `ACTION_TIME_TICK` OR `android:updatePeriodMillis`.

If the app was closed, `ACTION_TIME_TICK` did not fire.

`android:updatePeriodMillis` is sometimes blocked by OEMs, and AlarmManager, and it's not guaranteed to execute on the hour.

## Fixes
* Fixes #14372

## Approach
`AlarmManager.setWindow` reduces this discrepancy to 10 minutes (the reasonable minimum for setWindow), and is less likely to be blocked.

⚠️ It's fine for this to fire alongside other mechanisms, which work better when the app is open (`ACTION_TIME_TICK`)

## How Has This Been Tested?


```diff
 ---------------------------- PROCESS STARTED (10276) for package com.ichi2.anki.debug ----------------------------
17:10:00.462 WM-ForceStopRunnable     D  Performing cleanup operations.
17:10:00.474 Compatibil...geReporter  D  Compat change id reported: 160794467; UID 10213; state: ENABLED
17:10:00.475 WM-ForceStopRunnable     D  Application was force-stopped, rescheduling.
17:10:00.490 WM-PackageManagerHelper  D  Skipping component enablement for androidx.work.impl.background.systemalarm.RescheduleReceiver
17:10:00.511 ACRA                     I  ACRA is enabled for com.ichi2.anki.debug, initializing...
17:10:00.532 AnkiDroid                D  Startup - Application Start
17:10:00.533 AnkiDroidApp             I  Timber config: DEBUG
17:10:00.533 UsageAnalytics           I  initialize()
17:10:00.533 UsageAnalytics           D  App tracking id 'tid' = UA-125800786-1
17:10:00.540 WebViewFactory           I  Loading com.google.android.webview version 109.0.5414.123 (code 541412334)
17:10:00.542 ziparchive               W  Unable to open '/data/app/~~vXK58OHzI9vwltSMqHUJtQ==/com.google.android.trichromelibrary_541412334-CB-KlrByVXO4EHhZPnsnaw==/TrichromeLibrary.dm': No such file or directory
17:10:00.542 ziparchive               W  Unable to open '/data/app/~~vXK58OHzI9vwltSMqHUJtQ==/com.google.android.trichromelibrary_541412334-CB-KlrByVXO4EHhZPnsnaw==/TrichromeLibrary.dm': No such file or directory
17:10:00.542 chi2.anki.debug          W  Entry not found
17:10:00.542 nativeloader             D  Configuring classloader-namespace for other apk /data/app/~~vXK58OHzI9vwltSMqHUJtQ==/com.google.android.trichromelibrary_541412334-CB-KlrByVXO4EHhZPnsnaw==/TrichromeLibrary.apk. target_sdk_version=33, uses_libraries=ALL, library_path=/data/app/~~QQxb022gmUKTqMVRgLXkfw==/com.google.android.webview-5Hm-_eOq8T2dbUtiPOvEZw==/lib/arm64:/data/app/~~QQxb022gmUKTqMVRgLXkfw==/com.google.android.webview-5Hm-_eOq8T2dbUtiPOvEZw==/WebViewGoogle.apk!/lib/arm64-v8a:/data/app/~~vXK58OHzI9vwltSMqHUJtQ==/com.google.android.trichromelibrary_541412334-CB-KlrByVXO4EHhZPnsnaw==/TrichromeLibrary.apk!/lib/arm64-v8a, permitted_path=/data:/mnt/expand
17:10:00.544 nativeloader             D  Configuring classloader-namespace for other apk /data/app/~~QQxb022gmUKTqMVRgLXkfw==/com.google.android.webview-5Hm-_eOq8T2dbUtiPOvEZw==/WebViewGoogle.apk. target_sdk_version=33, uses_libraries=, library_path=/data/app/~~QQxb022gmUKTqMVRgLXkfw==/com.google.android.webview-5Hm-_eOq8T2dbUtiPOvEZw==/lib/arm64:/data/app/~~QQxb022gmUKTqMVRgLXkfw==/com.google.android.webview-5Hm-_eOq8T2dbUtiPOvEZw==/WebViewGoogle.apk!/lib/arm64-v8a:/data/app/~~vXK58OHzI9vwltSMqHUJtQ==/com.google.android.trichromelibrary_541412334-CB-KlrByVXO4EHhZPnsnaw==/TrichromeLibrary.apk!/lib/arm64-v8a, permitted_path=/data:/mnt/expand
17:10:00.550 chi2.anki.debug          W  Accessing hidden method Landroid/os/Trace;->isTagEnabled(J)Z (unsupported, reflection, allowed)
17:10:00.550 chi2.anki.debug          W  Accessing hidden method Landroid/os/Trace;->traceBegin(JLjava/lang/String;)V (unsupported, reflection, allowed)
17:10:00.550 chi2.anki.debug          W  Accessing hidden method Landroid/os/Trace;->traceEnd(J)V (unsupported, reflection, allowed)
17:10:00.550 chi2.anki.debug          W  Accessing hidden method Landroid/os/Trace;->asyncTraceBegin(JLjava/lang/String;I)V (unsupported, reflection, allowed)
17:10:00.550 chi2.anki.debug          W  Accessing hidden method Landroid/os/Trace;->asyncTraceEnd(JLjava/lang/String;I)V (unsupported, reflection, allowed)
17:10:00.552 cr_WVCFactoryProvider    I  Loaded version=109.0.5414.123 minSdkVersion=29 isBundle=false multiprocess=true packageId=2
17:10:00.556 cr_VariationsUtils       I  Failed reading seed file "/data/user/0/com.ichi2.anki.debug/app_webview/variations_seed_new"
17:10:00.556 cr_VariationsUtils       I  Failed reading seed file "/data/user/0/com.ichi2.anki.debug/app_webview/variations_seed"
17:10:00.558 cr_LibraryLoader         I  Successfully loaded native library
17:10:00.558 cr_CachingUmaRecorder    I  Flushed 9 samples from 9 histograms.
17:10:00.576 Compatibil...geReporter  D  Compat change id reported: 183155436; UID 10213; state: ENABLED
17:10:00.638 chromium                 E  [ERROR:simple_version_upgrade.cc(152)] Failed to write a new fake index.
17:10:00.638 chromium                 E  [ERROR:simple_version_upgrade.cc(152)] Failed to write a new fake index.
17:10:00.642 Compatibil...geReporter  D  Compat change id reported: 214741472; UID 10213; state: ENABLED
17:10:00.650 GoogleAnalyticsImpl      I  Not participating in analytics sample (sample percentage vs random: 10 30)
17:10:00.650 UsageAnalytics           D  Chaining to uncaughtExceptionHandler (org.chromium.base.JavaExceptionReporter@8e2840d)
17:10:00.650 UsageAnalytics           I  setOptIn(): from false to false
17:10:00.650 GoogleAnalyticsImpl      I  Not participating in analytics sample (sample percentage vs random: 10 54)
17:10:00.650 UsageAnalytics           D  setOptIn() optIn / sAnalytics.config().enabled(): false/false
17:10:00.651 UsageAnalytics           I  setDryRun(): true, warning dryRun is experimental
17:10:00.651 ThrowableFilterService   I  initialize()
17:10:00.652 ThrowableFilterService   D  Chaining to uncaughtExceptionHandler (com.ichi2.anki.analytics.UsageAnalytics$$ExternalSyntheticLambda0@66e11d3)
17:10:00.653 AnkiDroidApp$onCreate    I  AnkiDroidApp: listing debug info
17:10:00.656 TestUtils                D  isRunningAsUnitTest: false
17:10:00.658 NotificationChannelsKt   I  Creating notification channel with id/name: General Notifications/AnkiDroid
17:10:00.660 NotificationChannelsKt   I  Creating notification channel with id/name: Synchronization/Synchronization
17:10:00.660 NotificationChannelsKt   I  Creating notification channel with id/name: Review Reminders/Review Reminders
17:10:00.674 AnkiDroidApp             I  AnkiDroidApp: Starting Services
17:10:00.674 DayRolloverHandler       D  listening for rollover events
17:10:00.679 WidgetAlarmKt            D  Restoring 1 alarms for DeckPickerWidget
17:10:00.679 WidgetAlarmKt            V  Creating a new recurring alarm PendingIntent for widget ID: AppWidgetId(id=3)
17:10:00.683 WidgetAlarmKt            D  Restoring 1 alarms for CardAnalysisWidget
17:10:00.684 WidgetAlarmKt            V  Creating a new recurring alarm PendingIntent for widget ID: AppWidgetId(id=4)
17:10:00.685 TtsVoices                D  launching job
17:10:00.686 TtsVoices$...LocalesJob  D  executing job
17:10:00.686 TtsVoices                V  begin TTS creation
+ 17:10:00.689 DayRollove...eBroadcast  I  DayRolloverAlarm received com.ichi2.widget.ACTION_ROLLOVER
17:10:00.691 AnkiDroidApp             D  ChangeSubscriber - opExecuted called with changes: # anki.collection.OpChanges@7d4149f5
                                         study_queues: true
17:10:00.692 DeckPicker...$Companion  D  Fetching appWidgetIds for provider: com.ichi2.widget.deckpicker.DeckPickerWidget
17:10:00.693 TextToSpeech             I  Sucessfully bound to com.google.android.tts
17:10:00.696 DeckPicker...$Companion  D  AppWidgetIds to update: AppWidgetId(id=3)
17:10:00.700 TextToSpeech             I  Connected to TTS engine
17:10:00.700 CardAnalys...$Companion  D  Fetching appWidgetIds for provider: com.ichi2.widget.cardanalysis.CardAnalysisWidget
17:10:00.701 CardAnalys...$Companion  D  AppWidgetIds to update: AppWidgetId(id=4)
17:10:00.702 TextToSpeech             I  Setting up the connection to TTS engine...
17:10:00.704 WidgetStatus             D  WidgetStatus.update(): updating
17:10:00.704 Compatibil...geReporter  D  Compat change id reported: 171228096; UID 10213; state: ENABLED
17:10:00.720 Backend                  D  Opening rust backend with lang=[en-US]
17:10:00.726 rsdroid                  I  rsdroid::logging: rsdroid logging enabled
17:10:00.736 TtsVoices$createTts      V  TTS creation success
17:10:00.762 Media                    V  dir /storage/emulated/0/Android/data/com.ichi2.anki.debug/files/AnkiDroid/collection.media
17:10:00.762 Collection               I  (Re)opening Database: Path(path=/storage/emulated/0/Android/data/com.ichi2.anki.debug/files/AnkiDroid/collection.anki2)
17:10:00.780 MetaDB                   V  Opening MetaDB
17:10:00.782 AnkiDroidApp$onCreate    I  AnkiDroid Version = 2.24.0beta1-debug (8749e374bab346d8bb3c7fb80301e7517b7b0b06)  
                                         Backend Version = 0.1.64-anki25.09.2 (25.09.2 3890e12c9e48c028c3f12aa58cb64bd9f8895e30)  
                                         Android Version = 13 (SDK 33)  
                                         ProductFlavor = play  
                                         Device Info = Google | google | emu64a | sdk_gphone64_arm64 | sdk_gphone64_arm64 | ranchu  
                                         WebView Info = [com.google.android.webview | 541412334]: Mozilla/5.0 (Linux; Android 13; sdk_gphone64_arm64 Build/TE1A.240213.009; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/109.0.5414.123 Mobile Safari/537.36  
                                         ACRA UUID = 7be52d95-7b34-457d-bfdd-5d7fb723cd35  
                                         FSRS = 5.1.0 (Enabled: false)  
                                         Crash Reports Enabled = false
17:10:00.785 MetaDB                   D  MetaDB:: Cached small widget status
17:10:00.785 WidgetStatus             I  triggering small widget UI update
17:10:00.785 AnkiDroidW...ateService  D  updating small widget UI
17:10:00.788 WidgetStat...tUpdateJob  V  launchUpdateJob completed
17:10:00.790 Notificati...$Companion  I  NotificationService: OnStartCommand
17:10:00.863 TtsVoices$...LocalesJob  D  65 TTS Voices available
17:10:00.864 TextToSpeech             I  Disconnected from TTS engine
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)