### PR TITLE
refactor(card-browser): result listeners

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AbstractFlashcardViewer.kt
@@ -352,9 +352,6 @@ abstract class AbstractFlashcardViewer :
         private val callback: (result: ActivityResult, reloadRequired: Boolean) -> Unit = { _, _ -> },
     ) : ActivityResultCallback<ActivityResult> {
         override fun onActivityResult(result: ActivityResult) {
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
-                closeReviewer(DeckPicker.RESULT_DB_ERROR)
-            }
             if (result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
                 finishNoStorageAvailable()
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -195,7 +195,6 @@ open class CardBrowser :
             if (result.resultCode == RESULT_OK) {
                 forceRefreshSearch(useSearchTextValue = true)
             }
-            invalidateOptionsMenu() // maybe the availability of undo changed
         }
 
     init {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -18,7 +18,6 @@
 
 package com.ichi2.anki
 
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
@@ -32,7 +31,6 @@ import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
-import androidx.annotation.CheckResult
 import androidx.annotation.LayoutRes
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
@@ -59,7 +57,6 @@ import com.ichi2.anki.browser.CardBrowserViewModel.SearchState
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Initializing
 import com.ichi2.anki.browser.CardBrowserViewModel.SearchState.Searching
 import com.ichi2.anki.browser.CardOrNoteId
-import com.ichi2.anki.browser.IdsFile
 import com.ichi2.anki.browser.SaveSearchResult
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.browser.registerFindReplaceHandler
@@ -91,7 +88,6 @@ import com.ichi2.anki.model.CardsOrNotes.NOTES
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
 import com.ichi2.anki.observability.ChangeManager
-import com.ichi2.anki.previewer.PreviewerFragment
 import com.ichi2.anki.scheduling.registerOnForgetHandler
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
@@ -694,13 +690,6 @@ open class CardBrowser :
                     return true
                 }
             }
-            KeyEvent.KEYCODE_P -> {
-                if (event.isShiftPressed && event.isCtrlPressed) {
-                    Timber.i("Ctrl+Shift+P - Preview")
-                    onPreview()
-                    return true
-                }
-            }
             KeyEvent.KEYCODE_S -> {
                 if (event.isCtrlPressed && event.isAltPressed) {
                     Timber.i("Ctrl+Alt+S: Show saved searches")
@@ -859,13 +848,6 @@ open class CardBrowser :
     fun onUndo() {
         launchCatchingTask {
             undoAndShowSnackbar()
-        }
-    }
-
-    fun onPreview() {
-        launchCatchingTask {
-            val intent = viewModel.queryPreviewIntentData().toIntent(this@CardBrowser)
-            startActivity(intent)
         }
     }
 
@@ -1154,11 +1136,3 @@ suspend fun searchForRows(
     }.let { ids ->
         BrowserRowCollection(cardsOrNotes, ids.map { CardOrNoteId(it) }.toMutableList())
     }
-
-class PreviewerDestination(
-    val currentIndex: Int,
-    val idsFile: IdsFile,
-)
-
-@CheckResult
-fun PreviewerDestination.toIntent(context: Context) = PreviewerFragment.getIntent(context, idsFile, currentIndex)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -196,10 +196,6 @@ open class CardBrowser :
     private var onEditCardActivityResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
             Timber.i("onEditCardActivityResult: resultCode=%d", result.resultCode)
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
-                closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
-                return@registerForActivityResult
-            }
 
             // handle template edits
 
@@ -223,9 +219,6 @@ open class CardBrowser :
     private var onAddNoteActivityResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
             Timber.d("onAddNoteActivityResult: resultCode=%d", result.resultCode)
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
-                closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
-            }
             if (result.resultCode == RESULT_OK) {
                 forceRefreshSearch(useSearchTextValue = true)
             }
@@ -234,9 +227,6 @@ open class CardBrowser :
     private var onPreviewCardsActivityResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
             Timber.d("onPreviewCardsActivityResult: resultCode=%d", result.resultCode)
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
-                closeCardBrowser(DeckPicker.RESULT_DB_ERROR)
-            }
             // Previewing can now perform an "edit", so it can pass on a reloadRequired
             val data = result.data
             if (data != null &&
@@ -1049,15 +1039,6 @@ open class CardBrowser :
                 Timber.w(e, "Unable to get selected deck name")
                 getString(R.string.card_browser_unknown_deck_name)
             }
-
-    private fun closeCardBrowser(
-        result: Int,
-        data: Intent? = null,
-    ) {
-        // Set result and finish
-        setResult(result, data)
-        finish()
-    }
 
     /**
      * Implementation of `by viewModels()` for use in [onCreate]

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -224,21 +224,6 @@ open class CardBrowser :
             }
             invalidateOptionsMenu() // maybe the availability of undo changed
         }
-    private var onPreviewCardsActivityResult =
-        registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
-            Timber.d("onPreviewCardsActivityResult: resultCode=%d", result.resultCode)
-            // Previewing can now perform an "edit", so it can pass on a reloadRequired
-            val data = result.data
-            if (data != null &&
-                (
-                    data.getBooleanExtra(NoteEditorFragment.RELOAD_REQUIRED_EXTRA_KEY, false) ||
-                        data.getBooleanExtra(NoteEditorFragment.NOTE_CHANGED_EXTRA_KEY, false)
-                )
-            ) {
-                forceRefreshSearch()
-            }
-            invalidateOptionsMenu() // maybe the availability of undo changed
-        }
 
     init {
         ChangeManager.subscribe(this)
@@ -879,15 +864,10 @@ open class CardBrowser :
 
     fun onPreview() {
         launchCatchingTask {
-            val intentData = viewModel.queryPreviewIntentData()
-            onPreviewCardsActivityResult.launch(getPreviewIntent(intentData.currentIndex, intentData.idsFile))
+            val intent = viewModel.queryPreviewIntentData().toIntent(this@CardBrowser)
+            startActivity(intent)
         }
     }
-
-    private fun getPreviewIntent(
-        index: Int,
-        idsFile: IdsFile,
-    ): Intent = PreviewerDestination(index, idsFile).toIntent(this)
 
     fun addNoteFromCardBrowser() {
         onAddNoteActivityResult.launch(addNoteLauncher.toIntent(this))

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -189,29 +189,6 @@ open class CardBrowser :
     private val layout: Int
         get() = if (useSearchView) R.layout.activity_card_browser_searchview else R.layout.activity_card_browser
 
-    private var onEditCardActivityResult =
-        registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
-            Timber.i("onEditCardActivityResult: resultCode=%d", result.resultCode)
-
-            // handle template edits
-
-            // in use by reviewer?
-            result.data?.let {
-                if (
-                    it.getBooleanExtra(NoteEditorFragment.RELOAD_REQUIRED_EXTRA_KEY, false) ||
-                    it.getBooleanExtra(NoteEditorFragment.NOTE_CHANGED_EXTRA_KEY, false)
-                ) {
-                    forceRefreshSearch()
-                }
-            }
-
-            invalidateOptionsMenu() // maybe the availability of undo changed
-
-            // handle card edits
-            if (result.resultCode == RESULT_OK) {
-                viewModel.onCurrentNoteEdited()
-            }
-        }
     private var onAddNoteActivityResult =
         registerForActivityResult(StartActivityForResult()) { result: ActivityResult ->
             Timber.d("onAddNoteActivityResult: resultCode=%d", result.resultCode)
@@ -575,7 +552,7 @@ open class CardBrowser :
                     loadNoteEditorFragmentIfFragmented()
                 } else {
                     editNoteLauncher()?.let {
-                        onEditCardActivityResult.launch(it.toIntent(this@CardBrowser))
+                        startActivity(it.toIntent(this@CardBrowser))
                     }
                 }
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -214,7 +214,7 @@ import java.io.File
  *
  * Responsibilities:
  * * Setup/upgrades of the application: [handleStartup]
- * * Error handling [handleDbError] [handleDbLocked]
+ * * Error handling [handleDbLocked]
  * * Displaying a tree of decks, some of which may be collapsible: [deckListAdapter]
  *   * Allows users to study the decks
  *   * Displays deck progress
@@ -403,9 +403,6 @@ open class DeckPicker :
         override fun onActivityResult(result: ActivityResult) {
             if (result.resultCode == RESULT_MEDIA_EJECTED) {
                 onSdCardNotMounted()
-                return
-            } else if (result.resultCode == RESULT_DB_ERROR) {
-                handleDbError()
                 return
             }
             callback(result)
@@ -1796,11 +1793,6 @@ open class DeckPicker :
         showMediaCheckDialog()
     }
 
-    open fun handleDbError() {
-        Timber.i("Displaying Database Error")
-        showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_LOAD_FAILED)
-    }
-
     open fun handleDbLocked() {
         Timber.i("Displaying Database Locked")
         showDatabaseErrorDialog(DatabaseErrorDialogType.DIALOG_DB_LOCKED)
@@ -2157,7 +2149,6 @@ open class DeckPicker :
          * Result codes from other activities
          */
         const val RESULT_MEDIA_EJECTED = 202
-        const val RESULT_DB_ERROR = 203
 
         /**
          * If passed into the intent, the user should have been logged in and DeckPicker

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -437,14 +437,11 @@ class NoteEditorFragment :
             return@OnReceiveContentListener remaining
         }
 
-    private inner class NoteEditorActivityResultCallback(
+    private class NoteEditorActivityResultCallback(
         private val callback: (result: ActivityResult) -> Unit,
     ) : ActivityResultCallback<ActivityResult> {
         override fun onActivityResult(result: ActivityResult) {
             Timber.d("onActivityResult() with result: %s", result.resultCode)
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR) {
-                closeNoteEditor(DeckPicker.RESULT_DB_ERROR, null)
-            }
             callback(result)
         }
     }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/StudyOptionsFragment.kt
@@ -327,7 +327,7 @@ class StudyOptionsFragment :
                 result.resultCode,
             )
             activity?.invalidateMenu()
-            if (result.resultCode == DeckPicker.RESULT_DB_ERROR || result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
+            if (result.resultCode == DeckPicker.RESULT_MEDIA_EJECTED) {
                 closeStudyOptions(result.resultCode)
                 return@registerForActivityResult
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -16,6 +16,7 @@
 
 package com.ichi2.anki.browser
 
+import android.content.Context
 import android.content.DialogInterface
 import android.graphics.Color
 import android.os.Bundle
@@ -122,6 +123,7 @@ import com.ichi2.anki.model.LegacySortType
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.observability.ChangeManager
 import com.ichi2.anki.observability.undoableOp
+import com.ichi2.anki.previewer.PreviewerFragment
 import com.ichi2.anki.requireAnkiActivity
 import com.ichi2.anki.requireNavigationDrawerActivity
 import com.ichi2.anki.scheduling.ForgetCardsDialog
@@ -531,7 +533,7 @@ class CardBrowserFragment :
                             return true
                         }
                         R.id.action_preview_many -> {
-                            requireCardBrowserActivity().onPreview()
+                            onPreview()
                             return true
                         }
                         R.id.action_sort_by_size -> {
@@ -740,7 +742,7 @@ class CardBrowserFragment :
                             return true
                         }
                         R.id.action_preview_many -> {
-                            requireCardBrowserActivity().onPreview()
+                            onPreview()
                             return true
                         }
                         R.id.action_edit_note -> {
@@ -1158,6 +1160,13 @@ class CardBrowserFragment :
                     return true
                 }
             }
+            KeyEvent.KEYCODE_P -> {
+                if (event.isCtrlPressed && event.isShiftPressed) {
+                    Timber.i("Ctrl+Shift+P - Preview")
+                    onPreview()
+                    return true
+                }
+            }
             KeyEvent.KEYCODE_M -> {
                 if (event.isCtrlPressed) {
                     Timber.i("Ctrl+M: Search marked notes")
@@ -1254,6 +1263,13 @@ class CardBrowserFragment :
                 }
             showUndoSnackbar(message)
         }
+
+    fun onPreview() {
+        launchCatchingTask {
+            val intent = activityViewModel.queryPreviewIntentData().toIntent(requireContext())
+            startActivity(intent)
+        }
+    }
 
     fun rescheduleSelectedCards() {
         if (!activityViewModel.hasSelectedAnyRows()) {
@@ -1622,6 +1638,7 @@ class CardBrowserFragment :
                 shortcut("Ctrl+J", Translations::browsingToggleSuspend),
                 shortcut("Ctrl+Shift+I", Translations::actionsCardInfo),
                 shortcut("Ctrl+O", R.string.show_order_dialog),
+                shortcut("Ctrl+Shift+P", R.string.card_editor_preview_card),
                 shortcut("Ctrl+M", R.string.card_browser_show_marked),
                 shortcut("Esc", R.string.card_browser_select_none),
                 shortcut("Ctrl+1", R.string.gesture_flag_red),
@@ -1649,6 +1666,14 @@ class CardBrowserFragment :
         private const val CHANGE_DECK_KEY = "CHANGE_DECK"
     }
 }
+
+class PreviewerDestination(
+    val currentIndex: Int,
+    val idsFile: IdsFile,
+)
+
+@CheckResult
+fun PreviewerDestination.toIntent(context: Context) = PreviewerFragment.getIntent(context, idsFile, currentIndex)
 
 /**
  * Updates the content of the [SearchView] to a provided fragment, retaining state.

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -39,7 +39,6 @@ import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.Flag
-import com.ichi2.anki.PreviewerDestination
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.MultiSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ChangeMultiSelectMode.SingleSelectCause
 import com.ichi2.anki.browser.CardBrowserViewModel.ToggleSelectionState.SELECT_ALL

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -1401,12 +1401,6 @@ class CardBrowserViewModel(
         updateActiveColumns(replacements, cardsOrNotes)
     }
 
-    // TODO: Do a selective update, and accept a noteId as parameter
-    fun onCurrentNoteEdited() {
-        Timber.i("Reloading search due to note edit")
-        launchSearchForCards()
-    }
-
     /** Opens the UI to save the current [tempSearchQuery] as a saved search */
     fun saveCurrentSearch() =
         viewModelScope.launch {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description

After a keyboard refactoring, there were a few result listeners which remained. I wanted to see what was actually necessary.

* https://github.com/ankidroid/Anki-Android/pull/20877

Turns out: after the Rust backend migration, not a lot, most of this is handled in `opExecuted`, so the dead code was removed:

## Approach
* Remove RESULT_DB_ERROR
* Go through each listener, refactor it, then move it into the Fragment if feasible

## How Has This Been Tested?
API 33 phone

* Edited a note, both immediately and via preview. Screen was updated

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)