### PR TITLE
Fix: Optimize toggleCollapsed UI performance

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/tags/ManageTagsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/tags/ManageTagsViewModel.kt
@@ -117,8 +117,11 @@ class ManageTagsViewModel : ViewModel() {
                     }
                 val newCollapsed = !node.collapsed
                 withCol { tags.setCollapsed(tag, newCollapsed) }
-                // re-fetch tree to get updated collapsed state
-                tagList = flattenTree(withCol { tags.tree() })
+                // Update the in-memory list with the new collapsed state
+                tagList =
+                    tagList.map {
+                        if (it.fullTag == tag) it.copy(collapsed = newCollapsed) else it
+                    }
                 updateState { it.copy(visibleNodes = computeVisibleNodes(it.searchQuery)) }
             } catch (e: CancellationException) {
                 throw e


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The current method for the collapsed tag list is to discard it each time and then rebuild and flatten the entire list again. Flatten is a recursive operation along with having to allocate memory each time, this was very slow and caused a flaky test.

## Fixes
* Fixes #20821 

## Approach
Instead of doing a flatten, we can use the list loaded in memory to search for the required tag and change its state.

## How Has This Been Tested?
The runtime of the previous implementation is ~41ms and the new one is ~2ms. (This is device specific, put it here for some reference)

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->