### PR TITLE
fix: intro sync storage permission

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntroductionActivity.kt
@@ -27,10 +27,12 @@ import androidx.core.os.BundleCompat
 import com.ichi2.anki.account.AccountActivity
 import com.ichi2.anki.account.LoginFragment
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.introduction.CollectionPermissionScreenLauncher
 import com.ichi2.anki.introduction.SetupCollectionFragment
 import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption
 import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.FRAGMENT_KEY
 import com.ichi2.anki.introduction.SetupCollectionFragment.Companion.RESULT_KEY
+import com.ichi2.anki.introduction.hasCollectionStoragePermissions
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.utils.ext.setFragmentResultListener
 import timber.log.Timber
@@ -44,7 +46,16 @@ import timber.log.Timber
  */
 // TODO: Background of introduction_layout does not display on API 25 emulator: https://github.com/ankidroid/Anki-Android/pull/12033#issuecomment-1228429130
 @NeedsTest("Ensure that we can get here on first run without an exception dialog shown")
-class IntroductionActivity : AnkiActivity(R.layout.activity_introduction) {
+class IntroductionActivity :
+    AnkiActivity(R.layout.activity_introduction),
+    CollectionPermissionScreenLauncher {
+    override val permissionScreenLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
+            if (hasCollectionStoragePermissions()) {
+                openLoginDialog()
+            }
+        }
+
     @NeedsTest("ensure this is called when the activity ends")
     private val onLoginResult =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
@@ -73,6 +84,7 @@ class IntroductionActivity : AnkiActivity(R.layout.activity_introduction) {
     }
 
     private fun openLoginDialog() {
+        if (collectionPermissionScreenWasOpened()) return
         Timber.i("Opening login screen")
         val intent = AccountActivity.getIntent(context = this, forResult = true)
         onLoginResult.launch(intent)

--- a/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/IntroductionActivityTest.kt
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.ichi2.anki
+
+import android.Manifest.permission.INTERNET
+import android.content.Intent
+import androidx.core.os.bundleOf
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.SingleFragmentActivity.Companion.FRAGMENT_NAME_EXTRA
+import com.ichi2.anki.account.LoginFragment
+import com.ichi2.anki.introduction.SetupCollectionFragment
+import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption.DeckPickerWithNewCollection
+import com.ichi2.anki.introduction.SetupCollectionFragment.CollectionSetupOption.SyncFromExistingAccount
+import com.ichi2.anki.ui.windows.permissions.PermissionsActivity
+import com.ichi2.testutils.withDeniedPermissions
+import kotlinx.coroutines.test.runTest
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.reflect.jvm.jvmName
+import kotlin.test.assertNotNull
+
+/** Tests [IntroductionActivity] */
+@RunWith(AndroidJUnit4::class)
+class IntroductionActivityTest : RobolectricTest() {
+    @Test
+    fun `Sync without storage permission opens PermissionsActivity`() =
+        runTest {
+            // Robolectric runs at API 35 where selectAnkiDroidFolder returns AppPrivateFolder,
+            // whose required PermissionSet is just [INTERNET]. Denying INTERNET is the cheapest
+            // way to make hasCollectionStoragePermissions() return false in this environment.
+            withDeniedPermissions(INTERNET) {
+                val activity = startRegularActivity<IntroductionActivity>(Intent())
+
+                activity.clickSync()
+
+                val intent = assertNotNull(shadowOf(activity).nextStartedActivity)
+                assertThat(
+                    intent.component?.shortClassName,
+                    equalTo(PermissionsActivity::class.java.name),
+                )
+            }
+        }
+
+    @Test
+    fun `Sync with storage permission opens the login screen`() =
+        runTest {
+            val activity = startRegularActivity<IntroductionActivity>(Intent())
+
+            activity.clickSync()
+
+            val intent = assertNotNull(shadowOf(activity).nextStartedActivity)
+            assertThat(
+                "host activity is SingleFragmentActivity",
+                intent.component?.shortClassName,
+                equalTo(SingleFragmentActivity::class.java.name),
+            )
+            assertThat(
+                "hosted fragment is LoginFragment",
+                intent.getStringExtra(FRAGMENT_NAME_EXTRA),
+                equalTo(LoginFragment::class.jvmName),
+            )
+        }
+
+    @Test
+    fun `Get Started opens DeckPicker without the sync-from-login flag`() =
+        runTest {
+            val activity = startRegularActivity<IntroductionActivity>(Intent())
+
+            activity.supportFragmentManager.setFragmentResult(
+                SetupCollectionFragment.FRAGMENT_KEY,
+                bundleOf(SetupCollectionFragment.RESULT_KEY to DeckPickerWithNewCollection),
+            )
+
+            val intent = assertNotNull(shadowOf(activity).nextStartedActivity)
+            assertThat(
+                intent.component?.className,
+                equalTo(DeckPicker::class.java.name),
+            )
+            assertThat(
+                "DeckPicker isn't asked to sync (Get Started, not Sync)",
+                intent.getBooleanExtra(DeckPicker.INTENT_SYNC_FROM_LOGIN, false),
+                equalTo(false),
+            )
+            assertThat(
+                "intro is marked as shown so it doesn't reappear",
+                getPreferences().getBoolean(IntroductionActivity.INTRODUCTION_SLIDES_SHOWN, false),
+                equalTo(true),
+            )
+        }
+
+    private fun IntroductionActivity.clickSync() {
+        supportFragmentManager.setFragmentResult(
+            SetupCollectionFragment.FRAGMENT_KEY,
+            bundleOf(SetupCollectionFragment.RESULT_KEY to SyncFromExistingAccount),
+        )
+    }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Open storage permission screen from intro activity when sync is clicked

## Fixes
* Fixes #20884

## Approach
NA

## How Has This Been Tested?
Pixel Fold Emulator API 35

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->