### PR TITLE
fix(whiteboard): double back to exit

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/ReviewerFragment.kt
@@ -49,16 +49,13 @@ import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import anki.scheduler.CardAnswer.Rating
-import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.CollectionManager
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.Flag
 import com.ichi2.anki.R
-import com.ichi2.anki.android.back.doubleBackPressCallback
 import com.ichi2.anki.cardviewer.Gesture
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.utils.android.isRobolectric
-import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.anki.databinding.FragmentReviewerBinding
 import com.ichi2.anki.dialogs.showDeckOptionsSelectionDialog
 import com.ichi2.anki.dialogs.tags.TagsDialog
@@ -170,7 +167,7 @@ class ReviewerFragment :
         super.onViewCreated(view, savedInstanceState)
 
         binding.backButton.setOnClickListener {
-            requireActivity().onBackPressedDispatcher.onBackPressed()
+            requireActivity().finish()
         }
 
         setupBindings()
@@ -545,27 +542,20 @@ class ReviewerFragment :
             },
             false,
         )
-        val isUsingGesturesNavigation = compat.isUsingSystemGestureNavigation(requireContext())
-        val doubleBackCallback =
-            doubleBackPressCallback(
-                enabled = false,
-                onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
-                shouldReEnable = {
-                    viewModel.whiteboardEnabledFlow.value && isUsingGesturesNavigation
-                },
-            )
-        requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, doubleBackCallback)
+
         viewModel.whiteboardEnabledFlow.flowWithLifecycle(lifecycle).collectIn(lifecycleScope) { isEnabled ->
-            binding.whiteboardContainer.isVisible = isEnabled
-            doubleBackCallback.isEnabled =
-                isEnabled && compat.isUsingSystemGestureNavigation(requireContext())
-            if (whiteboardFragment == null && isEnabled) {
-                val whiteboardFragment = WhiteboardFragment()
-                whiteboardFragment.gestureFallbackListener = { gesture ->
-                    bindingMap.onGesture(gesture)
-                }
-                childFragmentManager.commit {
-                    add(R.id.whiteboard_container, whiteboardFragment, WhiteboardFragment::class.jvmName)
+            val existingFragment = whiteboardFragment
+            childFragmentManager.commit {
+                if (isEnabled) {
+                    if (existingFragment != null) {
+                        show(existingFragment)
+                    } else {
+                        val newFragment = WhiteboardFragment()
+                        newFragment.gestureFallbackListener = { gesture -> bindingMap.onGesture(gesture) }
+                        add(R.id.web_view_container, newFragment, WhiteboardFragment::class.jvmName)
+                    }
+                } else {
+                    existingFragment?.let { hide(it) }
                 }
             }
         }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -28,6 +28,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.PopupWindow
+import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.view.menu.MenuBuilder
 import androidx.appcompat.widget.PopupMenu
@@ -35,10 +36,13 @@ import androidx.core.view.updateLayoutParams
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
+import com.google.android.material.snackbar.Snackbar
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.DispatchKeyEventListener
 import com.ichi2.anki.R
+import com.ichi2.anki.android.back.doubleBackPressCallback
 import com.ichi2.anki.cardviewer.Gesture
+import com.ichi2.anki.compat.CompatHelper.Companion.compat
 import com.ichi2.anki.databinding.FragmentWhiteboardBinding
 import com.ichi2.anki.databinding.PopupBrushOptionsBinding
 import com.ichi2.anki.databinding.PopupEraserOptionsBinding
@@ -71,6 +75,7 @@ class WhiteboardFragment :
 
     val binding by viewBinding(FragmentWhiteboardBinding::bind)
     private lateinit var bindingMap: BindingMap<ReviewerBinding, WhiteboardAction>
+    private var doubleBackCallback: OnBackPressedCallback? = null
 
     private var eraserPopup: PopupWindow? = null
     private var brushConfigPopup: PopupWindow? = null
@@ -89,11 +94,32 @@ class WhiteboardFragment :
 
         setupUI()
         observeViewModel(binding.whiteboardView)
+        setupDoubleBackPress()
 
         binding.whiteboardView.onNewPath = viewModel::addPath
         binding.whiteboardView.onEraseGestureStart = viewModel::startPathEraseGesture
         binding.whiteboardView.onEraseGestureMove = viewModel::erasePathsToPoint
         binding.whiteboardView.onEraseGestureEnd = viewModel::endPathEraseGesture
+    }
+
+    private fun setupDoubleBackPress() {
+        val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
+        doubleBackCallback =
+            doubleBackPressCallback(
+                enabled = !isHidden && isUsingGesturesNavigation,
+                onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
+                shouldReEnable = {
+                    !isHidden && isUsingGesturesNavigation
+                },
+            ).also {
+                requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it)
+            }
+    }
+
+    override fun onHiddenChanged(hidden: Boolean) {
+        super.onHiddenChanged(hidden)
+        val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
+        doubleBackCallback?.isEnabled = !hidden && isUsingGesturesNavigation
     }
 
     private fun setupUI() {

--- a/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
+++ b/AnkiDroid/src/main/res/layout/fragment_reviewer.xml
@@ -96,11 +96,6 @@
                 android:layout_height="match_parent"
                 tools:backgroundTint="@color/white" />
 
-            <androidx.fragment.app.FragmentContainerView
-                android:id="@+id/whiteboard_container"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"/>
-
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
1. Navigation back button shouldn't trigger the double back press
2. It should also apply to the 'Drawing' screen

fixes done by moving the double back press logic to `WhiteboardFragment` and checking the fragment visibility

## Fixes
* Fixes #20922


## How Has This Been Tested?

Emulator 37

[Screen_recording_20260501_213816.webm](https://github.com/user-attachments/assets/e6db2071-4dc4-4b23-be5a-613482e3ef76)

[Screen_recording_20260502_062312.webm](https://github.com/user-attachments/assets/369b54fa-90f8-4bac-8c1b-ead8ac57c26a)

[Screen_recording_20260501_213908.webm](https://github.com/user-attachments/assets/d68c455c-3e98-4a22-b708-a5dab5914718)


## Learning (optional, can help others)

Fragments have a onHiddenChanged method


## Checklist
_Please, go through these checks before submitting the PR._

- [X] You have a descriptive commit message with a short title (first line, max 50 chars).
- [X] You have commented your code, particularly in hard-to-understand areas
- [X] You have performed a self-review of your own code
- [X] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->