### PR TITLE
feat(deck-options): handle computeMemory progress

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/pages/DeckOptions.kt
@@ -25,8 +25,8 @@ import android.webkit.WebView
 import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.FragmentActivity
+import anki.collection.ComputeParamsProgress
 import anki.collection.OpChanges
-import anki.collection.Progress
 import com.google.android.material.appbar.MaterialToolbar
 import com.ichi2.anki.CollectionManager.TR
 import com.ichi2.anki.CollectionManager.withCol
@@ -269,7 +269,9 @@ suspend fun FragmentActivity.updateDeckConfigsRaw(input: ByteArray): ByteArray {
         withContext(Dispatchers.Main) {
             withProgress(
                 extractProgress = {
-                    text = this.toOptimizingPresetString() ?: getString(R.string.dialog_processing)
+                    // TODO: Don't use the amount yet, unused as a progress indicator, and
+                    //  duplicates computeMemory's label
+                    text = this.toProgressText() ?: getString(R.string.dialog_processing)
                 },
             ) {
                 withContext(Dispatchers.IO) {
@@ -283,28 +285,39 @@ suspend fun FragmentActivity.updateDeckConfigsRaw(input: ByteArray): ByteArray {
 }
 
 /**
+ * Returns a string indicating progress, such as:
+ *
  * ```
  * Optimizing preset 1/20
  * 5.2% of 1000 reviews
  * ```
  *
- * @return the above string, or `null` if [ProgressContext] has no
- * [compute parameters][Progress.hasComputeParams]
+ * @return the above string, or `null` if a string could not be generated
  */
-private fun ProgressContext.toOptimizingPresetString(): String? {
-    if (!progress.hasComputeParams()) return null
+private fun ProgressContext.toProgressText(): String? =
+    when {
+        progress.hasComputeParams() -> progress.computeParams.toProgressText()
+        progress.hasComputeMemory() -> progress.computeMemory.label // Updating cards: X/Y...
+        else -> null
+    }
 
-    val value = progress.computeParams
+/**
+ * ```
+ * Optimizing preset 1/20
+ * 5.2% of 1000 reviews
+ * ```
+ */
+private fun ComputeParamsProgress.toProgressText(): String {
     val label =
         TR.deckConfigOptimizingPreset(
-            currentCount = value.currentPreset,
-            totalCount = value.totalPresets,
+            currentCount = currentPreset,
+            totalCount = totalPresets,
         )
-    val pct = if (value.total > 0) (value.current.toDouble() / value.total.toDouble() * 100.0) else 0.0
+    val pct = if (total > 0) (current.toDouble() / total.toDouble() * 100.0) else 0.0
     val reviewsLabel =
         TR.deckConfigPercentOfReviews(
             pct = "%.1f".format(pct),
-            reviews = value.reviews,
+            reviews = reviews,
         )
     return label + "\n" + reviewsLabel
 }


### PR DESCRIPTION
## Purpose / Description
We now show more information than just 'Processing'

## Fixes
* Fixes #16642

## Approach
* add logs to find the data in the proto
* handle `computeMemory`


## How Has This Been Tested?

* Enable FSRS
* Save
* A `computeMemory` progress dialog is shown

[Screen_recording_20260430_201904.webm](https://github.com/user-attachments/assets/e61f01bf-9764-4bcb-b941-6ba9b80c0283)

## Learning (optional, can help others)
Out 'Amount' progress indicator abstraction isn't entirely correct. In `computeMemory`, we have a label, we do not want to format `Amount` as a string, but we do want to use it to display as progress in the dialog.


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)