### PR TITLE
fix(api): Utils.joinTags mishandled spaces

### DIFF
--- a/AnkiDroid/jacoco.gradle
+++ b/AnkiDroid/jacoco.gradle
@@ -103,7 +103,7 @@ tasks.register('jacocoTestReport', JacocoReport) {
 }
 
 // Android library modules (do not yet support flavors play/full)
-def androidModulesToUnitTest = [":common:android", ":libanki", ":compat"]
+def androidModulesToUnitTest = [":api", ":common:android", ":libanki", ":compat"]
 // JVM modules: use 'test' task and 'classes/kotlin/main' class dir
 def jvmModulesToUnitTest = [":common"]
 

--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     implementation(libs.kotlin.stdlib)
     testImplementation(libs.junit.jupiter)
     testImplementation(libs.junit.vintage.engine)
+    testImplementation(libs.junit.platform.launcher)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlin.test)
 

--- a/api/src/main/java/com/ichi2/anki/api/Utils.kt
+++ b/api/src/main/java/com/ichi2/anki/api/Utils.kt
@@ -45,10 +45,7 @@ internal object Utils {
         if (tags.isNullOrEmpty()) {
             return ""
         }
-        for (t in tags) {
-            t!!.replace(" ".toRegex(), "_")
-        }
-        return tags.joinToString(" ")
+        return tags.joinToString(" ") { it!!.replace(" ", "_") }
     }
 
     fun splitTags(tags: String): Array<String> = tags.trim().split("\\s+".toRegex()).toTypedArray()

--- a/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
+++ b/api/src/test/java/com/ichi2/anki/api/ApiUtilsTest.kt
@@ -57,6 +57,11 @@ internal class ApiUtilsTest {
     }
 
     @Test
+    fun joinTagsShouldReplaceSpacesWithUnderscores() {
+        assertEquals("multi_word tag2", Utils.joinTags(linkedSetOf("multi word", "tag2")))
+    }
+
+    @Test
     fun splitTagsShouldReturnNullWhenStringIsValid() {
         val tags = "A B C"
         val output = Utils.splitTags(tags)


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - all except last commit

<!--- Please fill the necessary details below -->
## Purpose / Description
* `t!!.replace` result was unused
* using regex was overkill, `.replace` works


## Fixes 
* Fixes #20628
* Fixes #20892

## Approach
Simple: `joinToString`

## How Has This Been Tested?
Added a unit test

* CI failure before the fix was applied: https://github.com/david-allison/Anki-Android/actions/runs/25123701041/job/73630984958 => CI is now running tests

## Learning (optional, can help others)
* #20892 


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)