### PR TITLE
fix(study-screen): bury menu

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
@@ -39,40 +39,45 @@ fun ReviewerMenuView.setup(
         return
     }
 
-    viewModel.flagFlow
-        .flowWithLifecycle(lifecycle)
-        .collectLatestIn(lifecycle.coroutineScope) { flagCode ->
-            findItem(ViewerAction.FLAG_MENU.menuId)?.setPaddedIcon(context, flagCode.drawableRes)
-        }
-
-    val markItem = findItem(ViewerAction.MARK.menuId)
-    viewModel.isMarkedFlow
-        .flowWithLifecycle(lifecycle)
-        .collectLatestIn(lifecycle.coroutineScope) { isMarked ->
-            if (isMarked) {
-                markItem?.setPaddedIcon(context, R.drawable.ic_star)
-                markItem?.setTitle(R.string.menu_unmark_note)
-            } else {
-                markItem?.setPaddedIcon(context, R.drawable.ic_star_border_white)
-                markItem?.setTitle(R.string.menu_mark_note)
+    findItem(ViewerAction.FLAG_MENU.menuId)?.let { flagItem ->
+        viewModel.flagFlow
+            .flowWithLifecycle(lifecycle)
+            .collectLatestIn(lifecycle.coroutineScope) { flagCode ->
+                flagItem.setPaddedIcon(context, flagCode.drawableRes)
             }
-        }
+    }
 
-    val undoItem = findItem(ViewerAction.UNDO.menuId)
-    viewModel.undoLabelFlow
-        .flowWithLifecycle(lifecycle)
-        .collectLatestIn(lifecycle.coroutineScope) { label ->
-            undoItem?.title = label ?: CollectionManager.TR.undoUndo()
-            undoItem?.isEnabled = label != null
-        }
+    findItem(ViewerAction.MARK.menuId)?.let { markItem ->
+        viewModel.isMarkedFlow
+            .flowWithLifecycle(lifecycle)
+            .collectLatestIn(lifecycle.coroutineScope) { isMarked ->
+                if (isMarked) {
+                    markItem.setPaddedIcon(context, R.drawable.ic_star)
+                    markItem.setTitle(R.string.menu_unmark_note)
+                } else {
+                    markItem.setPaddedIcon(context, R.drawable.ic_star_border_white)
+                    markItem.setTitle(R.string.menu_mark_note)
+                }
+            }
+    }
 
-    val redoItem = findItem(ViewerAction.REDO.menuId)
-    viewModel.redoLabelFlow
-        .flowWithLifecycle(lifecycle)
-        .collectLatestIn(lifecycle.coroutineScope) { label ->
-            redoItem?.title = label ?: CollectionManager.TR.undoRedo()
-            redoItem?.isEnabled = label != null
-        }
+    findItem(ViewerAction.UNDO.menuId)?.let { undoItem ->
+        viewModel.undoLabelFlow
+            .flowWithLifecycle(lifecycle)
+            .collectLatestIn(lifecycle.coroutineScope) { label ->
+                undoItem.title = label ?: CollectionManager.TR.undoUndo()
+                undoItem.isEnabled = label != null
+            }
+    }
+
+    findItem(ViewerAction.REDO.menuId)?.let { redoItem ->
+        viewModel.redoLabelFlow
+            .flowWithLifecycle(lifecycle)
+            .collectLatestIn(lifecycle.coroutineScope) { label ->
+                redoItem.title = label ?: CollectionManager.TR.undoRedo()
+                redoItem.isEnabled = label != null
+            }
+    }
 
     findItem(ViewerAction.SUSPEND_MENU.menuId)?.let { suspendItem ->
         val suspendFlow = viewModel.canSuspendNoteFlow.flowWithLifecycle(lifecycle)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerMenu.kt
@@ -74,39 +74,41 @@ fun ReviewerMenuView.setup(
             redoItem?.isEnabled = label != null
         }
 
-    val suspendItem = findItem(ViewerAction.SUSPEND_MENU.menuId) ?: return
-    val suspendFlow = viewModel.canSuspendNoteFlow.flowWithLifecycle(lifecycle)
-    suspendFlow.collectLatestIn(lifecycle.coroutineScope) { canSuspendNote ->
-        if (canSuspendNote) {
-            if (suspendItem.hasSubMenu()) return@collectLatestIn
-            suspendItem.setTitle(ViewerAction.SUSPEND_MENU.titleRes)
-            val submenu =
-                SubMenuBuilder(context, suspendItem.menu, suspendItem).apply {
-                    add(Menu.NONE, ViewerAction.SUSPEND_NOTE.menuId, Menu.NONE, ViewerAction.SUSPEND_NOTE.titleRes)
-                    add(Menu.NONE, ViewerAction.SUSPEND_CARD.menuId, Menu.NONE, ViewerAction.SUSPEND_CARD.titleRes)
-                }
-            suspendItem.setSubMenu(submenu)
-        } else {
-            suspendItem.removeSubMenu()
-            suspendItem.setTitle(ViewerAction.SUSPEND_CARD.titleRes)
+    findItem(ViewerAction.SUSPEND_MENU.menuId)?.let { suspendItem ->
+        val suspendFlow = viewModel.canSuspendNoteFlow.flowWithLifecycle(lifecycle)
+        suspendFlow.collectLatestIn(lifecycle.coroutineScope) { canSuspendNote ->
+            if (canSuspendNote) {
+                if (suspendItem.hasSubMenu()) return@collectLatestIn
+                suspendItem.setTitle(ViewerAction.SUSPEND_MENU.titleRes)
+                val submenu =
+                    SubMenuBuilder(context, suspendItem.menu, suspendItem).apply {
+                        add(Menu.NONE, ViewerAction.SUSPEND_NOTE.menuId, Menu.NONE, ViewerAction.SUSPEND_NOTE.titleRes)
+                        add(Menu.NONE, ViewerAction.SUSPEND_CARD.menuId, Menu.NONE, ViewerAction.SUSPEND_CARD.titleRes)
+                    }
+                suspendItem.setSubMenu(submenu)
+            } else {
+                suspendItem.removeSubMenu()
+                suspendItem.setTitle(ViewerAction.SUSPEND_CARD.titleRes)
+            }
         }
     }
 
-    val buryItem = findItem(ViewerAction.BURY_MENU.menuId) ?: return
-    val flow = viewModel.canBuryNoteFlow.flowWithLifecycle(lifecycle)
-    flow.collectLatestIn(lifecycle.coroutineScope) { canBuryNote ->
-        if (canBuryNote) {
-            if (buryItem.hasSubMenu()) return@collectLatestIn
-            buryItem.setTitle(ViewerAction.BURY_MENU.titleRes)
-            val submenu =
-                SubMenuBuilder(context, buryItem.menu, buryItem).apply {
-                    add(Menu.NONE, ViewerAction.BURY_NOTE.menuId, Menu.NONE, ViewerAction.BURY_NOTE.titleRes)
-                    add(Menu.NONE, ViewerAction.BURY_CARD.menuId, Menu.NONE, ViewerAction.BURY_CARD.titleRes)
-                }
-            buryItem.setSubMenu(submenu)
-        } else {
-            buryItem.removeSubMenu()
-            buryItem.setTitle(ViewerAction.BURY_CARD.titleRes)
+    findItem(ViewerAction.BURY_MENU.menuId)?.let { buryItem ->
+        val buryFlow = viewModel.canBuryNoteFlow.flowWithLifecycle(lifecycle)
+        buryFlow.collectLatestIn(lifecycle.coroutineScope) { canBuryNote ->
+            if (canBuryNote) {
+                if (buryItem.hasSubMenu()) return@collectLatestIn
+                buryItem.setTitle(ViewerAction.BURY_MENU.titleRes)
+                val submenu =
+                    SubMenuBuilder(context, buryItem.menu, buryItem).apply {
+                        add(Menu.NONE, ViewerAction.BURY_NOTE.menuId, Menu.NONE, ViewerAction.BURY_NOTE.titleRes)
+                        add(Menu.NONE, ViewerAction.BURY_CARD.menuId, Menu.NONE, ViewerAction.BURY_CARD.titleRes)
+                    }
+                buryItem.setSubMenu(submenu)
+            } else {
+                buryItem.removeSubMenu()
+                buryItem.setTitle(ViewerAction.BURY_CARD.titleRes)
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose / Description

if `Suspend` wasn't on the menu actions, the `Bury` menu wouldn't be updated to `Bury card` when necessary

One of the bugs you discover by seeing the code instead of actual usage of the feature


## Approach
_How does this change address the problem?_

## How Has This Been Tested?

[Screen_recording_20260425_084857.webm](https://github.com/user-attachments/assets/8777714d-dcc7-43c2-bb9a-db80f8606bfd)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->