### PR TITLE
fix(browser): tag search precedence

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserViewModel.kt
@@ -1174,7 +1174,9 @@ class CardBrowserViewModel(
                 ).toSearchString()
             }.getOrThrow()
 
-        setFilterQuery(searchString.value)
+        // until we use SearchRequest for everything, we need to use () to ensure the OR
+        // takes precedence over an 'AND'
+        setFilterQuery("(${searchString.value})")
     }
 
     /** Previewing */

--- a/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/browser/CardBrowserViewModelTest.kt
@@ -1516,12 +1516,34 @@ class CardBrowserViewModelTest : JvmTest() {
         runViewModelTest {
             filterByTags(listOf("être"), CardStateFilter.ALL_CARDS)
 
-            assertThat(searchTerms, equalTo("tag:être"))
+            assertThat(searchTerms, equalTo("(tag:être)"))
             assertThat("all tagged cards are returned", rowCount, equalTo(3))
 
             updateQueryText("tag:être hêllo")
             launchSearchForCards(tempSearchQuery!!)
             assertThat("input is unchanged", searchTerms, equalTo("tag:être hêllo"))
+        }
+    }
+
+    /**
+     * Regression test: parentheses are required until we fully use SearchRequest
+     *
+     * Otherwise, the 'AND' takes precedence over the 'OR':
+     *
+     * `tag:a OR tag:b a` is parsed as `tag:a OR (tag:b a)`
+     */
+    @Test
+    fun `single tag filter is parenthesized to preserve precedence`() {
+        addBasicNote().update { tags = mutableListOf("foo", "bar") }
+
+        runViewModelTest {
+            filterByTags(listOf("foo", "bar"), CardStateFilter.ALL_CARDS)
+
+            assertThat(
+                "single-tag filter wraps the tag clause so user-appended terms append safely",
+                searchTerms,
+                equalTo("(tag:foo OR tag:bar)"),
+            )
         }
     }
 


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - test

## Purpose / Description

8058ce86032ff33d1d0aed15cd8fde445726dbc0 removed a `()`, but this is still necessary using the legacy SearchView: AND takes precedence over OR, so a multi-tag search returned incorrect results.

`tag:a OR tag:b a` is parsed as `tag:a OR (tag:b a)`

On a note with: [field: 'b'; tags: 'a']

* Before: `tag:a OR tag:b a` matches the note
* After: `(tag:a OR tag:b) a` does not match the note

## Approach
Add parentheses

## How Has This Been Tested?
Unit tested + commented

## Learning (optional, can help others)
I introduced this issue for:

* https://github.com/ankidroid/Anki-Android/pull/20524

Need more tests still

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->