### PR TITLE
fix: exiting whiteboard crash

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -545,13 +545,13 @@ class ReviewerFragment :
             },
             false,
         )
+        val isUsingGesturesNavigation = compat.isUsingSystemGestureNavigation(requireContext())
         val doubleBackCallback =
             doubleBackPressCallback(
                 enabled = false,
                 onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
                 shouldReEnable = {
-                    viewModel.whiteboardEnabledFlow.value &&
-                        compat.isUsingSystemGestureNavigation(requireContext())
+                    viewModel.whiteboardEnabledFlow.value && isUsingGesturesNavigation
                 },
             )
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, doubleBackCallback)


### PR DESCRIPTION
calling `requireContext()`  with the whiteboard after leaving the fragment caused a crash.

Fixed by storing the value of whether the system is using gestures navigation instead of retrieving it every time.

If the user changes the gestures navigation mode while using the reviewer, the activity and fragment are recreated, so that ends up not being a problem

java.lang.IllegalStateException: Fragment ReviewerFragment{a6a61db} (47dfdd3d-a8b4-49be-ad89-2e879c2630b8) not attached to a context. at androidx.fragment.app.Fragment.requireContext(Fragment.java:977) at com.ichi2.anki.ui.windows.reviewer.ReviewerFragment.setupWhiteboard$lambda$1(ReviewerFragment.kt:554) at com.ichi2.anki.ui.windows.reviewer.ReviewerFragment.setupWhiteboard$lambda$1(ReviewerFragment.kt:554)

## How Has This Been Tested?

1. Enable the whiteboard on the new study screen
2. Go back twice to leave the screen
3. No crash

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->