### PR TITLE
fix: RTL issues (ChangeNoteTypeDialog & InsertFieldDialog) & ChangeNoteType fix

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/analytics/AnalyticsDialogFragment.kt
@@ -16,9 +16,12 @@
 
 package com.ichi2.anki.analytics
 
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.DialogFragment
 
-abstract class AnalyticsDialogFragment : DialogFragment() {
+abstract class AnalyticsDialogFragment(
+    @LayoutRes contentLayoutId: Int = 0,
+) : DialogFragment(contentLayoutId) {
     override fun onResume() {
         super.onResume()
         UsageAnalytics.sendAnalyticsScreenView(this)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -483,6 +483,13 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
                 }
             }
 
+            // Updates to (Nothing) if the map changes
+            lifecycleScope.launch {
+                viewModel.templateChangeMapFlow.collect {
+                    createTemplateSpinner()
+                }
+            }
+
             lifecycleScope.launch {
                 viewModel.conversionTypeFlow.collect { type ->
                     when (val layout = Layout.fromConversionType(type)) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/ChangeNoteTypeDialog.kt
@@ -17,7 +17,6 @@
 
 package com.ichi2.anki.dialogs
 
-import android.app.Dialog
 import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
@@ -42,7 +41,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.adapter.FragmentStateAdapter
 import androidx.viewpager2.widget.ViewPager2
 import com.google.android.material.color.MaterialColors
-import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayoutMediator
@@ -75,10 +73,6 @@ import com.ichi2.anki.utils.InitStatus
 import com.ichi2.anki.withProgress
 import com.ichi2.utils.LanguageUtil
 import com.ichi2.utils.boldList
-import com.ichi2.utils.create
-import com.ichi2.utils.negativeButton
-import com.ichi2.utils.positiveButton
-import com.ichi2.utils.title
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -101,52 +95,51 @@ import timber.log.Timber
  *
  * @see ChangeNoteTypeViewModel
  */
-class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
+class ChangeNoteTypeDialog : AnalyticsDialogFragment(R.layout.dialog_change_note_type) {
     private val viewModel: ChangeNoteTypeViewModel by viewModels { defaultViewModelProviderFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.ThemeOverlay_AnkiDroid_AlertDialog_FullScreen)
         setupFlows()
     }
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        val binding = DialogChangeNoteTypeBinding.inflate(LayoutInflater.from(requireContext()))
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = DialogChangeNoteTypeBinding.bind(view)
 
-        return MaterialAlertDialogBuilder(requireContext())
-            .create {
-                title(text = TR.sentenceCase.changeNoteType)
-                positiveButton(R.string.dialog_ok)
-                negativeButton(R.string.dialog_cancel)
-                setView(binding.root)
-            }.apply {
-                show()
-                positiveButton.setOnClickListener {
-                    requireAnkiActivity().changeNoteType(viewModel)
-                    // dismiss() is handled via closeDialogFlow
-                }
-                launchCatchingTask {
-                    viewModel.flowOfInitStatus.collect {
-                        Timber.i("dialog init: %s", it)
-                        when (it) {
-                            InitStatus.Pending, InitStatus.InProgress -> {
-                                binding.changeNoteTypeLayout.isVisible = false
-                                binding.changeNoteTypeLoadingLayout.isVisible = true
-                                positiveButton.isEnabled = false
-                            }
-                            InitStatus.Completed -> {
-                                binding.changeNoteTypeLayout.isVisible = true
-                                binding.changeNoteTypeLoadingLayout.isVisible = false
-                                positiveButton.isEnabled = true
-                                setupChangeNoteTypeDialog(binding = binding)
-                            }
-                            is InitStatus.Failed -> {
-                                requireContext().showError(it.exception.toString(), it.exception.toCrashReportData(requireContext()))
-                                dismiss()
-                            }
-                        }
+        binding.toolbar.title = TR.sentenceCase.changeNoteType
+        binding.toolbar.setNavigationOnClickListener { dismiss() }
+        binding.btnSave.setOnClickListener {
+            requireAnkiActivity().changeNoteType(viewModel)
+            // dismiss() is handled via closeDialogFlow
+        }
+
+        launchCatchingTask {
+            viewModel.flowOfInitStatus.collect {
+                Timber.i("dialog init: %s", it)
+                when (it) {
+                    InitStatus.Pending, InitStatus.InProgress -> {
+                        binding.changeNoteTypeLayout.isVisible = false
+                        binding.changeNoteTypeLoadingLayout.isVisible = true
+                        binding.btnSave.isVisible = false
+                    }
+                    InitStatus.Completed -> {
+                        binding.changeNoteTypeLayout.isVisible = true
+                        binding.changeNoteTypeLoadingLayout.isVisible = false
+                        binding.btnSave.isVisible = true
+                        setupChangeNoteTypeDialog(binding = binding)
+                    }
+                    is InitStatus.Failed -> {
+                        requireContext().showError(it.exception.toString(), it.exception.toCrashReportData(requireContext()))
+                        dismiss()
                     }
                 }
             }
+        }
     }
 
     private fun setupFlows() {
@@ -330,12 +323,6 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
             }
         }
 
-        override fun onResume() {
-            super.onResume()
-            // update ViewPager2 height
-            binding.root.requestLayout()
-        }
-
         fun setupFlows() {
             lifecycleScope.launch {
                 Timber.d("setupFlows: collecting outputNoteTypeFlow")
@@ -467,12 +454,6 @@ class ChangeNoteTypeDialog : AnalyticsDialogFragment() {
                     }
                 }
             }
-        }
-
-        override fun onResume() {
-            super.onResume()
-            // update ViewPager2 height
-            binding.root.requestLayout()
         }
 
         fun setupFlows() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/InsertFieldDialog.kt
@@ -25,7 +25,6 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.CheckResult
 import androidx.annotation.StringRes
-import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.text.HtmlCompat
 import androidx.core.text.parseAsHtml
@@ -51,9 +50,6 @@ import com.ichi2.anki.dialogs.InsertFieldDialogViewModel.Tab
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SpecialField
 import com.ichi2.anki.model.SpecialFields
-import com.ichi2.utils.create
-import com.ichi2.utils.negativeButton
-import com.ichi2.utils.title
 import dev.androidbroadcast.vbpd.viewBinding
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -63,8 +59,7 @@ import org.jetbrains.annotations.VisibleForTesting
  *
  * @see [CardTemplateEditor.CardTemplateFragment]
  */
-class InsertFieldDialog : DialogFragment() {
-    private lateinit var binding: DialogInsertFieldBinding
+class InsertFieldDialog : DialogFragment(R.layout.dialog_insert_field) {
     private val viewModel by viewModels<InsertFieldDialogViewModel>()
     private val requestKey
         get() =
@@ -72,19 +67,20 @@ class InsertFieldDialog : DialogFragment() {
                 KEY_REQUEST_KEY
             }
 
-    /**
-     * A dialog for inserting field in card template editor
-     */
-    override fun onCreateDialog(savedInstanceState: Bundle?): AlertDialog {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setStyle(STYLE_NO_TITLE, R.style.ThemeOverlay_AnkiDroid_AlertDialog_FullScreen)
+    }
 
-        binding = DialogInsertFieldBinding.inflate(layoutInflater)
-        val dialog =
-            AlertDialog.Builder(requireContext()).create {
-                title(R.string.card_template_editor_select_field)
-                negativeButton(R.string.dialog_cancel)
-                setView(binding.root)
-            }
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        super.onViewCreated(view, savedInstanceState)
+        val binding = DialogInsertFieldBinding.bind(view)
+
+        binding.toolbar.title = getString(R.string.card_template_editor_select_field)
+        binding.toolbar.setNavigationOnClickListener { dismiss() }
 
         binding.viewPager.adapter = InsertFieldDialogAdapter(this)
         TabLayoutMediator(
@@ -123,8 +119,6 @@ class InsertFieldDialog : DialogFragment() {
                 dismiss()
             }
         }
-
-        return dialog
     }
 
     companion object {
@@ -206,11 +200,6 @@ class InsertFieldDialog : DialogFragment() {
                     override fun getItemCount(): Int = viewModel.fieldNames.size
                 }
         }
-
-        override fun onResume() {
-            super.onResume()
-            this.requireView().post { requireView().requestLayout() }
-        }
     }
 
     class SelectSpecialFieldFragment : Fragment(R.layout.dialog_generic_recycler_view) {
@@ -252,12 +241,6 @@ class InsertFieldDialog : DialogFragment() {
                     override fun getItemCount(): Int = viewModel.specialFields.size
                 }
             binding.root.layoutManager = LinearLayoutManager(context)
-        }
-
-        override fun onResume() {
-            super.onResume()
-            // update the height of the ViewPager
-            this.requireView().post { requireView().requestLayout() }
         }
     }
 

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -18,12 +18,34 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    >
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        app:navigationIcon="@drawable/close_icon"
+        app:titleTextAppearance="@style/TextAppearance.Material3.TitleMedium"
+        tools:title="Change note type">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/btn_save"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:layout_marginEnd="8dp"
+            android:text="@string/save"
+            android:visibility="gone"
+            tools:visibility="visible" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
     <LinearLayout
         android:id="@+id/change_note_type_loading_layout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         android:paddingVertical="48dp"
         android:gravity="center"
         android:visibility="visible"
@@ -37,55 +59,53 @@
             />
     </LinearLayout>
 
-    <ScrollView
+    <LinearLayout
         android:id="@+id/change_note_type_layout"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:orientation="vertical"
         android:visibility="gone"
-        tools:visibility="visible"
-        android:fadeScrollbars="false">
+        tools:visibility="visible">
+
+        <!-- Note type selector -->
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical">
-            <!-- Note type selector -->
-            <LinearLayout
-                android:layout_width="match_parent"
+            android:orientation="horizontal"
+            android:paddingTop="4dp"
+            android:paddingStart="24dp"
+            android:paddingEnd="24dp">
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/CardEditorModelText"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:orientation="horizontal"
-                android:paddingTop="16dp"
-                android:paddingStart="24dp"
-                android:paddingEnd="24dp">
-                <com.google.android.material.textview.MaterialTextView
-                    android:id="@+id/CardEditorModelText"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:layout_marginStart="8dp"
-                    android:gravity="start|center_vertical"
-                    android:textStyle="bold"
-                    android:text="@string/CardEditorModel" />
-                <Spinner
-                    android:id="@+id/dest_note_type_spinner"
-                    android:layout_width="match_parent"
-                    android:layout_height="?minTouchTargetSize"
-                    />
-            </LinearLayout>
-
-            <com.google.android.material.tabs.TabLayout
-                android:id="@+id/change_note_type_tab_layout"
+                android:layout_gravity="center"
+                android:layout_marginStart="8dp"
+                android:gravity="start|center_vertical"
+                android:textStyle="bold"
+                android:text="@string/CardEditorModel" />
+            <Spinner
+                android:id="@+id/dest_note_type_spinner"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@android:color/transparent"
-                app:tabMaxWidth="0dp"
-                app:tabGravity="fill"/>
-
-            <androidx.viewpager2.widget.ViewPager2
-                android:id="@+id/change_note_type_pager"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
+                android:layout_height="?minTouchTargetSize"
                 />
-
         </LinearLayout>
-    </ScrollView>
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/change_note_type_tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@android:color/transparent"
+            app:tabMaxWidth="0dp"
+            app:tabGravity="fill"/>
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/change_note_type_pager"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            />
+
+    </LinearLayout>
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_change_note_type.xml
@@ -27,7 +27,7 @@
         android:layout_height="wrap_content"
         android:minHeight="?attr/actionBarSize"
         app:navigationIcon="@drawable/close_icon"
-        app:titleTextAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:titleTextAppearance="@style/TextAppearance.AnkiDroid.TopAppBar.Title"
         tools:title="Change note type">
 
         <com.google.android.material.button.MaterialButton

--- a/AnkiDroid/src/main/res/layout/dialog_fields.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_fields.xml
@@ -13,13 +13,14 @@
   ~  You should have received a copy of the GNU General Public License along with
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:paddingHorizontal="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="8dp">
+    android:paddingTop="8dp"
+    android:fadeScrollbars="false">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -96,4 +97,4 @@
 
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/AnkiDroid/src/main/res/layout/dialog_generic_recycler_view.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_generic_recycler_view.xml
@@ -17,7 +17,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/dialog_recycler_view"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:clipToPadding="false"
     android:paddingTop="8dp"
     android:scrollbars="vertical"

--- a/AnkiDroid/src/main/res/layout/dialog_insert_field.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_insert_field.xml
@@ -17,39 +17,48 @@
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:orientation="vertical"
     >
-<com.google.android.material.tabs.TabLayout
 
-    android:id="@+id/tab_layout"
-    android:background="@android:color/transparent"
-    android:orientation="vertical"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    app:tabMaxWidth="0dp"
-    app:tabGravity="fill" >
-
-    <com.google.android.material.tabs.TabItem
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:minHeight="?attr/actionBarSize"
+        app:navigationIcon="@drawable/close_icon"
+        app:titleTextAppearance="@style/TextAppearance.AnkiDroid.TopAppBar.Title"
+        tools:title="Select field" />
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tab_layout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        app:tabGravity="fill"
+        app:tabMaxWidth="0dp">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
         android:text="@string/standard_fields_tab_header"
         />
 
-    <com.google.android.material.tabs.TabItem
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:text="@string/special_fields_tab_header"
-        />
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/special_fields_tab_header"
+            />
 
 
-</com.google.android.material.tabs.TabLayout>
+    </com.google.android.material.tabs.TabLayout>
 
     <androidx.viewpager2.widget.ViewPager2
         android:id="@+id/view_pager"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
+        android:layout_weight="1"
         />
 </LinearLayout>

--- a/AnkiDroid/src/main/res/layout/dialog_templates.xml
+++ b/AnkiDroid/src/main/res/layout/dialog_templates.xml
@@ -13,13 +13,14 @@
   ~  You should have received a copy of the GNU General Public License along with
   ~  this program.  If not, see <http://www.gnu.org/licenses/>.
   -->
-<androidx.constraintlayout.widget.ConstraintLayout
+<ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:paddingHorizontal="16dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:paddingTop="8dp">
+    android:paddingTop="8dp"
+    android:fadeScrollbars="false">
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -114,4 +115,4 @@
         </LinearLayout>
     </LinearLayout>
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/AnkiDroid/src/main/res/layout/fragment_filtered_deck_options.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_filtered_deck_options.xml
@@ -29,7 +29,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:navigationIcon="@drawable/close_icon"
-        app:titleTextAppearance="@style/TextAppearance.Material3.TitleMedium"
+        app:titleTextAppearance="@style/TextAppearance.AnkiDroid.TopAppBar.Title"
         tools:title="Filtered deck 10:10"
         tools:menu="@menu/filtered_options">
 

--- a/AnkiDroid/src/main/res/values/styles.xml
+++ b/AnkiDroid/src/main/res/values/styles.xml
@@ -231,6 +231,8 @@
         <item name="android:windowBackground">?android:attr/colorBackground</item>
     </style>
 
+    <style name="TextAppearance.AnkiDroid.TopAppBar.Title" parent="TextAppearance.Material3.TitleMedium" />
+
     <style name="AnkiDroid.AlertDialog.Body.Text" parent="MaterialAlertDialog.Material3.Body.Text">
         <!-- The default style uses onSurfaceVariant, which isn't defined yet -->
         <item name="android:textColor">?android:attr/textColor</item>


### PR DESCRIPTION
## Purpose / Description
The Tabbed layout had various issues with being hosted in a dialog:
* Layout was not updated properly if a TextView was made visible, being truncated horizontally
* Height was not updated on tab change
* if `requestLayout` was used, a tab change: Fields -> Template worked, but the user could not return from the 'Template' tab

## Fixes
* Fixes #20834
* Fixes #20843

## Approach
* Convert Dialogs to fullscreen to avoid the bugs
* #20843: Refresh spinners on update


## How Has This Been Tested?

### RTL
<img width="367" height="286" alt="Screenshot 2026-04-24 at 18 12 22" src="https://github.com/user-attachments/assets/40660f17-5065-4335-9c32-c4d6ff85c325" />
<img width="364" height="486" alt="Screenshot 2026-04-24 at 18 12 12" src="https://github.com/user-attachments/assets/412992c7-fa30-427b-99ad-eb10bbfcd998" />

### LTR
<img width="366" height="481" alt="Screenshot 2026-04-24 at 18 11 46" src="https://github.com/user-attachments/assets/e0307813-ab3c-4c59-a67b-9533a1916567" />
<img width="369" height="772" alt="Screenshot 2026-04-24 at 18 11 32" src="https://github.com/user-attachments/assets/0b8aea2d-1f54-447a-a5a4-22592364f18e" />


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)