### PR TITLE
fix(manage-note-types): progress not dismissed

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/dialogs/LoadingDialogFragment.kt
@@ -110,7 +110,8 @@ fun AnkiActivity.showLoadingDialog(
     // parameters were requested for the new dialog fragment
     removeImmediately(fragment)
     val loadingDialog = LoadingDialogFragment.newInstance(message, cancellable)
-    loadingDialog.show(supportFragmentManager, LoadingDialogFragment.TAG)
+    // showNow() avoids a race condition - removal is synchronous
+    loadingDialog.showNow(supportFragmentManager, LoadingDialogFragment.TAG)
 }
 
 /** Synchronously removes the provided [LoadingDialogFragment] if valid(not null) */


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - Diagnostics

## Purpose / Description
There was a race condition where removeImmediately executed before loadingDialog.showNow, which caused the loading dialog

## Fixes
* Fixes #19592

## Approach
* `showNow`

## How Has This Been Tested?

No longer hangs

```patch
Index: AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt
--- a/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/notetype/ManageNotetypes.kt	(date 1777562956615)
@@ -56,6 +56,7 @@
 import com.ichi2.utils.title
 import dev.androidbroadcast.vbpd.viewBinding
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 class ManageNotetypes : AnkiActivity(R.layout.activity_manage_note_types) {
     private val binding by viewBinding(ActivityManageNoteTypesBinding::bind)
@@ -98,6 +99,15 @@
             val addNewNotesType = AddNewNotesType(this)
             launchCatchingTask { addNewNotesType.showAddNewNotetypeDialog() }
         }
+        binding.floatingActionButton.setOnLongClickListener {
+            Timber.w("#19592 diagnostic: showLoadingDialog() then dismissLoadingDialog() back-to-back")
+            showLoadingDialog()
+            val findResult = supportFragmentManager.findFragmentByTag("LoadingDialogFragment")
+            Timber.w("#19592 diagnostic: findFragmentByTag right after show() = $findResult (expected: null)")
+            dismissLoadingDialog()
+            Timber.w("#19592 diagnostic: dismissLoadingDialog() returned; dialog should now be stuck")
+            true
+        }
         binding.btnClearSelection.setOnClickListener { viewModel.clearSelection() }
 
         binding.selectionToolbar.setOnClickListener {
```


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)