### PR TITLE
fix(add-note): RTL design with LTR text

### DIFF
--- a/AnkiDroid/src/main/res/layout/view_card_multimedia_editline.xml
+++ b/AnkiDroid/src/main/res/layout/view_card_multimedia_editline.xml
@@ -13,9 +13,10 @@
         android:freezesText="true"
         android:layout_alignParentStart="true"
         app:layout_constraintBottom_toTopOf="@+id/edit_text"
-        app:layout_constraintEnd_toStartOf="@id/media_button"
+        app:layout_constraintEnd_toStartOf="@+id/toggle_sticky"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        android:layout_marginEnd="16dp"
         tools:text="Front\nNewline" />
 
     <ImageButton


### PR DESCRIPTION
## Purpose / Description
If a LTR field name was used in RTL mode, the toggle sticky pin and the content overlapped

## Fixes
* Fixes #20842

## Approach
Fix constraints and add some margin

## How Has This Been Tested?

### Before
<img width="724" height="692" alt="image" src="https://github.com/user-attachments/assets/7b83b537-518f-4fce-8dae-f79ee01434cc" />

### After
<img width="365" height="350" alt="Screenshot 2026-04-24 at 18 31 12" src="https://github.com/user-attachments/assets/05727bb2-a293-4042-bf29-03f520f71e3a" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)