### PR TITLE
test: ensure org.json is not bundled

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/OrgJsonNotBundledTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/OrgJsonNotBundledTest.kt
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2026 David Allison <davidallisongithub@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki.tests
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import dalvik.system.DexFile
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.empty
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Regression test for https://github.com/ankidroid/Anki-Android/issues/20852
+ */
+@RunWith(AndroidJUnit4::class)
+class OrgJsonNotBundledTest {
+    @Test
+    fun orgJsonIsNotBundledInApk() {
+        val apkPath =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .applicationInfo
+                .sourceDir
+
+        // DexFile is deprecated since API 26 but still functional
+        // Reflection on BaseDexClassLoader.pathList is possible, but requires multiple lint
+        // suppressions on private APIs.
+        // We could pin this code to work on an earlier emulator if/when it's removed
+        @Suppress("DEPRECATION")
+        val orgJsonClasses =
+            DexFile(apkPath)
+                .entries()
+                .toList()
+                .filter { it.startsWith("org.json.") }
+
+        assertThat(
+            "`org.json` must come from android.jar, not be bundled in the APK. " +
+                "Use `compileOnly(libs.json)` rather than `implementation(libs.json)`.",
+            orgJsonClasses,
+            empty(),
+        )
+    }
+}


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - initial test, rewritten a few times. Comments are my own

## Fixes
* Fixes #20857

## How Has This Been Tested?
Tested on:

4d51a45cefa031ebe8a520ad77996bcb47498273 - pass
c95416cfa1ad3fc1094a013d66173e492ce9af3b - fail

## Learning (optional, can help others)

`DexFile` is deprecated since API 26 but still functional

Reflection on `BaseDexClassLoader.pathList` is possible, but requires multiple lint suppressions on private APIs.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)