### PR TITLE
feat: make new study screen the default one

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ControlsSettingsFragment.kt
@@ -30,6 +30,7 @@ import com.ichi2.anki.R
 import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.preferences.reviewer.ViewerAction
+import com.ichi2.anki.preferences.reviewer.WhiteboardAction
 import com.ichi2.anki.previewer.PreviewerAction
 import com.ichi2.anki.reviewer.CardSide
 import com.ichi2.anki.reviewer.MappableAction
@@ -269,7 +270,7 @@ enum class ControlPreferenceScreen(
 
     fun getActions(): List<MappableAction<*>> =
         when (this) {
-            REVIEWER -> if (Prefs.isNewStudyScreenEnabled) ViewerAction.entries else ViewerCommand.entries
+            REVIEWER -> if (Prefs.isNewStudyScreenEnabled) ViewerAction.entries + WhiteboardAction.entries else ViewerCommand.entries
             PREVIEWER -> PreviewerAction.entries
         }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewerOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/preferences/ReviewerOptionsFragment.kt
@@ -43,10 +43,13 @@ class ReviewerOptionsFragment :
                     ignoreDisplayCutout.isEnabled = value != getString(HideSystemBars.NONE.entryResId)
                 }
             }
-        val newReviewerPref = requirePreference<SwitchPreferenceCompat>(R.string.new_reviewer_options_key)
+        val oldReviewerPRef =
+            requirePreference<SwitchPreferenceCompat>(R.string.old_reviewer_key).apply {
+                setDefaultValue(!Prefs.isNewStudyScreenEnabled)
+            }
 
         fun setPrefsEnableState(newValue: Boolean) {
-            val prefs = preferenceScreen.allPreferences() - newReviewerPref
+            val prefs = preferenceScreen.allPreferences() - oldReviewerPRef
             for (pref in prefs) {
                 if (pref is HtmlHelpPreference) continue
                 if (pref.key == ignoreDisplayCutout.key && newValue) {
@@ -57,9 +60,10 @@ class ReviewerOptionsFragment :
             }
         }
 
-        setPrefsEnableState(newReviewerPref.isChecked)
-        newReviewerPref.setOnPreferenceChangeListener { newValue ->
-            setPrefsEnableState(newValue)
+        setPrefsEnableState(!oldReviewerPRef.isChecked)
+        oldReviewerPRef.setOnPreferenceChangeListener { newValue ->
+            Prefs.isNewStudyScreenEnabled = !newValue
+            setPrefsEnableState(!newValue)
         }
 
         // Show play buttons on cards with audio

--- a/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/settings/Prefs.kt
@@ -402,7 +402,7 @@ open class PrefsRepository(
         get() = getBoolean(R.string.developer_options_enabled_by_user_key, false) || BuildConfig.DEBUG
         set(value) = putBoolean(R.string.developer_options_enabled_by_user_key, value)
 
-    var isNewStudyScreenEnabled by booleanPref(R.string.new_reviewer_options_key, false)
+    var isNewStudyScreenEnabled by booleanPref(R.string.new_reviewer_options_key, true)
 
     val devIsCardBrowserFragmented: Boolean
         get() = getBoolean(R.string.dev_card_browser_fragmented, false)

--- a/AnkiDroid/src/main/res/values/10-preferences.xml
+++ b/AnkiDroid/src/main/res/values/10-preferences.xml
@@ -456,9 +456,8 @@ this formatter is used if the bind only applies to the answer">A: %s</string>
     <string name="toolbar" maxLength="41">Toolbar</string>
     <string name="toolbar_actions" maxLength="41">Toolbar actions</string>
     <string name="toolbar_position" maxLength="28">Toolbar position</string>
-    <string name="new_study_screen" maxLength="41">New study screen</string>
-    <string name="new_study_screen_summ"
-        ><![CDATA[Improved study screen that will succeed the current one. Some features of the old screen have been changed or removed. Please report any <a href="%1$s">feedback</a> or <a href="%2$s">bugs</a>.]]></string>
+    <string name="use_legacy_study_screen" maxLength="28">Use legacy study screen</string>
+    <string name="use_legacy_study_screen_summ">The previous study screen is deprecated. Kept to help on the transition to the new study screen</string>
     <string name="show_answer_feedback" maxLength="41">Show answer feedback</string>
     <string name="screen" maxLength="41">Screen</string>
     <string name="only_answer" maxLength="41" comment="Configuration of the 'Answer' commands to only answer the card"

--- a/AnkiDroid/src/main/res/values/constants.xml
+++ b/AnkiDroid/src/main/res/values/constants.xml
@@ -94,7 +94,6 @@
 
     <string name="link_anki_manual">https://docs.ankiweb.net/#/</string>
     <string name="link_anki_forum">https://forums.ankiweb.net/</string>
-    <string name="link_anki_forum_ankidroid">https://forums.ankiweb.net/c/ankidroid/22</string>
     <string name="link_forum">http://groups.google.com/group/anki-android</string>
     <string name="licence_wiki">http://www.gnu.org/licenses/gpl.html</string>
     <string name="dependency_license_wiki">https://github.com/ankidroid/Anki-Android/wiki/Licences</string>

--- a/AnkiDroid/src/main/res/values/preferences.xml
+++ b/AnkiDroid/src/main/res/values/preferences.xml
@@ -230,6 +230,7 @@
     <string name="pref_corrupt_fsrs_params">debug_corrupt_fsrs_params</string>
     <string name="new_congrats_screen_pref_key">new_congrats_screen</string>
     <string name="new_reviewer_options_key">newReviewerOptions</string>
+    <string name="old_reviewer_key">oldReviewer</string>
     <string name="pref_browser_find_replace">browserFindReplace</string>
     <string name="pref_new_review_reminders">newReviewReminders</string>
     <string name="developer_options_enabled_by_user_key">devOptionsEnabledByUser</string>

--- a/AnkiDroid/src/main/res/xml/preference_headers.xml
+++ b/AnkiDroid/src/main/res/xml/preference_headers.xml
@@ -39,7 +39,7 @@
 
     <com.ichi2.preferences.HeaderPreference
         android:fragment="com.ichi2.anki.preferences.ReviewerOptionsFragment"
-        android:title="@string/new_study_screen"
+        android:title="@string/pref_cat_reviewer"
         android:icon="@drawable/ic_cards_star"
         android:key="@string/new_reviewer_options_key"
         app:summaryEntries="@array/study_screen_summary_entries"

--- a/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
+++ b/AnkiDroid/src/main/res/xml/preferences_reviewer.xml
@@ -3,25 +3,17 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:search="http://schemas.android.com/apk/com.bytehamster.lib.preferencesearch"
-    android:title="@string/new_study_screen"
+    android:title="@string/pref_cat_reviewer"
     >
-
-    <com.ichi2.preferences.HtmlHelpPreference
-        android:summary="@string/new_study_screen_summ"
-        app:substitution1="@string/link_anki_forum_ankidroid"
-        app:substitution2="@string/link_help"
-        search:ignore="true"
-        />
-
     <SwitchPreferenceCompat
-        android:key="@string/new_reviewer_options_key"
-        android:title="@string/new_study_screen"
+        android:key="@string/old_reviewer_key"
+        android:title="@string/use_legacy_study_screen"
+        android:summary="@string/use_legacy_study_screen_summ"
         android:defaultValue="false"
         search:ignore="true"
         />
 
     <PreferenceCategory android:title="@string/screen">
-
         <ListPreference
             android:defaultValue="@string/reviewer_frame_style_card_value"
             android:entries="@array/reviewer_frame_style_entries"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/analytics/PreferencesAnalyticsTest.kt
@@ -103,6 +103,7 @@ class PreferencesAnalyticsTest : RobolectricTest() {
             R.string.ignore_display_cutout_key, // ignoreDisplayCutout
             R.string.reviewer_toolbar_position_key, // reviewerToolbarPosition
             R.string.answer_button_size_pref_key, // answerBtnSize
+            R.string.old_reviewer_key, // oldReviewer
         ).toStringResourceSet()
 
     @Test

--- a/AnkiDroid/src/test/java/com/ichi2/anki/preferences/ControlsSettingsFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/preferences/ControlsSettingsFragmentTest.kt
@@ -15,12 +15,12 @@
  */
 package com.ichi2.anki.preferences
 
-import androidx.test.espresso.matcher.ViewMatchers.assertThat
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
-import com.ichi2.testutils.HamcrestUtils
+import com.ichi2.testutils.getString
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.assertContains
 
 @RunWith(AndroidJUnit4::class)
 class ControlsSettingsFragmentTest : RobolectricTest() {
@@ -29,16 +29,13 @@ class ControlsSettingsFragmentTest : RobolectricTest() {
         for (screen in ControlPreferenceScreen.entries) {
             val xmlKeys =
                 PreferenceTestUtils.getKeysFromXml(targetContext, screen.xmlRes, excludeCategories = true).toMutableList().apply {
-                    remove("binding_BROWSE")
-                    remove("binding_STATISTICS")
-                    remove("binding_whiteboard_UNDO")
-                    remove("binding_whiteboard_REDO")
-                    remove("binding_whiteboard_CLEAR")
-                    remove("binding_whiteboard_TOGGLE_ERASER")
+                    ControlsSettingsFragment.legacyStudyScreenSettings.forEach { remove(getString(it)) }
                 }
             val enumKeys = screen.getActions().map { it.preferenceKey }
 
-            assertThat(xmlKeys, HamcrestUtils.containsInAnyOrder(enumKeys))
+            for (key in xmlKeys) {
+                assertContains(enumKeys, key)
+            }
         }
     }
 }


### PR DESCRIPTION

<!--- Please fill the necessary details below -->
## Purpose / Description

Probably the only blocker is the JS API. About that and any other blocker, please add to the issue discussion #20716  

## Fixes
* Closes #20716

## Approach

1. Rename the setting category from `New study screen` to `Study screen`
2. Remove the top summary on the settings category
3. Invert the SwitchPreference to enable the old study screen

## How Has This Been Tested?

[Screen_recording_20260425_185210.webm](https://github.com/user-attachments/assets/52e4b1b0-63ca-4662-b364-46fa4443bc80)

## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->