### PR TITLE
fix: Flaky test: AutoAdvanceTest > onCardChange reloads settings

### DIFF
--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvanceTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/autoadvance/AutoAdvanceTest.kt
@@ -169,13 +169,14 @@ class AutoAdvanceTest {
                     durationToShowQuestionFor = 2.seconds,
                 )
 
-            coEvery { AutoAdvanceSettings.createInstance(any()) } returns initialSettings andThen newSettings
+            coEvery { AutoAdvanceSettings.createInstance(1L) } returns initialSettings
 
             autoAdvance = createAutoAdvance()
             autoAdvance.isEnabled = true
             testScheduler.advanceUntilIdle()
 
             val newCard = mockk<Card>(relaxed = true)
+            coEvery { AutoAdvanceSettings.createInstance(2L) } returns newSettings
             every { newCard.currentDeckId() } returns 2L
             autoAdvance.onCardChange(newCard)
             testScheduler.advanceUntilIdle()


### PR DESCRIPTION
specify the id in the settings mock, so a race condition on `andThen` won't happen

## Fixes
* Fixes #20819 

## How Has This Been Tested?

Flaky Hammer™

https://github.com/BrayanDSO/Anki-Android/actions/runs/24804113671

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->