### PR TITLE
test: add Roborazzi screenshot diff script

### DIFF
--- a/.idea/dictionaries/davidallison.xml
+++ b/.idea/dictionaries/davidallison.xml
@@ -1,6 +1,7 @@
 <component name="ProjectDictionaryState">
   <dictionary name="davidallison">
     <words>
+      <w>.worktreeinclude</w>
       <w>Aedict</w>
       <w>Affero</w>
       <w>Awaitable</w>

--- a/.idea/dictionaries/usernames.xml
+++ b/.idea/dictionaries/usernames.xml
@@ -81,6 +81,7 @@
       <w>Yadav</w>
       <w>Zaur</w>
       <w>bresan</w>
+      <w>davidallison</w>
       <w>joshakaw</w>
       <w>krmanik</w>
       <w>lukstbit</w>

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,3 +1,5 @@
 # Includes the following files in Claude Code worktrees (gitignore syntax)
 # https://code.claude.com/docs/en/worktrees#copy-gitignored-files-into-worktrees
+#
+# When modifying this file, consider if items should be copied in tools/compare-screenshot-test.sh
 local.properties

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ScreenshotTest.kt
@@ -15,8 +15,13 @@
  */
 package com.ichi2.anki
 
+import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import com.github.takahirom.roborazzi.RoborazziOptions
+import com.github.takahirom.roborazzi.captureScreenRoboImage
+import com.github.takahirom.roborazzi.provideRoborazziContext
 import org.junit.experimental.categories.Category
 import org.robolectric.annotation.GraphicsMode
+import java.io.File
 
 interface ScreenshotTestCategory
 
@@ -25,4 +30,36 @@ interface ScreenshotTestCategory
  */
 @Category(ScreenshotTestCategory::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
-abstract class ScreenshotTest : RobolectricTest()
+abstract class ScreenshotTest : RobolectricTest() {
+    /**
+     * Captures a screenshot to `build/outputs/roborazzi/<TestClass>/<name>.png`.
+     *
+     * Writes to /diffs/ if there is an issue.
+     */
+    @OptIn(ExperimentalRoborazziApi::class)
+    protected fun captureScreen(name: String) {
+        // Note: this.javaClass should not be used inside a lambda, as 'this' will be unnamed
+        val classDir = "build/outputs/roborazzi/${this.javaClass.simpleName}"
+        val diffDir = File("$classDir/diffs")
+        // baseline is always in the root for the class, copied to /diffs/ if a change occurred
+        val baseline = File("$classDir/$name.png")
+        captureScreenRoboImage(
+            filePath = baseline.path,
+            roborazziOptions = provideRoborazziContext().options.withCompareOutputDir(diffDir.path),
+        )
+
+        // copy the baseline into /diffs (if it exists)
+        // /diffs/ is used so 'clean' baselines are not mixed with diffs to inspect
+        val diffWritten =
+            File(diffDir, "${name}_compare.png").exists() ||
+                File(diffDir, "${name}_actual.png").exists()
+        if (diffWritten && baseline.isFile) {
+            baseline.copyTo(File(diffDir, baseline.name), overwrite = true)
+        }
+    }
+}
+
+/** Sets the directory for _actual.png and _compare.png */
+@OptIn(ExperimentalRoborazziApi::class)
+private fun RoborazziOptions.withCompareOutputDir(dir: String): RoborazziOptions =
+    copy(compareOptions = compareOptions.copy(outputDirectoryPath = dir))

--- a/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
+++ b/AnkiDroid/src/test/java/com/ichi2/anki/ui/windows/reviewer/StudyScreenScreenshotTest.kt
@@ -16,8 +16,6 @@
 package com.ichi2.anki.ui.windows.reviewer
 
 import androidx.test.core.app.ActivityScenario
-import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
-import com.github.takahirom.roborazzi.captureScreenRoboImage
 import com.ichi2.anki.ScreenshotTest
 import com.ichi2.anki.previewer.CardViewerActivity
 import com.ichi2.anki.settings.Prefs
@@ -40,7 +38,6 @@ class StudyScreenScreenshotTest(
         RuntimeEnvironment.setQualifiers(config.qualifier.toString())
     }
 
-    @OptIn(ExperimentalRoborazziApi::class)
     @Test
     fun captureScreenshot() {
         ActivityScenario
@@ -48,7 +45,7 @@ class StudyScreenScreenshotTest(
                 ReviewerFragment.getIntent(targetContext),
             ).use { scenario ->
                 scenario.onActivity {
-                    captureScreenRoboImage(filePath = "build/outputs/roborazzi/${this.javaClass.simpleName}/$config.png")
+                    captureScreen(config.toString())
                 }
             }
     }

--- a/tools/compare-screenshot-test.sh
+++ b/tools/compare-screenshot-test.sh
@@ -154,9 +154,11 @@ gradle_quiet "${REPO_ROOT}/gradlew" -p "$REPO_ROOT" \
     ${GRADLE_TESTS_ARG[@]+"${GRADLE_TESTS_ARG[@]}"}
 
 
-shopt -s nullglob
-diffs=("${OUT_DIR}"/*_compare.png)
-shopt -u nullglob
+# Recurse — Roborazzi writes *_compare.png inside directories
+diffs=()
+while IFS= read -r line; do
+    diffs+=("$line")
+done < <(find "$OUT_DIR" -type f -name '*_compare.png')
 
 if [ ${#diffs[@]} -eq 0 ]; then
     label="${TEST_FILTER:-all screenshot tests}"

--- a/tools/compare-screenshot-test.sh
+++ b/tools/compare-screenshot-test.sh
@@ -1,0 +1,185 @@
+#!/bin/bash
+# Diff Roborazzi screenshot tests between a provided baseline commit and HEAD.
+#
+# Usage:
+#   tools/compare-screenshot-test.sh <baseline-commit> [test-class-fqn]
+#   tools/compare-screenshot-test.sh HEAD                          # diff working tree vs last commit
+#
+# With no test filter, runs every test tagged ScreenshotTestCategory.
+#
+# Implementation:
+#   Baseline output is produced in a worktree: ../Anki-Android-screenshot-baseline
+
+set -euo pipefail
+
+# Ensure the commit hash is provided as the first argument
+if [ $# -lt 1 ]; then
+    echo "usage: $(basename "$0") <baseline-commit> [test-class-fqn]" >&2
+    echo "       pass 'HEAD' to diff only your uncommitted changes" >&2
+    exit 1
+fi
+BASELINE="$1"
+TEST_FILTER="${2:-}"
+
+# Validate the baseline commit (arg 1)
+if ! git rev-parse --verify --quiet "${BASELINE}^{commit}" >/dev/null; then
+    echo "error: baseline '$BASELINE' is not a valid git commit" >&2
+    exit 1
+fi
+
+BASELINE_SHA="$(git rev-parse --verify "$BASELINE")"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+# Fail if using HEAD with a clean working tree
+if [ "$BASELINE_SHA" = "$HEAD_SHA" ] \
+   && git diff --quiet HEAD && git diff --cached --quiet; then
+    echo "error: nothing to compare. No unstaged changes." >&2
+    exit 1
+fi
+
+
+# /Users/davidallison/StudioProjects/Anki-Android
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+# /Users/davidallison/StudioProjects/Anki-Android-screenshot-baseline
+WORKTREE_DIR="${REPO_ROOT}/../Anki-Android-screenshot-baseline"
+OUT_DIR="${REPO_ROOT}/AnkiDroid/build/outputs/roborazzi"
+WORKTREE_OUT="${WORKTREE_DIR}/AnkiDroid/build/outputs/roborazzi"
+
+# baseline  4d7daca42e  test(card-browser): screenshot test
+# HEAD      18377ab3d1  feat(card-browser): enable edge to edge (+ uncommitted changes)
+echo "Comparing:"
+echo "baseline  $(git log -1 --format='%h  %s' "$BASELINE")"
+head_line="$(git log -1 --format='%h  %s' HEAD)"
+if ! git diff --quiet HEAD || ! git diff --cached --quiet; then
+    head_line="${head_line} (+ uncommitted changes)"
+fi
+echo "HEAD      ${head_line}"
+# If the user picked a non-HEAD baseline, remind them HEAD is also valid
+# and is the quickest way to check just their uncommitted edits.
+if [ "$BASELINE_SHA" != "$HEAD_SHA" ]; then
+    echo "Tip: pass 'HEAD' to diff only your uncommitted changes."
+fi
+echo
+
+# Display a tip to use arg 2
+GRADLE_TESTS_ARG=()
+if [ -n "$TEST_FILTER" ]; then
+    GRADLE_TESTS_ARG=(--tests "$TEST_FILTER")
+else
+    echo "Tip: use the 2nd arg to limit test runs. Syntax: \"com.ichi2.anki.**Test\""
+    echo
+fi
+
+## Function definitions
+
+# ANSI red, only when stdout is a TTY (no escape codes in pipes / CI logs).
+if [ -t 1 ]; then
+    RED=$'\033[31m'
+    NC=$'\033[0m'
+else
+    RED='' NC=''
+fi
+
+# Silence IPackageStatsObserver.java uses or overrides a deprecated API. Maintain progress output.
+gradle_quiet() {
+    "$@" 2> >(grep -v -E '^Note:' >&2)
+}
+
+# Open a directory in the OS file manager
+open_dir() {
+    case "$(uname -s)" in
+        Darwin)               open "$1" ;;
+        Linux)                xdg-open "$1" >/dev/null 2>&1 ;;
+        MINGW*|MSYS*|CYGWIN*) start "" "$1" ;;
+        *) echo "warning: don't know how to open '$1' on $(uname -s)" >&2 ;;
+    esac
+}
+
+# Create or reuse the screenshot-baseline worktree (../Anki-Android-screenshot-baseline)
+worktree_head=""
+if [ -e "$WORKTREE_DIR/.git" ]; then
+    worktree_head="$(git -C "$WORKTREE_DIR" rev-parse HEAD 2>/dev/null || true)"
+fi
+if [ "$worktree_head" = "$BASELINE_SHA" ]; then
+    echo "==> Reusing existing worktree at $BASELINE"
+else
+    git worktree remove --force "$WORKTREE_DIR" 2>/dev/null || true
+    rm -rf "$WORKTREE_DIR" # handle a hard kill.
+    git worktree add "$WORKTREE_DIR" "$BASELINE" >/dev/null
+fi
+
+# Keep in sync with .worktreeinclude.
+# Fixes 'SDK location not found'
+if [ -f "${REPO_ROOT}/local.properties" ]; then
+    cp "${REPO_ROOT}/local.properties" "${WORKTREE_DIR}/local.properties"
+fi
+
+echo "==> Recording baseline at $BASELINE"
+gradle_quiet "${WORKTREE_DIR}/gradlew" -p "$WORKTREE_DIR" \
+    :AnkiDroid:recordRoborazziPlayDebug -Pscreenshot -q \
+    -x installGitHook \
+    ${GRADLE_TESTS_ARG[@]+"${GRADLE_TESTS_ARG[@]}"}
+
+# Clear stale Roborazzi outputs
+gradle_quiet "${REPO_ROOT}/gradlew" -p "$REPO_ROOT" \
+    :AnkiDroid:clearRoborazziPlayDebug -q
+
+# Copy baselines to outputs/roborazzi/<TestClass>/**
+echo "==> Copying baselines to ${OUT_DIR#${REPO_ROOT}/}"
+staged=0
+shopt -s nullglob
+for class_dir in "${WORKTREE_OUT}"/*/; do
+    [ -d "$class_dir" ] || continue
+    class_name="$(basename "$class_dir")"
+    pngs=("${class_dir}"*.png)
+    if [ ${#pngs[@]} -eq 0 ]; then
+        echo "warning: skipping empty class dir ${class_name}" >&2
+        continue
+    fi
+    mkdir -p "${OUT_DIR}/${class_name}"
+    cp "${pngs[@]}" "${OUT_DIR}/${class_name}/"
+    staged=1
+done
+shopt -u nullglob
+
+if [ $staged -eq 0 ]; then
+    echo "error: baseline run produced no screenshots. Does the test filter '${TEST_FILTER:-(none)}' match any @Category(ScreenshotTestCategory) tests?" >&2
+    exit 1
+fi
+
+echo "==> Comparing baseline to HEAD"
+# *_actual.png / *_compare.png are written if there are differences
+gradle_quiet "${REPO_ROOT}/gradlew" -p "$REPO_ROOT" \
+    :AnkiDroid:compareRoborazziPlayDebug -Pscreenshot -q \
+    ${GRADLE_TESTS_ARG[@]+"${GRADLE_TESTS_ARG[@]}"}
+
+
+shopt -s nullglob
+diffs=("${OUT_DIR}"/*_compare.png)
+shopt -u nullglob
+
+if [ ${#diffs[@]} -eq 0 ]; then
+    label="${TEST_FILTER:-all screenshot tests}"
+    echo "No visual difference between $BASELINE and HEAD for ${label}."
+    exit 0
+fi
+
+# Screenshots were not equivalent. Explain and link the issues
+
+#   1 visual diff(s):
+#     diff: file:///Users/.../AnkiDroid/build/outputs/roborazzi/30_notes_compare.png
+echo "${RED}${#diffs[@]} visual diff(s)${NC} in file://${OUT_DIR}"
+for compare in "${diffs[@]}"; do
+    echo "  ${RED}diff:${NC} file://${compare}"
+done
+
+# Offer to open AnkiDroid/build/outputs/roborazzi if running in a TTY
+if [ -t 0 ]; then
+    read -n 1 -r -p "Press [R] to reveal files: "
+    echo
+    if [[ "$REPLY" =~ ^[Rr]$ ]]; then
+        open_dir "$OUT_DIR"
+    fi
+fi
+
+exit 1


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - everything except comments

## Purpose / Description
When I was testing edge-to-edge functionality, I wanted the ability to compare screenshots from my working tree against a baseline.

This script produces `_compare.png` files if any screenshot tests detect changes, well-linked if opened using the Android Studio terminal.

## Fixes
* Somewhat related to #20942

## Approach

A user can now execute the script in-IDE. Links open up in the terminal, with clean output of the failures.

```bash
# compare the working tree
tools/compare-screenshot-test.sh HEAD
# compare to a past snapshot
tools/compare-screenshot-test.sh 4d7daca42e94309e36592dd3de201e8853ff1f90
```

## How Has This Been Tested?

macOS only

<img width="1375" height="875" alt="Screenshot 2026-05-04 at 18 40 29" src="https://github.com/user-attachments/assets/1a2b80ca-f8e3-46dd-929b-e56965095846" />

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [x] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)