### PR TITLE
[Multimedia]refactor: extract multimedia related code from note editor

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -417,7 +417,7 @@ class NoteEditorFragment :
                 lifecycleScope.launch {
                     try {
                         val pasteAsPng = shouldPasteAsPng()
-                        onPaste(view as EditText, uri, description, pasteAsPng)
+                        multimediaController.onPaste(view as EditText, uri, description, pasteAsPng)
                     } catch (e: Exception) {
                         Timber.w(e)
                         CrashReportService.sendExceptionReport(e, "NoteEditor::onReceiveContent")
@@ -1830,7 +1830,7 @@ class NoteEditorFragment :
             lifecycleScope.launch {
                 val pasteAsPng = shouldPasteAsPng()
                 newEditText.setPasteListener { editText: EditText?, uri: Uri?, description: ClipDescription? ->
-                    onPaste(
+                    multimediaController.onPaste(
                         editText!!,
                         uri!!,
                         description!!,
@@ -1941,25 +1941,6 @@ class NoteEditorFragment :
                 onForceAdd()
             }
         }
-    }
-
-    private fun onPaste(
-        editText: EditText,
-        uri: Uri,
-        description: ClipDescription,
-        pasteAsPng: Boolean,
-    ): Boolean {
-        val mediaTag =
-            MediaRegistration.onPaste(
-                requireContext(),
-                uri,
-                description,
-                pasteAsPng,
-                showError = { type -> showSnackbar(type.toHumanReadableString(requireContext())) },
-            ) ?: return false
-
-        insertStringInField(editText, mediaTag)
-        return true
     }
 
     @NeedsTest("If a field is sticky after synchronization, the toggleStickyButton should be activated.")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -104,7 +104,6 @@ import com.ichi2.anki.dialogs.registerDeckSelectedHandler
 import com.ichi2.anki.dialogs.tags.TagsDialog
 import com.ichi2.anki.dialogs.tags.TagsDialogFactory
 import com.ichi2.anki.dialogs.tags.TagsDialogListener
-import com.ichi2.anki.exception.MediaSizeLimitExceededException
 import com.ichi2.anki.exception.toBytesShortString
 import com.ichi2.anki.libanki.Card
 import com.ichi2.anki.libanki.CardId
@@ -132,8 +131,6 @@ import com.ichi2.anki.multimedia.MultimediaResultContract
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
 import com.ichi2.anki.multimedia.MultimediaViewModel
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
-import com.ichi2.anki.multimediacard.fields.EFieldType
-import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.noteeditor.FieldState
@@ -141,6 +138,7 @@ import com.ichi2.anki.noteeditor.FieldState.FieldChangeType
 import com.ichi2.anki.noteeditor.FieldState.Type
 import com.ichi2.anki.noteeditor.NoteEditorFragmentDelegate
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.noteeditor.NoteEditorMultimediaController
 import com.ichi2.anki.noteeditor.Toolbar
 import com.ichi2.anki.noteeditor.Toolbar.TextFormatListener
 import com.ichi2.anki.noteeditor.Toolbar.TextWrapper
@@ -187,8 +185,6 @@ import com.ichi2.utils.openInputStreamSafe
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import net.ankiweb.rsdroid.Backend
 import org.json.JSONArray
@@ -228,7 +224,6 @@ class NoteEditorFragment :
     private var isTagsEdited = false
     private var isFieldEdited = false
     private var addNoteJob = RunOnlyOnce(scope = lifecycleScope)
-    private var multimediaActionJob: Job? = null
 
     private val getColUnsafe: Collection
         get() = CollectionManager.getColUnsafe()
@@ -258,7 +253,7 @@ class NoteEditorFragment :
     var editorNote: Note? = null
         private set
 
-    private val multimediaViewModel: MultimediaViewModel by activityViewModels()
+    internal val multimediaViewModel: MultimediaViewModel by activityViewModels()
 
     private var currentImageOccPath: String? = null
 
@@ -330,15 +325,19 @@ class NoteEditorFragment :
             when (result) {
                 is MultimediaResult.Cancelled -> {
                     Timber.d("Multimedia result canceled")
-                    handleMultimediaActions(result.fieldIndex)
+                    multimediaController.handleActions(result.fieldIndex)
                 }
                 is MultimediaResult.Success -> {
                     Timber.d("Getting multimedia result")
-                    handleMultimediaResult(result)
+                    multimediaController.handleResult(result)
                 }
                 null -> Timber.d("Multimedia launcher returned no result")
             }
         }
+
+    private val multimediaController: NoteEditorMultimediaController by lazy {
+        NoteEditorMultimediaController(this, multimediaFragmentLauncher)
+    }
 
     private val requestTemplateEditLauncher =
         registerForActivityResult(
@@ -1862,12 +1861,20 @@ class NoteEditorFragment :
         insertStringInField(getFieldForTest(fieldIndex), newString)
     }
 
-    private suspend fun getCurrentMultimediaEditableNote(): MultimediaEditableNote {
+    internal suspend fun getCurrentMultimediaEditableNote(): MultimediaEditableNote {
         val note = NoteService.createEmptyNote(editorNote!!.notetype)
         val fields = currentFieldStrings.requireNoNulls()
         withCol { NoteService.updateMultimediaNoteFromFields(this@withCol, fields, editorNote!!.noteTypeId, note) }
 
         return note
+    }
+
+    /** Returns the edit-field [FieldEditText] at [index] if present. */
+    internal fun editFieldAt(index: Int): FieldEditText? = editFields?.getOrNull(index)
+
+    /** Records that a multimedia capture has modified the note. */
+    internal fun markMultimediaChanged() {
+        changed = true
     }
 
     /** Determines whether pasted images should be handled as PNG format. **/
@@ -1964,7 +1971,7 @@ class NoteEditorFragment :
             mediaButton.setBackgroundResource(R.drawable.ic_attachment)
             mediaButton.setOnClickListener {
                 showMultimediaBottomSheet()
-                handleMultimediaActions(i)
+                multimediaController.handleActions(i)
             }
             if (addNote) {
                 // toggle sticky button
@@ -2012,99 +2019,7 @@ class NoteEditorFragment :
         multimediaBottomSheet.show(parentFragmentManager, "MultimediaBottomSheet")
     }
 
-    /**
-     * Handles user interactions with the multimedia options for a specific field in a note.
-     *
-     * This method is called when the user interacts with a option that allows them to add multimedia
-     * content to a field in a note being edited. It presents a `MultimediaBottomSheet`
-     * fragment to the user, which provides options for selecting different multimedia types.
-     *
-     * @param fieldIndex the index of the field in the note where the multimedia content should be added
-     */
-    private fun handleMultimediaActions(fieldIndex: Int) {
-        // Cancel any existing subscription to avoid duplicate listeners
-        multimediaActionJob?.cancel()
-
-        // Based on the type of multimedia action received, perform the corresponding operation
-        multimediaActionJob =
-            lifecycleScope.launch {
-                val note: MultimediaEditableNote = getCurrentMultimediaEditableNote()
-                if (note.isEmpty) return@launch
-
-                multimediaViewModel.multimediaAction.first { action ->
-                    Timber.i("Selected multimedia action: %s", action)
-                    val handler = MultimediaActionHandler.forAction(action)
-                    val field = handler.createField().also { note.setField(fieldIndex, it) }
-                    val intent =
-                        handler.buildIntent(
-                            requireContext(),
-                            MultimediaActivityExtra(fieldIndex, field, note),
-                        )
-                    multimediaFragmentLauncher.launch(intent)
-                    true
-                }
-            }
-    }
-
-    private fun handleMultimediaResult(result: MultimediaResult.Success) {
-        val field = result.field
-        // Process successful result only if field has data
-        if (field.type != EFieldType.TEXT || field.mediaFile != null) {
-            performAddMedia(result.fieldIndex, field, skipSizeCheck = false)
-        } else {
-            Timber.i("field imagePath and audioPath are both null")
-        }
-    }
-
-    /**
-     * Adds a media file to a specific field within the currently edited multimedia note.
-     *
-     * @param index The index of the field within the note to update.
-     * @param field The `IField` object representing the media file and its details.
-     * @param skipSizeCheck Whether to bypass the AnkiWeb media size limit check.
-     */
-
-    private fun performAddMedia(
-        index: Int,
-        field: IField,
-        skipSizeCheck: Boolean,
-    ) {
-        launchCatchingTask {
-            // Import field media
-            // This goes before setting formattedValue to update
-            // media paths with the checksum when they have the same name
-            try {
-                withCol {
-                    NoteService.importMediaToDirectory(this, field, skipSizeCheck = skipSizeCheck)
-                }
-
-                // Update UI
-                val fieldEditText = editFields!![index]
-                // Completely replace text for text fields (because current text was passed in)
-                val formattedValue = field.formattedValue
-                if (field.type === EFieldType.TEXT) {
-                    fieldEditText.setText(formattedValue)
-                } else if (fieldEditText.text != null) {
-                    insertStringInField(fieldEditText, formattedValue)
-                }
-                changed = true
-            } catch (e: MediaSizeLimitExceededException) {
-                showLargeMediaFileWarning(
-                    e.fileName,
-                    e.fileSize,
-                    onForceAdd = {
-                        // Recursive call to bypass the size check if the user wants to add anyway
-                        performAddMedia(index, field, skipSizeCheck = true)
-                    },
-                )
-            } catch (oomError: OutOfMemoryError) {
-                // TODO: a 'retry' flow would be possible here
-                throw Exception(oomError)
-            }
-        }
-    }
-
-    private fun showLargeMediaFileWarning(
+    internal fun showLargeMediaFileWarning(
         fileName: String,
         fileSize: Long,
         onForceAdd: () -> Unit,

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -328,7 +328,8 @@ class NoteEditorFragment :
             }
         }
 
-    private val multimediaController: NoteEditorMultimediaController by lazy {
+    @VisibleForTesting
+    internal val multimediaController: NoteEditorMultimediaController by lazy {
         NoteEditorMultimediaController(this, multimediaFragmentLauncher)
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -167,7 +167,6 @@ import com.ichi2.utils.ClipboardUtil
 import com.ichi2.utils.ClipboardUtil.MEDIA_MIME_TYPES
 import com.ichi2.utils.ClipboardUtil.hasMedia
 import com.ichi2.utils.ClipboardUtil.items
-import com.ichi2.utils.ContentResolverUtil
 import com.ichi2.utils.HashUtil
 import com.ichi2.utils.ImportUtils
 import com.ichi2.utils.IntentUtil.resolveMimeType
@@ -179,7 +178,6 @@ import com.ichi2.utils.iconAttr
 import com.ichi2.utils.message
 import com.ichi2.utils.negativeButton
 import com.ichi2.utils.neutralButton
-import com.ichi2.utils.openInputStreamSafe
 import com.ichi2.utils.positiveButton
 import com.ichi2.utils.show
 import com.ichi2.utils.title
@@ -596,80 +594,6 @@ class NoteEditorFragment :
      *
      * @param data the Intent containing the image information from the user's share action
      */
-    @NeedsTest("Test when the user directly passes image to the edit note field")
-    private suspend fun handleImageIntent(data: Intent) {
-        val imageUri =
-            if (data.action == Intent.ACTION_SEND) {
-                BundleCompat.getParcelable(requireArguments(), Intent.EXTRA_STREAM, Uri::class.java)
-            } else {
-                data.data
-            }
-
-        if (imageUri == null) {
-            Timber.d("NoteEditor:: Image Uri is null")
-            showSnackbar(R.string.something_wrong)
-            return
-        }
-
-        try {
-            requireContext().contentResolver.takePersistableUriPermission(imageUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            Timber.d("Persisted URI permission for $imageUri")
-        } catch (e: SecurityException) {
-            Timber.w(e, "Unable to persist URI permission")
-        }
-
-        val cachedImagePath = copyUriToInternalCache(imageUri)
-        if (cachedImagePath == null) {
-            Timber.w("Failed to cache image")
-            showSnackbar(R.string.something_wrong)
-            return
-        }
-        val cachedUri = Uri.fromFile(File(requireContext().cacheDir, cachedImagePath))
-        multimediaController.launchImagePaste(cachedUri)
-    }
-
-    /**
-     * Copies a given [Uri] to the app's internal cache directory.
-     *
-     * This is necessary because URIs provided by other apps (e.g., WhatsApp, gallery apps) via
-     * `Intent` are usually content URIs with temporary permissions that are only valid
-     * in the originating context (like an Activity). Once passed to other components (like Fragments),
-     * these permissions may be lost, resulting in a SecurityException.
-     *
-     * By caching the file in internal storage and referencing it via a file URI,
-     * we ensure persistent access to the image without relying on external content providers.
-     *
-     * @param uri The [Uri] pointing to the external image content.
-     * @return The name of the cached file, or `null` if the operation failed.
-     */
-    private fun copyUriToInternalCache(uri: Uri): String? {
-        return try {
-            val inputStream = requireContext().contentResolver.openInputStreamSafe(uri) ?: return null
-
-            val fileName = ContentResolverUtil.getFileName(requireContext().contentResolver, uri)
-            val cacheDir = requireContext().cacheDir
-            val destFile = File(cacheDir, fileName)
-
-            val canonicalCacheDir = cacheDir.canonicalFile
-            val canonicalDestFile = destFile.canonicalFile
-
-            if (!canonicalDestFile.path.startsWith(canonicalCacheDir.path)) {
-                Timber.w("Rejected path due to directory traversal risk: $fileName")
-                return null
-            }
-
-            destFile.outputStream().use { output ->
-                inputStream.copyTo(output)
-            }
-
-            Timber.d("copyUriToInternalCache() copied to ${destFile.absolutePath}")
-            destFile.name
-        } catch (e: Exception) {
-            Timber.w(e, "Failed to copy URI to internal cache")
-            null
-        }
-    }
-
     override fun onSaveInstanceState(outState: Bundle) {
         addInstanceStateToBundle(outState)
         super.onSaveInstanceState(outState)
@@ -894,7 +818,7 @@ class NoteEditorFragment :
             contents?.let { setEditFieldTexts(it) }
             tags?.let { setTags(it) }
             // If the activity was called to handle an image addition, launch a coroutine to process the image intent.
-            if (caller == NoteEditorCaller.ADD_IMAGE) lifecycleScope.launch { handleImageIntent(intent) }
+            if (caller == NoteEditorCaller.ADD_IMAGE) lifecycleScope.launch { multimediaController.handleImageIntent(intent) }
         } else {
             // Intercept spinner clicks to launch ChangeNoteTypeDialog instead of spinner dropdown
             noteTypeSpinner!!.setOnTouchListener { _, event ->

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -123,8 +123,6 @@ import com.ichi2.anki.libanki.Utils
 import com.ichi2.anki.libanki.clozeNumbersInNote
 import com.ichi2.anki.model.CardStateFilter
 import com.ichi2.anki.model.SelectableDeck
-import com.ichi2.anki.multimedia.MultimediaActionHandler
-import com.ichi2.anki.multimedia.MultimediaActivityExtra
 import com.ichi2.anki.multimedia.MultimediaBottomSheet
 import com.ichi2.anki.multimedia.MultimediaResult
 import com.ichi2.anki.multimedia.MultimediaResultContract
@@ -281,9 +279,6 @@ class NoteEditorFragment :
     private var sourceText: Array<String?>? = null
     private val fieldState = FieldState.fromEditor(this)
     private lateinit var toolbar: Toolbar
-
-    // Use the same HTML if the same image is pasted multiple times.
-    private var pastedImageCache: HashMap<String, String> = HashMap()
 
     // save field index as key and text as value when toggle sticky clicked in Field Edit Text
     @VisibleForTesting
@@ -522,8 +517,7 @@ class NoteEditorFragment :
             deckId = savedInstanceState.getLong("did")
             selectedTags = savedInstanceState.getStringArrayList("tags")
             reloadRequired = savedInstanceState.getBoolean(RELOAD_REQUIRED_EXTRA_KEY)
-            pastedImageCache =
-                savedInstanceState.getSerializableCompat<HashMap<String, String>>("imageCache")!!
+            multimediaController.onRestoreInstanceState(savedInstanceState)
             toggleStickyText =
                 savedInstanceState.getSerializableCompat<HashMap<Int, String?>>("toggleSticky")!!
             changed = savedInstanceState.getBoolean(NOTE_CHANGED_EXTRA_KEY)
@@ -631,21 +625,7 @@ class NoteEditorFragment :
             return
         }
         val cachedUri = Uri.fromFile(File(requireContext().cacheDir, cachedImagePath))
-
-        val note = getCurrentMultimediaEditableNote()
-        if (note.isEmpty) {
-            Timber.w("Note is null, returning")
-            return
-        }
-        val handler = MultimediaActionHandler.ImageFile
-        val extra =
-            MultimediaActivityExtra(
-                index = 0,
-                field = handler.createField(),
-                note = note,
-                imageUri = cachedUri.toString(),
-            )
-        multimediaFragmentLauncher.launch(handler.buildIntent(requireContext(), extra))
+        multimediaController.launchImagePaste(cachedUri)
     }
 
     /**
@@ -703,7 +683,7 @@ class NoteEditorFragment :
         savedInstanceState.putBoolean(NOTE_CHANGED_EXTRA_KEY, changed)
         savedInstanceState.putBoolean(RELOAD_REQUIRED_EXTRA_KEY, reloadRequired)
         savedInstanceState.putIntegerArrayList("customViewIds", customViewIds)
-        savedInstanceState.putSerializable("imageCache", pastedImageCache)
+        multimediaController.onSaveInstanceState(savedInstanceState)
         savedInstanceState.putSerializable("toggleSticky", toggleStickyText)
         if (selectedTags == null) {
             selectedTags = ArrayList(0)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/NoteEditorFragment.kt
@@ -127,7 +127,6 @@ import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.multimedia.MultimediaActionHandler
 import com.ichi2.anki.multimedia.MultimediaActivityExtra
 import com.ichi2.anki.multimedia.MultimediaBottomSheet
-import com.ichi2.anki.multimedia.MultimediaImageFragment
 import com.ichi2.anki.multimedia.MultimediaResult
 import com.ichi2.anki.multimedia.MultimediaResultContract
 import com.ichi2.anki.multimedia.MultimediaUtils.createImageFile
@@ -135,7 +134,6 @@ import com.ichi2.anki.multimedia.MultimediaViewModel
 import com.ichi2.anki.multimediacard.IMultimediaEditableNote
 import com.ichi2.anki.multimediacard.fields.EFieldType
 import com.ichi2.anki.multimediacard.fields.IField
-import com.ichi2.anki.multimediacard.fields.ImageField
 import com.ichi2.anki.multimediacard.impl.MultimediaEditableNote
 import com.ichi2.anki.noteeditor.CustomToolbarButton
 import com.ichi2.anki.noteeditor.FieldState
@@ -640,12 +638,15 @@ class NoteEditorFragment :
             Timber.w("Note is null, returning")
             return
         }
-        openMultimediaImageFragment(
-            fieldIndex = 0,
-            field = ImageField(),
-            multimediaNote = note,
-            imageUri = cachedUri,
-        )
+        val handler = MultimediaActionHandler.ImageFile
+        val extra =
+            MultimediaActivityExtra(
+                index = 0,
+                field = handler.createField(),
+                note = note,
+                imageUri = cachedUri.toString(),
+            )
+        multimediaFragmentLauncher.launch(handler.buildIntent(requireContext(), extra))
     }
 
     /**
@@ -2043,24 +2044,6 @@ class NoteEditorFragment :
                     true
                 }
             }
-    }
-
-    private fun openMultimediaImageFragment(
-        fieldIndex: Int,
-        field: IField,
-        multimediaNote: IMultimediaEditableNote,
-        imageUri: Uri? = null,
-    ) {
-        val multimediaExtra = MultimediaActivityExtra(fieldIndex, field, multimediaNote, imageUri?.toString())
-
-        val imageIntent =
-            MultimediaImageFragment.getIntent(
-                requireContext(),
-                multimediaExtra,
-                MultimediaImageFragment.ImageOptions.GALLERY,
-            )
-
-        multimediaFragmentLauncher.launch(imageIntent)
     }
 
     private fun handleMultimediaResult(result: MultimediaResult.Success) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioRecordingFragment.kt
@@ -104,9 +104,7 @@ class AudioRecordingFragment : MultimediaFragment(R.layout.fragment_audio_record
                 return@setOnClickListener
             }
 
-            field.mediaFile = viewModel.currentMultimediaPath.value
-            field.hasTemporaryMedia = true
-            setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
+            finishWithMedia()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/AudioVideoFragment.kt
@@ -67,9 +67,7 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
             when {
                 result.resultCode != Activity.RESULT_OK || result.data == null -> {
                     Timber.d("Uri is empty or Result not OK")
-                    if (viewModel.currentMultimediaUri.value == null) {
-                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
-                    }
+                    cancelIfEmpty()
                 }
                 else -> {
                     executeSafe(requireContext(), "pickMediaLauncher:unhandled") {
@@ -192,9 +190,7 @@ class AudioVideoFragment : MultimediaFragment(R.layout.fragment_audio_video) {
                 Timber.d("Audio or Video length is not valid")
                 return@setOnClickListener
             }
-            field.mediaFile = viewModel.currentMultimediaPath.value
-            field.hasTemporaryMedia = true
-            setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
+            finishWithMedia()
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaFragment.kt
@@ -185,4 +185,25 @@ abstract class MultimediaFragment(
             }
         }
     }
+
+    /**
+     * Finishes the activity with a [MultimediaResult.Cancelled] result when no media
+     * has been captured yet. Call from child-launcher cancel branches to propagate
+     * the cancellation without losing partial captures.
+     */
+    protected fun cancelIfEmpty() {
+        if (viewModel.currentMultimediaUri.value == null) {
+            setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
+        }
+    }
+
+    /**
+     * Attaches the currently captured media to [field] and finishes the activity
+     * with a [MultimediaResult.Success]. Call from confirm/done actions.
+     */
+    protected fun finishWithMedia() {
+        field.mediaFile = viewModel.currentMultimediaPath.value
+        field.hasTemporaryMedia = true
+        setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
+    }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/multimedia/MultimediaImageFragment.kt
@@ -96,9 +96,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             hasStartedImageSelection = false
             when (result.resultCode) {
                 Activity.RESULT_CANCELED -> {
-                    if (viewModel.currentMultimediaUri.value == null) {
-                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
-                    }
+                    cancelIfEmpty()
                 }
 
                 Activity.RESULT_OK -> {
@@ -123,9 +121,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             when (result.resultCode) {
                 Activity.RESULT_CANCELED -> {
                     // If user didn't draw, return the indexValue as a result and finish the activity
-                    if (viewModel.currentMultimediaUri.value == null) {
-                        setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
-                    }
+                    cancelIfEmpty()
                 }
 
                 Activity.RESULT_OK -> {
@@ -146,7 +142,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
             hasStartedImageSelection = false
             when {
                 !isPictureTaken && viewModel.currentMultimediaUri.value == null -> {
-                    setMultimediaResultAndFinish(MultimediaResult.Cancelled(indexValue))
+                    cancelIfEmpty()
                 }
 
                 isPictureTaken -> {
@@ -325,9 +321,7 @@ class MultimediaImageFragment : MultimediaFragment(R.layout.fragment_multimedia_
     }
 
     private fun finishAddingImage() {
-        field.mediaFile = viewModel.currentMultimediaPath.value
-        field.hasTemporaryMedia = true
-        setMultimediaResultAndFinish(MultimediaResult.Success(indexValue, field))
+        finishWithMedia()
     }
 
     private fun openGallery() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -9,6 +9,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.widget.EditText
 import androidx.activity.result.ActivityResultLauncher
+import androidx.annotation.VisibleForTesting
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.CollectionManager.withCol
@@ -266,7 +267,8 @@ internal class NoteEditorMultimediaController(
         }
     }
 
-    private companion object {
+    companion object {
+        @VisibleForTesting
         const val STATE_KEY_IMAGE_CACHE = "imageCache"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -3,13 +3,16 @@
 
 package com.ichi2.anki.noteeditor
 
+import android.content.ClipDescription
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.widget.EditText
 import androidx.activity.result.ActivityResultLauncher
 import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.MediaRegistration
 import com.ichi2.anki.NoteEditorFragment
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
@@ -186,6 +189,30 @@ internal class NoteEditorMultimediaController(
         pastedImageCache =
             state.getSerializableCompat<HashMap<String, String>>(STATE_KEY_IMAGE_CACHE)
                 ?: HashMap()
+    }
+
+    /**
+     * Handles clipboard/drag-and-drop paste of a media [uri] into [editText].
+     * Returns `true` if the paste produced a media tag, `false` otherwise.
+     */
+    fun onPaste(
+        editText: EditText,
+        uri: Uri,
+        description: ClipDescription,
+        pasteAsPng: Boolean,
+    ): Boolean {
+        val context = fragment.requireContext()
+        val mediaTag =
+            MediaRegistration.onPaste(
+                context,
+                uri,
+                description,
+                pasteAsPng,
+                showError = { type -> fragment.showSnackbar(type.toHumanReadableString(context)) },
+            ) ?: return false
+
+        fragment.insertStringInField(editText, mediaTag)
+        return true
     }
 
     /** Imports the captured media into the collection if the result carries any. */

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -4,10 +4,13 @@
 package com.ichi2.anki.noteeditor
 
 import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NoteEditorFragment
+import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.anki.exception.MediaSizeLimitExceededException
 import com.ichi2.anki.launchCatchingTask
 import com.ichi2.anki.multimedia.MultimediaActionHandler
@@ -34,6 +37,9 @@ internal class NoteEditorMultimediaController(
 ) {
     private var actionJob: Job? = null
 
+    // Use the same HTML if the same image is pasted multiple times.
+    private var pastedImageCache: HashMap<String, String> = HashMap()
+
     /**
      * Subscribes to the next [MultimediaActionHandler] emitted by the bottom sheet
      * and launches its capture screen against [fieldIndex]. Cancels any previously
@@ -59,6 +65,37 @@ internal class NoteEditorMultimediaController(
                     true
                 }
             }
+    }
+
+    /**
+     * Launches the image-picker screen pre-seeded with [imageUri], used by the
+     * share/paste path when an image is delivered from another app.
+     */
+    suspend fun launchImagePaste(imageUri: Uri) {
+        val note = fragment.getCurrentMultimediaEditableNote()
+        if (note.isEmpty) {
+            Timber.w("Note is null, returning")
+            return
+        }
+        val handler = MultimediaActionHandler.ImageFile
+        val extra =
+            MultimediaActivityExtra(
+                index = 0,
+                field = handler.createField(),
+                note = note,
+                imageUri = imageUri.toString(),
+            )
+        launcher.launch(handler.buildIntent(fragment.requireContext(), extra))
+    }
+
+    fun onSaveInstanceState(outState: Bundle) {
+        outState.putSerializable(STATE_KEY_IMAGE_CACHE, pastedImageCache)
+    }
+
+    fun onRestoreInstanceState(state: Bundle) {
+        pastedImageCache =
+            state.getSerializableCompat<HashMap<String, String>>(STATE_KEY_IMAGE_CACHE)
+                ?: HashMap()
     }
 
     /** Imports the captured media into the collection if the result carries any. */
@@ -110,5 +147,9 @@ internal class NoteEditorMultimediaController(
                 throw Exception(oomError)
             }
         }
+    }
+
+    private companion object {
+        const val STATE_KEY_IMAGE_CACHE = "imageCache"
     }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.noteeditor
+
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import androidx.lifecycle.lifecycleScope
+import com.ichi2.anki.CollectionManager.withCol
+import com.ichi2.anki.NoteEditorFragment
+import com.ichi2.anki.exception.MediaSizeLimitExceededException
+import com.ichi2.anki.launchCatchingTask
+import com.ichi2.anki.multimedia.MultimediaActionHandler
+import com.ichi2.anki.multimedia.MultimediaActivityExtra
+import com.ichi2.anki.multimedia.MultimediaResult
+import com.ichi2.anki.multimediacard.fields.EFieldType
+import com.ichi2.anki.multimediacard.fields.IField
+import com.ichi2.anki.servicelayer.NoteService
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+/**
+ * Owns the multimedia capture lifecycle for a [NoteEditorFragment].
+ *
+ * The [launcher] must already be registered on the fragment (an
+ * `ActivityResultLauncher` can only be created during fragment initialisation);
+ * its callback forwards to [handleActions] / [handleResult].
+ */
+internal class NoteEditorMultimediaController(
+    private val fragment: NoteEditorFragment,
+    private val launcher: ActivityResultLauncher<Intent>,
+) {
+    private var actionJob: Job? = null
+
+    /**
+     * Subscribes to the next [MultimediaActionHandler] emitted by the bottom sheet
+     * and launches its capture screen against [fieldIndex]. Cancels any previously
+     * pending subscription so rapid field switches don't stack.
+     */
+    fun handleActions(fieldIndex: Int) {
+        actionJob?.cancel()
+        actionJob =
+            fragment.lifecycleScope.launch {
+                val note = fragment.getCurrentMultimediaEditableNote()
+                if (note.isEmpty) return@launch
+
+                fragment.multimediaViewModel.multimediaAction.first { action ->
+                    Timber.i("Selected multimedia action: %s", action)
+                    val handler = MultimediaActionHandler.forAction(action)
+                    val field = handler.createField().also { note.setField(fieldIndex, it) }
+                    val intent =
+                        handler.buildIntent(
+                            fragment.requireContext(),
+                            MultimediaActivityExtra(fieldIndex, field, note),
+                        )
+                    launcher.launch(intent)
+                    true
+                }
+            }
+    }
+
+    /** Imports the captured media into the collection if the result carries any. */
+    fun handleResult(result: MultimediaResult.Success) {
+        val field = result.field
+        if (field.type != EFieldType.TEXT || field.mediaFile != null) {
+            performAddMedia(result.fieldIndex, field, skipSizeCheck = false)
+        } else {
+            Timber.i("field imagePath and audioPath are both null")
+        }
+    }
+
+    /**
+     * Adds a media file to a specific field within the currently edited multimedia note.
+     *
+     * @param index The index of the field within the note to update.
+     * @param field The `IField` object representing the media file and its details.
+     * @param skipSizeCheck Whether to bypass the AnkiWeb media size limit check.
+     */
+    private fun performAddMedia(
+        index: Int,
+        field: IField,
+        skipSizeCheck: Boolean,
+    ) {
+        fragment.launchCatchingTask {
+            try {
+                // Import field media before setting formattedValue so media paths
+                // reflect the checksum when names collide.
+                withCol {
+                    NoteService.importMediaToDirectory(this, field, skipSizeCheck = skipSizeCheck)
+                }
+
+                val fieldEditText = fragment.editFieldAt(index) ?: return@launchCatchingTask
+                val formattedValue = field.formattedValue
+                if (field.type === EFieldType.TEXT) {
+                    fieldEditText.setText(formattedValue)
+                } else if (fieldEditText.text != null) {
+                    fragment.insertStringInField(fieldEditText, formattedValue)
+                }
+                fragment.markMultimediaChanged()
+            } catch (e: MediaSizeLimitExceededException) {
+                fragment.showLargeMediaFileWarning(
+                    e.fileName,
+                    e.fileSize,
+                    onForceAdd = { performAddMedia(index, field, skipSizeCheck = true) },
+                )
+            } catch (oomError: OutOfMemoryError) {
+                // TODO: a 'retry' flow would be possible here
+                throw Exception(oomError)
+            }
+        }
+    }
+}

--- a/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaController.kt
@@ -7,9 +7,12 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
+import androidx.core.os.BundleCompat
 import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.NoteEditorFragment
+import com.ichi2.anki.R
+import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
 import com.ichi2.anki.exception.MediaSizeLimitExceededException
 import com.ichi2.anki.launchCatchingTask
@@ -19,10 +22,14 @@ import com.ichi2.anki.multimedia.MultimediaResult
 import com.ichi2.anki.multimediacard.fields.EFieldType
 import com.ichi2.anki.multimediacard.fields.IField
 import com.ichi2.anki.servicelayer.NoteService
+import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.utils.ContentResolverUtil
+import com.ichi2.utils.openInputStreamSafe
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import java.io.File
 
 /**
  * Owns the multimedia capture lifecycle for a [NoteEditorFragment].
@@ -65,6 +72,89 @@ internal class NoteEditorMultimediaController(
                     true
                 }
             }
+    }
+
+    /**
+     * Handles an image-share intent: extracts the source [Uri], persists URI permission,
+     * copies it into the app's cache, and launches the image picker seeded with the
+     * cached file.
+     */
+    @NeedsTest("Test when the user directly passes image to the edit note field")
+    suspend fun handleImageIntent(data: Intent) {
+        val imageUri =
+            if (data.action == Intent.ACTION_SEND) {
+                BundleCompat.getParcelable(fragment.requireArguments(), Intent.EXTRA_STREAM, Uri::class.java)
+            } else {
+                data.data
+            }
+
+        if (imageUri == null) {
+            Timber.d("NoteEditor:: Image Uri is null")
+            fragment.showSnackbar(R.string.something_wrong)
+            return
+        }
+
+        try {
+            fragment
+                .requireContext()
+                .contentResolver
+                .takePersistableUriPermission(imageUri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            Timber.d("Persisted URI permission for $imageUri")
+        } catch (e: SecurityException) {
+            Timber.w(e, "Unable to persist URI permission")
+        }
+
+        val cachedImagePath = copyUriToInternalCache(imageUri)
+        if (cachedImagePath == null) {
+            Timber.w("Failed to cache image")
+            fragment.showSnackbar(R.string.something_wrong)
+            return
+        }
+        val cachedUri = Uri.fromFile(File(fragment.requireContext().cacheDir, cachedImagePath))
+        launchImagePaste(cachedUri)
+    }
+
+    /**
+     * Copies a given [Uri] to the app's internal cache directory.
+     *
+     * This is necessary because URIs provided by other apps (e.g., WhatsApp, gallery apps) via
+     * `Intent` are usually content URIs with temporary permissions that are only valid
+     * in the originating context (like an Activity). Once passed to other components (like Fragments),
+     * these permissions may be lost, resulting in a SecurityException.
+     *
+     * By caching the file in internal storage and referencing it via a file URI,
+     * we ensure persistent access to the image without relying on external content providers.
+     *
+     * @param uri The [Uri] pointing to the external image content.
+     * @return The name of the cached file, or `null` if the operation failed.
+     */
+    private fun copyUriToInternalCache(uri: Uri): String? {
+        return try {
+            val context = fragment.requireContext()
+            val inputStream = context.contentResolver.openInputStreamSafe(uri) ?: return null
+
+            val fileName = ContentResolverUtil.getFileName(context.contentResolver, uri)
+            val cacheDir = context.cacheDir
+            val destFile = File(cacheDir, fileName)
+
+            val canonicalCacheDir = cacheDir.canonicalFile
+            val canonicalDestFile = destFile.canonicalFile
+
+            if (!canonicalDestFile.path.startsWith(canonicalCacheDir.path)) {
+                Timber.w("Rejected path due to directory traversal risk: $fileName")
+                return null
+            }
+
+            destFile.outputStream().use { output ->
+                inputStream.copyTo(output)
+            }
+
+            Timber.d("copyUriToInternalCache() copied to ${destFile.absolutePath}")
+            destFile.name
+        } catch (e: Exception) {
+            Timber.w(e, "Failed to copy URI to internal cache")
+            null
+        }
     }
 
     /**

--- a/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/AbstractFlashcardViewerTest.kt
@@ -25,6 +25,7 @@ import com.ichi2.anki.cardviewer.ViewerCommand
 import com.ichi2.anki.libanki.testutils.ext.addNote
 import com.ichi2.anki.libanki.testutils.ext.createBasicTypingNoteType
 import com.ichi2.anki.libanki.testutils.ext.newNote
+import com.ichi2.anki.noteeditor.openNoteEditorWithArgs
 import com.ichi2.anki.observability.undoableOp
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.reviewer.AutomaticAnswer
@@ -218,7 +219,7 @@ class AbstractFlashcardViewerTest : RobolectricTest() {
                     NoteEditorFragment.EXTRA_CARD_ID to viewer.currentCard!!.id,
                     FINISH_ANIMATION_EXTRA to animation as Parcelable,
                 )
-            val noteEditor = NoteEditorTest().openNoteEditorWithArgs(bundle)
+            val noteEditor = openNoteEditorWithArgs(bundle)
             val actualInverseAnimation =
                 BundleCompat.getParcelable(
                     noteEditor.requireArguments(),

--- a/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/NoteEditorTest.kt
@@ -45,6 +45,8 @@ import com.ichi2.anki.libanki.NotetypeJson
 import com.ichi2.anki.libanki.testutils.AnkiTest
 import com.ichi2.anki.model.SelectableDeck
 import com.ichi2.anki.noteeditor.NoteEditorLauncher
+import com.ichi2.anki.noteeditor.getNoteEditorFragment
+import com.ichi2.anki.noteeditor.openNoteEditorWithArgs
 import com.ichi2.testutils.getString
 import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
@@ -847,18 +849,6 @@ class NoteEditorTest : RobolectricTest() {
         return openNoteEditorWithArgs(bundle)
     }
 
-    fun openNoteEditorWithArgs(
-        arguments: Bundle,
-        action: String? = null,
-    ): NoteEditorFragment {
-        val activity =
-            startActivityNormallyOpenCollectionWithIntent(
-                NoteEditorActivity::class.java,
-                NoteEditorLauncher.PassArguments(arguments).toIntent(targetContext, action),
-            )
-        return activity.getNoteEditorFragment()
-    }
-
     @DuplicatedCode("NoteEditor in androidTest")
     @Throws(Throwable::class)
     fun ActivityScenario<NoteEditorActivity>.onNoteEditor(block: (NoteEditorFragment) -> Unit) {
@@ -873,10 +863,6 @@ class NoteEditorTest : RobolectricTest() {
         }
         wrapped.get()?.let { throw it }
     }
-
-    @DuplicatedCode("NoteEditor in androidTest")
-    fun NoteEditorActivity.getNoteEditorFragment(): NoteEditorFragment =
-        supportFragmentManager.findFragmentById(R.id.note_editor_fragment_frame) as NoteEditorFragment
 
     private enum class FromScreen {
         DECK_LIST,

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaActionHandlerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaActionHandlerTest.kt
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.multimedia
+
+import com.ichi2.anki.multimedia.MultimediaBottomSheet.MultimediaAction
+import com.ichi2.anki.multimediacard.fields.AudioRecordingField
+import com.ichi2.anki.multimediacard.fields.ImageField
+import com.ichi2.anki.multimediacard.fields.MediaClipField
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.not
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+
+class MultimediaActionHandlerTest {
+    @ParameterizedTest
+    @EnumSource(MultimediaAction::class)
+    fun `every action resolves to a handler bound to that action`(action: MultimediaAction) {
+        val handler = MultimediaActionHandler.forAction(action)
+        assertThat(handler.action, equalTo(action))
+    }
+
+    @Test
+    fun `image-file handler creates an ImageField`() {
+        assertThat(MultimediaActionHandler.ImageFile.createField(), instanceOf(ImageField::class.java))
+    }
+
+    @Test
+    fun `camera handler creates an ImageField`() {
+        assertThat(MultimediaActionHandler.Camera.createField(), instanceOf(ImageField::class.java))
+    }
+
+    @Test
+    fun `drawing handler creates an ImageField`() {
+        assertThat(MultimediaActionHandler.Drawing.createField(), instanceOf(ImageField::class.java))
+    }
+
+    @Test
+    fun `audio-clip handler creates a MediaClipField`() {
+        assertThat(MultimediaActionHandler.AudioFile.createField(), instanceOf(MediaClipField::class.java))
+    }
+
+    @Test
+    fun `video-clip handler creates a MediaClipField`() {
+        assertThat(MultimediaActionHandler.VideoFile.createField(), instanceOf(MediaClipField::class.java))
+    }
+
+    @Test
+    fun `audio-recording handler creates an AudioRecordingField`() {
+        assertThat(
+            MultimediaActionHandler.AudioRecording.createField(),
+            instanceOf(AudioRecordingField::class.java),
+        )
+    }
+
+    @Test
+    fun `createField returns a fresh instance per call`() {
+        val first = MultimediaActionHandler.ImageFile.createField()
+        val second = MultimediaActionHandler.ImageFile.createField()
+        assertThat(first, not(sameInstance(second)))
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaResultContractTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/multimedia/MultimediaResultContractTest.kt
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.multimedia
+
+import android.app.Activity
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.multimediacard.fields.ImageField
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.instanceOf
+import org.hamcrest.Matchers.nullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MultimediaResultContractTest {
+    private val contract = MultimediaResultContract()
+
+    @Test
+    fun `parseResult returns null when intent is null`() {
+        assertThat(contract.parseResult(Activity.RESULT_OK, null), nullValue())
+    }
+
+    @Test
+    fun `parseResult returns null when field index extra is missing`() {
+        assertThat(contract.parseResult(Activity.RESULT_OK, Intent()), nullValue())
+    }
+
+    @Test
+    fun `parseResult returns Cancelled when result code is canceled`() {
+        val intent =
+            Intent().apply {
+                putExtra(MultimediaResultContract.EXTRA_FIELD_INDEX, 3)
+            }
+
+        val result = contract.parseResult(Activity.RESULT_CANCELED, intent)
+
+        assertThat(result, instanceOf(MultimediaResult.Cancelled::class.java))
+        assertThat(result!!.fieldIndex, equalTo(3))
+    }
+
+    @Test
+    fun `parseResult returns Success when result code is ok and field is present`() {
+        val field = ImageField()
+        val intent =
+            Intent().apply {
+                putExtra(MultimediaResultContract.EXTRA_FIELD_INDEX, 1)
+                putExtra(MultimediaResultContract.EXTRA_FIELD, field)
+            }
+
+        val result = contract.parseResult(Activity.RESULT_OK, intent)
+
+        assertThat(result, instanceOf(MultimediaResult.Success::class.java))
+        val success = result as MultimediaResult.Success
+        assertThat(success.fieldIndex, equalTo(1))
+        assertThat(success.field, instanceOf(ImageField::class.java))
+    }
+
+    @Test
+    fun `parseResult returns null when result code is ok but field is missing`() {
+        val intent =
+            Intent().apply {
+                putExtra(MultimediaResultContract.EXTRA_FIELD_INDEX, 1)
+            }
+
+        assertThat(contract.parseResult(Activity.RESULT_OK, intent), nullValue())
+    }
+
+    @Test
+    fun `parseResult returns null for an unknown result code`() {
+        val intent =
+            Intent().apply {
+                putExtra(MultimediaResultContract.EXTRA_FIELD_INDEX, 0)
+            }
+
+        assertThat(contract.parseResult(Activity.RESULT_FIRST_USER, intent), nullValue())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaControllerTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorMultimediaControllerTest.kt
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.noteeditor
+
+import android.os.Bundle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.NoteEditorFragment
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.compat.CompatHelper.Companion.getSerializableCompat
+import com.ichi2.anki.noteeditor.NoteEditorMultimediaController.Companion.STATE_KEY_IMAGE_CACHE
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.notNullValue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NoteEditorMultimediaControllerTest : RobolectricTest() {
+    @Test
+    fun `controller is reachable from the hosted fragment`() {
+        val noteEditor = openNoteEditor()
+        assertThat(noteEditor.multimediaController, notNullValue())
+    }
+
+    @Test
+    fun `onSaveInstanceState writes the imageCache key`() {
+        val noteEditor = openNoteEditor()
+        val out = Bundle()
+
+        noteEditor.multimediaController.onSaveInstanceState(out)
+
+        assertThat(out.containsKey(STATE_KEY_IMAGE_CACHE), equalTo(true))
+    }
+
+    @Test
+    fun `restore then save round-trips the imageCache contents`() {
+        val noteEditor = openNoteEditor()
+        val seeded = hashMapOf("foo" to "<img src='foo.png'>")
+        val saved = Bundle().apply { putSerializable(STATE_KEY_IMAGE_CACHE, seeded) }
+
+        noteEditor.multimediaController.onRestoreInstanceState(saved)
+        val out = Bundle().also { noteEditor.multimediaController.onSaveInstanceState(it) }
+
+        val restored = out.getSerializableCompat<HashMap<String, String>>(STATE_KEY_IMAGE_CACHE)
+        assertThat(restored, equalTo(seeded))
+    }
+
+    @Test
+    fun `restore from a bundle without imageCache key keeps the cache empty`() {
+        val noteEditor = openNoteEditor()
+
+        noteEditor.multimediaController.onRestoreInstanceState(Bundle())
+        val out = Bundle().also { noteEditor.multimediaController.onSaveInstanceState(it) }
+
+        val restored = out.getSerializableCompat<HashMap<String, String>>(STATE_KEY_IMAGE_CACHE)
+        assertThat(restored?.isEmpty(), equalTo(true))
+    }
+
+    private fun openNoteEditor(): NoteEditorFragment {
+        ensureCollectionLoadIsSynchronous()
+        return openNoteEditorWithArgs(NoteEditorLauncher.AddNote().toBundle())
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorTestUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/noteeditor/NoteEditorTestUtils.kt
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Ashish Yadav <mailtoashish693@gmail.com>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.noteeditor
+
+import android.os.Bundle
+import com.ichi2.anki.NoteEditorActivity
+import com.ichi2.anki.NoteEditorFragment
+import com.ichi2.anki.R
+import com.ichi2.anki.RobolectricTest
+import com.ichi2.anki.common.annotations.DuplicatedCode
+
+/**
+ * Hosts a [NoteEditorActivity] with the given launcher [arguments] and returns the
+ * embedded [NoteEditorFragment]. Shared between tests that need to drive note-editor
+ * flows without re-implementing the activity setup.
+ */
+fun RobolectricTest.openNoteEditorWithArgs(
+    arguments: Bundle,
+    action: String? = null,
+): NoteEditorFragment {
+    val activity =
+        startActivityNormallyOpenCollectionWithIntent(
+            NoteEditorActivity::class.java,
+            NoteEditorLauncher.PassArguments(arguments).toIntent(targetContext, action),
+        )
+    return activity.getNoteEditorFragment()
+}
+
+@DuplicatedCode("NoteEditor in androidTest")
+fun NoteEditorActivity.getNoteEditorFragment(): NoteEditorFragment =
+    supportFragmentManager.findFragmentById(R.id.note_editor_fragment_frame) as NoteEditorFragment


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
This is the best way we can keep things decoupled and testable and since NoteEditor will be migrated in future I want to clean things as much as possible hence I am extracting things to a multimedia controller

## Fixes
NA

## Approach
See commit imo I have kept things detailed there

## How Has This Been Tested?
Locally  and unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->