### PR TITLE
refactor: extract `isSdCardMounted` from AnkiDroidApp to `:common:android`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -40,7 +40,7 @@ import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService.sendExceptionReport
-import com.ichi2.anki.common.utils.android.isSdCardMounted
+import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
@@ -303,7 +303,7 @@ open class AnkiDroidApp :
             Timber.e(e, "Could not initialize AnkiDroid directory")
             try {
                 val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
-                if (isSdCardMounted() && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
+                if (SdCard.isMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
                     // Don't send report if the user is using a custom directory as SD cards trip up here a lot
                     sendExceptionReport(e, "AnkiDroidApp.onCreate")
                 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -26,7 +26,6 @@ import android.content.res.Resources
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.os.Environment
 import android.system.Os
 import android.webkit.CookieManager
 import androidx.annotation.VisibleForTesting
@@ -41,6 +40,7 @@ import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
 import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService.sendExceptionReport
+import com.ichi2.anki.common.utils.android.isSdCardMounted
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper
 import com.ichi2.anki.contextmenu.AnkiCardContextMenu
@@ -303,7 +303,7 @@ open class AnkiDroidApp :
             Timber.e(e, "Could not initialize AnkiDroid directory")
             try {
                 val defaultDir = CollectionHelper.getDefaultAnkiDroidDirectory(this)
-                if (isSdCardMounted && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
+                if (isSdCardMounted() && CollectionHelper.getCurrentAnkiDroidDirectory(this) == defaultDir) {
                     // Don't send report if the user is using a custom directory as SD cards trip up here a lot
                     sendExceptionReport(e, "AnkiDroidApp.onCreate")
                 }
@@ -455,8 +455,6 @@ open class AnkiDroidApp :
 
         val appResources: Resources
             get() = instance.resources
-        val isSdCardMounted: Boolean
-            get() = Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()
 
         fun getMarketIntent(context: Context): Intent {
             val uri =

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -28,7 +28,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import com.ichi2.anki.common.crashreporting.CrashReportService
-import com.ichi2.anki.common.utils.android.isSdCardMounted
+import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.exception.StorageAccessException
@@ -87,7 +87,7 @@ object InitialActivity {
                 StartupFailure.DBError(e)
             }
 
-        if (!isSdCardMounted()) {
+        if (!SdCard.isMounted) {
             return StartupFailure.SDCardNotMounted
         } else if (!initializeAnkiDroidDirectory()) {
             return StartupFailure.DirectoryNotAccessible

--- a/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/InitialActivity.kt
@@ -28,6 +28,7 @@ import androidx.annotation.CheckResult
 import androidx.annotation.RequiresApi
 import androidx.core.content.edit
 import com.ichi2.anki.common.crashreporting.CrashReportService
+import com.ichi2.anki.common.utils.android.isSdCardMounted
 import com.ichi2.anki.compat.CompatHelper.Companion.sdkVersion
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.exception.StorageAccessException
@@ -86,7 +87,7 @@ object InitialActivity {
                 StartupFailure.DBError(e)
             }
 
-        if (!AnkiDroidApp.isSdCardMounted) {
+        if (!isSdCardMounted()) {
             return StartupFailure.SDCardNotMounted
         } else if (!initializeAnkiDroidDirectory()) {
             return StartupFailure.DirectoryNotAccessible

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -36,6 +36,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.common.utils.android.isSdCardMounted
 import com.ichi2.anki.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.anki.preferences.sharedPrefs
 import timber.log.Timber
@@ -111,7 +112,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
         private fun buildUpdate(context: Context): RemoteViews {
             Timber.d("updating small widget UI")
             val updateViews = RemoteViews(context.packageName, widgetSmallLayout)
-            val mounted = AnkiDroidApp.isSdCardMounted
+            val mounted = isSdCardMounted()
             if (!mounted) {
                 updateViews.setViewVisibility(R.id.widget_due, View.INVISIBLE)
                 updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/AnkiDroidWidgetSmall.kt
@@ -36,7 +36,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
-import com.ichi2.anki.common.utils.android.isSdCardMounted
+import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.compat.CompatHelper.Companion.registerReceiverCompat
 import com.ichi2.anki.preferences.sharedPrefs
 import timber.log.Timber
@@ -112,7 +112,7 @@ class AnkiDroidWidgetSmall : AnalyticsWidgetProvider() {
         private fun buildUpdate(context: Context): RemoteViews {
             Timber.d("updating small widget UI")
             val updateViews = RemoteViews(context.packageName, widgetSmallLayout)
-            val mounted = isSdCardMounted()
+            val mounted = SdCard.isMounted
             if (!mounted) {
                 updateViews.setViewVisibility(R.id.widget_due, View.INVISIBLE)
                 updateViews.setViewVisibility(R.id.widget_eta, View.INVISIBLE)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -19,6 +19,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.R
+import com.ichi2.anki.common.utils.android.isSdCardMounted
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.allDecksCounts
@@ -88,7 +89,7 @@ object WidgetStatus {
         }
 
     suspend fun updateSmallWidgetStatus(context: Context) {
-        if (!AnkiDroidApp.isSdCardMounted) {
+        if (!isSdCardMounted()) {
             Timber.w("updateStatus failed: no SD Card")
             return
         }

--- a/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/WidgetStatus.kt
@@ -19,7 +19,7 @@ import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.MetaDB
 import com.ichi2.anki.R
-import com.ichi2.anki.common.utils.android.isSdCardMounted
+import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.preferences.sharedPrefs
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.utils.ext.allDecksCounts
@@ -89,7 +89,7 @@ object WidgetStatus {
         }
 
     suspend fun updateSmallWidgetStatus(context: Context) {
-        if (!isSdCardMounted()) {
+        if (!SdCard.isMounted) {
             Timber.w("updateStatus failed: no SD Card")
             return
         }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -20,6 +20,7 @@ import android.content.Context
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.common.utils.android.isSdCardMounted
 import com.ichi2.anki.dialogs.utils.ankiListView
 import com.ichi2.anki.dialogs.utils.message
 import com.ichi2.anki.dialogs.utils.title
@@ -29,6 +30,7 @@ import com.ichi2.testutils.TestException
 import com.ichi2.testutils.withNoWritePermission
 import io.mockk.every
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.unmockkObject
 import org.hamcrest.CoreMatchers.containsString
@@ -81,10 +83,11 @@ class DeckPickerNoExternalFilesDirTest : RobolectricTest() {
             withNoWritePermission {
                 CollectionHelper.ankiDroidDirectoryOverride = tempFolder.newFolder()
 
-                mockkObject(CollectionHelper, CollectionManager, AnkiDroidApp)
+                mockkObject(CollectionHelper, CollectionManager)
+                mockkStatic(::isSdCardMounted)
                 every { CollectionHelper.isCurrentAnkiDroidDirAccessible(any()) } returns false
                 every { CollectionManager.getColUnsafe() } throws TestException("")
-                every { AnkiDroidApp.isSdCardMounted } returns true
+                every { isSdCardMounted() } returns true
 
                 setIntroductionSlidesShown(true)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DeckPickerNoExternalFilesDirTest.kt
@@ -20,7 +20,7 @@ import android.content.Context
 import androidx.appcompat.app.AlertDialog
 import androidx.core.content.edit
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import com.ichi2.anki.common.utils.android.isSdCardMounted
+import com.ichi2.anki.common.utils.android.SdCard
 import com.ichi2.anki.dialogs.utils.ankiListView
 import com.ichi2.anki.dialogs.utils.message
 import com.ichi2.anki.dialogs.utils.title
@@ -30,7 +30,6 @@ import com.ichi2.testutils.TestException
 import com.ichi2.testutils.withNoWritePermission
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.mockkStatic
 import io.mockk.unmockkAll
 import io.mockk.unmockkObject
 import org.hamcrest.CoreMatchers.containsString
@@ -83,11 +82,10 @@ class DeckPickerNoExternalFilesDirTest : RobolectricTest() {
             withNoWritePermission {
                 CollectionHelper.ankiDroidDirectoryOverride = tempFolder.newFolder()
 
-                mockkObject(CollectionHelper, CollectionManager)
-                mockkStatic(::isSdCardMounted)
+                mockkObject(CollectionHelper, CollectionManager, SdCard)
                 every { CollectionHelper.isCurrentAnkiDroidDirAccessible(any()) } returns false
                 every { CollectionManager.getColUnsafe() } throws TestException("")
-                every { isSdCardMounted() } returns true
+                every { SdCard.isMounted } returns true
 
                 setIntroductionSlidesShown(true)
 

--- a/common/android/src/main/java/com/ichi2/anki/common/utils/android/SdCard.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/utils/android/SdCard.kt
@@ -18,10 +18,19 @@ package com.ichi2.anki.common.utils.android
 import android.os.Environment
 
 /**
- * Whether the device's primary external storage (the "SD card") is currently mounted
- * and writable.
+ * Utilities for accessing an SD Card (if the user's device supports one).
  *
- * Returns false when storage is unmounted, removed, read-only, or in any other state
- * that prevents writes (see [Environment.getExternalStorageState]).
+ * The AnkiDroid collection folder can be stored on an external SD card. This was common
+ * in older versions of Android, and is still supported.
  */
-fun isSdCardMounted(): Boolean = Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()
+object SdCard {
+    /**
+     * Whether the device's primary external storage (the "SD card") is currently mounted
+     * and writable.
+     *
+     * Returns false when storage is unmounted, removed, read-only, or in any other state
+     * that prevents writes (see [Environment.getExternalStorageState]).
+     */
+    val isMounted: Boolean
+        get() = Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()
+}

--- a/common/android/src/main/java/com/ichi2/anki/common/utils/android/SdCard.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/utils/android/SdCard.kt
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.common.utils.android
+
+import android.os.Environment
+
+/**
+ * Whether the device's primary external storage (the "SD card") is currently mounted
+ * and writable.
+ *
+ * Returns false when storage is unmounted, removed, read-only, or in any other state
+ * that prevents writes (see [Environment.getExternalStorageState]).
+ */
+fun isSdCardMounted(): Boolean = Environment.MEDIA_MOUNTED == Environment.getExternalStorageState()


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Moving a step closer to extracting widget and finally feature to module, the PR extract `isSdCardMounted ` to `:common:android`

## Fixes
* Fixes part of #20737

## Approach
See commit

## How Has This Been Tested?
Local build

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->