### PR TITLE
feat(card-browser): implement "See more" for search history

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardBrowserSearchViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/CardBrowserSearchViewModel.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.libanki.NoteTypeNameID
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -78,11 +79,27 @@ class CardBrowserSearchViewModel(
             initialValue = "",
         )
 
+    val isHistoryExpandedFlow = savedStateHandle.getMutableStateFlow(STATE_HISTORY_EXPANDED, false)
+
     val searchHistoryFlow =
         MutableStateFlow<SearchHistoryItems>(
             SearchHistoryItems.Loading(searchHistoryManager.entries),
         )
     val searchHistoryAvailableFlow = searchHistoryFlow.map { it.isNotEmpty() }
+
+    val displayedSearchHistoryFlow: StateFlow<SearchHistoryItems> =
+        combine(searchHistoryFlow, isHistoryExpandedFlow) { items, expanded ->
+            if (expanded) items else items.truncated(MAX_SEARCH_HISTORY_ENTRIES)
+        }.stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = searchHistoryFlow.value,
+        )
+
+    val showHistoryToggleFlow =
+        searchHistoryFlow.map {
+            it.entryToSearchString.size > MAX_SEARCH_HISTORY_ENTRIES
+        }
 
     val closeSearchViewFlow = MutableSharedFlow<Unit>(extraBufferCapacity = 1, replay = 1)
 
@@ -192,6 +209,10 @@ class CardBrowserSearchViewModel(
     fun toggleAdvancedSearch() {
         Timber.i("Toggling advanced search to %s", !advancedSearchFlow.value)
         advancedSearchFlow.value = !advancedSearchFlow.value
+    }
+
+    fun toggleHistoryExpanded() {
+        isHistoryExpandedFlow.value = !isHistoryExpandedFlow.value
     }
 
     /**
@@ -340,6 +361,12 @@ class CardBrowserSearchViewModel(
         abstract val entryToSearchString: List<Pair<SearchHistoryEntry, SearchString?>>
 
         fun isNotEmpty() = entryToSearchString.isNotEmpty()
+
+        fun truncated(max: Int): SearchHistoryItems =
+            when (this) {
+                is Loading -> Loading(input.take(max))
+                is Loaded -> Loaded(entryToSearchString.take(max))
+            }
     }
 
     /** Wraps [SearchFilters] so sync updates do not trigger a search */
@@ -360,6 +387,10 @@ class CardBrowserSearchViewModel(
         private const val STATE_ADVANCED_SEARCH_ENABLED = "advancedSearch"
         private const val STATE_BASIC_SEARCH_TEXT = "basicSearchText"
         private const val STATE_ADVANCED_SEARCH_TEXT = "advancedSearchText"
+        private const val STATE_HISTORY_EXPANDED = "historyExpanded"
+
+        /** Limits the number of history items, so controls appear below without scrolling */
+        const val MAX_SEARCH_HISTORY_ENTRIES = 5
     }
 }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/StandardSearchFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/search/StandardSearchFragment.kt
@@ -52,7 +52,6 @@ import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckNameId
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.utils.ext.hasCheckedBackground
 import com.ichi2.anki.utils.ext.launchCollectionInLifecycleScope
 import com.ichi2.anki.utils.ext.showDialogFragment
@@ -208,15 +207,8 @@ class StandardSearchFragment :
             fun toSpannable() = searchString?.let { entry.toUserSpannable(it) } ?: SpannableString("")
         }
 
-        fun buildUiModelList(historyItems: SearchHistoryItems): List<SearchHistoryItemUiModel> =
-            historyItems.entryToSearchString
-                .take(MAX_SEARCH_HISTORY_ENTRIES)
-                .map {
-                    SearchHistoryItemUiModel(
-                        entry = it.first,
-                        searchString = it.second,
-                    )
-                }
+        fun toUiModels(items: SearchHistoryItems): List<SearchHistoryItemUiModel> =
+            items.entryToSearchString.map { SearchHistoryItemUiModel(entry = it.first, searchString = it.second) }
 
         class SearchHistoryAdapter(
             private val context: Context,
@@ -254,7 +246,7 @@ class StandardSearchFragment :
         val searchHistoryAdapter =
             SearchHistoryAdapter(
                 context = requireContext(),
-                searches = buildUiModelList(viewModel.searchHistoryFlow.value),
+                searches = toUiModels(viewModel.displayedSearchHistoryFlow.value),
             )
         binding.searchHistory.apply {
             adapter = searchHistoryAdapter
@@ -263,14 +255,22 @@ class StandardSearchFragment :
             }
         }
 
-        binding.seeMore.apply {
-            setOnClickListener { showSnackbar("TODO") }
+        binding.toggleSearchHistory.setOnClickListener {
+            viewModel.toggleHistoryExpanded()
         }
 
-        // replace the data when the search history is updated
-        viewModel.searchHistoryFlow.launchCollectionInLifecycleScope {
+        // replace the data when the displayed search history is updated
+        viewModel.displayedSearchHistoryFlow.launchCollectionInLifecycleScope {
             searchHistoryAdapter.clear()
-            searchHistoryAdapter.addAll(buildUiModelList(it))
+            searchHistoryAdapter.addAll(toUiModels(it))
+        }
+
+        viewModel.showHistoryToggleFlow.launchCollectionInLifecycleScope {
+            binding.toggleSearchHistory.isVisible = it
+        }
+
+        viewModel.isHistoryExpandedFlow.launchCollectionInLifecycleScope {
+            binding.toggleSearchHistory.setText(if (it) R.string.card_browser_see_less else R.string.card_browser_see_more)
         }
 
         viewModel.searchHistoryAvailableFlow.launchCollectionInLifecycleScope {
@@ -335,9 +335,6 @@ class StandardSearchFragment :
 
     companion object {
         const val TAG = "STANDARD"
-
-        /** Limits the number of history items, so controls appear below without scrolling */
-        const val MAX_SEARCH_HISTORY_ENTRIES = 5
     }
 }
 

--- a/AnkiDroid/src/main/res/layout/fragment_standard_search.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_standard_search.xml
@@ -129,13 +129,13 @@
             />
 
         <Button
-            android:id="@+id/see_more"
+            android:id="@+id/toggle_search_history"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="end"
             android:paddingStart="16dp"
             style="@style/Widget.Material3.Button.TextButton.Icon"
-            android:text="See more"
+            android:text="@string/card_browser_see_more"
             app:layout_constraintTop_toBottomOf="@id/search_history"
             />
 

--- a/AnkiDroid/src/main/res/values/07-cardbrowser.xml
+++ b/AnkiDroid/src/main/res/values/07-cardbrowser.xml
@@ -106,4 +106,8 @@
     <string name="save_changes_message">Please save your changes first</string>
 
     <string name="browser_find_replace_loading_fields">Retrieving fields names&#8230;</string>
+
+    <!-- Search history -->
+    <string name="card_browser_see_more">See more</string>
+    <string name="card_browser_see_less">See less</string>
 </resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardBrowserSearchViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/CardBrowserSearchViewModelTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.anki.browser.SearchHistory
 import com.ichi2.anki.browser.SearchHistory.SearchHistoryEntry
+import com.ichi2.anki.browser.search.CardBrowserSearchViewModel.Companion.MAX_SEARCH_HISTORY_ENTRIES
 import com.ichi2.anki.browser.search.CardBrowserSearchViewModel.UserMessage
 import com.ichi2.testutils.assertFalse
 import kotlinx.coroutines.flow.map
@@ -356,6 +357,70 @@ class CardBrowserSearchViewModelTest : RobolectricTest() {
                 deleteSavedSearch(SavedSearch("A", "sample query"))
 
                 assertEquals(false, expectMostRecentItem())
+            }
+        }
+
+    @Test
+    fun `search history - initially collapsed`() =
+        withViewModel {
+            assertThat("initially not expanded", isHistoryExpandedFlow.value, equalTo(false))
+        }
+
+    @Test
+    fun `search history - toggle expands and collapses`() =
+        withViewModel {
+            isHistoryExpandedFlow.test {
+                assertThat(expectMostRecentItem(), equalTo(false))
+                toggleHistoryExpanded()
+                assertThat(expectMostRecentItem(), equalTo(true))
+                toggleHistoryExpanded()
+                assertThat(expectMostRecentItem(), equalTo(false))
+            }
+        }
+
+    @Test
+    fun `search history - displayed list is truncated when collapsed`() =
+        withViewModel {
+            repeat(MAX_SEARCH_HISTORY_ENTRIES + 3) { i ->
+                submitSearch("search $i")
+            }
+            displayedSearchHistoryFlow.test {
+                val items = expectMostRecentItem()
+                assertThat(items.entryToSearchString, hasSize(MAX_SEARCH_HISTORY_ENTRIES))
+            }
+        }
+
+    @Test
+    fun `search history - displayed list shows all when expanded`() =
+        withViewModel {
+            val totalItems = MAX_SEARCH_HISTORY_ENTRIES + 3
+            repeat(totalItems) { i ->
+                submitSearch("search $i")
+            }
+            toggleHistoryExpanded()
+            displayedSearchHistoryFlow.test {
+                val items = expectMostRecentItem()
+                assertThat(items.entryToSearchString, hasSize(totalItems))
+            }
+        }
+
+    @Test
+    fun `search history - toggle button visible only when items exceed max`() =
+        withViewModel {
+            showHistoryToggleFlow.test {
+                assertThat(expectMostRecentItem(), equalTo(false))
+            }
+
+            repeat(MAX_SEARCH_HISTORY_ENTRIES) { i ->
+                submitSearch("search $i")
+            }
+            showHistoryToggleFlow.test {
+                assertThat(expectMostRecentItem(), equalTo(false))
+            }
+
+            submitSearch("one more search")
+            showHistoryToggleFlow.test {
+                assertThat(expectMostRecentItem(), equalTo(true))
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/StandardSearchFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/search/StandardSearchFragmentTest.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.browser.search
 
+import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.ichi2.anki.RobolectricTest
@@ -26,6 +27,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /** Test of [StandardSearchFragment] */
 @RunWith(AndroidJUnit4::class)
@@ -48,7 +51,7 @@ class StandardSearchFragmentTest : RobolectricTest() {
     @Test
     fun `history entries are truncated`() {
         val expectedMaxEntries = 5
-        assertEquals(expectedMaxEntries, StandardSearchFragment.MAX_SEARCH_HISTORY_ENTRIES)
+        assertEquals(expectedMaxEntries, CardBrowserSearchViewModel.MAX_SEARCH_HISTORY_ENTRIES)
 
         val history = SearchHistory()
         repeat(expectedMaxEntries + 1) {
@@ -58,6 +61,28 @@ class StandardSearchFragmentTest : RobolectricTest() {
         withFragment {
             assertEquals(expectedMaxEntries, binding.searchHistory.count)
             assertEquals(expectedMaxEntries + 1, viewModel.searchHistory.size)
+        }
+    }
+
+    @Test
+    fun `see more button is hidden when entries do not exceed limit`() {
+        val history = SearchHistory()
+        repeat(3) { history.addRecent(SearchHistoryEntry(it.toString())) }
+
+        withFragment {
+            assertFalse(binding.toggleSearchHistory.isVisible)
+        }
+    }
+
+    @Test
+    fun `see more button is visible when entries exceed limit`() {
+        val history = SearchHistory()
+        repeat(CardBrowserSearchViewModel.MAX_SEARCH_HISTORY_ENTRIES + 1) {
+            history.addRecent(SearchHistoryEntry(it.toString()))
+        }
+
+        withFragment {
+            assertTrue(binding.toggleSearchHistory.isVisible)
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
To implement the TODO for see more functionality for the new search view, previously a stub.

## Fixes
* Fixes #20816 

## Approach
The "See more" button toggles an isExpanded flag that controls whether buildUiModelList applies .take(5) or returns all entries. The button is hidden when there are 5 or fewer history items.

## How Has This Been Tested?
[Screen_recording_20260426_174248.webm](https://github.com/user-attachments/assets/dff63649-9750-41bb-84bc-2e6930d605d9)

Created unit tests in `StandardSearchFragmentTest.kt`:
- See more invisible when below limit
- See more visible when above limit
- See more expands history to all entries
- See less collapses history back to limit

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->