### PR TITLE
fix: ACRA crash reporting

### DIFF
--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -17,7 +17,10 @@ kotlin {
 }
 
 dependencies {
-    implementation(libs.json)
+    // #20852: JSON must be compile-time only: Bundling `org.json:json` into the APK ships a second
+    // copy with a different field schema (vs the system version in `android.jar`)
+    compileOnly(libs.json)
+    testImplementation(libs.json)
     implementation(libs.androidx.annotation)
     implementation(libs.slf4j.api)
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - explaining the bug

## Purpose / Description
Moving to a `java-library` bundled a second copy of `org.json` which uses an incompatible `JSONWriter`.

On a release build, R8 inlining causes a crash.

## Fixes
* Fixes #20852

## Approach
`compileOnly` ensures the JAR is not copied over, and the Android `org.json` implementation is used

## How Has This Been Tested?

The same command I used in my bisects

`unset TEST_RELEASE_BUILD && ./gradlew :AnkiDroid:assemblePlayRelease && adb uninstall com.ichi2.anki ; adb install /Users/davidallison/StudioProjects/Anki-Android/AnkiDroid/build/outputs/apk/play/release/AnkiDroid-play-arm64-v8a-release.apk`

* Help - Get help - Send troubleshooting report

## Learning

* Cause: 0da67f45639246846875b5dc53d0a44415532c23
  * https://github.com/ankidroid/Anki-Android/pull/20731

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)