### PR TITLE
Fix ManageNoteTypes multiple selection text for rtl languages

### DIFF
--- a/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/item_manage_note_type.xml
@@ -15,7 +15,7 @@
         android:textAppearance="?attr/textAppearanceListItem"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/edit_cards_button"
+        app:layout_constraintEnd_toStartOf="@id/actions_container"
         app:layout_constraintHorizontal_bias="0.0"
         tools:text="Basic (and reversed card)"
         />
@@ -29,43 +29,56 @@
         android:textColor="?android:attr/textColorSecondary"
         app:layout_constraintTop_toBottomOf="@id/note_name"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/edit_cards_button"
+        app:layout_constraintEnd_toStartOf="@id/actions_container"
         app:layout_constraintHorizontal_bias="0.0"
         app:flow_horizontalBias="0.0"
         tools:text="912 notes"
         />
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/edit_cards_button"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/actions_container"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:icon="@drawable/ic_edit_note"
-        style="@style/Widget.Material3.Button.IconButton"
-        android:contentDescription="@string/model_browser_template"
+        android:layout_height="match_parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/more_actions_button"
-        />
+        app:layout_constraintEnd_toEndOf="parent">
 
-    <com.google.android.material.button.MaterialButton
-        android:id="@+id/more_actions_button"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        app:icon="@drawable/ic_more_vertical"
-        style="@style/Widget.Material3.Button.IconButton"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/edit_cards_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_edit_note"
+            style="@style/Widget.Material3.Button.IconButton"
+            android:contentDescription="@string/model_browser_template"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/more_actions_button"
+            app:layout_constraintHorizontal_chainStyle="packed"
+            />
 
-    <CheckBox
-        android:id="@+id/checkbox"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:checked="false"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        android:visibility="gone"
-        />
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/more_actions_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:icon="@drawable/ic_more_vertical"
+            style="@style/Widget.Material3.Button.IconButton"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toEndOf="@id/edit_cards_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            />
+
+        <CheckBox
+            android:id="@+id/checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:checked="false"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:visibility="gone"
+            />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Purpose / Description

The notetype name was linked to buttons that disappear when starting to multi select notetypes. I added another layout containing the views that become visible/invisible(buttons/checkbox) so the notetype name always considers the buttons currently visible.

Some images using different languages:

<img width="270" height="600" alt="Screenshot_20260424_123104" src="https://github.com/user-attachments/assets/aa3eef7b-bf5e-41d8-8ccb-67d9b1b32965" /><img width="270" height="600" alt="Screenshot_20260424_123114" src="https://github.com/user-attachments/assets/1948007c-23fa-4dd6-a79d-9d34434eed98" />

<img width="280" height="600" alt="Screenshot_20260424_123032" src="https://github.com/user-attachments/assets/48ba8dd3-9ddb-419c-ab9a-1659d9397afc" /><img width="280" height="600" alt="Screenshot_20260424_123042" src="https://github.com/user-attachments/assets/50181b0a-1d27-4aec-b916-c66b414986f9" />


## Fixes
* Fixes #20832


## How Has This Been Tested?

Checked with different languages.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)
