### PR TITLE
fix(whiteboard): don't intercept touches when hidden

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardToolbar.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardToolbar.kt
@@ -182,11 +182,17 @@ class WhiteboardToolbar : LinearLayout {
      */
     fun show() = dragHandler.show()
 
-    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean = dragHandler.onInterceptTouchEvent(ev) || super.onInterceptTouchEvent(ev)
+    override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+        val intercepted = dragHandler.onInterceptTouchEvent(ev)
+        return dragHandler.isHidden || intercepted || super.onInterceptTouchEvent(ev)
+    }
 
     override fun onTouchEvent(event: MotionEvent): Boolean = dragHandler.onTouchEvent(event) || super.onTouchEvent(event)
 
     private inner class DragHandler {
+        var isHidden = false
+            private set
+
         private var dragStartX = 0f
         private var dragStartY = 0f
         private var initialTranslationX = 0f
@@ -281,6 +287,7 @@ class WhiteboardToolbar : LinearLayout {
         }
 
         fun show() {
+            isHidden = false
             val animator = animate().setDuration(200.milliseconds).setInterpolator(DecelerateInterpolator())
 
             when (currentAlignment) {
@@ -293,6 +300,7 @@ class WhiteboardToolbar : LinearLayout {
         }
 
         fun hide() {
+            isHidden = true
             val animator = animate().setDuration(200.milliseconds).setInterpolator(DecelerateInterpolator())
             val maxTrans = maxTranslation
 


### PR DESCRIPTION
## Fixes
* Fixes #20920

## Approach

Intercept all the events when the toolbar is hidden

## How Has This Been Tested?

Emulator 37

[Screen_recording_20260501_204600.webm](https://github.com/user-attachments/assets/331f0924-aed5-405d-8930-de896e024654)


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->