### PR TITLE
fix: back press trigger the discard dialog

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/DrawingFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/DrawingFragment.kt
@@ -23,8 +23,10 @@ import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.core.graphics.createBitmap
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.ichi2.anki.common.time.TimeManager
 import com.ichi2.anki.common.time.getTimestamp
 import com.ichi2.anki.compat.CompatHelper
@@ -34,6 +36,8 @@ import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardFragment
 import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardView
 import com.ichi2.themes.Themes
 import dev.androidbroadcast.vbpd.viewBinding
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 
 class DrawingFragment : Fragment(R.layout.fragment_drawing) {
     private val binding by viewBinding(FragmentDrawingBinding::bind)
@@ -47,15 +51,7 @@ class DrawingFragment : Fragment(R.layout.fragment_drawing) {
         super.onViewCreated(view, savedInstanceState)
         binding.toolbar.apply {
             setNavigationOnClickListener {
-                // avoid showing the discard changes dialog only if the user hasn't drawn anything,
-                // even if is is erased or undone, since they may want to undo/redo something.
-                if (whiteboardFragment?.isEmpty() == true) {
-                    requireActivity().onBackPressedDispatcher.onBackPressed()
-                } else {
-                    DiscardChangesDialog.showDialog(requireContext()) {
-                        requireActivity().onBackPressedDispatcher.onBackPressed()
-                    }
-                }
+                requireActivity().onBackPressedDispatcher.onBackPressed()
             }
             setOnMenuItemClickListener { item ->
                 when (item.itemId) {
@@ -64,6 +60,45 @@ class DrawingFragment : Fragment(R.layout.fragment_drawing) {
                 }
                 true
             }
+        }
+        setupBackPressHandling()
+    }
+
+    /**
+     * Wires the discard-dialog back-press flow and tells the child WhiteboardFragment
+     * to suppress its "go back again to exit" snackbar.
+     *
+     * Deferred via `view.post` so it runs after the child's `onViewCreated`, ensuring
+     * our [OnBackPressedCallback] is added to the dispatcher *after* the child's and
+     * wins LIFO. The relative order of parent vs child `onViewCreated` differs
+     * across platforms (Robolectric runs the child first; real devices have shown
+     * the opposite), so the post normalizes it.
+     */
+    private fun setupBackPressHandling() {
+        requireView().post {
+            if (!isAdded) return@post
+            val whiteboard = whiteboardFragment ?: return@post
+
+            whiteboard.setDrawingMode(true)
+
+            // Standard isEnabled pattern: only intercept the back press when there's
+            // content to discard. When empty, the callback stays disabled so the
+            // press falls through to the activity finishing and predictive back
+            // shows its system exit animation.
+            val backCallback =
+                object : OnBackPressedCallback(enabled = false) {
+                    override fun handleOnBackPressed() {
+                        DiscardChangesDialog.showDialog(requireContext()) {
+                            isEnabled = false
+                            requireActivity().onBackPressedDispatcher.onBackPressed()
+                        }
+                    }
+                }
+            requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, backCallback)
+
+            whiteboard.isEmptyFlow
+                .onEach { isEmpty -> backCallback.isEnabled = !isEmpty }
+                .launchIn(viewLifecycleOwner.lifecycleScope)
         }
     }
 

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -56,6 +56,7 @@ import com.ichi2.utils.dp
 import com.ichi2.utils.increaseHorizontalPaddingOfMenuIcons
 import com.ichi2.utils.toRGBAHex
 import dev.androidbroadcast.vbpd.viewBinding
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -103,23 +104,38 @@ class WhiteboardFragment :
     }
 
     private fun setupDoubleBackPress() {
-        val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
         doubleBackCallback =
             doubleBackPressCallback(
-                enabled = !isHidden && isUsingGesturesNavigation,
+                enabled = computeDoubleBackEnabled(),
                 onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
-                shouldReEnable = {
-                    !isHidden && isUsingGesturesNavigation
-                },
+                shouldReEnable = { computeDoubleBackEnabled() },
             ).also {
                 requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it)
             }
+        // Keep the callback in sync as the inputs change (host toggling drawing mode,
+        // hidden state changes from the reviewer's show/hide transactions).
+        viewModel.isDrawing
+            .onEach { doubleBackCallback?.isEnabled = computeDoubleBackEnabled() }
+            .launchIn(viewLifecycleOwner.lifecycleScope)
+    }
+
+    private fun computeDoubleBackEnabled(): Boolean {
+        val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
+        return !viewModel.isDrawing.value && !isHidden && isUsingGesturesNavigation
     }
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
-        val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
-        doubleBackCallback?.isEnabled = !hidden && isUsingGesturesNavigation
+        doubleBackCallback?.isEnabled = computeDoubleBackEnabled()
+    }
+
+    /**
+     * Switches the whiteboard into "drawing" mode, where the host owns back
+     * navigation (e.g. a discard-changes dialog) and the reviewer's "go back again
+     * to exit" snackbar is suppressed.
+     */
+    fun setDrawingMode(drawing: Boolean) {
+        viewModel.isDrawing.value = drawing
     }
 
     private fun setupUI() {
@@ -476,4 +492,15 @@ class WhiteboardFragment :
      * @return whether the whiteboard is completely empty, including the undo and redo stacks.
      */
     fun isEmpty(): Boolean = !viewModel.canUndo.value && !viewModel.canRedo.value
+
+    /**
+     * Emits `true` when the whiteboard is empty (cannot undo or redo) and `false` otherwise.
+     * Useful for hosts that need to react to content changes, e.g. to toggle a back-press
+     * callback's `isEnabled`.
+     */
+    val isEmptyFlow: Flow<Boolean>
+        get() =
+            combine(viewModel.canUndo, viewModel.canRedo) { canUndo, canRedo ->
+                !canUndo && !canRedo
+            }
 }

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModel.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardViewModel.kt
@@ -105,6 +105,13 @@ class WhiteboardViewModel(
     val toolbarAlignment = MutableStateFlow(ToolbarAlignment.BOTTOM)
     val isToolbarShown = MutableStateFlow(true)
 
+    /**
+     * Whether the whiteboard is hosted in a "drawing" flow (e.g. multimedia drawing
+     * capture) rather than the reviewer. In drawing mode the host owns the back
+     * navigation, so the "go back again to exit" snackbar is suppressed.
+     */
+    val isDrawing = MutableStateFlow(false)
+
     val eraserDisplayWidth =
         combine(eraserMode, inkEraserStrokeWidth, strokeEraserStrokeWidth) { mode, inkWidth, strokeWidth ->
             if (mode == EraserMode.INK) inkWidth else strokeWidth

--- a/AnkiDroid/src/test/java/com/ichi2/anki/DrawingFragmentTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/DrawingFragmentTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Ashish Yadav <mailtoashish693@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation; either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package com.ichi2.anki
+
+import android.graphics.Path
+import androidx.appcompat.app.AlertDialog
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.ui.windows.reviewer.whiteboard.WhiteboardFragment
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.shadows.ShadowDialog
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/** Tests for [DrawingFragment] */
+@RunWith(AndroidJUnit4::class)
+class DrawingFragmentTest : RobolectricTest() {
+    @Test
+    fun `back press finishes the activity when the whiteboard is empty`() {
+        val (activity, _) = launchDrawingActivity()
+
+        activity.onBackPressedDispatcher.onBackPressed()
+        advanceRobolectricLooper()
+
+        assertNull(ShadowDialog.getLatestDialog(), "no discard dialog should be shown for an empty whiteboard")
+        assertThat("activity finishes immediately", activity.isFinishing, equalTo(true))
+    }
+
+    @Test
+    fun `back press shows the discard dialog when the whiteboard has content`() {
+        val (activity, whiteboard) = launchDrawingActivity()
+        whiteboard.binding.whiteboardView.onNewPath
+            ?.invoke(samplePath())
+        advanceRobolectricLooper()
+
+        activity.onBackPressedDispatcher.onBackPressed()
+        advanceRobolectricLooper()
+
+        val dialog =
+            assertNotNull(
+                ShadowDialog.getLatestDialog() as? AlertDialog,
+                "discard dialog should be shown",
+            )
+        assertThat("activity is not finishing while dialog is open", activity.isFinishing, equalTo(false))
+
+        dialog.getButton(AlertDialog.BUTTON_POSITIVE).performClick()
+        advanceRobolectricLooper()
+        assertThat("activity finishes after discard is confirmed", activity.isFinishing, equalTo(true))
+    }
+
+    private fun launchDrawingActivity(): Pair<SingleFragmentActivity, WhiteboardFragment> {
+        val activity = startRegularActivity<SingleFragmentActivity>(DrawingFragment.getIntent(targetContext))
+        val drawingFragment =
+            activity.supportFragmentManager.findFragmentByTag(SingleFragmentActivity.FRAGMENT_TAG) as DrawingFragment
+        val whiteboardFragment =
+            drawingFragment.childFragmentManager.findFragmentById(R.id.fragment_container) as WhiteboardFragment
+        return activity to whiteboardFragment
+    }
+
+    private fun samplePath(): Path =
+        Path().apply {
+            moveTo(0f, 0f)
+            lineTo(10f, 10f)
+        }
+}


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
Show discard dialog in drawing fragment instead of snackbar since users has done changes and it doesnt make sense to show snackbar and press back again exits

## Fixes
* Fixes #20931

## Approach
NA

## How Has This Been Tested?
Pixel 10 and added unit test

## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->