### PR TITLE
fix(study-screen): icons bidirectionality

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuView.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/reviewer/ReviewerMenuView.kt
@@ -26,6 +26,8 @@ import android.widget.LinearLayout
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.view.menu.MenuItemImpl
 import androidx.appcompat.widget.ActionMenuView
+import androidx.core.content.ContextCompat
+import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.size
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -87,7 +89,7 @@ class ReviewerMenuView : LinearLayout {
         for (action in submenuActions) {
             val subMenu = findItem(action.parentMenu!!.menuId)?.subMenu ?: continue
             subMenu.add(Menu.NONE, action.menuId, Menu.NONE, action.title(context))?.apply {
-                action.drawableRes?.let { setIcon(it) }
+                action.drawableRes?.let { setIconRes(it) }
             }
         }
     }
@@ -114,7 +116,7 @@ class ReviewerMenuView : LinearLayout {
                     menu.add(Menu.NONE, action.menuId, Menu.NONE, title)
                 }
             with(menuItem) {
-                action.drawableRes?.let { setIcon(it) }
+                action.drawableRes?.let { setIconRes(it) }
                 setShowAsAction(menuActionType)
             }
         }
@@ -137,5 +139,13 @@ class ReviewerMenuView : LinearLayout {
                 }
             },
         )
+    }
+
+    // ActionMenuView drawables don't handle directionality by default
+    private fun MenuItem.setIconRes(resId: Int) {
+        ContextCompat.getDrawable(context, resId)?.mutate()?.let { drawable ->
+            DrawableCompat.setLayoutDirection(drawable, context.resources.configuration.layoutDirection)
+            setIcon(drawable)
+        }
     }
 }

--- a/AnkiDroid/src/main/res/drawable/ic_fast_forward.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_fast_forward.xml
@@ -1,5 +1,5 @@
-<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
-      
+<vector android:autoMirrored="true" xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="?attr/colorControlNormal" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+
     <path android:fillColor="@android:color/white" android:pathData="M5.58,16.89l5.77,-4.07c0.56,-0.4 0.56,-1.24 0,-1.63L5.58,7.11C4.91,6.65 4,7.12 4,7.93v8.14c0,0.81 0.91,1.28 1.58,0.82zM13,7.93v8.14c0,0.81 0.91,1.28 1.58,0.82l5.77,-4.07c0.56,-0.4 0.56,-1.24 0,-1.63l-5.77,-4.07c-0.67,-0.47 -1.58,0 -1.58,0.81z"/>
     
 </vector>

--- a/AnkiDroid/src/main/res/drawable/ic_undo_white.xml
+++ b/AnkiDroid/src/main/res/drawable/ic_undo_white.xml
@@ -1,4 +1,4 @@
-<vector android:height="24dp" android:tint="?attr/colorControlNormal"
+<vector android:autoMirrored="true" android:height="24dp" android:tint="?attr/colorControlNormal"
     android:viewportHeight="24.0" android:viewportWidth="24.0"
     android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="#FFFFFF" android:pathData="M12.5,8c-2.65,0 -5.05,0.99 -6.9,2.6L2,7v9h9l-3.62,-3.62c1.39,-1.16 3.16,-1.88 5.12,-1.88 3.54,0 6.55,2.31 7.6,5.5l2.37,-0.78C21.08,11.03 17.15,8 12.5,8z"/>


### PR DESCRIPTION
* Fixes #20833

## How Has This Been Tested?

Emulator 37 (the right icon is `Undo`, and the left one is `Redo`)

<img width="1080" height="2400" alt="Screenshot_20260424_065303" src="https://github.com/user-attachments/assets/d5916aac-be3d-42ae-9f03-4dcebc2ed7f2" />

## Learning (optional, can help others)

ActionMenuView doesn't support android:autoMirrored="true"

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->