### PR TITLE
fix: allow back nav if whiteboard is empty

### DIFF
--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/windows/reviewer/whiteboard/WhiteboardFragment.kt
@@ -106,20 +106,24 @@ class WhiteboardFragment :
         val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
         doubleBackCallback =
             doubleBackPressCallback(
-                enabled = !isHidden && isUsingGesturesNavigation,
+                enabled = !isHidden && isUsingGesturesNavigation && !isEmpty(),
                 onFirstBack = { showSnackbar(R.string.back_pressed_once, Snackbar.LENGTH_SHORT) },
                 shouldReEnable = {
-                    !isHidden && isUsingGesturesNavigation
+                    !isHidden && isUsingGesturesNavigation && !isEmpty()
                 },
             ).also {
                 requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner, it)
             }
+        combine(viewModel.canUndo, viewModel.canRedo) { canUndo, canRedo -> canUndo || canRedo }
+            .onEach { hasContent ->
+                doubleBackCallback?.isEnabled = !isHidden && isUsingGesturesNavigation && hasContent
+            }.launchIn(lifecycleScope)
     }
 
     override fun onHiddenChanged(hidden: Boolean) {
         super.onHiddenChanged(hidden)
         val isUsingGesturesNavigation = context?.let { compat.isUsingSystemGestureNavigation(it) } == true
-        doubleBackCallback?.isEnabled = !hidden && isUsingGesturesNavigation
+        doubleBackCallback?.isEnabled = !hidden && isUsingGesturesNavigation && !isEmpty()
     }
 
     private fun setupUI() {


### PR DESCRIPTION
<!--- Please fill the necessary details below -->
## Purpose / Description
If the whiteboard doesnt have any content then allow back navigation without snackbar

## Fixes
NA

## Approach
NA

## How Has This Been Tested?
Pixel 10:

https://github.com/user-attachments/assets/3ea34b89-7ac0-4f9d-a3e6-27b72284b14e



## Learning (optional, can help others)
NA

## Checklist
_Please, go through these checks before submitting the PR._

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)

<!--- Uncomment this section ONLY if this PR introduces new resources (external libraries, icons etc)
## Licenses
_For each new external resource, add a row to the table below:_

| Library | Description | License |
| --- | --- | --- |
| Sample Icon Library | Sample Description | [The Apache Software License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0.txt) |

**Maintainers:**

* [ ] Add the https://github.com/ankidroid/Anki-Android/labels/Licenses label
* [ ] Update the [licenses](https://github.com/ankidroid/Anki-Android/wiki/Licences) wiki when merging
--->