### PR TITLE
ci(translations): skip commit/push when Crowdin returns no string changes (#20853)

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -91,10 +91,21 @@ jobs:
       - name: Commit changes
         run: |
           git add docs/marketing/localized_description AnkiDroid/src/main/res
-          git commit -am 'Updated strings from Crowdin'
-          git push --set-upstream origin +i18n_sync
-          echo "The results of the sync are on the i18n_sync branch, PR them from there for merge."
-          echo "https://github.com/ankidroid/Anki-Android/compare/i18n_sync?expand=1"
+          # If Crowdin returned no string changes there is nothing to commit
+          # and `git commit` would exit 1 ("nothing to commit, working tree
+          # clean"), failing the whole workflow even though the run was
+          # operationally successful. Detect that case explicitly so the
+          # commit / push only runs when there are real changes -- the
+          # downstream `tr_check` step's HAS_CHANGES=false branch then
+          # short-circuits PR creation, leaving the run as a clean success.
+          if git diff --cached --quiet; then
+            echo "No string changes from Crowdin; skipping commit and push."
+          else
+            git commit -am 'Updated strings from Crowdin'
+            git push --set-upstream origin +i18n_sync
+            echo "The results of the sync are on the i18n_sync branch, PR them from there for merge."
+            echo "https://github.com/ankidroid/Anki-Android/compare/i18n_sync?expand=1"
+          fi
 
       - name: Check if there are strings changes
         id: tr_check


### PR DESCRIPTION
Closes #20853.

The \`Commit changes\` step in \`.github/workflows/sync_translations.yml\` ran \`git commit -am ...\` unconditionally. When Crowdin's download produces no actual string updates the working tree stays clean and \`git commit\` exits 1 with \"nothing to commit, working tree clean\", marking the entire run as failed even though the sync ran exactly as intended (linked example in the issue: https://github.com/ankidroid/Anki-Android/actions/runs/24928497735).

Wraps the commit / push in a \`git diff --cached --quiet\` check so the workflow short-circuits the no-change path with a log line and exits the step successfully. The downstream \`tr_check\` step then sees zero new commits on \`i18n_sync\`, sets \`HAS_CHANGES=false\`, and the \`Create PR\` step's \`if:\` gate skips cleanly. The run finishes as a green success instead of a red failure when there is genuinely nothing to translate.

I went with the explicit-skip pattern instead of \`continue-on-error: true\` (which would mask any real \`git push\` failure) and instead of marking the run \`neutral\` via \`actions/github-script\` (no longer first-class on GitHub-hosted runners). The result on the \"no string changes\" path is the same as the issue asks for: a successful check that doesn't trigger a failure notification.