### PR TITLE
Added debouncing to prevent from frequent triggering 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -29,7 +29,6 @@ import android.content.SharedPreferences
 import android.content.res.Configuration
 import android.graphics.Bitmap
 import android.graphics.Color
-import android.hardware.SensorManager
 import android.media.MediaPlayer
 import android.net.Uri
 import android.os.Build
@@ -87,6 +86,7 @@ import com.ichi2.anim.ActivityTransitionAnimation
 import com.ichi2.anki.AbstractFlashcardViewer.Signal.Companion.toSignal
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.android.AnkiShakeDetector
 import com.ichi2.anki.android.back.exitViaDoubleTapBackCallback
 import com.ichi2.anki.backend.stripHTMLAndSpecialFields
 import com.ichi2.anki.cardviewer.AndroidCardRenderContext
@@ -2170,7 +2170,7 @@ abstract class AbstractFlashcardViewer :
     internal inner class LinkDetectingGestureDetector :
         MyGestureDetector(),
         ShakeDetector.Listener {
-        private var shakeDetector: ShakeDetector? = null
+        private var shakeDetector: AnkiShakeDetector? = null
 
         init {
             initShakeDetector()
@@ -2179,11 +2179,14 @@ abstract class AbstractFlashcardViewer :
         private fun initShakeDetector() {
             Timber.d("Initializing shake detector")
             if (gestureProcessor.isBound(Gesture.SHAKE)) {
-                val sensorManager = getSystemService(SENSOR_SERVICE) as SensorManager
                 shakeDetector =
-                    ShakeDetector(this).apply {
-                        start(sensorManager, SensorManager.SENSOR_DELAY_UI)
-                    }
+                    AnkiShakeDetector
+                        .createInstance(
+                            context = this@AbstractFlashcardViewer,
+                            listener = this@LinkDetectingGestureDetector,
+                        )?.apply {
+                            start()
+                        }
             }
         }
 
@@ -2205,7 +2208,6 @@ abstract class AbstractFlashcardViewer :
         private val dispatchedTouchEvents = hashSetInit<MotionEvent>(2)
 
         override fun hearShake() {
-            Timber.d("Shake detected!")
             gestureProcessor.onShake()
         }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiShakeDetector.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/android/AnkiShakeDetector.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 Jatin Kumar <jnkr2409@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.android
+import android.content.Context
+import android.hardware.SensorManager
+import android.os.SystemClock
+import androidx.core.content.ContextCompat
+import androidx.core.content.getSystemService
+import com.squareup.seismic.ShakeDetector
+import timber.log.Timber
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/*
+ * Wrapper for a [ShakeDetector] to provide a cooldown mechanism.
+ * This prevents the "Undo" action or other gestures from triggering multiple times
+ * in rapid succession during a single physical shake event.
+ */
+class AnkiShakeDetector(
+    private val sensorManager: SensorManager,
+    /*
+     * Sensor Delay tells how often the app should check for phone movement.
+     *
+     * We use [SensorManager.SENSOR_DELAY_UI] because:
+     * - Enough Speed : It is fast enough to catch a normal shake.
+     * - Battery Friendly: It uses less power than "Game" or "Fastest" settings.
+     */
+    private val sensorDelay: Int = SensorManager.SENSOR_DELAY_UI,
+    private val listener: ShakeDetector.Listener,
+    /*
+     * The minimum time between shake events to prevent accidental double-triggers.
+     *
+     * Through trial and error, 800ms was determined to be the optimal 'sweet spot':
+     * - 500ms : A single physical shake often registered as two distinct events,
+     *   causing the flag to toggle on and immediately off again.
+     *
+     * - 1000ms+ : Felt unresponsive when the user wanted to quickly flag/unflag
+     *   multiple cards in a row.
+     *
+     * - 800ms : Consistently filters out the "rebound" of a single shake while
+     *   remaining responsive for intentional back-to-back actions.
+     */
+    private val cooldown: Duration = 800.milliseconds,
+) : ShakeDetector.Listener {
+    private val shakeDetector = ShakeDetector(this)
+    private var lastShakeTime = 0L
+
+    fun start() {
+        sensorManager.let {
+            shakeDetector.start(it, sensorDelay)
+        }
+    }
+
+    fun stop() {
+        shakeDetector.stop()
+    }
+
+    override fun hearShake() {
+        Timber.d("The time since the last shake was: ${SystemClock.elapsedRealtime() - lastShakeTime}")
+        val currentTime = SystemClock.elapsedRealtime()
+        if (currentTime - lastShakeTime < cooldown.inWholeMilliseconds) {
+            return
+        }
+        try {
+            listener.hearShake()
+        } finally {
+            lastShakeTime = SystemClock.elapsedRealtime()
+        }
+    }
+
+    companion object {
+        fun createInstance(
+            context: Context,
+            listener: ShakeDetector.Listener,
+        ): AnkiShakeDetector? {
+            val sensorManager = context.getSystemService<SensorManager>()
+            return sensorManager?.let {
+                AnkiShakeDetector(
+                    sensorManager = sensorManager,
+                    listener = listener,
+                )
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -17,7 +17,6 @@ package com.ichi2.anki.ui.windows.reviewer
 
 import android.content.Context
 import android.content.Intent
-import android.hardware.SensorManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.KeyEvent
@@ -53,6 +52,8 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
+import com.ichi2.anki.android.AnkiShakeDetector
+import com.ichi2.anki.android.back.doubleBackPressCallback
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
@@ -116,8 +117,7 @@ class ReviewerFragment :
 
     override val webViewLayout: SafeWebViewLayout get() = binding.webViewLayout
     private lateinit var bindingMap: BindingMap<ReviewerBinding, ViewerAction>
-    private var shakeDetector: ShakeDetector? = null
-    private val sensorManager get() = ContextCompat.getSystemService(requireContext(), SensorManager::class.java)
+    private var shakeDetector: AnkiShakeDetector? = null
     private val whiteboardFragment get() = childFragmentManager.findFragmentByTag(WhiteboardFragment::class.jvmName) as? WhiteboardFragment
     private val isBigScreen: Boolean get() = resources.configuration.smallestScreenWidthDp >= 720
 
@@ -143,7 +143,7 @@ class ReviewerFragment :
     override fun onStart() {
         super.onStart()
         if (!requireActivity().isChangingConfigurations) {
-            shakeDetector?.start(sensorManager, SensorManager.SENSOR_DELAY_UI)
+            shakeDetector?.start()
         }
     }
 
@@ -354,8 +354,8 @@ class ReviewerFragment :
             bindingMap.onGenericMotionEvent(event)
         }
         if (bindingMap.isBound(Gesture.SHAKE)) {
-            shakeDetector = ShakeDetector(this)
-            shakeDetector?.start(sensorManager, SensorManager.SENSOR_DELAY_UI)
+            shakeDetector = AnkiShakeDetector.createInstance(requireContext(), this)
+            shakeDetector?.start()
         }
     }
 


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
_The shake gesture was triggering multiple times on frequent shakes_

## Fixes
* Fixes #20810 

## Approach
_Added debouncing so that there should be atleast 2500ms between two shake gestures to prevent frequent triggering_

## How Has This Been Tested?

https://github.com/user-attachments/assets/23e12a0f-21c5-48e0-ba40-37b69b2cc4f8


You can set the shake gesture to any of the action specifically "set due date" and try to shake frequently on old screen and you can test with adding or editing notes in new study screen

## Learning (optional, can help others)
_Describe the research stage_

_Links to blog posts, patterns, libraries or addons used to solve this problem_

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->