### PR TITLE
fix(permissions): fix crash after null Intent

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivity.kt
@@ -26,12 +26,14 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.PermissionSet
 import com.ichi2.anki.R
 import com.ichi2.anki.databinding.ActivityPermissionsBinding
+import com.ichi2.anki.showThemedToast
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment.Companion.HAS_ALL_PERMISSIONS_KEY
 import com.ichi2.anki.ui.windows.permissions.PermissionsFragment.Companion.PERMISSIONS_FRAGMENT_RESULT_KEY
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import com.ichi2.themes.Themes
 import com.ichi2.themes.setTransparentStatusBar
 import dev.androidbroadcast.vbpd.viewBinding
+import timber.log.Timber
 
 /**
  * Screen responsible for getting permissions from the user.
@@ -60,10 +62,15 @@ class PermissionsActivity : AnkiActivity(R.layout.activity_permissions) {
 
         binding.continueButton.setOnClickListener { finish() }
 
-        val permissionSet =
-            requireNotNull(IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)) {
-                "PERMISSIONS_SET_EXTRA not set"
-            }
+        // #20881: Activity should not be launchd without extras
+        val permissionSet = IntentCompat.getParcelableExtra(intent, PERMISSIONS_SET_EXTRA, PermissionSet::class.java)
+        if (permissionSet == null) {
+            Timber.w("PERMISSIONS_SET_EXTRA not set; finishing")
+            showThemedToast(this, R.string.something_wrong, false)
+            setResult(RESULT_CANCELED)
+            finish()
+            return
+        }
         val permissionsFragment =
             requireNotNull(permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance()) {
                 "invalid permissionsFragment"

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/permissions/PermissionsActivityTest.kt
@@ -15,6 +15,8 @@
  */
 package com.ichi2.anki.ui.windows.permissions
 
+import android.content.Context
+import android.content.Intent
 import androidx.appcompat.widget.AppCompatButton
 import androidx.fragment.app.commitNow
 import androidx.test.core.app.ActivityScenario
@@ -26,14 +28,18 @@ import com.ichi2.anki.R
 import com.ichi2.anki.RobolectricTest
 import com.ichi2.testutils.HamcrestUtils.containsInAnyOrder
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowToast
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @RunWith(AndroidJUnit4::class)
 class PermissionsActivityTest : RobolectricTest() {
     @Test
     fun testActivityCantBeClosedByBackButton() {
-        testActivity(ARBITRARY_PERMISSION_SET) { activity ->
+        testActivity { activity ->
             activity.onBackPressedDispatcher.onBackPressed()
             assertThat("activity is not finishing", !activity.isFinishing)
         }
@@ -41,7 +47,7 @@ class PermissionsActivityTest : RobolectricTest() {
 
     @Test
     fun testOnClickingContinueActivityFinishes() {
-        testActivity(ARBITRARY_PERMISSION_SET) { activity ->
+        testActivity { activity ->
             activity.setContinueButtonEnabled(true)
             activity.findViewById<AppCompatButton>(R.id.continue_button).performClick()
             assertThat("activity is finishing", activity.isFinishing)
@@ -49,8 +55,17 @@ class PermissionsActivityTest : RobolectricTest() {
     }
 
     @Test
+    fun `error toast is shown if PERMISSIONS_SET_EXTRA is missing`() {
+        testInvalidActivityFinishes()
+        assertThat(
+            ShadowToast.getTextOfLatestToast(),
+            equalTo(getResourceString(R.string.something_wrong)),
+        )
+    }
+
+    @Test
     fun `Each screen starts normally and has the same permissions of a PermissionSet`() {
-        testActivity(ARBITRARY_PERMISSION_SET) { activity ->
+        testActivity { activity ->
             for (permissionSet in PermissionSet.entries) {
                 val fragment = permissionSet.permissionsFragment?.getDeclaredConstructor()?.newInstance() ?: continue
                 activity.supportFragmentManager.commitNow {
@@ -63,15 +78,22 @@ class PermissionsActivityTest : RobolectricTest() {
         }
     }
 
+    private fun testInvalidActivityFinishes() {
+        val ex = assertFailsWith<NullPointerException> { testActivity(permissionSet = null) { } }
+        assertEquals("Cannot run onActivity since Activity has been destroyed already", ex.message)
+    }
+
     private fun testActivity(
-        permissionSet: PermissionSet,
+        permissionSet: PermissionSet? = ARBITRARY_PERMISSION_SET,
         action: ActivityAction<PermissionsActivity>,
     ) {
+        val context = ApplicationProvider.getApplicationContext<Context>()
         val intent =
-            PermissionsActivity.getIntent(
-                ApplicationProvider.getApplicationContext(),
-                permissionSet,
-            )
+            if (permissionSet != null) {
+                PermissionsActivity.getIntent(context, permissionSet)
+            } else {
+                Intent(context, PermissionsActivity::class.java)
+            }
         ActivityScenario.launch<PermissionsActivity>(intent).use { scenario ->
             scenario.onActivity { activity ->
                 action.perform(activity)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - tests

## Purpose / Description
I believe this came through on a debug device and the path is not reachable via normal user methods. The intent should not be `null`

## Fixes
* Fixes #20881

## Approach
Check for null and finish the ativity

## How Has This Been Tested?
I flipped the ` == null`, the toast was shown, and the app was obviously glitchy in `full` mode without permissions


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)