### PR TITLE
chore: support Claude Code worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ hs_err_pid*
 # Ignore kotlin 2.0 compiler files (.salive: session-is-alive)
 # https://github.com/JetBrains/kotlin/blob/ca34e5d2fd255ed0501bae4fae3d3691dc40d375/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/compilerRunner/GradleKotlinCompilerRunner.kt#L458
 .kotlin/
+
+# Claude Code related
+/.claude/worktrees/

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,3 @@
+# Includes the following files in Claude Code worktrees (gitignore syntax)
+# https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees
+local.properties


### PR DESCRIPTION
gitignore the directory

> Add .claude/worktrees/ to your .gitignore so worktree contents don’t
appear as untracked files in your main checkout.

https://code.claude.com/docs/en/worktrees

copy `local.properties` into Claude Code worktrees

https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees

## How Has This Been Tested?

`claude --worktree`
... `open .`

* `local.properties`  doesn't exist if run on `main`
* `local.properties` exists after this branch


## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)