### PR TITLE
fix(study-screen): audio record behavior when put in the background

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/AudioPlayer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/AudioPlayer.kt
@@ -25,7 +25,9 @@ class AudioPlayer : Closeable {
 
     var isPlaying = false
         private set
-    private var isPrepared = false
+    var isPaused = false
+        private set
+    var isPrepared = false
 
     var onCompletion: (() -> Unit)? = null
 
@@ -37,6 +39,7 @@ class AudioPlayer : Closeable {
     init {
         mediaPlayer.setOnCompletionListener {
             isPlaying = false
+            isPaused = false
             onCompletion?.invoke()
         }
     }
@@ -50,6 +53,7 @@ class AudioPlayer : Closeable {
             mediaPlayer.reset()
             isPrepared = false
             isPlaying = false
+            isPaused = false
 
             mediaPlayer.setDataSource(filePath)
             mediaPlayer.setOnPreparedListener { mp ->
@@ -65,12 +69,31 @@ class AudioPlayer : Closeable {
         }
     }
 
+    fun pause() {
+        Timber.i("AudioPlayer::pause (isPlaying %b)", isPlaying)
+        if (isPlaying) {
+            mediaPlayer.pause()
+            isPlaying = false
+            isPaused = true
+        }
+    }
+
+    fun resume() {
+        Timber.i("AudioPlayer::resume (isPaused %b)", isPaused)
+        if (isPaused) {
+            mediaPlayer.start()
+            isPlaying = true
+            isPaused = false
+        }
+    }
+
     fun replay() {
         Timber.i("AudioPlayer::replay (isPlaying %b) (isPrepared %b)", isPlaying, isPrepared)
         if (isPrepared) {
             mediaPlayer.seekTo(0)
             mediaPlayer.start()
             isPlaying = true
+            isPaused = false
         }
     }
 
@@ -79,5 +102,6 @@ class AudioPlayer : Closeable {
         mediaPlayer.reset()
         isPrepared = false
         isPlaying = false
+        isPaused = false
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/AudioRecordView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/AudioRecordView.kt
@@ -80,6 +80,9 @@ class AudioRecordView : ConstraintLayout {
     private val cancelFadeOffset: Float
     private val lockOffset: Float
 
+    val isRecording: Boolean
+        get() = state == ViewState.RECORDING || state == ViewState.LOCKED
+
     private var recordingListener: RecordingListener? = null
 
     fun setRecordingListener(recordingListener: RecordingListener) {
@@ -293,6 +296,12 @@ class AudioRecordView : ConstraintLayout {
     fun setRecordDisplayVisibility(isVisible: Boolean) {
         binding.chronometer.isVisible = isVisible
         binding.recordingDisplayIcon.isVisible = isVisible
+    }
+
+    fun finishRecording() {
+        if (isRecording) {
+            stopRecording(RecordingBehavior.RELEASE)
+        }
     }
 
     private fun displayRunningRecord() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationFragment.kt
@@ -130,7 +130,8 @@ class CheckPronunciationFragment : Fragment(R.layout.fragment_check_pronunciatio
             .collectIn(lifecycleScope) { max ->
                 binding.playView.setPlaybackProgressBarMax(max)
             }
-        viewModel.playIconFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { iconRes ->
+        viewModel.isPlayingFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isPlaying ->
+            val iconRes = if (isPlaying) R.drawable.ic_replay else R.drawable.ic_play
             binding.playView.changePlayIcon(iconRes)
         }
         viewModel.replayFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationFragment.kt
@@ -77,8 +77,10 @@ class CheckPronunciationFragment : Fragment(R.layout.fragment_check_pronunciatio
         if (requireActivity().isChangingConfigurations) {
             return
         }
-        viewModel.resetAll()
-        binding.recordView.forceReset()
+        if (binding.recordView.isRecording) {
+            binding.recordView.finishRecording()
+        }
+        viewModel.pausePlayback()
     }
 
     private fun setupViewListeners() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
@@ -69,6 +69,16 @@ class CheckPronunciationViewModel(
         }
     }
 
+    fun pausePlayback() {
+        if (isPlaying) {
+            progressBarUpdateJob?.cancel()
+            audioPlayer.pause()
+            viewModelScope.launch {
+                isPlayingFlow.emit(false)
+            }
+        }
+    }
+
     fun onPlayOrReplay() {
         if (!isPlaybackVisibleFlow.value) return
 
@@ -77,6 +87,10 @@ class CheckPronunciationViewModel(
             viewModelScope.launch {
                 replayFlow.emit(Unit)
             }
+        } else if (audioPlayer.isPaused) {
+            viewModelScope.launch { isPlayingFlow.emit(true) }
+            audioPlayer.resume()
+            launchProgressBarUpdateJob()
         } else {
             viewModelScope.launch { isPlayingFlow.emit(true) }
             playCurrentFile()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModel.kt
@@ -18,7 +18,6 @@ package com.ichi2.anki.ui.windows.reviewer.audiorecord
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ichi2.anki.AnkiDroidApp
-import com.ichi2.anki.R
 import com.ichi2.anki.recorder.AudioRecorder
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -37,14 +36,14 @@ class CheckPronunciationViewModel(
         audioPlayer.onCompletion = {
             viewModelScope.launch {
                 playbackProgressFlow.emit(playbackProgressBarMaxFlow.value)
-                playIconFlow.emit(R.drawable.ic_play)
+                isPlayingFlow.emit(false)
             }
         }
     }
 
     val playbackProgressFlow = MutableStateFlow(0)
     val playbackProgressBarMaxFlow = MutableStateFlow(1)
-    val playIconFlow = MutableStateFlow(R.drawable.ic_play)
+    val isPlayingFlow = MutableStateFlow(false)
     val replayFlow = MutableSharedFlow<Unit>()
     val isPlaybackVisibleFlow = MutableStateFlow(false)
 
@@ -65,7 +64,7 @@ class CheckPronunciationViewModel(
         audioRecorder.stop()
         viewModelScope.launch {
             isPlaybackVisibleFlow.emit(true)
-            playIconFlow.emit(R.drawable.ic_play)
+            isPlayingFlow.emit(false)
             playbackProgressFlow.emit(0)
         }
     }
@@ -79,7 +78,7 @@ class CheckPronunciationViewModel(
                 replayFlow.emit(Unit)
             }
         } else {
-            viewModelScope.launch { playIconFlow.emit(R.drawable.ic_replay) }
+            viewModelScope.launch { isPlayingFlow.emit(true) }
             playCurrentFile()
         }
     }
@@ -90,7 +89,7 @@ class CheckPronunciationViewModel(
         viewModelScope.launch {
             isPlaybackVisibleFlow.emit(false)
             playbackProgressFlow.emit(0)
-            playIconFlow.emit(R.drawable.ic_play)
+            isPlayingFlow.emit(false)
         }
     }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModelTest.kt
@@ -17,7 +17,6 @@ package com.ichi2.anki.ui.windows.reviewer.audiorecord
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
-import com.ichi2.anki.R
 import com.ichi2.anki.recorder.AudioRecorder
 import com.ichi2.testutils.JvmTest
 import io.mockk.coVerify
@@ -45,6 +44,7 @@ class CheckPronunciationViewModelTest : JvmTest() {
     private var onCompletionCallback: (() -> Unit)? = null
 
     private var isPlayingMock = false
+    private var isPausedMock = false
 
     @Before
     fun setup() {
@@ -83,11 +83,12 @@ class CheckPronunciationViewModelTest : JvmTest() {
             // Precondition: Playback view must be visible to allow play
             viewModel.isPlaybackVisibleFlow.value = true
             isPlayingMock = false
+            isPausedMock = false
 
-            viewModel.playIconFlow.test {
-                assertEquals(R.drawable.ic_play, awaitItem())
+            viewModel.isPlayingFlow.test {
+                assertFalse(awaitItem())
                 viewModel.onPlayOrReplay()
-                assertEquals(R.drawable.ic_replay, awaitItem())
+                assertTrue(awaitItem())
             }
 
             verify { mockPlayer.play("test_file.3gp", any()) }
@@ -117,7 +118,7 @@ class CheckPronunciationViewModelTest : JvmTest() {
         }
 
     @Test
-    fun `when playback completes should reset icon and fill progress`() =
+    fun `when playback completes should reset playing state and fill progress`() =
         runTest {
             // Start playback to set the state
             viewModel.isPlaybackVisibleFlow.value = true
@@ -127,11 +128,11 @@ class CheckPronunciationViewModelTest : JvmTest() {
             isPlayingMock = true
 
             // Launch collectors concurrently
-            val iconJob =
+            val stateJob =
                 launch {
-                    viewModel.playIconFlow.test {
-                        assertEquals(R.drawable.ic_replay, awaitItem())
-                        assertEquals(R.drawable.ic_play, awaitItem())
+                    viewModel.isPlayingFlow.test {
+                        assertTrue(awaitItem())
+                        assertFalse(awaitItem())
                     }
                 }
             val progressJob =
@@ -147,7 +148,7 @@ class CheckPronunciationViewModelTest : JvmTest() {
             onCompletionCallback?.invoke()
 
             // Clean up
-            iconJob.cancel()
+            stateJob.cancel()
             progressJob.cancel()
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/audiorecord/CheckPronunciationViewModelTest.kt
@@ -56,6 +56,7 @@ class CheckPronunciationViewModelTest : JvmTest() {
             mockk(relaxUnitFun = true) {
                 every { play("test_file.3gp", capture(onPreparedCallback)) } just runs
                 every { isPlaying } answers { isPlayingMock }
+                every { isPaused } answers { isPausedMock }
                 every { duration } returns 3000
                 every { currentPosition } returns 1500
                 every { onCompletion = any() } answers {
@@ -115,6 +116,39 @@ class CheckPronunciationViewModelTest : JvmTest() {
             verify { mockPlayer.replay() }
             // Allow the progress bar job to complete
             isPlayingMock = false
+        }
+
+    @Test
+    fun `onPlayOrReplay when paused should resume playback and update UI`() =
+        runTest {
+            viewModel.isPlaybackVisibleFlow.value = true
+            isPlayingMock = false
+            isPausedMock = true
+
+            viewModel.isPlayingFlow.test {
+                assertFalse(awaitItem())
+                viewModel.onPlayOrReplay()
+                assertTrue(awaitItem())
+            }
+
+            verify { mockPlayer.resume() }
+        }
+
+    @Test
+    fun `pausePlayback should pause audio and update UI`() =
+        runTest {
+            viewModel.isPlaybackVisibleFlow.value = true
+            isPlayingMock = true
+            isPausedMock = false
+
+            viewModel.isPlayingFlow.value = true
+            viewModel.isPlayingFlow.test {
+                assertTrue(awaitItem())
+                viewModel.pausePlayback()
+                assertFalse(awaitItem())
+            }
+
+            verify { mockPlayer.pause() }
         }
 
     @Test


### PR DESCRIPTION
1. if the audio is playing, pause it
2. if it is recording, pause the recording

## Fixes
* Fixes https://github.com/ankidroid/Anki-Android/issues/20024

## How Has This Been Tested?

Galaxy Tab S9, Android 16

[Audio sample](https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=RDdQw4w9WgXcQ&start_radio=1)

https://github.com/user-attachments/assets/324a0b6f-7d23-4a73-a25d-950d7e90ae99


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->