### PR TITLE
fix(card-browser): black ripple

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/BrowserMultiColumnAdapter.kt
@@ -169,10 +169,7 @@ class BrowserMultiColumnAdapter(
             require(pressedColor != color)
             val rippleDrawable =
                 RippleDrawable(
-                    ColorStateList(
-                        arrayOf(intArrayOf(android.R.attr.state_pressed)),
-                        intArrayOf(pressedColor),
-                    ),
+                    ColorStateList.valueOf(pressedColor),
                     color.toDrawable(),
                     null,
                 )


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - Diagnostics, some correctness on the commit message

## Purpose / Description
No fallback was provided for other states in the `RippleDrawable`'s `ColorStateList`

When a press became a scroll in the RecyclerView, `getColorForState` returned 0 (transparent), the ripple animation set the alpha on this, producing a black ripple.

## Fixes
* Fixes #20902

## Approach
Fix this by setting a fallback color

## How Has This Been Tested?

```kotlin
            val rippleColorList =
                ColorStateList(
                    arrayOf(
                        intArrayOf(android.R.attr.state_pressed),
                        intArrayOf(),
                    ),
                    intArrayOf(
                        pressedColor,
                        android.graphics.Color.MAGENTA,
                    ),
                )
```

Black turned to magenta - Google Pixel 9 Pro

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)