### PR TITLE
Improve synchronization process when no pull request is needed

### DIFF
--- a/.github/workflows/sync_translations.yml
+++ b/.github/workflows/sync_translations.yml
@@ -88,27 +88,21 @@ jobs:
           cd ./tools/localization
           yarn start update
         
-      - name: Commit changes
-        run: |
-          git add docs/marketing/localized_description AnkiDroid/src/main/res
-          git commit -am 'Updated strings from Crowdin'
-          git push --set-upstream origin +i18n_sync
-          echo "The results of the sync are on the i18n_sync branch, PR them from there for merge."
-          echo "https://github.com/ankidroid/Anki-Android/compare/i18n_sync?expand=1"
-
-      - name: Check if there are strings changes
+      - name: Check for changes and handle results
         id: tr_check
         run: |
-          git checkout i18n_sync
-          COMMITS_COUNT=`git rev-list --count HEAD ^main`
-          if [ "$COMMITS_COUNT" -gt 0 ]; then
-            echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
-          else
+          git add docs/marketing/localized_description AnkiDroid/src/main/res
+          if git diff --cached --quiet; then
             echo "HAS_CHANGES=false" >> $GITHUB_OUTPUT
+            echo "Translation Sync Result: No new translation found on Crowdin. No Pull Request necessary" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "HAS_CHANGES=true" >> $GITHUB_OUTPUT
+            git commit -m 'Updated strings from Crowdin'
+            git push --set-upstream origin +i18n_sync
           fi
 
       - name: Create PR for strings changes if needed
-        if: ${{ steps.tr_check.outputs.HAS_CHANGES }}
+        if: steps.tr_check.outputs.HAS_CHANGES == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.MACHINE_ACCOUNT_PAT }}


### PR DESCRIPTION
> [!NOTE]  
> Syntax research for the GitHub API was assisted by Gemini-3-flash

## Purpose / Description
I fixed the translation sync workflow so it doesn't error out when there aren't any string to update

## Fixes
* Fixes #20853

## Approach
I used `github-script` to check for staged changes and manually trigger a neutral check result via the GitHub API if the tree is clean

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->