### PR TITLE
fix(ci): Remove 'Strings' label if PR no longer has strings

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -2,7 +2,7 @@ name: 🛠️ Add/Remove Labels
 
 on:
   pull_request_target:
-    types: [ opened, closed ]
+    types: [ opened, synchronize, closed ]
 
 jobs:
   merge_job:
@@ -101,6 +101,14 @@ jobs:
             ];
 
             let stringsLabel = "Strings";
+    
+            async function getPullRequest() {
+                return await github.rest.pulls.get({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: context.issue.number,
+                });
+            }
 
             async function addLabel(labels) {
               await github.rest.issues.addLabels({
@@ -134,6 +142,25 @@ jobs:
               })
             }
 
+            async function checkForComments() {
+              // Try to find comment to delete
+              for await (const page of github.paginate.iterator(
+                octokit.rest.issues.listComments,
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                },
+              )) {
+                for(const comment of page.data) {
+                  if (comment.user && comment.user.login === "github-actions[bot]" && comment.body.includes("This PR contains https://github.com/ankidroid/Anki-Android/labels/Strings changes")) {
+                    return true;
+                  }
+                }
+              }
+              return false;
+            }
+
             const changedFiles = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -143,6 +170,7 @@ jobs:
             // loop through list of files in current pr, then check if filename contains in i18n file name,
             // set boolean to true and use the boolean in outer loop to add label
             let fileChanged = false;
+            const pullRequestData = await getPullRequest();
             for (let files of changedFiles.data) {
               for (let i18n of I18N_FILES) {
                 if (files.filename.includes(i18n)) {
@@ -152,22 +180,17 @@ jobs:
               }
 
               if (fileChanged) {
-                addLabel([stringsLabel]);
-                addComments();
+                if (!pullRequestData.data.labels.find(label => label.name === stringsLabel)) {
+                  addLabel([stringsLabel]);
+                  if (!await checkForComments()) {
+                    addComments();
+                  }
+                }
                 break;
               }
             }
 
-            async function getPullRequest() {
-                return await github.rest.pulls.get({
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    pull_number: context.issue.number,
-                });
-            }
-
             // if no file changed, remove label
-            const pullRequestData = await getPullRequest();
             if (!fileChanged) {
               if (pullRequestData.data.labels.find(label => label.name === stringsLabel)) {
                 console.log(`Removing #${stringsLabel} label from PR #${context.issue.number}`);


### PR DESCRIPTION
> [!NOTE]
> PR description taken from https://github.com/swe-productivity/Anki-Android/pull/13
> with thanks to @cranberry-platypus

----

<!--- Please fill the necessary details below -->
## Purpose / Description

The labels actions for pull requests did not run on every update, but only when they
are opened and closed. This means that removing updates to strings in a PR would not remove
the `Strings` label.

## Fixes
* Fixes #16110

## Approach

The action already had logic to remove the `Strings` label, the only change was to change
the workflow trigger to include any updates to the PR.

## How Has This Been Tested?

Testing this is non-trivial, since a PR uses the workflows from the target branch. So,
for example, this PR would (the study repo has actions disabled) use the version of the
workflows on the main branch, not the updated ones in this PR. To test, I merged the
changes into the main branch of my fork, and opened a test PR:
https://github.com/cranberry-platypus/Anki-Android/pull/1

## Learning (optional, can help others)

https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [x] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)