### PR TITLE
refactor: replace multimedia action when-block with MultimediaActionHandler

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -122,8 +122,7 @@ import com.ichi2.anki.libanki.Utils
 import com.ichi2.anki.libanki.clozeNumbersInNote
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.multimedia.AudioRecordingFragment
-import com.ichi2.anki.multimedia.AudioVideoFragment
+import com.ichi2.anki.multimedia.MultimediaActionHandler
 import com.ichi2.anki.multimedia.MultimediaActivityExtra
 import com.ichi2.anki.multimedia.MultimediaBottomSheet
 import com.ichi2.anki.multimedia.MultimediaImageFragment
@@ -132,11 +131,9 @@ import com.ichi2.anki.multimedia.MultimediaResultContract
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
 import com.ichi2.anki.multimedia.MultimediaViewModel
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
-import com.ichi2.anki.multimediacard.fields.AudioRecordingField
 import com.ichi2.anki.multimediacard.fields.EFieldType
 import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.anki.multimediacard.fields.ImageField
-import com.ichi2.anki.multimediacard.fields.MediaClipField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.noteeditor.FieldState
@@ -2030,85 +2027,15 @@ class NoteEditorFragment :
                 if (note.isEmpty) return@launch
 
                 multimediaViewModel.multimediaAction.first { action ->
-                    when (action) {
-                        MultimediaBottomSheet.MultimediaAction.SELECT_IMAGE_FILE -> {
-                            Timber.i("Selected Image option")
-                            val field = ImageField()
-                            note.setField(fieldIndex, field)
-                            openMultimediaImageFragment(fieldIndex = fieldIndex, field, note)
-                        }
-
-                        MultimediaBottomSheet.MultimediaAction.SELECT_AUDIO_FILE -> {
-                            Timber.i("Selected audio clip option")
-                            val field = MediaClipField()
-                            note.setField(fieldIndex, field)
-                            val mediaIntent =
-                                AudioVideoFragment.getIntent(
-                                    requireContext(),
-                                    MultimediaActivityExtra(fieldIndex, field, note),
-                                    AudioVideoFragment.MediaOption.AUDIO_CLIP,
-                                )
-
-                            multimediaFragmentLauncher.launch(mediaIntent)
-                        }
-
-                        MultimediaBottomSheet.MultimediaAction.OPEN_DRAWING -> {
-                            Timber.i("Selected Drawing option")
-                            val field = ImageField()
-                            note.setField(fieldIndex, field)
-
-                            val drawingIntent =
-                                MultimediaImageFragment.getIntent(
-                                    requireContext(),
-                                    MultimediaActivityExtra(fieldIndex, field, note),
-                                    MultimediaImageFragment.ImageOptions.DRAWING,
-                                )
-
-                            multimediaFragmentLauncher.launch(drawingIntent)
-                        }
-
-                        MultimediaBottomSheet.MultimediaAction.SELECT_AUDIO_RECORDING -> {
-                            Timber.i("Selected audio recording option")
-                            val field = AudioRecordingField()
-                            note.setField(fieldIndex, field)
-                            val audioRecordingIntent =
-                                AudioRecordingFragment.getIntent(
-                                    requireContext(),
-                                    MultimediaActivityExtra(fieldIndex, field, note),
-                                )
-
-                            multimediaFragmentLauncher.launch(audioRecordingIntent)
-                        }
-
-                        MultimediaBottomSheet.MultimediaAction.SELECT_VIDEO_FILE -> {
-                            Timber.i("Selected video clip option")
-                            val field = MediaClipField()
-                            note.setField(fieldIndex, field)
-                            val mediaIntent =
-                                AudioVideoFragment.getIntent(
-                                    requireContext(),
-                                    MultimediaActivityExtra(fieldIndex, field, note),
-                                    AudioVideoFragment.MediaOption.VIDEO_CLIP,
-                                )
-
-                            multimediaFragmentLauncher.launch(mediaIntent)
-                        }
-
-                        MultimediaBottomSheet.MultimediaAction.OPEN_CAMERA -> {
-                            Timber.i("Selected Camera option")
-
-                            val field = ImageField()
-                            note.setField(fieldIndex, field)
-                            val imageIntent =
-                                MultimediaImageFragment.getIntent(
-                                    requireContext(),
-                                    MultimediaActivityExtra(fieldIndex, field, note),
-                                    MultimediaImageFragment.ImageOptions.CAMERA,
-                                )
-
-                            multimediaFragmentLauncher.launch(imageIntent)
-                        }
-                    }
+                    Timber.i("Selected multimedia action: %s", action)
+                    val handler = MultimediaActionHandler.forAction(action)
+                    val field = handler.createField().also { note.setField(fieldIndex, it) }
+                    val intent =
+                        handler.buildIntent(
+                            requireContext(),
+                            MultimediaActivityExtra(fieldIndex, field, note),
+                        )
+                    multimediaFragmentLauncher.launch(intent)
                     true
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActionHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaActionHandler.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.multimedia
+
+import android.content.Context
+import android.content.Intent
+import com.ichi2.anki.multimedia.MultimediaBottomSheet.MultimediaAction
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField
+import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.anki.multimediacard.fields.ImageField
+import com.ichi2.anki.multimediacard.fields.MediaClipField
+
+/**
+ * Binds a [MultimediaAction] to the field type it produces and the intent that
+ * launches the corresponding capture/selection screen.
+ */
+sealed interface MultimediaActionHandler {
+    /** The [MultimediaAction] this handler responds to. */
+    val action: MultimediaAction
+
+    /** Creates the [IField] that will hold the captured/selected media. */
+    fun createField(): IField
+
+    /** Builds the [Intent] that launches the capture/selection screen. */
+    fun buildIntent(
+        context: Context,
+        extra: MultimediaActivityExtra,
+    ): Intent
+
+    object ImageFile : MultimediaActionHandler {
+        override val action = MultimediaAction.SELECT_IMAGE_FILE
+
+        override fun createField(): IField = ImageField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent =
+            MultimediaImageFragment.getIntent(
+                context,
+                extra,
+                MultimediaImageFragment.ImageOptions.GALLERY,
+            )
+    }
+
+    object Camera : MultimediaActionHandler {
+        override val action = MultimediaAction.OPEN_CAMERA
+
+        override fun createField(): IField = ImageField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent =
+            MultimediaImageFragment.getIntent(
+                context,
+                extra,
+                MultimediaImageFragment.ImageOptions.CAMERA,
+            )
+    }
+
+    object Drawing : MultimediaActionHandler {
+        override val action = MultimediaAction.OPEN_DRAWING
+
+        override fun createField(): IField = ImageField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent =
+            MultimediaImageFragment.getIntent(
+                context,
+                extra,
+                MultimediaImageFragment.ImageOptions.DRAWING,
+            )
+    }
+
+    object AudioFile : MultimediaActionHandler {
+        override val action = MultimediaAction.SELECT_AUDIO_FILE
+
+        override fun createField(): IField = MediaClipField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent =
+            AudioVideoFragment.getIntent(
+                context,
+                extra,
+                AudioVideoFragment.MediaOption.AUDIO_CLIP,
+            )
+    }
+
+    object VideoFile : MultimediaActionHandler {
+        override val action = MultimediaAction.SELECT_VIDEO_FILE
+
+        override fun createField(): IField = MediaClipField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent =
+            AudioVideoFragment.getIntent(
+                context,
+                extra,
+                AudioVideoFragment.MediaOption.VIDEO_CLIP,
+            )
+    }
+
+    object AudioRecording : MultimediaActionHandler {
+        override val action = MultimediaAction.SELECT_AUDIO_RECORDING
+
+        override fun createField(): IField = AudioRecordingField()
+
+        override fun buildIntent(
+            context: Context,
+            extra: MultimediaActivityExtra,
+        ): Intent = AudioRecordingFragment.getIntent(context, extra)
+    }
+
+    companion object {
+        /** All registered handlers, exhaustively covering every [MultimediaAction]. */
+        private val all: List<MultimediaActionHandler> =
+            listOf(ImageFile, Camera, Drawing, AudioFile, VideoFile, AudioRecording)
+
+        /** Returns the handler for [action]; throws if no handler is registered. */
+        fun forAction(action: MultimediaAction): MultimediaActionHandler =
+            all.firstOrNull { it.action == action }
+                ?: error("No MultimediaActionHandler registered for $action")
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The current implementation of multimedia action handling in NoteEditorFragment relies on a large, hardcoded when block. This makes the fragment unnecessarily bulky

This PR introduces a MultimediaActionHandler sealed interface to encapsulate the logic for creating fields and building intents for different media actions (Camera, Gallery, Drawing, etc.), leading to a much cleaner and more modular dispatching mechanism.

## Fixes
NA

## Approach
See commits

## How Has This Been Tested?
Pixel 10

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->