### PR TITLE
feat(deck-picker): [Xiaomi] add toast: permissions may be needed to add a home screen shortcut

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -2001,6 +2001,11 @@ open class DeckPicker :
             if (AdaptionUtil.isVivo) {
                 showThemedToast(this, getString(R.string.create_shortcut_error_vivo), false)
             }
+            // #18601: MIUI gates shortcut creation behind Settings - Privacy Protection -
+            // Other permissions - AnkiDroid - Home screen shortcuts [add shortcuts to Home screen]
+            if (AdaptionUtil.isMiui) {
+                showThemedToast(this, getString(R.string.create_shortcut_error_miui, getString(R.string.app_name)), false)
+            }
             if (!success) {
                 showThemedToast(this, getString(R.string.create_shortcut_failed), false)
             }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DeckPicker.kt
@@ -1995,7 +1995,9 @@ open class DeckPicker :
                 .setLongLabel(shortcutData.longLabel)
                 .build()
         try {
+            // success does not mean the user selected 'create', only that the feature is supported
             val success = ShortcutManagerCompat.requestPinShortcut(this, shortcut, null)
+            Timber.i("Create shortcut for deck %d. Request displayed: %b", shortcutData.deckId, success)
 
             // User report: "success" is true even if Vivo does not have permission
             if (AdaptionUtil.isVivo) {
@@ -2003,6 +2005,7 @@ open class DeckPicker :
             }
             // #18601: MIUI gates shortcut creation behind Settings - Privacy Protection -
             // Other permissions - AnkiDroid - Home screen shortcuts [add shortcuts to Home screen]
+            // TODO: Determine the result of 'success'
             if (AdaptionUtil.isMiui) {
                 showThemedToast(this, getString(R.string.create_shortcut_error_miui, getString(R.string.app_name)), false)
             }

--- a/AnkiDroid/src/main/res/values/02-strings.xml
+++ b/AnkiDroid/src/main/res/values/02-strings.xml
@@ -281,6 +281,7 @@
 
 
     <string name="create_shortcut_error_vivo" comment="iManager is an app on Vivo phones">You may need to use iManager to allow AnkiDroid to add shortcuts</string>
+    <string name="create_shortcut_error_miui" comment="Keep the message as short, as this is shown in a toast. %s is the app name: 'AnkiDroid'">Allow ‘Home screen shortcuts’ in system settings for %s to add shortcuts</string>
     <string name="create_shortcut_failed" comment="home screen == launcher">Your home screen does not allow AnkiDroid to add shortcuts</string>
     <string name="create_shortcut_error">Error adding shortcut: %s</string>
     <string name="note_editor_capitalize" comment="This is for a switch with a checkbox - on: enabled" maxLength="28">Capitalize sentences</string>


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - Diagnostics/String suggestions

## Purpose / Description

Show a toast when Xiaomi tries to add a shortcut to the home screen, because it's a custom permission

## Fixes
* Fixes #18601

## Approach
This adds a basic toast to inform the user, as we did for Vivo in
https://github.com/ankidroid/Anki-Android/commit/e925c1b07fb9c609ad241eede7eb74b1251826a6


## How Has This Been Tested?

API 33 emulator, commented out the `isMiUi` check.

<img width="276" height="257" alt="Screenshot 2026-04-30 at 18 22 56" src="https://github.com/user-attachments/assets/011fff40-e804-489d-afa3-71b3b5a95a6c" />

## Learning (optional, can help others)
Xiaomi :/

I don't have permissions to install AnkiDroid via USB, but I can grab it on GitHub, so I couldn't test my changes on a Xiaomi device

----

My Redmi 8A (MIUI 12) has a 'Home screen shortcuts' permission in Settings - Privacy Protection - Other permissions - AnkiDroid

This was not visible on AnkiDroid's regular permissions screen, and 10 seconds of the permission 'ask' dialog on the screen permanently denied the permission.

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)