### PR TITLE
feat(card-browser): edge to edge support & code cleanup

### DIFF
--- a/.idea/dictionaries/android.xml
+++ b/.idea/dictionaries/android.xml
@@ -9,6 +9,7 @@
       <w>ENOENT</w>
       <w>FILESIZE</w>
       <w>ONEPLUS</w>
+      <w>Roborazzi</w>
       <w>allempty</w>
       <w>apkgfileprovider</w>
       <w>asynctasks</w>

--- a/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/CardBrowser.kt
@@ -18,6 +18,7 @@
 
 package com.ichi2.anki
 
+import android.graphics.Color
 import android.os.Bundle
 import android.view.KeyEvent
 import android.view.Menu
@@ -28,11 +29,16 @@ import android.view.WindowManager
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.LayoutRes
 import androidx.annotation.MainThread
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.commit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
@@ -190,6 +196,8 @@ open class CardBrowser :
         if (showedActivityFailedScreen(savedInstanceState)) {
             return
         }
+        // match the status bar theme of the rest of the app
+        enableEdgeToEdge(statusBarStyle = SystemBarStyle.dark(Color.TRANSPARENT))
         super.onCreate(savedInstanceState)
         binding = ActivityCardBrowserBinding.inflate(layoutInflater)
         if (!ensureStorageIsReady()) {
@@ -204,6 +212,7 @@ open class CardBrowser :
 
         setViewBinding(binding)
         initNavigationDrawer(findViewById(android.R.id.content))
+        applyToolbarInsets()
 
         /**
          * Check if noteEditorFrame is not null and if its visibility is set to VISIBLE.
@@ -367,6 +376,22 @@ open class CardBrowser :
     override fun setupBackPressedCallbacks() {
         onBackPressedDispatcher.addCallback(this, multiSelectOnBackPressedCallback)
         super.setupBackPressedCallbacks()
+    }
+
+    override fun fitsSystemWindows(): Boolean = false
+
+    private fun applyToolbarInsets() {
+        val container = findViewById<View>(R.id.toolbar_container) ?: return
+        ViewCompat.setOnApplyWindowInsetsListener(container) { view, insets ->
+            // systemBars (not just statusBars) so a landscape 3-button navigation bar,
+            // which is a side inset, is also cleared
+            val bars =
+                insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+                )
+            view.updatePadding(left = bars.left, top = bars.top, right = bars.right)
+            insets
+        }
     }
 
     private fun showSaveChangesDialog(launcher: NoteEditorLauncher) {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -134,6 +134,7 @@ import com.ichi2.anki.ui.RecyclerFastScroller
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.undoAndShowSnackbar
+import com.ichi2.anki.utils.bottomCornerClearance
 import com.ichi2.anki.utils.ext.addPrepareMenuProvider
 import com.ichi2.anki.utils.ext.getParcelableCompat
 import com.ichi2.anki.utils.ext.hasCheckedBackground
@@ -436,9 +437,9 @@ class CardBrowserFragment :
                     WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
                 )
             v.updatePadding(left = bars.left, right = bars.right)
-            // The bottom of the safe area is above the navigation bar.
+            // The bottom of the safe area is above the navigation bar and rounded display corners.
             // When scrolled to the bottom of the scrollbar should be aligned with the last row.
-            val safeAreaBottom = bars.bottom
+            val safeAreaBottom = maxOf(bars.bottom, insets.bottomCornerClearance(v))
             // Due to clipToPadding=false, only the last row is affected
             cardsListView.updatePadding(bottom = safeAreaBottom)
             // The scrollbar track stays full-height (edge to edge); only the handle is kept above

--- a/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/browser/CardBrowserFragment.kt
@@ -37,6 +37,7 @@ import androidx.core.view.MenuProvider
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentTransaction
@@ -129,6 +130,7 @@ import com.ichi2.anki.scheduling.ForgetCardsDialog
 import com.ichi2.anki.scheduling.SetDueDateDialog
 import com.ichi2.anki.settings.Prefs
 import com.ichi2.anki.snackbar.showSnackbar
+import com.ichi2.anki.ui.RecyclerFastScroller
 import com.ichi2.anki.ui.attachFastScroller
 import com.ichi2.anki.ui.internationalization.sentenceCase
 import com.ichi2.anki.undoAndShowSnackbar
@@ -302,7 +304,9 @@ class CardBrowserFragment :
         cardsListView =
             view.findViewById<RecyclerView>(R.id.card_browser_list).apply {
                 attachFastScroller(R.id.browser_scroller)
+                clipToPadding = false
             }
+        applyContentInsets(view)
         DividerItemDecoration(requireContext(), DividerItemDecoration.VERTICAL).apply {
             setDrawable(ContextCompat.getDrawable(requireContext(), R.drawable.browser_divider)!!)
             cardsListView.addItemDecoration(this)
@@ -422,6 +426,26 @@ class CardBrowserFragment :
         setupFragmentResultListeners()
 
         setupMenu()
+    }
+
+    private fun applyContentInsets(root: View) {
+        val browserScroller = root.findViewById<RecyclerFastScroller>(R.id.browser_scroller)
+        ViewCompat.setOnApplyWindowInsetsListener(root) { v, insets ->
+            val bars =
+                insets.getInsets(
+                    WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout(),
+                )
+            v.updatePadding(left = bars.left, right = bars.right)
+            // The bottom of the safe area is above the navigation bar.
+            // When scrolled to the bottom of the scrollbar should be aligned with the last row.
+            val safeAreaBottom = bars.bottom
+            // Due to clipToPadding=false, only the last row is affected
+            cardsListView.updatePadding(bottom = safeAreaBottom)
+            // The scrollbar track stays full-height (edge to edge); only the handle is kept above
+            // the safe-area boundary so it remains touchable and aligns with the last row.
+            browserScroller.handleBottomInset = safeAreaBottom
+            insets
+        }
     }
 
     private fun setupMenu() {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -94,7 +94,7 @@ class RecyclerFastScroller
         /**
          * Inset, in pixels, reserved at the bottom of the handle's travel.
          *
-         * For the navigation bar with edge to edge support.
+         * For rounded display corners with edge to edge support.
          *
          * The handle is constrained to `height - handleBottomInset`, so it stays touchable and its
          * bottom aligns with the list's last item at full scroll.
@@ -428,7 +428,7 @@ class RecyclerFastScroller
             val verticalScrollExtent = recyclerView!!.computeVerticalScrollExtent()
 
             // The track (bar) spans the full height, but the handle travels only the area above
-            // handleBottomInset so it stays clear of the navigation bar.
+            // handleBottomInset so it stays clear of the navigation bar / rounded corner.
             val fullBarHeight = bar.height
             val trackHeight = (fullBarHeight - handleBottomInset).coerceAtLeast(0)
             val maxScrollOffset = (verticalScrollRange - verticalScrollExtent).coerceAtLeast(1)

--- a/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/ui/RecyclerFastScroller.kt
@@ -56,6 +56,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.IdRes
+import androidx.annotation.VisibleForTesting
 import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.GravityCompat
 import androidx.interpolator.view.animation.FastOutLinearInInterpolator
@@ -78,14 +79,35 @@ class RecyclerFastScroller
         attrs: AttributeSet? = null,
         defStyleAttr: Int = 0,
     ) : FrameLayout(context, attrs, defStyleAttr) {
-        private val bar: View
-        private val handle: View
+        @VisibleForTesting
+        internal val bar: View
+
+        @VisibleForTesting
+        internal val handle: View
         val hiddenTranslationX: Int
         private val hide: Runnable
         private val minScrollHandleHeight: Int = 48.dp.toPx(context)
         var onHandleTouchListener: OnTouchListener? = null
 
         private var appBarLayoutOffset: Int = 0
+
+        /**
+         * Inset, in pixels, reserved at the bottom of the handle's travel.
+         *
+         * For the navigation bar with edge to edge support.
+         *
+         * The handle is constrained to `height - handleBottomInset`, so it stays touchable and its
+         * bottom aligns with the list's last item at full scroll.
+         *
+         * The track is drawn edge-to-edge while scrolling and its bottom retracts to the same
+         * positions as the last row of the content when approaching the end.
+         */
+        var handleBottomInset: Int = 0
+            set(value) {
+                if (field == value) return
+                field = value
+                requestLayout()
+            }
 
         private var recyclerView: RecyclerView? = null
 
@@ -344,8 +366,9 @@ class RecyclerFastScroller
                     // Force the handle to be selected since the user is touching the track (the parent container) and not the handle itself.
                     handle.isPressed = true
 
-                    // The valid scroll area is (height-handle.height), since the position of the handle is defined by it's top edge, we subtract it.
-                    val scrollableHeight = height - handle.height
+                    // The valid scroll area is (usable track - handle.height), since the position of the handle is defined by its top edge, we subtract it.
+                    // The usable track excludes handleBottomInset (nav bar) so the handle can't be dragged into it.
+                    val scrollableHeight = (height - handleBottomInset) - handle.height
 
                     // Subtract half the handle's height and divide by 2 so the handle centers below the user's finger instead of hanging above or below.
                     // Divide by the scrollableHeight to make sure that the handle doesn't go off the screen and we use coerceAtLeast to prevent divide by 0 errors
@@ -397,20 +420,26 @@ class RecyclerFastScroller
             if (recyclerView == null) return
 
             val scrollOffset = recyclerView!!.computeVerticalScrollOffset() + appBarLayoutOffset
-            val verticalScrollRange = (
-                recyclerView!!.computeVerticalScrollRange() +
-                    recyclerView!!.paddingBottom
-            )
+            // The content range and the visible viewport come from the RecyclerView itself.
+            // Sizing & positioning the handle against the viewport (rather than the track height)
+            // keeps it proportional even when the track is shortened to clear the navigation bar,
+            // so the handle reaches the bottom of the track exactly when the list reaches its end.
+            val verticalScrollRange = recyclerView!!.computeVerticalScrollRange()
+            val verticalScrollExtent = recyclerView!!.computeVerticalScrollExtent()
 
-            val barHeight = bar.height
-            val ratio = scrollOffset.toFloat() / (verticalScrollRange - barHeight)
+            // The track (bar) spans the full height, but the handle travels only the area above
+            // handleBottomInset so it stays clear of the navigation bar.
+            val fullBarHeight = bar.height
+            val trackHeight = (fullBarHeight - handleBottomInset).coerceAtLeast(0)
+            val maxScrollOffset = (verticalScrollRange - verticalScrollExtent).coerceAtLeast(1)
+            val ratio = (scrollOffset.toFloat() / maxScrollOffset).coerceIn(0f, 1f)
 
-            var calculatedHandleHeight = (barHeight.toFloat() / verticalScrollRange * barHeight).toInt()
+            var calculatedHandleHeight = (trackHeight.toFloat() * verticalScrollExtent / verticalScrollRange).toInt()
             if (calculatedHandleHeight < minScrollHandleHeight) {
                 calculatedHandleHeight = minScrollHandleHeight
             }
 
-            if (calculatedHandleHeight >= barHeight) {
+            if (calculatedHandleHeight >= trackHeight) {
                 translationX = hiddenTranslationX.toFloat()
                 hideOverride = true
                 return
@@ -418,9 +447,29 @@ class RecyclerFastScroller
 
             hideOverride = false
 
-            val y = ratio * (barHeight - calculatedHandleHeight)
+            val y = ratio * (trackHeight - calculatedHandleHeight)
 
             handle.layout(handle.left, y.toInt(), handle.right, y.toInt() + calculatedHandleHeight)
+
+            // The track is edge-to-edge (drawn under the navigation bar) while the bottom of the last
+            // row is below the viewport. Once that bottom scrolls into view the track follows it
+            // exactly, so they stay aligned.
+            val layoutManager = recyclerView!!.layoutManager
+            val lastPosition = (recyclerView!!.adapter?.itemCount ?: 0) - 1
+            // The last row's bottom comes from its real on-screen position
+            // Note: Offsets can't be used - LinearLayoutManager reports them in scrollbar units
+            val lastRowBottomEdge =
+                lastPosition
+                    .takeIf { it >= 0 }
+                    ?.let { layoutManager?.findViewByPosition(it) }
+                    ?.let { layoutManager!!.getDecoratedBottom(it) }
+
+            // off-screen (or not laid out) → edge-to-edge; visible → follow the row's bottom
+            val isEdgeToEdge = lastRowBottomEdge == null || lastRowBottomEdge >= fullBarHeight
+            val barBottom = bar.top + if (isEdgeToEdge) fullBarHeight else lastRowBottomEdge
+            if (bar.bottom != barBottom) {
+                bar.layout(bar.left, bar.top, bar.right, barBottom)
+            }
         }
 
         companion object {

--- a/AnkiDroid/src/main/java/com/ichi2/anki/utils/Insets.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/anki/utils/Insets.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki.utils
+
+import android.view.View
+import androidx.core.view.RoundedCornerCompat
+import androidx.core.view.WindowInsetsCompat
+
+/**
+ * The radius, in pixels, of the larger of the two bottom corner radii.
+ */
+val WindowInsetsCompat.bottomRoundedCornerRadius: Int
+    get() =
+        maxOf(
+            getRoundedCorner(RoundedCornerCompat.POSITION_BOTTOM_LEFT)?.radius ?: 0,
+            getRoundedCorner(RoundedCornerCompat.POSITION_BOTTOM_RIGHT)?.radius ?: 0,
+        )
+
+/**
+ * The vertical clearance, in pixels, which keeps end-aligned content clear of the
+ *  bottom rounded display corners.
+ *
+ * This takes insets into account: for example in landscape, the 3-button nav bar means very little
+ *  if no clearance from the corner is needed, as all content is shifted left.
+ *
+ * @param view supplies the layout direction: the end-side inset is the left system-bar inset
+ * in RTL, otherwise the right
+ */
+fun WindowInsetsCompat.bottomCornerClearance(view: View): Int {
+    val bars = getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+    val endInset = if (view.layoutDirection == View.LAYOUT_DIRECTION_RTL) bars.left else bars.right
+    // The subtraction over-approximates the arc: content `d` inboard only needs
+    // `r - sqrt(r² - (r - d)²)` of vertical clearance, and `r - d` is never less (a chord vs the
+    // arc), so the content never dips into the corner.
+    return (bottomRoundedCornerRadius - endInset).coerceAtLeast(0)
+}

--- a/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
+++ b/AnkiDroid/src/main/java/com/ichi2/themes/Themes.kt
@@ -70,10 +70,6 @@ object Themes {
         }
     }
 
-    fun setLegacyActionBar(context: Context) {
-        context.setTheme(R.style.ThemeOverlay_LegacyActionBar)
-    }
-
     /**
      * Updates [currentTheme] value based on preferences.
      * If `Follow system` is selected, it's updated to the theme set

--- a/AnkiDroid/src/main/res/layout/include_browser_toolbar.xml
+++ b/AnkiDroid/src/main/res/layout/include_browser_toolbar.xml
@@ -1,50 +1,56 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/toolbar"
+    android:id="@+id/toolbar_container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/appBarColor"
-    android:minHeight="?attr/actionBarSize"
-    android:theme="@style/ActionBarStyle"
-    app:navigationContentDescription="@string/abc_action_bar_up_description"
-    app:navigationIcon="?attr/homeAsUpIndicator">
+    android:background="?attr/appBarColor">
 
-    <com.ichi2.ui.FixedTextView
-        android:id="@+id/toolbar_title"
-        android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:textColor="@color/white"
-        android:textSize="20sp"
-        android:visibility="gone" />
-
-    <LinearLayout
-        android:id="@+id/toolbar_content"
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="?attr/selectableItemBackground"
-        android:orientation="vertical">
+        android:minHeight="?attr/actionBarSize"
+        android:theme="@style/ActionBarStyle"
+        app:navigationContentDescription="@string/abc_action_bar_up_description"
+        app:navigationIcon="?attr/homeAsUpIndicator">
 
         <com.ichi2.ui.FixedTextView
-            android:id="@+id/deck_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="center_vertical"
-            android:drawableEnd="@drawable/id_arrow_drop_down"
-            android:textAppearance="?attr/textAppearanceListItem"
+            android:id="@+id/toolbar_title"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
             android:textColor="@color/white"
-            android:maxLines="1"
-            android:ellipsize="end"
-            tools:text="Deck name here"
-            />
+            android:textSize="20sp"
+            android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/subtitle"
+        <LinearLayout
+            android:id="@+id/toolbar_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@color/white"
-            android:textAppearance="?attr/textAppearanceListItemSecondary"
-            tools:text="2 cards shown"/>
-    </LinearLayout>
-</androidx.appcompat.widget.Toolbar>
+            android:background="?attr/selectableItemBackground"
+            android:orientation="vertical">
+
+            <com.ichi2.ui.FixedTextView
+                android:id="@+id/deck_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:drawableEnd="@drawable/id_arrow_drop_down"
+                android:textAppearance="?attr/textAppearanceListItem"
+                android:textColor="@color/white"
+                android:maxLines="1"
+                android:ellipsize="end"
+                tools:text="Deck name here"
+                />
+
+            <TextView
+                android:id="@+id/subtitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textColor="@color/white"
+                android:textAppearance="?attr/textAppearanceListItemSecondary"
+                tools:text="2 cards shown"/>
+        </LinearLayout>
+    </androidx.appcompat.widget.Toolbar>
+</FrameLayout>

--- a/AnkiDroid/src/main/res/layout/item_card_browser.xml
+++ b/AnkiDroid/src/main/res/layout/item_card_browser.xml
@@ -3,7 +3,6 @@
     android:id="@+id/card_item_browser"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="?attr/selectableItemBackground"
     xmlns:tools="http://schemas.android.com/tools">
 
     <CheckBox

--- a/AnkiDroid/src/main/res/values/legacy_action_bar.xml
+++ b/AnkiDroid/src/main/res/values/legacy_action_bar.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="ThemeOverlay.LegacyActionBar" parent="">
-        <item name="windowActionBar">true</item>
-        <item name="windowNoTitle">false</item>
-    </style>
-</resources>

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
@@ -4,6 +4,7 @@ package com.ichi2.anki
 
 import android.view.View
 import android.view.View.MeasureSpec
+import androidx.core.view.RoundedCornerCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
@@ -28,8 +29,8 @@ import org.junit.runner.RunWith
  *
  * The list draws edge-to-edge under the navigation bar and the fast
  * scroller's track is full-height/edge-to-edge. Only the handle is held inside the safe area
- * (clearing the navigation bar), so at full scroll the handle's bottom lines up with the last
- * card's resting position.
+ * (clearing the navigation bar and rounded display corners), so at full scroll the handle's bottom
+ * lines up with the last card's resting position.
  */
 @RunWith(AndroidJUnit4::class)
 class CardBrowserInsetsTest : RobolectricTest() {
@@ -146,6 +147,25 @@ class CardBrowserInsetsTest : RobolectricTest() {
         }
 
     @Test
+    fun `rounded display corners are cleared when larger than the navigation bar`() =
+        withCardBrowser(noteCount = 1) { browser ->
+            val cornerRadius = 48.dp.toPx(targetContext)
+            browser.dispatchInsets(navBarBottom = 24.dp, bottomCornerRadius = 48.dp)
+            browser.layoutForTest()
+
+            assertThat(
+                "the last card rests above the rounded corners",
+                browser.cardList.restingContentBottomToParent,
+                equalTo(cornerRadius),
+            )
+            assertThat(
+                "the handle is inset to the last card's resting line",
+                browser.fastScroller.handleBottomInset,
+                equalTo(cornerRadius),
+            )
+        }
+
+    @Test
     fun `toolbar is padded past a side navigation bar and cutout`() =
         withCardBrowser(noteCount = 1) { browser ->
             // landscape with 3-button navigation: the navigation bar is a side inset and the
@@ -163,6 +183,52 @@ class CardBrowserInsetsTest : RobolectricTest() {
                 "toolbar is padded past the side navigation bar",
                 toolbar.paddingRight,
                 equalTo(48.dp.toPx(targetContext)),
+            )
+        }
+
+    @Test
+    fun `a side navigation bar clearing the corner removes the bottom buffer`() =
+        withCardBrowser(noteCount = 50) { browser ->
+            // landscape with 3-button navigation: the bar is wider than the corner radius, so the
+            // scroll handle is already inboard of the corner arc and no vertical buffer is needed
+            browser.dispatchInsets(navBarRight = 48.dp, bottomCornerRadius = 34.dp)
+            browser.layoutForTest()
+
+            val fragmentRoot =
+                browser.supportFragmentManager
+                    .findFragmentById(R.id.card_browser_frame)!!
+                    .requireView()
+            assertThat(
+                "content is padded past the side navigation bar",
+                fragmentRoot.paddingRight,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+            assertThat("no bottom buffer is reserved", browser.cardList.paddingBottom, equalTo(0))
+            assertThat("the handle may reach the parent's bottom", browser.fastScroller.handleBottomInset, equalTo(0))
+
+            browser.cardList.scrollToPosition(49)
+            browser.layoutForTest()
+            assertThat("list is fully scrolled", browser.cardList.canScrollVertically(1), equalTo(false))
+            assertThat(
+                "the track reaches the parent's bottom when fully scrolled",
+                browser.fastScroller.bar.bottom,
+                equalTo(browser.fastScroller.height),
+            )
+        }
+
+    @Test
+    fun `a partial side inset reduces the corner clearance by its width`() =
+        withCardBrowser(noteCount = 1) { browser ->
+            // a side inset narrower than the corner radius leaves the scroll handle inside the
+            // corner's horizontal extent, but part-way in: only the remainder of the radius is
+            // reserved (48dp radius - 24dp side inset)
+            browser.dispatchInsets(navBarRight = 24.dp, bottomCornerRadius = 48.dp)
+            browser.layoutForTest()
+
+            assertThat(
+                "the clearance is the corner radius less the side inset",
+                browser.fastScroller.handleBottomInset,
+                equalTo(24.dp.toPx(targetContext)),
             )
         }
 
@@ -188,6 +254,7 @@ class CardBrowserInsetsTest : RobolectricTest() {
         navBarBottom: Dp = 0.dp,
         navBarRight: Dp = 0.dp,
         cutoutLeft: Dp = 0.dp,
+        bottomCornerRadius: Dp = 0.dp,
     ) {
         val insets =
             with(targetContext) {
@@ -196,7 +263,16 @@ class CardBrowserInsetsTest : RobolectricTest() {
                     .setInsets(statusBars(), insetsOf(top = 24.dp))
                     .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
                     .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
-                    .build()
+                    .apply {
+                        val radius = bottomCornerRadius.toPx(targetContext)
+                        if (radius > 0) {
+                            // only the radius is read by the implementation; the center is unused
+                            setRoundedCorner(
+                                RoundedCornerCompat.POSITION_BOTTOM_LEFT,
+                                RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
+                            )
+                        }
+                    }.build()
             }
         ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
     }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserInsetsTest.kt
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.view.View
+import android.view.View.MeasureSpec
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import androidx.recyclerview.widget.RecyclerView
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.ichi2.anki.ui.RecyclerFastScroller
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.greaterThan
+import org.hamcrest.Matchers.lessThan
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Edge-to-edge inset handling for [CardBrowser].
+ *
+ * The list draws edge-to-edge under the navigation bar and the fast
+ * scroller's track is full-height/edge-to-edge. Only the handle is held inside the safe area
+ * (clearing the navigation bar), so at full scroll the handle's bottom lines up with the last
+ * card's resting position.
+ */
+@RunWith(AndroidJUnit4::class)
+class CardBrowserInsetsTest : RobolectricTest() {
+    @Test
+    fun `track is full-height but the handle is inset to the last card's resting line`() =
+        withCardBrowser(noteCount = 1) { browser ->
+            val navBarBottom = 48.dp.toPx(targetContext)
+            browser.dispatchInsets(navBarBottom = 48.dp)
+            browser.layoutForTest()
+
+            // `clipToPadding=false` lets content scroll under the bar, but the bottom padding is the
+            // resting position of the last card: a navigation bar's height above the parent's bottom
+            assertThat(
+                "last card rests a navigation bar's height above the parent's bottom",
+                browser.cardList.restingContentBottomToParent,
+                equalTo(navBarBottom),
+            )
+            // the track stays full-height/edge-to-edge: flush with the parent bottom
+            assertThat(
+                "fast scroller track spans to the parent's bottom",
+                browser.fastScroller.distanceToParentBottom,
+                equalTo(0),
+            )
+            //  but the handle is inset to the same line the last card rests on
+            assertThat(
+                "fast scroller handle is inset to the last card's resting line",
+                browser.fastScroller.handleBottomInset,
+                equalTo(browser.cardList.restingContentBottomToParent),
+            )
+        }
+
+    @Test
+    fun `track is full-height while scrollable, then trimmed to the inset at the bottom`() =
+        withCardBrowser(noteCount = 50) { browser ->
+            val navBarBottom = 48.dp.toPx(targetContext)
+            browser.dispatchInsets(navBarBottom = 48.dp)
+            browser.layoutForTest()
+
+            val scroller = browser.fastScroller
+            val track = scroller.bar
+            // the list must be scrollable for this scenario to be meaningful
+            assertThat("list is scrollable", browser.cardList.canScrollVertically(1), equalTo(true))
+
+            // not at the bottom: the track spans the full edge-to-edge height
+            assertThat(
+                "track is full-height while there is more to scroll",
+                track.bottom,
+                equalTo(scroller.height),
+            )
+
+            // scroll to the end and re-lay-out so the fast scroller re-positions
+            browser.cardList.scrollToPosition(49)
+            browser.layoutForTest()
+
+            // at the bottom: the track is trimmed by the inset, aligning with the handle & last row
+            assertThat("list is fully scrolled", browser.cardList.canScrollVertically(1), equalTo(false))
+            assertThat(
+                "track is trimmed to the handle inset once fully scrolled",
+                track.bottom,
+                equalTo(scroller.height - navBarBottom),
+            )
+        }
+
+    @Test
+    fun `track bottom follows the last row's bottom once it is on screen`() =
+        withCardBrowser(noteCount = 50) { browser ->
+            val navBarBottom = 48.dp.toPx(targetContext)
+            browser.dispatchInsets(navBarBottom = 48.dp)
+            browser.layoutForTest()
+
+            val scroller = browser.fastScroller
+            val track = scroller.bar
+            val list = browser.cardList
+
+            // scroll to the end, then back up by part of the inset so the last row's bottom sits
+            // between its resting line and the bottom of the screen
+            list.scrollToPosition(49)
+            browser.layoutForTest()
+            list.scrollBy(0, -navBarBottom / 2)
+            browser.layoutForTest()
+
+            val layoutManager = list.layoutManager!!
+            val lastRowBottom = layoutManager.getDecoratedBottom(layoutManager.findViewByPosition(49)!!)
+            assertThat(
+                "the last row's bottom is on screen, below its resting line",
+                lastRowBottom,
+                allOf(greaterThan(scroller.height - navBarBottom), lessThan(scroller.height)),
+            )
+            assertThat("the track's bottom matches the last row's bottom", track.bottom, equalTo(lastRowBottom))
+        }
+
+    @Test
+    fun `handle, track and last row rest on the same line when fully scrolled`() =
+        withCardBrowser(noteCount = 50) { browser ->
+            val navBarBottom = 48.dp.toPx(targetContext)
+            browser.dispatchInsets(navBarBottom = 48.dp)
+            browser.layoutForTest()
+
+            val scroller = browser.fastScroller
+            val track = scroller.bar
+            val handle = scroller.handle
+            val list = browser.cardList
+
+            list.scrollToPosition(49)
+            browser.layoutForTest()
+            assertThat("list is fully scrolled", list.canScrollVertically(1), equalTo(false))
+
+            val layoutManager = list.layoutManager!!
+            val lastRowBottom = layoutManager.getDecoratedBottom(layoutManager.findViewByPosition(49)!!)
+            val restingLine = scroller.height - navBarBottom
+            assertThat("the last row rests above the safe area", lastRowBottom, equalTo(restingLine))
+            assertThat("the track's bottom rests on the same line", track.bottom, equalTo(restingLine))
+            assertThat("the handle's bottom rests on the same line", handle.bottom, equalTo(restingLine))
+        }
+
+    @Test
+    fun `toolbar is padded past a side navigation bar and cutout`() =
+        withCardBrowser(noteCount = 1) { browser ->
+            // landscape with 3-button navigation: the navigation bar is a side inset and the
+            // camera cutout is on the opposite side
+            browser.dispatchInsets(navBarRight = 48.dp, cutoutLeft = 32.dp)
+            browser.layoutForTest()
+
+            val toolbar = browser.findViewById<View>(R.id.toolbar_container)
+            assertThat(
+                "toolbar is padded past the cutout",
+                toolbar.paddingLeft,
+                equalTo(32.dp.toPx(targetContext)),
+            )
+            assertThat(
+                "toolbar is padded past the side navigation bar",
+                toolbar.paddingRight,
+                equalTo(48.dp.toPx(targetContext)),
+            )
+        }
+
+    /** The gap, in pixels, between the bottom of this view and the bottom of its parent. */
+    private val View.distanceToParentBottom: Int
+        get() = (parent as View).height - bottom
+
+    /**
+     * The gap, in pixels, between the parent's bottom and where the last list item comes to rest.
+     * The list fills its parent, so with `clipToPadding=false` this is just the bottom padding.
+     */
+    private val RecyclerView.restingContentBottomToParent: Int
+        get() = distanceToParentBottom + paddingBottom
+
+    private val CardBrowser.cardList: RecyclerView
+        get() = findViewById(R.id.card_browser_list)
+
+    private val CardBrowser.fastScroller: RecyclerFastScroller
+        get() = findViewById(R.id.browser_scroller)
+
+    /** Dispatches realistic system-bar insets, which Robolectric otherwise reports as zero. */
+    private fun CardBrowser.dispatchInsets(
+        navBarBottom: Dp = 0.dp,
+        navBarRight: Dp = 0.dp,
+        cutoutLeft: Dp = 0.dp,
+    ) {
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(right = navBarRight, bottom = navBarBottom))
+                    .setInsets(displayCutout(), insetsOf(left = cutoutLeft))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+    }
+
+    /** Forces a measure/layout pass so view bounds (not just padding/insets) can be asserted. */
+    private fun CardBrowser.layoutForTest() {
+        val content = findViewById<View>(android.R.id.content)
+        val width = 1080
+        val height = 2400
+        content.measure(
+            MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(height, MeasureSpec.EXACTLY),
+        )
+        content.layout(0, 0, width, height)
+    }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -6,6 +6,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.view.RoundedCornerCompat
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.displayCutout
@@ -33,7 +34,7 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
 
     /**
      * When fully scrolled: the last row, the bottom of the scroll track and the bottom of the
-     * scroll handle all rest on the same line, above the navigation bar.
+     * scroll handle all rest on the same line, above the navigation bar/rounded corners.
      *
      * Screenshot counterpart of [CardBrowserInsetsTest]
      * `handle, track and last row rest on the same line when fully scrolled`, which asserts the
@@ -59,8 +60,8 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
     /**
      * Landscape with 3-button navigation: the navigation bar is a side inset and the camera
      * cutout is on the opposite side. The toolbar and content clear both sides, no bottom buffer
-     * is reserved (the navigation bar is a side inset) and the scroll track runs to the bottom
-     * edge. [CardBrowserInsetsTest] asserts the same geometry programmatically.
+     * is reserved (the side inset already clears the rounded corner) and the scroll track runs to
+     * the bottom edge. [CardBrowserInsetsTest] asserts the same geometry programmatically.
      */
     @Test
     fun cardBrowserLandscapeScrolledToBottom() {
@@ -78,6 +79,32 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
             advanceRobolectricLooper()
 
             captureScreen("landscape_scrolled_to_bottom")
+        }
+    }
+
+    /**
+     * Landscape with gesture navigation: no side inset, so when scrolled to the bottom, the
+     *  final row and scrollbar should rest above the corner, to allow interaction.
+     *
+     * Screenshot counterpart of [CardBrowserInsetsTest]
+     * `rounded display corners are cleared when larger than the navigation bar`.
+     */
+    @Test
+    fun cardBrowserLandscapeGestureNavigationScrolledToBottom() {
+        RuntimeEnvironment.setQualifiers("+land")
+        withCardBrowser(noteCount = 50) { browser ->
+            browser.simulateGestureNavigationBar()
+
+            val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
+            list.scrollToPosition(49)
+            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+            advanceRobolectricLooper()
+
+            // keep the auto-hiding fast scroller visible for the capture
+            browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
+            advanceRobolectricLooper()
+
+            captureScreen("landscape_gesture_scrolled_to_bottom")
         }
     }
 
@@ -114,8 +141,47 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
     }
 
     /**
+     * As [simulateNavigationBar], but for landscape with gesture navigation: a short bottom
+     * inset, with rounded display corners larger than it.
+     */
+    private fun CardBrowser.simulateGestureNavigationBar() {
+        val navBarHeight = 24.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(bottom = navBarHeight))
+                    .apply {
+                        val radius = 34.dp.toPx(targetContext)
+                        // only the radius is read by the implementation; the center is unused
+                        setRoundedCorner(
+                            RoundedCornerCompat.POSITION_BOTTOM_LEFT,
+                            RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
+                        )
+                    }.build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+        val decor = window.decorView as ViewGroup
+        val navBarOverlay =
+            View(this).apply {
+                setBackgroundColor(0x80000000.toInt())
+            }
+        decor.addView(
+            navBarOverlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                navBarHeight.toPx(targetContext),
+                Gravity.BOTTOM,
+            ),
+        )
+    }
+
+    /**
      * As [simulateNavigationBar], but for landscape with 3-button navigation: the navigation bar
-     * is a side inset, with the camera cutout on the opposite side.
+     * is a side inset (wider than the rounded corner it clears), with the camera cutout on the
+     * opposite side.
      */
     private fun CardBrowser.simulateSideNavigationBar() {
         val navBarWidth = 48.dp
@@ -126,7 +192,14 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
                     .setInsets(statusBars(), insetsOf(top = 24.dp))
                     .setInsets(navigationBars(), insetsOf(right = navBarWidth))
                     .setInsets(displayCutout(), insetsOf(left = 32.dp))
-                    .build()
+                    .apply {
+                        val radius = 34.dp.toPx(targetContext)
+                        // only the radius is read by the implementation; the center is unused
+                        setRoundedCorner(
+                            RoundedCornerCompat.POSITION_BOTTOM_LEFT,
+                            RoundedCornerCompat(RoundedCornerCompat.POSITION_BOTTOM_LEFT, radius, radius, radius),
+                        )
+                    }.build()
             }
         ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
 

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.anki
+
+import android.view.Gravity
+import android.view.View
+import android.view.ViewGroup
+import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.navigationBars
+import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import com.ichi2.testutils.insetsOf
+import com.ichi2.utils.dp
+import org.junit.Test
+
+/**
+ * Screenshot tests for [CardBrowser]
+ *
+ * `./gradlew :AnkiDroid:verifyRoborazziPlayDebug -Pscreenshot --tests "com.ichi2.anki.CardBrowserScreenshotTest"`
+ */
+class CardBrowserScreenshotTest : ScreenshotTest() {
+    @Test
+    fun cardBrowserWith30Notes() =
+        withCardBrowser(noteCount = 50) { browser ->
+            // Robolectric reports zero system-bar insets by default. Inject realistic ones
+            // so the app's edge-to-edge layout responds as it would on a real device.
+            val navBarHeight = 48.dp
+            val insets =
+                with(targetContext) {
+                    WindowInsetsCompat
+                        .Builder()
+                        .setInsets(statusBars(), insetsOf(top = 24.dp))
+                        .setInsets(navigationBars(), insetsOf(bottom = navBarHeight))
+                        .build()
+                }
+            ViewCompat.dispatchApplyWindowInsets(browser.window.decorView, insets)
+
+            // overlay a translucent band where the nav bar would sit
+            // to see if content is drawn underneath it
+            val decor = browser.window.decorView as ViewGroup
+            val navBarOverlay =
+                View(browser).apply {
+                    setBackgroundColor(0x80000000.toInt())
+                }
+            decor.addView(
+                navBarOverlay,
+                FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    navBarHeight.toPx(targetContext),
+                    Gravity.BOTTOM,
+                ),
+            )
+
+            captureScreen("30_notes")
+        }
+}

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserScreenshotTest.kt
@@ -8,11 +8,15 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsCompat.Type.displayCutout
 import androidx.core.view.WindowInsetsCompat.Type.navigationBars
 import androidx.core.view.WindowInsetsCompat.Type.statusBars
+import androidx.recyclerview.widget.RecyclerView
+import com.ichi2.anki.ui.RecyclerFastScroller
 import com.ichi2.testutils.insetsOf
 import com.ichi2.utils.dp
 import org.junit.Test
+import org.robolectric.RuntimeEnvironment
 
 /**
  * Screenshot tests for [CardBrowser]
@@ -23,35 +27,121 @@ class CardBrowserScreenshotTest : ScreenshotTest() {
     @Test
     fun cardBrowserWith30Notes() =
         withCardBrowser(noteCount = 50) { browser ->
-            // Robolectric reports zero system-bar insets by default. Inject realistic ones
-            // so the app's edge-to-edge layout responds as it would on a real device.
-            val navBarHeight = 48.dp
-            val insets =
-                with(targetContext) {
-                    WindowInsetsCompat
-                        .Builder()
-                        .setInsets(statusBars(), insetsOf(top = 24.dp))
-                        .setInsets(navigationBars(), insetsOf(bottom = navBarHeight))
-                        .build()
-                }
-            ViewCompat.dispatchApplyWindowInsets(browser.window.decorView, insets)
-
-            // overlay a translucent band where the nav bar would sit
-            // to see if content is drawn underneath it
-            val decor = browser.window.decorView as ViewGroup
-            val navBarOverlay =
-                View(browser).apply {
-                    setBackgroundColor(0x80000000.toInt())
-                }
-            decor.addView(
-                navBarOverlay,
-                FrameLayout.LayoutParams(
-                    FrameLayout.LayoutParams.MATCH_PARENT,
-                    navBarHeight.toPx(targetContext),
-                    Gravity.BOTTOM,
-                ),
-            )
-
+            browser.simulateNavigationBar()
             captureScreen("30_notes")
         }
+
+    /**
+     * When fully scrolled: the last row, the bottom of the scroll track and the bottom of the
+     * scroll handle all rest on the same line, above the navigation bar.
+     *
+     * Screenshot counterpart of [CardBrowserInsetsTest]
+     * `handle, track and last row rest on the same line when fully scrolled`, which asserts the
+     * same geometry programmatically.
+     */
+    @Test
+    fun cardBrowserScrolledToBottom() =
+        withCardBrowser(noteCount = 50) { browser ->
+            browser.simulateNavigationBar()
+
+            val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
+            list.scrollToPosition(49)
+            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+            advanceRobolectricLooper()
+
+            // keep the auto-hiding fast scroller visible for the capture
+            browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
+            advanceRobolectricLooper()
+
+            captureScreen("scrolled_to_bottom")
+        }
+
+    /**
+     * Landscape with 3-button navigation: the navigation bar is a side inset and the camera
+     * cutout is on the opposite side. The toolbar and content clear both sides, no bottom buffer
+     * is reserved (the navigation bar is a side inset) and the scroll track runs to the bottom
+     * edge. [CardBrowserInsetsTest] asserts the same geometry programmatically.
+     */
+    @Test
+    fun cardBrowserLandscapeScrolledToBottom() {
+        RuntimeEnvironment.setQualifiers("+land")
+        withCardBrowser(noteCount = 50) { browser ->
+            browser.simulateSideNavigationBar()
+
+            val list = browser.findViewById<RecyclerView>(R.id.card_browser_list)
+            list.scrollToPosition(49)
+            while (list.canScrollVertically(1)) list.scrollBy(0, 50)
+            advanceRobolectricLooper()
+
+            // keep the auto-hiding fast scroller visible for the capture
+            browser.findViewById<RecyclerFastScroller>(R.id.browser_scroller).show(animate = false)
+            advanceRobolectricLooper()
+
+            captureScreen("landscape_scrolled_to_bottom")
+        }
+    }
+
+    /**
+     * Robolectric reports zero system-bar insets by default. Inject realistic ones so the app's
+     * edge-to-edge layout responds as it would on a real device, and overlay a translucent band
+     * where the nav bar would sit to see if content is drawn underneath it.
+     */
+    private fun CardBrowser.simulateNavigationBar() {
+        val navBarHeight = 48.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(bottom = navBarHeight))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+        val decor = window.decorView as ViewGroup
+        val navBarOverlay =
+            View(this).apply {
+                setBackgroundColor(0x80000000.toInt())
+            }
+        decor.addView(
+            navBarOverlay,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                navBarHeight.toPx(targetContext),
+                Gravity.BOTTOM,
+            ),
+        )
+    }
+
+    /**
+     * As [simulateNavigationBar], but for landscape with 3-button navigation: the navigation bar
+     * is a side inset, with the camera cutout on the opposite side.
+     */
+    private fun CardBrowser.simulateSideNavigationBar() {
+        val navBarWidth = 48.dp
+        val insets =
+            with(targetContext) {
+                WindowInsetsCompat
+                    .Builder()
+                    .setInsets(statusBars(), insetsOf(top = 24.dp))
+                    .setInsets(navigationBars(), insetsOf(right = navBarWidth))
+                    .setInsets(displayCutout(), insetsOf(left = 32.dp))
+                    .build()
+            }
+        ViewCompat.dispatchApplyWindowInsets(window.decorView, insets)
+
+        val decor = window.decorView as ViewGroup
+        val navBarOverlay =
+            View(this).apply {
+                setBackgroundColor(0x80000000.toInt())
+            }
+        decor.addView(
+            navBarOverlay,
+            FrameLayout.LayoutParams(
+                navBarWidth.toPx(targetContext),
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                Gravity.END,
+            ),
+        )
+    }
 }

--- a/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/CardBrowserTest.kt
@@ -984,26 +984,6 @@ class CardBrowserTest : RobolectricTest() {
         advanceRobolectricLooper()
     }
 
-    /** Returns an instance of [CardBrowser] containing [noteCount] notes */
-    private fun getBrowserWithNotes(
-        noteCount: Int,
-        reversed: Boolean = false,
-    ): CardBrowser {
-        ensureCollectionLoadIsSynchronous()
-        if (reversed) {
-            for (i in 0 until noteCount) {
-                addBasicAndReversedNote(i.toString(), "back")
-            }
-        } else {
-            for (i in 0 until noteCount) {
-                addBasicNote(i.toString(), "back")
-            }
-        }
-        return super.startRegularActivity<CardBrowser>(Intent()).also {
-            advanceRobolectricLooper() // may be a fix for flaky tests
-        }
-    }
-
     private val browserWithNoNewCards: CardBrowser
         get() = getBrowserWithNotes(0)
 
@@ -2145,3 +2125,30 @@ val CardBrowser.menu: Menu
 
 val CardBrowser.selectedDeckNameForUi: String
     get() = CollectionManager.getColUnsafe().decks.name(viewModel.lastDeckId!!)
+
+/** Returns an instance of [CardBrowser] containing [noteCount] notes */
+context(test: RobolectricTest)
+fun getBrowserWithNotes(
+    noteCount: Int,
+    reversed: Boolean = false,
+): CardBrowser {
+    test.ensureCollectionLoadIsSynchronous()
+    if (reversed) {
+        for (i in 0 until noteCount) {
+            test.addBasicAndReversedNote(i.toString(), "back")
+        }
+    } else {
+        for (i in 0 until noteCount) {
+            test.addBasicNote(i.toString(), "back")
+        }
+    }
+    return test.startRegularActivity<CardBrowser>(Intent()).also {
+        advanceRobolectricLooper() // may be a fix for flaky tests
+    }
+}
+
+context(test: RobolectricTest)
+fun withCardBrowser(
+    noteCount: Int,
+    block: (CardBrowser) -> Unit,
+) = block(getBrowserWithNotes(noteCount))

--- a/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/testutils/InsetsUtils.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package com.ichi2.testutils
+
+import android.content.Context
+import androidx.core.graphics.Insets
+import com.ichi2.utils.Dp
+import com.ichi2.utils.dp
+
+/**
+ * Helper to build [Insets] using [Dp]
+ *
+ * Default parameters allow for succinct code:
+ *
+ * ```kt
+ * insetsOf(top = 24.dp)
+ * ```
+ *
+ * @see Insets.of
+ */
+context(context: Context)
+fun insetsOf(
+    left: Dp = 0.dp,
+    top: Dp = 0.dp,
+    right: Dp = 0.dp,
+    bottom: Dp = 0.dp,
+): Insets =
+    Insets.of(
+        left.toPx(context),
+        top.toPx(context),
+        right.toPx(context),
+        bottom.toPx(context),
+    )


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - understanding and fix of `windowBackground` issue
> Assisted-by: Claude Fable 5 - last commit

## Fixes
* Fixes part of #17334

## How Has This Been Tested?

API 24 + API 33 emulators, private branch with Roborazzi

(scrolling to the bottom does not truncate rows)

<img width="3318" height="2483" alt="image" src="https://github.com/user-attachments/assets/351268fe-5a8a-4448-8983-42088ca501de" />


<img width="363" height="641" alt="Screenshot 2026-05-04 at 08 11 24" src="https://github.com/user-attachments/assets/e529b922-37e3-4e3b-a720-63ebc5c5214a" />
<img width="306" height="640" alt="Screenshot 2026-05-04 at 08 09 52" src="https://github.com/user-attachments/assets/b2304d79-7cc8-4be0-a0c1-185e91c07fec" />

```patch
Subject: [PATCH] !!edge to edge
---
Index: AnkiDroid/src/main/res/values-v35/theme_black.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/values-v35/theme_black.xml b/AnkiDroid/src/main/res/values-v35/theme_black.xml
--- a/AnkiDroid/src/main/res/values-v35/theme_black.xml	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/AnkiDroid/src/main/res/values-v35/theme_black.xml	(revision 713e19ef60adb5637dc9243525f447dbe4e7b2cf)
@@ -15,9 +15,5 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="Base.V35.Dark.Black" parent="@style/Base.Theme.Dark.Black">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-
-    <style name="Theme_Dark.Black" parent="Base.V35.Dark.Black"/>
+    <style name="Theme_Dark.Black" parent="@style/Base.Theme.Dark.Black"/>
 </resources>
\ No newline at end of file
Index: AnkiDroid/src/main/res/values-v35/theme_dark.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/values-v35/theme_dark.xml b/AnkiDroid/src/main/res/values-v35/theme_dark.xml
--- a/AnkiDroid/src/main/res/values-v35/theme_dark.xml	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/AnkiDroid/src/main/res/values-v35/theme_dark.xml	(revision 713e19ef60adb5637dc9243525f447dbe4e7b2cf)
@@ -15,9 +15,5 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="Base.V35.Dark" parent="Base.V29.Dark">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-
-    <style name="Theme_Dark" parent="Base.V35.Dark"/>
+    <style name="Theme_Dark" parent="Base.V29.Dark"/>
 </resources>
Index: AnkiDroid/src/main/res/values-v35/theme_light.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/values-v35/theme_light.xml b/AnkiDroid/src/main/res/values-v35/theme_light.xml
--- a/AnkiDroid/src/main/res/values-v35/theme_light.xml	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/AnkiDroid/src/main/res/values-v35/theme_light.xml	(revision 713e19ef60adb5637dc9243525f447dbe4e7b2cf)
@@ -16,9 +16,5 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="Base.V35.Light" parent="Base.V29.Light">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-
-    <style name="Theme_Light" parent="Base.V35.Light"/>
+    <style name="Theme_Light" parent="Base.V29.Light"/>
 </resources>
Index: AnkiDroid/src/main/res/values-v35/theme_plain.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/AnkiDroid/src/main/res/values-v35/theme_plain.xml b/AnkiDroid/src/main/res/values-v35/theme_plain.xml
--- a/AnkiDroid/src/main/res/values-v35/theme_plain.xml	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/AnkiDroid/src/main/res/values-v35/theme_plain.xml	(revision 713e19ef60adb5637dc9243525f447dbe4e7b2cf)
@@ -15,9 +15,5 @@
   -->
 
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="DuplicateCrowdInStrings">
-    <style name="Base.V29.Light.Plain" parent="@style/Base.Theme.Light.Plain">
-        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
-    </style>
-
-    <style name="Theme_Light.Plain" parent="Base.V29.Light.Plain"/>
+    <style name="Theme_Light.Plain" parent="@style/Base.Theme.Light.Plain"/>
 </resources>
\ No newline at end of file
Index: gradle/libs.versions.toml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/gradle/libs.versions.toml b/gradle/libs.versions.toml
--- a/gradle/libs.versions.toml	(revision 182e7993e1207d0c493df461beefb86e3d098849)
+++ b/gradle/libs.versions.toml	(revision 713e19ef60adb5637dc9243525f447dbe4e7b2cf)
@@ -10,7 +10,7 @@
 # The API should be as low as possible in order to enable dependencies to stay on a lower minSdk.
 apiMinSdk = "16"
 
-targetSdk = "35"  # affects which SDKs download in ../robolectricDownloader.gradle
+targetSdk = "36"  # affects which SDKs download in ../robolectricDownloader.gradle
 acra = '5.13.1'
 ktlint = '1.8.0'
 # AGP is included in Android Studio and changelogs are not well maintained/at a stable URL
```

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)