### PR TITLE
Add more improvements for the new filtered deck screen

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
@@ -26,6 +26,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.CheckBox
 import android.widget.Spinner
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
@@ -42,6 +43,7 @@ import com.ichi2.anki.CardBrowser
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.FragmentFilteredDeckOptionsBinding
+import com.ichi2.anki.dialogs.DiscardChangesDialog
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.utils.ConfigAwareSingleFragmentActivity
 import com.ichi2.anki.utils.openUrl
@@ -53,7 +55,6 @@ import com.ichi2.utils.title
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
 import java.util.Locale.getDefault
-import kotlin.text.replaceFirstChar
 
 /**
  * Represents the screen where a filtered deck can be built or rebuilt after updating its properties.
@@ -64,6 +65,14 @@ import kotlin.text.replaceFirstChar
 class FilteredDeckOptionsFragment : Fragment(R.layout.fragment_filtered_deck_options) {
     private val binding by viewBinding(FragmentFilteredDeckOptionsBinding::bind)
     private val viewModel by viewModels<FilteredDeckOptionsViewModel>()
+    private val discardBackHandler =
+        object : OnBackPressedCallback(false) {
+            override fun handleOnBackPressed() {
+                DiscardChangesDialog.showDialog(context = requireActivity()) {
+                    requireActivity().finish()
+                }
+            }
+        }
 
     override fun onViewCreated(
         view: View,
@@ -91,6 +100,15 @@ class FilteredDeckOptionsFragment : Fragment(R.layout.fragment_filtered_deck_opt
         binding.secondFilterLimitInput.filters = arrayOf(InputFilter.LengthFilter(5))
         bindLabels()
         bindListeners()
+        requireActivity().onBackPressedDispatcher.addCallback(
+            viewLifecycleOwner,
+            discardBackHandler,
+        )
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewModel.hasUnsavedChanges.collect { status ->
+                discardBackHandler.isEnabled = status
+            }
+        }
         viewLifecycleOwner.lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.state.collect { state ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsFragment.kt
@@ -159,6 +159,12 @@ class FilteredDeckOptionsFragment : Fragment(R.layout.fragment_filtered_deck_opt
         // the deck name is also done for the normal deck options screen so we are consistent)
         binding.toolbar.title = state.title
         binding.deckNameInput.setTextIfChanged(state.name)
+        binding.deckNameInputLayout.error =
+            when (state.nameInputError) {
+                FilteredNameInputError.Empty -> getString(R.string.empty_cram_label)
+                FilteredNameInputError.AlreadyExists -> getString(R.string.error_name_exists)
+                null -> null
+            }
         binding.checkBoxAllowEmpty.setCheckedIfChanged(state.allowEmpty)
         binding.btnBuild.text = if (state.id == null) TR.decksBuild() else TR.actionsRebuild()
         binding.btnBuild.isEnabled = state.isBuildingAllowed

--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsState.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsState.kt
@@ -53,6 +53,8 @@ data class FilteredDeckOptions(
     val id: DeckId? = null,
     /** Name of the filtered deck, initial name with the following format: "Filtered deck HH:mm" */
     val name: String = "",
+    /** If not null, there's an error related to the text entered */
+    val nameInputError: FilteredNameInputError? = null,
     /**
      * String used as the title of the filtered options screen. Similar to [name], this will be the
      * name we get when first loading the deck data and will not change for the lifetime of the screen.
@@ -104,7 +106,9 @@ data class FilteredDeckOptions(
 val FilteredDeckOptions.isBuildingAllowed: Boolean
     get() {
         val hasNoInputErrors =
-            filter1State.error == null && !(isSecondFilterEnabled && filter2State?.error != null)
+            filter1State.error == null &&
+                !(isSecondFilterEnabled && filter2State?.error != null) &&
+                nameInputError == null
         return !isBuildingBrowserSearch && hasNoInputErrors
     }
 
@@ -121,6 +125,12 @@ data class SearchTermState(
 enum class SearchInputError {
     Empty,
     NotANumber,
+}
+
+/** Signals errors related to the filtered deck name */
+enum class FilteredNameInputError {
+    Empty,
+    AlreadyExists,
 }
 
 /** Type of custom delays the user can set. */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
@@ -53,6 +53,8 @@ class FilteredDeckOptionsViewModel(
     val state: StateFlow<FilteredDeckOptionsState>
         field = MutableStateFlow<FilteredDeckOptionsState>(Initializing())
 
+    private var decksNames = emptyList<String>()
+
     /** The [DeckId] of a filtered deck to edit or 0 if we are creating a new filtered deck. */
     private val did: DeckId
         get() = savedStateHandle.get<Long>(ARG_DECK_ID) ?: 0L
@@ -76,6 +78,7 @@ class FilteredDeckOptionsViewModel(
                     state.update { Initializing(throwable = throwable) }
                     return@launch
                 }
+            decksNames = withCol { safeGetDecksNames() }
             savedStateHandle[ARG_DATA] =
                 filteredDeckData.asInitialState(
                     cardsOptions = cardsOptions,
@@ -88,8 +91,14 @@ class FilteredDeckOptionsViewModel(
 
     fun onDeckNameChange(name: String) {
         Timber.i("Filtered deck name is changing")
+        val error =
+            when {
+                name.isBlank() -> FilteredNameInputError.Empty
+                decksNames.contains(name) -> FilteredNameInputError.AlreadyExists
+                else -> null
+            }
         if (currentState().name == name) return
-        updateCurrentState { copy(name = name) }
+        updateCurrentState { copy(name = name, nameInputError = error) }
     }
 
     fun onSearchChange(
@@ -339,6 +348,15 @@ class FilteredDeckOptionsViewModel(
             Result.success(sched.addOrUpdateFilteredDeck(deckData))
         } catch (ex: Exception) {
             Result.failure(ex)
+        }
+
+    /** Invokes the backend to get the names of decks. Errors are ignored, an empty list will be returned instead. */
+    private fun Collection.safeGetDecksNames(): List<String> =
+        try {
+            decks.allNamesAndIds(skipEmptyDefault = false, includeFiltered = true).map { it.name }
+        } catch (_: Exception) {
+            Timber.w("Failed to retrieve deck names")
+            emptyList()
         }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModel.kt
@@ -55,6 +55,10 @@ class FilteredDeckOptionsViewModel(
 
     private var decksNames = emptyList<String>()
 
+    val hasUnsavedChanges: StateFlow<Boolean>
+        field = MutableStateFlow<Boolean>(false)
+    private var initialState: FilteredDeckOptions? = null
+
     /** The [DeckId] of a filtered deck to edit or 0 if we are creating a new filtered deck. */
     private val did: DeckId
         get() = savedStateHandle.get<Long>(ARG_DECK_ID) ?: 0L
@@ -79,12 +83,15 @@ class FilteredDeckOptionsViewModel(
                     return@launch
                 }
             decksNames = withCol { safeGetDecksNames() }
-            savedStateHandle[ARG_DATA] =
-                filteredDeckData.asInitialState(
+            filteredDeckData
+                .asInitialState(
                     cardsOptions = cardsOptions,
                     defaultSearch1 = search,
                     defaultSearch2 = search2,
-                )
+                ).apply {
+                    savedStateHandle[ARG_DATA] = this
+                    initialState = this
+                }
             state.update { currentState() }
         }
     }
@@ -99,6 +106,7 @@ class FilteredDeckOptionsViewModel(
             }
         if (currentState().name == name) return
         updateCurrentState { copy(name = name, nameInputError = error) }
+        hasUnsavedChanges.update { wasStateModified() }
     }
 
     fun onSearchChange(
@@ -109,6 +117,7 @@ class FilteredDeckOptionsViewModel(
         val targetFilterState = currentFilterState(index)
         if (targetFilterState?.search == searchQuery) return
         updateCurrentFilterState(index) { copy(search = searchQuery) }
+        hasUnsavedChanges.update { wasStateModified() }
     }
 
     fun onLimitChange(
@@ -124,6 +133,7 @@ class FilteredDeckOptionsViewModel(
             }
         if (limit == currentFilterState(index)?.limit) return
         updateCurrentFilterState(index) { copy(limit = limit, error = inputError) }
+        hasUnsavedChanges.update { wasStateModified() }
     }
 
     fun onCardsOptionsChange(
@@ -133,6 +143,7 @@ class FilteredDeckOptionsViewModel(
         Timber.i("Filtered deck filter($filterIndex) cards options index changing to $cardOptionIndex")
         if (currentFilterState(filterIndex)?.index == cardOptionIndex) return
         updateCurrentFilterState(filterIndex) { copy(index = cardOptionIndex) }
+        hasUnsavedChanges.update { wasStateModified() }
     }
 
     fun onSearchInBrowser(filterIndex: FilterIndex) {
@@ -170,6 +181,7 @@ class FilteredDeckOptionsViewModel(
                 filter2State = filter2State ?: SearchTermState(),
             )
         }
+        hasUnsavedChanges.update { wasStateModified() }
     }
 
     fun onRescheduleChange(isEnabled: Boolean) {
@@ -214,7 +226,8 @@ class FilteredDeckOptionsViewModel(
     fun onShowExcludedCards() {
         Timber.i("Building unmovable cards search query to show in browser")
         viewModelScope.launch {
-            val manualFilters = mutableListOf(currentFilterState(FilterIndex.First)?.search ?: return@launch)
+            val manualFilters =
+                mutableListOf(currentFilterState(FilterIndex.First)?.search ?: return@launch)
             if (currentState().isSecondFilterEnabled && currentFilterState(FilterIndex.Second) != null) {
                 manualFilters.add(currentFilterState(FilterIndex.Second)?.search ?: return@launch)
             }
@@ -227,7 +240,8 @@ class FilteredDeckOptionsViewModel(
             val manualFilter = withCol { groupSearches(manualFilters, SearchJoiner.OR) }
             val implicitFilter = withCol { groupSearches(implicitFilters, SearchJoiner.OR) }
             try {
-                val browserSearch = withCol { buildSearchString(listOf(manualFilter, implicitFilter)) }
+                val browserSearch =
+                    withCol { buildSearchString(listOf(manualFilter, implicitFilter)) }
                 updateCurrentState { copy(browserQuery = browserSearch) }
             } catch (ex: Exception) {
                 updateCurrentState { copy(throwable = ex) }
@@ -279,6 +293,38 @@ class FilteredDeckOptionsViewModel(
         Timber.i("Clearing error from state")
         updateCurrentState { copy(throwable = null) }
     }
+
+    /**
+     * Checks the current state with the state that was loaded initially.
+     */
+    private fun wasStateModified(): Boolean {
+        val initial = initialState ?: return false
+        val current = (state.value as? FilteredDeckOptions) ?: return false
+        return initial.name != current.name ||
+            isFilter1Changed(initial, current) ||
+            initial.isSecondFilterEnabled != current.isSecondFilterEnabled ||
+            isFilter2Changed(initial, current)
+    }
+
+    private fun isFilter1Changed(
+        initial: FilteredDeckOptions,
+        current: FilteredDeckOptions,
+    ): Boolean =
+        initial.filter1State.search != current.filter1State.search ||
+            initial.filter1State.limit != current.filter1State.limit ||
+            initial.filter1State.index != current.filter1State.index
+
+    private fun isFilter2Changed(
+        initial: FilteredDeckOptions,
+        current: FilteredDeckOptions,
+    ): Boolean =
+        if (!current.isSecondFilterEnabled || !initial.isSecondFilterEnabled) {
+            false
+        } else {
+            initial.filter2State?.search != current.filter2State?.search ||
+                initial.filter2State?.limit != current.filter2State?.limit ||
+                initial.filter2State?.index != current.filter2State?.index
+        }
 
     /** Get the current state as it's found in the associated [SavedStateHandle]. Throws if state is not found. */
     private fun currentState(): FilteredDeckOptions = requireNotNull(savedStateHandle[ARG_DATA])

--- a/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
@@ -289,6 +289,27 @@ class FilteredDeckOptionsViewModelTest : RobolectricTest() {
             }
         }
 
+    @Test
+    fun `invalid name produces expected state`() {
+        runTest {
+            addDeck("A")
+            withViewModel {
+                assertNull(current.nameInputError)
+
+                onDeckNameChange("")
+                assertThat(current.nameInputError, equalTo(FilteredNameInputError.Empty))
+                assertFalse(current.isBuildingAllowed)
+
+                onDeckNameChange("A")
+                assertThat(current.nameInputError, equalTo(FilteredNameInputError.AlreadyExists))
+                assertFalse(current.isBuildingAllowed)
+
+                onDeckNameChange("Filtered")
+                assertTrue(current.isBuildingAllowed)
+            }
+        }
+    }
+
     /** Returns the current state as a [FilteredDeckOptions] or throw otherwise */
     private val FilteredDeckOptionsViewModel.current: FilteredDeckOptions
         get() = state.value as FilteredDeckOptions

--- a/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/filtered/FilteredDeckOptionsViewModelTest.kt
@@ -310,6 +310,71 @@ class FilteredDeckOptionsViewModelTest : RobolectricTest() {
         }
     }
 
+    @Test
+    fun `changing user input updates changed status`() =
+        runTest {
+            val testDid = createTestFilteredDeck()
+            withViewModel(did = testDid) {
+                assertThat(current.name, equalTo("Filtered"))
+                assertThat(current.filter1State.search, equalTo("flag:1"))
+                assertThat(current.filter1State.limit, equalTo("5"))
+                assertTrue(current.isSecondFilterEnabled)
+                assertThat(current.filter2State?.search, equalTo("flag:2"))
+                assertThat(current.filter2State?.limit, equalTo("5"))
+                assertFalse(hasUnsavedChanges.value)
+                // check status for name changes
+                onDeckNameChange("Not")
+                assertTrue(hasUnsavedChanges.value)
+                onDeckNameChange("Filtered")
+                assertFalse(hasUnsavedChanges.value)
+                // check status for filter 1 content changes
+                onSearchChange(FilterIndex.First, "flags:7")
+                assertTrue(hasUnsavedChanges.value)
+                onSearchChange(FilterIndex.First, "flag:1")
+                assertFalse(hasUnsavedChanges.value)
+                onLimitChange(FilterIndex.First, "100")
+                assertTrue(hasUnsavedChanges.value)
+                onLimitChange(FilterIndex.First, "5")
+                assertFalse(hasUnsavedChanges.value)
+                onCardsOptionsChange(FilterIndex.First, 10)
+                assertTrue(hasUnsavedChanges.value)
+                onCardsOptionsChange(FilterIndex.First, 1)
+                assertFalse(hasUnsavedChanges.value)
+                // check status if the second filter availability is changed
+                onSecondFilterStatusChange(false)
+                assertTrue(hasUnsavedChanges.value)
+                onSecondFilterStatusChange(true)
+                assertFalse(hasUnsavedChanges.value)
+                // check status for filter 2 content changes
+                onSearchChange(FilterIndex.Second, "flags:7")
+                assertTrue(hasUnsavedChanges.value)
+                onSearchChange(FilterIndex.Second, "flag:2")
+                assertFalse(hasUnsavedChanges.value)
+                onLimitChange(FilterIndex.Second, "100")
+                assertTrue(hasUnsavedChanges.value)
+                onLimitChange(FilterIndex.Second, "5")
+                assertFalse(hasUnsavedChanges.value)
+                onCardsOptionsChange(FilterIndex.Second, 10)
+                assertTrue(hasUnsavedChanges.value)
+                onCardsOptionsChange(FilterIndex.Second, 1)
+                assertFalse(hasUnsavedChanges.value)
+            }
+        }
+
+    @Test
+    fun `changed status is not updated for properties that are not observed`() =
+        runTest {
+            val testDid = createTestFilteredDeck()
+            withViewModel(did = testDid) {
+                assertFalse(current.allowEmpty)
+                assertTrue(current.shouldReschedule)
+                assertFalse(hasUnsavedChanges.value)
+                onAllowEmptyChange(true)
+                onRescheduleChange(false)
+                assertFalse(hasUnsavedChanges.value)
+            }
+        }
+
     /** Returns the current state as a [FilteredDeckOptions] or throw otherwise */
     private val FilteredDeckOptionsViewModel.current: FilteredDeckOptions
         get() = state.value as FilteredDeckOptions
@@ -337,6 +402,41 @@ class FilteredDeckOptionsViewModelTest : RobolectricTest() {
             moveToDeck("A", false)
             setup()
         }
+
+    /** Note: created filtered deck has the second filter enabled by default */
+    private suspend fun createTestFilteredDeck(): DeckId {
+        addDeck("A", true)
+        addNoteToDeckA { flagCardForNote(this, Flag.RED) }
+        addNoteToDeckA { flagCardForNote(this, Flag.GREEN) }
+        val data =
+            filteredDeckForUpdate {
+                id = 0
+                name = "Filtered"
+                config =
+                    filtered {
+                        reschedule = true
+                        searchTerms.add(
+                            searchTerm {
+                                search = "flag:1"
+                                limit = 5
+                                order =
+                                    Deck.Filtered.SearchTerm.Order
+                                        .forNumber(1)
+                            },
+                        )
+                        searchTerms.add(
+                            searchTerm {
+                                search = "flag:2"
+                                limit = 5
+                                order =
+                                    Deck.Filtered.SearchTerm.Order
+                                        .forNumber(1)
+                            },
+                        )
+                    }
+            }
+        return withCol { sched.addOrUpdateFilteredDeck(data) }.id
+    }
 
     companion object {
         private const val TEST_DECK_NAME = "TestFiltered"


### PR DESCRIPTION
## Purpose / Description

Fixes all remaining issues from the linked issue.

Note: I haven't implemented a discard changes for all actions just the filters' content and deck name. Feel free to push against this.

> ideally once the improved input validation code is merged

My opinion is that the validation itself should be in the ViewModel.

<img width="280" height="600" alt="Screenshot_20260425_122255" src="https://github.com/user-attachments/assets/fc38e82e-77a4-4626-9a67-dd60bbd7969f" /><img width="280" height="600" alt="Screenshot_20260425_122306" src="https://github.com/user-attachments/assets/9806ade2-b4f8-4e6d-aa75-f86fce973647" />
<img width="280" height="600" alt="Screenshot_20260425_122320" src="https://github.com/user-attachments/assets/3b1780e7-a8bc-4aa8-a39a-3e8e4ef42030" />


## Fixes

* Fixes #20537

## How Has This Been Tested?

Manually verified the requested behaviors. Ran tests.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

