### PR TITLE
Fix: (Refactor) Dynamic RTL/LTR alignment in Card Browser columns.

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -23,8 +23,10 @@ import android.graphics.drawable.RippleDrawable
 import android.graphics.drawable.StateListDrawable
 import android.text.TextUtils
 import android.util.TypedValue
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
+import android.view.View
 import android.view.ViewGroup
 import android.widget.CheckBox
 import android.widget.TextView
@@ -32,6 +34,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.VisibleForTesting
 import androidx.appcompat.widget.ThemeUtils
 import androidx.core.graphics.drawable.toDrawable
+import androidx.core.text.BidiFormatter
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import anki.search.BrowserRow.Color
@@ -73,6 +76,7 @@ class BrowserMultiColumnAdapter(
         get() = viewModel.cards
 
     private var originalTextSize = -1.0f
+    private val bidiFormatter = BidiFormatter.getInstance()
 
     inner class MultiColumnViewHolder(
         private val binding: ItemCardBrowserBinding,
@@ -264,7 +268,20 @@ class BrowserMultiColumnAdapter(
             holder.numberOfColumns = row.cellsCount
 
             for (i in 0 until row.cellsCount) {
-                holder.columnViews[i].text = renderColumn(i)
+                holder.columnViews[i].apply {
+                    val cellText = renderColumn(i)
+                    val isTextRtl = bidiFormatter.isRtl(cellText)
+                    text = bidiFormatter.unicodeWrap(cellText)
+                    if (isTextRtl) {
+                        layoutDirection = View.LAYOUT_DIRECTION_RTL
+                        textDirection = View.TEXT_DIRECTION_RTL
+                        gravity = Gravity.START or Gravity.CENTER_VERTICAL
+                    } else {
+                        layoutDirection = View.LAYOUT_DIRECTION_LTR
+                        textDirection = View.TEXT_DIRECTION_LTR
+                        gravity = Gravity.START or Gravity.CENTER_VERTICAL
+                    }
+                }
             }
             holder.setIsSelected(isSelected)
             val rowColor =


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

When using (RTL) languages, the Card Browser's text display and alignment are improved. 
This guarantees that even with mixed LTR/RTL text, column content respects the UI direction and keeps the appropriate padding.

## Fixes
* Fixes #20835

## Approach

- BidiFormatter Integration: When LTR text appears in an RTL layout, the user interface does not break since mixed direction strings in browser columns are handled by BidiFormatter.unicodeWrap().
- Layout Direction:
   - For example (AR/EN): The cell is set to LAYOUT_DIRECTION_RTL. This helps to understand that the starting point is on the right (Start).
   - To clarify that the left is the starting point (Start), the cell is set to LAYOUT_DIRECTION_LTR.
- Dynamic Padding: By switching the layout direction per cell, the existing paddingStart is automatically applied to the correct side of the text, providing the necessary 'breathing room' without reducing the total content area.

## How Has This Been Tested?

- Configuration: Tested on Android Emulator Pixle 10 Pro.
   - Reproduction Steps:
     1. Switch AnkiDroid language to English or Arabic.
     2. Open the Card Browser.

**Before**
<table>
  <tr>
    <td><img width="400" src="https://github.com/user-attachments/assets/e2212fff-3aa0-4cc3-9f1e-3bebbea75593" /></td>
    <td><img width="400" src="https://github.com/user-attachments/assets/cb10b73f-c7ca-4c82-84b1-658ea3e1154d" /></td>
  </tr>
</table>

**After**
<table>
  <tr>
    <td><img width="400" src="https://github.com/user-attachments/assets/3e2451b0-8c09-4528-83a8-4b8a5cfc638f" /></td>
    <td><img width="400" src="https://github.com/user-attachments/assets/3ffe4e97-5129-4430-aa7c-5e815e17c3ad"/></td>
  </tr>
</table>

## Checklist

- [x] You have a descriptive commit message with a short title.
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner]
- [ ] You have commented your code, particularly in hard-to-understand areas

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->
