### PR TITLE
fix(statistics): crash on 'Save PDF' double tap 

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -17,6 +17,7 @@ package com.ichi2.anki.pages
 
 import android.os.Bundle
 import android.print.PrintAttributes
+import android.print.PrintJob
 import android.print.PrintManager
 import android.view.View
 import androidx.core.content.ContextCompat.getSystemService
@@ -29,6 +30,7 @@ import com.ichi2.anki.databinding.PageStatisticsBinding
 import com.ichi2.anki.dialogs.DeckSelectionDialog
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.model.SelectableDeck
+import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startDeckSelection
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
@@ -38,6 +40,10 @@ class Statistics :
     DeckSelectionDialog.DeckSelectionListener {
     override val pagePath: String = "graphs"
     private val binding by viewBinding(PageStatisticsBinding::bind)
+
+    /** The PrintJob launched by this Fragment */
+    // After killing the app, printManager.printJobs can still list active jobs
+    private var pendingPrintJob: PrintJob? = null
 
     @Suppress("deprecation", "API35 properly handle edge-to-edge")
     override fun onViewCreated(
@@ -74,15 +80,20 @@ class Statistics :
      * It uses the Android PrintManager service to create a print job, based on the content of the WebView.
      * The resulting output is a PDF document. **/
     private fun exportWebViewContentAsPDF() {
-        val printManager = getSystemService(requireContext(), PrintManager::class.java)
+        if (pendingPrintJob?.isActive == true) {
+            showSnackbar(R.string.already_in_progress)
+            return
+        }
+        val printManager = getSystemService(requireContext(), PrintManager::class.java) ?: return
         val currentDateTime = getTimestamp(TimeManager.time)
         val jobName = "${getString(R.string.app_name)}-stats-$currentDateTime"
         val printAdapter = webViewLayout.createPrintDocumentAdapter(jobName)
-        printManager?.print(
-            jobName,
-            printAdapter,
-            PrintAttributes.Builder().build(),
-        )
+        pendingPrintJob =
+            printManager.print(
+                jobName,
+                printAdapter,
+                PrintAttributes.Builder().build(),
+            )
     }
 
     override fun onDeckSelected(deck: SelectableDeck?) {
@@ -119,3 +130,6 @@ class Statistics :
         private const val KEY_DECK_NAME = "key_deck_name"
     }
 }
+
+private val PrintJob.isActive: Boolean
+    get() = !isCompleted && !isFailed && !isCancelled

--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/Statistics.kt
@@ -34,6 +34,7 @@ import com.ichi2.anki.snackbar.showSnackbar
 import com.ichi2.anki.startDeckSelection
 import com.ichi2.anki.withProgress
 import dev.androidbroadcast.vbpd.viewBinding
+import timber.log.Timber
 
 class Statistics :
     PageFragment(R.layout.page_statistics),
@@ -81,9 +82,11 @@ class Statistics :
      * The resulting output is a PDF document. **/
     private fun exportWebViewContentAsPDF() {
         if (pendingPrintJob?.isActive == true) {
+            Timber.w("Duplicate print attempted - skipping")
             showSnackbar(R.string.already_in_progress)
             return
         }
+        Timber.i("Saving Stats to PDF")
         val printManager = getSystemService(requireContext(), PrintManager::class.java) ?: return
         val currentDateTime = getTimestamp(TimeManager.time)
         val jobName = "${getString(R.string.app_name)}-stats-$currentDateTime"

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -465,5 +465,7 @@ opening the system text to speech settings fails">Failed to open text to speech 
     <!-- Other errors -->
     <!-- Similar to TR.qtMiscNameExists(): "Name exists." -->
     <string name="error_name_exists">Name already exists</string>
+
+    <string comment="Shown when retrying a running action" name="already_in_progress">Already in progress</string>
 </resources>
 


### PR DESCRIPTION
## Purpose / Description
Double tapping 'Save PDF' crashed

## Fixes
* Fixes #20890

## Approach

* Check to see if a PrintJob already exists
* Add a generic snackbar for this type of issue

## How Has This Been Tested?

```
17:20:34.680 Statistics               I  Saving Stats to PDF
17:20:34.717 AnkiDroidApp$onCreate    I  SingleFragmentActivity::onPause
17:20:34.849 Statistics               W  Duplicate print attempted - skipping
17:20:34.852 SnackbarsKt              D  displayed snackbar: 'Already in progress'
17:20:34.852 SnackbarsKt              D  displayed snackbar: 'Already in progress'
```

## Learning
I thought we were done with the crashes

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)