### PR TITLE
refactor: extract `applicationScope` from AnkiDroidApp to `:common:android`

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/AnkiDroidApp.kt
@@ -39,6 +39,7 @@ import com.ichi2.anki.analytics.UsageAnalytics
 import com.ichi2.anki.browser.SharedPreferencesLastDeckIdRepository
 import com.ichi2.anki.common.annotations.LegacyNotifications
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService.sendExceptionReport
 import com.ichi2.anki.common.utils.annotation.KotlinCleanup
 import com.ichi2.anki.compat.CompatHelper
@@ -69,9 +70,6 @@ import com.ichi2.widget.DayRolloverAlarm
 import com.ichi2.widget.cardanalysis.CardAnalysisWidget
 import com.ichi2.widget.deckpicker.DeckPickerWidget
 import com.ichi2.widget.restoreRecurringAlarms
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import timber.log.Timber.DebugTree
@@ -377,24 +375,6 @@ open class AnkiDroidApp :
     }
 
     companion object {
-        /**
-         * [CoroutineScope] tied to the [Application], allowing executing of tasks which should
-         * execute as long as the app is running
-         *
-         * This scope is bound by default to [Dispatchers.Main.immediate][kotlinx.coroutines.MainCoroutineDispatcher.immediate].
-         * Use an alternate dispatcher if the main thread is not required: [Dispatchers.Default] or [Dispatchers.IO]
-         *
-         * This scope will not be cancelled; exceptions are handled by [SupervisorJob]
-         *
-         * See: [Operations that shouldn't be cancelled in Coroutines](https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad#d425)
-         *
-         * This replicates the manner which `lifecycleScope`/`viewModelScope` is exposed in Android
-         */
-        // lazy init required due to kotlinx-coroutines-test 1.10.0:
-        // Main was accessed when the platform dispatcher was absent and the test dispatcher
-        // was unset
-        val applicationScope by lazy { CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate) }
-
         /**
          * A [SharedPreferencesProvider] which does not require [onCreate] when run from tests
          *

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CoroutineHelpers.kt
@@ -42,6 +42,7 @@ import com.ichi2.anki.CrashReportData.HelpAction.AnkiBackendLink
 import com.ichi2.anki.CrashReportData.HelpAction.OpenDeckOptions
 import com.ichi2.anki.android.AnkiBroadcastReceiver
 import com.ichi2.anki.common.annotations.UseContextParameter
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.dialogs.DatabaseErrorDialog
 import com.ichi2.anki.dialogs.DatabaseErrorDialog.DatabaseErrorDialogType
@@ -648,7 +649,7 @@ fun AnkiBroadcastReceiver.runGloballyWithTimeout(
         return
     }
 
-    AnkiDroidApp.applicationScope.launch {
+    applicationScope.launch {
         try {
             withTimeout(minOf(timeout, 8.seconds)) {
                 block()

--- a/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DayRolloverHandler.kt
@@ -35,6 +35,7 @@ import anki.collection.OpChanges
 import anki.collection.opChanges
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.exception.ManuallyReportedException
 import com.ichi2.anki.libanki.EpochSeconds
@@ -82,7 +83,7 @@ object DayRolloverHandler : AnkiBroadcastReceiver() {
         // the outcome would be two calls to notifySubscribers, which is acceptable
         Timber.v("received ${intent.action}")
         // launch coroutine as we need access to `col.sched`
-        AnkiDroidApp.applicationScope.launchCatching(Dispatchers.IO, errorMessageHandler = { msg ->
+        applicationScope.launchCatching(Dispatchers.IO, errorMessageHandler = { msg ->
             CrashReportService.sendExceptionReport(
                 e = ManuallyReportedException(msg),
                 origin = "DayRolloverHandler::onReceive",

--- a/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/IntentHandler.kt
@@ -28,6 +28,7 @@ import androidx.core.content.FileProvider
 import androidx.core.content.IntentCompat
 import androidx.work.WorkManager
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.utils.trimToLength
 import com.ichi2.anki.dialogs.DialogHandler.Companion.storeMessage
 import com.ichi2.anki.dialogs.DialogHandlerMessage
@@ -235,7 +236,7 @@ class IntentHandler : AbstractIntentHandler() {
         // TODO improve the handling of the imported temporary files
         // Launching this scope without tying it to a lifecycle since ,
         // IntentHandler finishes quickly, but deletion may still be in progress
-        AnkiDroidApp.applicationScope.launch(Dispatchers.IO) {
+        applicationScope.launch(Dispatchers.IO) {
             try {
                 val file = File(path!!)
                 val fileUri =
@@ -295,7 +296,7 @@ class IntentHandler : AbstractIntentHandler() {
         // TODO improve the handling of the imported temporary files
         // Launching this scope without tying it to a lifecycle since ,
         // IntentHandler finishes quickly, but deletion may still be in progress
-        AnkiDroidApp.applicationScope.launch(Dispatchers.IO) {
+        applicationScope.launch(Dispatchers.IO) {
             try {
                 contentResolver.delete(sharedDeckUri, null, null)
                 Timber.i("onCreate: downloaded shared deck deleted")

--- a/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/TtsVoices.kt
@@ -24,6 +24,7 @@ package com.ichi2.anki
 
 import android.speech.tts.TextToSpeech
 import android.speech.tts.Voice
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.i18n.normalize
 import com.ichi2.anki.i18n.toAnkiTwoLetterCode
 import com.ichi2.anki.libanki.TemplateManager
@@ -146,7 +147,7 @@ object TtsVoices {
         // This is intended to be a global singleton outside the lifecycle of a specific activity
         // Most of the time of execution is waiting for the TTS Engine to initialize
         buildLocalesJob =
-            AnkiDroidApp.applicationScope.launch(Dispatchers.IO) {
+            applicationScope.launch(Dispatchers.IO) {
                 Timber.d("executing job")
                 loadTtsVoicesData()
                 buildLocalesJob = null

--- a/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/utils/ImportUtils.kt
@@ -31,6 +31,7 @@ import com.ichi2.anki.AnkiActivity
 import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.R
 import com.ichi2.anki.common.annotations.NeedsTest
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.compat.CompatHelper
@@ -326,7 +327,7 @@ object ImportUtils {
         ) {
             // Use applicationScope: IntentHandler calls this and does not have a lifecycleScope
             fun copyDebugInfo(debugInfo: String) =
-                AnkiDroidApp.applicationScope.launch {
+                applicationScope.launch {
                     Timber.i("copying debug info to clipboard")
                     val stringToCopy =
                         buildString {

--- a/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/DayRolloverAlarm.kt
@@ -26,9 +26,9 @@ import androidx.annotation.VisibleForTesting
 import androidx.core.app.PendingIntentCompat
 import androidx.core.content.getSystemService
 import anki.collection.opChanges
-import com.ichi2.anki.AnkiDroidApp.Companion.applicationScope
 import com.ichi2.anki.CollectionManager.withOpenColOrNull
 import com.ichi2.anki.android.AnkiBroadcastReceiver
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.exception.ManuallyReportedException

--- a/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/cardanalysis/CardAnalysisWidget.kt
@@ -24,10 +24,10 @@ import android.content.Context
 import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -89,7 +89,7 @@ class CardAnalysisWidget : AnalyticsWidgetProvider() {
                 return
             }
 
-            AnkiDroidApp.applicationScope.launch {
+            applicationScope.launch {
                 val isCollectionEmpty = isCollectionEmpty()
                 if (isCollectionEmpty) {
                     showCollectionDeck(context, appWidgetManager, appWidgetId, remoteViews)

--- a/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/widget/deckpicker/DeckPickerWidget.kt
@@ -24,11 +24,11 @@ import android.content.Context
 import android.content.Intent
 import android.view.View
 import android.widget.RemoteViews
-import com.ichi2.anki.AnkiDroidApp
 import com.ichi2.anki.CollectionManager.withCol
 import com.ichi2.anki.IntentHandler.Companion.intentToReviewDeckFromShortcuts
 import com.ichi2.anki.R
 import com.ichi2.anki.analytics.UsageAnalytics
+import com.ichi2.anki.common.coroutines.applicationScope
 import com.ichi2.anki.common.crashreporting.CrashReportService
 import com.ichi2.anki.isCollectionEmpty
 import com.ichi2.anki.libanki.DeckId
@@ -104,7 +104,7 @@ class DeckPickerWidget : AnalyticsWidgetProvider() {
                 showEmptyWidget(context, appWidgetManager, appWidgetId, remoteViews)
                 return
             }
-            AnkiDroidApp.applicationScope.launch {
+            applicationScope.launch {
                 val isCollectionEmpty = isCollectionEmpty()
                 if (isCollectionEmpty) {
                     showEmptyCollection(context, appWidgetManager, appWidgetId, remoteViews)

--- a/common/android/build.gradle.kts
+++ b/common/android/build.gradle.kts
@@ -60,6 +60,7 @@ dependencies {
 
     implementation(libs.androidx.annotation)
     implementation(libs.jakewharton.timber)
+    implementation(libs.kotlinx.coroutines.core)
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.junit.jupiter)

--- a/common/android/src/main/java/com/ichi2/anki/common/coroutines/ApplicationScope.kt
+++ b/common/android/src/main/java/com/ichi2/anki/common/coroutines/ApplicationScope.kt
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify it under
+ *  the terms of the GNU General Public License as published by the Free Software
+ *  Foundation; either version 3 of the License, or (at your option) any later
+ *  version.
+ *
+ *  This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ *  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ *  PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along with
+ *  this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki.common.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+
+/**
+ * [CoroutineScope] tied to the [android.app.Application], allowing executing of tasks
+ * which should execute as long as the app is running.
+ *
+ * This scope is bound by default to [Dispatchers.Main.immediate][kotlinx.coroutines.MainCoroutineDispatcher.immediate].
+ * Use an alternate dispatcher if the main thread is not required: [Dispatchers.Default] or [Dispatchers.IO]
+ *
+ * This scope will not be cancelled; exceptions are handled by [SupervisorJob]
+ *
+ * See: [Operations that shouldn't be cancelled in Coroutines](https://medium.com/androiddevelopers/coroutines-patterns-for-work-that-shouldnt-be-cancelled-e26c40f142ad#d425)
+ *
+ * This replicates the manner which `lifecycleScope`/`viewModelScope` is exposed in Android.
+ */
+// lazy init required due to kotlinx-coroutines-test 1.10.0:
+// Main was accessed when the platform dispatcher was absent and the test dispatcher
+// was unset
+val applicationScope: CoroutineScope by lazy {
+    CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Again one step forward to clean and organised code, extracting `applicationScope` from AnkiDroidApp 

## Fixes
* Fixes part of #20737

## Approach
See commit

## How Has This Been Tested?
Local build and tests pass

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->