### PR TITLE
refactor(card-browser): extract code from activity

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -468,7 +468,7 @@ open class CardBrowser :
             }
         }
 
-        fun onSelectedRowsChanged(rows: Set<Any>) = onSelectionChanged()
+        fun onSelectedRowsChanged(rows: Set<Any>) = invalidateOptionsMenu()
 
         fun onFilterQueryChanged(filterQuery: String) {
             // setQuery before expand does not set the view's value
@@ -511,7 +511,13 @@ open class CardBrowser :
                         searchItem!!.expandActionView()
                     }
                 }
-                is SearchState.Completed -> redrawAfterSearch()
+                is SearchState.Completed -> {
+                    Timber.i("CardBrowser:: Completed searchCards() Successfully")
+                    updateAppBarInfo(viewModel.deckId)
+                    // HACK: required now we use MenuProvider for searches
+                    // this causes a very brief flicker, as we call `setQuery` to restore the menu state
+                    searchView?.post { searchView?.clearFocus() }
+                }
                 is SearchState.Error -> {
                     showError(searchState.error, crashReportData = null)
                 }
@@ -750,11 +756,6 @@ open class CardBrowser :
         }
     }
 
-    fun onCardsUpdated() {
-        updateList()
-        invalidateOptionsMenu()
-    }
-
     fun showSavedSearches() {
         launchCatchingTask {
             val dialog =
@@ -812,30 +813,6 @@ open class CardBrowser :
         } else {
             viewModel.launchSearchForCards()
         }
-    }
-
-    @MainThread
-    private fun redrawAfterSearch() {
-        Timber.i("CardBrowser:: Completed searchCards() Successfully")
-        updateList()
-        // HACK: required now we use MenuProvider for searches
-        // this causes a very brief flicker, as we call `setQuery` to restore the menu state
-        searchView?.post {
-            searchView?.clearFocus()
-        }
-    }
-
-    @MainThread
-    private fun updateList() {
-        if (!colIsOpenUnsafe()) return
-        Timber.d("updateList")
-        updateAppBarInfo(viewModel.deckId)
-        onSelectionChanged()
-    }
-
-    private fun onSelectionChanged() {
-        Timber.d("onSelectionChanged")
-        invalidateOptionsMenu()
     }
 
     /**

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -76,7 +76,6 @@ import com.ichi2.anki.dialogs.registerSaveSearchHandler
 import com.ichi2.anki.dialogs.registerSavedSearchActionHandler
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
-import com.ichi2.anki.libanki.CardId
 import com.ichi2.anki.libanki.Collection
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.SortOrder
@@ -751,10 +750,8 @@ open class CardBrowser :
         }
     }
 
-    fun onCardsUpdated(cardIds: List<CardId>) {
-        // TODO: try to offload the cards processing in updateCardsInList() on a background thread,
-        // otherwise it could hang the main thread
-        updateCardsInList(cardIds)
+    fun onCardsUpdated() {
+        updateList()
         invalidateOptionsMenu()
     }
 
@@ -827,7 +824,6 @@ open class CardBrowser :
             if (searchView == null || searchView!!.isIconified) {
                 return@launchCatchingTask
             }
-            updateList()
             if (viewModel.hasSelectedAllDecks()) {
                 showSnackbar(numberOfCardsOrNoteShown, Snackbar.LENGTH_SHORT)
             } else {
@@ -842,7 +838,6 @@ open class CardBrowser :
                     setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
                 }
             }
-            invalidateOptionsMenu()
             // HACK: required now we use MenuProvider for searches
             // this causes a very brief flicker, as we call `setQuery` to restore the menu state
             searchView?.post {
@@ -857,7 +852,6 @@ open class CardBrowser :
         Timber.d("updateList")
         updateAppBarInfo(viewModel.deckId)
         onSelectionChanged()
-        invalidateOptionsMenu()
     }
 
     private fun onSelectionChanged() {
@@ -888,16 +882,6 @@ open class CardBrowser :
         stateFilter: CardStateFilter,
     ) {
         cardBrowserFragment.onSelectedTags(selectedTags, indeterminateTags, stateFilter)
-    }
-
-    /**
-     * Loads/Reloads (Updates the Q, A & etc) of cards in the [cardIds] list
-     * @param cardIds Card IDs that were changed
-     */
-    private fun updateCardsInList(
-        @Suppress("UNUSED_PARAMETER") cardIds: List<CardId>,
-    ) {
-        updateList()
     }
 
     private fun refreshBrowserUI() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -477,7 +477,15 @@ open class CardBrowser :
         }
 
         fun onDeckIdChanged(deckId: DeckId?) {
-            updateAppBarInfo(deckId)
+            if (useSearchView) return
+            launchCatchingTask {
+                findViewById<TextView>(R.id.deck_name)?.text =
+                    when (deckId) {
+                        null -> getString(R.string.card_browser_all_decks)
+                        ALL_DECKS_ID -> getString(R.string.card_browser_all_decks)
+                        else -> withCol { decks.getLegacy(deckId)?.name }
+                    }
+            }
         }
 
         fun onMultiSelectModeChanged(modeChange: ChangeMultiSelectMode) {
@@ -513,7 +521,8 @@ open class CardBrowser :
                 }
                 is SearchState.Completed -> {
                     Timber.i("CardBrowser:: Completed searchCards() Successfully")
-                    updateAppBarInfo(viewModel.deckId)
+                    // TODO: obtain these values from 'Completed'
+                    findViewById<TextView>(R.id.subtitle)?.text = formatCardCount(viewModel.rowCount, viewModel.cardsOrNotes)
                     // HACK: required now we use MenuProvider for searches
                     // this causes a very brief flicker, as we call `setQuery` to restore the menu state
                     searchView?.post { searchView?.clearFocus() }
@@ -601,7 +610,6 @@ open class CardBrowser :
         registerReceiver()
 
         window.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_HIDDEN)
-        updateAppBarInfo(viewModel.deckId)
     }
 
     override fun onKeyUp(
@@ -815,12 +823,6 @@ open class CardBrowser :
         }
     }
 
-    /**
-     * @return A message stating the number of cards/notes shown by the browser.
-     */
-    val numberOfCardsOrNoteShown: String
-        get() = formatCardCount(viewModel.rowCount, viewModel.cardsOrNotes)
-
     fun formatCardCount(
         count: Int,
         cardsOrNotes: CardsOrNotes,
@@ -914,23 +916,6 @@ open class CardBrowser :
 
     override val shortcuts
         get() = cardBrowserFragment.shortcuts
-
-    /**
-     * Sets the selected deck name and current selection count based on [numberOfCardsOrNoteShown]
-     */
-    private fun updateAppBarInfo(deckId: DeckId?) {
-        if (useSearchView) return
-        findViewById<TextView>(R.id.subtitle)?.text = numberOfCardsOrNoteShown
-        launchCatchingTask {
-            val deckName =
-                when (deckId) {
-                    null -> getString(R.string.card_browser_all_decks)
-                    ALL_DECKS_ID -> getString(R.string.card_browser_all_decks)
-                    else -> withCol { decks.getLegacy(deckId)?.name }
-                }
-            findViewById<TextView>(R.id.deck_name)?.text = deckName
-        }
-    }
 
     // region MenuHost delegation
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -161,10 +161,6 @@ open class CardBrowser :
     private val searchItem: MenuItem? get() = cardBrowserFragment.searchItem
     private val mySearchesItem: MenuItem? get() = cardBrowserFragment.mySearchesItem
 
-    // card that was clicked (not marked)
-    override val currentCardId: CardId?
-        get() = viewModel.currentCardId
-
     // Dev option for Issue 18709
     // TODO: Broken currently; needs R.layout.activity_card_browser_searchview
     val useSearchView: Boolean
@@ -725,12 +721,11 @@ open class CardBrowser :
      */
     @NeedsTest("note edits are saved")
     @NeedsTest("I/O edits are saved")
-    fun openNoteEditorForCurrentlySelectedRow() =
-        launchCatchingTask {
-            if (!viewModel.openNoteEditorForCurrentlySelectedRow()) {
-                showSnackbar(R.string.no_note_to_edit)
-            }
+    fun openNoteEditorForCurrentlySelectedRow() {
+        if (!viewModel.openNoteEditorForCurrentlySelectedRow()) {
+            showSnackbar(R.string.no_note_to_edit)
         }
+    }
 
     override fun onPause() {
         super.onPause()
@@ -829,10 +824,10 @@ open class CardBrowser :
             updateList()
             // Check whether deck is empty or not
             val isDeckEmpty = viewModel.rowCount == 0
-            val currentCardId = viewModel.updateCurrentCardId()
+            val focusedCardId = viewModel.resolveFocusedCardId()
             // Hide note editor frame if deck is empty and fragmented
             binding.noteEditorFrame?.visibility =
-                if (fragmented && !isDeckEmpty && currentCardId != null) {
+                if (fragmented && !isDeckEmpty && focusedCardId != null) {
                     loadNoteEditorFragmentIfFragmented()
                     View.VISIBLE
                 } else {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -628,7 +628,7 @@ open class CardBrowser :
                         Timber.i("E: Ignored in split mode")
                         return true
                     }
-                    openNoteEditorForCurrentlySelectedNote()
+                    openNoteEditorForCurrentlySelectedRow()
                     return true
                 } else {
                     Timber.i("E: Character added")
@@ -721,43 +721,14 @@ open class CardBrowser :
     }
 
     /**
-     * Opens the note editor for the given card.
-     *
-     * @param cardId The ID of the card to open in the note editor.
-     * Passing `null` indicates that no card is selected and will close the note editor
+     * @see CardBrowserViewModel.openNoteEditorForCurrentlySelectedRow
      */
     @NeedsTest("note edits are saved")
     @NeedsTest("I/O edits are saved")
-    fun setNoteEditorCard(cardId: CardId?) {
-        viewModel.setNoteEditorCard(cardId)
-    }
-
-    /**
-     * In case of selection, the first card that was selected, otherwise the first card of the list.
-     */
-    private suspend fun getCardIdForNoteEditor(): CardId? {
-        // Just select the first one if there's a multiselect occurring.
-        return if (viewModel.isInMultiSelectMode) {
-            viewModel.querySelectedCardIdAtPosition(0)
-        } else {
-            viewModel.getRowAtPosition(0).toCardId(viewModel.cardsOrNotes)
-        }
-    }
-
-    fun openNoteEditorForCurrentlySelectedNote() =
+    fun openNoteEditorForCurrentlySelectedRow() =
         launchCatchingTask {
-            // Check whether the deck is empty
-            if (viewModel.rowCount == 0) {
+            if (!viewModel.openNoteEditorForCurrentlySelectedRow()) {
                 showSnackbar(R.string.no_note_to_edit)
-                return@launchCatchingTask
-            }
-
-            try {
-                val cardId = getCardIdForNoteEditor()
-                setNoteEditorCard(cardId)
-            } catch (e: Exception) {
-                Timber.w(e, "Error Opening Note Editor")
-                showSnackbar(R.string.multimedia_editor_something_wrong)
             }
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -511,7 +511,7 @@ open class CardBrowser :
                         searchItem!!.expandActionView()
                     }
                 }
-                SearchState.Completed -> redrawAfterSearch()
+                is SearchState.Completed -> redrawAfterSearch()
                 is SearchState.Error -> {
                     showError(searchState.error, crashReportData = null)
                 }
@@ -814,35 +814,14 @@ open class CardBrowser :
         }
     }
 
-    @NeedsTest("searchView == null -> return early & ensure no snackbar when the screen is opened")
     @MainThread
     private fun redrawAfterSearch() {
-        launchCatchingTask {
-            Timber.i("CardBrowser:: Completed searchCards() Successfully")
-            updateList()
-            // check whether mSearchView is initialized as it is lateinit property.
-            if (searchView == null || searchView!!.isIconified) {
-                return@launchCatchingTask
-            }
-            if (viewModel.hasSelectedAllDecks()) {
-                showSnackbar(numberOfCardsOrNoteShown, Snackbar.LENGTH_SHORT)
-            } else {
-                // If we haven't selected all decks, allow the user the option to search all decks.
-                val message =
-                    if (viewModel.rowCount == 0) {
-                        getString(R.string.card_browser_no_cards_in_deck, selectedDeckNameForUi)
-                    } else {
-                        numberOfCardsOrNoteShown
-                    }
-                showSnackbar(message, Snackbar.LENGTH_SHORT) {
-                    setAction(R.string.card_browser_search_all_decks) { searchAllDecks() }
-                }
-            }
-            // HACK: required now we use MenuProvider for searches
-            // this causes a very brief flicker, as we call `setQuery` to restore the menu state
-            searchView?.post {
-                searchView?.clearFocus()
-            }
+        Timber.i("CardBrowser:: Completed searchCards() Successfully")
+        updateList()
+        // HACK: required now we use MenuProvider for searches
+        // this causes a very brief flicker, as we call `setQuery` to restore the menu state
+        searchView?.post {
+            searchView?.clearFocus()
         }
     }
 
@@ -863,17 +842,20 @@ open class CardBrowser :
      * @return A message stating the number of cards/notes shown by the browser.
      */
     val numberOfCardsOrNoteShown: String
-        get() {
-            val count = viewModel.rowCount
+        get() = formatCardCount(viewModel.rowCount, viewModel.cardsOrNotes)
 
-            @androidx.annotation.StringRes val subtitleId =
-                if (viewModel.cardsOrNotes == CARDS) {
-                    R.plurals.card_browser_subtitle
-                } else {
-                    R.plurals.card_browser_subtitle_notes_mode
-                }
-            return resources.getQuantityString(subtitleId, count, count)
-        }
+    fun formatCardCount(
+        count: Int,
+        cardsOrNotes: CardsOrNotes,
+    ): String {
+        @androidx.annotation.StringRes val subtitleId =
+            if (cardsOrNotes == CARDS) {
+                R.plurals.card_browser_subtitle
+            } else {
+                R.plurals.card_browser_subtitle_notes_mode
+            }
+        return resources.getQuantityString(subtitleId, count, count)
+    }
 
     @RustCleanup("this isn't how Desktop Anki does it")
     override fun onSelectedTags(

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -520,9 +520,7 @@ open class CardBrowser :
                     }
                 }
                 is SearchState.Completed -> {
-                    Timber.i("CardBrowser:: Completed searchCards() Successfully")
-                    // TODO: obtain these values from 'Completed'
-                    findViewById<TextView>(R.id.subtitle)?.text = formatCardCount(viewModel.rowCount, viewModel.cardsOrNotes)
+                    findViewById<TextView>(R.id.subtitle)?.text = searchState.formatCardCount(resources)
                     // HACK: required now we use MenuProvider for searches
                     // this causes a very brief flicker, as we call `setQuery` to restore the menu state
                     searchView?.post { searchView?.clearFocus() }
@@ -823,19 +821,6 @@ open class CardBrowser :
         }
     }
 
-    fun formatCardCount(
-        count: Int,
-        cardsOrNotes: CardsOrNotes,
-    ): String {
-        @androidx.annotation.StringRes val subtitleId =
-            if (cardsOrNotes == CARDS) {
-                R.plurals.card_browser_subtitle
-            } else {
-                R.plurals.card_browser_subtitle_notes_mode
-            }
-        return resources.getQuantityString(subtitleId, count, count)
-    }
-
     @RustCleanup("this isn't how Desktop Anki does it")
     override fun onSelectedTags(
         selectedTags: List<String>,
@@ -991,3 +976,11 @@ suspend fun searchForRows(
     }.let { ids ->
         BrowserRowCollection(cardsOrNotes, ids.map { CardOrNoteId(it) }.toMutableList())
     }
+
+/** Renders the row count for [this] event as a localized "X cards/notes" string. */
+fun SearchState.Completed.formatCardCount(resources: android.content.res.Resources): String =
+    resources.getQuantityString(
+        if (cardsOrNotes == CARDS) R.plurals.card_browser_subtitle else R.plurals.card_browser_subtitle_notes_mode,
+        rowCount,
+        rowCount,
+    )

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -52,6 +52,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeNoteTypeResponse
+import com.ichi2.anki.browser.CardBrowserViewModel.NoteEditorCommand
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
@@ -432,27 +433,6 @@ open class CardBrowser :
     val fragment: NoteEditorFragment?
         get() = supportFragmentManager.findFragmentById(R.id.note_editor_frame) as? NoteEditorFragment
 
-    /**
-     * Loads the NoteEditor fragment in container if the view is x-large.
-     *
-     * TODO: this should be a ViewModel concern.
-     */
-    suspend fun loadNoteEditorFragmentIfFragmented() {
-        if (!fragmented) {
-            return
-        }
-        // Show note editor frame
-        binding.noteEditorFrame!!.isVisible = true
-
-        val launcher = viewModel.editNoteLauncher() ?: return
-        // If there are unsaved changes in NoteEditor then show dialog for confirmation
-        if (fragment?.hasUnsavedChanges() == true) {
-            showSaveChangesDialog(launcher)
-        } else {
-            loadNoteEditorFragment(launcher)
-        }
-    }
-
     @Suppress("UNUSED_PARAMETER")
     private fun setupFlows() {
         // provides a name for each flow receiver to improve stack traces
@@ -531,32 +511,24 @@ open class CardBrowser :
             }
         }
 
-        fun onSelectedCardUpdated(unit: Unit) {
+        fun onNoteEditorCommand(command: NoteEditorCommand) {
             launchCatchingTask {
-                if (fragmented) {
-                    loadNoteEditorFragmentIfFragmented()
-                } else {
-                    viewModel.editNoteLauncher()?.let {
-                        startActivity(it.toIntent(this@CardBrowser))
-                    }
-                }
-            }
-        }
-
-        fun onNoteEditorPaneStateChanged(state: CardBrowserViewModel.NoteEditorPaneState) {
-            launchCatchingTask {
-                if (state.visible) {
-                    binding.noteEditorFrame?.isVisible = true
-                    state.launcher?.let { launcher ->
+                when (command) {
+                    is NoteEditorCommand.LoadInPane -> {
+                        binding.noteEditorFrame?.isVisible = true
                         if (fragment?.hasUnsavedChanges() == true) {
-                            showSaveChangesDialog(launcher)
+                            showSaveChangesDialog(command.launcher)
                         } else {
-                            loadNoteEditorFragment(launcher)
+                            loadNoteEditorFragment(command.launcher)
                         }
                     }
-                } else {
-                    binding.noteEditorFrame?.isVisible = false
-                    invalidateOptionsMenu()
+                    is NoteEditorCommand.LaunchActivity -> {
+                        startActivity(command.launcher.toIntent(this@CardBrowser))
+                    }
+                    NoteEditorCommand.HidePane -> {
+                        binding.noteEditorFrame?.isVisible = false
+                        invalidateOptionsMenu()
+                    }
                 }
             }
         }
@@ -587,8 +559,7 @@ open class CardBrowser :
         viewModel.flowOfDeckId.launchCollectionInLifecycleScope(::onDeckIdChanged)
         viewModel.flowOfMultiSelectModeChanged.launchCollectionInLifecycleScope(::onMultiSelectModeChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
-        viewModel.flowOfNoteEditorPaneState.launchCollectionInLifecycleScope(::onNoteEditorPaneStateChanged)
-        viewModel.cardSelectionEventFlow.launchCollectionInLifecycleScope(::onSelectedCardUpdated)
+        viewModel.flowOfNoteEditorCommand.launchCollectionInLifecycleScope(::onNoteEditorCommand)
         viewModel.flowOfSaveSearchNamePrompt.launchCollectionInLifecycleScope(::onSaveSearchNamePrompt)
         viewModel.flowOfChangeNoteType.launchCollectionInLifecycleScope(::onChangeNoteType)
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -43,7 +43,6 @@ import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
 import anki.collection.OpChanges
 import com.google.android.material.snackbar.Snackbar
-import com.ichi2.anim.ActivityTransitionAnimation.Direction
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.browser.BrowserRowCollection
@@ -116,25 +115,6 @@ open class CardBrowser :
     @get:VisibleForTesting
     val addNoteLauncher: NoteEditorLauncher
         get() = createAddNoteLauncher(viewModel)
-
-    /**
-     * Provides an instance of NoteEditorLauncher for editing the current selection.
-     */
-    private suspend fun editNoteLauncher(): NoteEditorLauncher? {
-        val cardIds = viewModel.getCardIdsForNoteEditor()
-
-        if (cardIds.isEmpty()) {
-            Timber.w("EditSelection skipped: card list is empty")
-            return null
-        }
-
-        return NoteEditorLauncher
-            .EditSelection(
-                cardIds = cardIds,
-                animation = Direction.DEFAULT,
-                inCardBrowserActivity = fragmented,
-            )
-    }
 
     fun onDeckSelected(deck: SelectableDeck?) {
         deck?.let { deck -> viewModel.setSelectedDeck(deck) }
@@ -455,6 +435,8 @@ open class CardBrowser :
 
     /**
      * Loads the NoteEditor fragment in container if the view is x-large.
+     *
+     * TODO: this should be a ViewModel concern.
      */
     suspend fun loadNoteEditorFragmentIfFragmented() {
         if (!fragmented) {
@@ -463,7 +445,7 @@ open class CardBrowser :
         // Show note editor frame
         binding.noteEditorFrame!!.isVisible = true
 
-        val launcher = editNoteLauncher() ?: return
+        val launcher = viewModel.editNoteLauncher() ?: return
         // If there are unsaved changes in NoteEditor then show dialog for confirmation
         if (fragment?.hasUnsavedChanges() == true) {
             showSaveChangesDialog(launcher)
@@ -542,9 +524,27 @@ open class CardBrowser :
                 if (fragmented) {
                     loadNoteEditorFragmentIfFragmented()
                 } else {
-                    editNoteLauncher()?.let {
+                    viewModel.editNoteLauncher()?.let {
                         startActivity(it.toIntent(this@CardBrowser))
                     }
+                }
+            }
+        }
+
+        fun onNoteEditorPaneStateChanged(state: CardBrowserViewModel.NoteEditorPaneState) {
+            launchCatchingTask {
+                if (state.visible) {
+                    binding.noteEditorFrame?.isVisible = true
+                    state.launcher?.let { launcher ->
+                        if (fragment?.hasUnsavedChanges() == true) {
+                            showSaveChangesDialog(launcher)
+                        } else {
+                            loadNoteEditorFragment(launcher)
+                        }
+                    }
+                } else {
+                    binding.noteEditorFrame?.isVisible = false
+                    invalidateOptionsMenu()
                 }
             }
         }
@@ -575,6 +575,7 @@ open class CardBrowser :
         viewModel.flowOfDeckId.launchCollectionInLifecycleScope(::onDeckIdChanged)
         viewModel.flowOfMultiSelectModeChanged.launchCollectionInLifecycleScope(::onMultiSelectModeChanged)
         viewModel.flowOfSearchState.launchCollectionInLifecycleScope(::searchStateChanged)
+        viewModel.flowOfNoteEditorPaneState.launchCollectionInLifecycleScope(::onNoteEditorPaneStateChanged)
         viewModel.cardSelectionEventFlow.launchCollectionInLifecycleScope(::onSelectedCardUpdated)
         viewModel.flowOfSaveSearchNamePrompt.launchCollectionInLifecycleScope(::onSaveSearchNamePrompt)
         viewModel.flowOfChangeNoteType.launchCollectionInLifecycleScope(::onChangeNoteType)
@@ -822,18 +823,6 @@ open class CardBrowser :
         launchCatchingTask {
             Timber.i("CardBrowser:: Completed searchCards() Successfully")
             updateList()
-            // Check whether deck is empty or not
-            val isDeckEmpty = viewModel.rowCount == 0
-            val focusedCardId = viewModel.resolveFocusedCardId()
-            // Hide note editor frame if deck is empty and fragmented
-            binding.noteEditorFrame?.visibility =
-                if (fragmented && !isDeckEmpty && focusedCardId != null) {
-                    loadNoteEditorFragmentIfFragmented()
-                    View.VISIBLE
-                } else {
-                    invalidateOptionsMenu()
-                    View.GONE
-                }
             // check whether mSearchView is initialized as it is lateinit property.
             if (searchView == null || searchView!!.isIconified) {
                 return@launchCatchingTask

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -162,11 +162,8 @@ open class CardBrowser :
     private val mySearchesItem: MenuItem? get() = cardBrowserFragment.mySearchesItem
 
     // card that was clicked (not marked)
-    override var currentCardId
+    override val currentCardId: CardId?
         get() = viewModel.currentCardId
-        set(value) {
-            viewModel.currentCardId = value
-        }
 
     // Dev option for Issue 18709
     // TODO: Broken currently; needs R.layout.activity_card_browser_searchview

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -265,7 +265,7 @@ class BrowserMultiColumnAdapter(
             }
             holder.setIsSelected(isSelected)
             val rowColor =
-                if (viewModel.focusedRow == id) {
+                if (viewModel.isFragmented && viewModel.focusedRow == id) {
                     ThemeUtils.getThemeAttrColor(context, R.attr.focusedRowBackgroundColor)
                 } else {
                     backendColorToColor(row.color)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -898,6 +898,7 @@ class CardBrowserFragment :
             progressIndicator.isVisible = searchState == Initializing || searchState == Searching
             if (searchState is SearchState.Completed) {
                 onSearchResultMessage(searchState.resultMessage)
+                invalidateMenu()
             }
         }
 
@@ -913,6 +914,7 @@ class CardBrowserFragment :
         }
 
         fun onCardsMarkedEvent(unit: Unit) {
+            // PERF: Add a parameter to update only the affected rows
             cardsAdapter.notifyDataSetChanged()
         }
 
@@ -1459,9 +1461,7 @@ class CardBrowserFragment :
 
     fun updateFlagForSelectedRows(flag: Flag) =
         launchCatchingTask {
-            // TODO: Use the return value to update only the affected rows
             withProgress { activityViewModel.updateSelectedCardsFlag(flag) }
-            ankiActivity.onCardsUpdated()
         }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -273,7 +273,9 @@ class CardBrowserFragment :
             BrowserMultiColumnAdapter(
                 requireContext(),
                 activityViewModel,
-                onTap = ::onTap,
+                onTap = { rowId ->
+                    activityViewModel.onTap(rowId.toRowSelection())
+                },
                 onLongPress = { rowId ->
                     activityViewModel.handleRowLongPress(rowId.toRowSelection())
                 },
@@ -1216,25 +1218,6 @@ class CardBrowserFragment :
             dialog.show(parentFragmentManager, ColumnSelectionDialogFragment.TAG)
         }
     }
-
-    // TODO: Move this to ViewModel and test
-    @VisibleForTesting
-    fun onTap(id: CardOrNoteId) =
-        launchCatchingTask {
-            activityViewModel.focusedRow = id
-            if (activityViewModel.isInMultiSelectMode) {
-                val wasSelected = activityViewModel.selectedRows.contains(id)
-                activityViewModel.toggleRowSelection(id.toRowSelection())
-                // Load NoteEditor on trailing side if card is selected
-                if (wasSelected) {
-                    activityViewModel.currentCardId = id.toCardId(activityViewModel.cardsOrNotes)
-                    requireCardBrowserActivity().loadNoteEditorFragmentIfFragmented()
-                }
-            } else {
-                val cardId = activityViewModel.queryDataForCardEdit(id)
-                requireCardBrowserActivity().setNoteEditorCard(cardId)
-            }
-        }
 
     // TODO: This dialog should survive activity recreation
     fun showChangeDeckDialog() =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -197,6 +197,9 @@ class CardBrowserFragment :
 
     private var undoSnackbar: Snackbar? = null
 
+    /** The focused row, should only be used for efficient `notifyItemChanged` calls */
+    private var focusedRow: CardOrNoteId? = null
+
     // Dev option for Issue 18709
     private val useSearchView: Boolean
         get() = requireCardBrowserActivity().useSearchView
@@ -862,6 +865,15 @@ class CardBrowserFragment :
 
         fun onSelectedRowsChanged(rows: Set<Any>) = cardsAdapter.notifyDataSetChanged()
 
+        fun onFocusedRowChanged(newFocused: CardOrNoteId?) {
+            val previous = focusedRow
+            focusedRow = newFocused
+            listOfNotNull(previous, newFocused)
+                .distinct()
+                .mapNotNull { activityViewModel.getPositionOfId(it) }
+                .forEach { cardsAdapter.notifyItemChanged(it) }
+        }
+
         fun onCardsMarkedEvent(unit: Unit) {
             cardsAdapter.notifyDataSetChanged()
         }
@@ -1024,6 +1036,7 @@ class CardBrowserFragment :
         activityViewModel.reverseDirectionFlow.launchCollectionInLifecycleScope(::reverseDirectionChanged)
         activityViewModel.flowOfIsTruncated.launchCollectionInLifecycleScope(::onIsTruncatedChanged)
         activityViewModel.flowOfSelectedRows.launchCollectionInLifecycleScope(::onSelectedRowsChanged)
+        activityViewModel.flowOfFocusedRow.launchCollectionInLifecycleScope(::onFocusedRowChanged)
         activityViewModel.flowOfActiveColumns.launchCollectionInLifecycleScope(::onColumnsChanged)
         activityViewModel.flowOfCardsUpdated.launchCollectionInLifecycleScope(::cardsUpdatedChanged)
         activityViewModel.flowOfMultiSelectModeChanged.launchCollectionInLifecycleScope(::onMultiSelectModeChanged)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -761,7 +761,7 @@ class CardBrowserFragment :
                             return true
                         }
                         R.id.action_edit_note -> {
-                            requireCardBrowserActivity().openNoteEditorForCurrentlySelectedNote()
+                            requireCardBrowserActivity().openNoteEditorForCurrentlySelectedRow()
                             return true
                         }
                         R.id.action_view_card_info -> {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -115,6 +115,7 @@ import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
 import com.ichi2.anki.export.ExportDialogFragment
 import com.ichi2.anki.filtered.FilteredDeckOptionsFragment
+import com.ichi2.anki.formatCardCount
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.libanki.DeckId
 import com.ichi2.anki.libanki.undoAvailable
@@ -859,7 +860,7 @@ class CardBrowserFragment :
             }
         }
 
-        fun onSearchResultMessage(result: SearchResultMessage) {
+        fun onSearchCompleted(state: SearchState.Completed) {
             val activity = requireCardBrowserActivity()
 
             // #3592: show the number of cards found the number of cards is not visible in the menu
@@ -879,10 +880,10 @@ class CardBrowserFragment :
                 }
             }
 
-            when (result) {
+            when (val result = state.resultMessage) {
                 is SearchResultMessage.CardCount ->
                     showSnackbar(
-                        message = activity.formatCardCount(result.count, result.cardsOrNotes),
+                        message = state.formatCardCount(resources),
                         searchAllDecks = result.includeSearchAllDecksAction,
                     )
                 SearchResultMessage.NoCardsInSelectedDeck ->
@@ -897,7 +898,7 @@ class CardBrowserFragment :
             cardsAdapter.notifyDataSetChanged()
             progressIndicator.isVisible = searchState == Initializing || searchState == Searching
             if (searchState is SearchState.Completed) {
-                onSearchResultMessage(searchState.resultMessage)
+                onSearchCompleted(searchState)
                 invalidateMenu()
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -1421,10 +1421,9 @@ class CardBrowserFragment :
 
     fun updateFlagForSelectedRows(flag: Flag) =
         launchCatchingTask {
-            // list of cards with updated flags
-            val updatedCardIds = withProgress { activityViewModel.updateSelectedCardsFlag(flag) }
-
-            ankiActivity.onCardsUpdated(updatedCardIds)
+            // TODO: Use the return value to update only the affected rows
+            withProgress { activityViewModel.updateSelectedCardsFlag(flag) }
+            ankiActivity.onCardsUpdated()
         }
 
     @VisibleForTesting(otherwise = VisibleForTesting.NONE)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -81,6 +81,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.MultiSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.RowSelection
+import com.ichi2.anki.browser.CardBrowserViewModel.SearchResultMessage
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
@@ -858,9 +859,46 @@ class CardBrowserFragment :
             }
         }
 
+        fun onSearchResultMessage(result: SearchResultMessage) {
+            val activity = requireCardBrowserActivity()
+
+            // #3592: show the number of cards found the number of cards is not visible in the menu
+            val isMenuSubtitleVisible = legacySearchView != null && legacySearchView!!.isIconified
+
+            fun showSnackbar(
+                message: String,
+                searchAllDecks: Boolean,
+            ) {
+                // Don't show a snackbar if the results are visible in the header.
+                // But do show the snackbar if an action is available
+                if (isMenuSubtitleVisible && !searchAllDecks) return
+
+                showSnackbar(message, Snackbar.LENGTH_SHORT) {
+                    if (!searchAllDecks) return@showSnackbar
+                    setAction(R.string.card_browser_search_all_decks) { activity.searchAllDecks() }
+                }
+            }
+
+            when (result) {
+                is SearchResultMessage.CardCount ->
+                    showSnackbar(
+                        message = activity.formatCardCount(result.count, result.cardsOrNotes),
+                        searchAllDecks = result.includeSearchAllDecksAction,
+                    )
+                SearchResultMessage.NoCardsInSelectedDeck ->
+                    showSnackbar(
+                        getString(R.string.card_browser_no_cards_in_deck, activity.selectedDeckNameForUi),
+                        searchAllDecks = true,
+                    )
+            }
+        }
+
         fun searchStateChanged(searchState: SearchState) {
             cardsAdapter.notifyDataSetChanged()
             progressIndicator.isVisible = searchState == Initializing || searchState == Searching
+            if (searchState is SearchState.Completed) {
+                onSearchResultMessage(searchState.resultMessage)
+            }
         }
 
         fun onSelectedRowsChanged(rows: Set<Any>) = cardsAdapter.notifyDataSetChanged()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -162,19 +162,27 @@ class CardBrowserViewModel(
     val flowOfSearchState = MutableSharedFlow<SearchState>()
 
     /**
-     * When the visibility of the note editor pane changes.
-     * @see NoteEditorPaneState
+     * Commands to drive the note editor either in a fragment or a standalone activity
+     * @see NoteEditorCommand
      */
-    val flowOfNoteEditorPaneState = MutableSharedFlow<NoteEditorPaneState>()
+    val flowOfNoteEditorCommand = MutableSharedFlow<NoteEditorCommand>()
 
-    /**
-     * @param visible whether the pane should be visible
-     * @param launcher proposed note to edit (if an unsaved note is not retained)
-     */
-    data class NoteEditorPaneState(
-        val visible: Boolean,
-        val launcher: NoteEditorLauncher?,
-    )
+    sealed interface NoteEditorCommand {
+        /** Tablet pane: show pane and load the editor with [launcher]. */
+        data class LoadInPane(
+            val launcher: NoteEditorLauncher,
+        ) : NoteEditorCommand
+
+        /** Phone: launch the standalone NoteEditor activity with [launcher]. */
+        data class LaunchActivity(
+            val launcher: NoteEditorLauncher,
+        ) : NoteEditorCommand
+
+        /** Tablet pane: hide the pane (no row available). */
+        data object HidePane : NoteEditorCommand
+
+        companion object
+    }
 
     /** Result of a completed search, used to drive a snackbar in the UI */
     sealed interface SearchResultMessage {
@@ -300,8 +308,6 @@ class CardBrowserViewModel(
                 started = SharingStarted.Lazily,
                 initialValue = SELECT_NONE,
             )
-
-    val cardSelectionEventFlow = MutableSharedFlow<Unit>()
 
     /**
      * If cards are marked or flagged
@@ -665,7 +671,7 @@ class CardBrowserViewModel(
                 // when in mutliselect, only deselecting should cause a change in focus
                 if (wasSelected && isFragmented) {
                     focusedRow = id
-                    cardSelectionEventFlow.emit(Unit)
+                    editNoteLauncher()?.let { flowOfNoteEditorCommand.emit(NoteEditorCommand.LoadInPane(it)) }
                 }
             } else {
                 setNoteEditorRow(id)
@@ -710,7 +716,10 @@ class CardBrowserViewModel(
             if (!isFragmented) {
                 endMultiSelectMode(SingleSelectCause.OpenNoteEditorActivity)
             }
-            cardSelectionEventFlow.emit(Unit)
+            val launcher = editNoteLauncher() ?: return@launch
+            flowOfNoteEditorCommand.emit(
+                if (isFragmented) NoteEditorCommand.LoadInPane(launcher) else NoteEditorCommand.LaunchActivity(launcher),
+            )
         }
 
     /**
@@ -1392,13 +1401,7 @@ class CardBrowserViewModel(
                     ensureActive()
                     this@CardBrowserViewModel.cards.replaceWith(cardsOrNotes, cards)
                     ensureFocusedRowValid()
-                    val panelVisible = isFragmented && this@CardBrowserViewModel.cards.isNotEmpty()
-                    flowOfNoteEditorPaneState.emit(
-                        NoteEditorPaneState(
-                            visible = panelVisible,
-                            launcher = if (panelVisible) editNoteLauncher() else null,
-                        ),
-                    )
+                    if (isFragmented) flowOfNoteEditorCommand.emit(NoteEditorCommand.fromCurrentSearchState())
                     flowOfSearchState.emit(SearchState.Completed.fromCurrentState())
                     selectUnvalidatedRowIds(cardOrNoteIdsToSelect)
                 }
@@ -1519,6 +1522,10 @@ class CardBrowserViewModel(
                     else -> SearchResultMessage.CardCount(includeSearchAllDecksAction = true)
                 },
         )
+
+    /** Builds the post-search trailing-pane command from current ViewModel state (tablet only). */
+    private suspend fun NoteEditorCommand.Companion.fromCurrentSearchState(): NoteEditorCommand =
+        editNoteLauncher()?.let { NoteEditorCommand.LoadInPane(it) } ?: NoteEditorCommand.HidePane
 
     companion object {
         /** Intent extra carrying the [DeckId] the browser should open scoped to. */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -176,6 +176,19 @@ class CardBrowserViewModel(
         val launcher: NoteEditorLauncher?,
     )
 
+    /** Result of a completed search, used to drive a snackbar in the UI */
+    sealed interface SearchResultMessage {
+        /** "X cards/notes shown | Search all decks" */
+        data class CardCount(
+            val count: Int,
+            val cardsOrNotes: CardsOrNotes,
+            val includeSearchAllDecksAction: Boolean,
+        ) : SearchResultMessage
+
+        /** "No cards in deck X" message; always paired with a "search all decks" action. */
+        data object NoCardsInSelectedDeck : SearchResultMessage
+    }
+
     /** text in the search box (potentially unsubmitted) */
     // this does not currently bind to the value in the UI and is only used for posting
     val flowOfFilterQuery = MutableSharedFlow<String>()
@@ -957,7 +970,7 @@ class CardBrowserViewModel(
             ChangeCardOrder.DirectionChange -> {
                 reverseDirectionFlow.update { ReverseDirection(orderAsc = !orderAsc) }
                 cards.reverse()
-                viewModelScope.launch { flowOfSearchState.emit(SearchState.Completed) }
+                viewModelScope.launch { flowOfSearchState.emit(SearchState.Completed.fromCurrentState()) }
             }
         }
     }
@@ -1388,7 +1401,7 @@ class CardBrowserViewModel(
                             launcher = if (panelVisible) editNoteLauncher() else null,
                         ),
                     )
-                    flowOfSearchState.emit(SearchState.Completed)
+                    flowOfSearchState.emit(SearchState.Completed.fromCurrentState())
                     selectUnvalidatedRowIds(cardOrNoteIdsToSelect)
                 }
 
@@ -1494,6 +1507,18 @@ class CardBrowserViewModel(
         }
 
     suspend fun getAvailableDecks(): List<SelectableDeck.Deck> = SelectableDeck.fromCollection(includeFiltered = false)
+
+    /** Builds a [SearchState.Completed] event reflecting the current ViewModel state. */
+    private fun SearchState.Completed.Companion.fromCurrentState(): SearchState.Completed =
+        SearchState.Completed(
+            resultMessage =
+                when {
+                    // TODO: better message if rowCount == 0 AND hasSelectedAllDecks
+                    hasSelectedAllDecks() -> SearchResultMessage.CardCount(rowCount, cardsOrNotes, includeSearchAllDecksAction = false)
+                    rowCount == 0 -> SearchResultMessage.NoCardsInSelectedDeck
+                    else -> SearchResultMessage.CardCount(rowCount, cardsOrNotes, includeSearchAllDecksAction = true)
+                },
+        )
 
     companion object {
         /** Intent extra carrying the [DeckId] the browser should open scoped to. */
@@ -1611,7 +1636,11 @@ class CardBrowserViewModel(
         data object Searching : SearchState
 
         /** A search has been completed */
-        data object Completed : SearchState
+        data class Completed(
+            val resultMessage: SearchResultMessage,
+        ) : SearchState {
+            companion object
+        }
 
         /**
          * A search error, for instance:

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -33,6 +33,7 @@ import anki.collection.OpChanges
 import anki.collection.OpChangesWithCount
 import anki.search.BrowserColumns
 import anki.search.BrowserRow
+import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.ALL_DECKS_ID
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager
@@ -73,6 +74,7 @@ import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.model.SortType
+import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.pages.CardInfoDestination
@@ -159,6 +161,21 @@ class CardBrowserViewModel(
 
     val flowOfSearchState = MutableSharedFlow<SearchState>()
 
+    /**
+     * When the visibility of the note editor pane changes.
+     * @see NoteEditorPaneState
+     */
+    val flowOfNoteEditorPaneState = MutableSharedFlow<NoteEditorPaneState>()
+
+    /**
+     * @param visible whether the pane should be visible
+     * @param launcher proposed note to edit (if an unsaved note is not retained)
+     */
+    data class NoteEditorPaneState(
+        val visible: Boolean,
+        val launcher: NoteEditorLauncher?,
+    )
+
     /** text in the search box (potentially unsubmitted) */
     // this does not currently bind to the value in the UI and is only used for posting
     val flowOfFilterQuery = MutableSharedFlow<String>()
@@ -171,18 +188,16 @@ class CardBrowserViewModel(
     val cardsOrNotes get() = flowOfCardsOrNotes.value
 
     /**
-     * Resolves the focused row to a card id, falling back to the first row if no row is focused.
-     * Updates [focusedRow] to the fallback row when one is used, so subsequent reads stay in sync.
-     *
-     * TODO: remove this from redrawAfterSearch and set the new row in the ViewModel
+     * Ensures [focusedRow] points to a row in the current [cards] list, falling back to the
+     * first row when [focusedRow] no longer visible.
      */
-    suspend fun resolveFocusedCardId(): CardId? {
-        if (cards.isEmpty()) {
-            focusedRow = null
-            return null
-        }
-        if (focusedRow == null) focusedRow = cards.first()
-        return focusedRow?.toCardId(cardsOrNotes)
+    private fun ensureFocusedRowValid() {
+        focusedRow =
+            when {
+                cards.isEmpty() -> null
+                focusedRow == null || focusedRow !in cards -> cards.first()
+                else -> focusedRow
+            }
     }
 
     var cardIdToBeScrolledTo: CardId? = null
@@ -323,6 +338,20 @@ class CardBrowserViewModel(
                 listOf(cardId)
             }
         }
+    }
+
+    /** Builds a [NoteEditorLauncher] for the current selection, or `null` if there's nothing to edit. */
+    suspend fun editNoteLauncher(): NoteEditorLauncher? {
+        val cardIds = getCardIdsForNoteEditor()
+        if (cardIds.isEmpty()) {
+            Timber.w("EditSelection skipped: card list is empty")
+            return null
+        }
+        return NoteEditorLauncher.EditSelection(
+            cardIds = cardIds,
+            animation = ActivityTransitionAnimation.Direction.DEFAULT,
+            inCardBrowserActivity = isFragmented,
+        )
     }
 
     fun requestChangeNoteType() =
@@ -1351,6 +1380,14 @@ class CardBrowserViewModel(
 
                     ensureActive()
                     this@CardBrowserViewModel.cards.replaceWith(cardsOrNotes, cards)
+                    ensureFocusedRowValid()
+                    val panelVisible = isFragmented && this@CardBrowserViewModel.cards.isNotEmpty()
+                    flowOfNoteEditorPaneState.emit(
+                        NoteEditorPaneState(
+                            visible = panelVisible,
+                            launcher = if (panelVisible) editNoteLauncher() else null,
+                        ),
+                    )
                     flowOfSearchState.emit(SearchState.Completed)
                     selectUnvalidatedRowIds(cardOrNoteIdsToSelect)
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -172,6 +172,7 @@ class CardBrowserViewModel(
 
     // card that was clicked (not marked)
     var currentCardId: CardId? = null
+        private set
 
     /**
      * Computes and stores the current card ID used by the note editor.
@@ -295,7 +296,7 @@ class CardBrowserViewModel(
     val flowOfSaveSearchNamePrompt = MutableSharedFlow<String>()
 
     var focusedRow: CardOrNoteId? = null
-        set(value) {
+        private set(value) {
             if (!isFragmented) return
             field = value
         }
@@ -606,6 +607,38 @@ class CardBrowserViewModel(
         flowOfInitCompleted.update { true }
         Timber.d("manualInit")
     }
+
+    /**
+     * Handles a tap on a row.
+     *
+     * Outside multi-select: opens the note editor for the tapped row.
+     *
+     * In multi-select: toggles the row's selection.
+     *
+     * When deselecting a row in fragmented mode, the trailing pane is updated:
+     *
+     * - CARDS - selects another selected row
+     * - NOTES - selection is unchanged (bug?)
+     */
+    fun onTap(rowSelection: RowSelection) =
+        launchCatchingIO(errorMessageHandler = { /* only log */ }) {
+            val id = rowSelection.rowId
+            focusedRow = id
+            if (isInMultiSelectMode) {
+                val wasSelected = id in selectedRows
+                toggleRowSelection(rowSelection)
+                if (wasSelected) {
+                    currentCardId = id.toCardId(cardsOrNotes)
+                    // load the trailing pane only when fragmented; on phones, multi-select tap
+                    // just toggles selection and must not navigate away
+                    if (isFragmented) {
+                        cardSelectionEventFlow.emit(Unit)
+                    }
+                }
+            } else {
+                setNoteEditorCard(queryDataForCardEdit(id))
+            }
+        }
 
     fun handleRowLongPress(rowSelection: RowSelection) =
         viewModelScope.launch {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -684,6 +684,19 @@ class CardBrowserViewModel(
         }
     }
 
+    /**
+     * Opens the note editor for the first selected row (if multi-selecting), else the first row.
+     *
+     * @return `false` if there are no rows to edit
+     */
+    suspend fun openNoteEditorForCurrentlySelectedRow(): Boolean {
+        if (cards.isEmpty()) return false
+        val row = if (isInMultiSelectMode) selectedRows.firstOrNull() else cards.firstOrNull()
+        val cardId = row?.toCardId(cardsOrNotes) ?: return false
+        setNoteEditorCard(cardId)
+        return true
+    }
+
     /** Whether any rows are selected */
     fun hasSelectedAnyRows(): Boolean = selectedRows.isNotEmpty()
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -170,23 +170,19 @@ class CardBrowserViewModel(
     private val flowOfCardsOrNotes = MutableStateFlow(CARDS)
     val cardsOrNotes get() = flowOfCardsOrNotes.value
 
-    // card that was clicked (not marked)
-    var currentCardId: CardId? = null
-        private set
-
     /**
-     * Computes and stores the current card ID used by the note editor.
+     * Resolves the focused row to a card id, falling back to the first row if no row is focused.
+     * Updates [focusedRow] to the fallback row when one is used, so subsequent reads stay in sync.
+     *
+     * TODO: remove this from redrawAfterSearch and set the new row in the ViewModel
      */
-    suspend fun updateCurrentCardId(): CardId? {
-        currentCardId =
-            // Early return if no cards available
-            if (cards.isEmpty()) {
-                null
-            } else {
-                focusedRow?.toCardId(cardsOrNotes)
-                    ?: cards.firstOrNull()?.toCardId(cardsOrNotes)
-            }
-        return currentCardId
+    suspend fun resolveFocusedCardId(): CardId? {
+        if (cards.isEmpty()) {
+            focusedRow = null
+            return null
+        }
+        if (focusedRow == null) focusedRow = cards.first()
+        return focusedRow?.toCardId(cardsOrNotes)
     }
 
     var cardIdToBeScrolledTo: CardId? = null
@@ -295,10 +291,12 @@ class CardBrowserViewModel(
      */
     val flowOfSaveSearchNamePrompt = MutableSharedFlow<String>()
 
-    var focusedRow: CardOrNoteId? = null
+    val flowOfFocusedRow: StateFlow<CardOrNoteId?>
+        field = MutableStateFlow<CardOrNoteId?>(null)
+    var focusedRow: CardOrNoteId?
+        get() = flowOfFocusedRow.value
         private set(value) {
-            if (!isFragmented) return
-            field = value
+            flowOfFocusedRow.value = value
         }
 
     suspend fun queryAllSelectedCardIds() = selectedRows.queryCardIds(this.cardsOrNotes)
@@ -312,7 +310,7 @@ class CardBrowserViewModel(
      * In 'Cards' mode, this returns only the selected cards.
      */
     suspend fun getCardIdsForNoteEditor(): List<CardId> {
-        val cardId = currentCardId ?: return emptyList()
+        val cardId = focusedRow?.toCardId(cardsOrNotes) ?: return emptyList()
 
         return if (cardsOrNotes == NOTES) {
             withCol {
@@ -392,8 +390,6 @@ class CardBrowserViewModel(
         val firstSelectedCard = selectedRows.firstOrNull()?.toCardId(cardsOrNotes) ?: return null
         return CardInfoDestination(firstSelectedCard, TR.currentCardBrowse())
     }
-
-    suspend fun queryDataForCardEdit(id: CardOrNoteId): CardId? = id.toCardId(cardsOrNotes)
 
     private suspend fun getInitialDeck(): SelectableDeck {
         suspend fun consumeIntentDeck(): SelectableDeck.Deck? {
@@ -623,27 +619,22 @@ class CardBrowserViewModel(
     fun onTap(rowSelection: RowSelection) =
         launchCatchingIO(errorMessageHandler = { /* only log */ }) {
             val id = rowSelection.rowId
-            focusedRow = id
             if (isInMultiSelectMode) {
                 val wasSelected = id in selectedRows
                 toggleRowSelection(rowSelection)
-                if (wasSelected) {
-                    currentCardId = id.toCardId(cardsOrNotes)
-                    // load the trailing pane only when fragmented; on phones, multi-select tap
-                    // just toggles selection and must not navigate away
-                    if (isFragmented) {
-                        cardSelectionEventFlow.emit(Unit)
-                    }
+                // when in mutliselect, only deselecting should cause a change in focus
+                if (wasSelected && isFragmented) {
+                    focusedRow = id
+                    cardSelectionEventFlow.emit(Unit)
                 }
             } else {
-                setNoteEditorCard(queryDataForCardEdit(id))
+                setNoteEditorRow(id)
             }
         }
 
     fun handleRowLongPress(rowSelection: RowSelection) =
         viewModelScope.launch {
             val id = rowSelection.rowId
-            currentCardId = id.toCardId(cardsOrNotes)
             if (isInMultiSelectMode && lastSelectedId != null) {
                 selectRowsBetween(lastSelectedId!!, id)
             } else {
@@ -658,7 +649,6 @@ class CardBrowserViewModel(
     fun handleRightClick(rowSelection: RowSelection) {
         viewModelScope.launch {
             val id = rowSelection.rowId
-            currentCardId = id.toCardId(cardsOrNotes)
             if (isInMultiSelectMode && lastSelectedId != null) {
                 selectRowsBetween(lastSelectedId!!, id)
             } else {
@@ -669,31 +659,29 @@ class CardBrowserViewModel(
     }
 
     /**
-     * Opens the note editor for the given card.
+     * Opens the note editor for the given row.
      *
-     * @param cardId The ID of the card to open in the note editor.
-     * Passing `null` indicates that no card is selected and will close the note editor
+     * @param row The row to focus and open in the note editor.
+     * Passing `null` indicates that no row is selected and will close the note editor.
      */
-    fun setNoteEditorCard(cardId: CardId?) {
-        currentCardId = cardId
-        if (!isFragmented) {
-            endMultiSelectMode(SingleSelectCause.OpenNoteEditorActivity)
-        }
+    private fun setNoteEditorRow(row: CardOrNoteId?) =
         viewModelScope.launch {
+            focusedRow = row
+            if (!isFragmented) {
+                endMultiSelectMode(SingleSelectCause.OpenNoteEditorActivity)
+            }
             cardSelectionEventFlow.emit(Unit)
         }
-    }
 
     /**
      * Opens the note editor for the first selected row (if multi-selecting), else the first row.
      *
      * @return `false` if there are no rows to edit
      */
-    suspend fun openNoteEditorForCurrentlySelectedRow(): Boolean {
+    fun openNoteEditorForCurrentlySelectedRow(): Boolean {
         if (cards.isEmpty()) return false
-        val row = if (isInMultiSelectMode) selectedRows.firstOrNull() else cards.firstOrNull()
-        val cardId = row?.toCardId(cardsOrNotes) ?: return false
-        setNoteEditorCard(cardId)
+        val row = (if (isInMultiSelectMode) selectedRows.firstOrNull() else cards.firstOrNull()) ?: return false
+        setNoteEditorRow(row)
         return true
     }
 
@@ -1391,8 +1379,6 @@ class CardBrowserViewModel(
     }
 
     suspend fun queryCardIdAtPosition(index: Int): CardId = cards.queryCardIdsAt(index).first()
-
-    suspend fun querySelectedCardIdAtPosition(index: Int): CardId? = selectedRows.toList()[index].toCardId(cardsOrNotes)
 
     /**
      * Obtains two lists of column headings with preview data

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -180,8 +180,6 @@ class CardBrowserViewModel(
     sealed interface SearchResultMessage {
         /** "X cards/notes shown | Search all decks" */
         data class CardCount(
-            val count: Int,
-            val cardsOrNotes: CardsOrNotes,
             val includeSearchAllDecksAction: Boolean,
         ) : SearchResultMessage
 
@@ -1511,12 +1509,14 @@ class CardBrowserViewModel(
     /** Builds a [SearchState.Completed] event reflecting the current ViewModel state. */
     private fun SearchState.Completed.Companion.fromCurrentState(): SearchState.Completed =
         SearchState.Completed(
+            rowCount = rowCount,
+            cardsOrNotes = cardsOrNotes,
             resultMessage =
                 when {
                     // TODO: better message if rowCount == 0 AND hasSelectedAllDecks
-                    hasSelectedAllDecks() -> SearchResultMessage.CardCount(rowCount, cardsOrNotes, includeSearchAllDecksAction = false)
+                    hasSelectedAllDecks() -> SearchResultMessage.CardCount(includeSearchAllDecksAction = false)
                     rowCount == 0 -> SearchResultMessage.NoCardsInSelectedDeck
-                    else -> SearchResultMessage.CardCount(rowCount, cardsOrNotes, includeSearchAllDecksAction = true)
+                    else -> SearchResultMessage.CardCount(includeSearchAllDecksAction = true)
                 },
         )
 
@@ -1637,6 +1637,8 @@ class CardBrowserViewModel(
 
         /** A search has been completed */
         data class Completed(
+            val rowCount: Int,
+            val cardsOrNotes: CardsOrNotes,
             val resultMessage: SearchResultMessage,
         ) : SearchState {
             companion object

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -2048,7 +2048,7 @@ fun CardBrowser.selectRowsWithPositions(vararg positions: Int) {
     }
 }
 
-fun CardBrowser.clickRowAtPosition(pos: Int) = cardBrowserFragment.onTap(viewModel.cards[pos])
+fun CardBrowser.clickRowAtPosition(pos: Int) = viewModel.onTap(viewModel.cards[pos].toRowSelection())
 
 fun CardBrowser.longClickRowAtPosition(pos: Int) = viewModel.handleRowLongPress(viewModel.cards[pos].toRowSelection())
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -55,6 +55,7 @@ import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleS
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeNoteTypeResponse
 import com.ichi2.anki.browser.CardBrowserViewModel.Companion.STATE_MULTISELECT_VALUES
 import com.ichi2.anki.browser.CardBrowserViewModel.RowSelection
+import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_ALL
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_NONE
 import com.ichi2.anki.browser.RepositionCardsRequest.NoRepositionableCardsError
@@ -1532,6 +1533,48 @@ class CardBrowserViewModelTest : JvmTest() {
         }
 
     @Test
+    fun `searchResultMessage - all decks selected, with rows`() =
+        runViewModelTest(notes = 3) {
+            flowOfSearchState.test {
+                ignoreEventsDuringViewModelInit()
+                setSelectedDeck(SelectableDeck.AllDecks)
+                val message = awaitSearchCompleted().resultMessage
+                val card = message as CardBrowserViewModel.SearchResultMessage.CardCount
+                assertThat("count", card.count, equalTo(3))
+                assertThat("cardsOrNotes", card.cardsOrNotes, equalTo(CardsOrNotes.CARDS))
+                assertThat("no all-decks action when already on all decks", card.includeSearchAllDecksAction, equalTo(false))
+            }
+        }
+
+    @Test
+    fun `searchResultMessage - specific deck with cards has all-decks action`() =
+        runViewModelTest {
+            val deck = addDeck("Specific")
+            addNoteToDeck(deck)
+            flowOfSearchState.test {
+                ignoreEventsDuringViewModelInit()
+                setSelectedDeck(deck)
+                val card = awaitSearchCompleted().resultMessage as CardBrowserViewModel.SearchResultMessage.CardCount
+                assertThat("includes all-decks action", card.includeSearchAllDecksAction, equalTo(true))
+            }
+        }
+
+    @Test
+    fun `searchResultMessage - specific deck with no cards`() =
+        runViewModelTest {
+            val deck = addDeck("Empty")
+            flowOfSearchState.test {
+                ignoreEventsDuringViewModelInit()
+                setSelectedDeck(deck)
+                assertThat(
+                    "empty deck → no-cards-in-selected-deck",
+                    awaitSearchCompleted().resultMessage,
+                    equalTo(CardBrowserViewModel.SearchResultMessage.NoCardsInSelectedDeck),
+                )
+            }
+        }
+
+    @Test
     fun `multiselect toggle state is restored`() {
         val handle = SavedStateHandle()
         runViewModelTest(savedStateHandle = handle, notes = 1) {
@@ -1915,6 +1958,14 @@ class CardBrowserViewModelTest : JvmTest() {
 private fun CardBrowserViewModel.selectRowsWithPositions(vararg positions: Int) {
     for (pos in positions) {
         selectRowAtPosition(pos)
+    }
+}
+
+/** Skip non-Completed [CardBrowserViewModel.SearchState] emissions and return the next [SearchState.Completed]. */
+private suspend fun TurbineTestContext<SearchState>.awaitSearchCompleted(): SearchState.Completed {
+    while (true) {
+        val item = awaitItem()
+        if (item is SearchState.Completed) return item
     }
 }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1445,7 +1445,7 @@ class CardBrowserViewModelTest : JvmTest() {
             cardSelectionEventFlow.test {
                 onTap(getRowAtPosition(1).toRowSelection()).join()
                 awaitItem()
-                assertThat("currentCardId set to tapped row", currentCardId, equalTo(getRowAtPosition(1).toCardId(cardsOrNotes)))
+                assertThat("focusedRow set to tapped row", focusedRow, equalTo(getRowAtPosition(1)))
                 assertThat("not in multi-select after tap", isInMultiSelectMode, equalTo(false))
             }
         }
@@ -1491,8 +1491,23 @@ class CardBrowserViewModelTest : JvmTest() {
             cardSelectionEventFlow.test {
                 onTap(deselectedId.toRowSelection()).join()
                 awaitItem()
-                assertThat("currentCardId points at deselected row", currentCardId, equalTo(deselectedId.toCardId(cardsOrNotes)))
                 assertThat("focusedRow points at deselected row", focusedRow, equalTo(deselectedId))
+            }
+        }
+
+    @Test
+    fun `onTap add-to-multi-select on tablet does not move focus`() =
+        runViewModelTest(notes = 3, isFragmented = true) {
+            // long-press row 1 to enter multi-select; focus and selection both land on row 1
+            handleRowLongPress(getRowAtPosition(1).toRowSelection()).join()
+            assertThat("initial focus on row 1", focusedRow, equalTo(getRowAtPosition(1)))
+
+            // tap row 2 to ADD it to the selection — focus must stay on row 1
+            cardSelectionEventFlow.test {
+                onTap(getRowAtPosition(2).toRowSelection()).join()
+                expectNoEvents() // no editor reload
+                assertThat("focus unchanged after add-to-multi-select", focusedRow, equalTo(getRowAtPosition(1)))
+                assertThat("row 2 was added to selection", getRowAtPosition(2) in selectedRows, equalTo(true))
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1443,9 +1443,12 @@ class CardBrowserViewModelTest : JvmTest() {
     @Test
     fun `onTap outside multi-select opens note editor`() =
         runViewModelTest(notes = 2) {
-            cardSelectionEventFlow.test {
+            flowOfNoteEditorCommand.test {
                 onTap(getRowAtPosition(1).toRowSelection()).join()
-                awaitItem()
+                assertInstanceOf<CardBrowserViewModel.NoteEditorCommand.LaunchActivity>(
+                    awaitItem(),
+                    "phone tap launches a standalone NoteEditor activity",
+                )
                 assertThat("focusedRow set to tapped row", focusedRow, equalTo(getRowAtPosition(1)))
                 assertThat("not in multi-select after tap", isInMultiSelectMode, equalTo(false))
             }
@@ -1456,7 +1459,7 @@ class CardBrowserViewModelTest : JvmTest() {
         runViewModelTest(notes = 2) {
             selectRowAtPosition(0)
             assertThat("in multi-select before tap", isInMultiSelectMode, equalTo(true))
-            cardSelectionEventFlow.test {
+            flowOfNoteEditorCommand.test {
                 onTap(getRowAtPosition(1).toRowSelection()).join()
                 expectNoEvents()
                 assertThat("tapped row is selected", getRowAtPosition(1) in selectedRows, equalTo(true))
@@ -1477,7 +1480,7 @@ class CardBrowserViewModelTest : JvmTest() {
         runViewModelTest(notes = 2, isFragmented = false) {
             selectRowAtPosition(0)
             selectRowAtPosition(1)
-            cardSelectionEventFlow.test {
+            flowOfNoteEditorCommand.test {
                 onTap(getRowAtPosition(0).toRowSelection()).join()
                 expectNoEvents()
             }
@@ -1489,9 +1492,12 @@ class CardBrowserViewModelTest : JvmTest() {
             selectRowAtPosition(0)
             selectRowAtPosition(1)
             val deselectedId = getRowAtPosition(0)
-            cardSelectionEventFlow.test {
+            flowOfNoteEditorCommand.test {
                 onTap(deselectedId.toRowSelection()).join()
-                awaitItem()
+                assertInstanceOf<CardBrowserViewModel.NoteEditorCommand.LoadInPane>(
+                    awaitItem(),
+                    "tablet deselect loads the editor in the trailing pane",
+                )
                 assertThat("focusedRow points at deselected row", focusedRow, equalTo(deselectedId))
             }
         }
@@ -1504,7 +1510,7 @@ class CardBrowserViewModelTest : JvmTest() {
             assertThat("initial focus on row 1", focusedRow, equalTo(getRowAtPosition(1)))
 
             // tap row 2 to ADD it to the selection — focus must stay on row 1
-            cardSelectionEventFlow.test {
+            flowOfNoteEditorCommand.test {
                 onTap(getRowAtPosition(2).toRowSelection()).join()
                 expectNoEvents() // no editor reload
                 assertThat("focus unchanged after add-to-multi-select", focusedRow, equalTo(getRowAtPosition(1)))
@@ -1571,6 +1577,44 @@ class CardBrowserViewModelTest : JvmTest() {
                     awaitSearchCompleted().resultMessage,
                     equalTo(CardBrowserViewModel.SearchResultMessage.NoCardsInSelectedDeck),
                 )
+            }
+        }
+
+    @Test
+    fun `search completion - tablet with rows emits LoadInPane`() =
+        runViewModelTest(notes = 2, isFragmented = true) {
+            flowOfNoteEditorCommand.test {
+                launchSearchForCards()
+                searchJob?.join()
+                assertInstanceOf<CardBrowserViewModel.NoteEditorCommand.LoadInPane>(
+                    awaitItem(),
+                    "tablet with rows loads the editor in the trailing pane",
+                )
+            }
+        }
+
+    @Test
+    fun `search completion - tablet with empty deck emits HidePane`() =
+        runViewModelTest(isFragmented = true) {
+            val deck = addDeck("Empty")
+            flowOfNoteEditorCommand.test {
+                setSelectedDeck(deck)
+                searchJob?.join()
+                assertThat(
+                    "empty deck → trailing pane hidden",
+                    awaitItem(),
+                    equalTo(CardBrowserViewModel.NoteEditorCommand.HidePane),
+                )
+            }
+        }
+
+    @Test
+    fun `search completion - phone does not emit a NoteEditorCommand`() =
+        runViewModelTest(notes = 2, isFragmented = false) {
+            flowOfNoteEditorCommand.test {
+                launchSearchForCards()
+                searchJob?.join()
+                expectNoEvents()
             }
         }
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1512,6 +1512,26 @@ class CardBrowserViewModelTest : JvmTest() {
         }
 
     @Test
+    fun `stale focusedRow falls back to first card after search`() =
+        runViewModelTest {
+            val deckOne = addDeck("One")
+            val deckTwo = addDeck("Two")
+            addNoteToDeck(deckOne)
+            addNoteToDeck(deckTwo)
+
+            setSelectedDeck(deckTwo)
+            searchJob?.join()
+            val deckTwoRow = cards.first()
+            handleRowLongPress(deckTwoRow.toRowSelection()).join()
+            assertThat("initial focus is on the deckTwo row", focusedRow, equalTo(deckTwoRow))
+
+            setSelectedDeck(deckOne)
+            searchJob?.join()
+            assertThat("focusedRow no longer points to filtered-out row", focusedRow, not(equalTo(deckTwoRow)))
+            assertThat("focusedRow falls back to first row of new search", focusedRow, equalTo(cards.first()))
+        }
+
+    @Test
     fun `multiselect toggle state is restored`() {
         val handle = SavedStateHandle()
         runViewModelTest(savedStateHandle = handle, notes = 1) {

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1440,6 +1440,63 @@ class CardBrowserViewModelTest : JvmTest() {
     }
 
     @Test
+    fun `onTap outside multi-select opens note editor`() =
+        runViewModelTest(notes = 2) {
+            cardSelectionEventFlow.test {
+                onTap(getRowAtPosition(1).toRowSelection()).join()
+                awaitItem()
+                assertThat("currentCardId set to tapped row", currentCardId, equalTo(getRowAtPosition(1).toCardId(cardsOrNotes)))
+                assertThat("not in multi-select after tap", isInMultiSelectMode, equalTo(false))
+            }
+        }
+
+    @Test
+    fun `onTap in multi-select toggles selection without emitting`() =
+        runViewModelTest(notes = 2) {
+            selectRowAtPosition(0)
+            assertThat("in multi-select before tap", isInMultiSelectMode, equalTo(true))
+            cardSelectionEventFlow.test {
+                onTap(getRowAtPosition(1).toRowSelection()).join()
+                expectNoEvents()
+                assertThat("tapped row is selected", getRowAtPosition(1) in selectedRows, equalTo(true))
+            }
+        }
+
+    @Test
+    fun `onTap deselects already-selected row in multi-select`() =
+        runViewModelTest(notes = 2) {
+            selectRowAtPosition(0)
+            selectRowAtPosition(1)
+            onTap(getRowAtPosition(0).toRowSelection()).join()
+            assertThat("tapped row no longer selected", getRowAtPosition(0) in selectedRows, equalTo(false))
+        }
+
+    @Test
+    fun `onTap deselect on phone does not emit selection event`() =
+        runViewModelTest(notes = 2, isFragmented = false) {
+            selectRowAtPosition(0)
+            selectRowAtPosition(1)
+            cardSelectionEventFlow.test {
+                onTap(getRowAtPosition(0).toRowSelection()).join()
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `onTap deselect on tablet emits selection event with focused id`() =
+        runViewModelTest(notes = 2, isFragmented = true) {
+            selectRowAtPosition(0)
+            selectRowAtPosition(1)
+            val deselectedId = getRowAtPosition(0)
+            cardSelectionEventFlow.test {
+                onTap(deselectedId.toRowSelection()).join()
+                awaitItem()
+                assertThat("currentCardId points at deselected row", currentCardId, equalTo(deselectedId.toCardId(cardsOrNotes)))
+                assertThat("focusedRow points at deselected row", focusedRow, equalTo(deselectedId))
+            }
+        }
+
+    @Test
     fun `multiselect toggle state is restored`() {
         val handle = SavedStateHandle()
         runViewModelTest(savedStateHandle = handle, notes = 1) {
@@ -1749,6 +1806,7 @@ class CardBrowserViewModelTest : JvmTest() {
         initMode: InitMode = InitMode.AUTOMATIC,
         savedStateHandle: SavedStateHandle = SavedStateHandle(),
         options: CardBrowserLaunchOptions? = null,
+        isFragmented: Boolean = false,
         testBody: suspend CardBrowserViewModel.() -> Unit,
     ) = runTest {
         repeat(notes) {
@@ -1761,7 +1819,7 @@ class CardBrowserViewModelTest : JvmTest() {
                 cacheDir = createTransientDirectory(),
                 options = options,
                 preferences = AnkiDroidApp.sharedPreferencesProvider,
-                isFragmented = false,
+                isFragmented = isFragmented,
                 manualInit = initMode == InitMode.MANUAL || initMode == InitMode.AUTOMATIC,
                 savedStateHandle = savedStateHandle,
             )

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1538,10 +1538,10 @@ class CardBrowserViewModelTest : JvmTest() {
             flowOfSearchState.test {
                 ignoreEventsDuringViewModelInit()
                 setSelectedDeck(SelectableDeck.AllDecks)
-                val message = awaitSearchCompleted().resultMessage
-                val card = message as CardBrowserViewModel.SearchResultMessage.CardCount
-                assertThat("count", card.count, equalTo(3))
-                assertThat("cardsOrNotes", card.cardsOrNotes, equalTo(CardsOrNotes.CARDS))
+                val completed = awaitSearchCompleted()
+                val card = completed.resultMessage as CardBrowserViewModel.SearchResultMessage.CardCount
+                assertThat("count", completed.rowCount, equalTo(3))
+                assertThat("cardsOrNotes", completed.cardsOrNotes, equalTo(CardsOrNotes.CARDS))
                 assertThat("no all-decks action when already on all decks", card.includeSearchAllDecksAction, equalTo(false))
             }
         }


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7

## Purpose / Description
I initially wanted to tackle

* https://github.com/ankidroid/Anki-Android/issues/19805

I first tackled removing `currentCardId` and replacing it with `focusedRow`

But after this, I felt the code still had too much logic in the activity, and I put in effort to bring this to the ViewModel, rather than adding more complexity with additional changes to `focusedRow`. This mostly revolved around `redrawAfterSearch`

This resulted in 150 less LOC in the `CardBrowser`

----

**Functional changes**

* On the initial search, if 'All decks' is not selected, a snackbar offering 'Search all decks' is shown.
  * #3592


## Approach
* See the commits, gradual refactorings + testing

## How Has This Been Tested?
API 33 Tablet Emulator; the ViewModel is heavily unit tested

## Learning (optional, can help others)

The activity should be simple now most of the concerns and the menu have been moved to `CardBrowserFragment`, `CardBrowser` was originally a horrifyingly complicated class, and we're getting close to being 'out-of-the-woods' here.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)