### PR TITLE
fix: API persist deck description on insert

### DIFF
--- a/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
+++ b/AnkiDroid/src/androidTest/java/com/ichi2/anki/tests/ContentProviderTest.kt
@@ -1802,6 +1802,51 @@ class ContentProviderTest : InstrumentedTest() {
         }
     }
 
+    @Test
+    fun testInsertDeckWithDescription() {
+        val deckName = "test_deck_with_desc"
+        val deckDesc = "This is the deck description"
+        val values =
+            ContentValues().apply {
+                put(FlashCardsContract.Deck.DECK_NAME, deckName)
+                put(FlashCardsContract.Deck.DECK_DESC, deckDesc)
+            }
+        val newDeckUri = contentResolver.insert(FlashCardsContract.Deck.CONTENT_ALL_URI, values)
+        assertNotNull("Check that URI returned from insert is not null", newDeckUri)
+        val newDeckId = newDeckUri!!.lastPathSegment!!.toLong()
+        testDeckIds.add(newDeckId)
+
+        val reopenedCol = reopenCol()
+        val savedDeck = reopenedCol.decks.getLegacy(newDeckId)
+        assertNotNull("Check that the inserted deck exists", savedDeck)
+        assertEquals(
+            "Check that the deck description was persisted",
+            deckDesc,
+            savedDeck!!.description,
+        )
+    }
+
+    @Test
+    fun testInsertDeckWithoutDescription() {
+        val deckName = "test_deck_no_desc"
+        val values =
+            ContentValues().apply {
+                put(FlashCardsContract.Deck.DECK_NAME, deckName)
+            }
+        val newDeckUri = contentResolver.insert(FlashCardsContract.Deck.CONTENT_ALL_URI, values)
+        assertNotNull("Check that URI returned from insert is not null", newDeckUri)
+        val newDeckId = newDeckUri!!.lastPathSegment!!.toLong()
+        testDeckIds.add(newDeckId)
+
+        val savedDeck = col.decks.getLegacy(newDeckId)
+        assertNotNull("Check that the inserted deck exists", savedDeck)
+        assertEquals(
+            "Description should default to empty when not provided",
+            "",
+            savedDeck!!.description,
+        )
+    }
+
     /**
      * Test that query for the next card in the schedule returns a valid result without any deck selector
      */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/provider/CardContentProvider.kt
@@ -1034,18 +1034,10 @@ class CardContentProvider : ContentProvider() {
                     throw IllegalArgumentException(filteredSubdeck.message)
                 }
                 val deck: Deck = col.decks.getLegacy(did)!!
-                @KotlinCleanup("remove the null check if deck is found to be not null in DeckManager.get(Long)")
-                @Suppress("SENSELESS_COMPARISON")
-                if (deck != null) {
-                    try {
-                        val deckDesc = values.getAsString(FlashCardsContract.Deck.DECK_DESC)
-                        if (deckDesc != null) {
-                            deck.put("desc", deckDesc)
-                        }
-                    } catch (e: JSONException) {
-                        Timber.e(e, "Could not set a field of new deck %s", deckName)
-                        return null
-                    }
+                val deckDesc = values.getAsString(FlashCardsContract.Deck.DECK_DESC)
+                if (deckDesc != null) {
+                    deck.description = deckDesc
+                    col.decks.save(deck)
                 }
                 Uri.withAppendedPath(FlashCardsContract.Deck.CONTENT_ALL_URI, did.toString())
             }


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
The description was set on the in-memory deck but never saved. Add the missing col.decks.save(deck) call and switch to the typed `Deck.description` setter. (I have aslo resolved the Cleanup )

## Fixes
* Fixes #20906

## Approach
See commit

## How Has This Been Tested?
I have added a tests so that it doesnt regress and verified the test locally (Passed)

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->