### PR TITLE
Silence lint errors related to queries manifest declarations in compat module

### DIFF
--- a/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/BaseCompat.kt
@@ -230,6 +230,7 @@ open class BaseCompat : Compat {
     ): ResolveInfo? = packageManager.resolveService(intent, flags.value.toInt())
 
     // Until API 33
+    @Suppress("QueryPermissionsNeeded") // queries declaration is available in the main module manifest
     override fun queryIntentActivities(
         packageManager: PackageManager,
         intent: Intent,

--- a/compat/src/main/java/com/ichi2/anki/compat/CompatV33.kt
+++ b/compat/src/main/java/com/ichi2/anki/compat/CompatV33.kt
@@ -66,6 +66,7 @@ open class CompatV33 :
         flags: ResolveInfoFlagsCompat,
     ): ResolveInfo? = packageManager.resolveService(intent, PackageManager.ResolveInfoFlags.of(flags.value))
 
+    @Suppress("QueryPermissionsNeeded") // queries declaration is available in the main module manifest
     override fun queryIntentActivities(
         packageManager: PackageManager,
         intent: Intent,


### PR DESCRIPTION
## Purpose / Description

I'm not sure if this is just me(in which case close this). Most of the times I run lint/ktlint from the command line but recently I'm starting to see these errors after the move to the compat module:

> BaseCompat.kt:237: Error: Consider adding a <queries> declaration to your manifest when calling this method; see https://g.co/dev/packagevisibility for details [QueryPermissionsNeeded]
>       ): List<ResolveInfo> = packageManager.queryIntentActivities(intent, flags.value.toInt())
>                                             ~~~~~~~~~~~~~~~~~~~~~
> CompatV33.kt:73: Error: Consider adding a <queries> declaration to your manifest when calling this method; see https://g.co/dev/packagevisibility for details [QueryPermissionsNeeded]
>       ): List<ResolveInfo> = packageManager.queryIntentActivities(intent, PackageManager.ResolveInfoFlags.of(flags.value))
>                                             ~~~~~~~~~~~~~~~~~~~~~
>   2 errors

It's very annoying so I silenced the errors.

## How Has This Been Tested?

Ran the previous int command that was working and it works now.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

