### PR TITLE
feat(study-screen): persist `Record voice` state

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerViewModel.kt
@@ -115,7 +115,7 @@ class ReviewerViewModel(
     val editNoteTagsFlow = MutableSharedFlow<NoteId>()
     val setDueDateFlow = MutableSharedFlow<CardId>()
     val answerFeedbackFlow = MutableSharedFlow<Rating>()
-    val voiceRecorderEnabledFlow = MutableStateFlow(false)
+    val voiceRecorderEnabledFlow = MutableStateFlow(repository.isRecordVoiceEnabled)
     val whiteboardEnabledFlow = MutableStateFlow(repository.isWhiteboardEnabled)
     val replayVoiceFlow = MutableSharedFlow<Unit>()
     val timeBoxReachedFlow = MutableSharedFlow<Collection.TimeboxReached>()
@@ -676,6 +676,12 @@ class ReviewerViewModel(
         repository.isWhiteboardEnabled = newValue
     }
 
+    private fun toggleRecordVoice() {
+        val newValue = !voiceRecorderEnabledFlow.value
+        voiceRecorderEnabledFlow.value = newValue
+        repository.isRecordVoiceEnabled = newValue
+    }
+
     fun executeAction(action: ViewerAction) {
         Timber.v("ReviewerViewModel::executeAction %s", action.name)
         launchCatchingIO {
@@ -720,7 +726,7 @@ class ReviewerViewModel(
                     ViewerAction.SHOW_HINT -> eval.emit("ankidroid.showHint()")
                     ViewerAction.SHOW_ALL_HINTS -> eval.emit("ankidroid.showAllHints()")
                     ViewerAction.TOGGLE_WHITEBOARD -> toggleWhiteboard()
-                    ViewerAction.RECORD_VOICE -> voiceRecorderEnabledFlow.emit(!voiceRecorderEnabledFlow.value)
+                    ViewerAction.RECORD_VOICE -> toggleRecordVoice()
                     ViewerAction.REPLAY_VOICE -> replayVoiceFlow.emit(Unit)
                     ViewerAction.PAGE_UP -> pageUpFlow.emit(Unit)
                     ViewerAction.PAGE_DOWN -> pageDownFlow.emit(Unit)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenRepository.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenRepository.kt
@@ -35,6 +35,7 @@ class StudyScreenRepository(
     val isMarkShownInToolbar: Boolean
     val isFlagShownInToolbar: Boolean
     var isWhiteboardEnabled by prefs.booleanPref(KEY_WHITEBOARD_ENABLED, false)
+    var isRecordVoiceEnabled by prefs.booleanPref(KEY_RECORD_VOICE_ENABLED, false)
     val isHtmlTypeAnswerEnabled get() = prefs.isHtmlTypeAnswerEnabled
 
     init {
@@ -74,5 +75,6 @@ class StudyScreenRepository(
 
     companion object {
         private const val KEY_WHITEBOARD_ENABLED = "whiteboardEnabled"
+        private const val KEY_RECORD_VOICE_ENABLED = "recordVoiceEnabled"
     }
 }


### PR DESCRIPTION
## Purpose / Description

A behavior of the old study screen that was request in the forums

https://forums.ankiweb.net/t/new-study-screen-official-thread/67394/100

## How Has This Been Tested?

Galaxy Tab S9, Emulator 36

1. Open the new study screen
2. Toggle `Record voice`
3. Exit the study screen
4. Open it again and see `Record voice` still enabled

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->