### PR TITLE
fix: `installGitHook` inside a worktree

### DIFF
--- a/AnkiDroid/build.gradle
+++ b/AnkiDroid/build.gradle
@@ -325,9 +325,15 @@ play {
 }
 
 // Install Git pre-commit hook for Ktlint
+// Resolve via git so worktrees (where `.git` is a file) are handled correctly.
+def gitHooksDir = providers.exec {
+    workingDir = rootProject.rootDir
+    commandLine "git", "rev-parse", "--git-path", "hooks"
+}.standardOutput.asText.map { rootProject.rootDir.toPath().resolve(it.trim()).toFile() }
+
 tasks.register('installGitHook', Copy) {
     from new File(rootProject.rootDir, 'pre-commit')
-    into { new File(rootProject.rootDir, '.git/hooks') }
+    into gitHooksDir
     filePermissions {
         user {
             read = write = execute = true


### PR DESCRIPTION
> [!NOTE]
> Assisted-by: Claude Opus 4.7 - all

## Purpose / Description
In a worktree, `.git` is a file

## Fixes
* Fixes #20952

## Approach

* `git rev-parse --git-path hooks`

## How Has This Been Tested?

* `gradlew -p /Users/davidallison/StudioProjects/Anki-Android :AnkiDroid:installGitHook --rerun-tasks`
* `/Users/davidallison/StudioProjects/Anki-Android/.claude/worktrees/parallel-A/gradlew -p /Users/davidallison/StudioProjects/Anki-Android/.claude/worktrees/parallel-A :AnkiDroid:installGitHook --rerun-tasks`


## Learning
https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---git-pathpath

## Checklist
- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the [Google Accessibility Scanner](https://play.google.com/store/apps/details?id=com.google.android.apps.accessibility.auditor)